### PR TITLE
Update Token Light Effects on various Abomination Vaults NPCs

### DIFF
--- a/packs/data/abomination-vaults-bestiary.db/dread-wisp.json
+++ b/packs/data/abomination-vaults-bestiary.db/dread-wisp.json
@@ -307,7 +307,6 @@
                     {
                         "domain": "all",
                         "key": "RollOption",
-                        "label": "Dread Flickering",
                         "option": "glowing",
                         "toggleable": true,
                         "value": true

--- a/packs/data/abomination-vaults-bestiary.db/dread-wisp.json
+++ b/packs/data/abomination-vaults-bestiary.db/dread-wisp.json
@@ -286,6 +286,9 @@
                     {
                         "key": "TokenLight",
                         "predicate": {
+                            "all": [
+                                "glowing"
+                            ],
                             "not": [
                                 "go-dark"
                             ]
@@ -300,6 +303,14 @@
                             "dim": 20,
                             "shadows": 0.1
                         }
+                    },
+                    {
+                        "domain": "all",
+                        "key": "RollOption",
+                        "label": "Dread Flickering",
+                        "option": "glowing",
+                        "toggleable": true,
+                        "value": true
                     }
                 ],
                 "slug": null,

--- a/packs/data/abomination-vaults-bestiary.db/flickerwisp.json
+++ b/packs/data/abomination-vaults-bestiary.db/flickerwisp.json
@@ -225,6 +225,11 @@
                 "rules": [
                     {
                         "key": "TokenLight",
+                        "predicate": {
+                            "all": [
+                                "glowing"
+                            ]
+                        },
                         "value": {
                             "animation": {
                                 "intensity": 1,
@@ -234,6 +239,14 @@
                             "bright": 5,
                             "color": "#fff9a3"
                         }
+                    },
+                    {
+                        "domain": "all",
+                        "key": "RollOption",
+                        "label": "Glowing",
+                        "option": "glowing",
+                        "toggleable": true,
+                        "value": true
                     }
                 ],
                 "slug": null,

--- a/packs/data/abomination-vaults-bestiary.db/flickerwisp.json
+++ b/packs/data/abomination-vaults-bestiary.db/flickerwisp.json
@@ -243,7 +243,6 @@
                     {
                         "domain": "all",
                         "key": "RollOption",
-                        "label": "Glowing",
                         "option": "glowing",
                         "toggleable": true,
                         "value": true

--- a/packs/data/abomination-vaults-bestiary.db/groetan-candle.json
+++ b/packs/data/abomination-vaults-bestiary.db/groetan-candle.json
@@ -227,7 +227,33 @@
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "key": "TokenLight",
+                        "predicate": {
+                            "all": [
+                                "glowing"
+                            ]
+                        },
+                        "value": {
+                            "animation": {
+                                "intensity": 1,
+                                "speed": 3,
+                                "type": "pulse"
+                            },
+                            "bright": 20,
+                            "color": "#fff9a3"
+                        }
+                    },
+                    {
+                        "domain": "all",
+                        "key": "RollOption",
+                        "label": "Glowing",
+                        "option": "glowing",
+                        "toggleable": true,
+                        "value": true
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""

--- a/packs/data/abomination-vaults-bestiary.db/groetan-candle.json
+++ b/packs/data/abomination-vaults-bestiary.db/groetan-candle.json
@@ -248,7 +248,6 @@
                     {
                         "domain": "all",
                         "key": "RollOption",
-                        "label": "Glowing",
                         "option": "glowing",
                         "toggleable": true,
                         "value": true

--- a/packs/data/abomination-vaults-bestiary.db/voidglutton.json
+++ b/packs/data/abomination-vaults-bestiary.db/voidglutton.json
@@ -496,7 +496,33 @@
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "key": "TokenLight",
+                        "predicate": {
+                            "all": [
+                                "glowing"
+                            ]
+                        },
+                        "value": {
+                            "animation": {
+                                "intensity": 1,
+                                "speed": 3,
+                                "type": "pulse"
+                            },
+                            "bright": 30,
+                            "color": "#fff9a3"
+                        }
+                    },
+                    {
+                        "domain": "all",
+                        "key": "RollOption",
+                        "label": "Glowing",
+                        "option": "glowing",
+                        "toggleable": true,
+                        "value": true
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""

--- a/packs/data/abomination-vaults-bestiary.db/voidglutton.json
+++ b/packs/data/abomination-vaults-bestiary.db/voidglutton.json
@@ -517,7 +517,6 @@
                     {
                         "domain": "all",
                         "key": "RollOption",
-                        "label": "Glowing",
                         "option": "glowing",
                         "toggleable": true,
                         "value": true

--- a/packs/data/abomination-vaults-bestiary.db/will-o-the-deep.json
+++ b/packs/data/abomination-vaults-bestiary.db/will-o-the-deep.json
@@ -232,7 +232,33 @@
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "key": "TokenLight",
+                        "predicate": {
+                            "all": [
+                                "glowing"
+                            ]
+                        },
+                        "value": {
+                            "animation": {
+                                "intensity": 1,
+                                "speed": 3,
+                                "type": "pulse"
+                            },
+                            "bright": 20,
+                            "color": "#fff9a3"
+                        }
+                    },
+                    {
+                        "domain": "all",
+                        "key": "RollOption",
+                        "label": "Glowing",
+                        "option": "glowing",
+                        "toggleable": true,
+                        "value": true
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""

--- a/packs/data/abomination-vaults-bestiary.db/will-o-the-deep.json
+++ b/packs/data/abomination-vaults-bestiary.db/will-o-the-deep.json
@@ -253,7 +253,6 @@
                     {
                         "domain": "all",
                         "key": "RollOption",
-                        "label": "Glowing",
                         "option": "glowing",
                         "toggleable": true,
                         "value": true


### PR DESCRIPTION
Updated Dread Wisp, Flickerwisp, Groetan Candle, Voidglutton, and Will-o'-the-Deep. Resolves https://github.com/foundryvtt/pf2e/issues/2329.