### PR TITLE
Fixed: Vivacious speed class feature.

### DIFF
--- a/packs/data/classfeatures.db/vivacious-speed.json
+++ b/packs/data/classfeatures.db/vivacious-speed.json
@@ -69,6 +69,7 @@
             {
                 "key": "FlatModifier",
                 "label": "Vivacious Speed (Half)",
+		"slug": "vivacious-speed-half",
                 "predicate": {
                     "not": [
                         "panache"


### PR DESCRIPTION
 Lack of 'slug' was causing second rule to be ignored. Slug was added.