### PR TITLE
Make second cleanup pass on boost management

### DIFF
--- a/src/module/actor/sheet/popups/ability-builder.ts
+++ b/src/module/actor/sheet/popups/ability-builder.ts
@@ -56,13 +56,13 @@ export class AbilityBuilderPopup extends Application {
             event.currentTarget.select();
         });
 
-        $html.find<HTMLInputElement>('input[name="data.build.manual"]').on("change", async (event) => {
+        $html.find<HTMLInputElement>("input[name=toggle-manual-mode]").on("change", async (event) => {
             if (event.originalEvent) {
                 await actor.toggleAbilityManagement();
             }
         });
 
-        $html.find<HTMLInputElement>('input[name="data.build.voluntaryFlaw"]').on("change", async (event) => {
+        $html.find<HTMLInputElement>("input[name=toggle-voluntary-flaw]").on("change", async (event) => {
             if (event.originalEvent) {
                 await actor.toggleVoluntaryFlaw();
             }

--- a/src/module/item/background/data.ts
+++ b/src/module/item/background/data.ts
@@ -11,7 +11,7 @@ type BackgroundData = Omit<BackgroundSource, "effects" | "flags"> &
 
 interface BackgroundSystemSource extends ABCSystemData {
     traits: ItemTraits;
-    boosts: Record<string, { value: AbilityString[]; selected: AbilityString | null }>;
+    boosts: Record<number, { value: AbilityString[]; selected: AbilityString | null }>;
     trainedLore: string;
     trainedSkills: {
         value: SkillAbbreviation[];

--- a/src/module/item/background/index.ts
+++ b/src/module/item/background/index.ts
@@ -1,7 +1,5 @@
-import { CharacterPF2e } from "@actor";
-import type { ItemPF2e, FeatPF2e } from "@item";
+import { ABCItemPF2e, FeatPF2e, ItemPF2e } from "@item";
 import { OneToFour } from "@module/data";
-import { ABCItemPF2e } from "../abc";
 import { BackgroundData } from "./data";
 
 class BackgroundPF2e extends ABCItemPF2e {
@@ -24,7 +22,7 @@ class BackgroundPF2e extends ABCItemPF2e {
     }
 
     override prepareActorData(this: Embedded<BackgroundPF2e>): void {
-        if (!(this.actor instanceof CharacterPF2e)) {
+        if (!this.actor.isOfType("character")) {
             console.error("Only a character can have a background");
             return;
         }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -652,8 +652,10 @@
             "Character": {
                 "AbilityBuilder": {
                     "Title": "Assign your boosts",
-                    "BoostIcon": "Boost",
-                    "FlawIcon": "Flaw",
+                    "Boost": "Boost",
+                    "Boosts": "Boosts",
+                    "Flaw": "Flaw",
+                    "Flaws": "Flaws",
                     "KeyIcon": "Key",
                     "VoluntaryFlaw": {
                         "Title": "Voluntary Flaw",

--- a/static/templates/actors/ability-builder.html
+++ b/static/templates/actors/ability-builder.html
@@ -26,14 +26,14 @@
                     <div class="row-column">
                         <button type="button" data-action="voluntary-flaw" data-ability="{{ability}}" class="flaw locked selected{{#unless boost.lockedFlaw}} hidden{{/unless}}">
                             {{#if boost.lockedFlaw}}<i class="fas fa-lock"></i>{{/if}}
-                            {{localize "PF2E.Actor.Character.AbilityBuilder.FlawIcon"}}
+                            {{localize "PF2E.Actor.Character.AbilityBuilder.Flaw"}}
                         </button>
                         <button type="button" data-action="ancestry-boost" data-ability="{{ability}}" class="boost
                             {{~#unless boost.available}} unavailable{{/unless}}
                             {{~#if boost.boosted}} selected{{/if}}
                             {{~#if boost.lockedBoost}} locked{{/if}}">
                             {{#if boost.lockedBoost}}<i class="fas fa-lock"></i>{{/if}}
-                            {{localize "PF2E.Actor.Character.AbilityBuilder.BoostIcon"}}
+                            {{localize "PF2E.Actor.Character.AbilityBuilder.Boost"}}
                         </button>
                     </div>
                 {{/each}}
@@ -50,13 +50,13 @@
             {{/if}}
 
             <div class="hover-content" id="ancestry-tooltip">
-                <h2>Boosts</h2>
+                <h2>{{localize "PF2E.Actor.Character.AbilityBuilder.Boosts"}}</h2>
                 <ul class="boost-details">
                     {{#each ancestryBoosts.labels as |boost|}}
                         <li><i class="fas fa-circle"></i>{{boost}}</li>
                     {{/each}}
                 </ul>
-                <h2>Flaws</h2>
+                <h2>{{localize "PF2E.Actor.Character.AbilityBuilder.Flaws"}}</h2>
                 <ul class="boost-details">
                     {{#each ancestryBoosts.flawLabels as |flaw|}}
                         <li><i class="fas fa-circle"></i>{{flaw}}</li>
@@ -71,55 +71,42 @@
                 <div class="row-heading" data-tooltip-content="#voluntary-flaw-tooltip">
                     {{#unless (eq ancestryBoosts.voluntaryBoostsRemaining 0)}}<div class="remaining extra">{{ancestryBoosts.voluntaryBoostsRemaining}}</div>{{/unless}}
 
-                    <input type="checkbox" id="{{document.id}}.voluntaryFlaw" name="data.build.voluntaryFlaw" {{#if voluntaryFlaw}}checked{{/if}}>
+                    <input type="checkbox" id="{{actor.id}}-voluntary-flaw" name="toggle-voluntary-flaw" {{checked voluntaryFlaw}}>
                     <div class="label">
-                        <label for="{{document.id}}.voluntaryFlaw">
-                            {{localize "PF2E.Actor.Character.AbilityBuilder.VoluntaryFlaw.Title"}}
-                        </label>
+                        <label for="{{actor.id}}-voluntary-flaw">{{localize "PF2E.Actor.Character.AbilityBuilder.VoluntaryFlaw.Title"}}</label>
                     </div>
                 </div>
                 {{#if voluntaryFlaw}}
                     {{#each ancestryBoosts.boosts as |boost ability|}}
                         <div class="row-column">
-                            <button type="button"
-                                data-action="voluntary-flaw"
-                                data-ability="{{ability}}"
-                                class="
-                                flaw
-                                {{#unless boost.canVoluntaryFlaw}}unavailable{{/unless}}
-                                {{#if boost.voluntaryFlaw}}selected{{/if}}
-                                ">
+                            <button type="button" data-action="voluntary-flaw" data-ability="{{ability}}"
+                                class="flaw
+                                {{~#unless boost.canVoluntaryFlaw}} unavailable{{/unless}}
+                                {{~#if boost.voluntaryFlaw}} selected{{/if}}"
+                            >
                                 {{#if boost.lockedFlaw}}<i class="fas fa-lock"></i>{{/if}}
-                                {{localize "PF2E.Actor.Character.AbilityBuilder.FlawIcon"}}
+                                {{localize "PF2E.Actor.Character.AbilityBuilder.Flaw"}}
                             </button>
-                            <button type="button"
-                                data-action="voluntary-boost"
-                                data-ability="{{ability}}"
+                            <button type="button" data-action="voluntary-boost" data-ability="{{ability}}"
                                 {{#unless boost.canVoluntaryBoost}}title="{{localize "PF2E.Actor.Character.AbilityBuilder.VoluntaryFlaw.Description"}}"{{/unless}}
-                                class="
-                                tooltip
-                                boost
-                                {{#unless boost.canVoluntaryBoost}}unavailable{{/unless}}
-                                {{#if boost.voluntaryBoost}}selected{{/if}}
-                                ">
-                                {{localize "PF2E.Actor.Character.AbilityBuilder.BoostIcon"}}
+                                class="tooltip boost
+                                {{~#unless boost.canVoluntaryBoost}} unavailable{{/unless}}
+                                {{~#if boost.voluntaryBoost}} selected{{/if}}"
+                            >
+                                {{localize "PF2E.Actor.Character.AbilityBuilder.Boost"}}
                             </button>
                         </div>
                     {{/each}}
                 {{/if}}
             {{/if}}
 
-            <div class="hover-content" id="voluntary-flaw-tooltip">
-                {{localize "PF2E.Actor.Character.AbilityBuilder.VoluntaryFlaw.Description"}}
-            </div>
+            <div class="hover-content" id="voluntary-flaw-tooltip">{{localize "PF2E.Actor.Character.AbilityBuilder.VoluntaryFlaw.Description"}}</div>
         </div>
-
         <hr />
-
         <!-- background boosts -->
         <div class="row{{#if manual}} not-eligible{{/if}}">
             {{#if background}}
-                <div class="row-heading" data-tooltip-content="#background-tooltip">
+                <div class="row-heading" data-tooltip-content=".background-tooltip">
                     {{#unless (eq backgroundBoosts.remaining 0)}}<div class="remaining extra">{{backgroundBoosts.remaining}}</div>{{/unless}}
                     <img class="" src="{{background.img}}" title="{{background.name}}" width="32" height="32" loading="lazy"/>
                     <div class="label">
@@ -129,15 +116,12 @@
                 </div>
                 {{#each backgroundBoosts.boosts as |boost ability|}}
                     <div class="row-column">
-                        <button type="button"
-                            data-action="background-boost"
-                            data-ability="{{ability}}"
-                            class="
-                            boost
-                            {{#if (not boost.available)}}unavailable{{/if}}
-                            {{#if boost.boosted}}boost selected{{/if}}
-                            ">
-                            {{localize "PF2E.Actor.Character.AbilityBuilder.BoostIcon"}}
+                        <button type="button" data-action="background-boost" data-ability="{{ability}}"
+                            class="boost
+                            {{~#if (not boost.available)}} unavailable{{/if}}
+                            {{~#if boost.boosted}} boost selected{{/if}}"
+                        >
+                            {{localize "PF2E.Actor.Character.AbilityBuilder.Boost"}}
                         </button>
                     </div>
                 {{/each}}
@@ -148,16 +132,14 @@
                         <div class="description">{{localize "PF2E.Actor.Character.AbilityBuilder.NotSelected"}}</div>
                     </div>
                 </div>
-                <div class="full-row">
-                    {{localize "PF2E.Actor.Character.AbilityBuilder.BackgroundMissingHelp"}}
-                </div>
+                <div class="full-row">{{localize "PF2E.Actor.Character.AbilityBuilder.BackgroundMissingHelp"}}</div>
             {{/if}}
 
-            <div class="hover-content" id="background-tooltip">
+            <div class="hover-content" class="background-tooltip">
                 {{#if backgroundBoosts.tooltip}}
                     {{backgroundBoosts.tooltip}}
                 {{else}}
-                    <h2>Boosts</h2>
+                    <h2>{{localize "PF2E.Actor.Character.AbilityBuilder.Boosts"}}</h2>
                     <ul class="boost-details">
                         {{#each backgroundBoosts.labels as |boost|}}
                             <li><i class="fas fa-circle"></i>{{boost}}</li>
@@ -181,14 +163,12 @@
                 </div>
                 {{#each abilities as |key ability|}}
                     <div class="row-column">
-                        <button type="button"
-                            data-action="class-key-ability"
-                            data-key="{{key}}"
-                            data-ability="{{ability}}"
+                        <button type="button" data-action="class-key-ability" data-key="{{key}}" data-ability="{{ability}}"
                             class="boost key-ability
                             {{~#if (not (contains ../keyOptions ability))}} hidden{{/if}}
                             {{~#if (eq ../class.data.data.keyAbility.selected ability)}} selected{{/if}}
-                            {{~#if ../manual}} hidden{{/if}}">
+                            {{~#if ../manual}} hidden{{/if}}"
+                        >
                             <i class="fas fa-key"></i>
                             {{localize "PF2E.Actor.Character.AbilityBuilder.KeyIcon"}}
                         </button>
@@ -201,9 +181,7 @@
                         <div class="description">{{localize "PF2E.Actor.Character.AbilityBuilder.NotSelected"}}</div>
                     </div>
                 </div>
-                <div class="full-row">
-                    {{localize "PF2E.Actor.Character.AbilityBuilder.ClassMissingHelp"}}
-                </div>
+                <div class="full-row">{{localize "PF2E.Actor.Character.AbilityBuilder.ClassMissingHelp"}}</div>
             {{/if}}
         </div>
 
@@ -227,12 +205,10 @@
                 </div>
                 {{#each ../abilities as |key ability|}}
                     <div class="row-column">
-                        <button type="button"
-                            data-action="level"
-                            data-level="{{level}}"
-                            data-ability="{{ability}}"
-                            class="boost {{#if (contains boosts.boosts ability)}} selected{{else}}{{#if boosts.full}} unavailable{{/if}}{{/if}}{{#if (not boosts.eligible)}} hidden{{/if}}">
-                            {{localize "PF2E.Actor.Character.AbilityBuilder.BoostIcon"}}
+                        <button type="button" data-action="level" data-level="{{level}}" data-ability="{{ability}}"
+                            class="boost {{#if (contains boosts.boosts ability)}} selected{{else}}{{#if boosts.full}} unavailable{{/if}}{{/if}}{{#if (not boosts.eligible)}} hidden{{/if}}"
+                        >
+                            {{localize "PF2E.Actor.Character.AbilityBuilder.Boost"}}
                         </button>
                     </div>
                 {{/each}}
@@ -245,19 +221,17 @@
                     <h3>{{localize "PF2E.Actor.Character.AbilityBuilder.AbilityScoreMethod.Title"}}</h3>
                     <p>{{localize "PF2E.Actor.Character.AbilityBuilder.AbilityScoreMethod.Description"}}</p>
                     <label>
-                        <input type="checkbox" name="data.build.manual" {{#if manual}}checked{{/if}}>
-                        {{localize "PF2E.Actor.Character.AbilityBuilder.AbilityScoreMethod.UseCustomLabel"}}
+                        <input type="checkbox" name="toggle-manual-mode"{{checked manual}}>
+                        {{localize "PF2E.Actor.Character.AbilityBuilder.AbilityScoreMethod.SetManually"}}
                     </label>
                 </div>
             </div>
             {{#each abilityScores as |ability key|}}
                 <div class="row-column">
                     {{#if ../manual}}
-                        <button type="button"
-                            data-action="class-keyAbility"
-                            data-key="{{lookup ../abilities key}}"
-                            data-ability="{{key}}"
-                            class="boost{{#if (eq ../class.data.data.keyAbility.selected key)}} selected{{/if}}">
+                        <button type="button" data-action="class-keyAbility" data-key="{{lookup ../abilities key}}" data-ability="{{key}}"
+                            class="boost{{#if (eq ../class.data.data.keyAbility.selected key)}} selected{{/if}}"
+                        >
                             <i class="fas fa-key"></i>
                             {{localize "PF2E.Actor.Character.AbilityBuilder.KeyIcon"}}
                         </button>


### PR DESCRIPTION
- Localize unlocalized headers
- Crunch down more non-rendering whitespace
- Use HandleBars helpers when available
- Change input name attributes that resemble data properties
- Remove unecessary id attributes