### PR TITLE
Update Undine Heritage BaseSpeed Rule Element

### DIFF
--- a/packs/data/heritages.db/undine.json
+++ b/packs/data/heritages.db/undine.json
@@ -16,7 +16,7 @@
             {
                 "key": "BaseSpeed",
                 "selector": "swim",
-                "value": "10"
+                "value": 10
             }
         ],
         "source": {


### PR DESCRIPTION
Removes quotation marks from Swim BaseSpeed Rule Element value on Undine heritage.
Resolves warnings in console and correctly displays swim speed on character sheet.

![image](https://user-images.githubusercontent.com/95336883/177046760-e0f8b5f7-da54-4e62-9327-3181d62ffbb3.png)

