### PR TITLE
Refine roll-option toggle disabling with disabledValue property

### DIFF
--- a/packs/data/feats.db/game-hunter-dedication.json
+++ b/packs/data/feats.db/game-hunter-dedication.json
@@ -42,8 +42,8 @@
             },
             {
                 "domain": "all",
-                "enabledIf": {
-                    "all": [
+                "disabledIf": {
+                    "not": [
                         "hunted-prey"
                     ]
                 },

--- a/packs/data/feats.db/triple-shot.json
+++ b/packs/data/feats.db/triple-shot.json
@@ -30,8 +30,8 @@
         "rules": [
             {
                 "domain": "ranged-attack-roll",
-                "enabledIf": {
-                    "all": [
+                "disabledIf": {
+                    "not": [
                         "double-shot"
                     ]
                 },


### PR DESCRIPTION
If a roll option toggle is disabled due to its `disabledIf` predicate failing, an additional `disabledValue` property (defaults to false) can control whether the roll option is still active when toggled on but disabled