### PR TITLE
Support increment/decrement/source for conditions in the familiar sheet

### DIFF
--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -1,7 +1,7 @@
 import { SkillAbbreviation } from "@actor/creature/data";
 import { MODIFIER_TYPE, ProficiencyModifier } from "@actor/modifiers";
 import { ActorSheetDataPF2e } from "@actor/sheet/data-types";
-import { ConditionPF2e, FeatPF2e, ItemPF2e, LorePF2e, PhysicalItemPF2e, SpellcastingEntryPF2e } from "@item";
+import { FeatPF2e, ItemPF2e, LorePF2e, PhysicalItemPF2e, SpellcastingEntryPF2e } from "@item";
 import { AncestryBackgroundClassManager } from "@item/abc/manager";
 import { isSpellConsumable } from "@item/consumable/spell-consumables";
 import { ItemDataPF2e, ItemSourcePF2e, LoreData } from "@item/data";
@@ -134,11 +134,6 @@ class CharacterSheetPF2e extends CreatureSheetPF2e<CharacterPF2e> {
         // Is the character's key ability score overridden by an Active Effect?
         sheetData.data.details.keyability.singleOption = this.actor.class?.data.data.keyAbility.value.length === 1;
 
-        sheetData.data.effects = {};
-
-        sheetData.data.effects.conditions = game.pf2e.ConditionManager.getFlattenedConditions(
-            this.actor.itemTypes.condition
-        );
         // Is the stamina variant rule enabled?
         sheetData.hasStamina = game.settings.get("pf2e", "staminaVariant") > 0;
 
@@ -583,36 +578,6 @@ class CharacterSheetPF2e extends CreatureSheetPF2e<CharacterPF2e> {
             });
 
         $html.find("a[data-action=perception-check]").tooltipster({ theme: "crb-hover" });
-
-        // Decrease effect value
-        $html.find(".tab.effects .effects-list .decrement").on("click", async (event) => {
-            const actor = this.actor;
-            const target = $(event.currentTarget);
-            const parent = target.parents(".item");
-            const effect = actor.items.get(parent.attr("data-item-id") ?? "");
-            if (effect instanceof ConditionPF2e) {
-                await actor.decreaseCondition(effect);
-            }
-        });
-
-        // Increase effect value
-        $html.find(".tab.effects .effects-list .increment").on("click", async (event) => {
-            type ConditionName = "dying" | "wounded" | "doomed";
-            const actor = this.actor;
-            const target = $(event.currentTarget);
-            const parent = target.parents(".item");
-            const effect = actor?.items.get(parent.attr("data-item-id") ?? "");
-            if (effect instanceof ConditionPF2e) {
-                if (["dying", "wounded", "doomed"].includes(effect.slug)) {
-                    const condition = effect.slug as ConditionName;
-                    this.actor.increaseCondition(condition, {
-                        max: this.actor.data.data.attributes[condition].max,
-                    });
-                } else {
-                    await actor.increaseCondition(effect);
-                }
-            }
-        });
 
         $html.find("button[data-action=edit-ability-scores]").on("click", async () => {
             await new AbilityBuilderPopup(this.actor).render(true);

--- a/src/module/actor/creature/sheet.ts
+++ b/src/module/actor/creature/sheet.ts
@@ -1,5 +1,5 @@
 import { ActorSheetPF2e } from "../sheet/base";
-import { SpellPF2e, SpellcastingEntryPF2e, PhysicalItemPF2e } from "@item";
+import { SpellPF2e, SpellcastingEntryPF2e, PhysicalItemPF2e, ConditionPF2e } from "@item";
 import { CreaturePF2e } from "@actor";
 import { ErrorPF2e, fontAwesomeIcon, objectHasKey, setHasElement, tupleHasValue } from "@util";
 import { goesToEleven, ZeroToFour } from "@module/data";
@@ -71,6 +71,7 @@ export abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends Act
             rarity: CONFIG.PF2E.rarityTraits,
             attitude: CONFIG.PF2E.attitude,
             pfsFactions: CONFIG.PF2E.pfsFactions,
+            conditions: game.pf2e.ConditionManager.getFlattenedConditions(this.actor.itemTypes.condition),
         };
     }
 
@@ -286,6 +287,26 @@ export abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends Act
 
         // Spell Browser
         $html.find(".spell-browse").on("click", (event) => this.onClickBrowseSpellCompendia(event));
+
+        // Decrease effect value
+        $html.find(".effects-list .decrement").on("click", async (event) => {
+            const target = $(event.currentTarget);
+            const parent = target.parents(".item");
+            const effect = this.actor.items.get(parent.attr("data-item-id") ?? "");
+            if (effect instanceof ConditionPF2e) {
+                await this.actor.decreaseCondition(effect);
+            }
+        });
+
+        // Increase effect value
+        $html.find(".effects-list .increment").on("click", async (event) => {
+            const target = $(event.currentTarget);
+            const parent = target.parents(".item");
+            const effect = this.actor?.items.get(parent.attr("data-item-id") ?? "");
+            if (effect instanceof ConditionPF2e) {
+                await this.actor.increaseCondition(effect);
+            }
+        });
     }
 
     protected getStrikeFromDOM(target: HTMLElement): CharacterStrike | NPCStrike | null {

--- a/src/module/actor/creature/types.ts
+++ b/src/module/actor/creature/types.ts
@@ -10,6 +10,7 @@ import { CreaturePF2e } from ".";
 import { SheetOptions } from "@module/sheet/helpers";
 import { ALIGNMENTS, ALIGNMENT_TRAITS } from "./values";
 import { TraitViewData } from "@actor/data/base";
+import { FlattenedCondition } from "@system/conditions";
 
 type Alignment = SetElement<typeof ALIGNMENTS>;
 type AlignmentTrait = SetElement<typeof ALIGNMENT_TRAITS>;
@@ -73,6 +74,7 @@ interface CreatureSheetData<TActor extends CreaturePF2e = CreaturePF2e> extends 
     rarity: ConfigPF2e["PF2E"]["rarityTraits"];
     attitude: ConfigPF2e["PF2E"]["attitude"];
     pfsFactions: ConfigPF2e["PF2E"]["pfsFactions"];
+    conditions: FlattenedCondition[];
 }
 
 type SpellcastingSheetData = SpellcastingEntryData & SpellcastingEntryListData;

--- a/src/module/actor/npc/sheet.ts
+++ b/src/module/actor/npc/sheet.ts
@@ -6,7 +6,7 @@ import { NPCPF2e } from "@actor/index";
 import { NPCSkillsEditor } from "@actor/npc/skills-editor";
 import { AbilityString } from "@actor/types";
 import { ABILITY_ABBREVIATIONS, SAVE_TYPES, SKILL_DICTIONARY } from "@actor/values";
-import { ConditionPF2e, SpellcastingEntryPF2e } from "@item";
+import { SpellcastingEntryPF2e } from "@item";
 import { EffectData } from "@item/data";
 import { PhysicalItemPF2e } from "@item/physical";
 import { Size } from "@module/data";
@@ -74,7 +74,6 @@ export class NPCSheetPF2e<TActor extends NPCPF2e> extends CreatureSheetPF2e<TAct
         this.prepareSaves(sheetData.data);
         this.prepareActions(sheetData);
         sheetData.attacks = this.prepareAttacks(sheetData.data);
-        sheetData.conditions = game.pf2e.ConditionManager.getFlattenedConditions(this.actor.itemTypes.condition);
         sheetData.effectItems = sheetData.items.filter(
             (data): data is NPCSheetItemData<EffectData> => data.type === "effect"
         );
@@ -205,26 +204,6 @@ export class NPCSheetPF2e<TActor extends NPCPF2e> extends CreatureSheetPF2e<TAct
             event.preventDefault();
             const identifyCreatureData = this.getIdentifyCreatureData();
             new RecallKnowledgePopup({}, identifyCreatureData).render(true);
-        });
-
-        $html.find(".decrement").on("click", async (event) => {
-            const actor = this.actor;
-            const target = $(event.currentTarget);
-            const parent = target.parents(".item");
-            const effect = actor.items.get(parent.attr("data-item-id") ?? "");
-            if (effect instanceof ConditionPF2e) {
-                await actor.decreaseCondition(effect);
-            }
-        });
-
-        $html.find(".increment").on("click", async (event) => {
-            const actor = this.actor;
-            const $target = $(event.currentTarget);
-            const parent = $target.parents(".item");
-            const effect = actor.items.get(parent.attr("data-item-id") ?? "");
-            if (effect instanceof ConditionPF2e) {
-                await actor.increaseCondition(effect);
-            }
         });
 
         $html.find(".item-control.generate-attack").on("click", async (event) => {

--- a/src/module/actor/npc/types.ts
+++ b/src/module/actor/npc/types.ts
@@ -3,7 +3,6 @@ import { HitPointsData, PerceptionData } from "@actor/data/base";
 import { SaveType } from "@actor/types";
 import { ActionData, EffectData, ItemDataPF2e } from "@item/data";
 import { IdentifyCreatureData } from "@module/recall-knowledge";
-import { FlattenedCondition } from "@system/conditions";
 import { NPCPF2e } from ".";
 import {
     NPCArmorClass,
@@ -82,7 +81,6 @@ interface NPCSheetData<T extends NPCPF2e> extends CreatureSheetData<T> {
     data: NPCSystemSheetData;
     items: NPCSheetItemData[];
     effectItems: EffectData[];
-    conditions: FlattenedCondition[];
     spellcastingEntries: SpellcastingSheetData[];
     orphanedSpells: boolean;
     identifyCreatureData: IdentifyCreatureData;

--- a/src/scripts/register-templates.ts
+++ b/src/scripts/register-templates.ts
@@ -45,6 +45,7 @@ export function registerTemplates() {
         "systems/pf2e/templates/actors/partials/coinage.html",
         "systems/pf2e/templates/actors/partials/item-line.html",
         "systems/pf2e/templates/actors/partials/carry-type.html",
+        "systems/pf2e/templates/actors/partials/conditions.html",
         "systems/pf2e/templates/actors/crafting-entry-alchemical.html",
         "systems/pf2e/templates/actors/crafting-entry-list.html",
         "systems/pf2e/templates/actors/spellcasting-spell-list.html",

--- a/src/styles/actor/character/_effects.scss
+++ b/src/styles/actor/character/_effects.scss
@@ -5,5 +5,13 @@
 
     .effects-list {
         @include effects-list;
+
+        .item {
+            border-top: 1px solid lighten($-alt-color, 40);
+            $border-color: lighten($-alt-color, 40);
+            border: solid transparent;
+            border-width: 0 0 1px;
+            border-image: linear-gradient(90deg, #f1edea, $border-color) 1 repeat;
+        }
     }
 }

--- a/src/styles/actor/familiar/_index.scss
+++ b/src/styles/actor/familiar/_index.scss
@@ -532,44 +532,6 @@
             }
         }
 
-        .effects-list {
-            display: flex;
-            flex: 1 0 auto;
-            flex-direction: row;
-            flex-wrap: wrap;
-            width: 100%;
-            padding: 0;
-
-            .separator {
-                flex: 0 0 1px;
-                height: 32px;
-                margin-right: 4px;
-                border-left: 2px solid #323232;
-            }
-
-            > .effect {
-                display: flex;
-                flex: 0 0 64;
-                height: 64px;
-                margin-right: 4px;
-                margin-bottom: 4px;
-                border-bottom: none !important;
-
-                .item-image {
-                    background-size: cover;
-                    border: 1px solid #323232;
-                    border-bottom: 1px solid #323232;
-                    border-radius: 3px;
-                    width: 64px;
-                }
-
-                .item-image:hover {
-                    border: 1px solid #f5efe0;
-                    border-radius: 3px;
-                }
-            }
-        }
-
         ul.familiar-abilities-list {
             list-style: none;
             margin: 0px;
@@ -594,72 +556,17 @@
             }
         }
 
-        .effects {
-            .list-row {
+        .effects-list {
+            @include p-reset;
+            @include effects-list;
+
+            .item {
+                @include p-reset;
                 margin: 0.25em 0;
-            }
-            .item-list {
-                list-style: none;
-                padding-left: 0;
-
-                .item-header {
-                    display: flex;
-                    flex-direction: row;
-                    align-items: center;
-                    justify-content: space-between;
-
-                    .item-name {
-                        display: flex;
-                        align-items: center;
-                        cursor: pointer;
-                        h4 {
-                            @include p-reset;
-                        }
-
-                        &:hover {
-                            h4 {
-                                color: var(--primary);
-                            }
-                        }
-                    }
-                    .item-controls {
-                        margin-left: none;
-                    }
-                }
-            }
-
-            .list-row.expandable .item-summary {
-                display: none;
-            }
-
-            .list-row.expanded .item-summary {
-                display: inline-block;
-            }
-
-            .item-image {
-                height: 32px;
-                width: 32px;
-                background-repeat: no-repeat;
-                background-size: 32px 32px;
-                margin-right: 0.5em;
-
-                i {
-                    display: none;
-                    font-size: 2em;
-                    color: var(--primary);
-                }
-                &:hover {
-                    background: none !important;
-                    i {
-                        display: block;
-                    }
-                }
             }
 
             .item-summary {
-                font-weight: normal;
                 font-size: var(--font-size-12);
-                width: auto;
             }
         }
     }

--- a/src/styles/mixins/_effects-list.scss
+++ b/src/styles/mixins/_effects-list.scss
@@ -13,11 +13,6 @@ $-alt-color: #786452 !default;
         justify-content: space-between;
         margin-left: 8px;
         padding: 8px 4px;
-        border-top: 1px solid lighten($-alt-color, 40);
-        $border-color: lighten($-alt-color, 40);
-        border: solid transparent;
-        border-width: 0 0 1px;
-        border-image: linear-gradient(90deg, #f1edea, $border-color) 1 repeat;
         width: 100%;
 
         p:empty {
@@ -29,6 +24,10 @@ $-alt-color: #786452 !default;
             align-items: center;
             cursor: pointer;
             flex: 1;
+
+            h4 {
+                margin: 0;
+            }
 
             .item-image {
                 color: transparent;

--- a/static/templates/actors/character/tabs/effects.html
+++ b/static/templates/actors/character/tabs/effects.html
@@ -4,56 +4,7 @@
             {{> systems/pf2e/templates/actors/partials/images/header_stroke.html}}
             <h3 class="item-name">{{localize 'PF2E.ConditionsLabel'}}</h3>
         </li>
-        {{#each data.effects.conditions as |item ii|}}
-        <li class="item effects expandable" data-item-id="{{item.id}}" data-action-index="{{ii}}">
-            <div class="item-name rollable">
-                <div class="item-image" style="background-image: url({{item.img}})">
-                    <i class="fas fa-comment-alt"></i>
-                </div>
-                <h4 class="action-name">{{item.name}}{{#unless item.active}}<span> (Inactive)</span>{{/unless}}</h4>
-            </div>
-            <div class="item-controls">
-                {{#if item.value}}
-                    <a class="item-control increment" title="{{localize 'PF2E.IncrementEffectTitle'}}"><i
-                        class="fas fa-plus"></i></a>
-                    <a class="item-control decrement" title="{{localize 'PF2E.DecrementEffectTitle'}}"><i
-                        class="fas fa-minus"></i></a>
-                {{/if}}
-                <a class="item-control item-delete" title="{{localize PF2E.DeleteItemTitle}}"><i
-                        class="fas fa-trash"></i></a>
-            </div>
-            <div class="item-summary">
-                <div class="item-description">
-                    <p>{{{enrichHTML item.description}}}</p>
-                </div>
-                {{#if item.references}}
-                <div class="condition-references">
-                    {{#if item.parents.length}}
-                    <div class="condition-parents">
-                        <p>Applied From:{{#each item.parents as |parent|}} <span
-                                data-item-id="{{parent.id}}">{{{enrichHTML parent.text}}}</span>{{/each}}</p>
-                    </div>
-                    {{/if}}
-                    {{#if item.children.length}}
-                    <div class="condition-children">
-                        <p>Also Applied:{{#each item.children as |child|}} {{{enrichHTML child.text}}}{{/each}}</p>
-                    </div>
-                    {{/if}}
-                    {{#if item.overrides.length}}
-                    <div class="condition-overriding">
-                        <p>Overriding:{{#each item.overrides as |o|}} {{{enrichHTML o.text}}}{{/each}}</p>
-                    </div>
-                    {{/if}}
-                    {{#if item.overriddenBy.length}}
-                    <div class="condition-overridden">
-                        <p>Overridden by:{{#each item.overriddenBy as |o|}} {{{enrichHTML o.text}}}{{/each}}</p>
-                    </div>
-                    {{/if}}
-                </div>
-                {{/if}}
-            </div>
-        </li>
-        {{/each}}
+        {{> systems/pf2e/templates/actors/partials/conditions.html}}
 
         <li class="action-header stroke-header">
             {{> systems/pf2e/templates/actors/partials/images/header_stroke.html}}

--- a/static/templates/actors/familiar-sheet.html
+++ b/static/templates/actors/familiar-sheet.html
@@ -191,33 +191,9 @@
                     <h4>{{localize "PF2E.ConditionsLabel"}}</h4>
                 </div>
                 <div class="section-body">
-                    <div class="effects">
-                        <ol class="item-list">
-                            {{#each items as |item idx|}}
-                            {{#if (eq item.type "condition")}}
-                            <li class="item list-row expandable" data-item-id="{{item._id}}">
-                                <div class="item-header">
-                                    <div class="item-name">
-                                        <div class="item-image" style="background-image: url({{item.img}})">
-                                            <i class="fas fa-comment-alt"></i>
-                                        </div>
-                                        <h4>{{item.name}}</h4>
-                                    </div>
-                                    {{#if ../owner}}
-                                    <div class="item-controls">
-                                        <a class="item-control item-delete" title="{{localize PF2E.DeleteItemTitle}}"><i
-                                                class="fas fa-trash"></i></a>
-                                    </div>
-                                    {{/if}}
-                                </div>
-                                <div class="item-summary">
-                                    <p>{{{enrichHTML item.data.description.value}}}</p>
-                                </div>
-                            </li>
-                            {{/if}}
-                            {{/each}}
-                        </ol>
-                    </div>
+                    <ol class="effects-list item-list">
+                        {{> systems/pf2e/templates/actors/partials/conditions.html}}
+                    </ol>
                 </div>
             </div>
             <!-- EFFECTS -->
@@ -226,33 +202,29 @@
                     <h4>{{localize "PF2E.EffectsLabel"}}</h4>
                 </div>
                 <div class="section-body">
-                    <div class="effects">
-                        <ol class="item-list">
-                            {{#each items as |item idx|}}
-                            {{#if (eq item.type "effect")}}
-                            <li class="item list-row expandable" data-item-id="{{item._id}}">
-                                <div class="item-header">
-                                    <div class="item-name">
-                                        <div class="item-image" style="background-image: url({{item.img}})">
-                                            <i class="fas fa-comment-alt"></i>
-                                        </div>
-                                        <h4>{{item.name}}</h4>
+                    <ol class="effects-list item-list">
+                        {{#each items as |item idx|}}
+                        {{#if (eq item.type "effect")}}
+                            <li class="item effects" data-item-id="{{item._id}}">
+                                <div class="item-name">
+                                    <div class="item-image" style="background-image: url({{item.img}})">
+                                        <i class="fas fa-comment-alt"></i>
                                     </div>
-                                    {{#if ../owner}}
-                                    <div class="item-controls">
-                                        <a class="item-control item-edit" title="{{localize 'PF2E.EditItemTitle'}}"><i
-                                                class="fas fa-edit"></i></a>
-                                        <a class="item-control item-delete" title="{{localize PF2E.DeleteItemTitle}}"><i
-                                                class="fas fa-trash"></i></a>
-                                    </div>
-                                    {{/if}}
+                                    <h4>{{item.name}}</h4>
                                 </div>
+                                {{#if ../owner}}
+                                <div class="item-controls">
+                                    <a class="item-control item-edit" title="{{localize 'PF2E.EditItemTitle'}}"><i
+                                            class="fas fa-edit"></i></a>
+                                    <a class="item-control item-delete" title="{{localize PF2E.DeleteItemTitle}}"><i
+                                            class="fas fa-trash"></i></a>
+                                </div>
+                                {{/if}}
                                 <div class="item-summary"></div>
                             </li>
-                            {{/if}}
-                            {{/each}}
-                        </ol>
-                    </div>
+                        {{/if}}
+                        {{/each}}
+                    </ol>
                 </div>
             </div>
         </div>

--- a/static/templates/actors/npc/tabs/effects.html
+++ b/static/templates/actors/npc/tabs/effects.html
@@ -5,56 +5,7 @@
         </div>
         <div class="section-body">
             <ol class="effects-list">
-                {{#each conditions as |item ii|}}
-                <li class="item effects expandable" data-item-id="{{item.id}}" data-action-index="{{ii}}">
-                    <div class="item-name rollable">
-                        <div class="item-image" style="background-image: url({{item.img}})">
-                            <i class="fas fa-comment-alt"></i>
-                        </div>
-                        <h4 class="action-name">{{item.name}}{{#unless item.active}}<span> (Inactive)</span>{{/unless}}</h4>
-                    </div>
-                    <div class="item-controls">
-                        {{#if item.value}}
-                            <a class="item-control increment" title="{{localize 'PF2E.IncrementEffectTitle'}}"><i
-                                class="fas fa-plus"></i></a>
-                            <a class="item-control decrement" title="{{localize 'PF2E.DecrementEffectTitle'}}"><i
-                                class="fas fa-minus"></i></a>
-                        {{/if}}
-                        <a class="item-control item-delete" title="{{localize 'PF2E.DeleteItemTitle'}}"><i
-                                class="fas fa-trash"></i></a>
-                    </div>
-                    <div class="item-summary">
-                        <div class="item-description">
-                            <p>{{{enrichHTML item.description}}}</p>
-                        </div>
-                        {{#if item.references}}
-                        <div class="condition-references">
-                            {{#if item.parents.length}}
-                            <div class="condition-parents">
-                                <p>Applied From:{{#each item.parents as |parent|}} <span
-                                        data-item-id="{{parent.id}}">{{{enrichHTML parent.text}}}</span>{{/each}}</p>
-                            </div>
-                            {{/if}}
-                            {{#if item.children.length}}
-                            <div class="condition-children">
-                                <p>Also Applied:{{#each item.children as |child|}} {{{enrichHTML child.text}}}{{/each}}</p>
-                            </div>
-                            {{/if}}
-                            {{#if item.overrides.length}}
-                            <div class="condition-overriding">
-                                <p>Overriding:{{#each item.overrides as |o|}} {{{enrichHTML o.text}}}{{/each}}</p>
-                            </div>
-                            {{/if}}
-                            {{#if item.overriddenBy.length}}
-                            <div class="condition-overridden">
-                                <p>Overridden by:{{#each item.overriddenBy as |o|}} {{{enrichHTML o.text}}}{{/each}}</p>
-                            </div>
-                            {{/if}}
-                        </div>
-                        {{/if}}
-                    </div>
-                </li>
-                {{/each}}
+                {{> systems/pf2e/templates/actors/partials/conditions.html}}
             </ol>
         </div>
     </div>

--- a/static/templates/actors/partials/conditions.html
+++ b/static/templates/actors/partials/conditions.html
@@ -1,0 +1,50 @@
+{{#each conditions as |item ii|}}
+<li class="item effects expandable" data-item-id="{{item.id}}" data-action-index="{{ii}}">
+    <div class="item-name rollable">
+        <div class="item-image" style="background-image: url({{item.img}})">
+            <i class="fas fa-comment-alt"></i>
+        </div>
+        <h4 class="action-name">{{item.name}}{{#unless item.active}}<span> (Inactive)</span>{{/unless}}</h4>
+    </div>
+    <div class="item-controls">
+        {{#if item.value}}
+            <a class="item-control increment" title="{{localize 'PF2E.IncrementEffectTitle'}}"><i
+                class="fas fa-plus"></i></a>
+            <a class="item-control decrement" title="{{localize 'PF2E.DecrementEffectTitle'}}"><i
+                class="fas fa-minus"></i></a>
+        {{/if}}
+        <a class="item-control item-delete" title="{{localize PF2E.DeleteItemTitle}}"><i
+                class="fas fa-trash"></i></a>
+    </div>
+    <div class="item-summary">
+        <div class="item-description">
+            <p>{{{enrichHTML item.description}}}</p>
+        </div>
+        {{#if item.references}}
+        <div class="condition-references">
+            {{#if item.parents.length}}
+            <div class="condition-parents">
+                <p>Applied From:{{#each item.parents as |parent|}} <span
+                        data-item-id="{{parent.id}}">{{{enrichHTML parent.text}}}</span>{{/each}}</p>
+            </div>
+            {{/if}}
+            {{#if item.children.length}}
+            <div class="condition-children">
+                <p>Also Applied:{{#each item.children as |child|}} {{{enrichHTML child.text}}}{{/each}}</p>
+            </div>
+            {{/if}}
+            {{#if item.overrides.length}}
+            <div class="condition-overriding">
+                <p>Overriding:{{#each item.overrides as |o|}} {{{enrichHTML o.text}}}{{/each}}</p>
+            </div>
+            {{/if}}
+            {{#if item.overriddenBy.length}}
+            <div class="condition-overridden">
+                <p>Overridden by:{{#each item.overriddenBy as |o|}} {{{enrichHTML o.text}}}{{/each}}</p>
+            </div>
+            {{/if}}
+        </div>
+        {{/if}}
+    </div>
+</li>
+{{/each}}

--- a/static/templates/actors/partials/dying-pips.html
+++ b/static/templates/actors/partials/dying-pips.html
@@ -1,0 +1,19 @@
+<span class="pips">
+    {{#if (eq data.attributes.dying.max 0)}}
+        <i class="fas fa-skull"></i>
+    {{else if (gte data.attributes.dying.value data.attributes.dying.max)}}
+        {{#times data.attributes.dying.max}}
+            <i class="fas fa-skull"></i>
+        {{/times}}
+    {{else}}
+        {{#times data.attributes.dying.value}}
+            <i class="fas fa-times-circle"></i>
+        {{/times}}
+        {{#times (sub data.attributes.dying.max data.attributes.dying.value)}}
+            <i class="far fa-circle"></i>
+        {{/times}}
+        {{#times data.attributes.doomed.value}}
+            <i class="fas fa-skull"></i>
+        {{/times}}
+    {{/if}}
+</span>


### PR DESCRIPTION
As a side effect, this also removes the wonky looking divider border from NPC sheet, and fixes condition and effect name alignment.

This also removes character sheet condition capping for doomed/dying/wounded, but that is not only bugged but also didn't work from token hud or effect panel.