### PR TITLE
Fix display of action traits on Strike damage rolls

### DIFF
--- a/src/module/system/damage/roll-dialog.ts
+++ b/src/module/system/damage/roll-dialog.ts
@@ -40,10 +40,7 @@ export class DamageRollModifiersDialog extends Application {
         let flavor = `<strong>${damage.name}</strong> (${outcomeLabel})`;
 
         if (damage.traits) {
-            const strikeTraits: Record<string, string | undefined> = {
-                ...CONFIG.PF2E.npcAttackTraits,
-                attack: "PF2E.TraitAttack",
-            };
+            const strikeTraits: Record<string, string | undefined> = CONFIG.PF2E.actionTraits;
 
             interface ToTagsParams {
                 labels?: Record<string, string | undefined>;


### PR DESCRIPTION
Before and after
![image](https://user-images.githubusercontent.com/106829671/176116740-1dba83b8-41ac-4337-8666-7f1c50d1cd30.png)
