### PR TITLE
Tone down the Light spell effect

### DIFF
--- a/packs/data/spell-effects.db/spell-effect-light.json
+++ b/packs/data/spell-effects.db/spell-effect-light.json
@@ -36,7 +36,7 @@
                         ],
                         "field": "item|data.level.value"
                     },
-                    "color": "#69699b",
+                    "color": "#343434",
                     "dim": {
                         "brackets": [
                             {


### PR DESCRIPTION
The light spell was washing out light colored tokens so it should be toned down a bit in color balance.

Before

![image](https://user-images.githubusercontent.com/80183198/174189190-72d938de-40b3-4a79-beb3-59d962ddd5a1.png)

After

![image](https://user-images.githubusercontent.com/80183198/174189208-647493c7-f205-414d-ba57-3e5ac72c677d.png)
