### PR TITLE
Review Bestary 2: Changed name of mag. weapon to base weapon

### DIFF
--- a/packs/data/pathfinder-bestiary-2.db/babau.json
+++ b/packs/data/pathfinder-bestiary-2.db/babau.json
@@ -947,10 +947,10 @@
                     "value": 1
                 },
                 "preciousMaterial": {
-                    "value": ""
+                    "value": null
                 },
                 "preciousMaterialGrade": {
-                    "value": ""
+                    "value": null
                 },
                 "price": {
                     "value": {
@@ -972,16 +972,16 @@
                     "value": ""
                 },
                 "propertyRune1": {
-                    "value": ""
+                    "value": null
                 },
                 "propertyRune2": {
-                    "value": ""
+                    "value": null
                 },
                 "propertyRune3": {
-                    "value": ""
+                    "value": null
                 },
                 "propertyRune4": {
-                    "value": ""
+                    "value": null
                 },
                 "quantity": 1,
                 "range": null,
@@ -1024,7 +1024,7 @@
                 }
             },
             "img": "systems/pf2e/icons/equipment/weapons/longspear.webp",
-            "name": "+1 Longspear",
+            "name": "Longspear",
             "sort": 800000,
             "type": "weapon"
         },

--- a/packs/data/pathfinder-bestiary-2.db/blodeuwedd.json
+++ b/packs/data/pathfinder-bestiary-2.db/blodeuwedd.json
@@ -1177,10 +1177,10 @@
                     "value": 1
                 },
                 "preciousMaterial": {
-                    "value": ""
+                    "value": null
                 },
                 "preciousMaterialGrade": {
-                    "value": ""
+                    "value": null
                 },
                 "price": {
                     "value": {}
@@ -1200,16 +1200,16 @@
                     "value": ""
                 },
                 "propertyRune1": {
-                    "value": ""
+                    "value": null
                 },
                 "propertyRune2": {
-                    "value": ""
+                    "value": null
                 },
                 "propertyRune3": {
-                    "value": ""
+                    "value": null
                 },
                 "propertyRune4": {
-                    "value": ""
+                    "value": null
                 },
                 "quantity": 1,
                 "range": 60,
@@ -1252,7 +1252,7 @@
                 }
             },
             "img": "systems/pf2e/icons/equipment/weapons/sling.webp",
-            "name": "+1 Sling",
+            "name": "Sling",
             "sort": 1000000,
             "type": "weapon"
         },

--- a/packs/data/pathfinder-bestiary-2.db/bralani.json
+++ b/packs/data/pathfinder-bestiary-2.db/bralani.json
@@ -1097,10 +1097,10 @@
                     "value": 1
                 },
                 "preciousMaterial": {
-                    "value": ""
+                    "value": null
                 },
                 "preciousMaterialGrade": {
-                    "value": ""
+                    "value": null
                 },
                 "price": {
                     "value": {
@@ -1122,16 +1122,16 @@
                     "value": ""
                 },
                 "propertyRune1": {
-                    "value": ""
+                    "value": null
                 },
                 "propertyRune2": {
-                    "value": ""
+                    "value": null
                 },
                 "propertyRune3": {
-                    "value": ""
+                    "value": null
                 },
                 "propertyRune4": {
-                    "value": ""
+                    "value": null
                 },
                 "quantity": 1,
                 "range": 60,
@@ -1175,7 +1175,7 @@
                 }
             },
             "img": "systems/pf2e/icons/equipment/weapons/composite-shortbow.webp",
-            "name": "+1 Composite Shortbow",
+            "name": "Composite Shortbow",
             "sort": 900000,
             "type": "weapon"
         },

--- a/packs/data/pathfinder-bestiary-2.db/monadic-deva.json
+++ b/packs/data/pathfinder-bestiary-2.db/monadic-deva.json
@@ -1731,10 +1731,10 @@
                     "value": 1
                 },
                 "preciousMaterial": {
-                    "value": ""
+                    "value": null
                 },
                 "preciousMaterialGrade": {
-                    "value": ""
+                    "value": null
                 },
                 "price": {
                     "value": {
@@ -1756,16 +1756,16 @@
                     "value": ""
                 },
                 "propertyRune1": {
-                    "value": ""
+                    "value": null
                 },
                 "propertyRune2": {
-                    "value": ""
+                    "value": null
                 },
                 "propertyRune3": {
-                    "value": ""
+                    "value": null
                 },
                 "propertyRune4": {
-                    "value": ""
+                    "value": null
                 },
                 "quantity": 1,
                 "range": null,
@@ -1808,7 +1808,7 @@
                 }
             },
             "img": "systems/pf2e/icons/equipment/weapons/mace.webp",
-            "name": "+1 Striking Mace",
+            "name": "Mace",
             "sort": 1500000,
             "type": "weapon"
         },

--- a/packs/data/pathfinder-bestiary-2.db/movanic-deva.json
+++ b/packs/data/pathfinder-bestiary-2.db/movanic-deva.json
@@ -1620,10 +1620,10 @@
                     "value": 1
                 },
                 "preciousMaterial": {
-                    "value": ""
+                    "value": null
                 },
                 "preciousMaterialGrade": {
-                    "value": ""
+                    "value": null
                 },
                 "price": {
                     "value": {
@@ -1645,16 +1645,16 @@
                     "value": ""
                 },
                 "propertyRune1": {
-                    "value": ""
+                    "value": null
                 },
                 "propertyRune2": {
-                    "value": ""
+                    "value": null
                 },
                 "propertyRune3": {
-                    "value": ""
+                    "value": null
                 },
                 "propertyRune4": {
-                    "value": ""
+                    "value": null
                 },
                 "quantity": 1,
                 "range": null,
@@ -1697,7 +1697,7 @@
                 }
             },
             "img": "systems/pf2e/icons/equipment/weapons/bastard-sword.webp",
-            "name": "+1 Striking Bastard Sword",
+            "name": "Bastard Sword",
             "sort": 1400000,
             "type": "weapon"
         },


### PR DESCRIPTION
For better localization weapon name of magical weapons needs to be base weapon name and use automatic renaming.