### PR TITLE
Update Adventurer's Pack with the correct amount of chalk

### DIFF
--- a/packs/data/equipment.db/adventurers-pack.json
+++ b/packs/data/equipment.db/adventurers-pack.json
@@ -35,7 +35,7 @@
                         "items": {},
                         "name": "Chalk",
                         "pack": "pf2e.equipment-srd",
-                        "quantity": 1
+                        "quantity": 10
                     },
                     "fabyb": {
                         "id": "UlIxxLm71UdRgCFE",


### PR DESCRIPTION
It should be 10 pieces of chalk, not just 1. This also causes a pricing discrepancy. A miniscule one, but a discrepancy nonetheless.