### PR TITLE
Prevent buttons from retaining focus when clicked

### DIFF
--- a/src/scripts/hooks/load.ts
+++ b/src/scripts/hooks/load.ts
@@ -55,5 +55,12 @@ export const Load = {
 
         // Make available immediately on load for module subclassing
         window.AutomaticBonusProgression = AutomaticBonusProgression;
+
+        // Prevent buttons from retaining focus when clicked so that canvas hotkeys still work
+        document.addEventListener("mouseup", (): void => {
+            if (document.activeElement instanceof HTMLButtonElement) {
+                document.activeElement.blur();
+            }
+        });
     },
 };


### PR DESCRIPTION
Currently, whenever a button is clicked, it retains focus--even when the button is one that closes a Foundry application. When the document body doesn't have focus, canvas hotkeys stop functioning until the canvas is clicked again. Removing button focus after any click successfully preserves hotkey functionality with (hopefully) no significant side effects.

Upstream issue: https://github.com/foundryvtt/foundryvtt/issues/7270