### PR TITLE
Add GitHub CD step

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,66 @@
+name: Deploy Release
+
+on:
+  workflow_dispatch
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Install Deps
+      run: |
+        npm ci
+
+    - name: Update manifest
+      id: update-manifest
+      run: node .github/workflows/updatebuildno.js
+
+    - name: Build
+      run: |
+        npm run build
+
+    - name: Test
+      run: |
+        npm run test
+
+    - name: Package release
+      working-directory: ./dist
+      run: zip -r ./pf2e.zip ./*
+
+    # Create a release for this specific version
+    - name: Create Release
+      id: create_version_release
+      uses: ncipollo/release-action@v1.10.0
+      with:
+        allowUpdates: true # set this to false if you want to prevent updating existing releases
+        name: ${{ steps.update-manifest.outputs.version }}
+        body: 'TODO: FILL DETAILS'
+        token: ${{ secrets.GITHUB_TOKEN }}
+        artifacts: './dist/system.json,./dist/pf2e.zip'
+        commit: ${{ github.sha }}
+        tag: v${{ steps.update-manifest.outputs.version }}
+
+    # Update the 'latest' release. The way that foundry works, this needs to be a persistent URL that points
+    # to the zip file for subsequent builds
+    - name: Create Release
+      id: create_latest_release
+      uses: ncipollo/release-action@v1.10.0
+      with:
+        allowUpdates: true
+        name: Latest
+        token: ${{ secrets.GITHUB_TOKEN }}
+        artifacts: './dist/system.json,./dist/pf2e.zip'
+        commit: ${{ github.sha }}
+        tag: latest

--- a/.github/workflows/updatebuildno.js
+++ b/.github/workflows/updatebuildno.js
@@ -1,0 +1,13 @@
+const fs = require("fs");
+
+const systemRaw = fs.readFileSync("system.json");
+let system = JSON.parse(systemRaw);
+
+system.url = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}`;
+system.manifest = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/releases/download/latest/system.json`;
+system.download = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/releases/download/v${system.version}/pf2e.zip`;
+
+fs.writeFileSync("system.json", JSON.stringify(system, null, 2));
+
+console.log(`Setting output version = ${system.version}`);
+console.log(`::set-output name=version::${system.version}`);

--- a/system.json
+++ b/system.json
@@ -587,9 +587,9 @@
     "gridDistance": 5,
     "gridUnits": "ft",
     "primaryTokenAttribute": "attributes.hp",
-    "url": "https://gitlab.com/hooking/foundry-vtt---pathfinder-2e",
-    "bugs": "https://gitlab.com/hooking/foundry-vtt---pathfinder-2e/-/issues",
-    "changelog": "https://gitlab.com/hooking/foundry-vtt---pathfinder-2e/-/raw/release-v9/CHANGELOG.md",
-    "manifest": "https://gitlab.com/hooking/foundry-vtt---pathfinder-2e/-/jobs/artifacts/release-v9/raw/system.json?job=build",
-    "download": "https://gitlab.com/hooking/foundry-vtt---pathfinder-2e/-/jobs/artifacts/release-v9/raw/pf2e.zip?job=build"
+    "url": "https://github.com/foundryvtt/pf2e",
+    "bugs": "https://github.com/foundryvtt/pf2e/issues",
+    "changelog": "https://github.com/foundryvtt/pf2e/blob/master/CHANGELOG.md",
+    "manifest": "https://github.com/foundryvtt/pf2e/releases/download/latest/system.json",
+    "download": "https://github.com/foundryvtt/pf2e/releases/download/latest/pf2e.zip"
 }

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -194,7 +194,6 @@ const config: Configuration = {
             ],
         }),
         new MiniCssExtractPlugin({ filename: "styles/[name].css" }),
-        new SimpleProgressWebpackPlugin({ format: "compact" }),
     ],
     resolve: {
         alias: {
@@ -215,6 +214,10 @@ const config: Configuration = {
         publicPath: "/systems/pf2e",
     },
 };
+
+if (!isProductionBuild) {
+    config.plugins?.push(new SimpleProgressWebpackPlugin({ format: "compact" }));
+}
 
 // eslint-disable-next-line import/no-default-export
 export default config;


### PR DESCRIPTION
This adds a CD workflow for the github actions for the pf2e repository.

The workflow creates two github releases: one named `v1.2.3` where `1.2.3` is the version that is located in the system.json file in source control. Secondly, there is a `latest` release that is created/updated that is a permanent location for the manifest to point to with an unchanging uri.

Because of how github releases work, this also creates/updates git tags on the repository with the same name as the releases as above.

The system.json is modified to change the manifest to point to the correct locations:

* The manifest location is set to the `system.json` located in the `latest` release
* The download location is set to the `pf2e.zip` located in the specific version release.

To use this workflow, after this PR gets merged, there should be a button in the "Actions" tab of github under the "Deploy Release". Select this "Run workflow" button and select the `release` branch and the magic will happen in a few minutes.