### PR TITLE
Add NPCs from PFS 1-13

### DIFF
--- a/packs/data/pathfinder-bestiary.db/poltergeist.json
+++ b/packs/data/pathfinder-bestiary.db/poltergeist.json
@@ -684,6 +684,51 @@
             "type": "action"
         },
         {
+            "_id": "q9pwZOGUR5waARMo",
+            "data": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.AtWillSpells]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "at-will-spells",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.2YRDYVnC1eljaXKK"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "At-Will Spells",
+            "sort": 900000,
+            "type": "action"
+        },
+        {
             "_id": "smEk0yh1Pe95Nvsc",
             "data": {
                 "actionCategory": {
@@ -720,7 +765,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Natural Invisibility",
-            "sort": 900000,
+            "sort": 1000000,
             "type": "action"
         },
         {
@@ -764,7 +809,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Rejuvenation",
-            "sort": 1000000,
+            "sort": 1100000,
             "type": "action"
         },
         {
@@ -804,7 +849,7 @@
             },
             "img": "systems/pf2e/icons/actions/Reaction.webp",
             "name": "Telekinetic Defense",
-            "sort": 1100000,
+            "sort": 1200000,
             "type": "action"
         },
         {
@@ -850,7 +895,7 @@
             },
             "img": "systems/pf2e/icons/actions/OneAction.webp",
             "name": "Frighten",
-            "sort": 1200000,
+            "sort": 1300000,
             "type": "action"
         },
         {
@@ -945,7 +990,7 @@
             },
             "img": "systems/pf2e/icons/actions/TwoActions.webp",
             "name": "Telekinetic Storm",
-            "sort": 1300000,
+            "sort": 1400000,
             "type": "action"
         },
         {
@@ -973,7 +1018,7 @@
             },
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Acrobatics",
-            "sort": 1400000,
+            "sort": 1500000,
             "type": "lore"
         },
         {
@@ -1001,7 +1046,7 @@
             },
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Intimidation",
-            "sort": 1500000,
+            "sort": 1600000,
             "type": "lore"
         },
         {
@@ -1029,7 +1074,7 @@
             },
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Stealth",
-            "sort": 1600000,
+            "sort": 1700000,
             "type": "lore"
         }
     ],

--- a/packs/data/pfs-season-1-bestiary.db/elite-skeletal-giant-pfs-1-18.json
+++ b/packs/data/pfs-season-1-bestiary.db/elite-skeletal-giant-pfs-1-18.json
@@ -716,7 +716,7 @@
             "type": "lore"
         }
     ],
-    "name": "Elite Skeletal Giant (1-18)",
+    "name": "Elite Skeletal Giant (PFS 1-18)",
     "token": {
         "disposition": -1,
         "height": 2,

--- a/packs/data/pfs-season-1-bestiary.db/flesh-golem-pfs-1-25.json
+++ b/packs/data/pfs-season-1-bestiary.db/flesh-golem-pfs-1-25.json
@@ -1,0 +1,466 @@
+{
+    "_id": "u2TGKzPfGniZLL14",
+    "data": {
+        "abilities": {
+            "cha": {
+                "mod": -5
+            },
+            "con": {
+                "mod": 3
+            },
+            "dex": {
+                "mod": -1
+            },
+            "int": {
+                "mod": -5
+            },
+            "str": {
+                "mod": 5
+            },
+            "wis": {
+                "mod": 0
+            }
+        },
+        "attributes": {
+            "ac": {
+                "details": "",
+                "value": 26
+            },
+            "allSaves": {
+                "value": ""
+            },
+            "hp": {
+                "details": "",
+                "max": 140,
+                "temp": 0,
+                "value": 140
+            },
+            "initiative": {
+                "ability": "perception"
+            },
+            "perception": {
+                "value": 12
+            },
+            "speed": {
+                "otherSpeeds": [],
+                "value": "25"
+            }
+        },
+        "details": {
+            "alignment": {
+                "value": "N"
+            },
+            "blurb": "",
+            "creatureType": "Construct",
+            "level": {
+                "value": 8
+            },
+            "privateNotes": "",
+            "publicNotes": "",
+            "source": {
+                "value": "Pathfinder Society Scenario 1-25: Grim Symphony"
+            }
+        },
+        "resources": {},
+        "saves": {
+            "fortitude": {
+                "saveDetail": "",
+                "value": 18
+            },
+            "reflex": {
+                "saveDetail": "",
+                "value": 14
+            },
+            "will": {
+                "saveDetail": "",
+                "value": 15
+            }
+        },
+        "traits": {
+            "ci": [],
+            "di": {
+                "custom": "",
+                "value": [
+                    "bleed",
+                    "death-effects",
+                    "disease",
+                    "doomed",
+                    "drained",
+                    "electricity",
+                    "fatigued",
+                    "healing",
+                    "magic",
+                    "mental",
+                    "necromancy",
+                    "nonlethal-attacks",
+                    "paralyzed",
+                    "poison",
+                    "sickened",
+                    "unconscious"
+                ]
+            },
+            "dr": [
+                {
+                    "exceptions": "except Adamantine",
+                    "type": "physical",
+                    "value": 5
+                }
+            ],
+            "dv": [],
+            "languages": {
+                "custom": "",
+                "selected": [],
+                "value": []
+            },
+            "rarity": "uncommon",
+            "senses": {
+                "value": "darkvision"
+            },
+            "size": {
+                "value": "lg"
+            },
+            "traits": {
+                "custom": "",
+                "value": [
+                    "construct",
+                    "golem",
+                    "mindless"
+                ]
+            }
+        }
+    },
+    "img": "systems/pf2e/icons/default-icons/npc.svg",
+    "items": [
+        {
+            "_id": "k1kPrQ3Krhcipl4E",
+            "data": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "value": []
+                },
+                "bonus": {
+                    "value": 20
+                },
+                "damageRolls": {
+                    "p5d1nbdm06qkq6wsqaq5": {
+                        "damage": "2d10+7",
+                        "damageType": "bludgeoning"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "magical",
+                        "reach-10"
+                    ]
+                },
+                "weaponType": {
+                    "value": "melee"
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Fist",
+            "sort": 100000,
+            "type": "melee"
+        },
+        {
+            "_id": "J66VJmEpPHpyEwLL",
+            "data": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Darkvision]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "darkvision",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.qCCLZhnp2HhP3Ex6"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Darkvision",
+            "sort": 200000,
+            "type": "action"
+        },
+        {
+            "_id": "95kvqPPSJNio8vAK",
+            "data": {
+                "actionCategory": {
+                    "value": "defensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>A severely damaged flesh golem has a chance of going berserk. If it has 40 or fewer HP at the start of its turn, the golem must succeed at a @Check[type:flat|dc:5] check or go berserk. A berserk golem wildly attacks the nearest living creature, or the nearest object if no creatures are nearby.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Berserk",
+            "sort": 300000,
+            "type": "action"
+        },
+        {
+            "_id": "EcSG9mNyifTC1iWV",
+            "data": {
+                "actionCategory": {
+                    "value": "defensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>harmed by fire ([[/r {5d8}[fire]]]{5d8 fire damage}, [[/r {3d4}[fire]]]{3d4 fire damage} from areas or persistent damage); healed by electricity (area [[/r {2d4}[healing]]]{2d4 Hit Points}); slowed by cold</p>\n<hr />\n<p>A golem is immune to spells and magical abilities other than its own, but each type of golem is affected by a few types of magic in special ways. These exceptions are listed in shortened form in the golem's stat block, with the full rules appearing here. If an entry lists multiple types (such as “cold and water”), either type of spell can affect the golem.</p>\n<ul>\n<li><strong>Harmed By</strong> Any magic of this type that targets the golem causes it to take the listed amount of damage (this damage has no type) instead of the usual effect. If the golem starts its turn in an area of magic of this type or is affected by a persistent effect of the appropriate type, it takes the damage listed in the parenthetical.</li>\n<li><strong>Healed By</strong> Any magic of this type that targets the golem makes the golem lose the slowed condition and gain HP equal to half the damage the spell would have dealt. If the golem starts its turn in an area of this type of magic, it gains the HP listed in the parenthetical.</li>\n<li><strong>Slowed By</strong> Any magic of this type that targets the golem causes it to be @Compendium[pf2e.conditionitems.Slowed]{Slowed 1} for [[/br 2d6 #rounds]]{2d6 rounds} instead of the usual effect. If the golem starts its turn in an area of this type of magic, it's slowed 1 for that round.</li>\n<li><strong>Vulnerable To</strong> Each golem is vulnerable to one or more specific spells, with the effects described in its stat block.</li>\n</ul>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "golem-golem-antimagic",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-family-ability-glossary.r34QDwKiWZoVymJa"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Golem Antimagic",
+            "sort": 400000,
+            "type": "action"
+        },
+        {
+            "_id": "uzwUjI3gD8tO8Chh",
+            "data": {
+                "actionCategory": {
+                    "value": "defensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>Casting a <em>@Compendium[pf2e.spells-srd.Flesh to Stone]{Flesh to Stone}</em> spell on the flesh golem affects the golem normally.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Vulnerable to Flesh to Stone",
+            "sort": 500000,
+            "type": "action"
+        },
+        {
+            "_id": "BaBWpspQzY07GuJo",
+            "data": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "description": {
+                    "value": "<p><strong>Requirements</strong> The golem is berserk</p>\n<hr />\n<p><strong>Effect</strong> The flesh golem Strikes with its fist at a -1 circumstance penalty. If it hits, it deals [[/r {1d6}]]{1d6 extra damage} and knocks the target @Compendium[pf2e.conditionitems.Prone]{Prone}.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [
+                    {
+                        "domain": "all",
+                        "key": "RollOption",
+                        "option": "berserk-slam",
+                        "toggleable": true
+                    },
+                    {
+                        "damageType": "bludgeoning",
+                        "diceNumber": 1,
+                        "dieSize": "d6",
+                        "key": "DamageDice",
+                        "predicate": {
+                            "all": [
+                                "berserk-slam"
+                            ]
+                        },
+                        "selector": "strike-damage"
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "predicate": {
+                            "all": [
+                                "berserk-slam"
+                            ]
+                        },
+                        "selector": "attack",
+                        "type": "circumstance",
+                        "value": -1
+                    },
+                    {
+                        "key": "Note",
+                        "predicate": {
+                            "all": [
+                                "berserk-slam"
+                            ]
+                        },
+                        "selector": "strike-damage",
+                        "text": "The target is knocked @Compendium[pf2e.conditionitems.Prone]{Prone}.",
+                        "title": "{item|name}"
+                    }
+                ],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Berserk Slam",
+            "sort": 600000,
+            "type": "action"
+        },
+        {
+            "_id": "mInccpo8OPs89BAi",
+            "data": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 19
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Athletics",
+            "sort": 700000,
+            "type": "lore"
+        }
+    ],
+    "name": "Flesh Golem (PFS 1-25)",
+    "token": {
+        "disposition": -1,
+        "height": 2,
+        "img": "systems/pf2e/icons/default-icons/npc.svg",
+        "name": "Flesh Golem",
+        "width": 2
+    },
+    "type": "npc"
+}

--- a/packs/data/pfs-season-1-bestiary.db/guard-pfs-1-17.json
+++ b/packs/data/pfs-season-1-bestiary.db/guard-pfs-1-17.json
@@ -1091,7 +1091,7 @@
             "type": "lore"
         }
     ],
-    "name": "Guard (1-17)",
+    "name": "Guard (PFS 1-17)",
     "token": {
         "disposition": -1,
         "height": 1,

--- a/packs/data/pfs-season-1-bestiary.db/murderous-bathhouse-3-4.json
+++ b/packs/data/pfs-season-1-bestiary.db/murderous-bathhouse-3-4.json
@@ -20,7 +20,7 @@
         "creatureType": "",
         "details": {
             "description": "<p>Linneus's grudge manifests as a haunt that isolates creatures in the bathroom and attempts to psychically drown them in one of three containers of water: the sink, the bath, or the wash bucket.</p>",
-            "disable": "<p>@Check[type:religion|dc:22](expert) to exorcise the spirit from one of the containers of water, or @Check[type:athletics|dc:23] or @Check[type:thievery|dc:23](trained) to overpower the ghostly force sealing a container and drain it. All three containers must be disabled to disable the entire haunt.</p>",
+            "disable": "<p>@Check[type:religion|dc:22] (expert) to exorcise the spirit from one of the containers of water, or @Check[type:athletics|dc:23] or @Check[type:thievery|dc:23] (trained) to overpower the ghostly force sealing a container and drain it. All three containers must be disabled to disable the entire haunt.</p>",
             "isComplex": true,
             "level": {
                 "value": 4

--- a/packs/data/pfs-season-1-bestiary.db/murderous-bathhouse-3-4.json
+++ b/packs/data/pfs-season-1-bestiary.db/murderous-bathhouse-3-4.json
@@ -20,7 +20,7 @@
         "creatureType": "",
         "details": {
             "description": "<p>Linneus's grudge manifests as a haunt that isolates creatures in the bathroom and attempts to psychically drown them in one of three containers of water: the sink, the bath, or the wash bucket.</p>",
-            "disable": "<p>@Check[type:religion|dc:22] (expert) to exorcise the spirit from one of the containers of water, or @Check[type:athletics|dc:23] or @Check[type:thievery|dc:23] (trained) to overpower the ghostly force sealing a container and drain it. All three containers must be disabled to disable the entire haunt.</p>",
+            "disable": "<p>@Check[type:religion|dc:22|name:Excorise the Spirit] (expert) to exorcise the spirit from one of the containers of water, or @Check[type:athletics|dc:23] or @Check[type:thievery|dc:23|name:Overpower the Ghostly Force] (trained) to overpower the ghostly force sealing a container and drain it. All three containers must be disabled to disable the entire haunt.</p>",
             "isComplex": true,
             "level": {
                 "value": 4

--- a/packs/data/pfs-season-1-bestiary.db/murderous-bathhouse-3-4.json
+++ b/packs/data/pfs-season-1-bestiary.db/murderous-bathhouse-3-4.json
@@ -26,7 +26,7 @@
                 "value": 4
             },
             "reset": "<p>The haunt deactivates and resets after 1 minute.</p>",
-            "routine": "<p>(one action) One creature within the room must attempt a @Check[type:will|dc:23]&nbsp;save as the haunt attempts to drown them.</p>\n<hr />\n<p><strong>Critical Success</strong> The creature is unaffected and temporarily immune for 1 minute.</p>\n<p><strong>Success</strong> The creature is unaffected.</p>\n<p><strong>Failure</strong> A ghostly version of the creature's face appears in the water of the sink, the bath, or the wash bucket. The creature immediately experiences the sensation of being underwater, and if it can't breathe water, it must begin to hold its breath to avoid suffocation. The haunt can affect only one creature per container remaining in the haunt. If the creature leaves the room, it's immediately freed.</p>\n<p><strong>Critical Failure</strong> As failure, but the creature immediately loses [[/r 1d4 #Actions]]{1d4} actions' worth of air.</p>"
+            "routine": "<p>(one action) One creature within the room must attempt a @Check[type:will|dc:23] save as the haunt attempts to drown them.</p>\n<hr />\n<p><strong>Critical Success</strong> The creature is unaffected and temporarily immune for 1 minute.</p>\n<p><strong>Success</strong> The creature is unaffected.</p>\n<p><strong>Failure</strong> A ghostly version of the creature's face appears in the water of the sink, the bath, or the wash bucket. The creature immediately experiences the sensation of being underwater, and if it can't breathe water, it must begin to hold its breath to avoid suffocation. The haunt can affect only one creature per container remaining in the haunt. If the creature leaves the room, it's immediately freed.</p>\n<p><strong>Critical Failure</strong> As failure, but the creature immediately loses [[/r 1d4 #Actions]]{1d4} actions' worth of air.</p>"
         },
         "saves": {
             "fortitude": {
@@ -82,7 +82,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p><strong>Trigger</strong> A creature opens the door to the haunted chamber;</p>\n<p><strong>Effect</strong> The manifestation slams the door shut. The force deals [[/r {3d8} [bludgeoning]]]{3d8 bludgeoning damage} to any creature in or adjacent to the door's space and pushes them into the room. A creature that succeeds at a @Check[type:reflex|dc:22] save takes no damage and rolls out of the way in a random direction. On a critical success, it can choose the direction. The haunt then rolls initiative.</p>"
+                    "value": "<p><strong>Trigger</strong> A creature opens the door to the haunted chamber</p>\n<hr />\n<p><strong>Effect</strong> The manifestation slams the door shut. The force deals [[/r {3d8} [bludgeoning]]]{3d8 bludgeoning damage} to any creature in or adjacent to the door's space and pushes them into the room. A creature that succeeds at a @Check[type:reflex|dc:22] save takes no damage and rolls out of the way in a random direction. On a critical success, it can choose the direction. The haunt then rolls initiative.</p>"
                 },
                 "requirements": {
                     "value": ""

--- a/packs/data/pfs-season-1-bestiary.db/murderous-bathhouse-3-4.json
+++ b/packs/data/pfs-season-1-bestiary.db/murderous-bathhouse-3-4.json
@@ -1,0 +1,119 @@
+{
+    "_id": "ORzg1jprbdWl64gA",
+    "data": {
+        "attributes": {
+            "ac": {
+                "value": 0
+            },
+            "hardness": 0,
+            "hp": {
+                "details": "",
+                "max": 0,
+                "temp": 0,
+                "value": 0
+            },
+            "stealth": {
+                "details": "<p>(trained)</p>",
+                "value": 12
+            }
+        },
+        "creatureType": "",
+        "details": {
+            "description": "<p>Linneus's grudge manifests as a haunt that isolates creatures in the bathroom and attempts to psychically drown them in one of three containers of water: the sink, the bath, or the wash bucket.</p>",
+            "disable": "<p>@Check[type:religion|dc:22](expert) to exorcise the spirit from one of the containers of water, or @Check[type:athletics|dc:23] or @Check[type:thievery|dc:23](trained) to overpower the ghostly force sealing a container and drain it. All three containers must be disabled to disable the entire haunt.</p>",
+            "isComplex": true,
+            "level": {
+                "value": 4
+            },
+            "reset": "<p>The haunt deactivates and resets after 1 minute.</p>",
+            "routine": "<p>(one action) One creature within the room must attempt a @Check[type:will|dc:23]&nbsp;save as the haunt attempts to drown them.</p>\n<hr />\n<p><strong>Critical Success</strong> The creature is unaffected and temporarily immune for 1 minute.</p>\n<p><strong>Success</strong> The creature is unaffected.</p>\n<p><strong>Failure</strong> A ghostly version of the creature's face appears in the water of the sink, the bath, or the wash bucket. The creature immediately experiences the sensation of being underwater, and if it can't breathe water, it must begin to hold its breath to avoid suffocation. The haunt can affect only one creature per container remaining in the haunt. If the creature leaves the room, it's immediately freed.</p>\n<p><strong>Critical Failure</strong> As failure, but the creature immediately loses [[/r 1d4 #Actions]]{1d4} actions' worth of air.</p>"
+        },
+        "saves": {
+            "fortitude": {
+                "saveDetail": "",
+                "value": 0
+            },
+            "reflex": {
+                "saveDetail": "",
+                "value": 0
+            },
+            "will": {
+                "saveDetail": "",
+                "value": 0
+            }
+        },
+        "source": {
+            "author": "",
+            "value": "Pathfinder Society Scenario #1-13: Devil at the Crossroads"
+        },
+        "statusEffects": [],
+        "traits": {
+            "di": {
+                "custom": "",
+                "selected": {},
+                "value": []
+            },
+            "dr": [],
+            "dv": [],
+            "rarity": "unique",
+            "size": {
+                "value": "med"
+            },
+            "traits": {
+                "custom": "",
+                "value": [
+                    "haunt"
+                ]
+            }
+        }
+    },
+    "img": "systems/pf2e/icons/default-icons/hazard.svg",
+    "items": [
+        {
+            "_id": "Npvqpp1yncgDSDyb",
+            "data": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "reaction"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p><strong>Trigger</strong> A creature opens the door to the haunted chamber;</p>\n<p><strong>Effect</strong> The manifestation slams the door shut. The force deals [[/r {3d8} [bludgeoning]]]{3d8 bludgeoning damage} to any creature in or adjacent to the door's space and pushes them into the room. A creature that succeeds at a @Check[type:reflex|dc:22] save takes no damage and rolls out of the way in a random direction. On a critical success, it can choose the direction. The haunt then rolls initiative.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Reaction.webp",
+            "name": "Isolate Victim",
+            "sort": 0,
+            "type": "action"
+        }
+    ],
+    "name": "Murderous Bathhouse (3-4)",
+    "token": {
+        "disposition": -1,
+        "height": 1,
+        "img": "systems/pf2e/icons/default-icons/hazard.svg",
+        "name": "Murderous Bathhouse",
+        "width": 1
+    },
+    "type": "hazard"
+}

--- a/packs/data/pfs-season-1-bestiary.db/murderous-bathhouse-5-6.json
+++ b/packs/data/pfs-season-1-bestiary.db/murderous-bathhouse-5-6.json
@@ -1,0 +1,119 @@
+{
+    "_id": "aGLtnb99MyPf3gp4",
+    "data": {
+        "attributes": {
+            "ac": {
+                "value": 0
+            },
+            "hardness": 0,
+            "hp": {
+                "details": "",
+                "max": 0,
+                "temp": 0,
+                "value": 0
+            },
+            "stealth": {
+                "details": "<p>(trained)</p>",
+                "value": 15
+            }
+        },
+        "creatureType": "",
+        "details": {
+            "description": "<p>Linneus's grudge manifests as a haunt that isolates creatures in the bathroom and attempts to psychically drown them in one of three containers of water: the sink, the bath, or the wash bucket.</p>",
+            "disable": "<p>@Check[type:religion|dc:25](expert) to exorcise the spirit from one of the containers of water, or @Check[type:athletics|dc:26] or @Check[type:thievery|dc:26](trained) to overpower the ghostly force sealing a container and drain it. All three containers must be disabled to disable the entire haunt.</p>",
+            "isComplex": true,
+            "level": {
+                "value": 6
+            },
+            "reset": "<p>The haunt deactivates and resets after 1 minute.</p>",
+            "routine": "<p>(one action) One creature within the room must attempt a @Check[type:will|dc:25] save as the haunt attempts to drown them.</p>\n<hr />\n<p><strong>Critical Success</strong> The creature is unaffected and temporarily immune for 1 minute.</p>\n<p><strong>Success</strong> The creature is unaffected.</p>\n<p><strong>Failure</strong> A ghostly version of the creature's face appears in the water of the sink, the bath, or the wash bucket. The creature immediately experiences the sensation of being underwater, and if it can't breathe water, it must begin to hold its breath to avoid suffocation. The haunt can affect only one creature per container remaining in the haunt. If the creature leaves the room, it's immediately freed.</p>\n<p><strong>Critical Failure</strong> As failure, but the creature immediately loses [[/r 1d4 #Actions]]{1d4} actions' worth of air.</p>"
+        },
+        "saves": {
+            "fortitude": {
+                "saveDetail": "",
+                "value": 0
+            },
+            "reflex": {
+                "saveDetail": "",
+                "value": 0
+            },
+            "will": {
+                "saveDetail": "",
+                "value": 0
+            }
+        },
+        "source": {
+            "author": "",
+            "value": "Pathfinder Society Scenario #1-13: Devil at the Crossroads"
+        },
+        "statusEffects": [],
+        "traits": {
+            "di": {
+                "custom": "",
+                "selected": {},
+                "value": []
+            },
+            "dr": [],
+            "dv": [],
+            "rarity": "unique",
+            "size": {
+                "value": "med"
+            },
+            "traits": {
+                "custom": "",
+                "value": [
+                    "haunt"
+                ]
+            }
+        }
+    },
+    "img": "systems/pf2e/icons/default-icons/hazard.svg",
+    "items": [
+        {
+            "_id": "Npvqpp1yncgDSDyb",
+            "data": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "reaction"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p><strong>Trigger</strong> A creature opens the door to the haunted chamber;</p>\n<p><strong>Effect</strong> The manifestation slams the door shut. The force deals [[/r {3d8} [bludgeoning]]]{3d8 bludgeoning damage} to any creature in or adjacent to the door's space and pushes them into the room. A creature that succeeds at a @Check[type:reflex|dc:25] save takes no damage and rolls out of the way in a random direction. On a critical success, it can choose the direction. The haunt then rolls initiative.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Reaction.webp",
+            "name": "Isolate Victim",
+            "sort": 0,
+            "type": "action"
+        }
+    ],
+    "name": "Murderous Bathhouse (5-6)",
+    "token": {
+        "disposition": -1,
+        "height": 1,
+        "img": "systems/pf2e/icons/default-icons/hazard.svg",
+        "name": "Murderous Bathhouse",
+        "width": 1
+    },
+    "type": "hazard"
+}

--- a/packs/data/pfs-season-1-bestiary.db/murderous-bathhouse-5-6.json
+++ b/packs/data/pfs-season-1-bestiary.db/murderous-bathhouse-5-6.json
@@ -20,7 +20,7 @@
         "creatureType": "",
         "details": {
             "description": "<p>Linneus's grudge manifests as a haunt that isolates creatures in the bathroom and attempts to psychically drown them in one of three containers of water: the sink, the bath, or the wash bucket.</p>",
-            "disable": "<p>@Check[type:religion|dc:25] (expert) to exorcise the spirit from one of the containers of water, or @Check[type:athletics|dc:26] or @Check[type:thievery|dc:26] (trained) to overpower the ghostly force sealing a container and drain it. All three containers must be disabled to disable the entire haunt.</p>",
+            "disable": "<p>@Check[type:religion|dc:25|name:Excorise the Spirit] (expert) to exorcise the spirit from one of the containers of water, or @Check[type:athletics|dc:26|name:Overpower the Ghostly Force] or @Check[type:thievery|dc:26] (trained) to overpower the ghostly force sealing a container and drain it. All three containers must be disabled to disable the entire haunt.</p>",
             "isComplex": true,
             "level": {
                 "value": 6

--- a/packs/data/pfs-season-1-bestiary.db/murderous-bathhouse-5-6.json
+++ b/packs/data/pfs-season-1-bestiary.db/murderous-bathhouse-5-6.json
@@ -20,7 +20,7 @@
         "creatureType": "",
         "details": {
             "description": "<p>Linneus's grudge manifests as a haunt that isolates creatures in the bathroom and attempts to psychically drown them in one of three containers of water: the sink, the bath, or the wash bucket.</p>",
-            "disable": "<p>@Check[type:religion|dc:25](expert) to exorcise the spirit from one of the containers of water, or @Check[type:athletics|dc:26] or @Check[type:thievery|dc:26](trained) to overpower the ghostly force sealing a container and drain it. All three containers must be disabled to disable the entire haunt.</p>",
+            "disable": "<p>@Check[type:religion|dc:25] (expert) to exorcise the spirit from one of the containers of water, or @Check[type:athletics|dc:26] or @Check[type:thievery|dc:26] (trained) to overpower the ghostly force sealing a container and drain it. All three containers must be disabled to disable the entire haunt.</p>",
             "isComplex": true,
             "level": {
                 "value": 6
@@ -82,7 +82,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p><strong>Trigger</strong> A creature opens the door to the haunted chamber;</p>\n<p><strong>Effect</strong> The manifestation slams the door shut. The force deals [[/r {3d8} [bludgeoning]]]{3d8 bludgeoning damage} to any creature in or adjacent to the door's space and pushes them into the room. A creature that succeeds at a @Check[type:reflex|dc:25] save takes no damage and rolls out of the way in a random direction. On a critical success, it can choose the direction. The haunt then rolls initiative.</p>"
+                    "value": "<p><strong>Trigger</strong> A creature opens the door to the haunted chamber</p>\n<hr />\n<p><strong>Effect</strong> The manifestation slams the door shut. The force deals [[/r {3d8} [bludgeoning]]]{3d8 bludgeoning damage} to any creature in or adjacent to the door's space and pushes them into the room. A creature that succeeds at a @Check[type:reflex|dc:25] save takes no damage and rolls out of the way in a random direction. On a critical success, it can choose the direction. The haunt then rolls initiative.</p>"
                 },
                 "requirements": {
                     "value": ""

--- a/packs/data/pfs-season-1-bestiary.db/palace-guard-pfs-1-17.json
+++ b/packs/data/pfs-season-1-bestiary.db/palace-guard-pfs-1-17.json
@@ -1055,7 +1055,7 @@
             "type": "lore"
         }
     ],
-    "name": "Palace Guard (1-17)",
+    "name": "Palace Guard (PFS 1-17)",
     "token": {
         "disposition": -1,
         "height": 1,

--- a/packs/data/pfs-season-1-bestiary.db/the-ascendant-3-4.json
+++ b/packs/data/pfs-season-1-bestiary.db/the-ascendant-3-4.json
@@ -63,7 +63,7 @@
             "privateNotes": "",
             "publicNotes": "",
             "source": {
-                "value": "Pathfinder Society: Season 1"
+                "value": "Pathfinder Society Scenario #1-13: Devil at the Crossroads"
             }
         },
         "resources": {
@@ -250,12 +250,16 @@
             "type": "spellcastingEntry"
         },
         {
-            "_id": "Tl7YIefkryT2eGTD",
+            "_id": "XqocduBIVhrD8vu2",
             "data": {
                 "ability": {
                     "value": ""
                 },
                 "area": {
+                    "areaType": "",
+                    "value": ""
+                },
+                "areasize": {
                     "value": ""
                 },
                 "category": {
@@ -264,8 +268,8 @@
                 "components": {
                     "focus": false,
                     "material": false,
-                    "somatic": false,
-                    "verbal": false
+                    "somatic": true,
+                    "verbal": true
                 },
                 "cost": {
                     "value": ""
@@ -274,24 +278,28 @@
                     "value": {}
                 },
                 "description": {
-                    "value": ""
+                    "value": "<p>You see things within 60 feet as they actually are. The GM rolls a secret counteract check against any illusion or transmutation in the area, but only for the purpose of determining whether you see through it (for instance, if the check succeeds against a polymorph spell, you can see the creature's true form, but you don't end the polymorph spell).</p>"
                 },
                 "duration": {
-                    "value": ""
+                    "value": "10 minutes"
                 },
                 "hasCounteractCheck": {
-                    "value": false
+                    "value": true
                 },
                 "level": {
                     "value": 6
                 },
                 "location": {
+                    "heightenedLevel": 6,
                     "value": "jBPgL5cdaBsnm9N1"
                 },
                 "materials": {
                     "value": ""
                 },
                 "prepared": {
+                    "value": ""
+                },
+                "primarycheck": {
                     "value": ""
                 },
                 "range": {
@@ -303,14 +311,20 @@
                     "value": ""
                 },
                 "school": {
-                    "value": "evocation"
+                    "value": "divination"
                 },
-                "slug": null,
-                "source": {
+                "secondarycasters": {
                     "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "true-seeing",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
                 },
                 "spellType": {
-                    "value": ""
+                    "value": "utility"
                 },
                 "sustained": {
                     "value": false
@@ -319,31 +333,43 @@
                     "value": ""
                 },
                 "time": {
-                    "value": ""
+                    "value": "2"
                 },
                 "traditions": {
-                    "value": []
+                    "value": [
+                        "arcane",
+                        "divine",
+                        "occult",
+                        "primal"
+                    ]
                 },
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "revelation"
+                    ]
                 }
             },
-            "img": "systems/pf2e/icons/default-icons/spell.svg",
-            "name": "true seeing Covetous Flames Any weapon the ascendant holds gains the effects of a flaming rune while they hold it. (Constant)",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.uqlxMQQeSGWEVjki"
+                }
+            },
+            "img": "systems/pf2e/icons/spells/true-seeing.webp",
+            "name": "True Seeing (Constant)",
             "sort": 200000,
             "type": "spell"
         },
         {
-            "_id": "yPIbPHoD3BjBWNbU",
+            "_id": "QdemKlqmVgeu8M9V",
             "data": {
                 "ability": {
                     "value": ""
                 },
                 "area": {
                     "areaType": "",
-                    "value": null
+                    "value": ""
                 },
                 "areasize": {
                     "value": ""
@@ -372,10 +398,21 @@
                 "hasCounteractCheck": {
                     "value": false
                 },
+                "heightening": {
+                    "levels": {
+                        "5": {
+                            "range": {
+                                "value": "1 mile"
+                            }
+                        }
+                    },
+                    "type": "fixed"
+                },
                 "level": {
                     "value": 4
                 },
                 "location": {
+                    "heightenedLevel": 4,
                     "value": "jBPgL5cdaBsnm9N1"
                 },
                 "materials": {
@@ -404,9 +441,9 @@
                 "secondarycheck": {
                     "value": ""
                 },
-                "slug": null,
+                "slug": "dimension-door",
                 "source": {
-                    "value": "https://2e.aonprd.com/Spells.aspx?ID=69"
+                    "value": "Pathfinder Core Rulebook"
                 },
                 "spellType": {
                     "value": "utility"
@@ -434,20 +471,25 @@
                     ]
                 }
             },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.VlNcjmYyu95vOUe8"
+                }
+            },
             "img": "systems/pf2e/icons/spells/dimension-door.webp",
-            "name": "Dimension Door (at will)",
+            "name": "Dimension Door (At Will)",
             "sort": 300000,
             "type": "spell"
         },
         {
-            "_id": "GjTQmeKSMFW0CCNp",
+            "_id": "xR1c5HpdXWzEcL6U",
             "data": {
                 "ability": {
                     "value": ""
                 },
                 "area": {
                     "areaType": "",
-                    "value": null
+                    "value": ""
                 },
                 "areasize": {
                     "value": ""
@@ -468,7 +510,7 @@
                     "value": {}
                 },
                 "description": {
-                    "value": "<p>You plant fear in the target; it must attempt a Will save.</p>\n<hr /><strong>Critical Success</strong> The target is unaffected.\n<p><strong>Success</strong> The target is @Compendium[pf2e.conditionitems.Frightened]{Frightened 1}.</p>\n<p><strong>Failure</strong> The target is @Compendium[pf2e.conditionitems.Frightened]{Frightened 2}.</p>\n<p><strong>Critical Failure</strong> The target is @Compendium[pf2e.conditionitems.Frightened]{Frightened 3} and @Compendium[pf2e.conditionitems.Fleeing]{Fleeing} for 1 round.</p>\n<hr /><strong>Heightened (3rd)</strong> You can target up to five creatures."
+                    "value": "<p>You block the target's motor impulses before they can leave its mind, threatening to freeze the target in place. The target must attempt a Will save.</p>\n<hr />\n<p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target is @Compendium[pf2e.conditionitems.Stunned]{Stunned 1}.</p>\n<p><strong>Failure</strong> The target is @Compendium[pf2e.conditionitems.Paralyzed]{Paralyzed} for 1 round.</p>\n<p><strong>Critical Failure</strong> The target is Paralyzed for 4 rounds. At the end of each of its turns, it can attempt a new Will save to reduce the remaining duration by 1 round, or end it entirely on a critical success.</p>\n<hr />\n<p><strong>Heightened (7th)</strong> You can target up to 10 creatures.</p>"
                 },
                 "duration": {
                     "value": "varies"
@@ -476,122 +518,21 @@
                 "hasCounteractCheck": {
                     "value": false
                 },
-                "level": {
-                    "value": 3
-                },
-                "location": {
-                    "uses": {
-                        "max": 2,
-                        "value": 2
+                "heightening": {
+                    "levels": {
+                        "7": {
+                            "target": {
+                                "value": "10 creatures"
+                            }
+                        }
                     },
-                    "value": "jBPgL5cdaBsnm9N1"
-                },
-                "materials": {
-                    "value": ""
-                },
-                "prepared": {
-                    "value": ""
-                },
-                "primarycheck": {
-                    "value": ""
-                },
-                "range": {
-                    "value": "30 feet"
-                },
-                "rules": [],
-                "save": {
-                    "basic": "",
-                    "value": "will"
-                },
-                "school": {
-                    "value": "enchantment"
-                },
-                "secondarycasters": {
-                    "value": ""
-                },
-                "secondarycheck": {
-                    "value": ""
-                },
-                "slug": null,
-                "source": {
-                    "value": "https://2e.aonprd.com/Spells.aspx?ID=110"
-                },
-                "spellType": {
-                    "value": "save"
-                },
-                "sustained": {
-                    "value": false
-                },
-                "target": {
-                    "value": "1 creature"
-                },
-                "time": {
-                    "value": "2"
-                },
-                "traditions": {
-                    "value": [
-                        "arcane",
-                        "divine",
-                        "occult",
-                        "primal"
-                    ]
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": [
-                        "emotion",
-                        "fear",
-                        "mental"
-                    ]
-                }
-            },
-            "img": "systems/pf2e/icons/spells/fear.webp",
-            "name": "Fear",
-            "sort": 400000,
-            "type": "spell"
-        },
-        {
-            "_id": "uqBajIEuL5sUMVe3",
-            "data": {
-                "ability": {
-                    "value": ""
-                },
-                "area": {
-                    "areaType": "",
-                    "value": null
-                },
-                "areasize": {
-                    "value": ""
-                },
-                "category": {
-                    "value": "spell"
-                },
-                "components": {
-                    "focus": false,
-                    "material": false,
-                    "somatic": true,
-                    "verbal": true
-                },
-                "cost": {
-                    "value": ""
-                },
-                "damage": {
-                    "value": {}
-                },
-                "description": {
-                    "value": "<p>You block the target's motor impulses before they can leave its mind, threatening to freeze the target in place. The target must attempt a Will save.</p>\n<hr />\n<p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target is @Compendium[pf2e.conditionitems.Stunned]{Stunned 1}.</p>\n<p><strong>Failure</strong> The target is @Compendium[pf2e.conditionitems.Paralyzed]{Paralyzed} for 1 round.</p>\n<p><strong>Critical Failure</strong> The target is @Compendium[pf2e.conditionitems.Paralyzed]{Paralyzed} for 4 rounds. At the end of each of its turns, it can attempt a new Will save to reduce the remaining duration by 1 round, or end it entirely on a critical success.</p>\n<hr />\n<p><strong>Heightened (7th)</strong> You can target up to 10 creatures.</p>"
-                },
-                "duration": {
-                    "value": "varies"
-                },
-                "hasCounteractCheck": {
-                    "value": false
+                    "type": "fixed"
                 },
                 "level": {
                     "value": 3
                 },
                 "location": {
+                    "heightenedLevel": 3,
                     "value": "jBPgL5cdaBsnm9N1"
                 },
                 "materials": {
@@ -620,9 +561,9 @@
                 "secondarycheck": {
                     "value": ""
                 },
-                "slug": null,
+                "slug": "paralyze",
                 "source": {
-                    "value": "https://2e.aonprd.com/Spells.aspx?ID=213"
+                    "value": "Pathfinder Core Rulebook"
                 },
                 "spellType": {
                     "value": "save"
@@ -652,20 +593,25 @@
                     ]
                 }
             },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.DCQHaLrYXMI37dvW"
+                }
+            },
             "img": "systems/pf2e/icons/spells/paralyze.webp",
             "name": "Paralyze",
-            "sort": 500000,
+            "sort": 400000,
             "type": "spell"
         },
         {
-            "_id": "USwFcgXHfunYkYKi",
+            "_id": "ZWh20S7rq7iSwBSB",
             "data": {
                 "ability": {
                     "value": ""
                 },
                 "area": {
                     "areaType": "",
-                    "value": null
+                    "value": ""
                 },
                 "areasize": {
                     "value": ""
@@ -694,10 +640,21 @@
                 "hasCounteractCheck": {
                     "value": false
                 },
+                "heightening": {
+                    "levels": {
+                        "6": {
+                            "target": {
+                                "value": "5 creatures"
+                            }
+                        }
+                    },
+                    "type": "fixed"
+                },
                 "level": {
                     "value": 2
                 },
                 "location": {
+                    "heightenedLevel": 2,
                     "value": "jBPgL5cdaBsnm9N1"
                 },
                 "materials": {
@@ -726,9 +683,9 @@
                 "secondarycheck": {
                     "value": ""
                 },
-                "slug": null,
+                "slug": "paranoia",
                 "source": {
-                    "value": "https://2e.aonprd.com/Spells.aspx?ID=214"
+                    "value": "Pathfinder Core Rulebook"
                 },
                 "spellType": {
                     "value": "save"
@@ -755,13 +712,18 @@
                     ]
                 }
             },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.Mkbq9xlAUxHUHyR2"
+                }
+            },
             "img": "systems/pf2e/icons/spells/paranoia.webp",
             "name": "Paranoia",
-            "sort": 600000,
+            "sort": 500000,
             "type": "spell"
         },
         {
-            "_id": "EPszuQOHdFNy8U5m",
+            "_id": "sDi7DbArgkHn3N47",
             "data": {
                 "ability": {
                     "value": ""
@@ -801,6 +763,7 @@
                     "value": 2
                 },
                 "location": {
+                    "heightenedLevel": 2,
                     "value": "jBPgL5cdaBsnm9N1"
                 },
                 "materials": {
@@ -829,9 +792,9 @@
                 "secondarycheck": {
                     "value": ""
                 },
-                "slug": null,
+                "slug": "silence",
                 "source": {
-                    "value": "https://2e.aonprd.com/Spells.aspx?ID=287"
+                    "value": "Pathfinder Core Rulebook"
                 },
                 "spellType": {
                     "value": "utility"
@@ -857,18 +820,167 @@
                     "value": []
                 }
             },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.gIdDLrbswTV3OBJy"
+                }
+            },
             "img": "systems/pf2e/icons/spells/silence.webp",
             "name": "Silence",
+            "sort": 600000,
+            "type": "spell"
+        },
+        {
+            "_id": "D0PJtazqlVTGfacs",
+            "data": {
+                "ability": {
+                    "value": ""
+                },
+                "area": {
+                    "areaType": "",
+                    "value": ""
+                },
+                "areasize": {
+                    "value": ""
+                },
+                "category": {
+                    "value": "spell"
+                },
+                "components": {
+                    "focus": false,
+                    "material": false,
+                    "somatic": true,
+                    "verbal": true
+                },
+                "cost": {
+                    "value": ""
+                },
+                "damage": {
+                    "value": {}
+                },
+                "description": {
+                    "value": "<p>You plant fear in the target; it must attempt a Will save.</p>\n<hr />\n<p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target is @Compendium[pf2e.conditionitems.Frightened]{Frightened 1}.</p>\n<p><strong>Failure</strong> The target is @Compendium[pf2e.conditionitems.Frightened]{Frightened 2}.</p>\n<p><strong>Critical Failure</strong> The target is @Compendium[pf2e.conditionitems.Frightened]{Frightened 3} and @Compendium[pf2e.conditionitems.Fleeing]{Fleeing} for 1 round.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You can target up to five creatures.</p>"
+                },
+                "duration": {
+                    "value": "varies"
+                },
+                "hasCounteractCheck": {
+                    "value": false
+                },
+                "heightening": {
+                    "levels": {
+                        "3": {
+                            "target": {
+                                "value": "5 creatures"
+                            }
+                        }
+                    },
+                    "type": "fixed"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": {
+                    "heightenedLevel": 3,
+                    "uses": {
+                        "max": 2,
+                        "value": 2
+                    },
+                    "value": "jBPgL5cdaBsnm9N1"
+                },
+                "materials": {
+                    "value": ""
+                },
+                "prepared": {
+                    "value": ""
+                },
+                "primarycheck": {
+                    "value": ""
+                },
+                "range": {
+                    "value": "30 feet"
+                },
+                "rules": [],
+                "save": {
+                    "basic": "",
+                    "value": "will"
+                },
+                "school": {
+                    "value": "enchantment"
+                },
+                "secondarycasters": {
+                    "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "fear",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "spellType": {
+                    "value": "save"
+                },
+                "sustained": {
+                    "value": false
+                },
+                "target": {
+                    "value": "1 creature"
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traditions": {
+                    "value": [
+                        "arcane",
+                        "divine",
+                        "occult",
+                        "primal"
+                    ]
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "emotion",
+                        "fear",
+                        "mental"
+                    ]
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.4koZzrnMXhhosn0D"
+                }
+            },
+            "img": "systems/pf2e/icons/spells/fear.webp",
+            "name": "Fear",
             "sort": 700000,
             "type": "spell"
         },
         {
-            "_id": "pT0622a9JrKaNwj2",
+            "_id": "cTM3OodvGMFsUbIA",
             "data": {
-                "baseItem": null,
-                "containerId": null,
-                "description": {
+                "MAP": {
                     "value": ""
+                },
+                "baseItem": "mace",
+                "bonus": {
+                    "value": 0
+                },
+                "bonusDamage": {
+                    "value": 0
+                },
+                "category": "simple",
+                "containerId": null,
+                "damage": {
+                    "damageType": "bludgeoning",
+                    "dice": 1,
+                    "die": "d6",
+                    "value": ""
+                },
+                "description": {
+                    "value": "<p>With a stout haft and a heavy metal head, a mace is sturdy and allows its wielder to deliver powerful blows and dent armor.</p>"
                 },
                 "equipped": {
                     "carryType": "worn",
@@ -878,6 +990,7 @@
                 "equippedBulk": {
                     "value": ""
                 },
+                "group": "club",
                 "hardness": 0,
                 "hp": {
                     "brokenThreshold": 0,
@@ -890,6 +1003,9 @@
                 "negateBulk": {
                     "value": "0"
                 },
+                "potencyRune": {
+                    "value": null
+                },
                 "preciousMaterial": {
                     "value": ""
                 },
@@ -897,35 +1013,83 @@
                     "value": ""
                 },
                 "price": {
-                    "value": {}
+                    "value": {
+                        "gp": 1
+                    }
                 },
-                "quantity": 1,
-                "rules": [],
-                "size": "med",
-                "slug": null,
-                "source": {
+                "property1": {
+                    "critDamage": "",
+                    "critDamageType": "",
+                    "critDice": null,
+                    "critDie": "",
+                    "criticalConditionType": "",
+                    "criticalConditionValue": null,
+                    "damageType": "",
+                    "dice": null,
+                    "die": "",
+                    "strikeConditionType": "",
+                    "strikeConditionValue": null,
                     "value": ""
                 },
+                "propertyRune1": {
+                    "value": ""
+                },
+                "propertyRune2": {
+                    "value": ""
+                },
+                "propertyRune3": {
+                    "value": ""
+                },
+                "propertyRune4": {
+                    "value": ""
+                },
+                "quantity": 1,
+                "range": null,
+                "reload": {
+                    "value": ""
+                },
+                "rules": [],
+                "size": "med",
+                "slug": "mace",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "specific": {
+                    "value": false
+                },
+                "splashDamage": {
+                    "value": 0
+                },
                 "stackGroup": null,
+                "strikingRune": {
+                    "value": ""
+                },
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "shove"
+                    ]
                 },
                 "usage": {
                     "value": "held-in-one-hand"
                 },
                 "weight": {
-                    "value": 0
+                    "value": "1"
                 }
             },
-            "img": "systems/pf2e/icons/default-icons/equipment.svg",
-            "name": "mace",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.equipment-srd.9iDqOLNFKxiTcFKE"
+                }
+            },
+            "img": "systems/pf2e/icons/equipment/weapons/mace.webp",
+            "name": "Mace",
             "sort": 800000,
-            "type": "equipment"
+            "type": "weapon"
         },
         {
-            "_id": "y7pQYNoOXLR5eQZb",
+            "_id": "GHTBn706QnWpTrXF",
             "data": {
                 "attack": {
                     "value": ""
@@ -937,15 +1101,15 @@
                     "value": 17
                 },
                 "damageRolls": {
-                    "e9v0j4thvbpd89we9ba9": {
+                    "1qn57xvhwl1ck2zk": {
                         "damage": "1d6+9",
                         "damageType": "bludgeoning"
                     },
-                    "1mc08kxb1abz38sz47ln": {
+                    "rzhty0sxyymhsvybpi1d": {
                         "damage": "1d6",
                         "damageType": "evil"
                     },
-                    "raggx8ytu53yhy4i9514": {
+                    "cbo3ilek98tfbepkwyoq": {
                         "damage": "1d6",
                         "damageType": "fire"
                     }
@@ -961,19 +1125,26 @@
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "shove"
+                    ]
                 },
                 "weaponType": {
                     "value": "melee"
                 }
             },
+            "flags": {
+                "pf2e": {
+                    "linkedWeapon": "cTM3OodvGMFsUbIA"
+                }
+            },
             "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "Flaming Mace (shove)",
+            "name": "Flaming Mace",
             "sort": 900000,
             "type": "melee"
         },
         {
-            "_id": "YiJhjUhx94mR2JBR",
+            "_id": "u2gBYeHoKZ4qo7eB",
             "data": {
                 "attack": {
                     "value": ""
@@ -985,11 +1156,11 @@
                     "value": 14
                 },
                 "damageRolls": {
-                    "4xu5qxpsrg317k2gtc87": {
+                    "94ag2815ec6s2ayi4cdl": {
                         "damage": "1d6+8",
                         "damageType": "bludgeoning"
                     },
-                    "6uz2ewnzciyeniyczt0x": {
+                    "fca8prpbtekst91u1uun": {
                         "damage": "1d6",
                         "damageType": "evil"
                     }
@@ -1019,7 +1190,7 @@
             "type": "melee"
         },
         {
-            "_id": "JQt53dbhMlVscoa0",
+            "_id": "XohUcPdAFeAe7lMz",
             "data": {
                 "attack": {
                     "value": ""
@@ -1031,17 +1202,17 @@
                     "value": 14
                 },
                 "damageRolls": {
-                    "tf012uq9jpeqfp5xec5t": {
+                    "f1r8p83cwwahpxapcsn8": {
                         "damage": "1d6+4",
                         "damageType": "piercing"
                     },
-                    "uerjl7edpza489160vdb": {
+                    "d27c93bqyggyz0ogqnwc": {
                         "damage": "1d6",
                         "damageType": "evil"
                     }
                 },
                 "description": {
-                    "value": "<p>(range increment 30 feet)</p>"
+                    "value": ""
                 },
                 "rules": [],
                 "slug": null,
@@ -1065,6 +1236,288 @@
             "type": "melee"
         },
         {
+            "_id": "sY6RtyIJfbHYjbfl",
+            "data": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.GreaterDarkvision]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "greater-darkvision",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.4Ho2xMPEC05aSxzr"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Greater Darkvision",
+            "sort": 1200000,
+            "type": "action"
+        },
+        {
+            "_id": "gJPlLVFxiqRdmpiS",
+            "data": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Telepathy]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "telepathy",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "aura",
+                        "divination",
+                        "magical"
+                    ]
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.kdhbPaBMK1d1fpbA"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Telepathy 30 feet",
+            "sort": 1300000,
+            "type": "action"
+        },
+        {
+            "_id": "txReBQTFbbmm6pA3",
+            "data": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.AtWillSpells]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "at-will-spells",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.2YRDYVnC1eljaXKK"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "At-Will Spells",
+            "sort": 1400000,
+            "type": "action"
+        },
+        {
+            "_id": "99rpfYKFeH8fn7CH",
+            "data": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.ConstantSpells]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "constant-spells",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.kakyXBG5WA8c6Zfd"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Constant Spells",
+            "sort": 1500000,
+            "type": "action"
+        },
+        {
+            "_id": "FlboUI0LOXJUi7ur",
+            "data": {
+                "actionCategory": {
+                    "value": "defensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": ""
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "predicate": {
+                            "any": [
+                                "magical",
+                                "arcane",
+                                "divine",
+                                "primal",
+                                "occult"
+                            ]
+                        },
+                        "selector": "saving-throw",
+                        "type": "untyped",
+                        "value": 1
+                    }
+                ],
+                "slug": "1-status-to-all-saves-vs-magic",
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.kquBnQ0kObZztnBc"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "+1 to All Saves vs Magic",
+            "sort": 1600000,
+            "type": "action"
+        },
+        {
+            "_id": "jas8bT1w5xGIzMab",
+            "data": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>Any weapon the ascendant holds gains the effects of a @Compendium[pf2e.equipment-srd.Flaming]{Flaming} rune while they hold it.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Covetous Flames",
+            "sort": 1700000,
+            "type": "action"
+        },
+        {
             "_id": "Amvw7x9z5fAeJSBT",
             "data": {
                 "actionCategory": {
@@ -1077,7 +1530,7 @@
                     "value": 2
                 },
                 "description": {
-                    "value": "<p>The ascendant beats their wings in a frenzied motion, creating a powerful blast of wind that disperses fog and gases and blows objects of light Bulk or less away. All creatures within 20 feet of the ascendant must succeed at a @Check[type:reflex|dc:24] save or be pushed 5 feet away from the ascendant, or 10 feet on a critical failure. A flying creature that fails its save gets a critical failure instead.</p>"
+                    "value": "<p>The ascendant beats their wings in a frenzied motion, creating a powerful blast of wind that disperses fog and gases and blows objects of light Bulk or less away. All creatures within @Template[type:emanation|distance:20]{20 feet} of the ascendant must succeed at a @Check[type:reflex|dc:24] save or be pushed 5 feet away from the ascendant, or 10 feet on a critical failure. A flying creature that fails its save gets a critical failure instead.</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -1101,7 +1554,7 @@
             },
             "img": "systems/pf2e/icons/actions/TwoActions.webp",
             "name": "Furious Wings",
-            "sort": 1200000,
+            "sort": 1800000,
             "type": "action"
         },
         {
@@ -1129,7 +1582,7 @@
             },
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Arcana",
-            "sort": 1300000,
+            "sort": 1900000,
             "type": "lore"
         },
         {
@@ -1157,7 +1610,7 @@
             },
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Deception",
-            "sort": 1400000,
+            "sort": 2000000,
             "type": "lore"
         },
         {
@@ -1185,7 +1638,7 @@
             },
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Intimidation",
-            "sort": 1500000,
+            "sort": 2100000,
             "type": "lore"
         },
         {
@@ -1213,7 +1666,7 @@
             },
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Occultism",
-            "sort": 1600000,
+            "sort": 2200000,
             "type": "lore"
         },
         {
@@ -1241,7 +1694,7 @@
             },
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Religion",
-            "sort": 1700000,
+            "sort": 2300000,
             "type": "lore"
         },
         {
@@ -1269,7 +1722,7 @@
             },
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Stealth",
-            "sort": 1800000,
+            "sort": 2400000,
             "type": "lore"
         }
     ],

--- a/packs/data/pfs-season-1-bestiary.db/the-ascendant-5-6.json
+++ b/packs/data/pfs-season-1-bestiary.db/the-ascendant-5-6.json
@@ -63,7 +63,7 @@
             "privateNotes": "",
             "publicNotes": "",
             "source": {
-                "value": "Pathfinder Society: Season 1"
+                "value": "Pathfinder Society Scenario #1-13: Devil at the Crossroads"
             }
         },
         "resources": {
@@ -250,12 +250,16 @@
             "type": "spellcastingEntry"
         },
         {
-            "_id": "2pzUmSBhyBPeUOUr",
+            "_id": "kjQQ3kAGSMzFHLmO",
             "data": {
                 "ability": {
                     "value": ""
                 },
                 "area": {
+                    "areaType": "",
+                    "value": ""
+                },
+                "areasize": {
                     "value": ""
                 },
                 "category": {
@@ -264,8 +268,8 @@
                 "components": {
                     "focus": false,
                     "material": false,
-                    "somatic": false,
-                    "verbal": false
+                    "somatic": true,
+                    "verbal": true
                 },
                 "cost": {
                     "value": ""
@@ -274,24 +278,28 @@
                     "value": {}
                 },
                 "description": {
-                    "value": ""
+                    "value": "<p>You see things within 60 feet as they actually are. The GM rolls a secret counteract check against any illusion or transmutation in the area, but only for the purpose of determining whether you see through it (for instance, if the check succeeds against a polymorph spell, you can see the creature's true form, but you don't end the polymorph spell).</p>"
                 },
                 "duration": {
-                    "value": ""
+                    "value": "10 minutes"
                 },
                 "hasCounteractCheck": {
-                    "value": false
+                    "value": true
                 },
                 "level": {
                     "value": 6
                 },
                 "location": {
+                    "heightenedLevel": 6,
                     "value": "flkn7WKcRA511YkF"
                 },
                 "materials": {
                     "value": ""
                 },
                 "prepared": {
+                    "value": ""
+                },
+                "primarycheck": {
                     "value": ""
                 },
                 "range": {
@@ -303,14 +311,20 @@
                     "value": ""
                 },
                 "school": {
-                    "value": "evocation"
+                    "value": "divination"
                 },
-                "slug": null,
-                "source": {
+                "secondarycasters": {
                     "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "true-seeing",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
                 },
                 "spellType": {
-                    "value": ""
+                    "value": "utility"
                 },
                 "sustained": {
                     "value": false
@@ -319,31 +333,43 @@
                     "value": ""
                 },
                 "time": {
-                    "value": ""
+                    "value": "2"
                 },
                 "traditions": {
-                    "value": []
+                    "value": [
+                        "arcane",
+                        "divine",
+                        "occult",
+                        "primal"
+                    ]
                 },
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "revelation"
+                    ]
                 }
             },
-            "img": "systems/pf2e/icons/default-icons/spell.svg",
-            "name": "true seeing Covetous Flames Any weapon the ascendant holds gains the effects of a flaming and striking rune while they hold it. (Constant)",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.uqlxMQQeSGWEVjki"
+                }
+            },
+            "img": "systems/pf2e/icons/spells/true-seeing.webp",
+            "name": "True Seeing (Constant)",
             "sort": 200000,
             "type": "spell"
         },
         {
-            "_id": "YiOIr07HdWP6gS84",
+            "_id": "Y6Vf0uAR7GSlK9WC",
             "data": {
                 "ability": {
                     "value": ""
                 },
                 "area": {
                     "areaType": "",
-                    "value": null
+                    "value": ""
                 },
                 "areasize": {
                     "value": ""
@@ -372,10 +398,21 @@
                 "hasCounteractCheck": {
                     "value": false
                 },
+                "heightening": {
+                    "levels": {
+                        "5": {
+                            "range": {
+                                "value": "1 mile"
+                            }
+                        }
+                    },
+                    "type": "fixed"
+                },
                 "level": {
                     "value": 4
                 },
                 "location": {
+                    "heightenedLevel": 4,
                     "value": "flkn7WKcRA511YkF"
                 },
                 "materials": {
@@ -404,9 +441,9 @@
                 "secondarycheck": {
                     "value": ""
                 },
-                "slug": null,
+                "slug": "dimension-door",
                 "source": {
-                    "value": "https://2e.aonprd.com/Spells.aspx?ID=69"
+                    "value": "Pathfinder Core Rulebook"
                 },
                 "spellType": {
                     "value": "utility"
@@ -434,20 +471,25 @@
                     ]
                 }
             },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.VlNcjmYyu95vOUe8"
+                }
+            },
             "img": "systems/pf2e/icons/spells/dimension-door.webp",
-            "name": "Dimension Door (at will)",
+            "name": "Dimension Door (At Will)",
             "sort": 300000,
             "type": "spell"
         },
         {
-            "_id": "fJvSQvKGFPC8gVuN",
+            "_id": "T5z12CFoaEKaeoMc",
             "data": {
                 "ability": {
                     "value": ""
                 },
                 "area": {
                     "areaType": "",
-                    "value": null
+                    "value": ""
                 },
                 "areasize": {
                     "value": ""
@@ -468,7 +510,7 @@
                     "value": {}
                 },
                 "description": {
-                    "value": "<p>You plant fear in the target; it must attempt a Will save.</p>\n<hr /><strong>Critical Success</strong> The target is unaffected.\n<p><strong>Success</strong> The target is @Compendium[pf2e.conditionitems.Frightened]{Frightened 1}.</p>\n<p><strong>Failure</strong> The target is @Compendium[pf2e.conditionitems.Frightened]{Frightened 2}.</p>\n<p><strong>Critical Failure</strong> The target is @Compendium[pf2e.conditionitems.Frightened]{Frightened 3} and @Compendium[pf2e.conditionitems.Fleeing]{Fleeing} for 1 round.</p>\n<hr /><strong>Heightened (3rd)</strong> You can target up to five creatures."
+                    "value": "<p>You block the target's motor impulses before they can leave its mind, threatening to freeze the target in place. The target must attempt a Will save.</p>\n<hr />\n<p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target is @Compendium[pf2e.conditionitems.Stunned]{Stunned 1}.</p>\n<p><strong>Failure</strong> The target is @Compendium[pf2e.conditionitems.Paralyzed]{Paralyzed} for 1 round.</p>\n<p><strong>Critical Failure</strong> The target is Paralyzed for 4 rounds. At the end of each of its turns, it can attempt a new Will save to reduce the remaining duration by 1 round, or end it entirely on a critical success.</p>\n<hr />\n<p><strong>Heightened (7th)</strong> You can target up to 10 creatures.</p>"
                 },
                 "duration": {
                     "value": "varies"
@@ -476,122 +518,21 @@
                 "hasCounteractCheck": {
                     "value": false
                 },
-                "level": {
-                    "value": 3
-                },
-                "location": {
-                    "uses": {
-                        "max": 2,
-                        "value": 2
+                "heightening": {
+                    "levels": {
+                        "7": {
+                            "target": {
+                                "value": "10 creatures"
+                            }
+                        }
                     },
-                    "value": "flkn7WKcRA511YkF"
-                },
-                "materials": {
-                    "value": ""
-                },
-                "prepared": {
-                    "value": ""
-                },
-                "primarycheck": {
-                    "value": ""
-                },
-                "range": {
-                    "value": "30 feet"
-                },
-                "rules": [],
-                "save": {
-                    "basic": "",
-                    "value": "will"
-                },
-                "school": {
-                    "value": "enchantment"
-                },
-                "secondarycasters": {
-                    "value": ""
-                },
-                "secondarycheck": {
-                    "value": ""
-                },
-                "slug": null,
-                "source": {
-                    "value": "https://2e.aonprd.com/Spells.aspx?ID=110"
-                },
-                "spellType": {
-                    "value": "save"
-                },
-                "sustained": {
-                    "value": false
-                },
-                "target": {
-                    "value": "1 creature"
-                },
-                "time": {
-                    "value": "2"
-                },
-                "traditions": {
-                    "value": [
-                        "arcane",
-                        "divine",
-                        "occult",
-                        "primal"
-                    ]
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": [
-                        "emotion",
-                        "fear",
-                        "mental"
-                    ]
-                }
-            },
-            "img": "systems/pf2e/icons/spells/fear.webp",
-            "name": "Fear",
-            "sort": 400000,
-            "type": "spell"
-        },
-        {
-            "_id": "EP1pNZgC07Te4JqI",
-            "data": {
-                "ability": {
-                    "value": ""
-                },
-                "area": {
-                    "areaType": "",
-                    "value": null
-                },
-                "areasize": {
-                    "value": ""
-                },
-                "category": {
-                    "value": "spell"
-                },
-                "components": {
-                    "focus": false,
-                    "material": false,
-                    "somatic": true,
-                    "verbal": true
-                },
-                "cost": {
-                    "value": ""
-                },
-                "damage": {
-                    "value": {}
-                },
-                "description": {
-                    "value": "<p>You block the target's motor impulses before they can leave its mind, threatening to freeze the target in place. The target must attempt a Will save.</p>\n<hr />\n<p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target is @Compendium[pf2e.conditionitems.Stunned]{Stunned 1}.</p>\n<p><strong>Failure</strong> The target is @Compendium[pf2e.conditionitems.Paralyzed]{Paralyzed} for 1 round.</p>\n<p><strong>Critical Failure</strong> The target is @Compendium[pf2e.conditionitems.Paralyzed]{Paralyzed} for 4 rounds. At the end of each of its turns, it can attempt a new Will save to reduce the remaining duration by 1 round, or end it entirely on a critical success.</p>\n<hr />\n<p><strong>Heightened (7th)</strong> You can target up to 10 creatures.</p>"
-                },
-                "duration": {
-                    "value": "varies"
-                },
-                "hasCounteractCheck": {
-                    "value": false
+                    "type": "fixed"
                 },
                 "level": {
                     "value": 3
                 },
                 "location": {
+                    "heightenedLevel": 3,
                     "value": "flkn7WKcRA511YkF"
                 },
                 "materials": {
@@ -620,9 +561,9 @@
                 "secondarycheck": {
                     "value": ""
                 },
-                "slug": null,
+                "slug": "paralyze",
                 "source": {
-                    "value": "https://2e.aonprd.com/Spells.aspx?ID=213"
+                    "value": "Pathfinder Core Rulebook"
                 },
                 "spellType": {
                     "value": "save"
@@ -652,20 +593,25 @@
                     ]
                 }
             },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.DCQHaLrYXMI37dvW"
+                }
+            },
             "img": "systems/pf2e/icons/spells/paralyze.webp",
             "name": "Paralyze",
-            "sort": 500000,
+            "sort": 400000,
             "type": "spell"
         },
         {
-            "_id": "Miche7QAUUVCijoW",
+            "_id": "hSccMVKaguIxPJCc",
             "data": {
                 "ability": {
                     "value": ""
                 },
                 "area": {
                     "areaType": "",
-                    "value": null
+                    "value": ""
                 },
                 "areasize": {
                     "value": ""
@@ -694,10 +640,21 @@
                 "hasCounteractCheck": {
                     "value": false
                 },
+                "heightening": {
+                    "levels": {
+                        "6": {
+                            "target": {
+                                "value": "5 creatures"
+                            }
+                        }
+                    },
+                    "type": "fixed"
+                },
                 "level": {
                     "value": 2
                 },
                 "location": {
+                    "heightenedLevel": 2,
                     "value": "flkn7WKcRA511YkF"
                 },
                 "materials": {
@@ -726,9 +683,9 @@
                 "secondarycheck": {
                     "value": ""
                 },
-                "slug": null,
+                "slug": "paranoia",
                 "source": {
-                    "value": "https://2e.aonprd.com/Spells.aspx?ID=214"
+                    "value": "Pathfinder Core Rulebook"
                 },
                 "spellType": {
                     "value": "save"
@@ -755,13 +712,18 @@
                     ]
                 }
             },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.Mkbq9xlAUxHUHyR2"
+                }
+            },
             "img": "systems/pf2e/icons/spells/paranoia.webp",
             "name": "Paranoia",
-            "sort": 600000,
+            "sort": 500000,
             "type": "spell"
         },
         {
-            "_id": "cVCAmxzVZcp7x2vz",
+            "_id": "RhDyd8lg9pcG8h7R",
             "data": {
                 "ability": {
                     "value": ""
@@ -801,6 +763,7 @@
                     "value": 2
                 },
                 "location": {
+                    "heightenedLevel": 2,
                     "value": "flkn7WKcRA511YkF"
                 },
                 "materials": {
@@ -829,9 +792,9 @@
                 "secondarycheck": {
                     "value": ""
                 },
-                "slug": null,
+                "slug": "silence",
                 "source": {
-                    "value": "https://2e.aonprd.com/Spells.aspx?ID=287"
+                    "value": "Pathfinder Core Rulebook"
                 },
                 "spellType": {
                     "value": "utility"
@@ -857,18 +820,167 @@
                     "value": []
                 }
             },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.gIdDLrbswTV3OBJy"
+                }
+            },
             "img": "systems/pf2e/icons/spells/silence.webp",
             "name": "Silence",
+            "sort": 600000,
+            "type": "spell"
+        },
+        {
+            "_id": "AhhjiZph09PZBFS6",
+            "data": {
+                "ability": {
+                    "value": ""
+                },
+                "area": {
+                    "areaType": "",
+                    "value": ""
+                },
+                "areasize": {
+                    "value": ""
+                },
+                "category": {
+                    "value": "spell"
+                },
+                "components": {
+                    "focus": false,
+                    "material": false,
+                    "somatic": true,
+                    "verbal": true
+                },
+                "cost": {
+                    "value": ""
+                },
+                "damage": {
+                    "value": {}
+                },
+                "description": {
+                    "value": "<p>You plant fear in the target; it must attempt a Will save.</p>\n<hr />\n<p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target is @Compendium[pf2e.conditionitems.Frightened]{Frightened 1}.</p>\n<p><strong>Failure</strong> The target is @Compendium[pf2e.conditionitems.Frightened]{Frightened 2}.</p>\n<p><strong>Critical Failure</strong> The target is @Compendium[pf2e.conditionitems.Frightened]{Frightened 3} and @Compendium[pf2e.conditionitems.Fleeing]{Fleeing} for 1 round.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You can target up to five creatures.</p>"
+                },
+                "duration": {
+                    "value": "varies"
+                },
+                "hasCounteractCheck": {
+                    "value": false
+                },
+                "heightening": {
+                    "levels": {
+                        "3": {
+                            "target": {
+                                "value": "5 creatures"
+                            }
+                        }
+                    },
+                    "type": "fixed"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": {
+                    "heightenedLevel": 3,
+                    "uses": {
+                        "max": 2,
+                        "value": 2
+                    },
+                    "value": "flkn7WKcRA511YkF"
+                },
+                "materials": {
+                    "value": ""
+                },
+                "prepared": {
+                    "value": ""
+                },
+                "primarycheck": {
+                    "value": ""
+                },
+                "range": {
+                    "value": "30 feet"
+                },
+                "rules": [],
+                "save": {
+                    "basic": "",
+                    "value": "will"
+                },
+                "school": {
+                    "value": "enchantment"
+                },
+                "secondarycasters": {
+                    "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "fear",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "spellType": {
+                    "value": "save"
+                },
+                "sustained": {
+                    "value": false
+                },
+                "target": {
+                    "value": "1 creature"
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traditions": {
+                    "value": [
+                        "arcane",
+                        "divine",
+                        "occult",
+                        "primal"
+                    ]
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "emotion",
+                        "fear",
+                        "mental"
+                    ]
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.4koZzrnMXhhosn0D"
+                }
+            },
+            "img": "systems/pf2e/icons/spells/fear.webp",
+            "name": "Fear",
             "sort": 700000,
             "type": "spell"
         },
         {
-            "_id": "C2lYw1VmEjOxa9B0",
+            "_id": "BxDCgYUwe9bAFdWn",
             "data": {
-                "baseItem": null,
-                "containerId": null,
-                "description": {
+                "MAP": {
                     "value": ""
+                },
+                "baseItem": "mace",
+                "bonus": {
+                    "value": 0
+                },
+                "bonusDamage": {
+                    "value": 0
+                },
+                "category": "simple",
+                "containerId": null,
+                "damage": {
+                    "damageType": "bludgeoning",
+                    "dice": 1,
+                    "die": "d6",
+                    "value": ""
+                },
+                "description": {
+                    "value": "<p>With a stout haft and a heavy metal head, a mace is sturdy and allows its wielder to deliver powerful blows and dent armor.</p>"
                 },
                 "equipped": {
                     "carryType": "worn",
@@ -878,6 +990,7 @@
                 "equippedBulk": {
                     "value": ""
                 },
+                "group": "club",
                 "hardness": 0,
                 "hp": {
                     "brokenThreshold": 0,
@@ -890,6 +1003,9 @@
                 "negateBulk": {
                     "value": "0"
                 },
+                "potencyRune": {
+                    "value": null
+                },
                 "preciousMaterial": {
                     "value": ""
                 },
@@ -897,35 +1013,83 @@
                     "value": ""
                 },
                 "price": {
-                    "value": {}
+                    "value": {
+                        "gp": 1
+                    }
                 },
-                "quantity": 1,
-                "rules": [],
-                "size": "med",
-                "slug": null,
-                "source": {
+                "property1": {
+                    "critDamage": "",
+                    "critDamageType": "",
+                    "critDice": null,
+                    "critDie": "",
+                    "criticalConditionType": "",
+                    "criticalConditionValue": null,
+                    "damageType": "",
+                    "dice": null,
+                    "die": "",
+                    "strikeConditionType": "",
+                    "strikeConditionValue": null,
                     "value": ""
                 },
+                "propertyRune1": {
+                    "value": ""
+                },
+                "propertyRune2": {
+                    "value": ""
+                },
+                "propertyRune3": {
+                    "value": ""
+                },
+                "propertyRune4": {
+                    "value": ""
+                },
+                "quantity": 1,
+                "range": null,
+                "reload": {
+                    "value": ""
+                },
+                "rules": [],
+                "size": "med",
+                "slug": "mace",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "specific": {
+                    "value": false
+                },
+                "splashDamage": {
+                    "value": 0
+                },
                 "stackGroup": null,
+                "strikingRune": {
+                    "value": ""
+                },
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "shove"
+                    ]
                 },
                 "usage": {
                     "value": "held-in-one-hand"
                 },
                 "weight": {
-                    "value": 0
+                    "value": "1"
                 }
             },
-            "img": "systems/pf2e/icons/default-icons/equipment.svg",
-            "name": "mace",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.equipment-srd.9iDqOLNFKxiTcFKE"
+                }
+            },
+            "img": "systems/pf2e/icons/equipment/weapons/mace.webp",
+            "name": "Mace",
             "sort": 800000,
-            "type": "equipment"
+            "type": "weapon"
         },
         {
-            "_id": "Ye1yGYYFsUNBu4EV",
+            "_id": "lxeVoaJKG3pcnHNw",
             "data": {
                 "attack": {
                     "value": ""
@@ -937,15 +1101,15 @@
                     "value": 20
                 },
                 "damageRolls": {
-                    "n75wmnjzvshncyipguv2": {
-                        "damage": "2d6+9",
+                    "tpsi79razapj036l": {
+                        "damage": "2d6 + 9",
                         "damageType": "bludgeoning"
                     },
-                    "ilquahmbn0belaobvowt": {
+                    "8ljukf2n92y4qc36ms91": {
                         "damage": "1d6",
                         "damageType": "evil"
                     },
-                    "hh1aviqkwiwdpv8xbh7n": {
+                    "qscw5ydv4rgt4cnokdlm": {
                         "damage": "1d6",
                         "damageType": "fire"
                     }
@@ -961,19 +1125,26 @@
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "shove"
+                    ]
                 },
                 "weaponType": {
                     "value": "melee"
                 }
             },
+            "flags": {
+                "pf2e": {
+                    "linkedWeapon": "BxDCgYUwe9bAFdWn"
+                }
+            },
             "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "Flaming Mace (shove)",
+            "name": "Flaming Mace",
             "sort": 900000,
             "type": "melee"
         },
         {
-            "_id": "W6h0y5SYAp3QWJuM",
+            "_id": "VfNFRpaHJQvgRnE0",
             "data": {
                 "attack": {
                     "value": ""
@@ -985,11 +1156,11 @@
                     "value": 17
                 },
                 "damageRolls": {
-                    "9490a9vst75ey87svk5z": {
+                    "m5keu5rntbwhficqpnuu": {
                         "damage": "2d6+8",
                         "damageType": "bludgeoning"
                     },
-                    "i9r0sbidl6kgrb4e9e3e": {
+                    "s7ng1ltal6q32fwsjizo": {
                         "damage": "1d6",
                         "damageType": "evil"
                     }
@@ -1019,7 +1190,7 @@
             "type": "melee"
         },
         {
-            "_id": "l4jIeASBNQIdSqkF",
+            "_id": "FULVmTNiY92fER9u",
             "data": {
                 "attack": {
                     "value": ""
@@ -1031,17 +1202,17 @@
                     "value": 17
                 },
                 "damageRolls": {
-                    "ojdtqj0i408by326evfh": {
+                    "oskkkkczdvdizyyr2iwq": {
                         "damage": "2d6+4",
                         "damageType": "piercing"
                     },
-                    "vm1pc49dk1jmhg4zh3s9": {
+                    "s70ikvlgh5u1hh1jj941": {
                         "damage": "1d6",
                         "damageType": "evil"
                     }
                 },
                 "description": {
-                    "value": "<p>(range increment 30 feet)</p>"
+                    "value": ""
                 },
                 "rules": [],
                 "slug": null,
@@ -1065,6 +1236,288 @@
             "type": "melee"
         },
         {
+            "_id": "8eOBxazoqlDlkeaZ",
+            "data": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.GreaterDarkvision]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "greater-darkvision",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.4Ho2xMPEC05aSxzr"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Greater Darkvision",
+            "sort": 1200000,
+            "type": "action"
+        },
+        {
+            "_id": "v4DDFEjwK29GAYmR",
+            "data": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Telepathy]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "telepathy",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "aura",
+                        "divination",
+                        "magical"
+                    ]
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.kdhbPaBMK1d1fpbA"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Telepathy 30 feet",
+            "sort": 1300000,
+            "type": "action"
+        },
+        {
+            "_id": "MYdz6LWVPdlPiGze",
+            "data": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.AtWillSpells]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "at-will-spells",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.2YRDYVnC1eljaXKK"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "At-Will Spells",
+            "sort": 1400000,
+            "type": "action"
+        },
+        {
+            "_id": "ZDeJngRgNpJ1IwVz",
+            "data": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.ConstantSpells]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "constant-spells",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.kakyXBG5WA8c6Zfd"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Constant Spells",
+            "sort": 1500000,
+            "type": "action"
+        },
+        {
+            "_id": "ucPIcsmSJrzGmayG",
+            "data": {
+                "actionCategory": {
+                    "value": "defensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": ""
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "predicate": {
+                            "any": [
+                                "magical",
+                                "arcane",
+                                "divine",
+                                "primal",
+                                "occult"
+                            ]
+                        },
+                        "selector": "saving-throw",
+                        "type": "untyped",
+                        "value": 1
+                    }
+                ],
+                "slug": "1-status-to-all-saves-vs-magic",
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.kquBnQ0kObZztnBc"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "+1 to All Saves vs Magic",
+            "sort": 1600000,
+            "type": "action"
+        },
+        {
+            "_id": "7RYfL3pdW794bMch",
+            "data": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>Any weapon the ascendant holds gains the effects of a @Compendium[pf2e.equipment-srd.Flaming]{Flaming} and @Compendium[pf2e.equipment-srd.Striking]{Striking} rune while they hold it.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Covetous Flames",
+            "sort": 1700000,
+            "type": "action"
+        },
+        {
             "_id": "Xmjisl9KBlX1Cq7D",
             "data": {
                 "actionCategory": {
@@ -1077,7 +1530,7 @@
                     "value": 2
                 },
                 "description": {
-                    "value": "<p>The ascendant beats their wings in a frenzied motion, creating a powerful blast of wind that disperses fog and gases, blows objects of light Bulk or less away. All creatures within 20 feet of the ascendant must succeed at a @Check[type:reflex|dc:23] save or be pushed 5 feet away from the ascendant, or 10 feet on a critical failure. A flying creature that fails its save gets a critical failure instead.</p>"
+                    "value": "<p>The ascendant beats their wings in a frenzied motion, creating a powerful blast of wind that disperses fog and gases, blows objects of light Bulk or less away. All creatures within @Template[type:emanation|distance:20]{20 feet} of the ascendant must succeed at a @Check[type:reflex|dc:23] save or be pushed 5 feet away from the ascendant, or 10 feet on a critical failure. A flying creature that fails its save gets a critical failure instead.</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -1101,7 +1554,7 @@
             },
             "img": "systems/pf2e/icons/actions/TwoActions.webp",
             "name": "Furious Wings",
-            "sort": 1200000,
+            "sort": 1800000,
             "type": "action"
         },
         {
@@ -1129,7 +1582,7 @@
             },
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Arcana",
-            "sort": 1300000,
+            "sort": 1900000,
             "type": "lore"
         },
         {
@@ -1157,7 +1610,7 @@
             },
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Deception",
-            "sort": 1400000,
+            "sort": 2000000,
             "type": "lore"
         },
         {
@@ -1185,7 +1638,7 @@
             },
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Intimidation",
-            "sort": 1500000,
+            "sort": 2100000,
             "type": "lore"
         },
         {
@@ -1213,7 +1666,7 @@
             },
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Occultism",
-            "sort": 1600000,
+            "sort": 2200000,
             "type": "lore"
         },
         {
@@ -1241,7 +1694,7 @@
             },
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Religion",
-            "sort": 1700000,
+            "sort": 2300000,
             "type": "lore"
         },
         {
@@ -1269,7 +1722,7 @@
             },
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Stealth",
-            "sort": 1800000,
+            "sort": 2400000,
             "type": "lore"
         }
     ],

--- a/packs/data/pfs-season-1-bestiary.db/unkillable-zombie-brute-pfs-1-13.json
+++ b/packs/data/pfs-season-1-bestiary.db/unkillable-zombie-brute-pfs-1-13.json
@@ -1,5 +1,5 @@
 {
-    "_id": "xKanh4M6QEF39bvd",
+    "_id": "fG2rxzrSiMS01Xqe",
     "data": {
         "abilities": {
             "cha": {
@@ -53,12 +53,12 @@
             "blurb": "",
             "creatureType": "Undead",
             "level": {
-                "value": 2
+                "value": 3
             },
             "privateNotes": "",
             "publicNotes": "<p>Necromantic augmentations have granted this zombie increased size and power.</p>\n<hr />\n<p>A zombie's only desire is to consume the living. Unthinking and ever-shambling harbingers of death, zombies stop only when they're destroyed.</p>",
             "source": {
-                "value": "Pathfinder Society Scenario 1-18: Lodge of the Living God"
+                "value": "Pathfinder Society Scenario #1-13: Devil at the Crossroads"
             }
         },
         "resources": {},
@@ -92,14 +92,19 @@
                     "unconscious"
                 ]
             },
-            "dr": [],
+            "dr": [
+                {
+                    "type": "all",
+                    "value": 3
+                }
+            ],
             "dv": [
                 {
-                    "type": "positive",
-                    "value": 10
+                    "type": "critical-hits",
+                    "value": 6
                 },
                 {
-                    "type": "slashing",
+                    "type": "positive",
                     "value": 10
                 }
             ],
@@ -128,76 +133,7 @@
     "img": "systems/pf2e/icons/default-icons/npc.svg",
     "items": [
         {
-            "_id": "9j9kz8bv8i4ae8b7",
-            "data": {
-                "active": true,
-                "alsoApplies": {
-                    "linked": [],
-                    "unlinked": []
-                },
-                "base": "Slowed",
-                "description": {
-                    "value": "<p>You have fewer actions. Slowed always includes a value. When you regain your actions at the start of your turn, reduce the number of actions you regain by your slowed value. Because slowed has its effect at the start of your turn, you don't immediately lose actions if you become slowed during your turn.</p>"
-                },
-                "duration": {
-                    "perpetual": true,
-                    "text": "",
-                    "value": 0
-                },
-                "group": "",
-                "hud": {
-                    "img": {
-                        "useStatusName": true,
-                        "value": "systems/pf2e/icons/conditions-2/slowed.webp"
-                    },
-                    "selectable": true,
-                    "statusName": "slowed"
-                },
-                "modifiers": [],
-                "overrides": [],
-                "references": {
-                    "children": [],
-                    "immunityFrom": [],
-                    "overriddenBy": [],
-                    "overrides": []
-                },
-                "removable": true,
-                "rules": [],
-                "slug": "slowed",
-                "source": {
-                    "value": ""
-                },
-                "sources": {
-                    "hud": true,
-                    "values": []
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                },
-                "value": {
-                    "immutable": false,
-                    "isValued": true,
-                    "modifiers": [],
-                    "value": 1
-                }
-            },
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.conditionitems.xYTAsEpcJE1Ccni3"
-                },
-                "pf2e": {
-                    "condition": true
-                }
-            },
-            "img": "systems/pf2e/icons/conditions/slowed.webp",
-            "name": "Slowed",
-            "sort": 100000,
-            "type": "condition"
-        },
-        {
-            "_id": "wdsdNrRHG7tMUw5P",
+            "_id": "vd376igQJJRr3OpH",
             "data": {
                 "attack": {
                     "value": ""
@@ -212,7 +148,7 @@
                     "value": 11
                 },
                 "damageRolls": {
-                    "izwzbwakdx5r2d8gxlh7": {
+                    "e4e9v1htkljt1ckzdfr1": {
                         "damage": "1d12+5",
                         "damageType": "bludgeoning"
                     }
@@ -238,11 +174,11 @@
             },
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Fist",
-            "sort": 200000,
+            "sort": 100000,
             "type": "melee"
         },
         {
-            "_id": "QWBpk7SbuXW6RHU1",
+            "_id": "OvNDXDsQn6S6DDkJ",
             "data": {
                 "actionCategory": {
                     "value": "interaction"
@@ -283,7 +219,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Darkvision",
-            "sort": 300000,
+            "sort": 200000,
             "type": "action"
         },
         {
@@ -323,11 +259,11 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Slow",
-            "sort": 400000,
+            "sort": 300000,
             "type": "action"
         },
         {
-            "_id": "BOFFwI5nKDfABluP",
+            "_id": "oNSDlUCQr0RZoHRA",
             "data": {
                 "actionCategory": {
                     "value": "defensive"
@@ -375,60 +311,11 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Negative Healing",
-            "sort": 500000,
+            "sort": 400000,
             "type": "action"
         },
         {
-            "_id": "IKKlqoLTFtO3pbQV",
-            "data": {
-                "actionCategory": {
-                    "value": "defensive"
-                },
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "description": {
-                    "value": "<p>@Template[type:emanation|distance:10]{10 feet} @Compendium[pf2e.bestiary-ability-glossary-srd.Aura]{Aura}</p>\n<hr />\n<p>The zombie emits an aura of rot and disease that causes wounds to fester and turn sour.</p>\n<p>Any living creature that starts its turn within 10 feet of the zombie and is not at full Hit Points takes [[/r {1d6}]]{1d6 damage} as its wounds fester. Creatures that take a critical hit from the zombie also take this damage immediately.</p>"
-                },
-                "requirements": {
-                    "value": ""
-                },
-                "rules": [],
-                "slug": "zombie-rotting-aura",
-                "source": {
-                    "value": "Pathfinder Bestiary"
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": [
-                        "aura",
-                        "disease",
-                        "necromancy"
-                    ]
-                },
-                "trigger": {
-                    "value": ""
-                },
-                "weapon": {
-                    "value": ""
-                }
-            },
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.bestiary-family-ability-glossary.CxiEpXt7Gw3tSIOh"
-                }
-            },
-            "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Rotting Aura",
-            "sort": 600000,
-            "type": "action"
-        },
-        {
-            "_id": "Is4V63biDtNBVpi2",
+            "_id": "sHMWhck9CMUHgpmo",
             "data": {
                 "actionCategory": {
                     "value": "offensive"
@@ -468,8 +355,8 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/FreeAction.webp",
-            "name": "Improved Push 5 feet",
-            "sort": 700000,
+            "name": "Improved Push",
+            "sort": 500000,
             "type": "action"
         },
         {
@@ -497,16 +384,16 @@
             },
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Athletics",
-            "sort": 800000,
+            "sort": 600000,
             "type": "lore"
         }
     ],
-    "name": "Zombie Brute (1-18)",
+    "name": "Unkillable Zombie Brute (PFS 1-13)",
     "token": {
         "disposition": -1,
         "height": 2,
         "img": "systems/pf2e/icons/default-icons/npc.svg",
-        "name": "Zombie Brute",
+        "name": "Unkillable Zombie Brute",
         "width": 2
     },
     "type": "npc"

--- a/packs/data/pfs-season-1-bestiary.db/zombie-brute-pfs-1-18.json
+++ b/packs/data/pfs-season-1-bestiary.db/zombie-brute-pfs-1-18.json
@@ -1,15 +1,15 @@
 {
-    "_id": "u2TGKzPfGniZLL14",
+    "_id": "xKanh4M6QEF39bvd",
     "data": {
         "abilities": {
             "cha": {
-                "mod": -5
+                "mod": -2
             },
             "con": {
-                "mod": 3
+                "mod": 4
             },
             "dex": {
-                "mod": -1
+                "mod": -3
             },
             "int": {
                 "mod": -5
@@ -24,22 +24,22 @@
         "attributes": {
             "ac": {
                 "details": "",
-                "value": 26
+                "value": 15
             },
             "allSaves": {
                 "value": ""
             },
             "hp": {
-                "details": "",
-                "max": 140,
+                "details": "negative healing",
+                "max": 70,
                 "temp": 0,
-                "value": 140
+                "value": 70
             },
             "initiative": {
                 "ability": "perception"
             },
             "perception": {
-                "value": 12
+                "value": 4
             },
             "speed": {
                 "otherSpeeds": [],
@@ -48,71 +48,67 @@
         },
         "details": {
             "alignment": {
-                "value": "N"
+                "value": "NE"
             },
             "blurb": "",
-            "creatureType": "Construct",
+            "creatureType": "Undead",
             "level": {
-                "value": 8
+                "value": 2
             },
             "privateNotes": "",
-            "publicNotes": "",
+            "publicNotes": "<p>Necromantic augmentations have granted this zombie increased size and power.</p>\n<hr />\n<p>A zombie's only desire is to consume the living. Unthinking and ever-shambling harbingers of death, zombies stop only when they're destroyed.</p>",
             "source": {
-                "value": "Pathfinder Society Scenario 1-25: Grim Symphony"
+                "value": "Pathfinder Society Scenario 1-18: Lodge of the Living God"
             }
         },
         "resources": {},
         "saves": {
             "fortitude": {
                 "saveDetail": "",
-                "value": 18
+                "value": 10
             },
             "reflex": {
                 "saveDetail": "",
-                "value": 14
+                "value": 3
             },
             "will": {
                 "saveDetail": "",
-                "value": 15
+                "value": 6
             }
         },
         "traits": {
+            "attitude": {
+                "value": "hostile"
+            },
             "ci": [],
             "di": {
                 "custom": "",
                 "value": [
-                    "bleed",
                     "death-effects",
                     "disease",
-                    "doomed",
-                    "drained",
-                    "electricity",
-                    "fatigued",
-                    "healing",
-                    "magic",
                     "mental",
-                    "necromancy",
-                    "nonlethal-attacks",
                     "paralyzed",
                     "poison",
-                    "sickened",
                     "unconscious"
                 ]
             },
-            "dr": [
+            "dr": [],
+            "dv": [
                 {
-                    "exceptions": "except Adamantine",
-                    "type": "physical",
-                    "value": 5
+                    "type": "positive",
+                    "value": 10
+                },
+                {
+                    "type": "slashing",
+                    "value": 10
                 }
             ],
-            "dv": [],
             "languages": {
                 "custom": "",
                 "selected": [],
                 "value": []
             },
-            "rarity": "uncommon",
+            "rarity": "common",
             "senses": {
                 "value": "darkvision"
             },
@@ -122,9 +118,9 @@
             "traits": {
                 "custom": "",
                 "value": [
-                    "construct",
-                    "golem",
-                    "mindless"
+                    "mindless",
+                    "undead",
+                    "zombie"
                 ]
             }
         }
@@ -132,20 +128,92 @@
     "img": "systems/pf2e/icons/default-icons/npc.svg",
     "items": [
         {
-            "_id": "k1kPrQ3Krhcipl4E",
+            "_id": "9j9kz8bv8i4ae8b7",
+            "data": {
+                "active": true,
+                "alsoApplies": {
+                    "linked": [],
+                    "unlinked": []
+                },
+                "base": "Slowed",
+                "description": {
+                    "value": "<p>You have fewer actions. Slowed always includes a value. When you regain your actions at the start of your turn, reduce the number of actions you regain by your slowed value. Because slowed has its effect at the start of your turn, you don't immediately lose actions if you become slowed during your turn.</p>"
+                },
+                "duration": {
+                    "perpetual": true,
+                    "text": "",
+                    "value": 0
+                },
+                "group": "",
+                "hud": {
+                    "img": {
+                        "useStatusName": true,
+                        "value": "systems/pf2e/icons/conditions-2/slowed.webp"
+                    },
+                    "selectable": true,
+                    "statusName": "slowed"
+                },
+                "modifiers": [],
+                "overrides": [],
+                "references": {
+                    "children": [],
+                    "immunityFrom": [],
+                    "overriddenBy": [],
+                    "overrides": []
+                },
+                "removable": true,
+                "rules": [],
+                "slug": "slowed",
+                "source": {
+                    "value": ""
+                },
+                "sources": {
+                    "hud": true,
+                    "values": []
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "value": {
+                    "immutable": false,
+                    "isValued": true,
+                    "modifiers": [],
+                    "value": 1
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.conditionitems.xYTAsEpcJE1Ccni3"
+                },
+                "pf2e": {
+                    "condition": true
+                }
+            },
+            "img": "systems/pf2e/icons/conditions/slowed.webp",
+            "name": "Slowed",
+            "sort": 100000,
+            "type": "condition"
+        },
+        {
+            "_id": "wdsdNrRHG7tMUw5P",
             "data": {
                 "attack": {
                     "value": ""
                 },
                 "attackEffects": {
-                    "value": []
+                    "custom": "",
+                    "value": [
+                        "improved-push"
+                    ]
                 },
                 "bonus": {
-                    "value": 20
+                    "value": 11
                 },
                 "damageRolls": {
-                    "p5d1nbdm06qkq6wsqaq5": {
-                        "damage": "2d10+7",
+                    "izwzbwakdx5r2d8gxlh7": {
+                        "damage": "1d12+5",
                         "damageType": "bludgeoning"
                     }
                 },
@@ -161,7 +229,6 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "magical",
                         "reach-10"
                     ]
                 },
@@ -171,11 +238,11 @@
             },
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Fist",
-            "sort": 100000,
+            "sort": 200000,
             "type": "melee"
         },
         {
-            "_id": "J66VJmEpPHpyEwLL",
+            "_id": "QWBpk7SbuXW6RHU1",
             "data": {
                 "actionCategory": {
                     "value": "interaction"
@@ -216,14 +283,14 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Darkvision",
-            "sort": 200000,
+            "sort": 300000,
             "type": "action"
         },
         {
-            "_id": "95kvqPPSJNio8vAK",
+            "_id": "TtcFIJZjrZ4Vaaml",
             "data": {
                 "actionCategory": {
-                    "value": "defensive"
+                    "value": "interaction"
                 },
                 "actionType": {
                     "value": "passive"
@@ -232,7 +299,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>A severely damaged flesh golem has a chance of going berserk. If it has 40 or fewer HP at the start of its turn, the golem must succeed at a @Check[type:flat|dc:5] check or go berserk. A berserk golem wildly attacks the nearest living creature, or the nearest object if no creatures are nearby.</p>"
+                    "value": "<p>A zombie is permanently @Compendium[pf2e.conditionitems.Slowed]{Slowed 1} and can't use reactions.</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -255,12 +322,12 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Berserk",
-            "sort": 300000,
+            "name": "Slow",
+            "sort": 400000,
             "type": "action"
         },
         {
-            "_id": "EcSG9mNyifTC1iWV",
+            "_id": "BOFFwI5nKDfABluP",
             "data": {
                 "actionCategory": {
                     "value": "defensive"
@@ -272,13 +339,114 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>harmed by fire ([[/r {5d8}[fire]]]{5d8 fire damage}, [[/r {3d4}[fire]]]{3d4 fire damage} from areas or persistent damage); healed by electricity (area [[/r {2d4}[healing]]]{2d4 Hit Points}); slowed by cold</p>\n<hr />\n<p>A golem is immune to spells and magical abilities other than its own, but each type of golem is affected by a few types of magic in special ways. These exceptions are listed in shortened form in the golem's stat block, with the full rules appearing here. If an entry lists multiple types (such as “cold and water”), either type of spell can affect the golem.</p>\n<ul>\n<li><strong>Harmed By</strong> Any magic of this type that targets the golem causes it to take the listed amount of damage (this damage has no type) instead of the usual effect. If the golem starts its turn in an area of magic of this type or is affected by a persistent effect of the appropriate type, it takes the damage listed in the parenthetical.</li>\n<li><strong>Healed By</strong> Any magic of this type that targets the golem makes the golem lose the slowed condition and gain HP equal to half the damage the spell would have dealt. If the golem starts its turn in an area of this type of magic, it gains the HP listed in the parenthetical.</li>\n<li><strong>Slowed By</strong> Any magic of this type that targets the golem causes it to be @Compendium[pf2e.conditionitems.Slowed]{Slowed 1} for [[/br 2d6 #rounds]]{2d6 rounds} instead of the usual effect. If the golem starts its turn in an area of this type of magic, it's slowed 1 for that round.</li>\n<li><strong>Vulnerable To</strong> Each golem is vulnerable to one or more specific spells, with the effects described in its stat block.</li>\n</ul>"
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.NegativeHealing]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "data.attributes.hp.negativeHealing",
+                        "value": true
+                    }
+                ],
+                "slug": "negative-healing",
+                "source": {
+                    "value": "Pathfinder Bestiary 2"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.TTCw5NusiSSkJU1x"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Negative Healing",
+            "sort": 500000,
+            "type": "action"
+        },
+        {
+            "_id": "IKKlqoLTFtO3pbQV",
+            "data": {
+                "actionCategory": {
+                    "value": "defensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Template[type:emanation|distance:10]{10 feet} @Compendium[pf2e.bestiary-ability-glossary-srd.Aura]{Aura}</p>\n<hr />\n<p>The zombie emits an aura of rot and disease that causes wounds to fester and turn sour.</p>\n<p>Any living creature that starts its turn within 10 feet of the zombie and is not at full Hit Points takes [[/r {1d6}]]{1d6 damage} as its wounds fester. Creatures that take a critical hit from the zombie also take this damage immediately.</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
                 "rules": [],
-                "slug": "golem-golem-antimagic",
+                "slug": "zombie-rotting-aura",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "aura",
+                        "disease",
+                        "necromancy"
+                    ]
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-family-ability-glossary.CxiEpXt7Gw3tSIOh"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Rotting Aura",
+            "sort": 600000,
+            "type": "action"
+        },
+        {
+            "_id": "Is4V63biDtNBVpi2",
+            "data": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "free"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.ImprovedPush]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "improved-push",
                 "source": {
                     "value": "Pathfinder Bestiary"
                 },
@@ -296,143 +464,22 @@
             },
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.bestiary-family-ability-glossary.r34QDwKiWZoVymJa"
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.6l7e7CHQLESlI57U"
                 }
             },
-            "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Golem Antimagic",
-            "sort": 400000,
+            "img": "systems/pf2e/icons/actions/FreeAction.webp",
+            "name": "Improved Push 5 feet",
+            "sort": 700000,
             "type": "action"
         },
         {
-            "_id": "uzwUjI3gD8tO8Chh",
-            "data": {
-                "actionCategory": {
-                    "value": "defensive"
-                },
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "description": {
-                    "value": "<p>Casting a <em>@Compendium[pf2e.spells-srd.Flesh to Stone]{Flesh to Stone}</em> spell on the flesh golem affects the golem normally.</p>"
-                },
-                "requirements": {
-                    "value": ""
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                },
-                "trigger": {
-                    "value": ""
-                },
-                "weapon": {
-                    "value": ""
-                }
-            },
-            "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Vulnerable to Flesh to Stone",
-            "sort": 500000,
-            "type": "action"
-        },
-        {
-            "_id": "BaBWpspQzY07GuJo",
-            "data": {
-                "actionCategory": {
-                    "value": "offensive"
-                },
-                "actionType": {
-                    "value": "action"
-                },
-                "actions": {
-                    "value": 1
-                },
-                "description": {
-                    "value": "<p><strong>Requirements</strong> The golem is berserk</p>\n<hr />\n<p><strong>Effect</strong> The flesh golem Strikes with its fist at a -1 circumstance penalty. If it hits, it deals [[/r {1d6}]]{1d6 extra damage} and knocks the target @Compendium[pf2e.conditionitems.Prone]{Prone}.</p>"
-                },
-                "requirements": {
-                    "value": ""
-                },
-                "rules": [
-                    {
-                        "domain": "all",
-                        "key": "RollOption",
-                        "option": "berserk-slam",
-                        "toggleable": true
-                    },
-                    {
-                        "damageType": "bludgeoning",
-                        "diceNumber": 1,
-                        "dieSize": "d6",
-                        "key": "DamageDice",
-                        "predicate": {
-                            "all": [
-                                "berserk-slam"
-                            ]
-                        },
-                        "selector": "strike-damage"
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "predicate": {
-                            "all": [
-                                "berserk-slam"
-                            ]
-                        },
-                        "selector": "attack",
-                        "type": "circumstance",
-                        "value": -1
-                    },
-                    {
-                        "key": "Note",
-                        "predicate": {
-                            "all": [
-                                "berserk-slam"
-                            ]
-                        },
-                        "selector": "strike-damage",
-                        "text": "The target is knocked @Compendium[pf2e.conditionitems.Prone]{Prone}.",
-                        "title": "{item|name}"
-                    }
-                ],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                },
-                "trigger": {
-                    "value": ""
-                },
-                "weapon": {
-                    "value": ""
-                }
-            },
-            "img": "systems/pf2e/icons/actions/OneAction.webp",
-            "name": "Berserk Slam",
-            "sort": 600000,
-            "type": "action"
-        },
-        {
-            "_id": "mInccpo8OPs89BAi",
+            "_id": "WHbE7viCeLXEGocR",
             "data": {
                 "description": {
                     "value": ""
                 },
                 "mod": {
-                    "value": 19
+                    "value": 9
                 },
                 "proficient": {
                     "value": 0
@@ -450,16 +497,16 @@
             },
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Athletics",
-            "sort": 700000,
+            "sort": 800000,
             "type": "lore"
         }
     ],
-    "name": "Flesh Golem (1-25)",
+    "name": "Zombie Brute (PFS 1-18)",
     "token": {
         "disposition": -1,
         "height": 2,
         "img": "systems/pf2e/icons/default-icons/npc.svg",
-        "name": "Flesh Golem",
+        "name": "Zombie Brute",
         "width": 2
     },
     "type": "npc"

--- a/packs/data/pfs-season-2-bestiary.db/fence-pfs-2-00.json
+++ b/packs/data/pfs-season-2-bestiary.db/fence-pfs-2-00.json
@@ -1481,7 +1481,7 @@
             "type": "lore"
         }
     ],
-    "name": "Fence (2-00)",
+    "name": "Fence (PFS 2-00)",
     "token": {
         "disposition": -1,
         "height": 1,

--- a/packs/data/pfs-season-2-bestiary.db/kobold-warrior-pfs-2-11.json
+++ b/packs/data/pfs-season-2-bestiary.db/kobold-warrior-pfs-2-11.json
@@ -987,7 +987,7 @@
             "type": "lore"
         }
     ],
-    "name": "Kobold Warrior (2-11)",
+    "name": "Kobold Warrior (PFS 2-11)",
     "token": {
         "disposition": -1,
         "height": 1,

--- a/packs/data/pfs-season-3-bestiary.db/fasiel-ibn-sazadin-1-2.json
+++ b/packs/data/pfs-season-3-bestiary.db/fasiel-ibn-sazadin-1-2.json
@@ -1020,7 +1020,7 @@
             "type": "lore"
         }
     ],
-    "name": "Fasiel Ibn Sazadin (Tier 1-2)",
+    "name": "Fasiel Ibn Sazadin (1-2)",
     "token": {
         "disposition": -1,
         "height": 1,

--- a/packs/data/pfs-season-3-bestiary.db/fasiel-ibn-sazadin-3-4.json
+++ b/packs/data/pfs-season-3-bestiary.db/fasiel-ibn-sazadin-3-4.json
@@ -1019,7 +1019,7 @@
             "type": "lore"
         }
     ],
-    "name": "Fasiel Ibn Sazadin (Tier 3-4)",
+    "name": "Fasiel Ibn Sazadin (3-4)",
     "token": {
         "disposition": -1,
         "height": 1,

--- a/packs/data/pfs-season-3-bestiary.db/filth-fire-pfs-3-01.json
+++ b/packs/data/pfs-season-3-bestiary.db/filth-fire-pfs-3-01.json
@@ -396,7 +396,7 @@
             "type": "lore"
         }
     ],
-    "name": "Filth Fire (3-01)",
+    "name": "Filth Fire (PFS 3-01)",
     "token": {
         "disposition": -1,
         "height": 1,

--- a/packs/data/pfs-season-3-bestiary.db/grimple-pfs-3-18.json
+++ b/packs/data/pfs-season-3-bestiary.db/grimple-pfs-3-18.json
@@ -1088,7 +1088,7 @@
             "type": "lore"
         }
     ],
-    "name": "Grimple (3-18)",
+    "name": "Grimple (PFS 3-18)",
     "token": {
         "disposition": -1,
         "height": 0.5,

--- a/packs/data/pfs-season-3-bestiary.db/nuglub-pfs-3-18.json
+++ b/packs/data/pfs-season-3-bestiary.db/nuglub-pfs-3-18.json
@@ -1127,7 +1127,7 @@
             "type": "lore"
         }
     ],
-    "name": "Nuglub (3-18)",
+    "name": "Nuglub (PFS 3-18)",
     "token": {
         "disposition": -1,
         "height": 1,


### PR DESCRIPTION
Adds ability glossary entry to Poltergeist in bestiary 1.
Corrects naming of several season 1, 2, and 3 PFS entries