### PR TITLE
Update NPCs from EC Book 3 Ch 3

### DIFF
--- a/packs/data/extinction-curse-bestiary.db/headless-xulgath.json
+++ b/packs/data/extinction-curse-bestiary.db/headless-xulgath.json
@@ -196,7 +196,7 @@
             "type": "action"
         },
         {
-            "_id": "EutDCqHtQv0OUH82",
+            "_id": "wez3wVjuYfKX3Jow",
             "data": {
                 "actionCategory": {
                     "value": "defensive"
@@ -208,29 +208,31 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p><strong>Trigger</strong> A creature within the monster's reach uses a manipulate action or a move action, makes a ranged attack, or leaves a square during a move action it's using.</p>\n<p>The monster attempts a melee Strike against the triggering creature. If the attack is a critical hit and the trigger was a manipulate action, the monster disrupts that action. This Strike doesn't count toward the monster's multiple attack penalty, and its multiple attack penalty doesn't apply to this Strike.</p>"
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.AttackOfOpportunity]</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "attack-of-opportunity",
                 "source": {
-                    "value": ""
+                    "value": "Pathfinder Bestiary"
                 },
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": [
-                        "aura",
-                        "olfactory"
-                    ]
+                    "value": []
                 },
                 "trigger": {
                     "value": ""
                 },
                 "weapon": {
                     "value": ""
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.hFtNbo1LKYCoDy2O"
                 }
             },
             "img": "systems/pf2e/icons/actions/Reaction.webp",
@@ -251,7 +253,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p><strong>Range</strong> 30 feet.</p>\n<p>A creature that enters the area must attempt a @Check[type:fortitude|dc:29] save. On a failure, the creature is @Compendium[pf2e.conditionitems.Sickened]{Sickened 2}, and on a critical failure, the creature is also @Compendium[pf2e.conditionitems.Slowed]{Slowed 1} for as long as it is @Compendium[pf2e.conditionitems.Sickened]{Sickened}. While within the aura, the creature takes a -2 circumstance penalty to saves to recover from the @Compendium[pf2e.conditionitems.Sickened]{Sickened} condition. A creature that succeeds at its save is temporarily immune to all xulgaths' stenches for 1 minute.</p>"
+                    "value": "<p>@Template[type:emanation|distance:30]{30 feet} @Compendium[pf2e.bestiary-ability-glossary-srd.Aura]{Aura}</p>\n<hr />\n<p>A creature that enters the area must attempt a @Check[type:fortitude|dc:29] save. On a failure, the creature is @Compendium[pf2e.conditionitems.Sickened]{Sickened 2}, and on a critical failure, the creature is also @Compendium[pf2e.conditionitems.Slowed]{Slowed 1} for as long as it is sickened. While within the aura, the creature takes a -2 circumstance penalty to saves to recover from the sickened condition. A creature that succeeds at its save is temporarily immune to all xulgaths' stenches for 1 minute.</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -365,7 +367,7 @@
             "type": "action"
         },
         {
-            "_id": "GfqGruCxQGK6AMcn",
+            "_id": "5tmklbtKv2YkK6j8",
             "data": {
                 "actionCategory": {
                     "value": "offensive"
@@ -377,20 +379,19 @@
                     "value": 1
                 },
                 "description": {
-                    "value": "<p><strong>Source</strong> <em>Bestiary pg. 343</em></p>\n<p><strong>Requirements</strong> The monster's last action was a success with a Strike that lists Grab in its damage entry, or it has a creature grabbed using this action.</p>\n<hr />\n<p><strong>Effect</strong> The monster automatically Grabs the target until the end of the monster's next turn. The creature is grabbed by whichever body part the monster attacked with, and that body part can't be used to Strike creatures until the grab is ended.</p>\n<p>Using Grab extends the duration of the monster's Grab until the end of its next turn for all creatures grabbed by it. A grabbed creature can use the @Compendium[pf2e.actionspf2e.Escape]{Escape} action to get out of the grab, and the Grab ends for a grabbed creatures if the monster moves away from it.</p>"
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Grab]</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "grab",
                 "source": {
-                    "value": ""
+                    "value": "Pathfinder Bestiary"
                 },
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "selected": {},
                     "value": []
                 },
                 "trigger": {
@@ -398,6 +399,11 @@
                 },
                 "weapon": {
                     "value": ""
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.Tkd8sH4pwFIPzqTr"
                 }
             },
             "img": "systems/pf2e/icons/actions/OneAction.webp",

--- a/packs/data/extinction-curse-bestiary.db/hooklimb-xulgath.json
+++ b/packs/data/extinction-curse-bestiary.db/hooklimb-xulgath.json
@@ -198,7 +198,7 @@
             "type": "melee"
         },
         {
-            "_id": "zzEcZu1lsPKAFeE9",
+            "_id": "0OIRUdkEUOJYVRrE",
             "data": {
                 "actionCategory": {
                     "value": "defensive"
@@ -210,20 +210,19 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p><strong>Trigger</strong> A creature within the the Hooklimb Xulgath's reach uses a manipulate action or a move action, makes a ranged attack, or leaves a square during a move action it's using.</p>\n<p>The Hooklimb Xulgath attempts a melee Strike against the triggering creature. If the attack is a critical hit and the trigger was a manipulate action, the Hooklimb Xulgath disrupts that action. This Strike doesn't count toward the Hooklimb Xulgath's multiple attack penalty, and its multiple attack penalty doesn't apply to this Strike.</p>"
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.AttackOfOpportunity]</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "attack-of-opportunity",
                 "source": {
-                    "value": ""
+                    "value": "Pathfinder Bestiary"
                 },
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "selected": {},
                     "value": []
                 },
                 "trigger": {
@@ -231,6 +230,11 @@
                 },
                 "weapon": {
                     "value": ""
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.hFtNbo1LKYCoDy2O"
                 }
             },
             "img": "systems/pf2e/icons/actions/Reaction.webp",
@@ -251,7 +255,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p><strong>Range</strong> 30 feet.</p>\n<p>A creature that enters the area must attempt a @Check[type:fortitude|dc:28] save. On a failure, the creature is @Compendium[pf2e.conditionitems.Sickened]{Sickened 2}, and on a critical failure, the creature is also @Compendium[pf2e.conditionitems.Slowed]{Slowed 1} for as long as it is @Compendium[pf2e.conditionitems.Sickened]{Sickened}. While within the aura, the creature takes a -2 circumstance penalty to saves to recover from the @Compendium[pf2e.conditionitems.Sickened]{Sickened} condition. A creature that succeeds at its save is temporarily immune to all xulgaths' stenches for 1 minute.</p>"
+                    "value": "<p>@Template[type:emanation|distance:30]{30 feet} @Compendium[pf2e.bestiary-ability-glossary-srd.Aura]{Aura}</p>\n<hr />\n<p>A creature that enters the area must attempt a @Check[type:fortitude|dc:28] save. On a failure, the creature is @Compendium[pf2e.conditionitems.Sickened]{Sickened 2}, and on a critical failure, the creature is also @Compendium[pf2e.conditionitems.Slowed]{Slowed 1} for as long as it is sickened. While within the aura, the creature takes a -2 circumstance penalty to saves to recover from the sickened condition. A creature that succeeds at its save is temporarily immune to all xulgaths' stenches for 1 minute.</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -364,7 +368,7 @@
             "type": "action"
         },
         {
-            "_id": "XpbkwstUH1qcjVQh",
+            "_id": "sAg8hYF3kFMZW1Xr",
             "data": {
                 "actionCategory": {
                     "value": "offensive"
@@ -376,20 +380,19 @@
                     "value": 1
                 },
                 "description": {
-                    "value": "<section class=\"details\">\n<p><strong>Type</strong> Claw</p>\n<p><strong>Requirements</strong> The monster hit the same enemy with two consecutive @Compendium[pf2e.actionspf2e.Strike]{Strikes} of the listed type in the same round.</p>\n</section>\n<section class=\"content\">\n<p>A <em>Rend</em> entry lists a Strike the monster has. The monster automatically deals that Strike's damage again to the enemy.</p>\n</section>"
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Rend]</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "rend",
                 "source": {
-                    "value": ""
+                    "value": "Pathfinder Bestiary"
                 },
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "selected": {},
                     "value": []
                 },
                 "trigger": {
@@ -397,6 +400,11 @@
                 },
                 "weapon": {
                     "value": ""
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.3JOi2cMcGhT3eze1"
                 }
             },
             "img": "systems/pf2e/icons/actions/OneAction.webp",

--- a/packs/data/extinction-curse-bestiary.db/hooklimb-xulgath.json
+++ b/packs/data/extinction-curse-bestiary.db/hooklimb-xulgath.json
@@ -344,7 +344,41 @@
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "domain": "damage-roll",
+                        "key": "RollOption",
+                        "option": "raking-claws",
+                        "toggleable": true,
+                        "value": false
+                    },
+                    {
+                        "key": "Note",
+                        "outcome": [
+                            "success"
+                        ],
+                        "predicate": {
+                            "all": [
+                                "raking-claws"
+                            ]
+                        },
+                        "selector": "claw-damage",
+                        "text": "PF2E.PersistentDamage.Bleed1d10.success"
+                    },
+                    {
+                        "key": "Note",
+                        "outcome": [
+                            "criticalSuccess"
+                        ],
+                        "predicate": {
+                            "all": [
+                                "raking-claws"
+                            ]
+                        },
+                        "selector": "claw-damage",
+                        "text": "PF2E.PersistentDamage.Bleed1d10.criticalSuccess"
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""
@@ -368,7 +402,7 @@
             "type": "action"
         },
         {
-            "_id": "sAg8hYF3kFMZW1Xr",
+            "_id": "XpbkwstUH1qcjVQh",
             "data": {
                 "actionCategory": {
                     "value": "offensive"
@@ -380,19 +414,20 @@
                     "value": 1
                 },
                 "description": {
-                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Rend]</p>"
+                    "value": "<section class=\"details\">\n<p><strong>Type</strong> Claw</p>\n<p><strong>Requirements</strong> The monster hit the same enemy with two consecutive @Compendium[pf2e.actionspf2e.Strike]{Strikes} of the listed type in the same round.</p>\n</section>\n<section class=\"content\">\n<p>A <em>Rend</em> entry lists a Strike the monster has. The monster automatically deals that Strike's damage again to the enemy.</p>\n</section>"
                 },
                 "requirements": {
                     "value": ""
                 },
                 "rules": [],
-                "slug": "rend",
+                "slug": null,
                 "source": {
-                    "value": "Pathfinder Bestiary"
+                    "value": ""
                 },
                 "traits": {
                     "custom": "",
                     "rarity": "common",
+                    "selected": {},
                     "value": []
                 },
                 "trigger": {
@@ -400,11 +435,6 @@
                 },
                 "weapon": {
                     "value": ""
-                }
-            },
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.3JOi2cMcGhT3eze1"
                 }
             },
             "img": "systems/pf2e/icons/actions/OneAction.webp",

--- a/packs/data/extinction-curse-bestiary.db/pin-tingwheely.json
+++ b/packs/data/extinction-curse-bestiary.db/pin-tingwheely.json
@@ -143,7 +143,7 @@
                 },
                 "rules": [],
                 "showSlotlessLevels": {
-                    "value": true
+                    "value": false
                 },
                 "showUnpreparedSpells": {
                     "value": false
@@ -271,9 +271,10 @@
                     "value": true
                 },
                 "level": {
-                    "value": 3
+                    "value": 2
                 },
                 "location": {
+                    "heightenedLevel": 3,
                     "value": "aGUovHznkIyYG8m6"
                 },
                 "materials": {
@@ -339,7 +340,7 @@
             },
             "img": "systems/pf2e/icons/spells/dispel-magic.webp",
             "name": "Dispel Magic",
-            "sort": 700000,
+            "sort": 200000,
             "type": "spell"
         },
         {
@@ -447,7 +448,7 @@
             },
             "img": "systems/pf2e/icons/spells/entangle.webp",
             "name": "Entangle",
-            "sort": 900000,
+            "sort": 300000,
             "type": "spell"
         },
         {
@@ -557,7 +558,7 @@
             },
             "img": "systems/pf2e/icons/spells/faerie-fire.webp",
             "name": "Faerie Fire",
-            "sort": 1000000,
+            "sort": 400000,
             "type": "spell"
         },
         {
@@ -597,15 +598,11 @@
                 "hasCounteractCheck": {
                     "value": false
                 },
-                "heightening": {
-                    "damage": {},
-                    "interval": 1,
-                    "type": "interval"
-                },
                 "level": {
-                    "value": 4
+                    "value": 2
                 },
                 "location": {
+                    "heightenedLevel": 4,
                     "value": "aGUovHznkIyYG8m6"
                 },
                 "materials": {
@@ -710,7 +707,7 @@
                     "value": false
                 },
                 "level": {
-                    "value": 4
+                    "value": 1
                 },
                 "location": {
                     "value": "aGUovHznkIyYG8m6"
@@ -781,7 +778,7 @@
             },
             "img": "systems/pf2e/icons/spells/dancing-lights.webp",
             "name": "Dancing Lights",
-            "sort": 200000,
+            "sort": 600000,
             "type": "spell"
         },
         {
@@ -822,7 +819,7 @@
                     "value": false
                 },
                 "level": {
-                    "value": 4
+                    "value": 1
                 },
                 "location": {
                     "value": "aGUovHznkIyYG8m6"
@@ -894,7 +891,7 @@
             },
             "img": "systems/pf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
-            "sort": 300000,
+            "sort": 700000,
             "type": "spell"
         },
         {
@@ -950,7 +947,7 @@
                     "type": "fixed"
                 },
                 "level": {
-                    "value": 4
+                    "value": 1
                 },
                 "location": {
                     "value": "aGUovHznkIyYG8m6"
@@ -1019,7 +1016,7 @@
             },
             "img": "systems/pf2e/icons/spells/ghost-sound.webp",
             "name": "Ghost Sound",
-            "sort": 400000,
+            "sort": 800000,
             "type": "spell"
         },
         {
@@ -1059,15 +1056,11 @@
                 "hasCounteractCheck": {
                     "value": false
                 },
-                "heightening": {
-                    "damage": {},
-                    "interval": 1,
-                    "type": "interval"
-                },
                 "level": {
-                    "value": 3
+                    "value": 1
                 },
                 "location": {
+                    "heightenedLevel": 3,
                     "value": "aGUovHznkIyYG8m6"
                 },
                 "materials": {
@@ -1122,7 +1115,6 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "auditory",
                         "visual"
                     ]
                 }
@@ -1134,7 +1126,7 @@
             },
             "img": "systems/pf2e/icons/spells/illusory-disguise.webp",
             "name": "Illusory Disguise",
-            "sort": 800000,
+            "sort": 900000,
             "type": "spell"
         },
         {
@@ -1175,7 +1167,7 @@
                     "value": false
                 },
                 "level": {
-                    "value": 4
+                    "value": 1
                 },
                 "location": {
                     "value": "aGUovHznkIyYG8m6"
@@ -1245,7 +1237,7 @@
             },
             "img": "systems/pf2e/icons/spells/shield.webp",
             "name": "Shield",
-            "sort": 600000,
+            "sort": 1000000,
             "type": "spell"
         },
         {

--- a/packs/data/extinction-curse-bestiary.db/resin-seep-xulgath.json
+++ b/packs/data/extinction-curse-bestiary.db/resin-seep-xulgath.json
@@ -122,12 +122,12 @@
     "img": "systems/pf2e/icons/default-icons/npc.svg",
     "items": [
         {
-            "_id": "aShMDRAGR7PT8eJW",
+            "_id": "zVt24DCFtj13gSdF",
             "data": {
                 "MAP": {
                     "value": ""
                 },
-                "baseItem": null,
+                "baseItem": "dagger",
                 "bonus": {
                     "value": 0
                 },
@@ -170,10 +170,10 @@
                     "value": 1
                 },
                 "preciousMaterial": {
-                    "value": ""
+                    "value": null
                 },
                 "preciousMaterialGrade": {
-                    "value": ""
+                    "value": null
                 },
                 "price": {
                     "value": {
@@ -195,16 +195,16 @@
                     "value": ""
                 },
                 "propertyRune1": {
-                    "value": ""
+                    "value": null
                 },
                 "propertyRune2": {
-                    "value": ""
+                    "value": null
                 },
                 "propertyRune3": {
-                    "value": ""
+                    "value": null
                 },
                 "propertyRune4": {
-                    "value": ""
+                    "value": null
                 },
                 "quantity": 1,
                 "range": null,
@@ -213,9 +213,9 @@
                 },
                 "rules": [],
                 "size": "med",
-                "slug": null,
+                "slug": "dagger",
                 "source": {
-                    "value": ""
+                    "value": "Pathfinder Core Rulebook"
                 },
                 "specific": {
                     "value": false
@@ -244,8 +244,13 @@
                     "value": "L"
                 }
             },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.equipment-srd.rQWaJhI5Bko5x14Z"
+                }
+            },
             "img": "systems/pf2e/icons/equipment/weapons/dagger.webp",
-            "name": "Dagger (+1 Striking)",
+            "name": "+1 striking Dagger",
             "sort": 100000,
             "type": "weapon"
         },

--- a/packs/data/extinction-curse-bestiary.db/resin-seep-xulgath.json
+++ b/packs/data/extinction-curse-bestiary.db/resin-seep-xulgath.json
@@ -250,7 +250,7 @@
                 }
             },
             "img": "systems/pf2e/icons/equipment/weapons/dagger.webp",
-            "name": "+1 striking Dagger",
+            "name": "Dagger",
             "sort": 100000,
             "type": "weapon"
         },

--- a/packs/data/extinction-curse-bestiary.db/runkrunk.json
+++ b/packs/data/extinction-curse-bestiary.db/runkrunk.json
@@ -455,14 +455,14 @@
                     {
                         "domain": "all",
                         "key": "RollOption",
-                        "option": "berserkSlam",
+                        "option": "berserk-slam",
                         "toggleable": true
                     },
                     {
                         "key": "FlatModifier",
                         "predicate": {
                             "all": [
-                                "berserkSlam"
+                                "berserk-slam"
                             ]
                         },
                         "selector": "fist-attack",
@@ -475,7 +475,7 @@
                         "key": "DamageDice",
                         "predicate": {
                             "all": [
-                                "berserkSlam"
+                                "berserk-slam"
                             ]
                         },
                         "selector": "fist-damage"
@@ -484,7 +484,7 @@
                         "key": "Note",
                         "predicate": {
                             "all": [
-                                "berserkSlam"
+                                "berserk-slam"
                             ]
                         },
                         "selector": "fist-attack",

--- a/packs/data/extinction-curse-bestiary.db/runkrunk.json
+++ b/packs/data/extinction-curse-bestiary.db/runkrunk.json
@@ -101,7 +101,7 @@
             },
             "dr": [
                 {
-                    "exceptions": "except adamantine",
+                    "exceptions": "except Adamantine",
                     "type": "physical",
                     "value": 10
                 }
@@ -155,7 +155,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>(magical, reach 10 feet)</p>"
+                    "value": ""
                 },
                 "rules": [],
                 "slug": null,
@@ -178,6 +178,51 @@
             "name": "Fist",
             "sort": 100000,
             "type": "melee"
+        },
+        {
+            "_id": "5TPY6WPs2yKNZ1jM",
+            "data": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Darkvision]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "darkvision",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.qCCLZhnp2HhP3Ex6"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Darkvision",
+            "sort": 200000,
+            "type": "action"
         },
         {
             "_id": "lB6Yf4JEFM6O42nb",
@@ -216,7 +261,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Awakened",
-            "sort": 200000,
+            "sort": 300000,
             "type": "action"
         },
         {
@@ -256,11 +301,11 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Berserk",
-            "sort": 300000,
+            "sort": 400000,
             "type": "action"
         },
         {
-            "_id": "uNwjmzK14RmDlkI3",
+            "_id": "mdOM5OxBjVA6iPqa",
             "data": {
                 "actionCategory": {
                     "value": "defensive"
@@ -272,20 +317,19 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>Harmed by cold and water (5d10, [[/r 2d6 #from areas or persistent damage]] from areas or persistent damage); Healed by acid (area 2d6 HP); Slowed by earth</p>\n<hr />\n<p>A golem is immune to spells and magical abilities other than its own, but each type of golem is affected by a few types of magic in special ways. These exceptions are listed in shortened form in the golem's stat block, with the full rules appearing here. If an entry lists multiple types (such as \"cold and water\"), either type of spell can affect the golem. <strong>Harmed By</strong> Any magic of this type that targets the golem causes it to take the listed amount of damage (this damage has no type) instead of the usual effect. If the golem starts its turn in an area of magic of this type or is affected by a persistent effect of the appropriate type, it takes the damage listed in the parenthetical. <strong>Healed By</strong> Any magic of this type that targets the golem makes the golem lose the slowed condition and gain HP equal to half the damage the spell would have dealt. If the golem starts its turn in an area of this type of magic, it gains the HP listed in the parenthetical. <strong>Slowed By</strong> Any magic of this type that targets the golem causes it to be slowed 1 for [[/br 2d6 #rounds]]{2d6 rounds} instead of the usual effect. If the golem starts its turn in an area of this type of magic, it's slowed 1 for that round. <strong>Vulnerable To</strong> Each golem is vulnerable to one or more specific spells, with the effects described in its stat block.</p>"
+                    "value": "<ul>\n<li><strong>Harmed By</strong> cold and water ([[/r {5d10}]]{5d10 damage}, [[/r {2d6}]]{2d6 damage} from areas or persistent damage)</li>\n<li><strong>Healed By</strong> acid (area [[/r {2d6}[healing]]]{2d6 Hit Points})</li>\n<li><strong>Slowed By</strong> earth</li>\n</ul>\n<hr />\n<p>A golem is immune to spells and magical abilities other than its own, but each type of golem is affected by a few types of magic in special ways. These exceptions are listed in shortened form in the golem's stat block, with the full rules appearing here. If an entry lists multiple types (such as \"cold and water\"), either type of spell can affect the golem.</p>\n<ul>\n<li><strong>Harmed By</strong> Any magic of this type that targets the golem causes it to take the listed amount of damage (this damage has no type) instead of the usual effect. If the golem starts its turn in an area of magic of this type or is affected by a persistent effect of the appropriate type, it takes the damage listed in the parenthetical.</li>\n<li><strong>Healed By</strong> Any magic of this type that targets the golem makes the golem lose the slowed condition and gain HP equal to half the damage the spell would have dealt. If the golem starts its turn in an area of this type of magic, it gains the HP listed in the parenthetical.</li>\n<li><strong>Slowed By</strong> Any magic of this type that targets the golem causes it to be @Compendium[pf2e.conditionitems.Slowed]{Slowed 1} for [[/br 2d6 #rounds]]{2d6 rounds} instead of the usual effect. If the golem starts its turn in an area of this type of magic, it's slowed 1 for that round.</li>\n<li><strong>Vulnerable To</strong> Each golem is vulnerable to one or more specific spells, with the effects described in its stat block.</li>\n</ul>"
                 },
                 "requirements": {
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "golem-golem-antimagic",
                 "source": {
-                    "value": ""
+                    "value": "Pathfinder Bestiary"
                 },
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "selected": {},
                     "value": []
                 },
                 "trigger": {
@@ -295,9 +339,14 @@
                     "value": ""
                 }
             },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-family-ability-glossary.r34QDwKiWZoVymJa"
+                }
+            },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Golem Antimagic",
-            "sort": 400000,
+            "sort": 500000,
             "type": "action"
         },
         {
@@ -340,7 +389,7 @@
             },
             "img": "systems/pf2e/icons/actions/FreeAction.webp",
             "name": "Quicken",
-            "sort": 500000,
+            "sort": 600000,
             "type": "action"
         },
         {
@@ -381,7 +430,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Vulnerable to Disintegrate",
-            "sort": 600000,
+            "sort": 700000,
             "type": "action"
         },
         {
@@ -397,12 +446,53 @@
                     "value": 1
                 },
                 "description": {
-                    "value": "<p><strong>Requirement</strong> The golem is berserk.</p>\n<hr />\n<p><strong>Effect</strong> The clay golem @Compendium[pf2e.actionspf2e.Strike]{Strikes} with its fist at a -1 circumstance penalty. If it hits, it deals an additional [[/r 1d8]] damage and knocks the target @Compendium[pf2e.conditionitems.Prone]{Prone}.</p>"
+                    "value": "<p><strong>Requirement</strong> The golem is berserk.</p>\n<hr />\n<p><strong>Effect</strong> The clay golem @Compendium[pf2e.actionspf2e.Strike]{Strikes} with its fist at a -1 circumstance penalty. If it hits, it deals an additional [[/r {1d8}[bludgeoning]]]{1d8 bludgeoning damage} and knocks the target @Compendium[pf2e.conditionitems.Prone]{Prone}.</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "domain": "all",
+                        "key": "RollOption",
+                        "option": "berserkSlam",
+                        "toggleable": true
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "predicate": {
+                            "all": [
+                                "berserkSlam"
+                            ]
+                        },
+                        "selector": "fist-attack",
+                        "type": "circumstance",
+                        "value": -1
+                    },
+                    {
+                        "diceNumber": 1,
+                        "dieSize": "d8",
+                        "key": "DamageDice",
+                        "predicate": {
+                            "all": [
+                                "berserkSlam"
+                            ]
+                        },
+                        "selector": "fist-damage"
+                    },
+                    {
+                        "key": "Note",
+                        "predicate": {
+                            "all": [
+                                "berserkSlam"
+                            ]
+                        },
+                        "selector": "fist-attack",
+                        "text": "PF2E.AttackEffects.KnockProne",
+                        "title": "{item|name}",
+                        "visibility": "gm"
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""
@@ -422,7 +512,7 @@
             },
             "img": "systems/pf2e/icons/actions/OneAction.webp",
             "name": "Berserk Slam",
-            "sort": 700000,
+            "sort": 800000,
             "type": "action"
         },
         {
@@ -466,7 +556,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Cursed Wound",
-            "sort": 800000,
+            "sort": 900000,
             "type": "action"
         },
         {
@@ -494,7 +584,7 @@
             },
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Athletics",
-            "sort": 900000,
+            "sort": 1000000,
             "type": "lore"
         },
         {
@@ -522,7 +612,7 @@
             },
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Nature",
-            "sort": 1000000,
+            "sort": 1100000,
             "type": "lore"
         }
     ],

--- a/packs/data/extinction-curse-bestiary.db/xulgath-bomber.json
+++ b/packs/data/extinction-curse-bestiary.db/xulgath-bomber.json
@@ -1189,7 +1189,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>@Template[type:emanation|distance:30]{30 feet} @Compendium[pf2e.bestiary-ability-glossary-srd.Aura]{Aura}</p>\n<hr />\n<p>A creature that enters the area must attempt a @Check[type:fortitude|dc:24] save. On a failure, the creature is @Compendium[pf2e.conditionitems.Sickened]{Sickened 2}, and on a critical failure, the creature is also @Compendium[pf2e.conditionitems.Slowed]{Slowed 1} for as long as it is sickened. While within the aura, the creature takes a -2 circumstance penalty to saves to recover from the sickened condition. A creature that succeeds at its save is temporarily immune to all xulgaths' stench for 1 minute.</p>"
+                    "value": "<p>@Template[type:emanation|distance:30]{30 feet} @Compendium[pf2e.bestiary-ability-glossary-srd.Aura]{Aura}</p>\n<hr />\n<p>A creature that enters the area must attempt a @Check[type:fortitude|dc:24] save. On a failure, the creature is @Compendium[pf2e.conditionitems.Sickened]{Sickened 2}, and on a critical failure, the creature is also @Compendium[pf2e.conditionitems.Slowed]{Slowed 1} for as long as it is sickened. While within the aura, the creature takes a -2 circumstance penalty to saves to recover from the sickened condition. A creature that succeeds at its save is temporarily immune to all xulgaths' stenches for 1 minute.</p>"
                 },
                 "requirements": {
                     "value": ""

--- a/packs/data/pathfinder-bestiary.db/clay-golem.json
+++ b/packs/data/pathfinder-bestiary.db/clay-golem.json
@@ -100,7 +100,7 @@
             },
             "dr": [
                 {
-                    "exceptions": "adamantine",
+                    "exceptions": "except Adamantine",
                     "type": "physical",
                     "value": 10
                 }
@@ -274,7 +274,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>harmed by cold and water ([[/r {5d10}]]{5d10 damage}, [[/r {2d6}]]{2d6 damage} from areas or persistent damage); healed by acid (area [[/r {2d6}[healing]]]{2d6 Hit Points}); slowed by earth</p>\n<hr />\n<p>A golem is immune to spells and magical abilities other than its own, but each type of golem is affected by a few types of magic in special ways. These exceptions are listed in shortened form in the golem's stat block, with the full rules appearing here. If an entry lists multiple types (such as \"cold and water\"), either type of spell can affect the golem.</p>\n<ul>\n<li><strong>Harmed By</strong> Any magic of this type that targets the golem causes it to take the listed amount of damage (this damage has no type) instead of the usual effect. If the golem starts its turn in an area of magic of this type or is affected by a persistent effect of the appropriate type, it takes the damage listed in the parenthetical.</li>\n<li><strong>Healed By</strong> Any magic of this type that targets the golem makes the golem lose the slowed condition and gain HP equal to half the damage the spell would have dealt. If the golem starts its turn in an area of this type of magic, it gains the HP listed in the parenthetical.</li>\n<li><strong>Slowed By</strong> Any magic of this type that targets the golem causes it to be @Compendium[pf2e.conditionitems.Slowed]{Slowed 1} for [[/br 2d6 #rounds]]{2d6 rounds} instead of the usual effect. If the golem starts its turn in an area of this type of magic, it's slowed 1 for that round.</li>\n<li><strong>Vulnerable To</strong> Each golem is vulnerable to one or more specific spells, with the effects described in its stat block.</li>\n</ul>"
+                    "value": "<ul>\n<li><strong>Harmed By</strong> cold and water ([[/r {5d10}]]{5d10 damage}, [[/r {2d6}]]{2d6 damage} from areas or persistent damage)</li>\n<li><strong>Healed By</strong> acid (area [[/r {2d6}[healing]]]{2d6 Hit Points})</li>\n<li><strong>Slowed By</strong> earth</li>\n</ul>\n<hr />\n<p>A golem is immune to spells and magical abilities other than its own, but each type of golem is affected by a few types of magic in special ways. These exceptions are listed in shortened form in the golem's stat block, with the full rules appearing here. If an entry lists multiple types (such as \"cold and water\"), either type of spell can affect the golem.</p>\n<ul>\n<li><strong>Harmed By</strong> Any magic of this type that targets the golem causes it to take the listed amount of damage (this damage has no type) instead of the usual effect. If the golem starts its turn in an area of magic of this type or is affected by a persistent effect of the appropriate type, it takes the damage listed in the parenthetical.</li>\n<li><strong>Healed By</strong> Any magic of this type that targets the golem makes the golem lose the slowed condition and gain HP equal to half the damage the spell would have dealt. If the golem starts its turn in an area of this type of magic, it gains the HP listed in the parenthetical.</li>\n<li><strong>Slowed By</strong> Any magic of this type that targets the golem causes it to be @Compendium[pf2e.conditionitems.Slowed]{Slowed 1} for [[/br 2d6 #rounds]]{2d6 rounds} instead of the usual effect. If the golem starts its turn in an area of this type of magic, it's slowed 1 for that round.</li>\n<li><strong>Vulnerable To</strong> Each golem is vulnerable to one or more specific spells, with the effects described in its stat block.</li>\n</ul>"
                 },
                 "requirements": {
                     "value": ""
@@ -402,7 +402,7 @@
                     "value": 1
                 },
                 "description": {
-                    "value": "<p><strong>Requirement</strong> The golem is berserk.</p>\n<hr />\n<p><strong>Effect</strong> The clay golem Strikes with its fist at a -1 circumstance penalty. If it hits, it deals an additional [[/r {1d8}[bludgeoning]]]{1d6 bludgeoning damage} and knocks the target @Compendium[pf2e.conditionitems.Prone]{Prone}.</p>"
+                    "value": "<p><strong>Requirement</strong> The golem is berserk.</p>\n<hr />\n<p><strong>Effect</strong> The clay golem Strikes with its fist at a -1 circumstance penalty. If it hits, it deals an additional [[/r {1d8}[bludgeoning]]]{1d8 bludgeoning damage} and knocks the target @Compendium[pf2e.conditionitems.Prone]{Prone}.</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -483,7 +483,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>A creature hit by the clay golem's fist must succeed at a @Check[type:fortitude|dc:29] save or be cursed until healed to its maximum HP. The cursed creature can't regain HP except via magic, and anyone casting a spell to heal the creature must succeed at a DC 29 counteract check or the healing has no effect. The golem's counteract level is equal to its creature level.</p>"
+                    "value": "<p>A creature hit by the clay golem's fist must succeed at a @Check[type:fortitude|dc:29] save or be cursed until healed to its maximum HP. The cursed creature can't regain HP except via magic, and anyone @Compendium[pf2e.actionspf2e.Cast a Spell]{Casting a Spell} to heal the creature must succeed at a DC 29 counteract check or the healing has no effect. The golem's counteract level is equal to its creature level.</p>"
                 },
                 "requirements": {
                     "value": ""


### PR DESCRIPTION
Update Headless Xulgath, Hooklimb Xulgath, Resin-Seep Xulgath, and Runkrunk.
Additionally, fix spells per SpartanCPA's suggestion on Pin Tingwheely. Also matched Clay Golem from B1 to Runkrunk, and fixed a small grammar error in Xulgath Bomber.