### PR TITLE
Correct spellheart usage and add toggles for resistances/damage

### DIFF
--- a/packs/data/equipment.db/five-feather-wreath-greater.json
+++ b/packs/data/equipment.db/five-feather-wreath-greater.json
@@ -50,7 +50,7 @@
             ]
         },
         "usage": {
-            "value": "held-in-one-hand"
+            "value": "affixed-to-armor-or-a-weapon"
         },
         "weight": {
             "value": "-"

--- a/packs/data/equipment.db/five-feather-wreath-major.json
+++ b/packs/data/equipment.db/five-feather-wreath-major.json
@@ -50,7 +50,7 @@
             ]
         },
         "usage": {
-            "value": "held-in-one-hand"
+            "value": "affixed-to-armor-or-a-weapon"
         },
         "weight": {
             "value": "-"

--- a/packs/data/equipment.db/five-feather-wreath.json
+++ b/packs/data/equipment.db/five-feather-wreath.json
@@ -50,7 +50,7 @@
             ]
         },
         "usage": {
-            "value": "held-in-one-hand"
+            "value": "affixed-to-armor-or-a-weapon"
         },
         "weight": {
             "value": "-"

--- a/packs/data/equipment.db/flaming-star-greater.json
+++ b/packs/data/equipment.db/flaming-star-greater.json
@@ -33,7 +33,54 @@
             }
         },
         "quantity": 1,
-        "rules": [],
+        "rules": [
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "label": "Flaming star bonus damage",
+                "option": "flaming-star-damage",
+                "toggleable": true
+            },
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "label": "Flaming star fire resistance",
+                "option": "flaming-star-resistance",
+                "toggleable": true
+            },
+            {
+                "key": "TokenEffectIcon",
+                "path": "systems/pf2e/icons/equipment/other/spellhearts/flaming-star.webp",
+                "predicate": {
+                    "any": [
+                        "flaming-star-damage",
+                        "flaming-star-resistance"
+                    ]
+                }
+            },
+            {
+                "damageType": "fire",
+                "diceNumber": 1,
+                "dieSize": "d6",
+                "key": "DamageDice",
+                "predicate": {
+                    "all": [
+                        "flaming-star-damage"
+                    ]
+                },
+                "selector": "strike-damage"
+            },
+            {
+                "key": "Resistance",
+                "predicate": {
+                    "all": [
+                        "flaming-star-resistance"
+                    ]
+                },
+                "type": "fire",
+                "value": 5
+            }
+        ],
         "size": "med",
         "source": {
             "value": "Pathfinder Secrets of Magic"

--- a/packs/data/equipment.db/flaming-star-greater.json
+++ b/packs/data/equipment.db/flaming-star-greater.json
@@ -50,7 +50,7 @@
             ]
         },
         "usage": {
-            "value": "held-in-one-hand"
+            "value": "affixed-to-armor-or-a-weapon"
         },
         "weight": {
             "value": "-"

--- a/packs/data/equipment.db/flaming-star-major.json
+++ b/packs/data/equipment.db/flaming-star-major.json
@@ -33,7 +33,54 @@
             }
         },
         "quantity": 1,
-        "rules": [],
+        "rules": [
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "label": "Flaming star bonus damage",
+                "option": "flaming-star-damage",
+                "toggleable": true
+            },
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "label": "Flaming star fire resistance",
+                "option": "flaming-star-resistance",
+                "toggleable": true
+            },
+            {
+                "key": "TokenEffectIcon",
+                "path": "systems/pf2e/icons/equipment/other/spellhearts/flaming-star.webp",
+                "predicate": {
+                    "any": [
+                        "flaming-star-damage",
+                        "flaming-star-resistance"
+                    ]
+                }
+            },
+            {
+                "damageType": "fire",
+                "diceNumber": 1,
+                "dieSize": "d8",
+                "key": "DamageDice",
+                "predicate": {
+                    "all": [
+                        "flaming-star-damage"
+                    ]
+                },
+                "selector": "strike-damage"
+            },
+            {
+                "key": "Resistance",
+                "predicate": {
+                    "all": [
+                        "flaming-star-resistance"
+                    ]
+                },
+                "type": "fire",
+                "value": 10
+            }
+        ],
         "size": "med",
         "source": {
             "value": "Pathfinder Secrets of Magic"

--- a/packs/data/equipment.db/flaming-star-major.json
+++ b/packs/data/equipment.db/flaming-star-major.json
@@ -50,7 +50,7 @@
             ]
         },
         "usage": {
-            "value": "held-in-one-hand"
+            "value": "affixed-to-armor-or-a-weapon"
         },
         "weight": {
             "value": "-"

--- a/packs/data/equipment.db/flaming-star.json
+++ b/packs/data/equipment.db/flaming-star.json
@@ -33,7 +33,54 @@
             }
         },
         "quantity": 1,
-        "rules": [],
+        "rules": [
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "label": "Flaming star bonus damage",
+                "option": "flaming-star-damage",
+                "toggleable": true
+            },
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "label": "Flaming star fire resistance",
+                "option": "flaming-star-resistance",
+                "toggleable": true
+            },
+            {
+                "key": "TokenEffectIcon",
+                "path": "systems/pf2e/icons/equipment/other/spellhearts/flaming-star.webp",
+                "predicate": {
+                    "any": [
+                        "flaming-star-damage",
+                        "flaming-star-resistance"
+                    ]
+                }
+            },
+            {
+                "damageType": "fire",
+                "diceNumber": 1,
+                "dieSize": "d4",
+                "key": "DamageDice",
+                "predicate": {
+                    "all": [
+                        "flaming-star-damage"
+                    ]
+                },
+                "selector": "strike-damage"
+            },
+            {
+                "key": "Resistance",
+                "predicate": {
+                    "all": [
+                        "flaming-star-resistance"
+                    ]
+                },
+                "type": "fire",
+                "value": 2
+            }
+        ],
         "size": "med",
         "source": {
             "value": "Pathfinder Secrets of Magic"

--- a/packs/data/equipment.db/flaming-star.json
+++ b/packs/data/equipment.db/flaming-star.json
@@ -50,7 +50,7 @@
             ]
         },
         "usage": {
-            "value": "held-in-one-hand"
+            "value": "affixed-to-armor-or-a-weapon"
         },
         "weight": {
             "value": "-"

--- a/packs/data/equipment.db/grim-sandglass-greater.json
+++ b/packs/data/equipment.db/grim-sandglass-greater.json
@@ -49,7 +49,7 @@
             ]
         },
         "usage": {
-            "value": "held-in-one-hand"
+            "value": "affixed-to-armor-or-a-weapon"
         },
         "weight": {
             "value": "-"

--- a/packs/data/equipment.db/grim-sandglass-greater.json
+++ b/packs/data/equipment.db/grim-sandglass-greater.json
@@ -33,7 +33,54 @@
             }
         },
         "quantity": 1,
-        "rules": [],
+        "rules": [
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "label": "Grim sandglass bonus damage",
+                "option": "grim-sandglass-damage",
+                "toggleable": true
+            },
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "label": "Grim sandglass negative resistance",
+                "option": "grim-sandglass-resistance",
+                "toggleable": true
+            },
+            {
+                "key": "TokenEffectIcon",
+                "path": "systems/pf2e/icons/equipment/other/spellhearts/grim-sandglass.webp",
+                "predicate": {
+                    "any": [
+                        "grim-sandglass-damage",
+                        "grim-sandglass-resistance"
+                    ]
+                }
+            },
+            {
+                "damageType": "negative",
+                "diceNumber": 1,
+                "dieSize": "d6",
+                "key": "DamageDice",
+                "predicate": {
+                    "all": [
+                        "grim-sandglass-damage"
+                    ]
+                },
+                "selector": "strike-damage"
+            },
+            {
+                "key": "Resistance",
+                "predicate": {
+                    "all": [
+                        "grim-sandglass-resistance"
+                    ]
+                },
+                "type": "negative",
+                "value": 5
+            }
+        ],
         "size": "med",
         "source": {
             "value": "Pathfinder Secrets of Magic"

--- a/packs/data/equipment.db/grim-sandglass-major.json
+++ b/packs/data/equipment.db/grim-sandglass-major.json
@@ -49,7 +49,7 @@
             ]
         },
         "usage": {
-            "value": "held-in-one-hand"
+            "value": "affixed-to-armor-or-a-weapon"
         },
         "weight": {
             "value": "-"

--- a/packs/data/equipment.db/grim-sandglass-major.json
+++ b/packs/data/equipment.db/grim-sandglass-major.json
@@ -33,7 +33,54 @@
             }
         },
         "quantity": 1,
-        "rules": [],
+        "rules": [
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "label": "Grim sandglass bonus damage",
+                "option": "grim-sandglass-damage",
+                "toggleable": true
+            },
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "label": "Grim sandglass negative resistance",
+                "option": "grim-sandglass-resistance",
+                "toggleable": true
+            },
+            {
+                "key": "TokenEffectIcon",
+                "path": "systems/pf2e/icons/equipment/other/spellhearts/grim-sandglass.webp",
+                "predicate": {
+                    "any": [
+                        "grim-sandglass-damage",
+                        "grim-sandglass-resistance"
+                    ]
+                }
+            },
+            {
+                "damageType": "negative",
+                "diceNumber": 1,
+                "dieSize": "d8",
+                "key": "DamageDice",
+                "predicate": {
+                    "all": [
+                        "grim-sandglass-damage"
+                    ]
+                },
+                "selector": "strike-damage"
+            },
+            {
+                "key": "Resistance",
+                "predicate": {
+                    "all": [
+                        "grim-sandglass-resistance"
+                    ]
+                },
+                "type": "negative",
+                "value": 10
+            }
+        ],
         "size": "med",
         "source": {
             "value": "Pathfinder Secrets of Magic"

--- a/packs/data/equipment.db/grim-sandglass.json
+++ b/packs/data/equipment.db/grim-sandglass.json
@@ -49,7 +49,7 @@
             ]
         },
         "usage": {
-            "value": "held-in-one-hand"
+            "value": "affixed-to-armor-or-a-weapon"
         },
         "weight": {
             "value": "-"

--- a/packs/data/equipment.db/grim-sandglass.json
+++ b/packs/data/equipment.db/grim-sandglass.json
@@ -33,7 +33,54 @@
             }
         },
         "quantity": 1,
-        "rules": [],
+        "rules": [
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "label": "Grim sandglass bonus damage",
+                "option": "grim-sandglass-damage",
+                "toggleable": true
+            },
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "label": "Grim sandglass negative resistance",
+                "option": "grim-sandglass-resistance",
+                "toggleable": true
+            },
+            {
+                "key": "TokenEffectIcon",
+                "path": "systems/pf2e/icons/equipment/other/spellhearts/grim-sandglass.webp",
+                "predicate": {
+                    "any": [
+                        "grim-sandglass-damage",
+                        "grim-sandglass-resistance"
+                    ]
+                }
+            },
+            {
+                "damageType": "negative",
+                "diceNumber": 1,
+                "dieSize": "d4",
+                "key": "DamageDice",
+                "predicate": {
+                    "all": [
+                        "grim-sandglass-damage"
+                    ]
+                },
+                "selector": "strike-damage"
+            },
+            {
+                "key": "Resistance",
+                "predicate": {
+                    "all": [
+                        "grim-sandglass-resistance"
+                    ]
+                },
+                "type": "negative",
+                "value": 2
+            }
+        ],
         "size": "med",
         "source": {
             "value": "Pathfinder Secrets of Magic"

--- a/packs/data/equipment.db/perfect-droplet-greater.json
+++ b/packs/data/equipment.db/perfect-droplet-greater.json
@@ -33,7 +33,34 @@
             }
         },
         "quantity": 1,
-        "rules": [],
+        "rules": [
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "label": "Perfect droplet water resistance",
+                "option": "perfect-droplet-resistance",
+                "toggleable": true
+            },
+            {
+                "key": "TokenEffectIcon",
+                "path": "systems/pf2e/icons/equipment/other/spellhearts/perfect-droplet.webp",
+                "predicate": {
+                    "any": [
+                        "perfect-droplet-resistance"
+                    ]
+                }
+            },
+            {
+                "key": "Resistance",
+                "predicate": {
+                    "all": [
+                        "perfect-droplet-resistance"
+                    ]
+                },
+                "type": "water",
+                "value": 5
+            }
+        ],
         "size": "med",
         "source": {
             "value": "Pathfinder Secrets of Magic"

--- a/packs/data/equipment.db/perfect-droplet-greater.json
+++ b/packs/data/equipment.db/perfect-droplet-greater.json
@@ -50,7 +50,7 @@
             ]
         },
         "usage": {
-            "value": "held-in-one-hand"
+            "value": "affixed-to-armor-or-a-weapon"
         },
         "weight": {
             "value": "-"

--- a/packs/data/equipment.db/perfect-droplet-major.json
+++ b/packs/data/equipment.db/perfect-droplet-major.json
@@ -33,7 +33,34 @@
             }
         },
         "quantity": 1,
-        "rules": [],
+        "rules": [
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "label": "Perfect droplet water resistance",
+                "option": "perfect-droplet-resistance",
+                "toggleable": true
+            },
+            {
+                "key": "TokenEffectIcon",
+                "path": "systems/pf2e/icons/equipment/other/spellhearts/perfect-droplet.webp",
+                "predicate": {
+                    "any": [
+                        "perfect-droplet-resistance"
+                    ]
+                }
+            },
+            {
+                "key": "Resistance",
+                "predicate": {
+                    "all": [
+                        "perfect-droplet-resistance"
+                    ]
+                },
+                "type": "water",
+                "value": 10
+            }
+        ],
         "size": "med",
         "source": {
             "value": "Pathfinder Secrets of Magic"

--- a/packs/data/equipment.db/perfect-droplet-major.json
+++ b/packs/data/equipment.db/perfect-droplet-major.json
@@ -50,7 +50,7 @@
             ]
         },
         "usage": {
-            "value": "held-in-one-hand"
+            "value": "affixed-to-armor-or-a-weapon"
         },
         "weight": {
             "value": "-"

--- a/packs/data/equipment.db/perfect-droplet.json
+++ b/packs/data/equipment.db/perfect-droplet.json
@@ -33,7 +33,34 @@
             }
         },
         "quantity": 1,
-        "rules": [],
+        "rules": [
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "label": "Perfect droplet water resistance",
+                "option": "perfect-droplet-resistance",
+                "toggleable": true
+            },
+            {
+                "key": "TokenEffectIcon",
+                "path": "systems/pf2e/icons/equipment/other/spellhearts/perfect-droplet.webp",
+                "predicate": {
+                    "any": [
+                        "perfect-droplet-resistance"
+                    ]
+                }
+            },
+            {
+                "key": "Resistance",
+                "predicate": {
+                    "all": [
+                        "perfect-droplet-resistance"
+                    ]
+                },
+                "type": "water",
+                "value": 2
+            }
+        ],
         "size": "med",
         "source": {
             "value": "Pathfinder Secrets of Magic"

--- a/packs/data/equipment.db/perfect-droplet.json
+++ b/packs/data/equipment.db/perfect-droplet.json
@@ -50,7 +50,7 @@
             ]
         },
         "usage": {
-            "value": "held-in-one-hand"
+            "value": "affixed-to-armor-or-a-weapon"
         },
         "weight": {
             "value": "-"

--- a/packs/data/equipment.db/trinity-geode-greater.json
+++ b/packs/data/equipment.db/trinity-geode-greater.json
@@ -33,7 +33,54 @@
             }
         },
         "quantity": 1,
-        "rules": [],
+        "rules": [
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "label": "Trinity geode bonus damage",
+                "option": "trinity-geode-damage",
+                "toggleable": true
+            },
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "label": "Trinity geode physical resistance",
+                "option": "trinity-geode-resistance",
+                "toggleable": true
+            },
+            {
+                "key": "TokenEffectIcon",
+                "path": "systems/pf2e/icons/equipment/other/spellhearts/trinity-geode.webp",
+                "predicate": {
+                    "any": [
+                        "trinity-geode-damage",
+                        "trinity-geode-resistance"
+                    ]
+                }
+            },
+            {
+                "damageType": "bludgeoning",
+                "diceNumber": 1,
+                "dieSize": "d6",
+                "key": "DamageDice",
+                "predicate": {
+                    "all": [
+                        "trinity-geode-damage"
+                    ]
+                },
+                "selector": "strike-damage"
+            },
+            {
+                "key": "Resistance",
+                "predicate": {
+                    "all": [
+                        "trinity-geode-resistance"
+                    ]
+                },
+                "type": "physical",
+                "value": 3
+            }
+        ],
         "size": "med",
         "source": {
             "value": "Pathfinder Secrets of Magic"

--- a/packs/data/equipment.db/trinity-geode-greater.json
+++ b/packs/data/equipment.db/trinity-geode-greater.json
@@ -50,7 +50,7 @@
             ]
         },
         "usage": {
-            "value": "held-in-one-hand"
+            "value": "affixed-to-armor-or-a-weapon"
         },
         "weight": {
             "value": "-"

--- a/packs/data/equipment.db/trinity-geode-major.json
+++ b/packs/data/equipment.db/trinity-geode-major.json
@@ -33,7 +33,54 @@
             }
         },
         "quantity": 1,
-        "rules": [],
+        "rules": [
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "label": "Trinity geode bonus damage",
+                "option": "trinity-geode-damage",
+                "toggleable": true
+            },
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "label": "Trinity geode physical resistance",
+                "option": "trinity-geode-resistance",
+                "toggleable": true
+            },
+            {
+                "key": "TokenEffectIcon",
+                "path": "systems/pf2e/icons/equipment/other/spellhearts/trinity-geode.webp",
+                "predicate": {
+                    "any": [
+                        "trinity-geode-damage",
+                        "trinity-geode-resistance"
+                    ]
+                }
+            },
+            {
+                "damageType": "bludgeoning",
+                "diceNumber": 1,
+                "dieSize": "d8",
+                "key": "DamageDice",
+                "predicate": {
+                    "all": [
+                        "trinity-geode-damage"
+                    ]
+                },
+                "selector": "strike-damage"
+            },
+            {
+                "key": "Resistance",
+                "predicate": {
+                    "all": [
+                        "trinity-geode-resistance"
+                    ]
+                },
+                "type": "physical",
+                "value": 5
+            }
+        ],
         "size": "med",
         "source": {
             "value": "Pathfinder Secrets of Magic"

--- a/packs/data/equipment.db/trinity-geode-major.json
+++ b/packs/data/equipment.db/trinity-geode-major.json
@@ -50,7 +50,7 @@
             ]
         },
         "usage": {
-            "value": "held-in-one-hand"
+            "value": "affixed-to-armor-or-a-weapon"
         },
         "weight": {
             "value": "-"

--- a/packs/data/equipment.db/trinity-geode.json
+++ b/packs/data/equipment.db/trinity-geode.json
@@ -33,7 +33,54 @@
             }
         },
         "quantity": 1,
-        "rules": [],
+        "rules": [
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "label": "Trinity geode bonus damage",
+                "option": "trinity-geode-damage",
+                "toggleable": true
+            },
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "label": "Trinity geode physical resistance",
+                "option": "trinity-geode-resistance",
+                "toggleable": true
+            },
+            {
+                "key": "TokenEffectIcon",
+                "path": "systems/pf2e/icons/equipment/other/spellhearts/trinity-geode.webp",
+                "predicate": {
+                    "any": [
+                        "trinity-geode-damage",
+                        "trinity-geode-resistance"
+                    ]
+                }
+            },
+            {
+                "damageType": "bludgeoning",
+                "diceNumber": 1,
+                "dieSize": "d4",
+                "key": "DamageDice",
+                "predicate": {
+                    "all": [
+                        "trinity-geode-damage"
+                    ]
+                },
+                "selector": "strike-damage"
+            },
+            {
+                "key": "Resistance",
+                "predicate": {
+                    "all": [
+                        "trinity-geode-resistance"
+                    ]
+                },
+                "type": "physical",
+                "value": 1
+            }
+        ],
         "size": "med",
         "source": {
             "value": "Pathfinder Secrets of Magic"

--- a/packs/data/equipment.db/trinity-geode.json
+++ b/packs/data/equipment.db/trinity-geode.json
@@ -50,7 +50,7 @@
             ]
         },
         "usage": {
-            "value": "held-in-one-hand"
+            "value": "affixed-to-armor-or-a-weapon"
         },
         "weight": {
             "value": "-"


### PR DESCRIPTION
Spellhearts work like talismans in that they're affixed to armor or weapons, rather than being held. This PR updates the data to accordingly, and also adds toggles to automate the bonus strike damage and damage resistances they grant when activated.

There already seem to be effects for the five-feather wreath spellhearts to add the acrobatics bonus, so I didn't add toggles for those - though I'm happy to convert those to toggles as well for consistency.