### PR TITLE
Add traits for feat & actions chat cards

### DIFF
--- a/static/templates/chat/action-card.html
+++ b/static/templates/chat/action-card.html
@@ -3,13 +3,17 @@
         <img src="{{item.img}}" title="{{item.name}}" width="36" height="36"/>
         <h3>{{item.name}}</h3>
     </header>
+    <div class="tags">
+        {{#each data.traits}}
+            {{#unless trait.mystified}}
+                <span class="tag" data-trait="{{this.name}}" data-description="{{this.description}}">{{localize this.label}}</span>
+            {{/unless}}
+        {{/each}}
+    </div>
     <div class="card-content">{{{data.description.value}}}</div>
     <footer class="card-footer">
         {{#each data.properties}}
             <span>{{localize this}}</span>
-        {{/each}}
-        {{#each data.traits}}
-            <span title="{{localize this.description}}">{{localize this.label}}</span>
         {{/each}}
     </footer>
 </div>

--- a/static/templates/chat/feat-card.html
+++ b/static/templates/chat/feat-card.html
@@ -3,7 +3,13 @@
         <img src="{{item.img}}" title="{{item.name}}" width="36" height="36"/>
         <h3>{{item.name}}</h3>
     </header>
-
+    <div class="tags">
+        {{#each data.traits}}
+            {{#unless trait.mystified}}
+                <span class="tag" data-trait="{{this.name}}" data-description="{{this.description}}">{{localize this.label}}</span>
+            {{/unless}}
+        {{/each}}
+    </div>
     <div class="card-content">
         {{{data.description.value}}}
     </div>


### PR DESCRIPTION
Closes #2378 

Traits were already present in actions chat cards, but in the footer with the other properties instead of below the header like other cards, so I moved them. 

![image](https://user-images.githubusercontent.com/23172861/172575520-60e0ed48-3e4d-489e-a37e-a1cbb62bcee1.png)
![image](https://user-images.githubusercontent.com/23172861/172575564-43f94eb8-d4fc-4905-9214-83e849d9c7b4.png)
