### PR TITLE
Expose longform actor skill names in actor.skills

### DIFF
--- a/src/module/actor/character/index.ts
+++ b/src/module/actor/character/index.ts
@@ -131,7 +131,7 @@ class CharacterPF2e extends CreaturePF2e {
             }
 
             const data = this.data.data.skills[shortForm];
-            skills[shortForm] = mergeObject(skill, {
+            skills[skill.slug] = skills[shortForm] = mergeObject(skill, {
                 rank: data.rank,
                 ability: data.ability,
                 abilityModifier: data.modifiers.find((m) => m.enabled && m.type === "ability") ?? null,

--- a/src/module/actor/character/types.ts
+++ b/src/module/actor/character/types.ts
@@ -1,6 +1,7 @@
 import { HitPointsSummary } from "@actor/base";
 import { SkillAbbreviation } from "@actor/creature/data";
 import { AbilityString } from "@actor/data";
+import { SkillLongForm } from "@actor/data/types";
 import { WeaponPF2e } from "@item";
 import { ZeroToFour } from "@module/data";
 import { Statistic } from "@system/statistic";
@@ -11,7 +12,9 @@ interface CharacterHitPointsSummary extends HitPointsSummary {
 
 type CharacterSkill = Statistic & { rank: ZeroToFour; ability: AbilityString };
 
-type CharacterSkills = Record<SkillAbbreviation, CharacterSkill> & Partial<Record<string, CharacterSkill>>;
+type CharacterSkills = Record<SkillAbbreviation, CharacterSkill> &
+    Record<SkillLongForm, CharacterSkill> &
+    Partial<Record<string, CharacterSkill>>;
 
 interface CreateAuxiliaryInteractParams {
     weapon: Embedded<WeaponPF2e>;

--- a/src/module/actor/creature/data.ts
+++ b/src/module/actor/creature/data.ts
@@ -13,6 +13,7 @@ import {
     Rollable,
     StrikeData,
 } from "@actor/data/base";
+import { SkillLongForm } from "@actor/data/types";
 import type { CREATURE_ACTOR_TYPES, SKILL_ABBREVIATIONS } from "@actor/data/values";
 import { CheckModifier, DamageDicePF2e, ModifierPF2e, RawModifier, StatisticModifier } from "@actor/modifiers";
 import { ActorAlliance } from "@actor/types";
@@ -38,8 +39,10 @@ interface BaseCreatureData<
 > extends Omit<BaseCreatureSource<TType>, "data" | "effects" | "flags" | "items" | "token" | "type">,
         BaseActorDataPF2e<TItem, TType, TSystemData, TSource> {}
 
-/** Skill and Lore statistics for rolling */
-type CreatureSkills = Record<SkillAbbreviation, Statistic> & Partial<Record<string, Statistic>>;
+/** Skill and Lore statistics for rolling. Both short and longform are supported, but eventually only long form will be */
+type CreatureSkills = Record<SkillAbbreviation, Statistic> &
+    Record<SkillLongForm, Statistic> &
+    Partial<Record<string, Statistic>>;
 
 interface CreatureSystemSource extends ActorSystemSource {
     details?: {

--- a/src/module/actor/creature/index.ts
+++ b/src/module/actor/creature/index.ts
@@ -67,7 +67,7 @@ export abstract class CreaturePF2e extends ActorPF2e {
             const label = game.i18n.format("PF2E.SkillCheckWithName", { skillName });
             const domains = ["all", "skill-check", longForm, `${skill.ability}-based`, `${skill.ability}-skill-check`];
 
-            current[shortForm] = new Statistic(this, {
+            current[longForm] = current[shortForm] = new Statistic(this, {
                 slug: longForm,
                 proficient: skill.visible,
                 domains,

--- a/src/module/actor/familiar/index.ts
+++ b/src/module/actor/familiar/index.ts
@@ -289,7 +289,8 @@ export class FamiliarPF2e extends CreaturePF2e {
             modifiers.push(...extractModifiers(statisticsModifiers, selectors).filter(filterModifier));
 
             const label = CONFIG.PF2E.skills[shortForm] ?? longForm;
-            const stat = mergeObject(new StatisticModifier(label, modifiers), {
+            const stat = mergeObject(new StatisticModifier(longForm, modifiers), {
+                label,
                 ability,
                 value: 0,
                 roll: async (args: RollParameters): Promise<Rolled<CheckRoll> | null> => {

--- a/src/module/actor/npc/index.ts
+++ b/src/module/actor/npc/index.ts
@@ -318,7 +318,7 @@ class NPCPF2e extends CreaturePF2e {
             const name = game.i18n.localize(`PF2E.Skill${SKILL_DICTIONARY[shortform].capitalize()}`);
 
             const stat = mergeObject(
-                new StatisticModifier(name, modifiers, this.getRollOptions(domains)),
+                new StatisticModifier(skill, modifiers, this.getRollOptions(domains)),
                 {
                     ability,
                     expanded: skill,
@@ -386,7 +386,7 @@ class NPCPF2e extends CreaturePF2e {
                 ].flat();
 
                 const stat = mergeObject(
-                    new StatisticModifier(itemData.name, modifiers, this.getRollOptions(domains)),
+                    new StatisticModifier(skill, modifiers, this.getRollOptions(domains)),
                     data.skills[shortform],
                     { overwrite: false }
                 );

--- a/src/module/actor/npc/skills-editor.ts
+++ b/src/module/actor/npc/skills-editor.ts
@@ -36,7 +36,6 @@ export class NPCSkillsEditor extends FormApplication<NPCPF2e> {
                 skill.isLore = true;
                 trainedSkills[key] = skill;
             } else if (skill.visible) {
-                skill.label = game.i18n.localize("PF2E.Skill" + skill.name);
                 trainedSkills[key] = skill;
             } else {
                 untrainedSkills[key] = skill;

--- a/static/templates/actors/familiar-sheet.html
+++ b/static/templates/actors/familiar-sheet.html
@@ -97,7 +97,7 @@
                                     {{numberFormat this.value decimals=0 sign=true}}
                                 </div>
                                 <div class="skills-name">
-                                    {{localize this.name}}
+                                    {{localize this.label}}
                                 </div>
                             </div>
                             {{/each}}


### PR DESCRIPTION
Also makes familiar and actor skill names the lower case longform name like character has it.

Eventually the shortform skills will be removed from actor.skills. The next release should publish a deprecation warning for short form names such as actor.skills.ath and actor.skills.thi