### PR TITLE
Update original spell chat card after selecting a variant of that spell

### DIFF
--- a/src/module/chat-message/listeners/cards.ts
+++ b/src/module/chat-message/listeners/cards.ts
@@ -70,7 +70,19 @@ export const ChatCards = {
                 else if (action === "spellDamage") spell?.rollDamage(event);
                 else if (action === "spellCounteract") spell?.rollCounteract(event);
                 else if (action === "spellTemplate") spell?.placeTemplate();
-                else if (action === "selectVariant") (await spell?.variantPrompt())?.toMessage();
+                else if (action === "selectVariant") {
+                    const variantSpell = await spell?.variantPrompt();
+                    if (variantSpell) {
+                        const spellLvl = $html.find<HTMLDivElement>("div.chat-card").attr("data-spell-lvl");
+                        const variantMessage = await variantSpell.toMessage(undefined, {
+                            create: false,
+                            data: { spellLvl },
+                        });
+                        if (variantMessage) {
+                            await message.update(variantMessage.toObject());
+                        }
+                    }
+                }
                 // Consumable usage
                 else if (action === "consume") {
                     if (item instanceof ConsumablePF2e) {


### PR DESCRIPTION
Replace the chat message content with the variant spell content instead of adding a new variant spell chat card.

![Recording 2022-07-06 at 21 11 17](https://user-images.githubusercontent.com/41452412/177625861-e682a7b1-7326-4a5e-8674-b5b30e9e7630.gif)
