### PR TITLE
Add Owb Prophet Forsakens as Deities

### DIFF
--- a/packs/data/deities.db/enkaar-the-malformed-prisoner.json
+++ b/packs/data/deities.db/enkaar-the-malformed-prisoner.json
@@ -1,0 +1,43 @@
+{
+    "_id": "upRQcwjjaksc1g7h",
+    "data": {
+        "ability": [],
+        "alignment": {
+            "follower": [
+                "N"
+            ],
+            "own": "NE"
+        },
+        "description": {
+            "value": "<p>This mutilated horror is the Forsaken patron of fetters, lethargy, and physical corruption.</p>\n<p>An owb prophet can transfer the power they gain from a Forsaken patron to those who worship them, effectively serving as a deity. Each owb prophet decides their own follower alignments, edicts, and anathema.</p>"
+        },
+        "domains": {
+            "alternate": [],
+            "primary": [
+                "ambition",
+                "darkness",
+                "nightmares",
+                "trickery"
+            ]
+        },
+        "font": [
+            "heal"
+        ],
+        "rules": [],
+        "skill": "ste",
+        "source": {
+            "value": "Pathfinder Bestiary  3"
+        },
+        "spells": {
+            "1": "Compendium.pf2e.spells-srd.R8bqnYiThB6MYTxD",
+            "3": "Compendium.pf2e.spells-srd.KHnhPHL4x1AQHfbC",
+            "5": "Compendium.pf2e.spells-srd.rxvS7EMJ7qmexAyA"
+        },
+        "weapons": [
+            "spiked-chain"
+        ]
+    },
+    "img": "systems/pf2e/icons/default-icons/deity.svg",
+    "name": "Enkaar, the Malformed Prisoner",
+    "type": "deity"
+}

--- a/packs/data/deities.db/eyes-that-watch.json
+++ b/packs/data/deities.db/eyes-that-watch.json
@@ -1,0 +1,43 @@
+{
+    "_id": "pqrmviqboqjeS4z8",
+    "data": {
+        "ability": [],
+        "alignment": {
+            "follower": [
+                "N"
+            ],
+            "own": "NE"
+        },
+        "description": {
+            "value": "<p>This strange trio of feline eyes is the Forsaken patron of inferiority, cats, and strangers.</p>\n<p>An owb prophet can transfer the power they gain from a Forsaken patron to those who worship them, effectively serving as a deity. Each owb prophet decides their own follower alignments, edicts, and anathema.</p>"
+        },
+        "domains": {
+            "alternate": [],
+            "primary": [
+                "ambition",
+                "darkness",
+                "nightmares",
+                "trickery"
+            ]
+        },
+        "font": [
+            "heal"
+        ],
+        "rules": [],
+        "skill": "ste",
+        "source": {
+            "value": "Pathfinder Bestiary  3"
+        },
+        "spells": {
+            "1": "Compendium.pf2e.spells-srd.R8bqnYiThB6MYTxD",
+            "3": "Compendium.pf2e.spells-srd.KHnhPHL4x1AQHfbC",
+            "5": "Compendium.pf2e.spells-srd.rxvS7EMJ7qmexAyA"
+        },
+        "weapons": [
+            "dagger"
+        ]
+    },
+    "img": "systems/pf2e/icons/default-icons/deity.svg",
+    "name": "Eyes That Watch",
+    "type": "deity"
+}

--- a/packs/data/deities.db/grasping-iovett.json
+++ b/packs/data/deities.db/grasping-iovett.json
@@ -1,0 +1,43 @@
+{
+    "_id": "XxIxEaW8NG952Bc0",
+    "data": {
+        "ability": [],
+        "alignment": {
+            "follower": [
+                "N"
+            ],
+            "own": "NE"
+        },
+        "description": {
+            "value": "<p>A beautiful form of indescribable variety, Iovett is the Forsaken patron of accidents, parasites, and reckless lust.</p>\n<p>An owb prophet can transfer the power they gain from a Forsaken patron to those who worship them, effectively serving as a deity. Each owb prophet decides their own follower alignments, edicts, and anathema.</p>"
+        },
+        "domains": {
+            "alternate": [],
+            "primary": [
+                "ambition",
+                "darkness",
+                "nightmares",
+                "trickery"
+            ]
+        },
+        "font": [
+            "heal"
+        ],
+        "rules": [],
+        "skill": "ste",
+        "source": {
+            "value": "Pathfinder Bestiary  3"
+        },
+        "spells": {
+            "1": "Compendium.pf2e.spells-srd.R8bqnYiThB6MYTxD",
+            "2": "Compendium.pf2e.spells-srd.vLA0q0WOK2YPuJs6",
+            "5": "Compendium.pf2e.spells-srd.rxvS7EMJ7qmexAyA"
+        },
+        "weapons": [
+            "shortsword"
+        ]
+    },
+    "img": "systems/pf2e/icons/default-icons/deity.svg",
+    "name": "Grasping Iovett",
+    "type": "deity"
+}

--- a/packs/data/deities.db/husk.json
+++ b/packs/data/deities.db/husk.json
@@ -1,0 +1,43 @@
+{
+    "_id": "Gy78DCwfY4ltBGI6",
+    "data": {
+        "ability": [],
+        "alignment": {
+            "follower": [
+                "N"
+            ],
+            "own": "NE"
+        },
+        "description": {
+            "value": "<p>This androgynous creature is the Forsaken patron of emptiness, loneliness, and narcissism.</p>\n<p>An owb prophet can transfer the power they gain from a Forsaken patron to those who worship them, effectively serving as a deity. Each owb prophet decides their own follower alignments, edicts, and anathema.</p>"
+        },
+        "domains": {
+            "alternate": [],
+            "primary": [
+                "ambition",
+                "darkness",
+                "nightmares",
+                "trickery"
+            ]
+        },
+        "font": [
+            "heal"
+        ],
+        "rules": [],
+        "skill": "ste",
+        "source": {
+            "value": "Pathfinder Bestiary  3"
+        },
+        "spells": {
+            "1": "Compendium.pf2e.spells-srd.R8bqnYiThB6MYTxD",
+            "2": "Compendium.pf2e.spells-srd.gIdDLrbswTV3OBJy",
+            "5": "Compendium.pf2e.spells-srd.rxvS7EMJ7qmexAyA"
+        },
+        "weapons": [
+            "shortsword"
+        ]
+    },
+    "img": "systems/pf2e/icons/default-icons/deity.svg",
+    "name": "Husk",
+    "type": "deity"
+}

--- a/packs/data/deities.db/lady-razor.json
+++ b/packs/data/deities.db/lady-razor.json
@@ -1,0 +1,43 @@
+{
+    "_id": "1LiO5bDQIlJmXk35",
+    "data": {
+        "ability": [],
+        "alignment": {
+            "follower": [
+                "N"
+            ],
+            "own": "NE"
+        },
+        "description": {
+            "value": "<p>This stern magistrate forbids showing kindness or mercy to family members. Lady Razor is the Forsaken patron of family strife, suspicion, and vengeance.</p>\n<p>An owb prophet can transfer the power they gain from a Forsaken patron to those who worship them, effectively serving as a deity. Each owb prophet decides their own follower alignments, edicts, and anathema.</p>"
+        },
+        "domains": {
+            "alternate": [],
+            "primary": [
+                "ambition",
+                "darkness",
+                "nightmares",
+                "trickery"
+            ]
+        },
+        "font": [
+            "heal"
+        ],
+        "rules": [],
+        "skill": "ste",
+        "source": {
+            "value": "Pathfinder Bestiary  3"
+        },
+        "spells": {
+            "1": "Compendium.pf2e.spells-srd.R8bqnYiThB6MYTxD",
+            "4": "Compendium.pf2e.spells-srd.8M03UxGXjYyDFAoy",
+            "5": "Compendium.pf2e.spells-srd.rxvS7EMJ7qmexAyA"
+        },
+        "weapons": [
+            "dagger"
+        ]
+    },
+    "img": "systems/pf2e/icons/default-icons/deity.svg",
+    "name": "Lady Razor",
+    "type": "deity"
+}

--- a/packs/data/deities.db/reshmit-of-the-heavy-voice.json
+++ b/packs/data/deities.db/reshmit-of-the-heavy-voice.json
@@ -1,0 +1,43 @@
+{
+    "_id": "FeMWwhaVbaoqu3q6",
+    "data": {
+        "ability": [],
+        "alignment": {
+            "follower": [
+                "N"
+            ],
+            "own": "NE"
+        },
+        "description": {
+            "value": "<p>Taking the form of a massive shadow, Reshmit is the Forsaken patron of broken things, forgetting, and unexpected violence.</p>\n<p>An owb prophet can transfer the power they gain from a Forsaken patron to those who worship them, effectively serving as a deity. Each owb prophet decides their own follower alignments, edicts, and anathema.</p>"
+        },
+        "domains": {
+            "alternate": [],
+            "primary": [
+                "ambition",
+                "darkness",
+                "nightmares",
+                "trickery"
+            ]
+        },
+        "font": [
+            "heal"
+        ],
+        "rules": [],
+        "skill": "ste",
+        "source": {
+            "value": "Pathfinder Bestiary  3"
+        },
+        "spells": {
+            "1": "Compendium.pf2e.spells-srd.R8bqnYiThB6MYTxD",
+            "4": "Compendium.pf2e.spells-srd.FhOaQDTSnsY7tiam",
+            "5": "Compendium.pf2e.spells-srd.rxvS7EMJ7qmexAyA"
+        },
+        "weapons": [
+            "morningstar"
+        ]
+    },
+    "img": "systems/pf2e/icons/default-icons/deity.svg",
+    "name": "Reshmit of the Heavy Voice",
+    "type": "deity"
+}

--- a/packs/data/deities.db/thalaphyrr-martyr-minder.json
+++ b/packs/data/deities.db/thalaphyrr-martyr-minder.json
@@ -1,0 +1,43 @@
+{
+    "_id": "9Z1vOSaLsEiAs2yN",
+    "data": {
+        "ability": [],
+        "alignment": {
+            "follower": [
+                "N"
+            ],
+            "own": "NE"
+        },
+        "description": {
+            "value": "<p>The Forsaken patron of failed heroics, imprisonment, and squandered time.</p>\n<p>An owb prophet can transfer the power they gain from a Forsaken patron to those who worship them, effectively serving as a deity. Each owb prophet decides their own follower alignments, edicts, and anathema.</p>"
+        },
+        "domains": {
+            "alternate": [],
+            "primary": [
+                "ambition",
+                "darkness",
+                "nightmares",
+                "trickery"
+            ]
+        },
+        "font": [
+            "heal"
+        ],
+        "rules": [],
+        "skill": "ste",
+        "source": {
+            "value": "Pathfinder Bestiary  3"
+        },
+        "spells": {
+            "1": "Compendium.pf2e.spells-srd.R8bqnYiThB6MYTxD",
+            "3": "Compendium.pf2e.spells-srd.WsUwpfmhKrKwoIe3",
+            "5": "Compendium.pf2e.spells-srd.rxvS7EMJ7qmexAyA"
+        },
+        "weapons": [
+            "spear"
+        ]
+    },
+    "img": "systems/pf2e/icons/default-icons/deity.svg",
+    "name": "Thalaphyrr Martyr-Minder",
+    "type": "deity"
+}


### PR DESCRIPTION
Bestiary 3 has a sidebar where an Owb Prophet can act as a deity. This PR adds the provided information for these options. Note that none of the Forsakens listed specify a folllower alignment, edict, anathema, or divine ability for the "Raised by Faith" background. All of that information appears to be GM Fiat

![image](https://user-images.githubusercontent.com/64166996/177076137-95f25c30-f71e-4e01-abb3-1a59331f3f34.png)

![image](https://user-images.githubusercontent.com/64166996/177076158-9f291489-5b00-452f-a5bb-79fd426c526b.png)
