### PR TITLE
Fix display of traits and IWR on vehicle sheet

### DIFF
--- a/src/module/actor/vehicle/sheet.ts
+++ b/src/module/actor/vehicle/sheet.ts
@@ -1,7 +1,6 @@
 import { ActorSheetPF2e } from "../sheet/base";
 import { VehiclePF2e } from "@actor/vehicle";
 import { ItemDataPF2e } from "@item/data";
-import { VehicleTrait } from "./data";
 import { isPhysicalData } from "@item/data/helpers";
 import { PhysicalItemPF2e } from "@item";
 
@@ -23,28 +22,11 @@ export class VehicleSheetPF2e extends ActorSheetPF2e<VehiclePF2e> {
     override async getData() {
         const sheetData: any = await super.getData();
 
-        // update properties
         sheetData.actorSizes = CONFIG.PF2E.actorSizes;
         sheetData.actorSize = sheetData.actorSizes[sheetData.data.traits.size.value];
 
         sheetData.actorRarities = CONFIG.PF2E.rarityTraits;
         sheetData.actorRarity = sheetData.actorRarities[sheetData.data.traits.rarity];
-        sheetData.isNotCommon = sheetData.data.traits.rarity !== "common";
-
-        // Update broken threshold
-        if (sheetData.data.attributes !== undefined) {
-            sheetData.data.attributes.hp.brokenThreshold = Math.floor(sheetData.data.attributes.hp.max / 2);
-        }
-
-        // Update save labels
-        sheetData.data.saves.fortitude.label = CONFIG.PF2E.saves["fortitude"];
-        sheetData.data.traits.traits.selected = sheetData.data.traits.traits.value.reduce(
-            (traits: { [K in VehicleTrait]?: string }, trait: VehicleTrait) => ({
-                ...traits,
-                [trait]: CONFIG.PF2E.vehicleTraits[trait],
-            }),
-            {}
-        );
 
         this.prepareItems(sheetData);
 

--- a/src/scripts/config/traits.ts
+++ b/src/scripts/config/traits.ts
@@ -670,7 +670,11 @@ const hazardTraits = {
 };
 
 const vehicleTraits = {
+    ...magicSchools,
+    artifact: "PF2E.TraitArtifact",
+    clockwork: "PF2E.TraitClockwork",
     magical: "PF2E.TraitMagical",
+    teleportation: "PF2E.TraitTeleportation",
 };
 
 export {

--- a/src/styles/actor/vehicle/_index.scss
+++ b/src/styles/actor/vehicle/_index.scss
@@ -14,6 +14,7 @@ aside .sidebar {
     .hitpoints .container {
         display: grid;
     }
+
     .armor-class {
         grid: "ac hardness" 1fr;
 
@@ -23,6 +24,10 @@ aside .sidebar {
         .hardness {
             background: url(../assets/sheet/shield-red.webp) no-repeat top center;
         }
+    }
+
+    li.tag {
+        font-size: var(--font-size-10);
     }
 }
 

--- a/src/styles/ui/_tags.scss
+++ b/src/styles/ui/_tags.scss
@@ -4,6 +4,7 @@
     gap: 2px;
     list-style-type: none;
     margin-bottom: 2px;
+    padding-left: 0;
 
     .tag, .tag option {
         @include micro;

--- a/static/templates/actors/vehicle/sidebar/vehicle-resistances.html
+++ b/static/templates/actors/vehicle/sidebar/vehicle-resistances.html
@@ -1,56 +1,41 @@
 <div class="sidebar_title">
-    <h2>{{localize 'PF2E.ResistancesLabel'}}</h2>
+    <h2>{{localize "PF2E.ResistancesLabel"}}</h2>
 </div>
-
 <ol class="resistances tags">
-    {{#each data.traits.dr.selected as |v k|}}
-    <li class="tag tag_secondary {{k}}">
-        {{v}}
-    </li>
+    {{#each data.traits.dr as |resistance|}}
+        <li class="tag tag_secondary" data-slug="{{resistance.type}}">{{localize resistance.label}} {{resistance.value}}</li>
     {{/each}}
-    {{#if owner}}
-    <li class="tag edit-btn">
-        <a class="crb-trait-selector" data-trait-selector="resistances">
-            {{> systems/pf2e/templates/actors/character/icons/plus.html}}
-        </a>
-    </li>
+    {{#if options.editable}}
+        <li class="tag edit-btn">
+            <a class="crb-trait-selector" data-trait-selector="resistances">
+                {{> "systems/pf2e/templates/actors/character/icons/plus.html"}}
+            </a>
+        </li>
     {{/if}}
 </ol>
-
-<div class="sidebar_title">
-    <h2>{{localize 'PF2E.WeaknessesLabel'}}</h2>
-</div>
-
+<div class="sidebar_title"><h2>{{localize "PF2E.WeaknessesLabel"}}</h2></div>
 <ol class="weaknesses tags">
-    {{#each data.traits.dv.selected as |v k|}}
-    <li class="tag tag_secondary {{k}}">
-        {{v}}
-    </li>
+    {{#each data.traits.dv as |weakness|}}
+        <li class="tag tag_secondary" data-slug="{{weakness.type}}">{{localize weakness.label}} {{weakness.value}}</li>
     {{/each}}
-    {{#if owner}}
-    <li class="tag edit-btn">
-        <a class="crb-trait-selector" data-trait-selector="weaknesses">
-            {{> systems/pf2e/templates/actors/character/icons/plus.html}}
-        </a>
-    </li>
+    {{#if options.editable}}
+        <li class="tag edit-btn">
+            <a class="crb-trait-selector" data-trait-selector="weaknesses">
+                {{> "systems/pf2e/templates/actors/character/icons/plus.html"}}
+            </a>
+        </li>
     {{/if}}
 </ol>
-
-<div class="sidebar_title">
-    <h2>{{localize 'PF2E.ImmunitiesLabel'}}</h2>
-</div>
-
+<div class="sidebar_title"><h2>{{localize "PF2E.ImmunitiesLabel"}}</h2></div>
 <ol class="immunities tags">
-    {{#each data.traits.di.selected as |v k|}}
-    <li class="tag tag_secondary {{k}}">
-        {{localize v}}
-    </li>
+    {{#each immunities as |trait|}}
+        <li class="tag tag_secondary" data-slug="{{trait.value}}">{{trait.label}}</li>
     {{/each}}
-    {{#if owner}}
-    <li class="tag edit-btn">
-        <a class="crb-trait-selector" data-trait-selector="basic" data-title="PF2E.ImmunitiesLabel" data-config-types="immunityTypes" data-property="data.traits.di">
-            {{> systems/pf2e/templates/actors/character/icons/plus.html}}
-        </a>
-    </li>
+    {{#if options.editable}}
+        <li class="tag edit-btn">
+            <a class="crb-trait-selector" data-trait-selector="basic" data-title="PF2E.ImmunitiesLabel" data-config-types="immunityTypes" data-property="data.traits.di">
+                {{> "systems/pf2e/templates/actors/character/icons/plus.html"}}
+            </a>
+        </li>
     {{/if}}
 </ol>

--- a/static/templates/actors/vehicle/sidebar/vehicle-saves.html
+++ b/static/templates/actors/vehicle/sidebar/vehicle-saves.html
@@ -1,20 +1,16 @@
 <div class="sidebar_title">
-  <h2>{{localize 'PF2E.SavesHeader'}}</h2>
+    <h2>{{localize "PF2E.SavesHeader"}}</h2>
 </div>
 <ul class="sidebar-saves">
-  {{#each data.saves as |save sid|}}
-  <li class="roll-data" data-save="{{sid}}">
-
-    <h2 class="sidebar_label">{{localize save.label}}</h2>
-
-    <div class="save-roll" title="{{localize save.label}}">
-      {{#if ../owner}}
-      <a class="roll-icon save-name">
-        {{> systems/pf2e/templates/actors/character/icons/d20.html}}
-      </a>
-      {{/if}}
-      <input name="data.saves.{{sid}}.value" type="number" value="{{save.value}}" data-dtype="Number" placeholder="0" />
-    </div>
-  </li>
-  {{/each}}
+    <li class="roll-data" data-save="fortitude">
+        <h2 class="sidebar_label">{{localize "PF2E.SavesFortitude"}}</h2>
+        <div class="save-roll">
+            {{#if options.editable}}
+                <a class="roll-icon save-name">
+                    {{> systems/pf2e/templates/actors/character/icons/d20.html}}
+                </a>
+            {{/if}}
+            <input name="data.saves.fortitude.value" type="number" value="{{data.saves.fortitude.value}}" placeholder="0" />
+        </div>
+    </li>
 </ul>

--- a/static/templates/actors/vehicle/vehicle-header.html
+++ b/static/templates/actors/vehicle/vehicle-header.html
@@ -4,20 +4,18 @@
             <input name="name" type="text" value="{{actor.name}}" placeholder="{{localize "PF2E.CharacterNamePlaceholder"}}" />
         </h1>
         <div class="traits-bar">
-            {{#if isNotCommon}}
-                <span class="trait {{data.traits.rarity}}">{{localize actorRarity}}</span>
-            {{/if}}
+            {{#unless (eq data.traits.rarity "common")}}
+                <span class="trait {{data.traits.rarity}}" data-trait="{{data.traits.rarity}}">{{localize actorRarity}}</span>
+            {{/unless}}
             <span class="trait size">{{localize actorSize}}</span>
-            {{#each actor.data.traits.traits.selected as |trait id|}}
-                <span class="trait">{{localize trait}}</span>
+            {{#each traits as |trait|}}
+                <span class="trait" data-trait="{{trait.value}}">{{trait.label}}</span>
             {{/each}}
         </div>
     </div>
     <div class="char-level">
         <div class="level">
-            <label>
-                {{localize "PF2E.vehicle.VehicleLevelLabel"}}
-            </label>
+            <label>{{localize "PF2E.vehicle.VehicleLevelLabel"}}</label>
             <input name="data.details.level.value" type="number" value="{{data.details.level.value}}" placeholder="1" size="2" />
         </div>
     </div>


### PR DESCRIPTION
Also remove extraneous bits from VehicleSheetPF2e#getData and add traits needed for published vehicles

Closes #2630

Before:
![Screenshot from 2022-06-22 23-16-41](https://user-images.githubusercontent.com/106829671/175208254-0d79955b-1112-4dc0-9f8c-a91089cba4c7.png)

After:
![Screenshot from 2022-06-22 23-17-16](https://user-images.githubusercontent.com/106829671/175208273-4a81b3ac-de75-4b69-bf3b-302290c8ad83.png)

