### PR TITLE
Remove "battle-form" from predicates on items containing BattleForm REs

### DIFF
--- a/packs/data/feat-effects.db/effect-rampaging-form-frozen-winds-kitsune.json
+++ b/packs/data/feat-effects.db/effect-rampaging-form-frozen-winds-kitsune.json
@@ -92,8 +92,7 @@
                 "key": "DamageDice",
                 "predicate": {
                     "all": [
-                        "unarmed",
-                        "battle-form"
+                        "unarmed"
                     ]
                 },
                 "selector": "strike-damage"

--- a/packs/data/feat-effects.db/effect-rampaging-form.json
+++ b/packs/data/feat-effects.db/effect-rampaging-form.json
@@ -92,8 +92,7 @@
                 "key": "DamageDice",
                 "predicate": {
                     "all": [
-                        "unarmed",
-                        "battle-form"
+                        "unarmed"
                     ]
                 },
                 "selector": "strike-damage"

--- a/packs/data/spell-effects.db/spell-effect-aberrant-form-chuul.json
+++ b/packs/data/spell-effects.db/spell-effect-aberrant-form-chuul.json
@@ -15,16 +15,6 @@
         },
         "rules": [
             {
-                "key": "Note",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
-                "selector": "{item|_id}-damage",
-                "text": "<p class=\"compact-text\"><strong>Grab</strong> You can spend an action after a hit to Grab the target.</p>"
-            },
-            {
                 "key": "BattleForm",
                 "overrides": {
                     "senses": {
@@ -114,6 +104,11 @@
                     ],
                     "field": "item|data.level.value"
                 }
+            },
+            {
+                "key": "Note",
+                "selector": "{item|_id}-damage",
+                "text": "<p class=\"compact-text\"><strong>Grab</strong> You can spend an action after a hit to Grab the target.</p>"
             }
         ],
         "source": {

--- a/packs/data/spell-effects.db/spell-effect-aberrant-form-gogiteth.json
+++ b/packs/data/spell-effects.db/spell-effect-aberrant-form-gogiteth.json
@@ -15,16 +15,6 @@
         },
         "rules": [
             {
-                "key": "Note",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
-                "selector": "jaws-damage",
-                "text": "<p class='compact-text'><strong>Grab</strong> You can spend an action after a hit to Grab the target.</p>"
-            },
-            {
                 "key": "BattleForm",
                 "overrides": {
                     "senses": {
@@ -148,6 +138,11 @@
                     ],
                     "field": "item|data.level.value"
                 }
+            },
+            {
+                "key": "Note",
+                "selector": "jaws-damage",
+                "text": "<p class='compact-text'><strong>Grab</strong> You can spend an action after a hit to Grab the target.</p>"
             }
         ],
         "source": {

--- a/packs/data/spell-effects.db/spell-effect-aberrant-form-gug.json
+++ b/packs/data/spell-effects.db/spell-effect-aberrant-form-gug.json
@@ -61,11 +61,6 @@
                         "aberration"
                     ]
                 },
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "value": {
                     "brackets": [
                         {

--- a/packs/data/spell-effects.db/spell-effect-aerial-form-bat.json
+++ b/packs/data/spell-effects.db/spell-effect-aerial-form-bat.json
@@ -176,11 +176,6 @@
             },
             {
                 "key": "FlatModifier",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "fly-speed",
                 "type": "status",
                 "value": {

--- a/packs/data/spell-effects.db/spell-effect-aerial-form-bird.json
+++ b/packs/data/spell-effects.db/spell-effect-aerial-form-bird.json
@@ -172,11 +172,6 @@
             },
             {
                 "key": "FlatModifier",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "fly-speed",
                 "type": "status",
                 "value": {

--- a/packs/data/spell-effects.db/spell-effect-aerial-form-pterosaur.json
+++ b/packs/data/spell-effects.db/spell-effect-aerial-form-pterosaur.json
@@ -134,11 +134,6 @@
             },
             {
                 "key": "FlatModifier",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "fly-speed",
                 "type": "status",
                 "value": {

--- a/packs/data/spell-effects.db/spell-effect-aerial-form-wasp.json
+++ b/packs/data/spell-effects.db/spell-effect-aerial-form-wasp.json
@@ -130,21 +130,11 @@
             },
             {
                 "key": "Note",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "strike-damage",
                 "text": "<p class=\"compact-text\"><strong>Aerial Form (Wasp)</strong> plus [[/r {1d6}[persistent,poison]]]{1d6} @Compendium[pf2e.conditionitems.Persistent Damage]{Persistent Poison Damage}<br><strong>Heightened(6th) Double persistent damage dice</strong></p>"
             },
             {
                 "key": "FlatModifier",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "fly-speed",
                 "type": "status",
                 "value": {

--- a/packs/data/spell-effects.db/spell-effect-angel-form-balisse.json
+++ b/packs/data/spell-effects.db/spell-effect-angel-form-balisse.json
@@ -123,11 +123,6 @@
                 "diceNumber": 1,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "scimitar-damage"
             },
             {
@@ -135,11 +130,6 @@
                 "diceNumber": 1,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "scimitar-damage"
             }
         ],

--- a/packs/data/spell-effects.db/spell-effect-angel-form-choral.json
+++ b/packs/data/spell-effects.db/spell-effect-angel-form-choral.json
@@ -161,11 +161,6 @@
                 "diceNumber": 1,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "fist-damage"
             },
             {
@@ -173,11 +168,6 @@
                 "diceNumber": 1,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "piercing-hymn-damage"
             },
             {
@@ -185,11 +175,6 @@
                 "outcome": [
                     "criticalSuccess"
                 ],
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "piercing-hymn-damage",
                 "text": "<p class='compact-text'><strong>Piercing Hymn</strong> @Compendium[pf2e.conditionitems.Deafened]{Deafened} for 1 round on a critical hit</p>"
             }

--- a/packs/data/spell-effects.db/spell-effect-angel-form-monadic-deva.json
+++ b/packs/data/spell-effects.db/spell-effect-angel-form-monadic-deva.json
@@ -120,11 +120,6 @@
                 "diceNumber": 1,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "holy-mace-damage"
             },
             {
@@ -132,11 +127,6 @@
                 "diceNumber": 1,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "holy-mace-damage"
             }
         ],

--- a/packs/data/spell-effects.db/spell-effect-angel-form-movanic-deva.json
+++ b/packs/data/spell-effects.db/spell-effect-angel-form-movanic-deva.json
@@ -127,11 +127,6 @@
                 "diceNumber": 1,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "bastard-sword-damage"
             },
             {
@@ -139,11 +134,6 @@
                 "diceNumber": 1,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "bastard-sword-damage"
             }
         ],

--- a/packs/data/spell-effects.db/spell-effect-animal-form-snake.json
+++ b/packs/data/spell-effects.db/spell-effect-animal-form-snake.json
@@ -163,11 +163,6 @@
             {
                 "damageType": "poison",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "fangs-damage",
                 "value": {
                     "brackets": [

--- a/packs/data/spell-effects.db/spell-effect-cosmic-form-moon.json
+++ b/packs/data/spell-effects.db/spell-effect-cosmic-form-moon.json
@@ -78,11 +78,6 @@
                 "diceNumber": 1,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "fist-damage"
             },
             {
@@ -90,11 +85,6 @@
                 "outcome": [
                     "criticalSuccess"
                 ],
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "strike-damage",
                 "text": "<p class='compact-text'><strong>Cosmic Form (Moon)</strong> The target is @Compendium[pf2e.conditionitems.Stupefied]{Stupefied 2} for 1 round.</p>"
             }

--- a/packs/data/spell-effects.db/spell-effect-cosmic-form-sun.json
+++ b/packs/data/spell-effects.db/spell-effect-cosmic-form-sun.json
@@ -15,29 +15,6 @@
         },
         "rules": [
             {
-                "key": "Note",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
-                "selector": "strike-damage",
-                "text": "<p class=\"compact-text\"><strong>Cosmic Form (Sun)</strong> plus [[/r {1d6}[persistent,fire]]] @Compendium[pf2e.conditionitems.Persistent Damage]{Persistent Fire Damage}</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
-                "selector": "strike-damage",
-                "text": "<p class=\"compact-text\"><strong>Cosmic Form (Sun)</strong> the target is @Compendium[pf2e.conditionitems.Dazzled]{Dazzled} for 1 round.</p>"
-            },
-            {
                 "key": "BattleForm",
                 "overrides": {
                     "armorClass": {
@@ -94,6 +71,19 @@
                     },
                     "tempHP": 20
                 }
+            },
+            {
+                "key": "Note",
+                "selector": "strike-damage",
+                "text": "<p class=\"compact-text\"><strong>Cosmic Form (Sun)</strong> plus [[/r {1d6}[persistent,fire]]] @Compendium[pf2e.conditionitems.Persistent Damage]{Persistent Fire Damage}</p>"
+            },
+            {
+                "key": "Note",
+                "outcome": [
+                    "criticalSuccess"
+                ],
+                "selector": "strike-damage",
+                "text": "<p class=\"compact-text\"><strong>Cosmic Form (Sun)</strong> the target is @Compendium[pf2e.conditionitems.Dazzled]{Dazzled} for 1 round.</p>"
             }
         ],
         "source": {

--- a/packs/data/spell-effects.db/spell-effect-daemon-form-ceustodaemon.json
+++ b/packs/data/spell-effects.db/spell-effect-daemon-form-ceustodaemon.json
@@ -15,18 +15,6 @@
         },
         "rules": [
             {
-                "key": "FlatModifier",
-                "predicate": {
-                    "all": [
-                        "battle-form",
-                        "death-effects"
-                    ]
-                },
-                "selector": "saving-throw",
-                "type": "status",
-                "value": 2
-            },
-            {
                 "hasHands": true,
                 "key": "BattleForm",
                 "overrides": {
@@ -99,12 +87,18 @@
                 }
             },
             {
-                "key": "Note",
+                "key": "FlatModifier",
                 "predicate": {
                     "all": [
-                        "battle-form"
+                        "death-effects"
                     ]
                 },
+                "selector": "saving-throw",
+                "type": "status",
+                "value": 2
+            },
+            {
+                "key": "Note",
                 "selector": "strike-damage",
                 "text": "<p class=\"compact-text\"><strong>Daemon Form (Ceustodaemon)</strong> any successful jaws or claw Strike deals an additional [[/r {1d6}]]{1d6 damage}, and you take the same amount of damage</p>"
             },
@@ -113,11 +107,6 @@
                 "diceNumber": 1,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "strike-damage"
             }
         ],

--- a/packs/data/spell-effects.db/spell-effect-daemon-form-leukodaemon.json
+++ b/packs/data/spell-effects.db/spell-effect-daemon-form-leukodaemon.json
@@ -15,31 +15,6 @@
         },
         "rules": [
             {
-                "key": "FlatModifier",
-                "predicate": {
-                    "any": [
-                        "battle-form",
-                        "death-effects",
-                        "disease"
-                    ]
-                },
-                "selector": "saving-throw",
-                "type": "status",
-                "value": 2
-            },
-            {
-                "damageType": "evil",
-                "diceNumber": 1,
-                "dieSize": "d6",
-                "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
-                "selector": "strike-damage"
-            },
-            {
                 "hasHands": true,
                 "key": "BattleForm",
                 "overrides": {
@@ -130,6 +105,25 @@
                         }
                     ]
                 }
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": {
+                    "any": [
+                        "death-effects",
+                        "disease"
+                    ]
+                },
+                "selector": "saving-throw",
+                "type": "status",
+                "value": 2
+            },
+            {
+                "damageType": "evil",
+                "diceNumber": 1,
+                "dieSize": "d6",
+                "key": "DamageDice",
+                "selector": "strike-damage"
             }
         ],
         "source": {

--- a/packs/data/spell-effects.db/spell-effect-daemon-form-meladaemon.json
+++ b/packs/data/spell-effects.db/spell-effect-daemon-form-meladaemon.json
@@ -15,18 +15,6 @@
         },
         "rules": [
             {
-                "key": "FlatModifier",
-                "predicate": {
-                    "all": [
-                        "battle-form",
-                        "death-effects"
-                    ]
-                },
-                "selector": "saving-throw",
-                "type": "status",
-                "value": 2
-            },
-            {
                 "hasHands": true,
                 "key": "BattleForm",
                 "overrides": {
@@ -100,12 +88,18 @@
                 }
             },
             {
-                "key": "Note",
+                "key": "FlatModifier",
                 "predicate": {
                     "all": [
-                        "battle-form"
+                        "death-effects"
                     ]
                 },
+                "selector": "saving-throw",
+                "type": "status",
+                "value": 2
+            },
+            {
+                "key": "Note",
                 "selector": "claw-damage",
                 "text": "<p class=\"compact-text\"><strong>Daemon Form (Meladaemon)</strong> @Localize[PF2E.PersistentDamage.Bleed1d6.success], and you can spend an action after a hit to @Compendium[pf2e.bestiary-ability-glossary-srd.Grab]{Grab} the target</p>"
             },
@@ -114,11 +108,6 @@
                 "diceNumber": 1,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "strike-damage"
             },
             {
@@ -126,11 +115,6 @@
                 "diceNumber": 1,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "claw-damage"
             }
         ],

--- a/packs/data/spell-effects.db/spell-effect-daemon-form-piscodaemon.json
+++ b/packs/data/spell-effects.db/spell-effect-daemon-form-piscodaemon.json
@@ -15,18 +15,6 @@
         },
         "rules": [
             {
-                "key": "FlatModifier",
-                "predicate": {
-                    "all": [
-                        "battle-form",
-                        "death-effects"
-                    ]
-                },
-                "selector": "saving-throw",
-                "type": "status",
-                "value": 2
-            },
-            {
                 "hasHands": true,
                 "key": "BattleForm",
                 "overrides": {
@@ -95,15 +83,21 @@
                 }
             },
             {
+                "key": "FlatModifier",
+                "predicate": {
+                    "all": [
+                        "death-effects"
+                    ]
+                },
+                "selector": "saving-throw",
+                "type": "status",
+                "value": 2
+            },
+            {
                 "damageType": "evil",
                 "diceNumber": 1,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "strike-damage"
             },
             {
@@ -111,20 +105,10 @@
                 "diceNumber": 1,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "tentacle-damage"
             },
             {
                 "key": "Note",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "claw-damage",
                 "text": "<p class=\"compact-text\"><strong>Daemon Form (Piscodaemon)</strong> @Localize[PF2E.PersistentDamage.Bleed1d6.success], and you can spend an action after a hit to @Compendium[pf2e.bestiary-ability-glossary-srd.Grab]{Grab} the target</p>"
             }

--- a/packs/data/spell-effects.db/spell-effect-demon-form-hezrou.json
+++ b/packs/data/spell-effects.db/spell-effect-demon-form-hezrou.json
@@ -93,20 +93,10 @@
                 "diceNumber": 1,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "strike-damage"
             },
             {
                 "key": "Note",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "claw-damage",
                 "text": "<p class='compact-text'><strong>Demon Form (Hezrou)</strong> You can spend an action after a hit to @Compendium[pf2e.bestiary-ability-glossary-srd.Grab]{Grab} the target</p>"
             }

--- a/packs/data/spell-effects.db/spell-effect-demon-form-nabasu.json
+++ b/packs/data/spell-effects.db/spell-effect-demon-form-nabasu.json
@@ -92,11 +92,6 @@
                 "diceNumber": 1,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "strike-damage"
             }
         ],

--- a/packs/data/spell-effects.db/spell-effect-demon-form-vrock.json
+++ b/packs/data/spell-effects.db/spell-effect-demon-form-vrock.json
@@ -111,11 +111,6 @@
                 "diceNumber": 1,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "strike-damage"
             }
         ],

--- a/packs/data/spell-effects.db/spell-effect-devil-form-barbazu.json
+++ b/packs/data/spell-effects.db/spell-effect-devil-form-barbazu.json
@@ -116,20 +116,10 @@
                 "diceNumber": 1,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "strike-damage"
             },
             {
                 "key": "Note",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "glaive-damage",
                 "text": "<p class=\"compact-text\"><strong>Devil Form (Barbazu)</strong> @Localize[PF2E.PersistentDamage.Bleed1d6.success]</p>"
             }

--- a/packs/data/spell-effects.db/spell-effect-devil-form-erinys.json
+++ b/packs/data/spell-effects.db/spell-effect-devil-form-erinys.json
@@ -102,11 +102,6 @@
                 "diceNumber": 1,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "strike-damage"
             },
             {
@@ -114,11 +109,6 @@
                 "diceNumber": 1,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "strike-damage"
             }
         ],

--- a/packs/data/spell-effects.db/spell-effect-devil-form-osyluth.json
+++ b/packs/data/spell-effects.db/spell-effect-devil-form-osyluth.json
@@ -130,11 +130,6 @@
                 "diceNumber": 1,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "strike-damage"
             },
             {
@@ -142,11 +137,6 @@
                 "diceNumber": 1,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "stinger-damage"
             }
         ],

--- a/packs/data/spell-effects.db/spell-effect-devil-form-sarglagon.json
+++ b/packs/data/spell-effects.db/spell-effect-devil-form-sarglagon.json
@@ -97,11 +97,6 @@
                 "diceNumber": 1,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "strike-damage"
             },
             {
@@ -109,11 +104,6 @@
                 "diceNumber": 1,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "tentacle-arm-damage"
             }
         ],

--- a/packs/data/spell-effects.db/spell-effect-dinosaur-form-deinonychus.json
+++ b/packs/data/spell-effects.db/spell-effect-dinosaur-form-deinonychus.json
@@ -179,12 +179,6 @@
             },
             {
                 "key": "Note",
-                "predicate": {
-                    "all": [
-                        "battle-form",
-                        "talon"
-                    ]
-                },
                 "selector": "strike-damage",
                 "text": "<p class='compact-text'>Add [[/r {1}[persistent,bleed]]] @Compendium[pf2e.conditionitems.Persistent Damage]{Persistent Bleed Damage}</p>"
             }

--- a/packs/data/spell-effects.db/spell-effect-dinosaur-form-triceratops.json
+++ b/packs/data/spell-effects.db/spell-effect-dinosaur-form-triceratops.json
@@ -177,11 +177,6 @@
                 "outcome": [
                     "criticalSuccess"
                 ],
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "horn-damage",
                 "text": "<p class='compact-text'>Add @Localize[PF2E.PersistentDamage.Bleed1d6.success] on a critical hit</p>"
             }

--- a/packs/data/spell-effects.db/spell-effect-dragon-form-black.json
+++ b/packs/data/spell-effects.db/spell-effect-dragon-form-black.json
@@ -209,20 +209,10 @@
                 "diceNumber": 2,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "jaws-damage"
             },
             {
                 "key": "FlatModifier",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "fly-speed",
                 "type": "status",
                 "value": {

--- a/packs/data/spell-effects.db/spell-effect-dragon-form-blue.json
+++ b/packs/data/spell-effects.db/spell-effect-dragon-form-blue.json
@@ -209,20 +209,10 @@
                 "diceNumber": 1,
                 "dieSize": "d12",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "jaws-damage"
             },
             {
                 "key": "FlatModifier",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "fly-speed",
                 "type": "status",
                 "value": {

--- a/packs/data/spell-effects.db/spell-effect-dragon-form-brass.json
+++ b/packs/data/spell-effects.db/spell-effect-dragon-form-brass.json
@@ -209,20 +209,10 @@
                 "diceNumber": 2,
                 "dieSize": "d4",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "jaws-damage"
             },
             {
                 "key": "FlatModifier",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "fly-speed",
                 "type": "status",
                 "value": {

--- a/packs/data/spell-effects.db/spell-effect-dragon-form-bronze.json
+++ b/packs/data/spell-effects.db/spell-effect-dragon-form-bronze.json
@@ -209,20 +209,10 @@
                 "diceNumber": 1,
                 "dieSize": "d12",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "jaws-damage"
             },
             {
                 "key": "FlatModifier",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "fly-speed",
                 "type": "status",
                 "value": {

--- a/packs/data/spell-effects.db/spell-effect-dragon-form-copper.json
+++ b/packs/data/spell-effects.db/spell-effect-dragon-form-copper.json
@@ -209,20 +209,10 @@
                 "diceNumber": 2,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "jaws-damage"
             },
             {
                 "key": "FlatModifier",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "fly-speed",
                 "type": "status",
                 "value": {

--- a/packs/data/spell-effects.db/spell-effect-dragon-form-gold.json
+++ b/packs/data/spell-effects.db/spell-effect-dragon-form-gold.json
@@ -209,20 +209,10 @@
                 "diceNumber": 2,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "jaws-damage"
             },
             {
                 "key": "FlatModifier",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "fly-speed",
                 "type": "status",
                 "value": {

--- a/packs/data/spell-effects.db/spell-effect-dragon-form-green.json
+++ b/packs/data/spell-effects.db/spell-effect-dragon-form-green.json
@@ -209,20 +209,10 @@
                 "diceNumber": 2,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "jaws-damage"
             },
             {
                 "key": "FlatModifier",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "fly-speed",
                 "type": "status",
                 "value": {

--- a/packs/data/spell-effects.db/spell-effect-dragon-form-red.json
+++ b/packs/data/spell-effects.db/spell-effect-dragon-form-red.json
@@ -208,20 +208,10 @@
                 "diceNumber": 2,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "jaws-damage"
             },
             {
                 "key": "FlatModifier",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "fly-speed",
                 "type": "status",
                 "value": {

--- a/packs/data/spell-effects.db/spell-effect-dragon-form-silver.json
+++ b/packs/data/spell-effects.db/spell-effect-dragon-form-silver.json
@@ -179,20 +179,10 @@
                 "diceNumber": 2,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "jaws-damage"
             },
             {
                 "key": "FlatModifier",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "fly-speed",
                 "type": "status",
                 "value": {

--- a/packs/data/spell-effects.db/spell-effect-dragon-form-white.json
+++ b/packs/data/spell-effects.db/spell-effect-dragon-form-white.json
@@ -180,20 +180,10 @@
                 "diceNumber": 2,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "jaws-damage"
             },
             {
                 "key": "FlatModifier",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "fly-speed",
                 "type": "status",
                 "value": {

--- a/packs/data/spell-effects.db/spell-effect-elemental-form-fire.json
+++ b/packs/data/spell-effects.db/spell-effect-elemental-form-fire.json
@@ -146,11 +146,6 @@
             },
             {
                 "key": "Note",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "strike-damage",
                 "text": {
                     "brackets": [

--- a/packs/data/spell-effects.db/spell-effect-elemental-form-water.json
+++ b/packs/data/spell-effects.db/spell-effect-elemental-form-water.json
@@ -137,11 +137,6 @@
             },
             {
                 "key": "Note",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "attack",
                 "text": "<p class='compact-text'>You can spend an action immediately after a hit to push the target 5 feet with the effects of a successful @Compendium[pf2e.actionspf2e.Shove]{Shove}</p>"
             },

--- a/packs/data/spell-effects.db/spell-effect-elephant-form.json
+++ b/packs/data/spell-effects.db/spell-effect-elephant-form.json
@@ -189,11 +189,6 @@
                 "outcome": [
                     "success"
                 ],
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "trunk-attack",
                 "text": "<p class=\"compact-text\"><strong>@Localize[PF2E.BattleForm.Note.GrabbingTrunk.Title]</strong> @Localize[PF2E.BattleForm.Note.GrabbingTrunk.Text]</p>"
             }

--- a/packs/data/spell-effects.db/spell-effect-fey-form-elananx.json
+++ b/packs/data/spell-effects.db/spell-effect-fey-form-elananx.json
@@ -91,11 +91,6 @@
                 "diceNumber": 1,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "jaws-damage"
             },
             {

--- a/packs/data/spell-effects.db/spell-effect-fey-form-unicorn.json
+++ b/packs/data/spell-effects.db/spell-effect-fey-form-unicorn.json
@@ -86,11 +86,6 @@
             {
                 "damageType": "good",
                 "key": "FlatModifier",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "horn-damage",
                 "value": 1
             },

--- a/packs/data/spell-effects.db/spell-effect-insect-form-centipede.json
+++ b/packs/data/spell-effects.db/spell-effect-insect-form-centipede.json
@@ -132,11 +132,6 @@
             },
             {
                 "key": "Note",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "strike-damage",
                 "text": "<p class=\"compact-text\"><strong>Insect Form (Centipede)</strong> plus @Localize[PF2E.PersistentDamage.Poison1d4.success]<br><strong>Heightened(5th)</strong> Double persistent damage dice</strong></p>"
             },

--- a/packs/data/spell-effects.db/spell-effect-insect-form-scorpion.json
+++ b/packs/data/spell-effects.db/spell-effect-insect-form-scorpion.json
@@ -178,11 +178,6 @@
             },
             {
                 "key": "Note",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "stinger-damage",
                 "text": "<p class=\"compact-text\"><strong>Insect Form (Scorpion)</strong> plus @Localize[PF2E.PersistentDamage.Poison1d4.success]<br><strong>Heightened(5th)</strong> Double persistent damage dice</strong></p>"
             },

--- a/packs/data/spell-effects.db/spell-effect-insect-form-spider.json
+++ b/packs/data/spell-effects.db/spell-effect-insect-form-spider.json
@@ -166,21 +166,11 @@
             },
             {
                 "key": "Note",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "fangs-damage",
                 "text": "<p class=\"compact-text\"><strong>Insect Form (Spider)</strong> plus @Localize[PF2E.PersistentDamage.Poison1d4.success]<br><strong>Heightened(5th)</strong> Double persistent damage dice</strong></p>"
             },
             {
                 "key": "Note",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "pf2e.battleform.attack.web-attack",
                 "text": "<p class=\"compact-text\"><strong>Insect Form (Spider)</strong> A successful Web attack entangles the target for 1 round, but deals no damage</p>"
             },

--- a/packs/data/spell-effects.db/spell-effect-monstrosity-form-phoenix.json
+++ b/packs/data/spell-effects.db/spell-effect-monstrosity-form-phoenix.json
@@ -156,11 +156,8 @@
             {
                 "key": "Note",
                 "predicate": {
-                    "all": [
-                        "battle-form"
-                    ],
                     "not": [
-                        "agile"
+                        "weapon:trait:agile"
                     ]
                 },
                 "selector": "strike-damage",

--- a/packs/data/spell-effects.db/spell-effect-monstrosity-form-purple-worm.json
+++ b/packs/data/spell-effects.db/spell-effect-monstrosity-form-purple-worm.json
@@ -162,8 +162,7 @@
                 "key": "Note",
                 "predicate": {
                     "all": [
-                        "agile",
-                        "battle-form"
+                        "weapon:trait:agile"
                     ]
                 },
                 "selector": "strike-damage",

--- a/packs/data/spell-effects.db/spell-effect-ooze-form-black-pudding.json
+++ b/packs/data/spell-effects.db/spell-effect-ooze-form-black-pudding.json
@@ -170,11 +170,6 @@
                 "damageType": "acid",
                 "dieSize": "d8",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "strike-damage",
                 "value": {
                     "brackets": [

--- a/packs/data/spell-effects.db/spell-effect-ooze-form-gelatinous-cube.json
+++ b/packs/data/spell-effects.db/spell-effect-ooze-form-gelatinous-cube.json
@@ -167,11 +167,6 @@
             },
             {
                 "key": "Note",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "strike-damage",
                 "text": "<p class='compact-text'><strong>Ooze Form (Gelatinous Cube)</strong> A creature hit by your cube face Strike must succeed at a Fortitude save against your spell DC or be @Compendium[pf2e.conditionitems.Stunned]{Stunned 1} (or @Compendium[pf2e.conditionitems.Paralyzed]{Paralyzed} for 1 round on a critical failure); this save has the incapacitation trait.</p>"
             },

--- a/packs/data/spell-effects.db/spell-effect-ooze-form-gray-ooze.json
+++ b/packs/data/spell-effects.db/spell-effect-ooze-form-gray-ooze.json
@@ -171,11 +171,6 @@
                 "damageType": "acid",
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "strike-damage",
                 "value": {
                     "brackets": [
@@ -198,11 +193,6 @@
             },
             {
                 "key": "Note",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "strike-damage",
                 "text": "<p class='compact-text'><strong>Ooze Form (Gray Ooze)</strong> You can spend an action after a hit to @Compendium[pf2e.bestiary-ability-glossary-srd.Grab]{Grab} the target</p>"
             },

--- a/packs/data/spell-effects.db/spell-effect-ooze-form-ochre-jelly.json
+++ b/packs/data/spell-effects.db/spell-effect-ooze-form-ochre-jelly.json
@@ -170,11 +170,6 @@
                 "damageType": "acid",
                 "dieSize": "d8",
                 "key": "DamageDice",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "strike-damage",
                 "value": {
                     "brackets": [
@@ -197,11 +192,6 @@
             },
             {
                 "key": "Note",
-                "predicate": {
-                    "all": [
-                        "battle-form"
-                    ]
-                },
                 "selector": "strike-damage",
                 "text": "<p class='compact-text'><strong>Ooze Form (Ochre Jelly)</strong> You can spend an action after a hit to @Compendium[pf2e.bestiary-ability-glossary-srd.Grab]{Grab} the target</p>"
             },


### PR DESCRIPTION
This is no longer needed unless the RE comes from an item that doesn't have a BattleForm RE