### PR TITLE
Correct names of Quick Change and Quick Shape feats.

### DIFF
--- a/packs/data/feats.db/quick-change.json
+++ b/packs/data/feats.db/quick-change.json
@@ -42,6 +42,6 @@
         }
     },
     "img": "systems/pf2e/icons/features/feats/feats.webp",
-    "name": "Quick Change (Vigilante)",
+    "name": "Quick Change",
     "type": "feat"
 }

--- a/packs/data/feats.db/quick-shape.json
+++ b/packs/data/feats.db/quick-shape.json
@@ -36,6 +36,6 @@
         }
     },
     "img": "systems/pf2e/icons/features/feats/feats.webp",
-    "name": "Quick Change (Beastkin)",
+    "name": "Quick Shape",
     "type": "feat"
 }


### PR DESCRIPTION
Change Quick Change (Beastkin) to be correctly named Quick Shape
Change Quick Change (Vigilante) to just Quick Change