### PR TITLE
Remove extraneous "Range" trait being added to NPC attacks

### DIFF
--- a/src/module/actor/npc/index.ts
+++ b/src/module/actor/npc/index.ts
@@ -535,15 +535,6 @@ class NPCPF2e extends CreaturePF2e {
                     .map((m) => `${m.label} ${m.modifier < 0 ? "" : "+"}${m.modifier}`)
                     .join(", ");
 
-                if (
-                    action.attackRollType === "PF2E.NPCAttackRanged" &&
-                    !action.traits.some((trait) => trait.name === "range")
-                ) {
-                    action.traits.splice(1, 0, {
-                        name: "range",
-                        label: game.i18n.localize("PF2E.TraitRange"),
-                    });
-                }
                 // Add a damage roll breakdown
                 action.damageBreakdown = Object.values(meleeData.data.damageRolls).flatMap((roll) => {
                     const damageType = game.i18n.localize(CONFIG.PF2E.damageTypes[roll.damageType as DamageType]);

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -3689,7 +3689,6 @@
         "TraitRadiation": "Radiation",
         "TraitRage": "Rage",
         "TraitRakshasa": "Rakshasa",
-        "TraitRange": "Range",
         "TraitRange5": "Range 5 ft",
         "TraitRange10": "Range 10 ft",
         "TraitRange15": "Range 15 ft",


### PR DESCRIPTION
This weird thing here:

![image](https://user-images.githubusercontent.com/106829671/172540664-9c57305a-8652-43c9-bafe-f78abda476e3.png)
