### PR TITLE
Add support for spell variants of spells with a variable cast time

### DIFF
--- a/src/module/actor/sheet/item-summary-renderer.ts
+++ b/src/module/actor/sheet/item-summary-renderer.ts
@@ -195,11 +195,17 @@ export class CreatureSheetItemRenderer<AType extends CreaturePF2e> extends ItemS
                 }
 
                 if (actor instanceof CharacterPF2e) {
-                    if (chatData.isAttack) {
+                    if (chatData.variants) {
+                        const label = game.i18n.localize("PF2E.Item.Spell.Variants.SelectVariantLabel");
                         buttons.append(
-                            `<span><button class="spell_attack" data-action="spellAttack">${game.i18n.localize(
-                                "PF2E.AttackLabel"
-                            )}</button></span>`
+                            `<span><button class="spell_attack" data-action="selectVariant">${label}</button></span>`
+                        );
+                        break;
+                    }
+                    if (chatData.isAttack) {
+                        const label = game.i18n.localize("PF2E.AttackLabel");
+                        buttons.append(
+                            `<span><button class="spell_attack" data-action="spellAttack">${label}</button></span>`
                         );
                     }
                     if (chatData.hasDamage) {
@@ -211,12 +217,12 @@ export class CreatureSheetItemRenderer<AType extends CreaturePF2e> extends ItemS
 
                 break;
             case "consumable":
-                if (item instanceof ConsumablePF2e && item.charges.max > 0 && item.isIdentified)
+                if (item instanceof ConsumablePF2e && item.charges.max > 0 && item.isIdentified) {
+                    const label = game.i18n.localize("PF2E.ConsumableUseLabel");
                     buttons.append(
-                        `<span><button class="consume" data-action="consume">${game.i18n.localize(
-                            "PF2E.ConsumableUseLabel"
-                        )} ${item.name}</button></span>`
+                        `<span><button class="consume" data-action="consume">${label} ${item.name}</button></span>`
                     );
+                }
                 break;
             default:
         }
@@ -239,6 +245,9 @@ export class CreatureSheetItemRenderer<AType extends CreaturePF2e> extends ItemS
                     break;
                 case "consume":
                     if (item instanceof ConsumablePF2e) item.consume();
+                    break;
+                case "selectVariant":
+                    spell?.variantPrompt().then((variant) => variant?.toMessage());
                     break;
             }
         });

--- a/src/module/chat-message/data.ts
+++ b/src/module/chat-message/data.ts
@@ -26,6 +26,7 @@ type ChatMessageFlagsPF2e = foundry.data.ChatMessageFlags & {
         preformatted?: "flavor" | "content" | "both";
         isFromConsumable?: boolean;
         journalEntry?: DocumentUUID;
+        spellVariant?: { overlayIds: string[] };
         [key: string]: unknown;
     };
     core: NonNullable<foundry.data.ChatMessageFlags["core"]>;

--- a/src/module/chat-message/index.ts
+++ b/src/module/chat-message/index.ts
@@ -111,6 +111,13 @@ class ChatMessagePF2e extends ChatMessage<ActorPF2e> {
             item.trickMagicEntry = trick;
         }
 
+        const spellVariant = this.data.flags.pf2e.spellVariant;
+        if (spellVariant && item?.isOfType("spell")) {
+            return item.loadVariant({
+                overlayIds: spellVariant.overlayIds,
+            });
+        }
+
         return item;
     }
 

--- a/src/module/chat-message/listeners/cards.ts
+++ b/src/module/chat-message/listeners/cards.ts
@@ -70,6 +70,7 @@ export const ChatCards = {
                 else if (action === "spellDamage") spell?.rollDamage(event);
                 else if (action === "spellCounteract") spell?.rollCounteract(event);
                 else if (action === "spellTemplate") spell?.placeTemplate();
+                else if (action === "selectVariant") (await spell?.variantPrompt())?.toMessage();
                 // Consumable usage
                 else if (action === "consume") {
                     if (item instanceof ConsumablePF2e) {

--- a/src/module/item/sheet/data-types.ts
+++ b/src/module/item/sheet/data-types.ts
@@ -88,6 +88,13 @@ export interface SpellSheetData extends ItemSheetDataPF2e<SpellPF2e> {
     isCantrip: boolean;
     isFocusSpell: boolean;
     isRitual: boolean;
+    isVariant: boolean;
+    variants: {
+        name: string;
+        id: string;
+        sort: number;
+        actions: string;
+    }[];
     magicSchools: ConfigPF2e["PF2E"]["magicSchools"];
     spellCategories: ConfigPF2e["PF2E"]["spellCategories"];
     spellLevels: ConfigPF2e["PF2E"]["spellLevels"];

--- a/src/module/item/spell/data/types.ts
+++ b/src/module/item/spell/data/types.ts
@@ -48,6 +48,19 @@ export interface SpellHeightenLayer {
     data: Partial<SpellSystemData>;
 }
 
+interface SpellOverlayOverride extends Partial<SpellSource> {
+    overlayType: "override";
+}
+
+/** Not implemented */
+interface SpellOverlayDamage {
+    overlayType: "damage";
+    choices: DamageType[];
+}
+
+type SpellOverlay = SpellOverlayOverride | SpellOverlayDamage;
+type SpellOverlayType = SpellOverlay["overlayType"];
+
 interface SpellSystemSource extends ItemSystemSource, ItemLevelData {
     traits: SpellTraits;
     level: {
@@ -87,6 +100,7 @@ interface SpellSystemSource extends ItemSystemSource, ItemLevelData {
         value: Record<string, SpellDamage>;
     };
     heightening?: SpellHeighteningFixed | SpellHeighteningInterval;
+    overlays?: Record<string, SpellOverlay>;
     save: {
         basic: string;
         value: SaveType | "";
@@ -122,4 +136,4 @@ interface SpellSystemData extends SpellSystemSource, ItemSystemData {
     traits: SpellTraits;
 }
 
-export { SpellData, SpellSource, SpellSystemData, SpellSystemSource };
+export { SpellData, SpellSource, SpellSystemData, SpellSystemSource, SpellOverlay, SpellOverlayType };

--- a/src/module/item/spell/overlay.ts
+++ b/src/module/item/spell/overlay.ts
@@ -1,0 +1,128 @@
+import { PickAThingPrompt, PickAThingConstructorArgs, PickableThing } from "@module/apps/pick-a-thing-prompt";
+import { SpellOverlay, SpellOverlayType, SpellSource } from "./data";
+import { ErrorPF2e } from "@util";
+import { SpellPF2e } from ".";
+
+class SpellOverlayCollection extends Collection<SpellOverlay> {
+    constructor(public readonly spell: SpellPF2e, entries?: Record<string, SpellOverlay>) {
+        super(Object.entries(entries ?? {}));
+    }
+
+    /** Returns all variants based on override overlays */
+    get overrideVariants(): Embedded<SpellPF2e>[] {
+        return [...this.entries()].reduce((result: Embedded<SpellPF2e>[], [overlayId, data]) => {
+            if (data.overlayType === "override") {
+                const spell = this.spell.loadVariant({ overlayIds: [overlayId] });
+                if (spell) return [...result, spell];
+            }
+            return result;
+        }, []);
+    }
+
+    getType(overlayId: string): SpellOverlayType {
+        return this.get(overlayId, { strict: true }).overlayType;
+    }
+
+    async create(
+        overlayType: SpellOverlayType,
+        options: { renderSheet: boolean } = { renderSheet: false }
+    ): Promise<void> {
+        const id = randomID();
+
+        switch (overlayType) {
+            case "override":
+                await this.spell.update({
+                    [`data.overlays.${id}`]: {
+                        _id: id,
+                        sort: this.overrideVariants.length + 1,
+                        overlayType: "override",
+                    },
+                });
+                if (options.renderSheet) {
+                    const variantSpell = this.spell.loadVariant({ overlayIds: [id] });
+                    if (variantSpell) {
+                        variantSpell.sheet.render(true);
+                    }
+                }
+                break;
+        }
+    }
+
+    async updateOverride(
+        variantSpell: Embedded<SpellPF2e>,
+        data: Partial<SpellSource>,
+        options?: DocumentModificationContext
+    ): Promise<Embedded<SpellPF2e>> {
+        // Perform local data update of spell variant data
+        variantSpell.data.update(data, options);
+
+        // Diff data and only save the difference
+        const variantSource = variantSpell.toObject();
+        const originSource = this.spell.toObject();
+        const difference = diffObject(originSource, variantSource);
+
+        if (Object.keys(difference).length === 0) return variantSpell;
+        // Restore overlayType
+        difference.overlayType = "override";
+
+        // Delete old entry to ensure clean data
+        await this.spell.update(
+            {
+                [`data.overlays.-=${variantSpell.id}`]: null,
+            },
+            { render: false }
+        );
+        // Save new diff object
+        await this.spell.update({
+            [`data.overlays.${variantSpell.id}`]: difference,
+        });
+
+        if (variantSpell.sheet.rendered) {
+            variantSpell.sheet.render(true);
+        }
+
+        return variantSpell;
+    }
+
+    async deleteOverlay(overlayId: string): Promise<void> {
+        this.verifyOverlayId(overlayId);
+
+        await this.spell.update({
+            [`data.overlays.-=${overlayId}`]: null,
+        });
+        this.delete(overlayId);
+    }
+
+    protected verifyOverlayId(overlayId: string): void {
+        if (!this.has(overlayId)) {
+            throw ErrorPF2e(
+                `Spell ${this.spell.name} (${this.spell.uuid}) does not have an overlay with id: ${overlayId}`
+            );
+        }
+    }
+}
+
+class SpellVariantPrompt extends PickAThingPrompt<Embedded<SpellPF2e>> {
+    constructor(data: PickAThingConstructorArgs<Embedded<SpellPF2e>>) {
+        super(data);
+        this.choices = data.choices ?? [];
+    }
+
+    static override get defaultOptions(): ApplicationOptions {
+        return {
+            ...super.defaultOptions,
+            width: "auto",
+            classes: ["choice-set-prompt"],
+        };
+    }
+
+    override get template(): string {
+        return "systems/pf2e/templates/items/spell-variant-prompt.html";
+    }
+
+    protected override getChoices(): PickableThing<Embedded<SpellPF2e>>[] {
+        return this.choices;
+    }
+}
+
+export { SpellOverlayCollection, SpellVariantPrompt };

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1817,8 +1817,15 @@
             "IconLabel": "Icon",
             "NameLabel": "Name",
             "SidebarSummary": "{type} Summary",
-            "Spells": {
-                "PlaceMeasuredTemplate": "Place {size}-{unit} {shape}"
+            "Spell": {
+                "PlaceMeasuredTemplate": "Place {size}-{unit} {shape}",
+                "Variants": {
+                    "DeleteDialogTitle": "Delete Spell Variant",
+                    "DeleteDialogText": "Are you sure you want to delete '{variantName}'?",
+                    "LabelPlural": "Spell Variants",
+                    "SelectVariantLabel": "Select Variant",
+                    "SheetTitle": "{originalName} (Variant)"
+                }
             },
             "Physical": {
                 "LevelLabel": "Item {level}",
@@ -2795,6 +2802,7 @@
             "title": "Create a scroll or wand",
             "wand": "Wand"
         },
+        "SelectLabel": "Select",
         "SellAllTreasureTitle": "Sell All Treasure",
         "SellAllTreasureQuestion": "Convert all treasure items into coins",
         "Senses": "Senses",

--- a/static/templates/actors/spellcasting-spell-list.html
+++ b/static/templates/actors/spellcasting-spell-list.html
@@ -122,7 +122,7 @@
                             </div>
 
                             {{#if @root.options.editable}}
-                                <button type="button" class="cast-spell" data-action="cast-spell">{{localize "PF2E.CastLabel"}}</button>
+                                <button type="button" class="cast-spell" data-action="cast-spell">{{#if spell.hasVariants}}{{localize "PF2E.SelectLabel"}}{{else}}{{localize "PF2E.CastLabel"}}{{/if}}</button>
                                 {{#unless (and entry.isFlexible (not section.isCantrip))}}
                                     <div class="item-controls">
                                         {{#if entry.isPrepared}}

--- a/static/templates/chat/spell-card.html
+++ b/static/templates/chat/spell-card.html
@@ -19,34 +19,38 @@
     </section>
 
     <section class="card-buttons">
-        {{#if data.isSave}}
-            <button type="button" data-action="save" data-save="{{data.save.type}}" data-dc="{{data.save.value}}" data-owner-title="{{data.save.breakdown}}">{{data.save.label}}</button>
-        {{/if}}
-        {{#if (or data.check data.hasDamage data.hasCounteractCheck.value data.area.areaType)}}
-            <section class="owner-buttons" data-visibility="owner">
-                {{#if data.check}}
-                    <div class="spell-attack-buttons">
-                        <button type="button" data-action="spellAttack">{{localize "PF2E.AttackLabel"}}</button>
-                        <button type="button" data-action="spellAttack2">{{localize "PF2E.MAPAbbreviationLabel" penalty=data.check.map1}}</button>
-                        <button type="button" data-action="spellAttack3">{{localize "PF2E.MAPAbbreviationLabel" penalty=data.check.map2}}</button>
-                    </div>
-                {{/if}}
-                {{#if data.hasDamage}}
-                    <div class="spell-button">
-                        <button type="button" data-action="spellDamage">{{data.damageLabel}}</button>
-                    </div>
-                {{/if}}
-                {{#if data.hasCounteractCheck.value}}
-                    <div class="spell-button">
-                        <button type="button" data-action="spellCounteract">{{localize "PF2E.Counteract"}}</button>
-                    </div>
-                {{/if}}
-                {{#if data.area.areaType}}
-                    <div class="spell-button">
-                        <button type="button" data-action="spellTemplate">{{localize "PF2E.Item.Spells.PlaceMeasuredTemplate" shape=data.areaType size=data.areaSize unit=data.areaUnit}}</button>
-                    </div>
-                {{/if}}
-            </section>
+        {{#if item.hasVariants}}
+            <button type="button" data-action="selectVariant">{{localize "PF2E.Item.Spell.Variants.SelectVariantLabel"}}</button>
+        {{else}}
+            {{#if data.isSave}}
+                <button type="button" data-action="save" data-save="{{data.save.type}}" data-dc="{{data.save.value}}" data-owner-title="{{data.save.breakdown}}">{{data.save.label}}</button>
+            {{/if}}
+            {{#if (or data.check data.hasDamage data.hasCounteractCheck.value data.area.areaType)}}
+                <section class="owner-buttons" data-visibility="owner">
+                    {{#if data.check}}
+                        <div class="spell-attack-buttons">
+                            <button type="button" data-action="spellAttack">{{localize "PF2E.AttackLabel"}}</button>
+                            <button type="button" data-action="spellAttack2">{{localize "PF2E.MAPAbbreviationLabel" penalty=data.check.map1}}</button>
+                            <button type="button" data-action="spellAttack3">{{localize "PF2E.MAPAbbreviationLabel" penalty=data.check.map2}}</button>
+                        </div>
+                    {{/if}}
+                    {{#if data.hasDamage}}
+                        <div class="spell-button">
+                            <button type="button" data-action="spellDamage">{{data.damageLabel}}</button>
+                        </div>
+                    {{/if}}
+                    {{#if data.hasCounteractCheck.value}}
+                        <div class="spell-button">
+                            <button type="button" data-action="spellCounteract">{{localize "PF2E.Counteract"}}</button>
+                        </div>
+                    {{/if}}
+                    {{#if data.area.areaType}}
+                        <div class="spell-button">
+                            <button type="button" data-action="spellTemplate">{{localize "PF2E.Item.Spell.PlaceMeasuredTemplate" shape=data.areaType size=data.areaSize unit=data.areaUnit}}</button>
+                        </div>
+                    {{/if}}
+                </section>
+            {{/if}}
         {{/if}}
     </section>
 

--- a/static/templates/items/item-sheet.html
+++ b/static/templates/items/item-sheet.html
@@ -45,7 +45,7 @@
                 {{#if (and isPhysical user.isGM)}}
                     <a class="list-row" data-tab="mystification">{{localize "PF2E.ItemMystification"}}</a>
                 {{/if}}
-                {{#if enabledRulesUI}}
+                {{#if (and enabledRulesUI (not isVariant))}}
                     <a class="list-row" data-tab="rules">{{localize "PF2E.ItemRules"}}</a>
                 {{/if}}
             </h4>
@@ -80,10 +80,12 @@
             {{/if}}
 
             <!-- Rules -->
-            <div class="tab item-rules" data-tab="rules">
-                {{!-- Use ~ so that text areas don't add further indentation --}}
-                {{~> systems/pf2e/templates/items/rules-panel.html item=item}}
-            </div>
+            {{#if (not isVariant)}}
+                <div class="tab item-rules" data-tab="rules">
+                    {{!-- Use ~ so that text areas don't add further indentation --}}
+                    {{~> systems/pf2e/templates/items/rules-panel.html item=item}}
+                </div>
+            {{/if}}
         </section>
     </article>
 </form>

--- a/static/templates/items/spell-details.html
+++ b/static/templates/items/spell-details.html
@@ -1,3 +1,25 @@
+{{#if (not isVariant)}}
+<div class="form-list" data-can-drop="true">
+    <h3>
+        {{localize "PF2E.Item.Spell.Variants.LabelPlural"}}
+        <div class="item-controls">
+            <i class="fas fa-plus" data-action="variant-create"></i>
+        </div>
+    </h3>
+
+    {{#each variants as |variant|}}
+    <div class="details-container-flex-row" data-can-drag="true" data-variant-id="{{variant.id}}" draggable="true">
+        <label>{{variant.name}}</label>
+        <span class="activity-icon">{{variant.actions}}</span>
+        <div class="item-controls">
+            <a data-action="variant-edit" data-id="{{variant.id}}"><i class="fas fa-edit"></i></a>
+            <a data-action="variant-delete" data-id="{{variant.id}}"><i class="fas fa-trash"></i></a>
+        </div>
+    </div>
+    {{/each}}
+</div>
+{{/if}}
+
 <ol class="form-list">
     <div class="form-group">
         <label>{{localize "PF2E.SpellCategoryLabel"}}</label>

--- a/static/templates/items/spell-variant-prompt.html
+++ b/static/templates/items/spell-variant-prompt.html
@@ -1,0 +1,16 @@
+<div class="content">
+    <h3>{{localize prompt}}</h3>
+    <div class="choices">
+        {{#each choices as |choice|}}
+            <button type="button" value="{{choice.value}}"{{#if choice.img}} class="with-image"{{/if}}>
+                {{#if choice.img}}<img src="{{choice.img}}" />{{/if}}
+                <span>{{choice.label}}</span>
+            </button>
+        {{/each}}
+        {{#if allowNoSelection}}
+            <button type="button" data-action="close">
+                <span>{{localize "PF2E.UI.RuleElements.ChoiceSet.Decline"}}</span>
+            </button>
+        {{/if}}
+    </div>
+</div>


### PR DESCRIPTION
This enables the creation of spell variants based on cast time (like Heal) and adds a prompt to select which variant to cast.

https://user-images.githubusercontent.com/41452412/173586017-499d679d-8195-4f75-88c7-70bd819c9553.mp4


Example setup for the Heal spell with variants:
- The description of the base spell can stay the same:
![image](https://user-images.githubusercontent.com/41452412/173581713-994fd25f-4e26-476e-b7ad-fd23b5961530.png)
  
- Add a new variant in the details tab:
![image](https://user-images.githubusercontent.com/41452412/173582058-a811d072-20dd-43de-af64-59f43e88b5be.png)
  
- Variants have their own spell sheet and can be edited independently of the base spell:
![image](https://user-images.githubusercontent.com/41452412/173582519-d5bcc3cc-e63b-4726-8c2e-46402f2787e8.png)
![image](https://user-images.githubusercontent.com/41452412/173584375-1cefe977-9229-4585-a67b-93ed3f917677.png)
  
- Add additional variants as needed:
![image](https://user-images.githubusercontent.com/41452412/173584042-e13b0fc6-da64-4fe5-916c-bf2d5c171fbc.png)
<br>
<br>
The variants can be sorted via drag and drop on the spell sheet and the prompt buttons are displayed in the same order.


