### PR TITLE
Automate ifrit feats

### DIFF
--- a/packs/data/feat-effects.db/effect-saoc-astrology.json
+++ b/packs/data/feat-effects.db/effect-saoc-astrology.json
@@ -65,7 +65,7 @@
             }
         ],
         "source": {
-            "value": ""
+            "value": "Pathfinder Lost Omens: Character Guide"
         },
         "start": {
             "initiative": null,

--- a/packs/data/feats.db/blazing-aura.json
+++ b/packs/data/feats.db/blazing-aura.json
@@ -11,7 +11,7 @@
             "value": null
         },
         "description": {
-            "value": "<p><strong>Frequency</strong> once per day.</p>\n<p><strong>Trigger</strong> Your turn begins.</p>\n<hr />\n<p>You explode in flame. Enemies in a @Template[type:emanation|distance:20] take [[/r {7d6}[fire]]]{7d6 fire damage} (basic Reflex save using your class DC or spell DC, whichever is higher). Allies in the area are @Compendium[pf2e.conditionitems.Quickened]{Quickened} for 1 round and can use the additional action to Strike or Stride.</p>"
+            "value": "<p><strong>Frequency</strong> once per day.</p>\n<p><strong>Trigger</strong> Your turn begins.</p>\n<hr />\n<p>You explode in flame. Enemies in a @Template[type:emanation|distance:20] take [[/r {7d6}[fire]]]{7d6 fire damage} (@Check[type:reflex|dc:resolve(@actor.attributes.classOrSpellDC.value)|basic:true] using your class DC or spell DC, whichever is higher). Allies in the area are @Compendium[pf2e.conditionitems.Quickened]{Quickened} for 1 round and can use the additional action to Strike or Stride.</p>"
         },
         "featType": {
             "value": "ancestry"
@@ -19,7 +19,7 @@
         "level": {
             "value": 17
         },
-        "location": "",
+        "location": null,
         "prerequisites": {
             "value": []
         },

--- a/packs/data/feats.db/brightsoul.json
+++ b/packs/data/feats.db/brightsoul.json
@@ -19,12 +19,36 @@
         "level": {
             "value": 1
         },
-        "location": "",
+        "location": null,
         "onlyLevel1": true,
         "prerequisites": {
             "value": []
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "predicate": {
+                    "any": [
+                        "action:hide",
+                        "action:sneak"
+                    ]
+                },
+                "selector": "stealth",
+                "type": "circumstance",
+                "value": -2
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": {
+                    "all": [
+                        "light"
+                    ]
+                },
+                "selector": "saving-throw",
+                "type": "circumstance",
+                "value": 1
+            }
+        ],
         "source": {
             "value": "Pathfinder Lost Omens: Ancestry Guide"
         },

--- a/packs/data/feats.db/charred-remains.json
+++ b/packs/data/feats.db/charred-remains.json
@@ -11,7 +11,7 @@
             "value": null
         },
         "description": {
-            "value": "<p><strong>Frequency</strong> once per day</p>\n<hr />\n<p>Your next fire spell leaves embers in its wake. If your next action is to Cast a Spell with an area and the fire trait, for 1 minute, your spell's area becomes difficult terrain as well as hazardous terrain, dealing 1 fire damage for each square a creature moves through.</p>"
+            "value": "<p><strong>Frequency</strong> once per day</p>\n<hr />\n<p>Your next fire spell leaves embers in its wake. If your next action is to Cast a Spell with an area and the fire trait, for 1 minute, your spell's area becomes difficult terrain as well as hazardous terrain, dealing [[/r {1}[fire]]]{1 fire damage} for each square a creature moves through.</p>"
         },
         "featType": {
             "value": "ancestry"
@@ -19,7 +19,7 @@
         "level": {
             "value": 9
         },
-        "location": "",
+        "location": null,
         "prerequisites": {
             "value": []
         },

--- a/packs/data/feats.db/cindersoul.json
+++ b/packs/data/feats.db/cindersoul.json
@@ -11,7 +11,7 @@
             "value": null
         },
         "description": {
-            "value": "<p>The fire of your elemental ancestor manifests like dying embers of a blaze, and your inner charcoal helps staunch bleeding, purify simple poisons, and absorb acid. The DC for you to recover from persistent acid, bleed, and poison damage is 10 instead of 15 (or 5 if you have particularly effective assistance).</p>"
+            "value": "<p>The fire of your elemental ancestor manifests like dying embers of a blaze, and your inner charcoal helps staunch bleeding, purify simple poisons, and absorb acid. The DC for you to recover from persistent acid, bleed, and poison damage is @Check[type:flat|dc:10]{10} instead of 15 (or @Check[type:flat|dc:5]{5} if you have particularly effective assistance).</p>"
         },
         "featType": {
             "value": "ancestry"
@@ -19,7 +19,7 @@
         "level": {
             "value": 1
         },
-        "location": "",
+        "location": null,
         "onlyLevel1": true,
         "prerequisites": {
             "value": []

--- a/packs/data/feats.db/embers-eyes.json
+++ b/packs/data/feats.db/embers-eyes.json
@@ -19,11 +19,28 @@
         "level": {
             "value": 1
         },
-        "location": "",
+        "location": null,
+        "maxTakable": 2,
         "prerequisites": {
             "value": []
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "Sense",
+                "label": "PF2E.SensesLowLightVision",
+                "selector": "lowLightVision"
+            },
+            {
+                "key": "Sense",
+                "label": "PF2E.SensesDarkvision",
+                "predicate": {
+                    "all": [
+                        "self:low-light-vision:from-ancestry"
+                    ]
+                },
+                "selector": "darkvision"
+            }
+        ],
         "source": {
             "value": "Pathfinder Lost Omens: Ancestry Guide"
         },

--- a/packs/data/feats.db/heat-wave.json
+++ b/packs/data/feats.db/heat-wave.json
@@ -11,7 +11,7 @@
             "value": null
         },
         "description": {
-            "value": "<p><strong>Trigger</strong> An effect would deal fire damage to you, even if you resist all the damage.</p>\n<p><strong>Frequency</strong> once per 10 minutes</p>\n<hr />\n<p>You harness the oncoming flames and twist them into a screen of heat and smoke, granting you concealment until the beginning of your next turn.</p>"
+            "value": "<p><strong>Trigger</strong> An effect would deal fire damage to you, even if you resist all the damage.</p>\n<p><strong>Frequency</strong> once per 10 minutes</p>\n<hr />\n<p>You harness the oncoming flames and twist them into a screen of heat and smoke, granting you @Compendium[pf2e.conditionitems.Concealed]{concealment} until the beginning of your next turn.</p>"
         },
         "featType": {
             "value": "ancestry"
@@ -19,7 +19,7 @@
         "level": {
             "value": 5
         },
-        "location": "",
+        "location": null,
         "prerequisites": {
             "value": []
         },

--- a/packs/data/feats.db/radiant-burst.json
+++ b/packs/data/feats.db/radiant-burst.json
@@ -11,7 +11,7 @@
             "value": 2
         },
         "description": {
-            "value": "<p><strong>Frequency</strong> once per day</p>\n<hr />\n<p>Your skin glows with intensity. Creatures within 10 feet who can see you must succeed at a Fortitude save against your class DC or spell DC, whichever is higher.</p>\n<hr />\n<p><strong>Critical Success</strong> The creature is unaffected.</p>\n<p><strong>Success</strong> The creature is @Compendium[pf2e.conditionitems.Dazzled]{Dazzled} for 1 round.</p>\n<p><strong>Failure</strong> The creature is @Compendium[pf2e.conditionitems.Blinded]{Blinded} for 1 round and dazzled for 4 rounds.</p>\n<p><strong>Critical Failure</strong> The creature is blinded for 4 rounds and dazzled for 10 minutes.</p>"
+            "value": "<p><strong>Frequency</strong> once per day</p>\n<hr />\n<p>Your skin glows with intensity. Creatures within 10 feet who can see you must succeed at a @Check[type:fortitude|dc:resolve(@actor.attributes.classOrSpellDC.value)] against your class DC or spell DC, whichever is higher.</p>\n<hr />\n<p><strong>Critical Success</strong> The creature is unaffected.</p>\n<p><strong>Success</strong> The creature is @Compendium[pf2e.conditionitems.Dazzled]{Dazzled} for 1 round.</p>\n<p><strong>Failure</strong> The creature is @Compendium[pf2e.conditionitems.Blinded]{Blinded} for 1 round and dazzled for 4 rounds.</p>\n<p><strong>Critical Failure</strong> The creature is blinded for 4 rounds and dazzled for 10 minutes.</p>"
         },
         "featType": {
             "value": "ancestry"
@@ -19,7 +19,7 @@
         "level": {
             "value": 13
         },
-        "location": "",
+        "location": null,
         "prerequisites": {
             "value": []
         },

--- a/packs/data/feats.db/saoc-astrology.json
+++ b/packs/data/feats.db/saoc-astrology.json
@@ -11,7 +11,7 @@
             "value": 1
         },
         "description": {
-            "value": "<p><strong>Frequency</strong> 3 times per day</p>\n<p><strong>Access</strong> Lirgeni nationality</p>\n<p><strong>Requirements</strong> You must spend 10 minutes just after your daily preparations examining the sky or consulting a star chart or you can't use this action that day.</p>\n<hr />\n<p>The ancient Saoc Brethren were the masters of astrology, and while your knowledge may be but a pale shadow of their wisdom, it still comes in handy. You recall the stars' predictions about your current situation. If your next action requires you to attempt one or more skill checks, roll 1d8. On a result of 6, 7, or 8, you gain a +2 circumstance bonus to the first such skill check you attempt. On a 3, 4, or 5, you gain a +1 circumstance bonus. On a 2, you gain nothing. On a 1, you take a -1 circumstance penalty to the skill check.</p>"
+            "value": "<p><strong>Frequency</strong> 3 times per day</p>\n<p><strong>Access</strong> Lirgeni nationality</p>\n<p><strong>Requirements</strong> You must spend 10 minutes just after your daily preparations examining the sky or consulting a star chart or you can't use this action that day.</p>\n<hr />\n<p>The ancient Saoc Brethren were the masters of astrology, and while your knowledge may be but a pale shadow of their wisdom, it still comes in handy. You recall the stars' predictions about your current situation. If your next action requires you to attempt one or more skill checks, roll [[/r 1d8]]. On a result of 6, 7, or 8, you gain a +2 circumstance bonus to the first such skill check you attempt. On a 3, 4, or 5, you gain a +1 circumstance bonus. On a 2, you gain nothing. On a 1, you take a -1 circumstance penalty to the skill check.</p>\n<p>@Compendium[pf2e.feat-effects.Effect: Saoc Astrology]{Effect: Saoc Astrology}</p>"
         },
         "featType": {
             "value": "ancestry"
@@ -19,7 +19,7 @@
         "level": {
             "value": 1
         },
-        "location": "",
+        "location": null,
         "prerequisites": {
             "value": []
         },

--- a/packs/data/feats.db/sinister-appearance.json
+++ b/packs/data/feats.db/sinister-appearance.json
@@ -19,7 +19,7 @@
         "level": {
             "value": 1
         },
-        "location": "",
+        "location": null,
         "prerequisites": {
             "value": []
         },
@@ -27,6 +27,24 @@
             {
                 "key": "GrantItem",
                 "uuid": "Compendium.pf2e.feats-srd.Intimidating Glare"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "data.skills.itm.rank",
+                "value": 1
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": {
+                    "all": [
+                        "action:impersonate",
+                        "tiefling-version-of-self"
+                    ]
+                },
+                "selector": "deception",
+                "type": "circumstance",
+                "value": 2
             }
         ],
         "source": {

--- a/packs/data/heritages.db/ifrit.json
+++ b/packs/data/heritages.db/ifrit.json
@@ -3,7 +3,7 @@
     "data": {
         "ancestry": null,
         "description": {
-            "value": "<p>You descend from fire elementals or bear the mark of the Inner Spheres, and your features illustrate the influence that elemental fire has over you. You gain the ifrit trait, in addition to the traits from your ancestry. You gain resistance to fire equal to half your level (minimum 1), and you treat environmental heat effects as if they were one step less severe (incredible heat becomes extreme, extreme heat becomes severe, and so on). You can choose from ifrit feats and feats from your ancestry whenever you gain an ancestry feat.</p>\n<hr />\n<p>GENIEKIN FEATS</p>\n<p>At 1st level, you gain one ancestry feat, and you gain an additional ancestry feat every 4 levels thereafter (at 5th, 9th, 13th, and 17th levels). As a geniekin you can choose from among the following ancestry feats, in addition to those available to your specific geniekin heritage and your ancestry.</p>"
+            "value": "<p>You descend from fire elementals or bear the mark of the Inner Spheres, and your features illustrate the influence that elemental fire has over you. You gain the ifrit trait, in addition to the traits from your ancestry. You gain resistance to fire equal to half your level (minimum 1), and you treat environmental heat effects as if they were one step less severe (incredible heat becomes extreme, extreme heat becomes severe, and so on). You can choose from ifrit feats and feats from your ancestry whenever you gain an ancestry feat.</p>"
         },
         "rules": [
             {

--- a/packs/data/heritages.db/oread.json
+++ b/packs/data/heritages.db/oread.json
@@ -3,7 +3,7 @@
     "data": {
         "ancestry": null,
         "description": {
-            "value": "<p>An earth elemental ancestor has influenced your bloodline, and your features highlight this elemental planar connection. You might have a crystalline or metallic sheen to your skin or hair, rough and stony flesh, or glittering gemstone eyes. You gain the oread trait, in addition to the traits from your ancestry. You also gain @Compendium[pf2e.ancestryfeatures.Low-Light Vision]{Low-Light Vision}, or you gain @Compendium[pf2e.ancestryfeatures.Darkvision]{Darkvision} if your ancestry already has low-light vision. You can choose from oread feats and feats from your ancestry whenever you gain an ancestry feat.</p>\n<hr />\n<p>GENIEKIN FEATS</p>\n<p>At 1st level, you gain one ancestry feat, and you gain an additional ancestry feat every 4 levels thereafter (at 5th, 9th, 13th, and 17th levels). As a geniekin you can choose from among the following ancestry feats, in addition to those available to your specific geniekin heritage and your ancestry.</p>"
+            "value": "<p>An earth elemental ancestor has influenced your bloodline, and your features highlight this elemental planar connection. You might have a crystalline or metallic sheen to your skin or hair, rough and stony flesh, or glittering gemstone eyes. You gain the oread trait, in addition to the traits from your ancestry. You also gain @Compendium[pf2e.ancestryfeatures.Low-Light Vision]{Low-Light Vision}, or you gain @Compendium[pf2e.ancestryfeatures.Darkvision]{Darkvision} if your ancestry already has low-light vision. You can choose from oread feats and feats from your ancestry whenever you gain an ancestry feat.</p>"
         },
         "rules": [
             {

--- a/packs/data/heritages.db/suli.json
+++ b/packs/data/heritages.db/suli.json
@@ -3,7 +3,7 @@
     "data": {
         "ancestry": null,
         "description": {
-            "value": "<p>You are descended from a janni or otherwise embody a dichotomy of opposing elemental planar forces. You gain the suli trait, in addition to the traits from your ancestry. You also gain @Compendium[pf2e.ancestryfeatures.Low-Light Vision]{Low-Light Vision}, or you gain @Compendium[pf2e.ancestryfeatures.Darkvision]{Darkvision} if your ancestry already has low-light vision. You can choose from suli feats and feats from your ancestry whenever you gain an ancestry feat.</p>\n<hr />\n<p>GENIEKIN FEATS</p>\n<p>At 1st level, you gain one ancestry feat, and you gain an additional ancestry feat every 4 levels thereafter (at 5th, 9th, 13th, and 17th levels). As a geniekin you can choose from among the following ancestry feats, in addition to those available to your specific geniekin heritage and your ancestry.</p>"
+            "value": "<p>You are descended from a janni or otherwise embody a dichotomy of opposing elemental planar forces. You gain the suli trait, in addition to the traits from your ancestry. You also gain @Compendium[pf2e.ancestryfeatures.Low-Light Vision]{Low-Light Vision}, or you gain @Compendium[pf2e.ancestryfeatures.Darkvision]{Darkvision} if your ancestry already has low-light vision. You can choose from suli feats and feats from your ancestry whenever you gain an ancestry feat.</p>"
         },
         "rules": [
             {

--- a/packs/data/heritages.db/sylph.json
+++ b/packs/data/heritages.db/sylph.json
@@ -3,7 +3,7 @@
     "data": {
         "ancestry": null,
         "description": {
-            "value": "<p>You are descended from air elementals or were born under the element's influence. You gain the sylph trait, in addition to the traits from your ancestry. You also gain @Compendium[pf2e.ancestryfeatures.Low-Light Vision]{Low-Light Vision} or @Compendium[pf2e.ancestryfeatures.Darkvision]{Darkvision} if your ancestry already has low-light vision. You can choose from sylph feats and feats from your ancestry whenever you gain an ancestry feat.</p>\n<hr />\n<p>GENIEKIN FEATS</p>\n<p>At 1st level, you gain one ancestry feat, and you gain an additional ancestry feat every 4 levels thereafter (at 5th, 9th, 13th, and 17th levels). As a geniekin you can choose from among the following ancestry feats, in addition to those available to your specific geniekin heritage and your ancestry.</p>"
+            "value": "<p>You are descended from air elementals or were born under the element's influence. You gain the sylph trait, in addition to the traits from your ancestry. You also gain @Compendium[pf2e.ancestryfeatures.Low-Light Vision]{Low-Light Vision} or @Compendium[pf2e.ancestryfeatures.Darkvision]{Darkvision} if your ancestry already has low-light vision. You can choose from sylph feats and feats from your ancestry whenever you gain an ancestry feat.</p>"
         },
         "rules": [
             {

--- a/packs/data/heritages.db/undine.json
+++ b/packs/data/heritages.db/undine.json
@@ -3,7 +3,7 @@
     "data": {
         "ancestry": null,
         "description": {
-            "value": "<p>A water elemental ancestor influences your bloodline. You gain the undine trait, in addition to the traits from your ancestry. You gain a swim Speed of 10 feet and the amphibious trait. Like all creatures with the amphibious trait, you can breathe both water and air. You can choose from undine feats and feats from your ancestry whenever you gain an ancestry feat.</p>\n<hr />\n<p>GENIEKIN FEATS</p>\n<p>At 1st level, you gain one ancestry feat, and you gain an additional ancestry feat every 4 levels thereafter (at 5th, 9th, 13th, and 17th levels). As a geniekin you can choose from among the geniekin ancestry feats, in addition to those available to your specific geniekin heritage and your ancestry.</p>"
+            "value": "<p>A water elemental ancestor influences your bloodline. You gain the undine trait, in addition to the traits from your ancestry. You gain a swim Speed of 10 feet and the amphibious trait. Like all creatures with the amphibious trait, you can breathe both water and air. You can choose from undine feats and feats from your ancestry whenever you gain an ancestry feat.</p>"
         },
         "rules": [
             {


### PR DESCRIPTION
PR also removes text from all geniekin heritages about saying 'you can take the feats listed below', as this isn't relevant in foundry, where you find relevant ancestry feats using the compendium browser tags. This is the same approach taken by Archives of Nethys. 

closes #1830 