### PR TITLE
Fix malformed spell chat message html

### DIFF
--- a/src/styles/legacy/_chat.scss
+++ b/src/styles/legacy/_chat.scss
@@ -47,7 +47,7 @@
         display: flex;
         flex-basis: 100%;
         flex-direction: column;
-        margin: 5px 0;
+        margin: 4px 0;
 
         span {
             display: block;

--- a/static/templates/chat/spell-card.html
+++ b/static/templates/chat/spell-card.html
@@ -5,7 +5,7 @@
         <h4>{{data.levelLabel}}</h4>
     </header>
 
-    <div class="item-properties tags">
+    <section class="item-properties tags">
         {{#each data.traits}}
             <span class="tag" data-trait="{{this.name}}" data-description="{{this.description}}">{{localize this.label}}</span>
         {{/each}}
@@ -46,7 +46,7 @@
                         <button type="button" data-action="spellTemplate">{{localize "PF2E.Item.Spells.PlaceMeasuredTemplate" shape=data.areaType size=data.areaSize unit=data.areaUnit}}</button>
                     </div>
                 {{/if}}
-            </div>
+            </section>
         {{/if}}
     </section>
 


### PR DESCRIPTION
Coupled with the margin tweak, this reduces the awkward gap for info only spells