### PR TITLE
Ensure module-art registration completes before compendium reindexing

### DIFF
--- a/src/scripts/hooks/ready.ts
+++ b/src/scripts/hooks/ready.ts
@@ -67,7 +67,6 @@ export const Ready = {
 
             PlayerConfigPF2e.activateColorScheme();
 
-            registerModuleArt();
             activateSocketListener();
 
             // Extend drag data for things such as condition value
@@ -87,7 +86,9 @@ export const Ready = {
             });
 
             // Compile compendium search index
-            ui.compendium.onReady();
+            registerModuleArt().then(() => {
+                ui.compendium.onReady();
+            });
 
             // Now that all game data is available, reprepare actor data among those actors currently in an encounter
             const participants = game.combats.contents.flatMap((e) => e.combatants.contents);

--- a/src/scripts/register-module-art.ts
+++ b/src/scripts/register-module-art.ts
@@ -18,7 +18,7 @@ export async function registerModuleArt(): Promise<void> {
                 continue;
             }
 
-            const index = await pack.getIndex();
+            const index = pack.indexed ? pack.index : await pack.getIndex();
             for (const [actorId, paths] of Object.entries(art)) {
                 const record = index.get(actorId);
                 if (!record) continue;

--- a/types/foundry/client/collections/compendium-collection.d.ts
+++ b/types/foundry/client/collections/compendium-collection.d.ts
@@ -17,7 +17,12 @@ declare global {
         /** A subsidiary collection which contains the more minimal index of the pack */
         index: CompendiumIndex;
 
+        /** A debounced function which will clear the contents of the Compendium pack if it is not accessed frequently. */
         protected _flush: () => unknown;
+
+        /** Has this Compendium pack been fully indexed? */
+        indexed: boolean;
+
         /**
          * The amount of time that Document instances within this CompendiumCollection are held in memory.
          * Accessing the contents of the Compendium pack extends the duration of this lifetime.


### PR DESCRIPTION
Also adds a pair of debug messages at start and completion of reindexing