### PR TITLE
Update Skill Mastery (Rogue) to correct feat type

### DIFF
--- a/packs/data/feats.db/skill-mastery-rogue.json
+++ b/packs/data/feats.db/skill-mastery-rogue.json
@@ -14,7 +14,7 @@
             "value": "<p>Increase your proficiency rank in one of your skills from expert to master and in another of your skills from trained to expert. You gain a skill feat associated with one of the skills you chose.</p>\n<hr />\n<p><strong>Special</strong> You can select this feat up to five times.</p>"
         },
         "featType": {
-            "value": "class"
+            "value": "archetype"
         },
         "level": {
             "value": 8


### PR DESCRIPTION
Corrects skill type for Archetype Skill "Skill Mastery (Rogue)" from "Class" to "Archetype"