### PR TITLE
Fix styling of long transparent tags in chat messages

### DIFF
--- a/src/styles/ui/_tags.scss
+++ b/src/styles/ui/_tags.scss
@@ -101,7 +101,14 @@
 }
 
 li.chat-message .tags .tag {
-    height: 1rem;
+    height: unset;
+    line-height: 1.65em;
+    min-height: 1em;
+
+    &_transparent {
+        line-height: 1.25em;
+        padding: 0.1em 0.25em;
+    }
 }
 
 .damage-tag {


### PR DESCRIPTION
Before:
![Screenshot from 2022-06-19 00-54-01](https://user-images.githubusercontent.com/106829671/174467852-ce5950d9-e539-4594-b044-787b52dc4ee1.png)

After:
![Screenshot from 2022-06-19 00-54-20](https://user-images.githubusercontent.com/106829671/174467854-f3f14616-3e56-4d4e-89cb-e4f38af0169e.png)

