### PR TITLE
Fix erroneous use of PointerEvent in place of MouseEvent

### DIFF
--- a/src/module/system/statistic/index.ts
+++ b/src/module/system/statistic/index.ts
@@ -280,7 +280,7 @@ class StatisticCheck {
         const { secret, skipDialog } = (() => {
             if (isObject<{ event: { originalEvent?: unknown } }>(args)) {
                 const event = args.event?.originalEvent ?? args.event;
-                if (event instanceof PointerEvent) {
+                if (event instanceof MouseEvent) {
                     return mergeObject({ secret: args.secret, skipDialog: args.skipDialog }, eventToRollParams(event));
                 }
             }

--- a/src/scripts/sheet-util.ts
+++ b/src/scripts/sheet-util.ts
@@ -4,7 +4,7 @@ interface ParamsFromEvent {
     skipDialog: boolean;
 }
 
-export function eventToRollParams(event: JQuery.TriggeredEvent | PointerEvent): ParamsFromEvent {
+export function eventToRollParams(event: JQuery.TriggeredEvent | MouseEvent): ParamsFromEvent {
     const skipDefault = !game.user.settings.showRollDialogs;
     const params: ParamsFromEvent = { skipDialog: event.shiftKey ? !skipDefault : skipDefault };
     if (event.ctrlKey || event.metaKey) params.secret = true;


### PR DESCRIPTION
This change fixes some minor inconsistencies depending on the type of event the browser emits. Specifically, there was an issue with Token Action HUD where skill checks weren't picking up modifier keys properly because Firefox (at least on my machine) was emitting a MouseEvent, meaning the branch to check modifiers was missed and shift/ctrl didn't affect the roll settings.