### PR TITLE
Add effects for Aquatic Combat

### DIFF
--- a/packs/data/feature-effects.db/effect-aquatic-combat-no-swim-speed.json
+++ b/packs/data/feature-effects.db/effect-aquatic-combat-no-swim-speed.json
@@ -48,6 +48,17 @@
                 "value": 5
             },
             {
+                "definition": {
+                    "all": [
+                        "weapon:damage:type:piercing"
+                    ]
+                },
+                "key": "AdjustStrike",
+                "mode": "multiply",
+                "property": "range-increment",
+                "value": 0.5
+            },
+            {
                 "key": "Note",
                 "predicate": {
                     "all": [

--- a/packs/data/feature-effects.db/effect-aquatic-combat-no-swim-speed.json
+++ b/packs/data/feature-effects.db/effect-aquatic-combat-no-swim-speed.json
@@ -1,0 +1,85 @@
+{
+    "_id": "ZwWqIFU50EY7vl2l",
+    "data": {
+        "badge": null,
+        "description": {
+            "value": "<p>Use these rules for battles in water or underwater:</p>\n<ul>\n<li>You're @Compendium[pf2e.conditionitems.Flat-Footed]{Flat-Footed} unless you have a swim Speed.</li>\n<li>You gain resistance 5 to acid and fire.</li>\n<li>You take a -2 circumstance penalty to melee slashing or bludgeoning attacks that pass through water.</li>\n<li>Ranged attacks that deal bludgeoning or slashing damage automatically miss if the attacker or target is underwater, and piercing ranged attacks made by an underwater creature or against an underwater target have their range increments halved.</li>\n<li>You can't cast fire spells or use actions with the fire trait underwater.</li>\n<li>At the GM's discretion, some ground-based actions might not work underwater or while floating.</li>\n</ul>"
+        },
+        "duration": {
+            "expiry": null,
+            "sustained": false,
+            "unit": "unlimited",
+            "value": -1
+        },
+        "level": {
+            "value": 1
+        },
+        "rules": [
+            {
+                "key": "Note",
+                "predicate": {
+                    "all": [
+                        "fire"
+                    ]
+                },
+                "selector": "all",
+                "text": "<p>You can't cast fire spells or use actions with the fire trait underwater.</p>"
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": {
+                    "any": [
+                        "slashing",
+                        "bludgeoning"
+                    ]
+                },
+                "selector": "attack",
+                "type": "circumstance",
+                "value": -2
+            },
+            {
+                "key": "Resistance",
+                "type": "acid",
+                "value": 5
+            },
+            {
+                "key": "Resistance",
+                "type": "fire",
+                "value": 5
+            },
+            {
+                "key": "Note",
+                "predicate": {
+                    "all": [
+                        "ranged"
+                    ]
+                },
+                "selector": "attack",
+                "text": "<p>Ranged attacks that deal bludgeoning or slashing damage automatically miss if the attacker or target is underwater, and piercing ranged attacks made by an underwater creature or against an underwater target have their range increments halved.</p>"
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.conditionitems.Flat-Footed"
+            }
+        ],
+        "source": {
+            "value": "Pathfinder Core Rulebook"
+        },
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "target": null,
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        }
+    },
+    "img": "systems/pf2e/icons/spells/wall-of-water.webp",
+    "name": "Effect: Aquatic Combat (No Swim Speed)",
+    "type": "effect"
+}

--- a/packs/data/feature-effects.db/effect-aquatic-combat-no-swim-speed.json
+++ b/packs/data/feature-effects.db/effect-aquatic-combat-no-swim-speed.json
@@ -29,8 +29,8 @@
                 "key": "FlatModifier",
                 "predicate": {
                     "any": [
-                        "slashing",
-                        "bludgeoning"
+                        "weapon:damage:type:slashing",
+                        "weapon:damage:type:bludgeoning"
                     ]
                 },
                 "selector": "attack",

--- a/packs/data/feature-effects.db/effect-aquatic-combat.json
+++ b/packs/data/feature-effects.db/effect-aquatic-combat.json
@@ -48,6 +48,17 @@
                 "value": 5
             },
             {
+                "definition": {
+                    "all": [
+                        "weapon:damage:type:piercing"
+                    ]
+                },
+                "key": "AdjustStrike",
+                "mode": "multiply",
+                "property": "range-increment",
+                "value": 0.5
+            },
+            {
                 "key": "Note",
                 "predicate": {
                     "all": [
@@ -56,7 +67,7 @@
                 },
                 "selector": "attack",
                 "text": "<p>Ranged attacks that deal bludgeoning or slashing damage automatically miss if the attacker or target is underwater, and piercing ranged attacks made by an underwater creature or against an underwater target have their range increments halved.</p>"
-            }
+            },
         ],
         "source": {
             "value": "Pathfinder Core Rulebook"

--- a/packs/data/feature-effects.db/effect-aquatic-combat.json
+++ b/packs/data/feature-effects.db/effect-aquatic-combat.json
@@ -1,0 +1,81 @@
+{
+    "_id": "TPbr1kErAAJKBi3V",
+    "data": {
+        "badge": null,
+        "description": {
+            "value": "<p>Use these rules for battles in water or underwater:</p>\n<ul>\n<li>You're @Compendium[pf2e.conditionitems.Flat-Footed]{Flat-Footed} unless you have a swim Speed.</li>\n<li>You gain resistance 5 to acid and fire.</li>\n<li>You take a -2 circumstance penalty to melee slashing or bludgeoning attacks that pass through water.</li>\n<li>Ranged attacks that deal bludgeoning or slashing damage automatically miss if the attacker or target is underwater, and piercing ranged attacks made by an underwater creature or against an underwater target have their range increments halved.</li>\n<li>You can't cast fire spells or use actions with the fire trait underwater.</li>\n<li>At the GM's discretion, some ground-based actions might not work underwater or while floating.</li>\n</ul>"
+        },
+        "duration": {
+            "expiry": null,
+            "sustained": false,
+            "unit": "unlimited",
+            "value": -1
+        },
+        "level": {
+            "value": 1
+        },
+        "rules": [
+            {
+                "key": "Note",
+                "predicate": {
+                    "all": [
+                        "fire"
+                    ]
+                },
+                "selector": "all",
+                "text": "<p>You can't cast fire spells or use actions with the fire trait underwater.</p>"
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": {
+                    "any": [
+                        "slashing",
+                        "bludgeoning"
+                    ]
+                },
+                "selector": "attack",
+                "type": "circumstance",
+                "value": -2
+            },
+            {
+                "key": "Resistance",
+                "type": "acid",
+                "value": 5
+            },
+            {
+                "key": "Resistance",
+                "type": "fire",
+                "value": 5
+            },
+            {
+                "key": "Note",
+                "predicate": {
+                    "all": [
+                        "ranged"
+                    ]
+                },
+                "selector": "attack",
+                "text": "<p>Ranged attacks that deal bludgeoning or slashing damage automatically miss if the attacker or target is underwater, and piercing ranged attacks made by an underwater creature or against an underwater target have their range increments halved.</p>"
+            }
+        ],
+        "source": {
+            "value": "Pathfinder Core Rulebook"
+        },
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "target": null,
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        }
+    },
+    "img": "systems/pf2e/icons/spells/wall-of-water.webp",
+    "name": "Effect: Aquatic Combat",
+    "type": "effect"
+}

--- a/packs/data/feature-effects.db/effect-aquatic-combat.json
+++ b/packs/data/feature-effects.db/effect-aquatic-combat.json
@@ -29,8 +29,8 @@
                 "key": "FlatModifier",
                 "predicate": {
                     "any": [
-                        "slashing",
-                        "bludgeoning"
+                        "weapon:damage:type:slashing",
+                        "weapon:damage:type:bludgeoning"
                     ]
                 },
                 "selector": "attack",

--- a/packs/data/feature-effects.db/effect-aquatic-combat.json
+++ b/packs/data/feature-effects.db/effect-aquatic-combat.json
@@ -67,7 +67,7 @@
                 },
                 "selector": "attack",
                 "text": "<p>Ranged attacks that deal bludgeoning or slashing damage automatically miss if the attacker or target is underwater, and piercing ranged attacks made by an underwater creature or against an underwater target have their range increments halved.</p>"
-            },
+            }
         ],
         "source": {
             "value": "Pathfinder Core Rulebook"


### PR DESCRIPTION
Added two effects, one for if the creature in question has a swim speed, and one for no swim speed.