### PR TITLE
Make familiar sheet inherit from creature sheet

### DIFF
--- a/src/module/actor/creature/sheet.ts
+++ b/src/module/actor/creature/sheet.ts
@@ -170,7 +170,7 @@ export abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends Act
 
         // Roll skill checks
         $html.find(".skill-name.rollable, .skill-score.rollable").on("click", (event) => {
-            const skill = event.currentTarget.parentElement?.dataset.skill ?? "";
+            const skill = event.currentTarget.closest<HTMLElement>("[data-skill]")?.dataset.skill ?? "";
             const key = objectHasKey(SKILL_DICTIONARY, skill) ? SKILL_DICTIONARY[skill] : skill;
             const rollParams = eventToRollParams(event);
             this.actor.skills[key]?.check.roll(rollParams);

--- a/src/module/actor/familiar/index.ts
+++ b/src/module/actor/familiar/index.ts
@@ -69,6 +69,16 @@ export class FamiliarPF2e extends CreaturePF2e {
             reflex: {},
             will: {},
         };
+
+        // Fields not filled in template.json nor used but that still need to exist are created during preparation
+        // so they can exist pleasantly while they do nothing. They should either be automated via specific familiar item type,
+        // or added to template.json and manually edited. Doing either requires developer investment and interest into
+        // something that is regularly buffed to be even more pointless, uninteresting, and worthless.
+        systemData.traits = mergeObject(systemData.traits, {
+            dv: [],
+            di: [],
+            dr: [],
+        });
     }
 
     /** Active effects on a familiar require a master, so wait until embedded documents are prepared */

--- a/src/module/actor/familiar/index.ts
+++ b/src/module/actor/familiar/index.ts
@@ -70,10 +70,9 @@ export class FamiliarPF2e extends CreaturePF2e {
             will: {},
         };
 
-        // Fields not filled in template.json nor used but that still need to exist are created during preparation
-        // so they can exist pleasantly while they do nothing. They should either be automated via specific familiar item type,
-        // or added to template.json and manually edited. Doing either requires developer investment and interest into
-        // something that is regularly buffed to be even more pointless, uninteresting, and worthless.
+        // Fields that need to exist for sheet compatibility so that they can exist pleasantly while doing nothing.
+        // They should be automated via specific familiar item types, or added to template.json and manually edited.
+        // This requires dev investment and interest aimed at what amounts to feat expensive set dressing (familiars).
         systemData.traits = mergeObject(systemData.traits, {
             dv: [],
             di: [],

--- a/src/module/actor/familiar/sheet.ts
+++ b/src/module/actor/familiar/sheet.ts
@@ -1,17 +1,20 @@
+import { CharacterPF2e } from "@actor";
 import { SKILL_DICTIONARY } from "@actor/data/values";
 import { FamiliarPF2e } from "@actor/familiar";
-import type { ItemPF2e } from "@item/base";
+import { ActorSheetPF2e } from "@actor/sheet/base";
+import { ActorSheetDataPF2e } from "@actor/sheet/data-types";
 import { eventToRollParams } from "@scripts/sheet-util";
 import { objectHasKey } from "@util";
+import { FamiliarSheetData } from "./types";
 
 /**
  * @category Actor
  */
-export class FamiliarSheetPF2e extends ActorSheet<FamiliarPF2e, ItemPF2e> {
+export class FamiliarSheetPF2e extends ActorSheetPF2e<FamiliarPF2e> {
     static override get defaultOptions() {
         const options = super.defaultOptions;
         mergeObject(options, {
-            classes: [...options.classes, "actor", "familiar"],
+            classes: ["sheet", "actor", "familiar"],
             width: 650,
             height: 680,
             tabs: [{ navSelector: ".sheet-navigation", contentSelector: ".sheet-content", initial: "attributes" }],
@@ -23,37 +26,19 @@ export class FamiliarSheetPF2e extends ActorSheet<FamiliarPF2e, ItemPF2e> {
         return "systems/pf2e/templates/actors/familiar-sheet.html";
     }
 
-    override async getData() {
+    override async getData(options?: ActorSheetOptions): Promise<FamiliarSheetData> {
+        const baseData = await super.getData(options);
         const familiar = this.actor;
         // Get all potential masters of the familiar
-        const masters = game.actors.filter((a) => a.type === "character" && a.testUserPermission(game.user, "OWNER"));
+        const masters = game.actors.filter(
+            (a): a is CharacterPF2e => a.isOfType("character") && a.testUserPermission(game.user, "OWNER")
+        );
 
         // list of abilities that can be selected as spellcasting ability
         const abilities = CONFIG.PF2E.abilities;
 
         const size = CONFIG.PF2E.actorSizes[familiar.data.data.traits.size.value] ?? null;
-        const familiarAbilities = this.actor.master?.attributes?.familiarAbilities ?? {
-            value: 0,
-            breakdown: "",
-        };
-
-        const familiarTraits: Record<string, string> = CONFIG.PF2E.creatureTraits;
-        const traitDescriptions: Record<string, string> = CONFIG.PF2E.traitsDescriptions;
-
-        const traits = this.actor.data.data.traits.traits.value
-            .map((trait) => ({
-                value: trait,
-                label: familiarTraits[trait] ?? trait,
-                description: traitDescriptions[trait] ?? "",
-            }))
-            .sort();
-
-        // TEMPORARY solution for change in 0.8 where actor in super.getData() is an object instead of the data.
-        // The correct solution is to subclass ActorSheetPF2e, but that is a more involved fix.
-        const actorData = this.actor.toObject(false);
-        const baseData = await super.getData();
-        baseData.actor = actorData;
-        baseData.data = actorData.data;
+        const familiarAbilities = this.actor.master?.attributes?.familiarAbilities ?? { value: 0 };
 
         // Update save labels
         if (baseData.data.saves) {
@@ -70,20 +55,15 @@ export class FamiliarSheetPF2e extends ActorSheet<FamiliarPF2e, ItemPF2e> {
             abilities,
             size,
             familiarAbilities,
-            traits,
         };
     }
+
+    protected override prepareItems(_sheetData: ActorSheetDataPF2e<FamiliarPF2e>): void {}
 
     override activateListeners($html: JQuery): void {
         super.activateListeners($html);
 
         // rollable stats
-        $html.find('[data-saving-throw]:not([data-saving-throw=""])').on("click", "*", (event) => {
-            const save = $(event.currentTarget).closest("[data-saving-throw]").attr("data-saving-throw");
-            if (objectHasKey(this.actor.saves, save)) {
-                this.actor.saves[save].check.roll(eventToRollParams(event));
-            }
-        });
 
         $html.find<HTMLElement>("[data-skill-check] *").on("click", (event) => {
             const skill = event.currentTarget.closest<HTMLElement>("[data-skill-check]")?.dataset.skillCheck ?? "";
@@ -100,52 +80,6 @@ export class FamiliarSheetPF2e extends ActorSheet<FamiliarPF2e, ItemPF2e> {
         $html.find("[data-attack-roll] *").on("click", (event) => {
             const options = this.actor.getRollOptions(["all", "attack"]);
             this.actor.data.data.attack.roll({ event, options });
-        });
-
-        // expand and condense item description
-        $html.find(".item-list").on("click", ".expandable", (event) => {
-            $(event.currentTarget).removeClass("expandable").addClass("expanded");
-        });
-
-        $html.find(".item-list").on("click", ".expanded", (event) => {
-            $(event.currentTarget).removeClass("expanded").addClass("expandable");
-        });
-
-        if (!this.isEditable) return;
-
-        // item controls
-        $html.find(".item-list").on("click", '[data-item-id]:not([data-item-id=""]) .item-edit', (event) => {
-            const itemID = $(event.currentTarget).closest("[data-item-id]").attr("data-item-id");
-            const item = this.actor.items.get(itemID ?? "");
-            if (item) {
-                item.sheet.render(true);
-            }
-        });
-
-        $html.find(".item-list").on("click", '[data-item-id]:not([data-item-id=""]) .item-delete', (event) => {
-            const itemID = $(event.currentTarget).closest("[data-item-id]").attr("data-item-id") ?? "";
-            const item = this.actor.items.get(itemID);
-            if (!item) return;
-
-            new Dialog({
-                title: `Remove ${item.type}?`,
-                content: `<p>Are you sure you want to remove ${item.name}?</p>`,
-                buttons: {
-                    delete: {
-                        icon: '<i class="fas fa-trash"></i>',
-                        label: "Remove",
-                        callback: () => {
-                            item.delete();
-                        },
-                    },
-                    cancel: {
-                        icon: '<i class="fas fa-times"></i>',
-                        label: "Cancel",
-                    },
-                },
-                default: "cancel",
-            }).render(true);
-            return false;
         });
     }
 }

--- a/src/module/actor/familiar/sheet.ts
+++ b/src/module/actor/familiar/sheet.ts
@@ -1,16 +1,13 @@
 import { CharacterPF2e } from "@actor";
-import { SKILL_DICTIONARY } from "@actor/data/values";
+import { CreatureSheetPF2e } from "@actor/creature/sheet";
 import { FamiliarPF2e } from "@actor/familiar";
-import { ActorSheetPF2e } from "@actor/sheet/base";
 import { ActorSheetDataPF2e } from "@actor/sheet/data-types";
-import { eventToRollParams } from "@scripts/sheet-util";
-import { objectHasKey } from "@util";
 import { FamiliarSheetData } from "./types";
 
 /**
  * @category Actor
  */
-export class FamiliarSheetPF2e extends ActorSheetPF2e<FamiliarPF2e> {
+export class FamiliarSheetPF2e extends CreatureSheetPF2e<FamiliarPF2e> {
     static override get defaultOptions() {
         const options = super.defaultOptions;
         mergeObject(options, {
@@ -63,16 +60,7 @@ export class FamiliarSheetPF2e extends ActorSheetPF2e<FamiliarPF2e> {
     override activateListeners($html: JQuery): void {
         super.activateListeners($html);
 
-        // rollable stats
-
-        $html.find<HTMLElement>("[data-skill-check] *").on("click", (event) => {
-            const skill = event.currentTarget.closest<HTMLElement>("[data-skill-check]")?.dataset.skillCheck ?? "";
-            const key = objectHasKey(SKILL_DICTIONARY, skill) ? SKILL_DICTIONARY[skill] : skill;
-            const rollParams = eventToRollParams(event);
-            this.actor.skills[key]?.check.roll(rollParams);
-        });
-
-        $html.find("[data-perception-check] *").on("click", (event) => {
+        $html.find("[data-action=perception-check]").on("click", (event) => {
             const options = this.actor.getRollOptions(["all", "perception"]);
             this.actor.attributes.perception.roll({ event, options });
         });

--- a/src/module/actor/familiar/types.ts
+++ b/src/module/actor/familiar/types.ts
@@ -1,8 +1,8 @@
 import { CharacterPF2e } from "@actor";
-import { ActorSheetDataPF2e } from "@actor/sheet/data-types";
+import { CreatureSheetData } from "@actor/creature/types";
 import { FamiliarPF2e } from ".";
 
-interface FamiliarSheetData extends ActorSheetDataPF2e<FamiliarPF2e> {
+interface FamiliarSheetData extends CreatureSheetData<FamiliarPF2e> {
     master: CharacterPF2e | null;
     masters: CharacterPF2e[];
     abilities: ConfigPF2e["PF2E"]["abilities"];

--- a/src/module/actor/familiar/types.ts
+++ b/src/module/actor/familiar/types.ts
@@ -1,0 +1,13 @@
+import { CharacterPF2e } from "@actor";
+import { ActorSheetDataPF2e } from "@actor/sheet/data-types";
+import { FamiliarPF2e } from ".";
+
+interface FamiliarSheetData extends ActorSheetDataPF2e<FamiliarPF2e> {
+    master: CharacterPF2e | null;
+    masters: CharacterPF2e[];
+    abilities: ConfigPF2e["PF2E"]["abilities"];
+    size: string;
+    familiarAbilities: { value: number };
+}
+
+export { FamiliarSheetData };

--- a/src/styles/actor/familiar/_index.scss
+++ b/src/styles/actor/familiar/_index.scss
@@ -489,7 +489,7 @@
                 flex-direction: column;
                 justify-content: center;
 
-                .skills-item {
+                .skill-name {
                     display: flex;
                     flex-direction: row;
                     align-items: center;
@@ -505,21 +505,19 @@
                         padding: none;
                         border: 1px solid #323232;
                     }
+
+                    .name {
+                        flex: 4;
+                    }
+
+                    .score {
+                        flex: 1;
+                        text-align: center;
+                        padding-left: 1em;
+                        color: var(--primary);
+                        font-weight: bold;
+                    }
                 }
-
-
-                .skills-name {
-                    flex: 4;
-                }
-
-                .skills-score {
-                    flex: 1;
-                    text-align: center;
-                    padding-left: 1em;
-                    color: var(--primary);
-                    font-weight: bold;
-                }
-
             }
 
             .skills-attack {

--- a/src/styles/actor/familiar/_index.scss
+++ b/src/styles/actor/familiar/_index.scss
@@ -60,7 +60,7 @@
                     align-items: baseline;
                     text-transform: capitalize;
                     gap: 0.25em;
-                    
+
                     input {
                         font-weight: bold;
                         width: calc(100% - 6px);
@@ -81,11 +81,11 @@
                             }
                         }
                     }
-    
+
                     .charname-value {
                         flex: 1 1;
                     }
-    
+
                     .familiar-title {
                         flex: 0 1;
                         text-align: right;
@@ -152,20 +152,20 @@
                                     border: 1px solid transparent;
                                     background: none;
                                     height: auto;
-    
+
                                     &:hover, &:focus {
                                         border: 1px solid black;
                                         box-shadow: 0 0 10px #00005a;
                                     }
                                 }
-    
+
                                 .total-hp{
                                     flex-grow: 1;
                                 }
                             }
 
 
-                            
+
                             &.rollable {
                                 cursor: pointer;
                                 margin-bottom: 1px;
@@ -188,7 +188,7 @@
                             flex-direction: row;
                             justify-content: space-between;
                             padding-bottom: 1px;
-                
+
                             .saves {
                                 display: flex;
                                 flex-direction: column;
@@ -196,17 +196,17 @@
                                 column-gap: 0.5em;
                                 margin-bottom: 1px;
                                 cursor: pointer;
-                    
-                                .save-name {
+
+                                .name {
                                     font-weight: bold;
                                     text-transform: capitalize;
                                 }
-                    
-                                .save-val {
+
+                                .value {
                                     font-style: normal;
                                 }
                             }
-                
+
                             .saves:hover {
                                 margin-bottom: 0px;
                                 border-bottom: 1px solid #323232;
@@ -221,7 +221,7 @@
             display: flex;
             flex-direction: column;
             margin: 6px 6px;
-    
+
             .section-header {
                 display: flex;
                 flex: 0;
@@ -237,14 +237,14 @@
                 color: #f5efe0;
                 font-size: 0.8rem;
                 padding: 4px 8px;
-    
+
                 h4 {
                     flex: auto;
                     margin-bottom: 0px;
                     text-transform: uppercase;
                 }
             }
-    
+
             .section-body {
                 display: flex;
                 flex: auto;
@@ -256,7 +256,7 @@
                 padding: 4px;
                 border: 1px solid $primary-color;
                 border-radius: 0px 0px 3px 3px;
-                    
+
                 input {
                     font-family: var(--body-serif);
                     font-weight: bold;
@@ -288,7 +288,7 @@
                 &[type="text"] {
                     background-color: rgba(0, 0, 0, 0.05);
                 }
-    
+
                 &:focus {
                     box-shadow: none;
                 }
@@ -318,7 +318,7 @@
             .familiar-senses {
                 flex-basis: 30%;
                 height: min-content;
-                
+
                 .tags {
                     margin: 0;
                     padding: 0;
@@ -334,13 +334,13 @@
                 flex-basis: 30%;
             }
         }
-        
+
         .detail{
             display: flex;
             flex-direction: column;
             flex-wrap: nowrap;
             margin-top: 3px;
-        
+
             .detail-label {
                 font-size: var(--font-size-10);
                 font-weight: 800;
@@ -364,7 +364,7 @@
                 &[type="text"] {
                     background-color: rgba(0, 0, 0, 0.05);
                 }
-    
+
                 &:focus {
                     box-shadow: none;
                 }
@@ -398,7 +398,7 @@
             .familiar-senses {
                 flex-basis: 50%;
                 height: min-content;
-                
+
 
                 .tags {
                     margin: 0;
@@ -415,13 +415,13 @@
                 flex-basis: 30%;
             }
         }
-        
+
         .detail{
             display: flex;
             flex-direction: column;
             flex-wrap: nowrap;
             margin-top: 3px;
-        
+
             .detail-label {
                 font-size: var(--font-size-10);
                 font-weight: 800;
@@ -463,7 +463,7 @@
                 gap: 1em;
             }
         }
-        
+
         .main-section {
             display: flex;
             flex-direction: row;
@@ -481,14 +481,14 @@
             display: flex;
             flex-direction: column;
             width: 150px;
-            
+
             .skills-list {
                 display: flex;
                 column-gap: 0.25em;
                 row-gap: 0.25em;
                 flex-direction: column;
                 justify-content: center;
-                
+
                 .skills-item {
                     display: flex;
                     flex-direction: row;
@@ -500,18 +500,18 @@
                     font-size: var(--font-size-14);
 
                     font-family: var(--serif);
-                    
+
                     &:hover {
                         padding: none;
                         border: 1px solid #323232;
                     }
                 }
-                
-                
+
+
                 .skills-name {
                     flex: 4;
                 }
-        
+
                 .skills-score {
                     flex: 1;
                     text-align: center;
@@ -519,7 +519,7 @@
                     color: var(--primary);
                     font-weight: bold;
                 }
-            
+
             }
 
             .skills-attack {
@@ -541,14 +541,14 @@
             flex-wrap: wrap;
             width: 100%;
             padding: 0;
-    
+
             .separator {
                 flex: 0 0 1px;
                 height: 32px;
                 margin-right: 4px;
                 border-left: 2px solid #323232;
             }
-    
+
             > .effect {
                 display: flex;
                 flex: 0 0 64;
@@ -556,7 +556,7 @@
                 margin-right: 4px;
                 margin-bottom: 4px;
                 border-bottom: none !important;
-    
+
                 .item-image {
                     background-size: cover;
                     border: 1px solid #323232;
@@ -564,7 +564,7 @@
                     border-radius: 3px;
                     width: 64px;
                 }
-    
+
                 .item-image:hover {
                     border: 1px solid #f5efe0;
                     border-radius: 3px;
@@ -576,12 +576,12 @@
             list-style: none;
             margin: 0px;
             padding: 0px;
-            
+
             li {
                 .title-block {
                     font-style: block;
                 }
-    
+
                 .save-val {
                     font-style: italic;
                 }
@@ -589,7 +589,7 @@
 
             .familiar-ability {
                 font-style: italic;
-            }   
+            }
 
             &:nth-child(odd) {
                 background-color: rgba(0, 0, 0, 0.1);
@@ -603,7 +603,7 @@
             .item-list {
                 list-style: none;
                 padding-left: 0;
-                
+
                 .item-header {
                     display: flex;
                     flex-direction: row;
@@ -617,7 +617,7 @@
                         h4 {
                             @include p-reset;
                         }
-                        
+
                         &:hover {
                             h4 {
                                 color: var(--primary);

--- a/static/templates/actors/familiar-sheet.html
+++ b/static/templates/actors/familiar-sheet.html
@@ -67,10 +67,9 @@
                     {{#if data.master.id}}
                     <div class="saves-list">
                         {{#each data.saves}}
-                        <div class="saves saving-throw rollable" title="{{this.breakdown}}"
-                            data-saving-throw="{{@key}}">
-                            <div class="save-name">{{localize this.label}}</div>
-                            <div class="save-val">{{numberFormat this.value decimals=0 sign=true}}</div>
+                        <div class="saves save-name rollable" title="{{this.breakdown}}" data-save="{{@key}}">
+                            <div class="name">{{localize this.label}}</div>
+                            <div class="value">{{numberFormat this.value decimals=0 sign=true}}</div>
                         </div>
                         {{/each}}
                     </div>
@@ -149,7 +148,7 @@
                     <div class="familiar-content">
                         <div class="detail">
                             <div class="detail-label">{{localize "PF2E.Familiar.TotalNumberFamiliarAbilities"}}</div>
-                            <div title="{{familiarAbilities.breakdown}}">
+                            <div>
                                 <h4>{{numberFormat familiarAbilities.value decimals=0}}</h4>
                             </div>
                         </div>
@@ -201,7 +200,7 @@
                         <ol class="item-list">
                             {{#each items as |item idx|}}
                             {{#if (eq item.type "condition")}}
-                            <li class="list-row expandable" data-item-id="{{item._id}}">
+                            <li class="item list-row expandable" data-item-id="{{item._id}}">
                                 <div class="item-header">
                                     <div class="item-name">
                                         <div class="item-image" style="background-image: url({{item.img}})">
@@ -236,7 +235,7 @@
                         <ol class="item-list">
                             {{#each items as |item idx|}}
                             {{#if (eq item.type "effect")}}
-                            <li class="list-row expandable" data-item-id="{{item._id}}">
+                            <li class="item list-row expandable" data-item-id="{{item._id}}">
                                 <div class="item-header">
                                     <div class="item-name">
                                         <div class="item-image" style="background-image: url({{item.img}})">
@@ -253,9 +252,7 @@
                                     </div>
                                     {{/if}}
                                 </div>
-                                <div class="item-summary">
-                                    <p>{{{enrichHTML item.data.description.value}}}</p>
-                                </div>
+                                <div class="item-summary"></div>
                             </li>
                             {{/if}}
                             {{/each}}

--- a/static/templates/actors/familiar-sheet.html
+++ b/static/templates/actors/familiar-sheet.html
@@ -41,8 +41,7 @@
                         </div>
                         <div class="hpac-value">{{numberFormat data.attributes.ac.value decimals=0 sign=false}}</div>
                     </div>
-                    <div class="hp-ac rollable perception" title="{{data.attributes.perception.breakdown}}"
-                        data-perception-check>
+                    <div class="hp-ac rollable perception" title="{{data.attributes.perception.breakdown}}" data-action="perception-check">
                         <div class="hpac-label">
                             <i class="fas fa-eye"></i>
                             <h4>{{localize "PF2E.Familiar.Perception"}}</h4>
@@ -91,13 +90,9 @@
                         {{#if data.master.id}}
                         <div class="skills-list">
                             {{#each data.skills}}
-                            <div class="skills-item" title="{{this.breakdown}}" data-skill-check="{{@key}}">
-                                <div class="skills-score">
-                                    {{numberFormat this.value decimals=0 sign=true}}
-                                </div>
-                                <div class="skills-name">
-                                    {{localize this.label}}
-                                </div>
+                            <div class="skill-name rollable" title="{{this.breakdown}}" data-skill="{{@key}}">
+                                <div class="score">{{numberFormat this.value decimals=0 sign=true}}</div>
+                                <div class="name">{{localize this.label}}</div>
                             </div>
                             {{/each}}
                         </div>


### PR DESCRIPTION
This allows familiar sheets to prevent certain types of items from being added to it, and also piggyback off of existing sheet events.