### PR TITLE
Update Demon Form (Babau) and Elephant Form effects.

### DIFF
--- a/packs/data/spell-effects.db/spell-effect-demon-form-babau.json
+++ b/packs/data/spell-effects.db/spell-effect-demon-form-babau.json
@@ -1,6 +1,7 @@
 {
     "_id": "X1kkbRrh4zJuDGjl",
     "data": {
+        "badge": null,
         "description": {
             "value": "<p>You corrupt yourself with the sin of the Abyss, transforming into a Medium demon battle form. When you cast this spell, choose babau, hezrou, nabasu, or vrock. If you choose hezrou, the battle form is Large and you must have enough space to expand into or the spell is lost. While in this form, you gain the demon and fiend traits. You have hands in this battle form and can use manipulate actions. You can Dismiss the spell.</p>\n<p>You gain the following statistics and abilities regardless of the form that you choose:</p>\n<ul>\n<li>AC = 20 + your level. Ignore your armor check's penalty and Speed reduction.</li>\n<li>30 temporary Hit Points, weakness 5 to cold iron, and weakness 5 to good.</li>\n<li>Darkvision.</li>\n<li>One or more attacks specific to the battle form you use. You're trained with them. Your attack modifier is +22, and you use the listed damage. These attacks are Strength based (for the purpose of the enfeebled condition, for example). If your attack modifier is higher for the given unarmed attack or weapon, you can use it instead.</li>\n<li>Athletics modifier of +23, unless your own modifier is higher.</li>\n</ul>\n<p>You also gain specific abilities based on the type of demon you choose:</p>\n<ul>\n<li><strong>Babau</strong> Speed 25 feet;\n<ul>\n<li><strong>Melee</strong> <span class=\"pf2-icon\">1</span> longspear (reach 10 feet), <strong>Damage</strong> 2d8+10 piercing plus 1d6 evil;</li>\n<li><strong>Melee</strong> <span class=\"pf2-icon\">1</span> jaws, <strong>Damage</strong> 2d10 piercing plus 1d6 evil;</li>\n<li><strong>Melee</strong> <span class=\"pf2-icon\">1</span> claw (agile), <strong>Damage</strong> 2d4 slashing plus 1d6 evil;</li>\n<li>all Strikes deal 2d6 additional precision damage to @Compendium[pf2e.conditionitems.Flat-Footed]{Flat-Footed} creatures.</li>\n</ul>\n</li>\n</ul>"
         },
@@ -109,7 +110,8 @@
                 "key": "DamageDice",
                 "predicate": {
                     "all": [
-                        "target:condition:flat-footed"
+                        "target:condition:flat-footed",
+                        "battle-form"
                     ]
                 },
                 "selector": "strike-damage"
@@ -119,6 +121,11 @@
                 "diceNumber": 1,
                 "dieSize": "d6",
                 "key": "DamageDice",
+                "predicate": {
+                    "all": [
+                        "battle-form"
+                    ]
+                },
                 "selector": "strike-damage"
             }
         ],

--- a/packs/data/spell-effects.db/spell-effect-demon-form-babau.json
+++ b/packs/data/spell-effects.db/spell-effect-demon-form-babau.json
@@ -120,11 +120,6 @@
                 "diceNumber": 1,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "strike-damage"
             }
         ],

--- a/packs/data/spell-effects.db/spell-effect-demon-form-babau.json
+++ b/packs/data/spell-effects.db/spell-effect-demon-form-babau.json
@@ -110,8 +110,7 @@
                 "key": "DamageDice",
                 "predicate": {
                     "all": [
-                        "target:condition:flat-footed",
-                        "battle-form"
+                        "target:condition:flat-footed"
                     ]
                 },
                 "selector": "strike-damage"

--- a/packs/data/spell-effects.db/spell-effect-elephant-form.json
+++ b/packs/data/spell-effects.db/spell-effect-elephant-form.json
@@ -86,6 +86,33 @@
                 "value": {
                     "brackets": [
                         {
+                            "end": 4,
+                            "start": 4,
+                            "value": {
+                                "size": "lg",
+                                "skills": {
+                                    "ath": {
+                                        "modifier": 18
+                                    }
+                                },
+                                "strikes": {
+                                    "foot": {
+                                        "damage": {
+                                            "modifier": 9
+                                        },
+                                        "modifier": 16
+                                    },
+                                    "tusk": {
+                                        "damage": {
+                                            "modifier": 9
+                                        },
+                                        "modifier": 16
+                                    }
+                                },
+                                "tempHP": 15
+                            }
+                        },
+                        {
                             "end": 6,
                             "start": 5,
                             "value": {

--- a/packs/data/spell-effects.db/spell-effect-elephant-form.json
+++ b/packs/data/spell-effects.db/spell-effect-elephant-form.json
@@ -44,8 +44,10 @@
                             "damage": {
                                 "damageType": "bludgeoning",
                                 "dice": 2,
-                                "die": "d8"
+                                "die": "d8",
+                                "modifier": 9
                             },
+                            "modifier": 16,
                             "group": "brawling",
                             "traits": [
                                 "unarmed"
@@ -57,6 +59,7 @@
                             "damage": {
                                 "dice": 0
                             },
+                            "modifier": 16,
                             "group": "brawling",
                             "traits": [
                                 "unarmed",
@@ -69,8 +72,10 @@
                             "damage": {
                                 "damageType": "piercing",
                                 "dice": 2,
-                                "die": "d6"
+                                "die": "d6",
+                                "modifier": 9
                             },
+                            "modifier": 16,
                             "group": "brawling",
                             "traits": [
                                 "unarmed",
@@ -85,33 +90,6 @@
                 },
                 "value": {
                     "brackets": [
-                        {
-                            "end": 4,
-                            "start": 4,
-                            "value": {
-                                "size": "lg",
-                                "skills": {
-                                    "ath": {
-                                        "modifier": 18
-                                    }
-                                },
-                                "strikes": {
-                                    "foot": {
-                                        "damage": {
-                                            "modifier": 9
-                                        },
-                                        "modifier": 16
-                                    },
-                                    "tusk": {
-                                        "damage": {
-                                            "modifier": 9
-                                        },
-                                        "modifier": 16
-                                    }
-                                },
-                                "tempHP": 15
-                            }
-                        },
                         {
                             "end": 6,
                             "start": 5,


### PR DESCRIPTION
Update Effect: Demon Form (Babau)
- add battleform predicate to enable precision / evil damage
Update Effect: Elephant Form
- re-add damage/attack modifiers for base spell