### PR TITLE
Add Spear Launcher Hazard to Fall of Plaguestone

### DIFF
--- a/packs/data/fall-of-plaguestone.db/spear-launcher.json
+++ b/packs/data/fall-of-plaguestone.db/spear-launcher.json
@@ -1,0 +1,165 @@
+{
+    "_id": "jpw5eHse4EcmYSp6",
+    "data": {
+        "attributes": {
+            "ac": {
+                "value": 18
+            },
+            "hardness": 8,
+            "hp": {
+                "details": "",
+                "max": 32,
+                "temp": 0,
+                "value": 32
+            },
+            "stealth": {
+                "details": "<p>(trained)</p>",
+                "value": 10
+            }
+        },
+        "creatureType": "",
+        "customModifiers": {},
+        "details": {
+            "description": "<p>An old heavy crossbow is hidden in a pile of trash, loaded with a wooden spear, and connected to the rope holding the door.</p>",
+            "disable": "<p>@Check[type:thievery|dc:18|traits:secret]{Thievery (trained)} on the rope allows a PC to tie the rope off and open the door without setting off the trap.</p>",
+            "isComplex": false,
+            "level": {
+                "value": 2
+            },
+            "reset": "",
+            "routine": ""
+        },
+        "saves": {
+            "fortitude": {
+                "saveDetail": "",
+                "value": 11
+            },
+            "reflex": {
+                "saveDetail": "",
+                "value": 3
+            },
+            "will": {
+                "saveDetail": "",
+                "value": 0
+            }
+        },
+        "source": {
+            "author": "",
+            "value": "Pathfinder Adventure: The Fall of Plaguestone"
+        },
+        "statusEffects": [],
+        "traits": {
+            "di": {
+                "custom": "",
+                "selected": {},
+                "value": [
+                    "critical-hits",
+                    "object-immunities",
+                    "precision"
+                ]
+            },
+            "dr": [],
+            "dv": [],
+            "rarity": "common",
+            "size": {
+                "value": "med"
+            },
+            "traits": {
+                "custom": "",
+                "value": [
+                    "mechanical",
+                    "trap"
+                ]
+            }
+        }
+    },
+    "img": "systems/pf2e/icons/default-icons/hazard.svg",
+    "items": [
+        {
+            "_id": "YapaAOg2pzlW9uPP",
+            "data": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "reaction"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p><strong>Trigger</strong> The rope is cut or otherwise untied from the door.</p>\n<hr />\n<p><strong>Effect</strong> The trap makes an attack against the creature that manipulated the rope.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Reaction.webp",
+            "name": "Spear",
+            "sort": 0,
+            "type": "action"
+        },
+        {
+            "_id": "ZizBeGklUEvX03AL",
+            "data": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "value": []
+                },
+                "bonus": {
+                    "value": 14
+                },
+                "damageRolls": {
+                    "rog0seeifjsp345c0itf": {
+                        "damage": "2d6+6",
+                        "damageType": "piercing"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "weaponType": {
+                    "value": "ranged"
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Spear",
+            "sort": 0,
+            "type": "melee"
+        }
+    ],
+    "name": "Spear Launcher",
+    "token": {
+        "disposition": -1,
+        "height": 1,
+        "img": "systems/pf2e/icons/default-icons/hazard.svg",
+        "name": "Spear Launcher",
+        "width": 1
+    },
+    "type": "hazard"
+}

--- a/packs/data/fall-of-plaguestone.db/spear-launcher.json
+++ b/packs/data/fall-of-plaguestone.db/spear-launcher.json
@@ -21,7 +21,7 @@
         "customModifiers": {},
         "details": {
             "description": "<p>An old heavy crossbow is hidden in a pile of trash, loaded with a wooden spear, and connected to the rope holding the door.</p>",
-            "disable": "<p>@Check[type:thievery|dc:18|traits:secret]{Thievery (trained)} on the rope allows a PC to tie the rope off and open the door without setting off the trap.</p>",
+            "disable": "<p>@Check[type:thievery|dc:18|traits:action:disable-device]{Thievery (trained)} on the rope allows a PC to tie the rope off and open the door without setting off the trap.</p>",
             "isComplex": false,
             "level": {
                 "value": 2

--- a/packs/data/fall-of-plaguestone.db/spear-launcher.json
+++ b/packs/data/fall-of-plaguestone.db/spear-launcher.json
@@ -88,7 +88,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p><strong>Trigger</strong> The rope is cut or otherwise untied from the door.</p>\n<hr />\n<p><strong>Effect</strong> The trap makes an attack against the creature that manipulated the rope.</p>"
+                    "value": "<p><strong>Trigger</strong> The rope is cut or otherwise untied from the door</p>\n<hr />\n<p><strong>Effect</strong> The trap makes an attack against the creature that manipulated the rope</p>"
                 },
                 "requirements": {
                     "value": ""


### PR DESCRIPTION
The description of this hazard is different from what is in the CRB, so adding a new version that matches the text from Fall of Plaguestone.