### PR TITLE
Fix Forge Warden shield stats from CR errata 1.

### DIFF
--- a/packs/data/equipment.db/forge-warden.json
+++ b/packs/data/equipment.db/forge-warden.json
@@ -11,7 +11,7 @@
         },
         "containerId": null,
         "description": {
-            "value": "<p>The religious symbol of Torag, the forge god-an ornate hammer of dwarven construction-adorns the face of this steel shield (Hardness 6, HP 24, BT 12). The shield is a religious symbol of Torag.</p>\n<p>You and any adjacent allies have fire resistance 5 while you have the shield raised. When used for a Shield Block, the <em>forge warden</em> rings out like the hammer strike of a blacksmith, and the symbol glows as if lit by the fires of a furnace.</p>\n<hr />\n<p><strong>Activate</strong> <span class=\"pf2-icon\">F</span> command (fire)</p>\n<p><strong>Trigger</strong> You use the forge warden to Shield Block an adjacent creature's attack and the shield takes damage</p>\n<hr />\n<p><strong>Effect</strong> The attacking creature takes 2d6 fire damage.</p>"
+            "value": "<p>The religious symbol of Torag, the forge god-an ornate hammer of dwarven construction-adorns the face of this steel shield (Hardness 10, HP 40, BT 20). The shield is a religious symbol of Torag.</p>\n<p>You and any adjacent allies have fire resistance 5 while you have the shield raised. When used for a Shield Block, the <em>forge warden</em> rings out like the hammer strike of a blacksmith, and the symbol glows as if lit by the fires of a furnace.</p>\n<hr />\n<p><strong>Activate</strong> <span class=\"pf2-icon\">F</span> command (fire)</p>\n<p><strong>Trigger</strong> You use the forge warden to Shield Block an adjacent creature's attack and the shield takes damage</p>\n<hr />\n<p><strong>Effect</strong> The attacking creature takes 2d6 fire damage.</p>"
         },
         "dex": {
             "value": 0
@@ -20,11 +20,11 @@
             "value": ""
         },
         "group": null,
-        "hardness": 6,
+        "hardness": 10,
         "hp": {
-            "brokenThreshold": 12,
-            "max": 24,
-            "value": 24
+            "brokenThreshold": 20,
+            "max": 40,
+            "value": 40
         },
         "level": {
             "value": 10


### PR DESCRIPTION
Page 588: Forge warden's durability is too low. Increase its basic shield statistics to Hardness 10, HP 40, BT 20.