### PR TITLE
Restrict mauler dedication critical specialisation to expert proficiency

### DIFF
--- a/packs/data/feats.db/mauler-dedication.json
+++ b/packs/data/feats.db/mauler-dedication.json
@@ -73,6 +73,12 @@
                                 "weapon:trait:two-hand-d10",
                                 "weapon:trait:two-hand-d12"
                             ]
+                        },
+                        {
+                            "gte": [
+                                "weapon:proficiency:rank",
+                                2
+                            ]
                         }
                     ]
                 }


### PR DESCRIPTION
Mauler Dedication only grants the critical specialisation effect for weapons in which the character is at least an expert.