### PR TITLE
Add clickable compendium link to usage chat message for used consumables

### DIFF
--- a/src/module/item/consumable/index.ts
+++ b/src/module/item/consumable/index.ts
@@ -118,8 +118,12 @@ class ConsumablePF2e extends PhysicalItemPF2e {
         } else {
             const exhausted = max > 1 && current === 1;
             const key = exhausted ? "UseExhausted" : max > 1 ? "UseMulti" : "UseSingle";
+            // Add compendium link if it has a sourceId, just the name otherwise
+            const name = this.sourceId
+                ? game.pf2e.TextEditor.enrichHTML("@" + this.sourceId.replace(".", "[") + "]")
+                : this.name;
             const content = game.i18n.format(`PF2E.ConsumableMessage.${key}`, {
-                name: this.name,
+                name: name,
                 current: current - 1,
             });
 


### PR DESCRIPTION
If you use the last consumable of a stack, it disappears from your inventory and you no longer have easy access to the compendium description for any draggable effects, etc.
This change adds a clickable link to the compendium item into the chat when you use an item.

Addresses issue #2103 

![image](https://user-images.githubusercontent.com/85046656/172076361-f872f6fa-d2c4-453b-a08e-4864c6a67f50.png)
