### PR TITLE
Automate lizardfolk feats

### DIFF
--- a/packs/data/feat-effects.db/effect-guided-by-the-stars.json
+++ b/packs/data/feat-effects.db/effect-guided-by-the-stars.json
@@ -1,0 +1,100 @@
+{
+    "_id": "raLQ458uiyd3lI2K",
+    "data": {
+        "badge": null,
+        "description": {
+            "value": "<p>You roll twice and take the better result on your next skill check or saving throw. If it's night and you can see the stars, you gain a +1 circumstance bonus to the triggering roll.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 0
+        },
+        "level": {
+            "value": 1
+        },
+        "rules": [
+            {
+                "choices": [
+                    {
+                        "label": "Skill",
+                        "value": "skill-check"
+                    },
+                    {
+                        "label": "Save",
+                        "value": "saving-throw"
+                    }
+                ],
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.GuidedByTheStars.Prompt",
+                "rollOption": "guided-by-the-stars"
+            },
+            {
+                "keep": "higher",
+                "key": "RollTwice",
+                "predicate": {
+                    "all": [
+                        "guided-by-the-stars:skill-check"
+                    ]
+                },
+                "removeAfterRoll": "True",
+                "selector": "skill-check"
+            },
+            {
+                "keep": "higher",
+                "key": "RollTwice",
+                "predicate": {
+                    "all": [
+                        "guided-by-the-stars:saving-throw"
+                    ]
+                },
+                "removeAfterRoll": "True",
+                "selector": "saving-throw"
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": {
+                    "all": [
+                        "night-time",
+                        "can-see-stars"
+                    ]
+                },
+                "selector": "skill-check",
+                "type": "circumstance",
+                "value": 1
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": {
+                    "all": [
+                        "night-time",
+                        "can-see-stars"
+                    ]
+                },
+                "selector": "saving-throw",
+                "type": "circumstance",
+                "value": 1
+            }
+        ],
+        "source": {
+            "value": "Pathfinder Lost Omens: Ancestry Guide"
+        },
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "target": null,
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        }
+    },
+    "img": "systems/pf2e/icons/spells/guiding-star.webp",
+    "name": "Effect: Guided by the Stars",
+    "type": "effect"
+}

--- a/packs/data/feat-effects.db/effect-shed-tail.json
+++ b/packs/data/feat-effects.db/effect-shed-tail.json
@@ -1,0 +1,50 @@
+{
+    "_id": "OK7zMlYy25JciBp6",
+    "data": {
+        "badge": null,
+        "description": {
+            "value": "<p>You take a -2 circumstance penalty on checks to Balance.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "days",
+            "value": 7
+        },
+        "level": {
+            "value": 1
+        },
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "predicate": {
+                    "all": [
+                        "action:balance"
+                    ]
+                },
+                "selector": "acrobatics",
+                "type": "circumstance",
+                "value": -2
+            }
+        ],
+        "source": {
+            "value": "Pathfinder Lost Omens: Character Guide"
+        },
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "target": null,
+        "tokenIcon": {
+            "show": false
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        }
+    },
+    "img": "systems/pf2e/icons/unarmed-attacks/tail.webp",
+    "name": "Effect: Shed Tail",
+    "type": "effect"
+}

--- a/packs/data/feats.db/envenom-fangs.json
+++ b/packs/data/feats.db/envenom-fangs.json
@@ -11,7 +11,7 @@
             "value": 1
         },
         "description": {
-            "value": "<p><strong>Frequency</strong> a number of times per day equal to your level</p>\n<hr />\n<p>You envenom your fangs. If the next fangs Strike you make before the end of your next turn hits and deals damage, the Strike deals an additional 1d6 poison damage. On a critical failure, the poison is wasted as normal.</p>"
+            "value": "<p><strong>Frequency</strong> a number of times per day equal to your level</p>\n<hr />\n<p>You envenom your fangs. If the next fangs Strike you make before the end of your next turn hits and deals damage, the Strike deals an additional [[/r {1d6}[poison]]]{1d6 poison damage}. On a critical failure, the poison is wasted as normal.</p>"
         },
         "featType": {
             "value": "ancestry"
@@ -19,6 +19,7 @@
         "level": {
             "value": 5
         },
+        "location": null,
         "prerequisites": {
             "value": [
                 {

--- a/packs/data/feats.db/geckos-grip.json
+++ b/packs/data/feats.db/geckos-grip.json
@@ -19,6 +19,7 @@
         "level": {
             "value": 5
         },
+        "location": null,
         "prerequisites": {
             "value": [
                 {
@@ -26,7 +27,13 @@
                 }
             ]
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "BaseSpeed",
+                "selector": "climb",
+                "value": 15
+            }
+        ],
         "source": {
             "value": "Pathfinder Lost Omens: Character Guide"
         },

--- a/packs/data/feats.db/lizardfolk-lore.json
+++ b/packs/data/feats.db/lizardfolk-lore.json
@@ -19,10 +19,24 @@
         "level": {
             "value": 1
         },
+        "location": null,
         "prerequisites": {
             "value": []
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "data.skills.nat.rank",
+                "value": 1
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "data.skills.sur.rank",
+                "value": 1
+            }
+        ],
         "source": {
             "value": "Pathfinder Lost Omens: Character Guide"
         },

--- a/packs/data/feats.db/parthenogenic-hatchling.json
+++ b/packs/data/feats.db/parthenogenic-hatchling.json
@@ -11,7 +11,7 @@
             "value": null
         },
         "description": {
-            "value": "<p>You were hatched from an unfertilized egg during hard times for your people, and you are a biological copy of your mother. You gain a +1 circumstance bonus to saving throws against diseases. Each of your successful saving throws against a disease reduces its stage by 2, or by 1 for a virulent disease. Each critical success against an ongoing disease reduces its stage by 3, or by 2 for a virulent disease. You take damage only every 2 hours from thirst and every 2 days from starvation, rather than every hour and every day.</p>"
+            "value": "<p>You were hatched from an unfertilized egg during hard times for your people, and you are a biological copy of your mother.</p>\n<p>You gain a +1 circumstance bonus to saving throws against diseases. Each of your successful saving throws against a disease reduces its stage by 2, or by 1 for a virulent disease. Each critical success against an ongoing disease reduces its stage by 3, or by 2 for a virulent disease.</p>\n<p>You take damage only every 2 hours from thirst and every 2 days from starvation, rather than every hour and every day.</p>"
         },
         "featType": {
             "value": "ancestry"
@@ -19,10 +19,23 @@
         "level": {
             "value": 1
         },
+        "location": null,
         "prerequisites": {
             "value": []
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "Note",
+                "predicate": {
+                    "all": [
+                        "disease"
+                    ]
+                },
+                "selector": "saving-throw",
+                "text": "@Localize[PF2E.SpecificRule.Lizardfolk.ParthenogenicHatchling.Note]",
+                "title": "{item|name}"
+            }
+        ],
         "source": {
             "value": "Pathfinder Lost Omens: Character Guide"
         },

--- a/packs/data/feats.db/razor-claws.json
+++ b/packs/data/feats.db/razor-claws.json
@@ -19,7 +19,7 @@
         "level": {
             "value": 1
         },
-        "location": "",
+        "location": null,
         "prerequisites": {
             "value": []
         },
@@ -30,6 +30,17 @@
                     "dieSize": "d6"
                 },
                 "selector": "claw-damage"
+            },
+            {
+                "definition": {
+                    "all": [
+                        "weapon:claw"
+                    ]
+                },
+                "key": "AdjustStrike",
+                "mode": "add",
+                "property": "weapon-traits",
+                "value": "versatile-p"
             }
         ],
         "source": {

--- a/packs/data/feats.db/read-the-stars.json
+++ b/packs/data/feats.db/read-the-stars.json
@@ -11,7 +11,7 @@
             "value": null
         },
         "description": {
-            "value": "<p>You're incredibly skilled in iruxi astrology, and you can gain useful (if cryptic) hints from the stars' alignment. Once per night, if you can clearly see the stars, you can spend 1 hour reading the heavens to see how they relate to a particular goal, event, or activity that will occur within 1 week. The GM rolls a secret check, either a DC 28 Astrology Lore check or a DC 32 Occultism check. On a success, you learn a cryptic clue or piece of advice that could help with the chosen event, and on a critical failure, you learn a misleading cryptic clue or piece of advice.</p>"
+            "value": "<p>You're incredibly skilled in iruxi astrology, and you can gain useful (if cryptic) hints from the stars' alignment. Once per night, if you can clearly see the stars, you can spend 1 hour reading the heavens to see how they relate to a particular goal, event, or activity that will occur within 1 week. The GM rolls a secret check, either a @Check[type:astrology-lore|dc:28|traits:secret] check or a @Check[type:occultism|dc:32|traits:secret] check. On a success, you learn a cryptic clue or piece of advice that could help with the chosen event, and on a critical failure, you learn a misleading cryptic clue or piece of advice.</p>"
         },
         "featType": {
             "value": "ancestry"
@@ -19,7 +19,7 @@
         "level": {
             "value": 9
         },
-        "location": "",
+        "location": null,
         "prerequisites": {
             "value": [
                 {

--- a/packs/data/feats.db/reptile-rider.json
+++ b/packs/data/feats.db/reptile-rider.json
@@ -11,7 +11,7 @@
             "value": null
         },
         "description": {
-            "value": "<p>To you, crocodilians, giant lizards, and dinosaurs are loyal steeds, not monsters. You gain the @Compendium[pf2e.feats-srd.Ride]{Ride} feat, even if you don't meet the prerequisites. You gain a +1 circumstance bonus to Nature checks to Handle an Animal as long as the animal is a reptile, dinosaur, or even a non-sapient dragon.</p>"
+            "value": "<p>To you, crocodilians, giant lizards, and dinosaurs are loyal steeds, not monsters. You gain the @Compendium[pf2e.feats-srd.Ride]{Ride} feat, even if you don't meet the prerequisites. You gain a +1 circumstance bonus to Nature checks to Handle an Animal as long as the animal is a reptile, dinosaur, or even a non-sapient dragon.</p>\n<hr />\n<p><em><strong>Note</strong> This feat refers to Nature checks to Handle an Animal. This check does not exist in Pathfinder 2, and so the feat instead gives a bonus to Nature checks to @Compendium[pf2e.actionspf2e.Command an Animal]{Command an Animal}. </em></p>"
         },
         "featType": {
             "value": "ancestry"
@@ -19,7 +19,7 @@
         "level": {
             "value": 1
         },
-        "location": "",
+        "location": null,
         "prerequisites": {
             "value": []
         },
@@ -27,6 +27,24 @@
             {
                 "key": "GrantItem",
                 "uuid": "Compendium.pf2e.feats-srd.Ride"
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": {
+                    "all": [
+                        "action:command-an-animal",
+                        {
+                            "or": [
+                                "target:tag:reptile",
+                                "target:trait:dinosaur",
+                                "target:tag:non-sapient-dragon"
+                            ]
+                        }
+                    ]
+                },
+                "selector": "nature",
+                "type": "circumstance",
+                "value": 1
             }
         ],
         "source": {

--- a/packs/data/feats.db/scion-transformation.json
+++ b/packs/data/feats.db/scion-transformation.json
@@ -19,11 +19,39 @@
         "level": {
             "value": 17
         },
-        "location": "",
+        "location": null,
         "prerequisites": {
             "value": []
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "selector": "hp",
+                "value": "@actor.level"
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": {
+                    "all": [
+                        "weapon:melee"
+                    ]
+                },
+                "selector": "strike-damage",
+                "type": "status",
+                "value": 2
+            },
+            {
+                "key": "CreatureSize",
+                "resizeEquipment": true,
+                "value": "large"
+            },
+            {
+                "key": "FlatModifier",
+                "selector": "dex-based",
+                "type": "status",
+                "value": -1
+            }
+        ],
         "source": {
             "value": "Pathfinder Lost Omens: Ancestry Guide"
         },

--- a/packs/data/feats.db/swift-swimmer.json
+++ b/packs/data/feats.db/swift-swimmer.json
@@ -19,6 +19,7 @@
         "level": {
             "value": 5
         },
+        "location": null,
         "prerequisites": {
             "value": [
                 {
@@ -26,7 +27,13 @@
                 }
             ]
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "BaseSpeed",
+                "selector": "swim",
+                "value": 25
+            }
+        ],
         "source": {
             "value": "Pathfinder Lost Omens: Character Guide"
         },

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -1161,6 +1161,11 @@
                 }
             },
             "LitTorch": "Torch is lit",
+            "Lizardfolk": {
+                "ParthenogenicHatchling": {
+                    "Note": "Each of your successful saving throws against a disease reduces its stage by 2, or by 1 for a virulent disease. Each critical success against an ongoing disease reduces its stage by 3, or by 2 for a virulent disease."
+                }
+            },
             "MartialProficiency": {
                 "AdvancedAzarketiWeapons": "Advanced Azarketi Weapons",
                 "AdvancedCatfolkWeapons": "Advanced Catfolk Weapons",


### PR DESCRIPTION
Reptile Rider refers to an action that doesn't exist in PF2, and so I've assumed they mean Command an Animal, like all the other ancestry riding feats.
Scion Transformation is permanent, and so I've copied the rules effects from Enlarge.