### PR TITLE
Warn about mode before priority for AELike

### DIFF
--- a/src/module/rules/rule-element/ae-like.ts
+++ b/src/module/rules/rule-element/ae-like.ts
@@ -31,12 +31,12 @@ class AELikeRuleElement extends RuleElementPF2e {
     }
 
     protected validateData(): void {
-        if (Number.isNaN(this.priority)) {
-            return this.warn("priority");
-        }
-
         if (!AELikeRuleElement.CHANGE_MODES.includes(this.data.mode)) {
             return this.warn("mode");
+        }
+
+        if (Number.isNaN(this.priority)) {
+            return this.warn("priority");
         }
 
         const actor = this.item.actor;


### PR DESCRIPTION
priority is derived from mode, so missing mode and priority will warn about priority currently, when it should warn about mode first.