### PR TITLE
Add NPCs and Hazards from PFS 3-17

### DIFF
--- a/packs/data/pathfinder-bestiary.db/gibbering-mouther.json
+++ b/packs/data/pathfinder-bestiary.db/gibbering-mouther.json
@@ -462,7 +462,7 @@
                     "value": "action"
                 },
                 "actions": {
-                    "value": 2
+                    "value": 1
                 },
                 "description": {
                     "value": "<p>@Check[type:reflex|dc:22|traits:damaging-effect], [[/r {3d8}[piercing]]]{3d8 piercing}, Escape DC 22, Rupture 8</p>\n<hr />\n<p>@Localize[PF2E.NPC.Abilities.Glossary.Engulf]</p>"
@@ -492,7 +492,7 @@
                     "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.zU3Ovaet4xQ5Gmvy"
                 }
             },
-            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
             "name": "Engulf",
             "sort": 800000,
             "type": "action"

--- a/packs/data/pathfinder-bestiary.db/nightmare.json
+++ b/packs/data/pathfinder-bestiary.db/nightmare.json
@@ -663,7 +663,7 @@
             "type": "lore"
         },
         {
-            "_id": "HkbNyN3Fvx6VJh4g",
+            "_id": "jDbiUgjBMSjHc8yn",
             "data": {
                 "description": {
                     "value": ""
@@ -686,7 +686,7 @@
                 }
             },
             "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Stealth",
+            "name": "Survival",
             "sort": 1100000,
             "type": "lore"
         }

--- a/packs/data/pfs-season-3-bestiary.db/angry-void-boils.json
+++ b/packs/data/pfs-season-3-bestiary.db/angry-void-boils.json
@@ -1,0 +1,119 @@
+{
+    "_id": "FHsq4Yw458ogI2RQ",
+    "data": {
+        "attributes": {
+            "ac": {
+                "value": 0
+            },
+            "hardness": 0,
+            "hp": {
+                "details": "",
+                "max": 0,
+                "temp": 0,
+                "value": 0
+            },
+            "stealth": {
+                "details": "<p>(expert)</p>",
+                "value": 18
+            }
+        },
+        "creatureType": "",
+        "details": {
+            "description": "<p>Tumor-like growths erupt from the isle as it responds to psychic attack, spewing black lightning and fire in every direction.</p>",
+            "disable": "<p>@Check[type:occultism|dc:28] (trained) to reshape the substance of the dream, or @Check[type:performance|dc:32] (trained) or @Check[type:religion|dc:30] (trained) to invoke Desna's blessing through hymns or prayers. Each check to disable the hazard is a two-action activity; two total successes are required to disable the hazard.</p>",
+            "isComplex": true,
+            "level": {
+                "value": 8
+            },
+            "reset": "",
+            "routine": "<p>(1 action) On the hazard's initiative, a boil erupts from the ground and bursts. This blast strikes as many enemies as possible in a @Template[type:burst|distance:15] anywhere on the isle, dealing [[/r {5d8}[force]]]{5d8 force damage} (@Check[type:reflex|dc:26|basic:true] or @Check[type:will|dc:26|basic:true], target's choice) to enemies in the area. Aslynn avoids targeting the nightmares with the blast.</p>"
+        },
+        "saves": {
+            "fortitude": {
+                "saveDetail": "",
+                "value": 0
+            },
+            "reflex": {
+                "saveDetail": "",
+                "value": 0
+            },
+            "will": {
+                "saveDetail": "",
+                "value": 0
+            }
+        },
+        "source": {
+            "author": "",
+            "value": "Pathfinder Society Scenario #3-17: Dreams of a Dustbound Isle"
+        },
+        "statusEffects": [],
+        "traits": {
+            "di": {
+                "custom": "",
+                "selected": {},
+                "value": []
+            },
+            "dr": [],
+            "dv": [],
+            "rarity": "unique",
+            "size": {
+                "value": "med"
+            },
+            "traits": {
+                "custom": "",
+                "value": [
+                    "environmental"
+                ]
+            }
+        }
+    },
+    "img": "systems/pf2e/icons/default-icons/hazard.svg",
+    "items": [
+        {
+            "_id": "cn5qQknUXG6zS1KY",
+            "data": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "reaction"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p><strong>Trigger</strong> Sarnia's psychic intrusion begins;</p>\n<p><strong>Effect</strong> The hazard rolls initiative.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Reaction.webp",
+            "name": "Awaken",
+            "sort": 0,
+            "type": "action"
+        }
+    ],
+    "name": "Angry Void Boils",
+    "token": {
+        "disposition": -1,
+        "height": 1,
+        "img": "systems/pf2e/icons/default-icons/hazard.svg",
+        "name": "Angry Void Boils",
+        "width": 1
+    },
+    "type": "hazard"
+}

--- a/packs/data/pfs-season-3-bestiary.db/angry-void-boils.json
+++ b/packs/data/pfs-season-3-bestiary.db/angry-void-boils.json
@@ -20,7 +20,7 @@
         "creatureType": "",
         "details": {
             "description": "<p>Tumor-like growths erupt from the isle as it responds to psychic attack, spewing black lightning and fire in every direction.</p>",
-            "disable": "<p>@Check[type:occultism|dc:28] (trained) to reshape the substance of the dream, or @Check[type:performance|dc:32] (trained) or @Check[type:religion|dc:30] (trained) to invoke Desna's blessing through hymns or prayers. Each check to disable the hazard is a two-action activity; two total successes are required to disable the hazard.</p>",
+            "disable": "<p>@Check[type:occultism|dc:28|name:Reshape the Dream] (trained) to reshape the substance of the dream, or @Check[type:performance|dc:32|name:Invoke Desna's Blessing] (trained) or @Check[type:religion|dc:30|name:Invoke Desna's Blessing] (trained) to invoke Desna's blessing through hymns or prayers. Each check to disable the hazard is a two-action activity; two total successes are required to disable the hazard.</p>",
             "isComplex": true,
             "level": {
                 "value": 8

--- a/packs/data/pfs-season-3-bestiary.db/horrid-nightmare.json
+++ b/packs/data/pfs-season-3-bestiary.db/horrid-nightmare.json
@@ -1,0 +1,704 @@
+{
+    "_id": "sfStaEmGGvXWftsn",
+    "data": {
+        "abilities": {
+            "cha": {
+                "mod": 3
+            },
+            "con": {
+                "mod": 3
+            },
+            "dex": {
+                "mod": 3
+            },
+            "int": {
+                "mod": 1
+            },
+            "str": {
+                "mod": 6
+            },
+            "wis": {
+                "mod": 4
+            }
+        },
+        "attributes": {
+            "ac": {
+                "details": "",
+                "value": 27
+            },
+            "allSaves": {
+                "value": ""
+            },
+            "hp": {
+                "details": "",
+                "max": 150,
+                "temp": 0,
+                "value": 150
+            },
+            "initiative": {
+                "ability": "perception"
+            },
+            "perception": {
+                "value": 16
+            },
+            "speed": {
+                "otherSpeeds": [
+                    {
+                        "type": "fly",
+                        "value": "90"
+                    }
+                ],
+                "value": "40"
+            }
+        },
+        "details": {
+            "alignment": {
+                "value": "NE"
+            },
+            "blurb": "Variant nightmare",
+            "creatureType": "Beast",
+            "level": {
+                "value": 8
+            },
+            "privateNotes": "",
+            "publicNotes": "<p>Nightmares are flaming equine harbingers of death.</p>",
+            "source": {
+                "value": "Pathfinder Society Scenario #3-17: Dreams of a Dustbound Isle"
+            }
+        },
+        "resources": {
+            "focus": {
+                "max": 1,
+                "value": 1
+            }
+        },
+        "saves": {
+            "fortitude": {
+                "saveDetail": "",
+                "value": 17
+            },
+            "reflex": {
+                "saveDetail": "",
+                "value": 17
+            },
+            "will": {
+                "saveDetail": "",
+                "value": 14
+            }
+        },
+        "traits": {
+            "ci": [],
+            "di": {
+                "custom": "",
+                "value": []
+            },
+            "dr": [
+                {
+                    "exceptions": "",
+                    "type": "fire",
+                    "value": 5
+                }
+            ],
+            "dv": [],
+            "languages": {
+                "custom": "",
+                "selected": [],
+                "value": [
+                    "abyssal",
+                    "daemonic",
+                    "infernal"
+                ]
+            },
+            "rarity": "uncommon",
+            "senses": {
+                "value": "darkvision"
+            },
+            "size": {
+                "value": "lg"
+            },
+            "traits": {
+                "custom": "",
+                "value": [
+                    "beast",
+                    "fiend"
+                ]
+            }
+        }
+    },
+    "img": "systems/pf2e/icons/default-icons/npc.svg",
+    "items": [
+        {
+            "_id": "jW0BtgVKN8XQhLKs",
+            "data": {
+                "autoHeightenLevel": {
+                    "value": null
+                },
+                "description": {
+                    "value": ""
+                },
+                "displayLevels": {},
+                "prepared": {
+                    "flexible": false,
+                    "value": "innate"
+                },
+                "proficiency": {
+                    "value": 0
+                },
+                "rules": [],
+                "showSlotlessLevels": {
+                    "value": false
+                },
+                "showUnpreparedSpells": {
+                    "value": true
+                },
+                "slots": {
+                    "slot0": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot1": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot10": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot11": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot2": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot3": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot4": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot5": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot6": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot7": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot8": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot9": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    }
+                },
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "spelldc": {
+                    "dc": 24,
+                    "mod": 0,
+                    "value": 16
+                },
+                "tradition": {
+                    "value": "divine"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/spellcastingEntry.svg",
+            "name": "Divine Innate Spells",
+            "sort": 100000,
+            "type": "spellcastingEntry"
+        },
+        {
+            "_id": "aFTYkeNI6jd2TfGi",
+            "data": {
+                "ability": {
+                    "value": ""
+                },
+                "area": {
+                    "areaType": "",
+                    "value": ""
+                },
+                "areasize": {
+                    "value": ""
+                },
+                "category": {
+                    "value": "spell"
+                },
+                "components": {
+                    "focus": false,
+                    "material": true,
+                    "somatic": true,
+                    "verbal": true
+                },
+                "cost": {
+                    "value": ""
+                },
+                "damage": {
+                    "value": {}
+                },
+                "description": {
+                    "value": "<p>You and your allies traverse the barriers between planes of existence. The targets move to another plane, such as the Plane of Fire, the Shadow Plane, or the Abyss. You must have specific knowledge of the destination plane and use a magic tuning fork created from material from that plane as a focus for the spell. While the tuning forks for most prominent planes are uncommon, just like the spell plane shift, more obscure planes and demiplanes often have rare tuning forks. The spell is highly imprecise, and you appear 1d20x25 miles from the last place one of the targets (of your choice) was located the last time that target traveled to the plane. If it's the first time traveling to a particular plane for all targets, you appear at a random location on the plane. Plane shift doesn't provide a means of return travel, though casting plane shift again allows you to return to your previous plane unless there are extenuating circumstances.</p>"
+                },
+                "duration": {
+                    "value": ""
+                },
+                "hasCounteractCheck": {
+                    "value": false
+                },
+                "level": {
+                    "value": 7
+                },
+                "location": {
+                    "heightenedLevel": 7,
+                    "value": "jW0BtgVKN8XQhLKs"
+                },
+                "materials": {
+                    "value": ""
+                },
+                "prepared": {
+                    "value": ""
+                },
+                "primarycheck": {
+                    "value": ""
+                },
+                "range": {
+                    "value": "touch"
+                },
+                "rules": [],
+                "save": {
+                    "basic": "",
+                    "value": ""
+                },
+                "school": {
+                    "value": "conjuration"
+                },
+                "secondarycasters": {
+                    "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "plane-shift",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "spellType": {
+                    "value": "utility"
+                },
+                "sustained": {
+                    "value": false
+                },
+                "target": {
+                    "value": "self and rider"
+                },
+                "time": {
+                    "value": "10 minutes"
+                },
+                "traditions": {
+                    "value": [
+                        "arcane",
+                        "divine",
+                        "occult",
+                        "primal"
+                    ]
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "uncommon",
+                    "value": [
+                        "teleportation"
+                    ]
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.5bTt2CvYHPvaR7QQ"
+                }
+            },
+            "img": "systems/pf2e/icons/spells/plane-shift.webp",
+            "name": "Plane Shift (Self and Rider Only)",
+            "sort": 200000,
+            "type": "spell"
+        },
+        {
+            "_id": "hvrW7fEOtezPrmRv",
+            "data": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "custom": "",
+                    "value": []
+                },
+                "bonus": {
+                    "value": 19
+                },
+                "damageRolls": {
+                    "37n5ctsnmpa4visxcesk": {
+                        "damage": "2d10+10",
+                        "damageType": "piercing"
+                    },
+                    "s5drabfyhg8fwmzvid9y": {
+                        "damage": "1d6",
+                        "damageType": "evil"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "evil",
+                        "magical"
+                    ]
+                },
+                "weaponType": {
+                    "value": "melee"
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Jaws",
+            "sort": 300000,
+            "type": "melee"
+        },
+        {
+            "_id": "NHSqYE5ZeWiln3Vx",
+            "data": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "custom": "",
+                    "value": []
+                },
+                "bonus": {
+                    "value": 19
+                },
+                "damageRolls": {
+                    "fj0pge7sp6mqmbl9ivn8": {
+                        "damage": "1d8+10",
+                        "damageType": "bludgeoning"
+                    },
+                    "3ukubwqjozdrn1hku9zh": {
+                        "damage": "1d6",
+                        "damageType": "evil"
+                    },
+                    "ze5vpj7fkh010vy3cpwj": {
+                        "damage": "1d8",
+                        "damageType": "fire"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "agile",
+                        "evil",
+                        "fire",
+                        "magical"
+                    ]
+                },
+                "weaponType": {
+                    "value": "melee"
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Hoof",
+            "sort": 400000,
+            "type": "melee"
+        },
+        {
+            "_id": "f0JUzUCQYwMZkmpA",
+            "data": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Darkvision]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "darkvision",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.qCCLZhnp2HhP3Ex6"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Darkvision",
+            "sort": 500000,
+            "type": "action"
+        },
+        {
+            "_id": "nbWXPfh7WyVCERN9",
+            "data": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Template[type:emanation|distance:15]{15 feet} @Compendium[pf2e.bestiary-ability-glossary-srd.Aura]{Aura}</p>\n<hr />\n<p>The nightmare continually exhales black smoke that creates @Compendium[pf2e.conditionitems.Concealed]{Concealment} in an aura around it. Nightmares and their riders can see through this smoke. A creature that begins its turn in the area becomes @Compendium[pf2e.conditionitems.Sickened]{Sickened 2} (@Check[type:fortitude|dc:25] negates) and is then temporarily immune sickness from the smoke for 1 minute. The nightmare, its rider, any creature currently holding its breath (or that does not need to breathe), and any creature immune to poison are immune to the aura's sickened effect but not the concealment.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "aura"
+                    ]
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Smoke",
+            "sort": 600000,
+            "type": "action"
+        },
+        {
+            "_id": "Huqh2NJEkx1xBpoO",
+            "data": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "description": {
+                    "value": "<p>The nightmare Strides or Flies up to triple its Speed. Its hooves burst with intense flame, dealing [[/r {4d6}[fire]]]{4d6 fire damage} (@Check[type:reflex|dc:26|basic:true] save) once to each creature other than the nightmare's rider that the nightmare moves adjacent to during its gallop.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "fire"
+                    ]
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Flaming Gallop",
+            "sort": 700000,
+            "type": "action"
+        },
+        {
+            "_id": "Uc8jZ7kcYg667DHe",
+            "data": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 15
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Acrobatics",
+            "sort": 800000,
+            "type": "lore"
+        },
+        {
+            "_id": "HQNMZ60QblKLLYm7",
+            "data": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 18
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Athletics",
+            "sort": 900000,
+            "type": "lore"
+        },
+        {
+            "_id": "BXeLODiU99tE51Sl",
+            "data": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 17
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Intimidation",
+            "sort": 1000000,
+            "type": "lore"
+        },
+        {
+            "_id": "jDbiUgjBMSjHc8yn",
+            "data": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 16
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Survival",
+            "sort": 1100000,
+            "type": "lore"
+        }
+    ],
+    "name": "Horrid Nightmare",
+    "token": {
+        "disposition": -1,
+        "height": 2,
+        "img": "systems/pf2e/icons/default-icons/npc.svg",
+        "name": "Horrid Nightmare",
+        "width": 2
+    },
+    "type": "npc"
+}

--- a/packs/data/pfs-season-3-bestiary.db/shadow-pfs-3-17.json
+++ b/packs/data/pfs-season-3-bestiary.db/shadow-pfs-3-17.json
@@ -1,0 +1,451 @@
+{
+    "_id": "d0kPtsi2DH3V9WJu",
+    "data": {
+        "abilities": {
+            "cha": {
+                "mod": 3
+            },
+            "con": {
+                "mod": 0
+            },
+            "dex": {
+                "mod": 4
+            },
+            "int": {
+                "mod": -2
+            },
+            "str": {
+                "mod": -5
+            },
+            "wis": {
+                "mod": 2
+            }
+        },
+        "attributes": {
+            "ac": {
+                "details": "",
+                "value": 20
+            },
+            "allSaves": {
+                "value": ""
+            },
+            "hp": {
+                "details": "",
+                "max": 40,
+                "temp": 0,
+                "value": 40
+            },
+            "initiative": {
+                "ability": "perception"
+            },
+            "perception": {
+                "value": 10
+            },
+            "speed": {
+                "otherSpeeds": [
+                    {
+                        "type": "fly",
+                        "value": "30"
+                    }
+                ],
+                "value": "0"
+            }
+        },
+        "details": {
+            "alignment": {
+                "value": "CE"
+            },
+            "blurb": "",
+            "creatureType": "Undead",
+            "level": {
+                "value": 4
+            },
+            "privateNotes": "",
+            "publicNotes": "<p>The mysterious undead known as shadows lurk in dark places and feed on those who stray too far from the light. Those who parley with shadows, typically by keeping them at bay with a glowing weapon, may learn great secrets, for they are ideal spies.</p>",
+            "source": {
+                "value": "Pathfinder Society Scenario #3-17: Dreams of a Dustbound Isle"
+            }
+        },
+        "resources": {},
+        "saves": {
+            "fortitude": {
+                "saveDetail": "",
+                "value": 8
+            },
+            "reflex": {
+                "saveDetail": "",
+                "value": 14
+            },
+            "will": {
+                "saveDetail": "",
+                "value": 12
+            }
+        },
+        "traits": {
+            "attitude": {
+                "value": "hostile"
+            },
+            "ci": [],
+            "di": {
+                "custom": "",
+                "value": [
+                    "death-effects",
+                    "disease",
+                    "paralyzed",
+                    "poison",
+                    "precision",
+                    "unconscious"
+                ]
+            },
+            "dr": [
+                {
+                    "exceptions": "except force, ghost touch, or positive; double resistance vs. non-magical",
+                    "type": "all",
+                    "value": 5
+                }
+            ],
+            "dv": [],
+            "languages": {
+                "custom": "",
+                "selected": [],
+                "value": [
+                    "necril"
+                ]
+            },
+            "rarity": "common",
+            "senses": {
+                "value": "darkvision"
+            },
+            "size": {
+                "value": "med"
+            },
+            "traits": {
+                "custom": "",
+                "value": [
+                    "incorporeal",
+                    "undead"
+                ]
+            }
+        }
+    },
+    "img": "systems/pf2e/icons/default-icons/npc.svg",
+    "items": [
+        {
+            "_id": "x47iDfIE9albveGl",
+            "data": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "custom": "",
+                    "value": []
+                },
+                "bonus": {
+                    "value": 15
+                },
+                "damageRolls": {
+                    "0": {
+                        "damage": "2d6+3",
+                        "damageType": "negative"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "finesse",
+                        "magical"
+                    ]
+                },
+                "weaponType": {
+                    "value": "melee"
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Shadow Hand",
+            "sort": 100000,
+            "type": "melee"
+        },
+        {
+            "_id": "20wHQZMjGAPl30DH",
+            "data": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Darkvision]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "darkvision",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.qCCLZhnp2HhP3Ex6"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Darkvision",
+            "sort": 200000,
+            "type": "action"
+        },
+        {
+            "_id": "ACHlnYzXVxizzqPw",
+            "data": {
+                "actionCategory": {
+                    "value": "defensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>An object shedding magical light (such as from the <em>@Compendium[pf2e.spells-srd.Light]{Light}</em> spell) is treated as magical when used to attack the shadow.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Light Vulnerability",
+            "sort": 300000,
+            "type": "action"
+        },
+        {
+            "_id": "0Qt9ULbGzJV8ZG3W",
+            "data": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>When a creature's shadow is pulled free by Steal Shadow, it becomes a @Compendium[pf2e.pathfinder-bestiary.Shadow]{Shadow Spawn} under the command of the shadow that created it. This shadow spawn doesn't have Steal Shadow and is perpetually and incurably @Compendium[pf2e.conditionitems.Clumsy]{Clumsy 2}. If the creature the shadow spawn was pulled from dies, the shadow spawn becomes a full-fledged, autonomous shadow. If the creature recovers from its @Compendium[pf2e.conditionitems.Enfeebled]{Enfeeblement}, its shadow returns to it and the shadow spawn is extinguished.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Shadow Spawn",
+            "sort": 400000,
+            "type": "action"
+        },
+        {
+            "_id": "0QWVJ7Of8cQNKp0N",
+            "data": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>The shadow can @Compendium[pf2e.actionspf2e.Hide]{Hide} or end its @Compendium[pf2e.actionspf2e.Sneak]{Sneak} in a creature's or object's shadow.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Slink in Shadows",
+            "sort": 500000,
+            "type": "action"
+        },
+        {
+            "_id": "Kjifw1jgDvfmrEGU",
+            "data": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "description": {
+                    "value": "<p><strong>Requirement</strong> The shadow hit a living creature with a shadow hand Strike on its previous action.</p>\n<hr />\n<p><strong>Effect</strong> The shadow pulls at the target's shadow, making the creature @Compendium[pf2e.conditionitems.Enfeebled]{Enfeebled 1} (or @Compendium[pf2e.conditionitems.Enfeebled]{Enfeebled 2} on a critical hit). This is cumulative with other enfeebled conditions from shadows, to a maximum of enfeebled 4. If this increases a creature's enfeebled value to 3 or more, the target's shadow is separated from its body. Enfeebled from Steal Shadow decreases by 1 every hour.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "divine",
+                        "necromancy"
+                    ]
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Steal Shadow",
+            "sort": 600000,
+            "type": "action"
+        },
+        {
+            "_id": "MN0vvAiaLlor6r9T",
+            "data": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 10
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Acrobatics",
+            "sort": 700000,
+            "type": "lore"
+        },
+        {
+            "_id": "vJe05g3F9QTjJFzu",
+            "data": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 14
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Stealth",
+            "sort": 800000,
+            "type": "lore"
+        }
+    ],
+    "name": "Shadow (PFS 3-17)",
+    "token": {
+        "disposition": -1,
+        "height": 1,
+        "img": "systems/pf2e/icons/default-icons/npc.svg",
+        "name": "Shadow",
+        "width": 1
+    },
+    "type": "npc"
+}

--- a/packs/data/pfs-season-3-bestiary.db/smoldering-nightmare.json
+++ b/packs/data/pfs-season-3-bestiary.db/smoldering-nightmare.json
@@ -1,0 +1,704 @@
+{
+    "_id": "2wV0Yv8uQpmRs2E5",
+    "data": {
+        "abilities": {
+            "cha": {
+                "mod": 2
+            },
+            "con": {
+                "mod": 2
+            },
+            "dex": {
+                "mod": 2
+            },
+            "int": {
+                "mod": 1
+            },
+            "str": {
+                "mod": 4
+            },
+            "wis": {
+                "mod": 3
+            }
+        },
+        "attributes": {
+            "ac": {
+                "details": "",
+                "value": 21
+            },
+            "allSaves": {
+                "value": ""
+            },
+            "hp": {
+                "details": "",
+                "max": 64,
+                "temp": 0,
+                "value": 64
+            },
+            "initiative": {
+                "ability": "perception"
+            },
+            "perception": {
+                "value": 11
+            },
+            "speed": {
+                "otherSpeeds": [
+                    {
+                        "type": "fly",
+                        "value": "90"
+                    }
+                ],
+                "value": "40"
+            }
+        },
+        "details": {
+            "alignment": {
+                "value": "NE"
+            },
+            "blurb": "Variant nightmare",
+            "creatureType": "Beast",
+            "level": {
+                "value": 4
+            },
+            "privateNotes": "",
+            "publicNotes": "<p>Nightmares are flaming equine harbingers of death.</p>",
+            "source": {
+                "value": "Pathfinder Society Scenario #3-17: Dreams of a Dustbound Isle"
+            }
+        },
+        "resources": {
+            "focus": {
+                "max": 1,
+                "value": 1
+            }
+        },
+        "saves": {
+            "fortitude": {
+                "saveDetail": "",
+                "value": 12
+            },
+            "reflex": {
+                "saveDetail": "",
+                "value": 12
+            },
+            "will": {
+                "saveDetail": "",
+                "value": 9
+            }
+        },
+        "traits": {
+            "ci": [],
+            "di": {
+                "custom": "",
+                "value": []
+            },
+            "dr": [
+                {
+                    "exceptions": "",
+                    "type": "fire",
+                    "value": 5
+                }
+            ],
+            "dv": [],
+            "languages": {
+                "custom": "",
+                "selected": [],
+                "value": [
+                    "abyssal",
+                    "daemonic",
+                    "infernal"
+                ]
+            },
+            "rarity": "uncommon",
+            "senses": {
+                "value": "darkvision"
+            },
+            "size": {
+                "value": "lg"
+            },
+            "traits": {
+                "custom": "",
+                "value": [
+                    "beast",
+                    "fiend"
+                ]
+            }
+        }
+    },
+    "img": "systems/pf2e/icons/default-icons/npc.svg",
+    "items": [
+        {
+            "_id": "jW0BtgVKN8XQhLKs",
+            "data": {
+                "autoHeightenLevel": {
+                    "value": null
+                },
+                "description": {
+                    "value": ""
+                },
+                "displayLevels": {},
+                "prepared": {
+                    "flexible": false,
+                    "value": "innate"
+                },
+                "proficiency": {
+                    "value": 0
+                },
+                "rules": [],
+                "showSlotlessLevels": {
+                    "value": false
+                },
+                "showUnpreparedSpells": {
+                    "value": true
+                },
+                "slots": {
+                    "slot0": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot1": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot10": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot11": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot2": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot3": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot4": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot5": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot6": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot7": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot8": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot9": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    }
+                },
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "spelldc": {
+                    "dc": 24,
+                    "mod": 0,
+                    "value": 16
+                },
+                "tradition": {
+                    "value": "divine"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/spellcastingEntry.svg",
+            "name": "Divine Innate Spells",
+            "sort": 100000,
+            "type": "spellcastingEntry"
+        },
+        {
+            "_id": "aFTYkeNI6jd2TfGi",
+            "data": {
+                "ability": {
+                    "value": ""
+                },
+                "area": {
+                    "areaType": "",
+                    "value": ""
+                },
+                "areasize": {
+                    "value": ""
+                },
+                "category": {
+                    "value": "spell"
+                },
+                "components": {
+                    "focus": false,
+                    "material": true,
+                    "somatic": true,
+                    "verbal": true
+                },
+                "cost": {
+                    "value": ""
+                },
+                "damage": {
+                    "value": {}
+                },
+                "description": {
+                    "value": "<p>You and your allies traverse the barriers between planes of existence. The targets move to another plane, such as the Plane of Fire, the Shadow Plane, or the Abyss. You must have specific knowledge of the destination plane and use a magic tuning fork created from material from that plane as a focus for the spell. While the tuning forks for most prominent planes are uncommon, just like the spell plane shift, more obscure planes and demiplanes often have rare tuning forks. The spell is highly imprecise, and you appear 1d20x25 miles from the last place one of the targets (of your choice) was located the last time that target traveled to the plane. If it's the first time traveling to a particular plane for all targets, you appear at a random location on the plane. Plane shift doesn't provide a means of return travel, though casting plane shift again allows you to return to your previous plane unless there are extenuating circumstances.</p>"
+                },
+                "duration": {
+                    "value": ""
+                },
+                "hasCounteractCheck": {
+                    "value": false
+                },
+                "level": {
+                    "value": 7
+                },
+                "location": {
+                    "heightenedLevel": 7,
+                    "value": "jW0BtgVKN8XQhLKs"
+                },
+                "materials": {
+                    "value": ""
+                },
+                "prepared": {
+                    "value": ""
+                },
+                "primarycheck": {
+                    "value": ""
+                },
+                "range": {
+                    "value": "touch"
+                },
+                "rules": [],
+                "save": {
+                    "basic": "",
+                    "value": ""
+                },
+                "school": {
+                    "value": "conjuration"
+                },
+                "secondarycasters": {
+                    "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "plane-shift",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "spellType": {
+                    "value": "utility"
+                },
+                "sustained": {
+                    "value": false
+                },
+                "target": {
+                    "value": "self and rider"
+                },
+                "time": {
+                    "value": "10 minutes"
+                },
+                "traditions": {
+                    "value": [
+                        "arcane",
+                        "divine",
+                        "occult",
+                        "primal"
+                    ]
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "uncommon",
+                    "value": [
+                        "teleportation"
+                    ]
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.5bTt2CvYHPvaR7QQ"
+                }
+            },
+            "img": "systems/pf2e/icons/spells/plane-shift.webp",
+            "name": "Plane Shift (Self and Rider Only)",
+            "sort": 200000,
+            "type": "spell"
+        },
+        {
+            "_id": "hvrW7fEOtezPrmRv",
+            "data": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "custom": "",
+                    "value": []
+                },
+                "bonus": {
+                    "value": 13
+                },
+                "damageRolls": {
+                    "37n5ctsnmpa4visxcesk": {
+                        "damage": "2d8+4",
+                        "damageType": "piercing"
+                    },
+                    "s5drabfyhg8fwmzvid9y": {
+                        "damage": "1d6",
+                        "damageType": "evil"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "evil",
+                        "magical"
+                    ]
+                },
+                "weaponType": {
+                    "value": "melee"
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Jaws",
+            "sort": 300000,
+            "type": "melee"
+        },
+        {
+            "_id": "NHSqYE5ZeWiln3Vx",
+            "data": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "custom": "",
+                    "value": []
+                },
+                "bonus": {
+                    "value": 13
+                },
+                "damageRolls": {
+                    "fj0pge7sp6mqmbl9ivn8": {
+                        "damage": "1d6+4",
+                        "damageType": "bludgeoning"
+                    },
+                    "3ukubwqjozdrn1hku9zh": {
+                        "damage": "1d6",
+                        "damageType": "evil"
+                    },
+                    "ze5vpj7fkh010vy3cpwj": {
+                        "damage": "1d6",
+                        "damageType": "fire"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "agile",
+                        "evil",
+                        "fire",
+                        "magical"
+                    ]
+                },
+                "weaponType": {
+                    "value": "melee"
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Hoof",
+            "sort": 400000,
+            "type": "melee"
+        },
+        {
+            "_id": "f0JUzUCQYwMZkmpA",
+            "data": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Darkvision]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "darkvision",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.qCCLZhnp2HhP3Ex6"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Darkvision",
+            "sort": 500000,
+            "type": "action"
+        },
+        {
+            "_id": "nbWXPfh7WyVCERN9",
+            "data": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Template[type:emanation|distance:15]{15 feet} @Compendium[pf2e.bestiary-ability-glossary-srd.Aura]{Aura}</p>\n<hr />\n<p>The nightmare continually exhales black smoke that creates @Compendium[pf2e.conditionitems.Concealed]{Concealment} in an aura around it. Nightmares and their riders can see through this smoke. A creature that begins its turn in the area becomes @Compendium[pf2e.conditionitems.Sickened]{Sickened 2} (@Check[type:fortitude|dc:20] negates) and is then temporarily immune sickness from the smoke for 1 minute. The nightmare, its rider, any creature currently holding its breath (or that does not need to breathe), and any creature immune to poison are immune to the aura's sickened effect but not the concealment.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "aura"
+                    ]
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Smoke",
+            "sort": 600000,
+            "type": "action"
+        },
+        {
+            "_id": "Huqh2NJEkx1xBpoO",
+            "data": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "description": {
+                    "value": "<p>The nightmare Strides or Flies up to triple its Speed. Its hooves burst with intense flame, dealing [[/r {2d6}[fire]]]{2d6 fire damage} (@Check[type:reflex|dc:21|basic:true] save) once to each creature other than the nightmare's rider that the nightmare moves adjacent to during its gallop.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "fire"
+                    ]
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Flaming Gallop",
+            "sort": 700000,
+            "type": "action"
+        },
+        {
+            "_id": "Uc8jZ7kcYg667DHe",
+            "data": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 10
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Acrobatics",
+            "sort": 800000,
+            "type": "lore"
+        },
+        {
+            "_id": "HQNMZ60QblKLLYm7",
+            "data": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 12
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Athletics",
+            "sort": 900000,
+            "type": "lore"
+        },
+        {
+            "_id": "BXeLODiU99tE51Sl",
+            "data": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 10
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Intimidation",
+            "sort": 1000000,
+            "type": "lore"
+        },
+        {
+            "_id": "jDbiUgjBMSjHc8yn",
+            "data": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 9
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Survival",
+            "sort": 1100000,
+            "type": "lore"
+        }
+    ],
+    "name": "Smoldering Nightmare",
+    "token": {
+        "disposition": -1,
+        "height": 2,
+        "img": "systems/pf2e/icons/default-icons/npc.svg",
+        "name": "Smoldering Nightmare",
+        "width": 2
+    },
+    "type": "npc"
+}

--- a/packs/data/pfs-season-3-bestiary.db/void-boils.json
+++ b/packs/data/pfs-season-3-bestiary.db/void-boils.json
@@ -1,0 +1,119 @@
+{
+    "_id": "qulQzbgDOLz969yg",
+    "data": {
+        "attributes": {
+            "ac": {
+                "value": 0
+            },
+            "hardness": 0,
+            "hp": {
+                "details": "",
+                "max": 0,
+                "temp": 0,
+                "value": 0
+            },
+            "stealth": {
+                "details": "<p>(expert)</p>",
+                "value": 15
+            }
+        },
+        "creatureType": "",
+        "details": {
+            "description": "<p>Tumor-like growths erupt from the isle as it responds to psychic attack, spewing black lightning and fire in every direction.</p>",
+            "disable": "<p>@Check[type:occultism|dc:26] (trained) to reshape the substance of the dream, or @Check[type:performance|dc:30] (trained) or @Check[type:religion|dc:28] (trained) to invoke Desna's blessing through hymns or prayers. Each check to disable the hazard is a two-action activity; two total successes are required to disable the hazard.</p>",
+            "isComplex": true,
+            "level": {
+                "value": 6
+            },
+            "reset": "",
+            "routine": "<p>(1 action) On the hazard's initiative, a boil erupts from the ground and bursts. This blast strikes as many enemies as possible in a @Template[type:burst|distance:15] anywhere on the isle, dealing [[/r {4d8}[force]]]{4d8 force damage} (@Check[type:reflex|dc:24|basic:true] or @Check[type:will|dc:24|basic:true], target's choice) to enemies in the area. Aslynn avoids targeting the nightmares with the blast.</p>"
+        },
+        "saves": {
+            "fortitude": {
+                "saveDetail": "",
+                "value": 0
+            },
+            "reflex": {
+                "saveDetail": "",
+                "value": 0
+            },
+            "will": {
+                "saveDetail": "",
+                "value": 0
+            }
+        },
+        "source": {
+            "author": "",
+            "value": "Pathfinder Society Scenario #3-17: Dreams of a Dustbound Isle"
+        },
+        "statusEffects": [],
+        "traits": {
+            "di": {
+                "custom": "",
+                "selected": {},
+                "value": []
+            },
+            "dr": [],
+            "dv": [],
+            "rarity": "unique",
+            "size": {
+                "value": "med"
+            },
+            "traits": {
+                "custom": "",
+                "value": [
+                    "environmental"
+                ]
+            }
+        }
+    },
+    "img": "systems/pf2e/icons/default-icons/hazard.svg",
+    "items": [
+        {
+            "_id": "cn5qQknUXG6zS1KY",
+            "data": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "reaction"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p><strong>Trigger</strong> Sarnia's psychic intrusion begins;</p>\n<p><strong>Effect</strong> The hazard rolls initiative.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Reaction.webp",
+            "name": "Awaken",
+            "sort": 0,
+            "type": "action"
+        }
+    ],
+    "name": "Void Boils",
+    "token": {
+        "disposition": -1,
+        "height": 1,
+        "img": "systems/pf2e/icons/default-icons/hazard.svg",
+        "name": "Void Boils",
+        "width": 1
+    },
+    "type": "hazard"
+}

--- a/packs/data/pfs-season-3-bestiary.db/void-boils.json
+++ b/packs/data/pfs-season-3-bestiary.db/void-boils.json
@@ -20,7 +20,7 @@
         "creatureType": "",
         "details": {
             "description": "<p>Tumor-like growths erupt from the isle as it responds to psychic attack, spewing black lightning and fire in every direction.</p>",
-            "disable": "<p>@Check[type:occultism|dc:26] (trained) to reshape the substance of the dream, or @Check[type:performance|dc:30] (trained) or @Check[type:religion|dc:28] (trained) to invoke Desna's blessing through hymns or prayers. Each check to disable the hazard is a two-action activity; two total successes are required to disable the hazard.</p>",
+            "disable": "<p>@Check[type:occultism|dc:26|name:Reshape the Dream] (trained) to reshape the substance of the dream, or @Check[type:performance|dc:30|name:Invoke Desna's Blessing] (trained) or @Check[type:religion|dc:28|name:Invoke Desna's Blessing] (trained) to invoke Desna's blessing through hymns or prayers. Each check to disable the hazard is a two-action activity; two total successes are required to disable the hazard.</p>",
             "isComplex": true,
             "level": {
                 "value": 6

--- a/packs/data/pfs-season-3-bestiary.db/waking-nightmare.json
+++ b/packs/data/pfs-season-3-bestiary.db/waking-nightmare.json
@@ -20,7 +20,7 @@
         "creatureType": "",
         "details": {
             "description": "<p>Faceless statues struggle against each other to stay above the black dust.</p>",
-            "disable": "<p>@Check[type:diplomacy|dc:24] (expert) to urge the statues to work together, @Check[type:intimidation|dc:27] (expert) to Coerce the statues away, or @Check[type:occultism|dc:30] (trained) to oppose the psychic influence. Each check to disable the haunt is a two-action activity; three total successes are required to disable the haunt.</p>",
+            "disable": "<p>@Check[type:diplomacy|dc:24|name:Convince the Statues] (expert) to urge the statues to work together, @Check[type:intimidation|dc:27|traits:action:coerce|name:Coerce the Statues] (expert) to Coerce the statues away, or @Check[type:occultism|dc:30|name:Oppose Psychic Influence] (trained) to oppose the psychic influence. Each check to disable the haunt is a two-action activity; three total successes are required to disable the haunt.</p>",
             "isComplex": true,
             "level": {
                 "value": 7
@@ -82,7 +82,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>Trigger A living creature spends 1 round in the area;</p>\n<p>Effect A whispered shout carries through the air: \"I have a face! I have a name! My sisters may be forgotten, but I will reclaim what's mine\" Sinking statues desperately grasp at creatures in the area, struggling to stay above the surface. The haunt attempts an [[/r 1d20+18 #Athletics]]{Athletics check (with a +18 modifier)} to @Compendium[pf2e.actionspf2e.Grapple]{Grapple} each creature in the area. On a success, a creature is @Compendium[pf2e.conditionitems.Grabbed]{Grabbed} (Escape DC 28). The haunt then rolls initiative.</p>"
+                    "value": "<p>Trigger A living creature spends 1 round in the area;</p>\n<p>Effect A whispered shout carries through the air: \"I have a face! I have a name! My sisters may be forgotten, but I will reclaim what's mine\" Sinking statues desperately grasp at creatures in the area, struggling to stay above the surface. The haunt attempts an [[/r 1d20+18 #Grapple]]{Athletics check (with a +18 modifier)} to @Compendium[pf2e.actionspf2e.Grapple]{Grapple} each creature in the area. On a success, a creature is @Compendium[pf2e.conditionitems.Grabbed]{Grabbed} (Escape DC 28). The haunt then rolls initiative.</p>"
                 },
                 "requirements": {
                     "value": ""

--- a/packs/data/pfs-season-3-bestiary.db/waking-nightmare.json
+++ b/packs/data/pfs-season-3-bestiary.db/waking-nightmare.json
@@ -1,0 +1,121 @@
+{
+    "_id": "wun5VzDIMSZCVLuI",
+    "data": {
+        "attributes": {
+            "ac": {
+                "value": 0
+            },
+            "hardness": 0,
+            "hp": {
+                "details": "",
+                "max": 0,
+                "temp": 0,
+                "value": 0
+            },
+            "stealth": {
+                "details": "<p>(expert)</p>",
+                "value": 18
+            }
+        },
+        "creatureType": "",
+        "details": {
+            "description": "<p>Faceless statues struggle against each other to stay above the black dust.</p>",
+            "disable": "<p>@Check[type:diplomacy|dc:24] (expert) to urge the statues to work together, @Check[type:intimidation|dc:27] (expert) to Coerce the statues away, or @Check[type:occultism|dc:30] (trained) to oppose the psychic influence. Each check to disable the haunt is a two-action activity; three total successes are required to disable the haunt.</p>",
+            "isComplex": true,
+            "level": {
+                "value": 7
+            },
+            "reset": "<p>The haunt deactivates 1 minute after all creatures leave the area but resets immediately thereafter.</p>",
+            "routine": "<p>(1 action) On the haunt's initiative, creatures in the area sink deeper into the dust as statues grasp at them. Creatures in the area take [[/r {2d10+9[mental]]]{2d10+9 mental damage} (@Check[type:will|dc:25|basic:true] saving throw). On a critical failure, the creature is also @Compendium[pf2e.conditionitems.Confused]{Confused} for 1 round. Creatures @Compendium[pf2e.conditionitems.Grabbed]{Grabbed} by the haunt take a -1 circumstance penalty to their saving throw.</p>"
+        },
+        "saves": {
+            "fortitude": {
+                "saveDetail": "",
+                "value": 0
+            },
+            "reflex": {
+                "saveDetail": "",
+                "value": 0
+            },
+            "will": {
+                "saveDetail": "",
+                "value": 0
+            }
+        },
+        "source": {
+            "author": "",
+            "value": "Pathfinder Society Scenario #3-17: Dreams of a Dustbound Isle"
+        },
+        "statusEffects": [],
+        "traits": {
+            "di": {
+                "custom": "",
+                "selected": {},
+                "value": []
+            },
+            "dr": [],
+            "dv": [],
+            "rarity": "unique",
+            "size": {
+                "value": "med"
+            },
+            "traits": {
+                "custom": "",
+                "value": [
+                    "haunt"
+                ]
+            }
+        }
+    },
+    "img": "systems/pf2e/icons/default-icons/hazard.svg",
+    "items": [
+        {
+            "_id": "9awhcUUChblK5dxi",
+            "data": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "reaction"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>Trigger A living creature spends 1 round in the area;</p>\n<p>Effect A whispered shout carries through the air: \"I have a face! I have a name! My sisters may be forgotten, but I will reclaim what's mine\" Sinking statues desperately grasp at creatures in the area, struggling to stay above the surface. The haunt attempts an [[/r 1d20+18 #Athletics]]{Athletics check (with a +18 modifier)} to @Compendium[pf2e.actionspf2e.Grapple]{Grapple} each creature in the area. On a success, a creature is @Compendium[pf2e.conditionitems.Grabbed]{Grabbed} (Escape DC 28). The haunt then rolls initiative.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "attack"
+                    ]
+                },
+                "trigger": {
+                    "value": ""
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Reaction.webp",
+            "name": "Seize",
+            "sort": 0,
+            "type": "action"
+        }
+    ],
+    "name": "Waking Nightmare",
+    "token": {
+        "disposition": -1,
+        "height": 1,
+        "img": "systems/pf2e/icons/default-icons/hazard.svg",
+        "name": "Waking Nightmare",
+        "width": 1
+    },
+    "type": "hazard"
+}

--- a/packs/data/pfs-season-3-bestiary.db/waking-terror.json
+++ b/packs/data/pfs-season-3-bestiary.db/waking-terror.json
@@ -1,0 +1,121 @@
+{
+    "_id": "yhQALO3emgx8Z5N9",
+    "data": {
+        "attributes": {
+            "ac": {
+                "value": 0
+            },
+            "hardness": 0,
+            "hp": {
+                "details": "",
+                "max": 0,
+                "temp": 0,
+                "value": 0
+            },
+            "stealth": {
+                "details": "<p>(expert)</p>",
+                "value": 21
+            }
+        },
+        "creatureType": "",
+        "details": {
+            "description": "<p>Faceless statues struggle against each other to stay above the black dust.</p>",
+            "disable": "<p>@Check[type:diplomacy|dc:27] (expert) to urge the statues to work together, @Check[type:intimidation|dc:30] (expert) to Coerce the statues away, or @Check[type:occultism|dc:33] (trained) to oppose the psychic influence. Each check to disable the haunt is a two-action activity; three total successes are required to disable the haunt.</p>",
+            "isComplex": true,
+            "level": {
+                "value": 9
+            },
+            "reset": "<p>The haunt deactivates 1 minute after all creatures leave the area but resets immediately thereafter.</p>",
+            "routine": "<p>(1 action) On the haunt's initiative, creatures in the area sink deeper into the dust as statues grasp at them. Creatures in the area take [[/r {2d10+13[mental]]]{2d10+13 mental damage} (@Check[type:will|dc:28|basic:true] saving throw). On a critical failure, the creature is also @Compendium[pf2e.conditionitems.Confused]{Confused} for 1 round. Creatures @Compendium[pf2e.conditionitems.Grabbed]{Grabbed} by the haunt take a -1 circumstance penalty to their saving throw.</p>"
+        },
+        "saves": {
+            "fortitude": {
+                "saveDetail": "",
+                "value": 0
+            },
+            "reflex": {
+                "saveDetail": "",
+                "value": 0
+            },
+            "will": {
+                "saveDetail": "",
+                "value": 0
+            }
+        },
+        "source": {
+            "author": "",
+            "value": "Pathfinder Society Scenario #3-17: Dreams of a Dustbound Isle"
+        },
+        "statusEffects": [],
+        "traits": {
+            "di": {
+                "custom": "",
+                "selected": {},
+                "value": []
+            },
+            "dr": [],
+            "dv": [],
+            "rarity": "unique",
+            "size": {
+                "value": "med"
+            },
+            "traits": {
+                "custom": "",
+                "value": [
+                    "haunt"
+                ]
+            }
+        }
+    },
+    "img": "systems/pf2e/icons/default-icons/hazard.svg",
+    "items": [
+        {
+            "_id": "9awhcUUChblK5dxi",
+            "data": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "reaction"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>Trigger A living creature spends 1 round in the area;</p>\n<p>Effect A whispered shout carries through the air: \"I have a face! I have a name! My sisters may be forgotten, but I will reclaim what's mine\" Sinking statues desperately grasp at creatures in the area, struggling to stay above the surface. The haunt attempts an [[/r 1d20+21 #Athletics]]{Athletics check (with a +21 modifier)} to @Compendium[pf2e.actionspf2e.Grapple]{Grapple} each creature in the area. On a success, a creature is @Compendium[pf2e.conditionitems.Grabbed]{Grabbed} (Escape DC 31). The haunt then rolls initiative.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "attack"
+                    ]
+                },
+                "trigger": {
+                    "value": ""
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Reaction.webp",
+            "name": "Seize",
+            "sort": 0,
+            "type": "action"
+        }
+    ],
+    "name": "Waking Terror",
+    "token": {
+        "disposition": -1,
+        "height": 1,
+        "img": "systems/pf2e/icons/default-icons/hazard.svg",
+        "name": "Waking Terror",
+        "width": 1
+    },
+    "type": "hazard"
+}

--- a/packs/data/pfs-season-3-bestiary.db/waking-terror.json
+++ b/packs/data/pfs-season-3-bestiary.db/waking-terror.json
@@ -20,7 +20,7 @@
         "creatureType": "",
         "details": {
             "description": "<p>Faceless statues struggle against each other to stay above the black dust.</p>",
-            "disable": "<p>@Check[type:diplomacy|dc:27] (expert) to urge the statues to work together, @Check[type:intimidation|dc:30] (expert) to Coerce the statues away, or @Check[type:occultism|dc:33] (trained) to oppose the psychic influence. Each check to disable the haunt is a two-action activity; three total successes are required to disable the haunt.</p>",
+            "disable": "<p>@Check[type:diplomacy|dc:27|name:Convince the Statues] (expert) to urge the statues to work together, @Check[type:intimidation|dc:30|traits:action:coerce|name:Coerce the Statues] (expert) to Coerce the statues away, or @Check[type:occultism|dc:33|name:Oppose Psychic Influence] (trained) to oppose the psychic influence. Each check to disable the haunt is a two-action activity; three total successes are required to disable the haunt.</p>",
             "isComplex": true,
             "level": {
                 "value": 9
@@ -82,7 +82,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>Trigger A living creature spends 1 round in the area;</p>\n<p>Effect A whispered shout carries through the air: \"I have a face! I have a name! My sisters may be forgotten, but I will reclaim what's mine\" Sinking statues desperately grasp at creatures in the area, struggling to stay above the surface. The haunt attempts an [[/r 1d20+21 #Athletics]]{Athletics check (with a +21 modifier)} to @Compendium[pf2e.actionspf2e.Grapple]{Grapple} each creature in the area. On a success, a creature is @Compendium[pf2e.conditionitems.Grabbed]{Grabbed} (Escape DC 31). The haunt then rolls initiative.</p>"
+                    "value": "<p>Trigger A living creature spends 1 round in the area;</p>\n<p>Effect A whispered shout carries through the air: \"I have a face! I have a name! My sisters may be forgotten, but I will reclaim what's mine\" Sinking statues desperately grasp at creatures in the area, struggling to stay above the surface. The haunt attempts an [[/r 1d20+21 #Grapple]]{Athletics check (with a +21 modifier)} to @Compendium[pf2e.actionspf2e.Grapple]{Grapple} each creature in the area. On a success, a creature is @Compendium[pf2e.conditionitems.Grabbed]{Grabbed} (Escape DC 31). The haunt then rolls initiative.</p>"
                 },
                 "requirements": {
                     "value": ""


### PR DESCRIPTION
Corrects Gibbering Mouther and Nightmare
PFS difference for Shadow 3-17: Note that variant shadow has enfeebled 2 on a critical hit. The B1 version does not.