### PR TITLE
fix lyzerius bomb damage

### DIFF
--- a/packs/data/outlaws-of-alkenstar-bestiary.db/shoma-lyzerius.json
+++ b/packs/data/outlaws-of-alkenstar-bestiary.db/shoma-lyzerius.json
@@ -1282,6 +1282,10 @@
                 "damageRolls": {
                     "95wm3xl6jdk3f2tbxmj3": {
                         "damage": "1",
+                        "damageType": "bludgeoning"
+                    },
+                    "b3k0zb93xdoqmixyhjmf": {
+                        "damage": "1",
                         "damageType": "fire"
                     }
                 },
@@ -1344,13 +1348,34 @@
                 "damageRolls": {
                     "hgsuoshxj9abhsx6b1ct": {
                         "damage": "1",
+                        "damageType": "acid"
+                    },
+                    "j6ok0v9wbxol0mdvxafs": {
+                        "damage": "1",
                         "damageType": "fire"
                     }
                 },
                 "description": {
-                    "value": "<p>[[/r {2d6}[persistent,acid]]] @Compendium[pf2e.conditionitems.Persistent Damage]{Persistent Acid Damage}</p>"
+                    "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "key": "Note",
+                        "outcome": [
+                            "success"
+                        ],
+                        "selector": "{item|_id}-damage",
+                        "text": "PF2E.BombNotes.AcidFlask.Moderate.success"
+                    },
+                    {
+                        "key": "Note",
+                        "outcome": [
+                            "criticalSuccess"
+                        ],
+                        "selector": "{item|_id}-damage",
+                        "text": "PF2E.BombNotes.AcidFlask.Moderate.criticalSuccess"
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""


### PR DESCRIPTION
all bombs should deal their base damage plus 1 fire damage and acid flask should have the moderate acid flask rule elements.