### PR TITLE
Update Slayer's Strike Rule Element

### DIFF
--- a/packs/data/feats.db/slayers-strike.json
+++ b/packs/data/feats.db/slayers-strike.json
@@ -29,7 +29,7 @@
         },
         "rules": [
             {
-                "domain": "saving-throw",
+                "domain": "damage",
                 "key": "RollOption",
                 "option": "slayers-strike",
                 "toggleable": true


### PR DESCRIPTION
Closes #2832 

Corrects Slayer's Strike DamageDice RE doman from "saving-throw" to "damage"