### PR TITLE
Remove toggle from Panache class feature, add RE slugs where necessary

### DIFF
--- a/packs/data/classfeatures.db/panache.json
+++ b/packs/data/classfeatures.db/panache.json
@@ -23,39 +23,7 @@
         "prerequisites": {
             "value": []
         },
-        "rules": [
-            {
-                "domain": "all",
-                "key": "RollOption",
-                "option": "panache",
-                "toggleable": true
-            },
-            {
-                "key": "FlatModifier",
-                "predicate": {
-                    "all": [
-                        "panache"
-                    ],
-                    "any": [
-                        "action:tumble-through"
-                    ]
-                },
-                "selector": "acrobatics",
-                "type": "circumstance",
-                "value": 1
-            },
-            {
-                "key": "FlatModifier",
-                "predicate": {
-                    "all": [
-                        "panache"
-                    ]
-                },
-                "selector": "speed",
-                "type": "status",
-                "value": 5
-            }
-        ],
+        "rules": [],
         "source": {
             "value": ""
         },

--- a/packs/data/classfeatures.db/vivacious-speed.json
+++ b/packs/data/classfeatures.db/vivacious-speed.json
@@ -28,10 +28,11 @@
                 "key": "FlatModifier",
                 "predicate": {
                     "all": [
-                        "panache"
+                        "self:effect:panache"
                     ]
                 },
                 "selector": "speed",
+                "slug": "vivacious-full",
                 "type": "status",
                 "value": {
                     "brackets": [
@@ -68,20 +69,16 @@
             },
             {
                 "key": "FlatModifier",
-                "label": "Vivacious Speed (Half)",
                 "predicate": {
                     "not": [
-                        "panache"
+                        "self:effect:panache"
                     ]
                 },
                 "selector": "speed",
+                "slug": "vivacious-half",
                 "type": "status",
                 "value": {
                     "brackets": [
-                        {
-                            "end": 2,
-                            "value": 0
-                        },
                         {
                             "end": 10,
                             "start": 3,

--- a/packs/data/feature-effects.db/effect-panache.json
+++ b/packs/data/feature-effects.db/effect-panache.json
@@ -2,7 +2,7 @@
     "_id": "uBJsxCzNhje8m8jj",
     "data": {
         "description": {
-            "value": "<p>You care as much about the way you accomplish something as whether you actually accomplish it in the first place. When you perform an action with particular bravado, you can leverage this moment of verve to perform spectacular, deadly maneuvers. This state of flair is called panache, and you are either in a state of panache or you are not.</p>\n<p>Granted by @Compendium[pf2e.classfeatures.Panache]{Panache}</p>\n<p>Implemented Effects:</p>\n<ul>\n<li>Enables panache property for panache effects</li>\n<li>Sets token effect</li>\n</ul>"
+            "value": "<p>You care as much about the way you accomplish something as whether you actually accomplish it in the first place. When you perform an action with particular bravado, you can leverage this moment of verve to perform spectacular, deadly maneuvers. This state of flair is called panache, and you are either in a state of panache or you are not.</p>\n<p>Granted by @Compendium[pf2e.classfeatures.Panache]{Panache}</p>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -15,11 +15,26 @@
         },
         "rules": [
             {
-                "key": "ActiveEffectLike",
-                "mode": "override",
-                "path": "flags.pf2e.rollOptions.all.panache",
-                "priority": 10,
-                "value": true
+                "domain": "all",
+                "key": "RollOption",
+                "option": "panache"
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": {
+                    "all": [
+                        "action:tumble-through"
+                    ]
+                },
+                "selector": "acrobatics",
+                "type": "circumstance",
+                "value": 1
+            },
+            {
+                "key": "FlatModifier",
+                "selector": "speed",
+                "type": "status",
+                "value": 5
             }
         ],
         "source": {


### PR DESCRIPTION
Panache needs more cleanup in the other feats so as to not rely on a statically-set roll option, but this is a start.