### PR TITLE
Allow thrown weapons to have reload 0

### DIFF
--- a/packs/data/equipment.db/shuriken.json
+++ b/packs/data/equipment.db/shuriken.json
@@ -39,13 +39,13 @@
             "value": "0"
         },
         "potencyRune": {
-            "value": null
+            "value": 0
         },
         "preciousMaterial": {
-            "value": ""
+            "value": null
         },
         "preciousMaterialGrade": {
-            "value": ""
+            "value": null
         },
         "price": {
             "value": {
@@ -67,26 +67,29 @@
             "value": ""
         },
         "propertyRune1": {
-            "value": ""
+            "value": null
         },
         "propertyRune2": {
-            "value": ""
+            "value": null
         },
         "propertyRune3": {
-            "value": ""
+            "value": null
         },
         "propertyRune4": {
-            "value": ""
+            "value": null
         },
         "quantity": 1,
         "range": 20,
         "reload": {
-            "value": "-"
+            "value": "0"
         },
         "rules": [],
         "size": "med",
         "source": {
             "value": "Pathfinder Core Rulebook"
+        },
+        "specific": {
+            "value": false
         },
         "splashDamage": {
             "value": null

--- a/src/module/item/weapon/index.ts
+++ b/src/module/item/weapon/index.ts
@@ -96,7 +96,7 @@ class WeaponPF2e extends PhysicalItemPF2e {
     }
 
     get isThrown(): boolean {
-        return this.isRanged && this.reload === "-";
+        return this.isRanged && this.data.data.traits.value.some((t) => t.startsWith("thrown"));
     }
 
     override get material(): WeaponMaterialData {
@@ -105,7 +105,7 @@ class WeaponPF2e extends PhysicalItemPF2e {
 
     /** Does this weapon require ammunition in order to make a strike? */
     get requiresAmmo(): boolean {
-        return this.isRanged && ![null, "-"].includes(this.reload);
+        return this.isRanged && !this.isThrown && ![null, "-"].includes(this.reload);
     }
 
     get ammo(): Embedded<ConsumablePF2e> | null {
@@ -188,7 +188,7 @@ class WeaponPF2e extends PhysicalItemPF2e {
         const traitsArray = systemData.traits.value;
         // Thrown weapons always have a reload of "-"
         if (systemData.baseItem === "alchemical-bomb" || traitsArray.some((t) => /^thrown(?:-\d+)?$/.test(t))) {
-            this.data.data.reload.value = "-";
+            this.data.data.reload.value ??= "-";
         }
 
         // Force a weapon to be ranged if it is among a set of certain groups or has a thrown trait


### PR DESCRIPTION
Currently, a weapon is defined as being thrown if it is ranged and has reload of `-` or `null`. Also, thrown weapons' reload times are forcibly set to `-` as this is the value that _almost_ all thrown weapons use. However, the [shuriken](https://2e.aonprd.com/Weapons.aspx?ID=79) has a reload of 0. This is currently impossible to set in the system, as even if one tries to manually alter it, it is set back to `-`.

I've changed four things:
- The reload value is set to `-` only if it is not already set to something else. This allows setting thrown weapons to have a different reload value.
- The definition of a thrown weapon is now a ranged weapon with the "thrown" trait. This removes the dependency on the reload value.
- The definition of a weapon requiring ammunition is now a ranged weapon that _is not thrown_ and has a non-`-` reload time.
- The shuriken now has a reload of 0.