### PR TITLE
Migrate ancestry critical specialisation feats to CriticalSpecialization rule element

### DIFF
--- a/packs/data/feats.db/catfolk-weapon-rake.json
+++ b/packs/data/feats.db/catfolk-weapon-rake.json
@@ -19,7 +19,7 @@
         "level": {
             "value": 5
         },
-        "location": "",
+        "location": null,
         "prerequisites": {
             "value": [
                 {
@@ -29,239 +29,17 @@
         },
         "rules": [
             {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
+                "key": "CriticalSpecialization",
                 "predicate": {
-                    "all": [
-                        "catfolk"
+                    "any": [
+                        "weapon:trait:catfolk",
+                        "weapon:base:hatchet",
+                        "weapon:base:kama",
+                        "weapon:base:kukri",
+                        "weapon:base:scimitar",
+                        "weapon:base:sickle"
                     ]
-                },
-                "selector": "axe-weapon-group-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> Choose one creature adjacent to the initial target and within reach. If its AC is lower than your attack roll result for the critical hit, you deal damage to that creature equal to the result of the weapon damage die you rolled (including extra dice for its potency rune, if any). This amount isn't doubled, and no bonuses or other additional dice apply to this damage.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "predicate": {
-                    "all": [
-                        "catfolk"
-                    ]
-                },
-                "selector": "bomb-weapon-group-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> Increase the radius of the bomb's splash damage (if any) to 10 feet.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "predicate": {
-                    "all": [
-                        "catfolk"
-                    ]
-                },
-                "selector": "bow-weapon-group-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> If the target of the critical hit is adjacent to a surface, it gets stuck to that surface by the missile. The target is @Compendium[pf2e.conditionitems.Immobilized]{Immobilized} and must spend an Interact action to attempt a DC 10 Athletics check to pull the missile free; it can't move from its space until it succeeds. The creature doesn't become stuck if it is incorporeal, is liquid (like a water elemental or some oozes), or could otherwise escape without effort.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "predicate": {
-                    "all": [
-                        "catfolk"
-                    ]
-                },
-                "selector": "brawling-weapon-group-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> The target must succeed at a Fortitude save against your class DC or be @Compendium[pf2e.conditionitems.Slowed]{Slowed 1} until the end of your next turn.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "predicate": {
-                    "all": [
-                        "catfolk"
-                    ]
-                },
-                "selector": "club-weapon-group-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> You knock the target away from you up to 10 feet (you choose the distance). This is forced movement.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "predicate": {
-                    "all": [
-                        "catfolk"
-                    ]
-                },
-                "selector": "dart-weapon-group-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> The target takes @Localize[PF2E.PersistentDamage.Bleed1d6.success]. You gain an item bonus to this bleed damage equal to the weapon's item bonus to attack rolls.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "predicate": {
-                    "all": [
-                        "catfolk"
-                    ]
-                },
-                "selector": "flail-weapon-group-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> The target is knocked @Compendium[pf2e.conditionitems.Prone]{Prone}.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "predicate": {
-                    "all": [
-                        "catfolk"
-                    ]
-                },
-                "selector": "hammer-weapon-group-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> The target is knocked @Compendium[pf2e.conditionitems.Prone]{Prone}.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "predicate": {
-                    "all": [
-                        "catfolk"
-                    ]
-                },
-                "selector": "knife-weapon-group-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> The target takes @Localize[PF2E.PersistentDamage.Bleed1d6.success]. You gain an item bonus to this bleed damage equal to the weapon's item bonus to attack rolls.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "predicate": {
-                    "all": [
-                        "catfolk"
-                    ]
-                },
-                "selector": "pick-weapon-group-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> The weapon viciously pierces the target, who takes [[/r 2]] additional damage per weapon damage die.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "predicate": {
-                    "all": [
-                        "catfolk"
-                    ]
-                },
-                "selector": "polearm-weapon-group-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> The target is moved 5 feet in a direction of your choice. This is forced movement.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "predicate": {
-                    "all": [
-                        "catfolk"
-                    ]
-                },
-                "selector": "shield-weapon-group-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> You knock the target back from you 5 feet. This is forced movement.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "predicate": {
-                    "all": [
-                        "catfolk"
-                    ]
-                },
-                "selector": "sling-weapon-group-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> The target must succeed at a Fortitude save against your class DC or be @Compendium[pf2e.conditionitems.Stunned]{Stunned 1}.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "predicate": {
-                    "all": [
-                        "catfolk"
-                    ]
-                },
-                "selector": "spear-weapon-group-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> The weapon pierces the target, weakening its attacks. The target is @Compendium[pf2e.conditionitems.Clumsy]{Clumsy 1} until the start of your next turn.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "predicate": {
-                    "all": [
-                        "catfolk"
-                    ]
-                },
-                "selector": "sword-weapon-group-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> The target is made off-balance by your attack, becoming @Compendium[pf2e.conditionitems.Flat-Footed]{Flat-Footed} until the start of your next turn.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "hatchet-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> Choose one creature adjacent to the initial target and within reach. If its AC is lower than your attack roll result for the critical hit, you deal damage to that creature equal to the result of the weapon damage die you rolled (including extra dice for its potency rune, if any). This amount isn't doubled, and no bonuses or other additional dice apply to this damage.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "kama-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> The target takes @Localize[PF2E.PersistentDamage.Bleed1d6.success]. You gain an item bonus to this bleed damage equal to the weapon's item bonus to attack rolls.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "kukri-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> The target takes @Localize[PF2E.PersistentDamage.Bleed1d6.success]. You gain an item bonus to this bleed damage equal to the weapon's item bonus to attack rolls.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "scimitar-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> The target is made off-balance by your attack, becoming @Compendium[pf2e.conditionitems.Flat-Footed]{Flat-Footed} until the start of your next turn.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "sickle-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> The target takes @Localize[PF2E.PersistentDamage.Bleed1d6.success]. You gain an item bonus to this bleed damage equal to the weapon's item bonus to attack rolls.</p>"
+                }
             }
         ],
         "source": {

--- a/packs/data/feats.db/conrasu-weapon-understanding.json
+++ b/packs/data/feats.db/conrasu-weapon-understanding.json
@@ -29,7 +29,6 @@
                 "predicate": {
                     "any": [
                         "weapon:trait:conrasu",
-                        "weapon:base:composite-shortbow",
                         "weapon:base:glaive",
                         "weapon:base:longspear",
                         "weapon:base:longsword",

--- a/packs/data/feats.db/conrasu-weapon-understanding.json
+++ b/packs/data/feats.db/conrasu-weapon-understanding.json
@@ -19,11 +19,26 @@
         "level": {
             "value": 5
         },
-        "location": "",
+        "location": null,
         "prerequisites": {
             "value": []
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "CriticalSpecialization",
+                "predicate": {
+                    "any": [
+                        "weapon:trait:conrasu",
+                        "weapon:base:composite-shortbow",
+                        "weapon:base:glaive",
+                        "weapon:base:longspear",
+                        "weapon:base:longsword",
+                        "weapon:base:shortbow",
+                        "weapon:base:spear"
+                    ]
+                }
+            }
+        ],
         "source": {
             "value": "Pathfinder Lost Omens: The Mwangi Expanse"
         },

--- a/packs/data/feats.db/dwarven-weapon-cunning.json
+++ b/packs/data/feats.db/dwarven-weapon-cunning.json
@@ -19,6 +19,7 @@
         "level": {
             "value": 5
         },
+        "location": null,
         "prerequisites": {
             "value": [
                 {
@@ -26,7 +27,19 @@
                 }
             ]
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "CriticalSpecialization",
+                "predicate": {
+                    "any": [
+                        "weapon:trait:dwarf",
+                        "weapon:base:battle-axe",
+                        "weapon:base:pick",
+                        "weapon:base:warhammer"
+                    ]
+                }
+            }
+        ],
         "source": {
             "value": "Pathfinder Core Rulebook"
         },

--- a/packs/data/feats.db/elven-weapon-elegance.json
+++ b/packs/data/feats.db/elven-weapon-elegance.json
@@ -36,7 +36,7 @@
                         "weapon:base:longbow",
                         "weapon:base:longsword",
                         "weapon:base:rapier",
-                        "weapon:base:shortbow",
+                        "weapon:base:shortbow"
                     ]
                 }
             }

--- a/packs/data/feats.db/elven-weapon-elegance.json
+++ b/packs/data/feats.db/elven-weapon-elegance.json
@@ -34,7 +34,6 @@
                     "any": [
                         "weapon:trait:elf",
                         "weapon:base:longbow",
-                        "weapon:base:composite-longbow",
                         "weapon:base:longsword",
                         "weapon:base:rapier",
                         "weapon:base:shortbow",

--- a/packs/data/feats.db/elven-weapon-elegance.json
+++ b/packs/data/feats.db/elven-weapon-elegance.json
@@ -37,7 +37,6 @@
                         "weapon:base:longsword",
                         "weapon:base:rapier",
                         "weapon:base:shortbow",
-                        "weapon:base:composite-shortbow"
                     ]
                 }
             }

--- a/packs/data/feats.db/elven-weapon-elegance.json
+++ b/packs/data/feats.db/elven-weapon-elegance.json
@@ -27,7 +27,22 @@
                 }
             ]
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "CriticalSpecialization",
+                "predicate": {
+                    "any": [
+                        "weapon:trait:elf",
+                        "weapon:base:longbow",
+                        "weapon:base:composite-longbow",
+                        "weapon:base:longsword",
+                        "weapon:base:rapier",
+                        "weapon:base:shortbow",
+                        "weapon:base:composite-shortbow"
+                    ]
+                }
+            }
+        ],
         "source": {
             "value": "Pathfinder Core Rulebook"
         },

--- a/packs/data/feats.db/genie-weapon-flourish.json
+++ b/packs/data/feats.db/genie-weapon-flourish.json
@@ -19,7 +19,7 @@
         "level": {
             "value": 5
         },
-        "location": "",
+        "location": null,
         "prerequisites": {
             "value": [
                 {
@@ -29,62 +29,16 @@
         },
         "rules": [
             {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "falchion-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> The target is made off-balance by your attack, becoming @Compendium[pf2e.conditionitems.Flat-Footed]{Flat-Footed} until the start of your next turn.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "ranseur-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> The target is moved 5 feet in a direction of your choice. This is forced movement.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "scimitar-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> The target is made off-balance by your attack, becoming @Compendium[pf2e.conditionitems.Flat-Footed]{Flat-Footed} until the start of your next turn.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "trident-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> The weapon pierces the target, weakening its attacks. The target is @Compendium[pf2e.conditionitems.Clumsy]{Clumsy 1} until the start of your next turn.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
+                "key": "CriticalSpecialization",
                 "predicate": {
-                    "all": [
-                        "geniekin"
+                    "any": [
+                        "weapon:trait:geniekin",
+                        "weapon:base:falchion",
+                        "weapon:base:ranseur",
+                        "weapon:base:scimitar",
+                        "weapon:base:trident"
                     ]
-                },
-                "selector": "sword-weapon-group-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> The target is made off-balance by your attack, becoming @Compendium[pf2e.conditionitems.Flat-Footed]{Flat-Footed} until the start of your next turn.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "predicate": {
-                    "all": [
-                        "geniekin"
-                    ]
-                },
-                "selector": "knife-weapon-group-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> The target takes @Localize[PF2E.PersistentDamage.Bleed1d6.success]. You gain an item bonus to this bleed damage equal to the weapon's item bonus to attack rolls.</p>"
+                }
             }
         ],
         "source": {

--- a/packs/data/feats.db/gnoll-weapon-practicality.json
+++ b/packs/data/feats.db/gnoll-weapon-practicality.json
@@ -19,7 +19,7 @@
         "level": {
             "value": 5
         },
-        "location": "",
+        "location": null,
         "prerequisites": {
             "value": [
                 {
@@ -27,7 +27,21 @@
                 }
             ]
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "CriticalSpecialization",
+                "predicate": {
+                    "any": [
+                        "weapon:trait:gnoll",
+                        "weapon:base:flail",
+                        "weapon:base:khopesh",
+                        "weapon:base:mambele",
+                        "weapon:base:spear",
+                        "weapon:base:war-flail"
+                    ]
+                }
+            }
+        ],
         "source": {
             "value": "Pathfinder Lost Omens: The Mwangi Expanse"
         },

--- a/packs/data/feats.db/gnome-weapon-innovator.json
+++ b/packs/data/feats.db/gnome-weapon-innovator.json
@@ -19,6 +19,7 @@
         "level": {
             "value": 5
         },
+        "location": null,
         "prerequisites": {
             "value": [
                 {
@@ -26,7 +27,18 @@
                 }
             ]
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "CriticalSpecialization",
+                "predicate": {
+                    "any": [
+                        "weapon:trait:gnome",
+                        "weapon:base:glaive",
+                        "weapon:base:kukri"
+                    ]
+                }
+            }
+        ],
         "source": {
             "value": "Pathfinder Core Rulebook"
         },

--- a/packs/data/feats.db/goblin-weapon-frenzy.json
+++ b/packs/data/feats.db/goblin-weapon-frenzy.json
@@ -19,6 +19,7 @@
         "level": {
             "value": 5
         },
+        "location": null,
         "prerequisites": {
             "value": [
                 {
@@ -26,7 +27,16 @@
                 }
             ]
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "CriticalSpecialization",
+                "predicate": {
+                    "all": [
+                        "weapon:trait:goblin"
+                    ]
+                }
+            }
+        ],
         "source": {
             "value": "Pathfinder Core Rulebook"
         },

--- a/packs/data/feats.db/grippli-weapon-innovator.json
+++ b/packs/data/feats.db/grippli-weapon-innovator.json
@@ -19,7 +19,7 @@
         "level": {
             "value": 5
         },
-        "location": "",
+        "location": null,
         "prerequisites": {
             "value": [
                 {
@@ -27,7 +27,21 @@
                 }
             ]
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "CriticalSpecialization",
+                "predicate": {
+                    "any": [
+                        "weapon:trait:grippli",
+                        "weapon:base:blowgun",
+                        "weapon:base:hatchet",
+                        "weapon:base:scythe",
+                        "weapon:base:shortbow",
+                        "weapon:base:composite-shortbow"
+                    ]
+                }
+            }
+        ],
         "source": {
             "value": "Pathfinder Lost Omens: The Mwangi Expanse"
         },

--- a/packs/data/feats.db/grippli-weapon-innovator.json
+++ b/packs/data/feats.db/grippli-weapon-innovator.json
@@ -36,7 +36,7 @@
                         "weapon:base:blowgun",
                         "weapon:base:hatchet",
                         "weapon:base:scythe",
-                        "weapon:base:shortbow",
+                        "weapon:base:shortbow"
                     ]
                 }
             }

--- a/packs/data/feats.db/grippli-weapon-innovator.json
+++ b/packs/data/feats.db/grippli-weapon-innovator.json
@@ -37,7 +37,6 @@
                         "weapon:base:hatchet",
                         "weapon:base:scythe",
                         "weapon:base:shortbow",
-                        "weapon:base:composite-shortbow"
                     ]
                 }
             }

--- a/packs/data/feats.db/halfling-weapon-trickster.json
+++ b/packs/data/feats.db/halfling-weapon-trickster.json
@@ -19,6 +19,7 @@
         "level": {
             "value": 5
         },
+        "location": null,
         "prerequisites": {
             "value": [
                 {
@@ -26,7 +27,18 @@
                 }
             ]
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "CriticalSpecialization",
+                "predicate": {
+                    "any": [
+                        "weapon:trait:halfling",
+                        "weapon:base:shortsword",
+                        "weapon:base:sling"
+                    ]
+                }
+            }
+        ],
         "source": {
             "value": "Pathfinder Core Rulebook"
         },

--- a/packs/data/feats.db/hobgoblin-weapon-discipline.json
+++ b/packs/data/feats.db/hobgoblin-weapon-discipline.json
@@ -19,7 +19,7 @@
         "level": {
             "value": 5
         },
-        "location": "",
+        "location": null,
         "prerequisites": {
             "value": [
                 {
@@ -27,7 +27,18 @@
                 }
             ]
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "CriticalSpecialization",
+                "predicate": {
+                    "any": [
+                        "weapon:group:polearm",
+                        "weapon:group:spear",
+                        "weapon:group:sword"
+                    ]
+                }
+            }
+        ],
         "source": {
             "value": "Pathfinder Lost Omens: Character Guide"
         },

--- a/packs/data/feats.db/kobold-weapon-innovator.json
+++ b/packs/data/feats.db/kobold-weapon-innovator.json
@@ -19,7 +19,7 @@
         "level": {
             "value": 5
         },
-        "location": "",
+        "location": null,
         "prerequisites": {
             "value": [
                 {
@@ -27,7 +27,21 @@
                 }
             ]
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "CriticalSpecialization",
+                "predicate": {
+                    "any": [
+                        "weapon:trait:kobold",
+                        "weapon:base:crossbow",
+                        "weapon:base:greatpick",
+                        "weapon:base:light-pick",
+                        "weapon:base:pick",
+                        "weapon:base:spear"
+                    ]
+                }
+            }
+        ],
         "source": {
             "value": "Pathfinder Lost Omens: Ancestry Guide"
         },

--- a/packs/data/feats.db/orc-weapon-carnage.json
+++ b/packs/data/feats.db/orc-weapon-carnage.json
@@ -19,7 +19,7 @@
         "level": {
             "value": 5
         },
-        "location": "",
+        "location": null,
         "prerequisites": {
             "value": [
                 {
@@ -29,215 +29,14 @@
         },
         "rules": [
             {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "falchion-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> The target is made off-balance by your attack, becoming @Compendium[pf2e.conditionitems.Flat-Footed]{Flat-Footed} until the start of your next turn.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "greataxe-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> Choose one creature adjacent to the initial target and within reach. If its AC is lower than your attack roll result for the critical hit, you deal damage to that creature equal to the result of the weapon damage die you rolled (including extra dice for its potency rune, if any). This amount isn't doubled, and no bonuses or other additional dice apply to this damage.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
+                "key": "CriticalSpecialization",
                 "predicate": {
                     "any": [
-                        "orc"
+                        "weapon:trait:orc",
+                        "weapon:group:falchion",
+                        "weapon:group:greataxe"
                     ]
-                },
-                "selector": "axe-weapon-group-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> Choose one creature adjacent to the initial target and within reach. If its AC is lower than your attack roll result for the critical hit, you deal damage to that creature equal to the result of the weapon damage die you rolled (including extra dice for its potency rune, if any). This amount isn't doubled, and no bonuses or other additional dice apply to this damage.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "predicate": {
-                    "any": [
-                        "orc"
-                    ]
-                },
-                "selector": "bomb-weapon-group-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> Increase the radius of the bomb's splash damage (if any) to 10 feet.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "predicate": {
-                    "any": [
-                        "orc"
-                    ]
-                },
-                "selector": "bow-weapon-group-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> If the target of the critical hit is adjacent to a surface, it gets stuck to that surface by the missile. The target is @Compendium[pf2e.conditionitems.Immobilized]{Immobilized} and must spend an Interact action to attempt a DC 10 Athletics check to pull the missile free; it can't move from its space until it succeeds. The creature doesn't become stuck if it is incorporeal, is liquid (like a water elemental or some oozes), or could otherwise escape without effort.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "predicate": {
-                    "any": [
-                        "orc"
-                    ]
-                },
-                "selector": "brawling-weapon-group-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> The target must succeed at a Fortitude save against your class DC or be @Compendium[pf2e.conditionitems.Slowed]{Slowed 1} until the end of your next turn.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "predicate": {
-                    "any": [
-                        "orc"
-                    ]
-                },
-                "selector": "club-weapon-group-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> You knock the target away from you up to 10 feet (you choose the distance). This is forced movement.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "predicate": {
-                    "any": [
-                        "orc"
-                    ]
-                },
-                "selector": "dart-weapon-group-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> The target takes [[/r {1d6}[persistent,bleed] # Critical Specialization]] @Compendium[pf2e.conditionitems.Persistent Damage]{Persistent Bleed Damage}. You gain an item bonus to this bleed damage equal to the weapon's item bonus to attack rolls.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "predicate": {
-                    "any": [
-                        "orc"
-                    ]
-                },
-                "selector": "flail-weapon-group-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> The target is knocked @Compendium[pf2e.conditionitems.Prone]{Prone}.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "predicate": {
-                    "any": [
-                        "orc"
-                    ]
-                },
-                "selector": "hammer-weapon-group-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> The target is knocked @Compendium[pf2e.conditionitems.Prone]{Prone}.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "predicate": {
-                    "any": [
-                        "orc"
-                    ]
-                },
-                "selector": "knife-weapon-group-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> The target takes [[/r {1d6}[persistent,bleed] # Critical Specialization]] @Compendium[pf2e.conditionitems.Persistent Damage]{Persistent Bleed Damage}. You gain an item bonus to this bleed damage equal to the weapon's item bonus to attack rolls.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "predicate": {
-                    "any": [
-                        "orc"
-                    ]
-                },
-                "selector": "pick-weapon-group-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> The weapon viciously pierces the target, who takes 2 additional damage per weapon damage die.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "predicate": {
-                    "any": [
-                        "orc"
-                    ]
-                },
-                "selector": "polearm-weapon-group-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> The target is moved 5 feet in a direction of your choice. This is forced movement.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "predicate": {
-                    "any": [
-                        "orc"
-                    ]
-                },
-                "selector": "shield-weapon-group-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> You knock the target back from you 5 feet. This is forced movement.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "predicate": {
-                    "any": [
-                        "orc"
-                    ]
-                },
-                "selector": "sling-weapon-group-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> The target must succeed at a Fortitude save against your class DC or be @Compendium[pf2e.conditionitems.Stunned]{Stunned 1}.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "predicate": {
-                    "any": [
-                        "orc"
-                    ]
-                },
-                "selector": "spear-weapon-group-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> The weapon pierces the target, weakening its attacks. The target is @Compendium[pf2e.conditionitems.Clumsy]{Clumsy 1} until the start of your next turn.</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "predicate": {
-                    "any": [
-                        "orc"
-                    ]
-                },
-                "selector": "sword-weapon-group-damage",
-                "text": "<p class='compact-text'><strong>Critical Specialization</strong> The target is made off-balance by your attack, becoming @Compendium[pf2e.conditionitems.Flat-Footed]{Flat-Footed} until the start of your next turn.</p>"
+                }
             }
         ],
         "source": {

--- a/packs/data/feats.db/vanths-weapon-execution.json
+++ b/packs/data/feats.db/vanths-weapon-execution.json
@@ -34,7 +34,6 @@
                     "any": [
                         "weapon:base:bo-staff",
                         "weapon:base:longbow",
-                        "weapon:base:composite-longbow",
                         "weapon:base:scythe",
                         "weapon:base:staff"
                     ]

--- a/packs/data/feats.db/vanths-weapon-execution.json
+++ b/packs/data/feats.db/vanths-weapon-execution.json
@@ -29,44 +29,16 @@
         },
         "rules": [
             {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "staff-damage",
-                "text": "﻿<p class='compact-text'>@Localize[PF2E.WeaponDescriptionClub]</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "bo-staff-damage",
-                "text": "﻿<p class='compact-text'>@Localize[PF2E.WeaponDescriptionClub]</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "longbow-damage",
-                "text": "﻿<p class='compact-text'>@Localize[PF2E.WeaponDescriptionBow]</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "composite-longbow-damage",
-                "text": "﻿<p class='compact-text'>@Localize[PF2E.WeaponDescriptionBow]</p>"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "sycthe-damage",
-                "text": "<p class='compact-text'>@Localize[PF2E.WeaponDescriptionPolearm]</p>"
+                "key": "CriticalSpecialization",
+                "predicate": {
+                    "any": [
+                        "weapon:base:bo-staff",
+                        "weapon:base:longbow",
+                        "weapon:base:composite-longbow",
+                        "weapon:base:scythe",
+                        "weapon:base:staff"
+                    ]
+                }
             }
         ],
         "source": {


### PR DESCRIPTION
Missing tengu, as they're complex and need a choice set