### PR TITLE
Handle null price values for Coins

### DIFF
--- a/src/module/item/physical/helpers.ts
+++ b/src/module/item/physical/helpers.ts
@@ -10,7 +10,8 @@ class CoinsPF2e implements Coins {
     gp: number;
     pp: number;
 
-    constructor(data: Coins = {}) {
+    constructor(data?: Coins | null) {
+        data ??= {};
         this.cp = data.cp ?? 0;
         this.sp = data.sp ?? 0;
         this.gp = data.gp ?? 0;

--- a/src/module/migration/migrations/746-standardize-pricing.ts
+++ b/src/module/migration/migrations/746-standardize-pricing.ts
@@ -1,9 +1,9 @@
 import { ItemSourcePF2e } from "@item/data";
 import { isPhysicalData } from "@item/data/helpers";
-import { Coins } from "@item/physical/data";
 import { TreasureSystemSource } from "@item/treasure/data";
 import { CoinsPF2e } from "@item/physical/helpers";
 import { MigrationBase } from "../base";
+import { isObject } from "@util";
 
 export class Migration746StandardizePricing extends MigrationBase {
     static override version = 0.746;
@@ -11,8 +11,8 @@ export class Migration746StandardizePricing extends MigrationBase {
     override async updateItem(item: ItemSourcePF2e): Promise<void> {
         if (!isPhysicalData(item) && item.type !== "kit") return;
 
-        if (typeof item.data.price === "string") {
-            item.data.price = { value: CoinsPF2e.fromString(item.data.price).strip() };
+        if (!isObject(item.data.price)) {
+            item.data.price = { value: CoinsPF2e.fromString(String(item.data.price)).strip() };
         }
 
         if (item.type === "treasure") {
@@ -27,19 +27,10 @@ export class Migration746StandardizePricing extends MigrationBase {
                 systemData["-=value"] = null;
                 delete systemData.value;
             }
-        } else {
-            const systemData: PhysicalDataOld = item.data;
-            if (typeof systemData.price.value === "string") {
-                systemData.price.value = CoinsPF2e.fromString(systemData.price.value).strip();
-            }
+        } else if (!isObject(item.data.price.value)) {
+            item.data.price.value = CoinsPF2e.fromString(String(item.data.price.value)).strip();
         }
     }
-}
-
-interface PhysicalDataOld {
-    price: {
-        value: string | Coins;
-    };
 }
 
 interface TreasureSystemOld extends TreasureSystemSource {


### PR DESCRIPTION
Updates the old migration to remove null as well if it finds it.