### PR TITLE
Update Amnesiac and Discarded Duplicate to include a third free boost (with migration)

### DIFF
--- a/packs/data/backgrounds.db/amnesiac.json
+++ b/packs/data/backgrounds.db/amnesiac.json
@@ -21,6 +21,17 @@
                     "str",
                     "wis"
                 ]
+            },
+            "2": {
+                "selected": null,
+                "value": [
+                    "cha",
+                    "con",
+                    "dex",
+                    "int",
+                    "str",
+                    "wis"
+                ]
             }
         },
         "description": {

--- a/packs/data/backgrounds.db/discarded-duplicate.json
+++ b/packs/data/backgrounds.db/discarded-duplicate.json
@@ -21,6 +21,17 @@
                     "str",
                     "wis"
                 ]
+            },
+            "2": {
+                "selected": null,
+                "value": [
+                    "cha",
+                    "con",
+                    "dex",
+                    "int",
+                    "str",
+                    "wis"
+                ]
             }
         },
         "description": {

--- a/packs/scripts/run-migration.ts
+++ b/packs/scripts/run-migration.ts
@@ -33,6 +33,8 @@ import { Migration757HillockHalfling } from "@module/migration/migrations/757-hi
 import { Migration759CritSpecRE } from "@module/migration/migrations/759-crit-spec-re";
 import { Migration760SeparateNoteTitle } from "@module/migration/migrations/760-separate-note-title";
 import { Migration761ShotRules } from "@module/migration/migrations/761-update-shot-rules";
+import { Migration762UpdateBackgroundItems } from "@module/migration/migrations/762-update-background-items";
+// ^^^ don't let your IDE use the index in these imports. you need to specify the full path ^^^
 
 const { window } = new JSDOM();
 globalThis.document = window.document;
@@ -67,6 +69,7 @@ const migrations: MigrationBase[] = [
     new Migration759CritSpecRE(),
     new Migration760SeparateNoteTitle(),
     new Migration761ShotRules(),
+    new Migration762UpdateBackgroundItems(),
 ];
 
 global.deepClone = <T>(original: T): T => {

--- a/src/module/migration/migrations/762-update-background-items.ts
+++ b/src/module/migration/migrations/762-update-background-items.ts
@@ -1,0 +1,21 @@
+import { ItemSourcePF2e } from "@item/data";
+import { MigrationBase } from "../base";
+
+/** Add missing third boost from a pair of backgrounds */
+export class Migration762UpdateBackgroundItems extends MigrationBase {
+    static override version = 0.762;
+
+    override async updateItem(source: ItemSourcePF2e): Promise<void> {
+        if (
+            source.type === "background" &&
+            (source.data.slug === "amnesiac" || source.data.slug === "discarded-duplicate")
+        ) {
+            if (Object.values(source.data.boosts).length !== 3) {
+                source.data.boosts["2"] = {
+                    value: ["cha", "con", "dex", "int", "str", "wis"],
+                    selected: null,
+                };
+            }
+        }
+    }
+}

--- a/src/module/migration/migrations/index.ts
+++ b/src/module/migration/migrations/index.ts
@@ -161,3 +161,4 @@ export { Migration758PrunePCAttributes } from "./758-prune-pc-attributes";
 export { Migration759CritSpecRE } from "./759-crit-spec-re";
 export { Migration760SeparateNoteTitle } from "./760-separate-note-title";
 export { Migration761ShotRules } from "./761-update-shot-rules";
+export { Migration762UpdateBackgroundItems } from "./762-update-background-items";

--- a/src/module/migration/runner/base.ts
+++ b/src/module/migration/runner/base.ts
@@ -14,7 +14,7 @@ interface CollectionDiff<T extends foundry.data.ActiveEffectSource | ItemSourceP
 export class MigrationRunnerBase {
     migrations: MigrationBase[];
 
-    static LATEST_SCHEMA_VERSION = 0.761;
+    static LATEST_SCHEMA_VERSION = 0.762;
 
     static MINIMUM_SAFE_VERSION = 0.618;
 

--- a/static/templates/actors/ability-builder.html
+++ b/static/templates/actors/ability-builder.html
@@ -142,7 +142,9 @@
                     <h2>{{localize "PF2E.Actor.Character.AbilityBuilder.Boosts"}}</h2>
                     <ul class="boost-details">
                         {{#each backgroundBoosts.labels as |boost|}}
-                            <li><i class="fas fa-circle"></i>{{boost}}</li>
+                            {{#if boost}}
+                                <li><i class="fas fa-circle"></i>{{boost}}</li>
+                            {{/if}}
                         {{/each}}
                     </ul>
                 {{/if}}


### PR DESCRIPTION
UI shows this correctly, but unable to add a third one from the UI, so this is done manually.

![image](https://user-images.githubusercontent.com/102023/175855301-a2789aae-e9dd-47c7-b1ef-383e749358f7.png)
