### PR TITLE
Add Adjust Modifier REs to Mighty Bulwark

### DIFF
--- a/packs/data/feats.db/mighty-bulwark.json
+++ b/packs/data/feats.db/mighty-bulwark.json
@@ -39,9 +39,21 @@
                 "value": 4
             },
             {
-                "domain": "reflex",
-                "key": "RollOption",
-                "option": "self:armor:bulwark-all"
+                "key": "AdjustModifier",
+                "predicate": {
+                    "all": [
+                        "self:armor:trait:bulwark"
+                    ]
+                },
+                "selector": "reflex",
+                "slug": "dex",
+                "suppress": true
+            },
+            {
+                "key": "AdjustModifier",
+                "selector": "reflex",
+                "slug": "bulwark",
+                "suppress": true
             }
         ],
         "source": {

--- a/packs/scripts/run-migration.ts
+++ b/packs/scripts/run-migration.ts
@@ -36,6 +36,7 @@ import { Migration748BatchConsumablePricing } from "@module/migration/migrations
 import { Migration749AssuranceREs } from "@module/migration/migrations/749-assurance-res";
 import { Migration752StrikeVsWeaponTraits } from "@module/migration/migrations/752-strike-vs-weapon-traits";
 import { Migration753WeaponReloadTimes } from "@module/migration/migrations/753-weapon-reload-times";
+import { Migration754MightyBulwarkAdjustModifiers } from "@module/migration/migrations/754-mighty-bulwark-adjust-modifiers";
 
 const migrations: MigrationBase[] = [
     new Migration717TakeFeatLimits(),
@@ -68,6 +69,7 @@ const migrations: MigrationBase[] = [
     new Migration749AssuranceREs(),
     new Migration752StrikeVsWeaponTraits(),
     new Migration753WeaponReloadTimes(),
+    new Migration754MightyBulwarkAdjustModifiers(),
 ];
 
 global.deepClone = <T>(original: T): T => {

--- a/src/module/actor/modifiers.ts
+++ b/src/module/actor/modifiers.ts
@@ -87,8 +87,8 @@ export interface ModifierAdjustment {
     damageType?: DamageType;
     relabel?: string;
     suppress: boolean;
-    getNewValue(current: number): number;
-    getDamageType(current: DamageType | null): DamageType | null;
+    getNewValue?: (current: number) => number;
+    getDamageType?: (current: DamageType | null) => DamageType | null;
 }
 
 export interface RawModifier extends BaseRawModifier {
@@ -520,7 +520,7 @@ export class StatisticModifier {
             type ResolvedAdjustment = { value: number; relabel: string | null };
             const resolvedAdjustment = adjustments.reduce(
                 (resolved: ResolvedAdjustment, adjustment) => {
-                    const newValue = adjustment.getNewValue(resolved.value);
+                    const newValue = adjustment.getNewValue?.(resolved.value) ?? resolved.value;
                     if (newValue !== resolved.value) {
                         resolved.value = newValue;
                         resolved.relabel = adjustment.relabel ?? null;
@@ -537,7 +537,7 @@ export class StatisticModifier {
 
             // If applicable, change the damage type of this modifier, using only the final adjustment found
             modifier.damageType = adjustments.reduce(
-                (damageType: DamageType | null, adjustment) => adjustment.getDamageType(damageType),
+                (damageType: DamageType | null, adjustment) => adjustment.getDamageType?.(damageType) ?? damageType,
                 modifier.damageType
             );
         }

--- a/src/module/migration/migrations/754-mighty-bulwark-adjust-modifiers.ts
+++ b/src/module/migration/migrations/754-mighty-bulwark-adjust-modifiers.ts
@@ -1,0 +1,38 @@
+import { ItemSourcePF2e } from "@item/data";
+import { MigrationBase } from "../base";
+
+/** Add Adjust Modifier REs to Mighty Bulwark to suppress dexterity and standard bulwark modifiers */
+export class Migration754MightyBulwarkAdjustModifiers extends MigrationBase {
+    static override version = 0.754;
+
+    override async updateItem(source: ItemSourcePF2e): Promise<void> {
+        if (!(source.type === "feat" && source.data.slug === "mighty-bulwark")) {
+            return;
+        }
+
+        const newRules = [
+            {
+                key: "FlatModifier",
+                predicate: { all: ["self:armor:trait:bulwark"] },
+                selector: "reflex",
+                type: "untyped",
+                value: 4,
+            },
+            {
+                key: "AdjustModifier",
+                predicate: { all: ["self:armor:trait:bulwark"] },
+                selector: "reflex",
+                slug: "dex",
+                suppress: true,
+            },
+            {
+                key: "AdjustModifier",
+                selector: "reflex",
+                slug: "bulwark",
+                suppress: true,
+            },
+        ];
+
+        source.data.rules = newRules;
+    }
+}

--- a/src/module/migration/migrations/index.ts
+++ b/src/module/migration/migrations/index.ts
@@ -153,3 +153,4 @@ export { Migration750FixCorruptedPrice } from "./750-fix-corrupted-price";
 export { Migration751ResetRollOptions } from "./751-reset-roll-options";
 export { Migration752StrikeVsWeaponTraits } from "./752-strike-vs-weapon-traits";
 export { Migration753WeaponReloadTimes } from "./753-weapon-reload-times";
+export { Migration754MightyBulwarkAdjustModifiers } from "./754-mighty-bulwark-adjust-modifiers";

--- a/src/module/migration/runner/base.ts
+++ b/src/module/migration/runner/base.ts
@@ -14,7 +14,7 @@ interface CollectionDiff<T extends foundry.data.ActiveEffectSource | ItemSourceP
 export class MigrationRunnerBase {
     migrations: MigrationBase[];
 
-    static LATEST_SCHEMA_VERSION = 0.753;
+    static LATEST_SCHEMA_VERSION = 0.754;
 
     static MINIMUM_SAFE_VERSION = 0.618;
 

--- a/src/module/system/statistic/index.ts
+++ b/src/module/system/statistic/index.ts
@@ -80,7 +80,8 @@ export class Statistic<T extends BaseStatisticData = StatisticData> {
     slug: string;
 
     constructor(public actor: ActorPF2e, public readonly data: T, public options?: RollOptionParameters) {
-        this.slug = this.data.slug;
+        this.slug = data.slug;
+        this.ability = data.ability ?? null;
 
         // Add some base modifiers depending on data values
         this.modifiers = [data.modifiers ?? []].flat();
@@ -93,8 +94,9 @@ export class Statistic<T extends BaseStatisticData = StatisticData> {
             this.proficient = data.proficient === undefined ? true : !!data.proficient;
         }
 
-        if (actor instanceof CharacterPF2e && data.ability) {
-            this.abilityModifier = AbilityModifier.fromScore(data.ability, actor.abilities[data.ability].value);
+        if (actor instanceof CharacterPF2e && this.ability) {
+            this.abilityModifier = AbilityModifier.fromScore(this.ability, actor.abilities[this.ability].value);
+            this.abilityModifier.adjustments = actor.getModifierAdjustments(data.domains ?? [], this.ability);
             this.modifiers.unshift(this.abilityModifier);
         }
 


### PR DESCRIPTION
This will make the display of the (Mighty) Bulwark modifier less confusing (before it would show both Bulwark and Dexterity until rolled)