### PR TITLE
Add Lore & Skill support for choice rule elements and make Assurance work on Lores as well

### DIFF
--- a/packs/data/feats.db/assurance.json
+++ b/packs/data/feats.db/assurance.json
@@ -30,76 +30,7 @@
         },
         "rules": [
             {
-                "choices": [
-                    {
-                        "label": "PF2E.SkillAcr",
-                        "value": "acrobatics"
-                    },
-                    {
-                        "label": "PF2E.SkillArc",
-                        "value": "arcana"
-                    },
-                    {
-                        "label": "PF2E.SkillAth",
-                        "value": "athletics"
-                    },
-                    {
-                        "label": "PF2E.SkillCra",
-                        "value": "crafting"
-                    },
-                    {
-                        "label": "PF2E.SkillDec",
-                        "value": "deception"
-                    },
-                    {
-                        "label": "PF2E.SkillDip",
-                        "value": "diplomacy"
-                    },
-                    {
-                        "label": "PF2E.SkillItm",
-                        "value": "intimidation"
-                    },
-                    {
-                        "label": "PF2E.SkillMed",
-                        "value": "medicine"
-                    },
-                    {
-                        "label": "PF2E.SkillNat",
-                        "value": "nature"
-                    },
-                    {
-                        "label": "PF2E.SkillOcc",
-                        "value": "occultism"
-                    },
-                    {
-                        "label": "PF2E.SkillPrf",
-                        "value": "performance"
-                    },
-                    {
-                        "label": "PF2E.SkillRel",
-                        "value": "religion"
-                    },
-                    {
-                        "label": "PF2E.SkillSoc",
-                        "value": "society"
-                    },
-                    {
-                        "label": "PF2E.SkillSte",
-                        "value": "stealth"
-                    },
-                    {
-                        "label": "PF2E.SkillSur",
-                        "value": "survival"
-                    },
-                    {
-                        "label": "PF2E.SkillThi",
-                        "value": "thievery"
-                    },
-                    {
-                        "label": "PF2E.SkillLore",
-                        "value": "lore"
-                    }
-                ],
+                "choices": "skills",
                 "flag": "assurance",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.Skill"

--- a/src/module/actor/character/index.ts
+++ b/src/module/actor/character/index.ts
@@ -146,6 +146,11 @@ class CharacterPF2e extends CreaturePF2e {
         return skills as CharacterSkills;
     }
 
+    get lores(): CharacterSkills {
+        const lores = Object.entries(this.skills).filter(([key]) => !(key in SKILL_DICTIONARY_REVERSE));
+        return Object.fromEntries(lores) as CharacterSkills;
+    }
+
     get heroPoints(): { value: number; max: number } {
         return deepClone(this.data.data.resources.heroPoints);
     }
@@ -2103,6 +2108,7 @@ class CharacterPF2e extends CreaturePF2e {
 
     /* -------------------------------------------- */
     /*  Event Listeners and Handlers                */
+
     /* -------------------------------------------- */
 
     protected override async _preUpdate(
@@ -2178,11 +2184,13 @@ interface CharacterPF2e {
         dataId: string[],
         context?: DocumentModificationContext
     ): Promise<ActiveEffectPF2e[]>;
+
     deleteEmbeddedDocuments(
         embeddedName: "Item",
         dataId: string[],
         context?: DocumentModificationContext
     ): Promise<ItemPF2e[]>;
+
     deleteEmbeddedDocuments(
         embeddedName: "ActiveEffect" | "Item",
         dataId: string[],

--- a/src/module/actor/character/index.ts
+++ b/src/module/actor/character/index.ts
@@ -94,7 +94,7 @@ import {
 import { CharacterSheetTabVisibility } from "./data/sheet";
 import { CHARACTER_SHEET_TABS } from "./data/values";
 import { StrikeWeaponTraits } from "./strike-weapon-traits";
-import { CharacterHitPointsSummary, CharacterSkills, CreateAuxiliaryParams } from "./types";
+import { CharacterHitPointsSummary, CharacterSkill, CharacterSkills, CreateAuxiliaryParams } from "./types";
 
 class CharacterPF2e extends CreaturePF2e {
     /** Core singular embeds for PCs */
@@ -146,9 +146,9 @@ class CharacterPF2e extends CreaturePF2e {
         return skills as CharacterSkills;
     }
 
-    get lores(): CharacterSkills {
+    get lores(): Record<string, CharacterSkill> {
         const lores = Object.entries(this.skills).filter(([key]) => !(key in SKILL_DICTIONARY_REVERSE));
-        return Object.fromEntries(lores) as CharacterSkills;
+        return Object.fromEntries(lores) as Record<string, CharacterSkill>;
     }
 
     get heroPoints(): { value: number; max: number } {

--- a/src/module/rules/rule-element/choice-set/rule-element.ts
+++ b/src/module/rules/rule-element/choice-set/rule-element.ts
@@ -204,7 +204,7 @@ class ChoiceSetRuleElement extends RuleElementPF2e {
         if (actor instanceof CharacterPF2e) {
             return Object.entries(actor.lores).map(([value, statistic]) => ({
                 value,
-                label: statistic?.label ?? value,
+                label: statistic.label,
             }));
         } else {
             return [];

--- a/src/module/rules/rule-element/choice-set/rule-element.ts
+++ b/src/module/rules/rule-element/choice-set/rule-element.ts
@@ -175,6 +175,8 @@ class ChoiceSetRuleElement extends RuleElementPF2e {
     private referenceChoices(reference: string): PickableThing<string>[] {
         if (reference === "lores") {
             return this.getLoreChoices();
+        } else if (reference === "skills") {
+            return this.getSkillChoices();
         }
         return this.choicesFromPath(reference);
     }
@@ -190,13 +192,19 @@ class ChoiceSetRuleElement extends RuleElementPF2e {
                 }))
             );
         }
-
-        // special handling for lores, since these are not defined in CONFIG
-        if (path === "skills") {
-            result.push(...this.getLoreChoices());
-        }
-
         return result;
+    }
+
+    private getSkillChoices(): PickableThing<string>[] {
+        const actor = this.actor;
+        if (actor instanceof CharacterPF2e) {
+            return Object.entries(actor.skills).map(([value, statistic]) => ({
+                value,
+                label: statistic?.label ?? value,
+            }));
+        } else {
+            return [];
+        }
     }
 
     private getLoreChoices(): PickableThing<string>[] {


### PR DESCRIPTION
Properly handle lores in choice skill rule elements, offer a way to reference lores in choice set rule elements, make assurance work with lores.

This popup now includes lores as well
```json
{"choices":"skills"}
```

This will allow you to choose between lores
```json
{"choices":"lores"}
```