### PR TITLE
Remove more uses of `duplicate`

### DIFF
--- a/src/module/item/consumable/spell-consumables.ts
+++ b/src/module/item/consumable/spell-consumables.ts
@@ -68,7 +68,7 @@ export async function createConsumableFromSpell(
     consumableData.data.description.value =
         (spell.sourceId ? "@" + spell.sourceId.replace(".", "[") + "]" : spell.description) + `\n<hr/>${description}`;
     consumableData.data.spell = {
-        data: duplicate(spell.toObject()),
+        data: spell.toObject(),
         heightenedLevel: heightenedLevel,
     };
     return consumableData;


### PR DESCRIPTION
Also noticed and removed a check for an NPC actor type along the way--these methods, despite their names, currently only apply to hazards and will hopefully be gone soon