### PR TITLE
Add or Update NPCs from PFS 1-01

### DIFF
--- a/packs/data/pathfinder-bestiary.db/goblin-pyro.json
+++ b/packs/data/pathfinder-bestiary.db/goblin-pyro.json
@@ -983,37 +983,12 @@
                         }
                     },
                     {
-                        "category": "simple",
-                        "damage": {
-                            "base": {
-                                "damageType": "bludgeoning",
-                                "dice": 1,
-                                "die": "d4"
-                            }
-                        },
-                        "key": "Strike",
-                        "range": null,
-                        "traits": [
-                            "improvised"
-                        ]
-                    },
-                    {
-                        "damageType": "fire",
-                        "key": "FlatModifier",
-                        "predicate": {
-                            "all": [
-                                "lit-torch"
-                            ]
-                        },
-                        "selector": "{item|_id}-damage",
-                        "value": 1
-                    },
-                    {
                         "domain": "all",
                         "key": "RollOption",
                         "label": "PF2E.SpecificRule.LitTorch",
                         "option": "lit-torch",
-                        "toggleable": true
+                        "toggleable": true,
+                        "value": false
                     },
                     {
                         "key": "TokenEffectIcon",

--- a/packs/data/pfs-season-1-bestiary.db/collapsing-floor.json
+++ b/packs/data/pfs-season-1-bestiary.db/collapsing-floor.json
@@ -21,7 +21,7 @@
         "creatureType": "",
         "details": {
             "description": "<p>Around the edges of the pit, more rotting boards are ready to give way.</p>",
-            "disable": "<p>@Check[type:crafting|dc:16] to reinforce the beams</p>",
+            "disable": "<p>@Check[type:crafting|dc:16|name:Reinforce Beams] to reinforce the beams</p>",
             "isComplex": false,
             "level": {
                 "value": 2

--- a/packs/data/pfs-season-1-bestiary.db/collapsing-floor.json
+++ b/packs/data/pfs-season-1-bestiary.db/collapsing-floor.json
@@ -9,9 +9,9 @@
             "hasHealth": true,
             "hp": {
                 "details": "",
-                "max": 10,
+                "max": 0,
                 "temp": 0,
-                "value": 10
+                "value": 0
             },
             "stealth": {
                 "details": "",
@@ -21,7 +21,7 @@
         "creatureType": "",
         "details": {
             "description": "<p>Around the edges of the pit, more rotting boards are ready to give way.</p>",
-            "disable": "<p>Craft DC 16 to reinforce the beams</p>",
+            "disable": "<p>@Check[type:crafting|dc:16] to reinforce the beams</p>",
             "isComplex": false,
             "level": {
                 "value": 2
@@ -44,7 +44,8 @@
             }
         },
         "source": {
-            "value": ""
+            "author": "",
+            "value": "Pathfinder Society Scenario #1-01: The Absalom Initiation"
         },
         "statusEffects": [],
         "traits": {

--- a/packs/data/pfs-season-1-bestiary.db/crowd-agitator.json
+++ b/packs/data/pfs-season-1-bestiary.db/crowd-agitator.json
@@ -58,7 +58,7 @@
             "privateNotes": "",
             "publicNotes": "",
             "source": {
-                "value": "Pathfinder Society: Season 1"
+                "value": "Pathfinder Society Scenario #1-01: The Absalom Initiation"
             }
         },
         "resources": {},

--- a/packs/data/pfs-season-1-bestiary.db/crowd-with-chamberpots.json
+++ b/packs/data/pfs-season-1-bestiary.db/crowd-with-chamberpots.json
@@ -9,9 +9,9 @@
             "hasHealth": true,
             "hp": {
                 "details": "",
-                "max": 10,
+                "max": 1,
                 "temp": 0,
-                "value": 10
+                "value": 0
             },
             "stealth": {
                 "details": "",
@@ -21,14 +21,14 @@
         "creatureType": "",
         "customModifiers": {},
         "details": {
-            "description": "<p>The crowd is riled up enough to start throwing chamberpots at the interlopers, but not riled up enough to risk their lives. The crowd fills nine contiguous squares but can be shaped to fit the streets.</p>\n<p>Characters can move through the crowd, but spaces occupied by the crowd are difficult terrain.</p>",
-            "disable": "",
+            "description": "<p>The crowd is riled up enough to start throwing chamberpots at the interlopers, but not riled up enough to risk their lives. The crowd fills nine contiguous squares but can be shaped to fit the streets. Characters can move through the crowd, but spaces occupied by the crowd are difficult terrain.</p>",
+            "disable": "<p>After more people in the crowd have become shaken or taken damage than there are crowd leaders left standing, the crowd disperses. For abilities affecting an area, count each affected square as one member of the crowd.</p>",
             "isComplex": true,
             "level": {
-                "value": 2
+                "value": 4
             },
             "reset": "<p>After more people in the crowd have become shaken or taken damage than there are crowd leaders left standing, the crowd disperses. For abilities affecting an area, count each affected square as one member of the crowd.</p>",
-            "routine": "<p><span class=\"pf2-icon\">3</span> The crowd uses its first action to Stride away from any opponent adjacent to them (or to get within 30 feet), then uses each remaining action to make a chamber pot Strike at a different target.</p>"
+            "routine": "<p>(3 actions) The crowd uses its first action to Stride away from any opponent adjacent to them (or to get within 30 feet), then uses each remaining action to make a chamber pot Strike at a different target.</p>"
         },
         "saves": {
             "fortitude": {
@@ -45,7 +45,8 @@
             }
         },
         "source": {
-            "value": ""
+            "author": "",
+            "value": "Pathfinder Society Scenario #1-01: The Absalom Initiation"
         },
         "statusEffects": [],
         "traits": {
@@ -141,7 +142,7 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "range-increment-20"
+                        "range-20"
                     ]
                 },
                 "weaponType": {

--- a/packs/data/pfs-season-1-bestiary.db/crowd-with-trash.json
+++ b/packs/data/pfs-season-1-bestiary.db/crowd-with-trash.json
@@ -9,9 +9,9 @@
             "hasHealth": true,
             "hp": {
                 "details": "",
-                "max": 10,
+                "max": 1,
                 "temp": 0,
-                "value": 10
+                "value": 0
             },
             "stealth": {
                 "details": "",
@@ -21,14 +21,14 @@
         "creatureType": "",
         "customModifiers": {},
         "details": {
-            "description": "<p>The crowd is riled up enough to start throwing garbage at the interlopers, but not riled up enough to risk their lives. The crowd fills nine contiguous squares but can be shaped to fit the streets.</p>\n<p>Characters can move through the crowd, but spaces occupied by the crowd are difficult terrain.</p>",
-            "disable": "",
+            "description": "<p>The crowd is riled up enough to start throwing garbage at the interlopers, but not riled up enough to risk their lives. The crowd fills nine contiguous squares but can be shaped to fit the streets. Characters can move through the crowd, but spaces occupied by the crowd are difficult terrain.</p>",
+            "disable": "<p>After more people in the crowd have become shaken or taken damage than there are crowd leaders left standing, the crowd disperses. For abilities affecting an area, count each affected square as one member of the crowd.</p>",
             "isComplex": true,
             "level": {
                 "value": 2
             },
             "reset": "<p>After more people in the crowd have become shaken or taken damage than there are crowd leaders left standing, the crowd disperses. For abilities affecting an area, count each affected square as one member of the crowd.</p>",
-            "routine": "<p><span class=\"pf2-icon\">3</span> The crowd uses its first action to Stride away from any opponent adjacent to them (or to get within 30 feet), then uses each remaining action to make a trash Strike at a different target.</p>"
+            "routine": "<p>(3 actions) The crowd uses its first action to Stride away from any opponent adjacent to them (or to get within 30 feet), then uses each remaining action to make a trash Strike at a different target.</p>"
         },
         "saves": {
             "fortitude": {
@@ -45,7 +45,8 @@
             }
         },
         "source": {
-            "value": ""
+            "author": "",
+            "value": "Pathfinder Society Scenario #1-01: The Absalom Initiation"
         },
         "statusEffects": [],
         "traits": {
@@ -141,7 +142,7 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "range-increment-20"
+                        "range-20"
                     ]
                 },
                 "weaponType": {

--- a/packs/data/pfs-season-1-bestiary.db/crumbling-floor.json
+++ b/packs/data/pfs-season-1-bestiary.db/crumbling-floor.json
@@ -21,7 +21,7 @@
         "creatureType": "",
         "details": {
             "description": "<p>Around the edges of the pit, more rotting boards are ready to give way.</p>",
-            "disable": "<p>@Check[type:crafting|dc:14] to reinforce the beams</p>",
+            "disable": "<p>@Check[type:crafting|dc:14|name:Reinforce Beams] to reinforce the beams</p>",
             "isComplex": false,
             "level": {
                 "value": 0

--- a/packs/data/pfs-season-1-bestiary.db/crumbling-floor.json
+++ b/packs/data/pfs-season-1-bestiary.db/crumbling-floor.json
@@ -9,9 +9,9 @@
             "hasHealth": true,
             "hp": {
                 "details": "",
-                "max": 10,
+                "max": 0,
                 "temp": 0,
-                "value": 10
+                "value": 0
             },
             "stealth": {
                 "details": "",
@@ -21,7 +21,7 @@
         "creatureType": "",
         "details": {
             "description": "<p>Around the edges of the pit, more rotting boards are ready to give way.</p>",
-            "disable": "<p>Craft DC 14 to reinforce the beams</p>",
+            "disable": "<p>@Check[type:crafting|dc:14] to reinforce the beams</p>",
             "isComplex": false,
             "level": {
                 "value": 0
@@ -44,7 +44,8 @@
             }
         },
         "source": {
-            "value": ""
+            "author": "",
+            "value": "Pathfinder Society Scenario #1-01: The Absalom Initiation"
         },
         "statusEffects": [],
         "traits": {

--- a/packs/data/pfs-season-1-bestiary.db/deeply-flawed-ritual.json
+++ b/packs/data/pfs-season-1-bestiary.db/deeply-flawed-ritual.json
@@ -9,9 +9,9 @@
             "hasHealth": true,
             "hp": {
                 "details": "",
-                "max": 10,
+                "max": 0,
                 "temp": 0,
-                "value": 10
+                "value": 0
             },
             "stealth": {
                 "details": "",
@@ -21,13 +21,13 @@
         "creatureType": "",
         "details": {
             "description": "<p>A flawed ritual emits surges of shadowy energy and opens tiny breaches into the Shadow Plane.</p>",
-            "disable": "<p>Seven flaws have appeared in the ritual circle, dancing like shadowy flames. Each of Tavvar's three aides keeps one flaw under control as long as they are alive, while Tavvar herself staves off the ritual's implosion as listed in the ritual anchor ability below.</p>\n<p>Each flaw can be repaired with a successful DC 24 Occultism check or DC 20 (trained) check using a skill related to the flaw's original cause (see the table below). Regardless of success or failure, a PC who attempts an Occultism check to disable the hazard learns the cause of the flaws and the skills that can be used to overcome it.</p>\n<p>Each success on a check to repair a flaw using these other skills reduces the DC of the Occultism check to repair a flaw by 2. Instead of using skill checks, the PCs can use force to stabilize the ritual. A PC who defeats a shadow wisp automatically repairs one flaw.</p>\n<table class=\"pf2-table\">\n<thead>\n<tr>\n<th>d4</th>\n<th>Cause of Flaw</th>\n<th>Skills to Overcome</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>1</td>\n<td>Harried (a \"publish or perish\" culture at the College of Mystery led to Tavvar cutting corners in the ritual's execution, so some runes aren't drawn quite right)</td>\n<td>Arcana of Thievery</td>\n</tr>\n<tr>\n<td>2</td>\n<td>Misplaced Affection (Tavvar is from Nidal and subconsciously hopes the ritual will show that there is some good in her homeland; she included some Shadowtongue in the runes and it's enhancing the energy</td>\n<td>Society or Religion</td>\n</tr>\n<tr>\n<td>3</td>\n<td>Cloistered (Tavvar hasn't done much field work and made a dangerous mistake in which mushrooms she used in the ink for the runes)</td>\n<td>Crafting or Nature</td>\n</tr>\n<tr>\n<td>4</td>\n<td>Restrained (Tavvar's own hesitation and self-doubt has led to the ritual slipping out of her control)</td>\n<td>Deception or Diplomacy</td>\n</tr>\n</tbody>\n</table>",
+            "disable": "<p>Seven flaws have appeared in the ritual circle, dancing like shadowy flames. Each of Tavvar's three aides keeps one flaw under control as long as they are alive, while Tavvar herself staves off the ritual's implosion as listed in the ritual anchor ability below.</p>\n<p>Each flaw can be repaired with a successful @Check[type:occultism|dc:24] check or DC 20 (trained) check using a skill related to the flaw's original cause (see the table below). Regardless of success or failure, a PC who attempts an Occultism check to disable the hazard learns the cause of the flaws and the skills that can be used to overcome it.</p>\n<p>Each success on a check to repair a flaw using these other skills reduces the DC of the Occultism check to repair a flaw by 2. Instead of using skill checks, the PCs can use force to stabilize the ritual. A PC who defeats a shadow wisp automatically repairs one flaw.</p>\n<table class=\"pf2-table\">\n<thead>\n<tr>\n<th>d4</th>\n<th>Cause of Flaw</th>\n<th>Skills to Overcome</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>1</td>\n<td>Harried (a \"publish or perish\" culture at the College of Mystery led to Tavvar cutting corners in the ritual's execution, so some runes aren't drawn quite right)</td>\n<td>@Check[type:arcana|dc:20](trained) or @Check[type:thievery|dc:20](trained)</td>\n</tr>\n<tr>\n<td>2</td>\n<td>Misplaced Affection (Tavvar is from Nidal and subconsciously hopes the ritual will show that there is some good in her homeland; she included some Shadowtongue in the runes and it's enhancing the energy</td>\n<td>@Check[type:society|dc:20](trained) or @Check[type:religion|dc:20](trained)</td>\n</tr>\n<tr>\n<td>3</td>\n<td>Cloistered (Tavvar hasn't done much field work and made a dangerous mistake in which mushrooms she used in the ink for the runes)</td>\n<td>@Check[type:crafting|dc:20](trained) or @Check[type:nature|dc:20](trained)</td>\n</tr>\n<tr>\n<td>4</td>\n<td>Restrained (Tavvar's own hesitation and self-doubt has led to the ritual slipping out of her control)</td>\n<td>@Check[type:deception|dc:20](trained) or @Check[type:diplomacy|dc:20](trained)</td>\n</tr>\n</tbody>\n</table>",
             "isComplex": true,
             "level": {
-                "value": 2
+                "value": 5
             },
             "reset": "",
-            "routine": "<p>(1 action) On each of its turns, the ritual lets out a surge of shadowy energy, dealing [[/r {4d6}[negative]]]{4d6 negative damage} (@Check[type:fortitude|dc:18|basic:true|name:Flawed Ritual] save) to each character who participated in ritual the past round (including Tavvar and her aides as well as any PC who attempted a skill check to disable the hazard).</p>\n<p>A non-participant can step in front of a participant as a reaction. This blocks the damage from the ritual caster, but the non-participant must then attempt the Fortitude save. In addition to dealing damage, the ritual's surge of energy brings a @Compendium[pf2e.pfs-season-1-bestiary.Greater Shadow Wisp]{Greater Shadow Wisp} into the room.</p>\n<p>Wisps act at the end of the ritual's turn. If there are already two shadow wisps in the room, instead of creating a new wisp, the ritual restores [[/r {10}[healing]]]{10 Hit Points} to each wisp.</p>"
+            "routine": "<p>(1 action) On each of its turns, the ritual lets out a surge of shadowy energy, dealing [[/r {4d6}[negative]]]{4d6 negative damage} (@Check[type:fortitude|dc:22|basic:true|name:Flawed Ritual] save) to each character who participated in ritual the past round (including Tavvar and her aides as well as any PC who attempted a skill check to disable the hazard). A non-participant can step in front of a participant as a reaction. This blocks the damage from the ritual caster, but the non-participant must then attempt the Fortitude save.</p>\n<p>In addition to dealing damage, the ritual's surge of energy brings a @Compendium[pf2e.pfs-season-1-bestiary.Greater Shadow Wisp]{Greater Shadow Wisp} into the room. Wisps act at the end of the ritual's turn. If there are already two shadow wisps in the room, instead of creating a new wisp, the ritual restores [[/r {10}[healing]]]{10 Hit Points} to each wisp.</p>"
         },
         "saves": {
             "fortitude": {
@@ -44,7 +44,8 @@
             }
         },
         "source": {
-            "value": ""
+            "author": "",
+            "value": "Pathfinder Society Scenario #1-01: The Absalom Initiation"
         },
         "statusEffects": [],
         "traits": {
@@ -61,7 +62,7 @@
                 "value": "med"
             },
             "traits": {
-                "custom": "",
+                "custom": "mindless",
                 "value": [
                     "magical"
                 ]
@@ -83,7 +84,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>If Tavvar dies, the ritual immediately ends disastrously.</p>\n<p>With a loud pop, it explodes, filling the room with negative energy before dissipating. This deals [[/r {4d6}[negative]]]{4d6 negative damage} to all creatures in area <strong>B5</strong> (@Check[type:fortitude|dc:18|basic:true|name:Flawed Ritual] save). The NPCs ritualists automatically critically fail their saving throws.</p>\n<p>The explosion ends the ritual but does not remove any @Compendium[pf2e.pfs-season-1-bestiary.Greater Shadow Wisp]{Greater Shadow Wisps} that are already in the room.</p>"
+                    "value": "<p>If Tavvar dies, the ritual immediately ends disastrously. With a loud pop, it explodes, inflicting an additional surge of shadowy energy on every creature in area <strong>B5</strong> before dissipating. This ends the ritual but does not remove any shadows that are already in the room.</p>"
                 },
                 "requirements": {
                     "value": ""

--- a/packs/data/pfs-season-1-bestiary.db/flawed-ritual.json
+++ b/packs/data/pfs-season-1-bestiary.db/flawed-ritual.json
@@ -9,9 +9,9 @@
             "hasHealth": true,
             "hp": {
                 "details": "",
-                "max": 10,
+                "max": 0,
                 "temp": 0,
-                "value": 10
+                "value": 0
             },
             "stealth": {
                 "details": "",
@@ -21,13 +21,13 @@
         "creatureType": "",
         "details": {
             "description": "<p>A flawed ritual emits surges of shadowy energy and opens tiny breaches into the Shadow Plane.</p>",
-            "disable": "<p>Seven flaws have appeared in the ritual circle, dancing like shadowy flames. Each of Tavvar's three aides keeps one flaw under control as long as they are alive, while Tavvar herself staves off the ritual's implosion as listed in the ritual anchor ability below.</p>\n<p>Each flaw can be repaired with a successful DC 22 Occultism check or DC 18 (trained) check using a skill related to the flaw's original cause (see the table below). Regardless of success or failure, a PC who attempts an Occultism check to disable the hazard learns the cause of the flaws and the skills that can be used to overcome it.</p>\n<p>Each success on a check to repair a flaw using these other skills reduces the DC of the Occultism check to repair a flaw by 2. Instead of using skill checks, the PCs can use force to stabilize the ritual. A PC who defeats a shadow wisp automatically repairs one flaw.</p>\n<table class=\"pf2-table\">\n<thead>\n<tr>\n<th>d4</th>\n<th>Cause of Flaw</th>\n<th>Skills to Overcome</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>1</td>\n<td>Harried (a \"publish or perish\" culture at the College of Mystery led to Tavvar cutting corners in the ritual's execution, so some runes aren't drawn quite right)</td>\n<td>Arcana of Thievery</td>\n</tr>\n<tr>\n<td>2</td>\n<td>Misplaced Affection (Tavvar is from Nidal and subconsciously hopes the ritual will show that there is some good in her homeland; she included some Shadowtongue in the runes and it's enhancing the energy</td>\n<td>Society or Religion</td>\n</tr>\n<tr>\n<td>3</td>\n<td>Cloistered (Tavvar hasn't done much field work and made a dangerous mistake in which mushrooms she used in the ink for the runes)</td>\n<td>Crafting or Nature</td>\n</tr>\n<tr>\n<td>4</td>\n<td>Restrained (Tavvar's own hesitation and self-doubt has led to the ritual slipping out of her control)</td>\n<td>Deception or Diplomacy</td>\n</tr>\n</tbody>\n</table>",
+            "disable": "<p>Seven flaws have appeared in the ritual circle, dancing like shadowy flames. Each of Tavvar's three aides keeps one flaw under control as long as they are alive, while Tavvar herself staves off the ritual's implosion as listed in the ritual anchor ability below.</p>\n<p>Each flaw can be repaired with a successful @Check[type:occultism|dc:22] or DC 18 (trained) check using a skill related to the flaw's original cause (see the table below). Regardless of success or failure, a PC who attempts an Occultism check to disable the hazard learns the cause of the flaws and the skills that can be used to overcome it.</p>\n<p>Each success on a check to repair a flaw using these other skills reduces the DC of the Occultism check to repair a flaw by 2. Instead of using skill checks, the PCs can use force to stabilize the ritual. A PC who defeats a shadow wisp automatically repairs one flaw.</p>\n<table class=\"pf2-table\">\n<thead>\n<tr>\n<th>d4</th>\n<th>Cause of Flaw</th>\n<th>Skills to Overcome</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>1</td>\n<td>Harried (a \"publish or perish\" culture at the College of Mystery led to Tavvar cutting corners in the ritual's execution, so some runes aren't drawn quite right)</td>\n<td>@Check[type:arcana|dc:18](trained) or @Check[type:thievery|dc:18](trained)</td>\n</tr>\n<tr>\n<td>2</td>\n<td>Misplaced Affection (Tavvar is from Nidal and subconsciously hopes the ritual will show that there is some good in her homeland; she included some Shadowtongue in the runes and it's enhancing the energy</td>\n<td>@Check[type:society|dc:18](trained) or @Check[type:religion|dc:18](trained)</td>\n</tr>\n<tr>\n<td>3</td>\n<td>Cloistered (Tavvar hasn't done much field work and made a dangerous mistake in which mushrooms she used in the ink for the runes)</td>\n<td>@Check[type:crafting|dc:18](trained) or @Check[type:nature|dc:18](trained)</td>\n</tr>\n<tr>\n<td>4</td>\n<td>Restrained (Tavvar's own hesitation and self-doubt has led to the ritual slipping out of her control)</td>\n<td>@Check[type:deception|dc:18](trained) or @Check[type:diplomacy|dc:18](trained)</td>\n</tr>\n</tbody>\n</table>",
             "isComplex": true,
             "level": {
                 "value": 2
             },
             "reset": "",
-            "routine": "<p>(1 action) On each of its turns, the ritual lets out a surge of shadowy energy, dealing [[/r {2d6}[negative]]]{2d6 negative damage} (@Check[type:fortitude|dc:18|basic:true] save) to each character who participated in ritual the past round (including Tavvar and her aides as well as any PC who attempted a skill check to disable the hazard).</p>\n<p>A non-participant can step in front of a participant as a reaction. This blocks the damage from the ritual caster, but the non-participant must then attempt the Fortitude save. In addition to dealing damage, the ritual's surge of energy brings a @Compendium[pf2e.pfs-season-1-bestiary.Shadow Wisp]{Shadow Wisp} into the room.</p>\n<p>Wisps act at the end of the ritual's turn. If there are already two shadow wisps in the room, instead of creating a new wisp, the ritual restores [[/r {10}[healing]]]{10 Hit Points} to each wisp.</p>"
+            "routine": "<p>(1 action) On each of its turns, the ritual lets out a surge of shadowy energy, dealing [[/r {2d6}[negative]]]{2d6 negative damage} (@Check[type:fortitude|dc:18|basic:true] save) to each character who participated in ritual the past round (including Tavvar and her aides as well as any PC who attempted a skill check to disable the hazard). A non-participant can step in front of a participant as a reaction. This blocks the damage from the ritual caster, but the non-participant must then attempt the Fortitude save.</p>\n<p>In addition to dealing damage, the ritual's surge of energy brings a @Compendium[pf2e.pfs-season-1-bestiary.Shadow Wisp]{Shadow Wisp} into the room. Wisps act at the end of the ritual's turn. If there are already two shadow wisps in the room, instead of creating a new wisp, the ritual restores [[/r {10}[healing]]]{10 Hit Points} to each wisp.</p>"
         },
         "saves": {
             "fortitude": {
@@ -44,7 +44,8 @@
             }
         },
         "source": {
-            "value": ""
+            "author": "",
+            "value": "Pathfinder Society Scenario #1-01: The Absalom Initiation"
         },
         "statusEffects": [],
         "traits": {
@@ -83,7 +84,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>If Tavvar dies, the ritual immediately ends disastrously.</p>\n<p>With a loud pop, it explodes, filling the room with negative energy before dissipating. This deals [[/r {2d6}[negative]]]{2d6 negative damage} to all creatures in area <strong>B5</strong> (@Check[type:fortitude|dc:18|basic:true|name:Flawed Ritual] save). The NPCs ritualists automatically critically fail their saving throws.</p>\n<p>The explosion ends the ritual but does not remove any @Compendium[pf2e.pfs-season-1-bestiary.Shadow Wisp]{Shadow Wisps} that are already in the room.</p>"
+                    "value": "<p>If Tavvar dies, the ritual immediately ends disastrously. With a loud pop, it explodes, filling the room with negative energy before dissipating. This deals [[/r {2d6}[negative]]]{2d6 negative damage} to all creatures in area <strong>B5</strong> (@Check[type:fortitude|dc:18|basic:true|name:Flawed Ritual] save). The NPCs ritualists automatically critically fail their saving throws. The explosion ends the ritual but does not remove any @Compendium[pf2e.pfs-season-1-bestiary.Shadow Wisp]{Shadow Wisps} that are already in the room.</p>"
                 },
                 "requirements": {
                     "value": ""

--- a/packs/data/pfs-season-1-bestiary.db/fleshforge-dreg-acid-spit.json
+++ b/packs/data/pfs-season-1-bestiary.db/fleshforge-dreg-acid-spit.json
@@ -58,7 +58,7 @@
             "privateNotes": "",
             "publicNotes": "",
             "source": {
-                "value": "Pathfinder Society: Season 1"
+                "value": "Pathfinder Society Scenario #1-01: The Absalom Initiation"
             }
         },
         "resources": {},
@@ -208,7 +208,7 @@
             "type": "melee"
         },
         {
-            "_id": "KfOqNmtG1IB3zRCi",
+            "_id": "dTNAPXbNzoaBpscT",
             "data": {
                 "attack": {
                     "value": ""
@@ -237,11 +237,16 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "range-increment-30"
+                        "range-30"
                     ]
                 },
                 "weaponType": {
                     "value": "ranged"
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Item.S7lN7mstAZdxeEzb"
                 }
             },
             "img": "systems/pf2e/icons/default-icons/melee.svg",
@@ -339,7 +344,7 @@
         "disposition": -1,
         "height": 1,
         "img": "systems/pf2e/icons/default-icons/npc.svg",
-        "name": "Fleshforge Dreg (Acid Spit)",
+        "name": "Fleshforge Dreg",
         "width": 1
     },
     "type": "npc"

--- a/packs/data/pfs-season-1-bestiary.db/fleshforge-dreg-acid-spit.json
+++ b/packs/data/pfs-season-1-bestiary.db/fleshforge-dreg-acid-spit.json
@@ -244,11 +244,6 @@
                     "value": "ranged"
                 }
             },
-            "flags": {
-                "core": {
-                    "sourceId": "Item.S7lN7mstAZdxeEzb"
-                }
-            },
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Acid Spit",
             "sort": 300000,

--- a/packs/data/pfs-season-1-bestiary.db/fleshforge-dreg-leaping-charge.json
+++ b/packs/data/pfs-season-1-bestiary.db/fleshforge-dreg-leaping-charge.json
@@ -58,7 +58,7 @@
             "privateNotes": "",
             "publicNotes": "",
             "source": {
-                "value": "Pathfinder Society: Season 1"
+                "value": "Pathfinder Society Scenario #1-01: The Absalom Initiation"
             }
         },
         "resources": {},
@@ -356,7 +356,7 @@
         "disposition": -1,
         "height": 1,
         "img": "systems/pf2e/icons/default-icons/npc.svg",
-        "name": "Fleshforge Dreg (Leaping Charge)",
+        "name": "Fleshforge Dreg",
         "width": 1
     },
     "type": "npc"

--- a/packs/data/pfs-season-1-bestiary.db/fleshforge-dreg-reach.json
+++ b/packs/data/pfs-season-1-bestiary.db/fleshforge-dreg-reach.json
@@ -58,7 +58,7 @@
             "privateNotes": "",
             "publicNotes": "",
             "source": {
-                "value": "Pathfinder Society: Season 1"
+                "value": "Pathfinder Society Scenario #1-01: The Absalom Initiation"
             }
         },
         "resources": {},
@@ -347,7 +347,7 @@
         "disposition": -1,
         "height": 1,
         "img": "systems/pf2e/icons/default-icons/npc.svg",
-        "name": "Fleshforge Dreg (Reach)",
+        "name": "Fleshforge Dreg",
         "width": 1
     },
     "type": "npc"

--- a/packs/data/pfs-season-1-bestiary.db/fleshforge-dreg-roots.json
+++ b/packs/data/pfs-season-1-bestiary.db/fleshforge-dreg-roots.json
@@ -1,5 +1,5 @@
 {
-    "_id": "t1QyIgwLORMhHNL4",
+    "_id": "JEwMnYFfyxr5i6Dy",
     "data": {
         "abilities": {
             "cha": {
@@ -138,7 +138,7 @@
                     "value": 12
                 },
                 "damageRolls": {
-                    "im06j3q7calu3h1d02i4": {
+                    "pipt414ux93n6sn9020m": {
                         "damage": "1d10+6",
                         "damageType": "bludgeoning"
                     }
@@ -178,7 +178,7 @@
                     "value": 12
                 },
                 "damageRolls": {
-                    "s6jpih9zwwqp5u60uzai": {
+                    "2sr5mi2vkdc9lcrh4feq": {
                         "damage": "1d6+6",
                         "damageType": "bludgeoning"
                     }
@@ -208,19 +208,19 @@
             "type": "melee"
         },
         {
-            "_id": "NGpcOOJuyLudCfKX",
+            "_id": "oAp0cXHklPdIO1ku",
             "data": {
                 "actionCategory": {
-                    "value": "offensive"
+                    "value": "interaction"
                 },
                 "actionType": {
                     "value": "action"
                 },
                 "actions": {
-                    "value": 2
+                    "value": 1
                 },
                 "description": {
-                    "value": "<p>The fleshforge dreg breathes flames that deal [[/r {4d6}[fire]]]{4d6 fire damage} to all creatures in a @Template[type:cone|distance:15] (@Check[type:reflex|dc:15|basic:true] save).</p>\n<p>The fleshforge dreg can't use its breath weapon again for [[/br 1d4 #rounds]]{1d4 rounds}.</p>"
+                    "value": "<p>The fleshforge prototype roots into the surface it is standing on. It gains @Compendium[pf2e.bestiary-ability-glossary-srd.Fast Healing]{Fast Healing 5} until it leaves that space.</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -234,11 +234,7 @@
                     "custom": "",
                     "rarity": "common",
                     "selected": {},
-                    "value": [
-                        "fire",
-                        "arcane",
-                        "evocation"
-                    ]
+                    "value": []
                 },
                 "trigger": {
                     "value": ""
@@ -247,8 +243,13 @@
                     "value": ""
                 }
             },
-            "img": "systems/pf2e/icons/actions/TwoActions.webp",
-            "name": "Breath Weapon",
+            "flags": {
+                "core": {
+                    "sourceId": "Item.VJ5TbUDkLaYjZE3R"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Roots",
             "sort": 300000,
             "type": "action"
         },
@@ -337,12 +338,12 @@
             "type": "lore"
         }
     ],
-    "name": "Fleshforge Dreg (Breath Weapon)",
+    "name": "Fleshforge Dreg (Roots)",
     "token": {
         "disposition": -1,
         "height": 1,
         "img": "systems/pf2e/icons/default-icons/npc.svg",
-        "name": "Fleshforge Dreg",
+        "name": "Fleshforge Dreg (Acid Spit)",
         "width": 1
     },
     "type": "npc"

--- a/packs/data/pfs-season-1-bestiary.db/fleshforge-dreg-roots.json
+++ b/packs/data/pfs-season-1-bestiary.db/fleshforge-dreg-roots.json
@@ -343,7 +343,7 @@
         "disposition": -1,
         "height": 1,
         "img": "systems/pf2e/icons/default-icons/npc.svg",
-        "name": "Fleshforge Dreg (Acid Spit)",
+        "name": "Fleshforge Dreg",
         "width": 1
     },
     "type": "npc"

--- a/packs/data/pfs-season-1-bestiary.db/fleshforge-dreg-shield.json
+++ b/packs/data/pfs-season-1-bestiary.db/fleshforge-dreg-shield.json
@@ -58,7 +58,7 @@
             "privateNotes": "",
             "publicNotes": "",
             "source": {
-                "value": "Pathfinder Society: Season 1"
+                "value": "Pathfinder Society Scenario #1-01: The Absalom Initiation"
             }
         },
         "resources": {},
@@ -126,6 +126,109 @@
     "img": "systems/pf2e/icons/default-icons/npc.svg",
     "items": [
         {
+            "_id": "9Dn4q0ElKrJMB5oh",
+            "data": {
+                "armor": {
+                    "value": 2
+                },
+                "baseItem": null,
+                "category": "shield",
+                "check": {
+                    "value": 0
+                },
+                "containerId": null,
+                "description": {
+                    "value": "<p>The fleshforge dreg's large arm can be used as a shield (Hardness 3, HP 20, BT 10) and it gains the Shield Block reaction.</p>\n<p>The prototype's AC is 21 with its shield raised. If the shield is destroyed, it can no longer use its fist attack.</p>\n<table class=\"pf2-table\">\n<thead>\n<tr>\n<th>Hardness</th>\n<th>HP</th>\n<th>BT</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>3</td>\n<td>20</td>\n<td>10</td>\n</tr>\n</tbody>\n</table>"
+                },
+                "dex": {
+                    "value": 0
+                },
+                "equipped": {
+                    "carryType": "held",
+                    "handsHeld": 1,
+                    "invested": null
+                },
+                "equippedBulk": {
+                    "value": ""
+                },
+                "group": null,
+                "hardness": 3,
+                "hp": {
+                    "brokenThreshold": 10,
+                    "max": 20,
+                    "value": 20
+                },
+                "level": {
+                    "value": 0
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "potency": {},
+                "potencyRune": {
+                    "value": 0
+                },
+                "preciousMaterial": {
+                    "value": null
+                },
+                "preciousMaterialGrade": {
+                    "value": null
+                },
+                "price": {
+                    "value": {}
+                },
+                "propertyRune1": {
+                    "value": ""
+                },
+                "propertyRune2": {
+                    "value": ""
+                },
+                "propertyRune3": {
+                    "value": ""
+                },
+                "propertyRune4": {
+                    "value": ""
+                },
+                "quantity": 1,
+                "resiliencyRune": {
+                    "value": ""
+                },
+                "rules": [],
+                "size": "med",
+                "slug": "steel-shield",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "speed": {
+                    "value": 0
+                },
+                "stackGroup": null,
+                "strength": {
+                    "value": 0
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "unique",
+                    "value": []
+                },
+                "usage": {
+                    "value": "held-in-one-hand"
+                },
+                "weight": {
+                    "value": "-"
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.equipment-srd.Yr9yCuJiAlFh3QEB"
+                }
+            },
+            "img": "systems/pf2e/icons/features/feats/accursed-clay-fist.webp",
+            "name": "Fleshforge Dreg Arm",
+            "sort": 100000,
+            "type": "armor"
+        },
+        {
             "_id": "zRIrkULRfpQVitb9",
             "data": {
                 "attack": {
@@ -162,7 +265,7 @@
             },
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Fist",
-            "sort": 100000,
+            "sort": 200000,
             "type": "melee"
         },
         {
@@ -204,11 +307,11 @@
             },
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Tentacle",
-            "sort": 200000,
+            "sort": 300000,
             "type": "melee"
         },
         {
-            "_id": "SdNlcjZkKUma40M2",
+            "_id": "tM0bp9fZQ8wkx5Nk",
             "data": {
                 "actionCategory": {
                     "value": "defensive"
@@ -249,7 +352,7 @@
             },
             "img": "systems/pf2e/icons/actions/Reaction.webp",
             "name": "Shield Block",
-            "sort": 300000,
+            "sort": 400000,
             "type": "action"
         },
         {
@@ -277,7 +380,7 @@
             },
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Acrobatics",
-            "sort": 400000,
+            "sort": 500000,
             "type": "lore"
         },
         {
@@ -305,7 +408,7 @@
             },
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Athletics",
-            "sort": 500000,
+            "sort": 600000,
             "type": "lore"
         },
         {
@@ -333,7 +436,7 @@
             },
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Survival",
-            "sort": 600000,
+            "sort": 700000,
             "type": "lore"
         }
     ],
@@ -342,7 +445,7 @@
         "disposition": -1,
         "height": 1,
         "img": "systems/pf2e/icons/default-icons/npc.svg",
-        "name": "Fleshforge Dreg (Shield)",
+        "name": "Fleshforge Dreg",
         "width": 1
     },
     "type": "npc"

--- a/packs/data/pfs-season-1-bestiary.db/fleshforge-prototype-acid-spit.json
+++ b/packs/data/pfs-season-1-bestiary.db/fleshforge-prototype-acid-spit.json
@@ -58,7 +58,7 @@
             "privateNotes": "",
             "publicNotes": "",
             "source": {
-                "value": "Pathfinder Society: Season 1"
+                "value": "Pathfinder Society Scenario #1-01: The Absalom Initiation"
             }
         },
         "resources": {},
@@ -237,7 +237,7 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "range-increment-30"
+                        "range-30"
                     ]
                 },
                 "weaponType": {
@@ -339,7 +339,7 @@
         "disposition": -1,
         "height": 1,
         "img": "systems/pf2e/icons/default-icons/npc.svg",
-        "name": "Fleshforge Prototype (Acid Spit)",
+        "name": "Fleshforge Prototype",
         "width": 1
     },
     "type": "npc"

--- a/packs/data/pfs-season-1-bestiary.db/fleshforge-prototype-breath-weapon.json
+++ b/packs/data/pfs-season-1-bestiary.db/fleshforge-prototype-breath-weapon.json
@@ -58,7 +58,7 @@
             "privateNotes": "",
             "publicNotes": "",
             "source": {
-                "value": "Pathfinder Society: Season 1"
+                "value": "Pathfinder Society Scenario #1-01: The Absalom Initiation"
             }
         },
         "resources": {},
@@ -341,7 +341,7 @@
         "disposition": -1,
         "height": 1,
         "img": "systems/pf2e/icons/default-icons/npc.svg",
-        "name": "Fleshforge Prototype (Breath Weapon)",
+        "name": "Fleshforge Prototype",
         "width": 1
     },
     "type": "npc"

--- a/packs/data/pfs-season-1-bestiary.db/fleshforge-prototype-leaping-charge.json
+++ b/packs/data/pfs-season-1-bestiary.db/fleshforge-prototype-leaping-charge.json
@@ -58,7 +58,7 @@
             "privateNotes": "",
             "publicNotes": "",
             "source": {
-                "value": "Pathfinder Society: Season 1"
+                "value": "Pathfinder Society Scenario #1-01: The Absalom Initiation"
             }
         },
         "resources": {},
@@ -356,7 +356,7 @@
         "disposition": -1,
         "height": 1,
         "img": "systems/pf2e/icons/default-icons/npc.svg",
-        "name": "Fleshforge Prototype (Leaping Charge)",
+        "name": "Fleshforge Prototype",
         "width": 1
     },
     "type": "npc"

--- a/packs/data/pfs-season-1-bestiary.db/fleshforge-prototype-reach.json
+++ b/packs/data/pfs-season-1-bestiary.db/fleshforge-prototype-reach.json
@@ -58,7 +58,7 @@
             "privateNotes": "",
             "publicNotes": "",
             "source": {
-                "value": "Pathfinder Society: Season 1"
+                "value": "Pathfinder Society Scenario #1-01: The Absalom Initiation"
             }
         },
         "resources": {},
@@ -172,7 +172,10 @@
                     "value": ""
                 },
                 "attackEffects": {
-                    "value": []
+                    "custom": "",
+                    "value": [
+                        "grab"
+                    ]
                 },
                 "bonus": {
                     "value": 15
@@ -184,7 +187,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>(agile)</p>\n<p>The fleshforge prototype's tentacle Strikes gain reach 10 feet and Grab</p>"
+                    "value": ""
                 },
                 "rules": [],
                 "slug": null,
@@ -343,7 +346,7 @@
         "disposition": -1,
         "height": 1,
         "img": "systems/pf2e/icons/default-icons/npc.svg",
-        "name": "Fleshforge Prototype (Reach)",
+        "name": "Fleshforge Prototype",
         "width": 1
     },
     "type": "npc"

--- a/packs/data/pfs-season-1-bestiary.db/fleshforge-prototype-roots.json
+++ b/packs/data/pfs-season-1-bestiary.db/fleshforge-prototype-roots.json
@@ -58,7 +58,7 @@
             "privateNotes": "",
             "publicNotes": "",
             "source": {
-                "value": "Pathfinder Society: Season 1"
+                "value": "Pathfinder Society Scenario #1-01: The Absalom Initiation"
             }
         },
         "resources": {},
@@ -338,7 +338,7 @@
         "disposition": -1,
         "height": 1,
         "img": "systems/pf2e/icons/default-icons/npc.svg",
-        "name": "Fleshforge Prototype (Roots)",
+        "name": "Fleshforge Prototype",
         "width": 1
     },
     "type": "npc"

--- a/packs/data/pfs-season-1-bestiary.db/fleshforge-prototype-shield.json
+++ b/packs/data/pfs-season-1-bestiary.db/fleshforge-prototype-shield.json
@@ -58,7 +58,7 @@
             "privateNotes": "",
             "publicNotes": "",
             "source": {
-                "value": "Pathfinder Society: Season 1"
+                "value": "Pathfinder Society Scenario #1-01: The Absalom Initiation"
             }
         },
         "resources": {},
@@ -126,6 +126,109 @@
     "img": "systems/pf2e/icons/default-icons/npc.svg",
     "items": [
         {
+            "_id": "IAIJOSaEM4wuS4ap",
+            "data": {
+                "armor": {
+                    "value": 2
+                },
+                "baseItem": null,
+                "category": "shield",
+                "check": {
+                    "value": 0
+                },
+                "containerId": null,
+                "description": {
+                    "value": "<p>The fleshforge dreg's large arm can be used as a shield (Hardness 5, HP 20, BT 10) and it gains the Shield Block reaction.</p>\n<p>The prototype's AC is 21 with its shield raised. If the shield is destroyed, it can no longer use its fist attack.</p>\n<table class=\"pf2-table\">\n<thead>\n<tr>\n<th>Hardness</th>\n<th>HP</th>\n<th>BT</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>5</td>\n<td>20</td>\n<td>10</td>\n</tr>\n</tbody>\n</table>"
+                },
+                "dex": {
+                    "value": 0
+                },
+                "equipped": {
+                    "carryType": "held",
+                    "handsHeld": 1,
+                    "invested": null
+                },
+                "equippedBulk": {
+                    "value": ""
+                },
+                "group": null,
+                "hardness": 5,
+                "hp": {
+                    "brokenThreshold": 10,
+                    "max": 20,
+                    "value": 20
+                },
+                "level": {
+                    "value": 0
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "potency": {},
+                "potencyRune": {
+                    "value": 0
+                },
+                "preciousMaterial": {
+                    "value": null
+                },
+                "preciousMaterialGrade": {
+                    "value": null
+                },
+                "price": {
+                    "value": {}
+                },
+                "propertyRune1": {
+                    "value": ""
+                },
+                "propertyRune2": {
+                    "value": ""
+                },
+                "propertyRune3": {
+                    "value": ""
+                },
+                "propertyRune4": {
+                    "value": ""
+                },
+                "quantity": 1,
+                "resiliencyRune": {
+                    "value": ""
+                },
+                "rules": [],
+                "size": "med",
+                "slug": "steel-shield",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "speed": {
+                    "value": 0
+                },
+                "stackGroup": null,
+                "strength": {
+                    "value": 0
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "unique",
+                    "value": []
+                },
+                "usage": {
+                    "value": "held-in-one-hand"
+                },
+                "weight": {
+                    "value": "-"
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.equipment-srd.Yr9yCuJiAlFh3QEB"
+                }
+            },
+            "img": "systems/pf2e/icons/features/feats/accursed-clay-fist.webp",
+            "name": "Fleshforge Dreg Arm",
+            "sort": 100000,
+            "type": "armor"
+        },
+        {
             "_id": "RCBb2BsGeUNPKoF8",
             "data": {
                 "attack": {
@@ -162,7 +265,7 @@
             },
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Fist",
-            "sort": 100000,
+            "sort": 200000,
             "type": "melee"
         },
         {
@@ -204,7 +307,7 @@
             },
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Tentacle",
-            "sort": 200000,
+            "sort": 300000,
             "type": "melee"
         },
         {
@@ -249,7 +352,7 @@
             },
             "img": "systems/pf2e/icons/actions/Reaction.webp",
             "name": "Shield Block",
-            "sort": 300000,
+            "sort": 400000,
             "type": "action"
         },
         {
@@ -277,7 +380,7 @@
             },
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Acrobatics",
-            "sort": 400000,
+            "sort": 500000,
             "type": "lore"
         },
         {
@@ -305,7 +408,7 @@
             },
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Athletics",
-            "sort": 500000,
+            "sort": 600000,
             "type": "lore"
         },
         {
@@ -333,7 +436,7 @@
             },
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Survival",
-            "sort": 600000,
+            "sort": 700000,
             "type": "lore"
         }
     ],
@@ -342,7 +445,7 @@
         "disposition": -1,
         "height": 1,
         "img": "systems/pf2e/icons/default-icons/npc.svg",
-        "name": "Fleshforge Prototype (Shield)",
+        "name": "Fleshforge Prototype",
         "width": 1
     },
     "type": "npc"

--- a/packs/data/pfs-season-1-bestiary.db/goblin-warrior-pfs-1-01.json
+++ b/packs/data/pfs-season-1-bestiary.db/goblin-warrior-pfs-1-01.json
@@ -1,0 +1,905 @@
+{
+    "_id": "Et2jn8eZ1nQStapE",
+    "data": {
+        "abilities": {
+            "cha": {
+                "mod": 1
+            },
+            "con": {
+                "mod": 1
+            },
+            "dex": {
+                "mod": 3
+            },
+            "int": {
+                "mod": 0
+            },
+            "str": {
+                "mod": 0
+            },
+            "wis": {
+                "mod": -1
+            }
+        },
+        "attributes": {
+            "ac": {
+                "details": "",
+                "value": 16
+            },
+            "allSaves": {
+                "value": ""
+            },
+            "hp": {
+                "details": "",
+                "max": 6,
+                "temp": 0,
+                "value": 6
+            },
+            "initiative": {
+                "ability": "perception"
+            },
+            "perception": {
+                "value": 2
+            },
+            "speed": {
+                "otherSpeeds": [],
+                "value": "25"
+            }
+        },
+        "details": {
+            "alignment": {
+                "value": "CE"
+            },
+            "blurb": "",
+            "creatureType": "Humanoid",
+            "level": {
+                "value": -1
+            },
+            "privateNotes": "",
+            "publicNotes": "<p>The frontline fighters of goblin tribes prefer to fight in large groups-especially when they can outnumber their foes at least three to one.</p>\n<hr />\n<p>These small humanoids have green or gray skin and large heads with wide ears. While some goblins are civilized and have worked hard to be considered upstanding members of humanoid communities, most are impetuous and vicious creatures who delight in wreaking havoc. These goblins think nothing of slaughtering livestock, stealing infants, or burning down a building purely for momentary delight. They revel in playing malicious tricks on taller humanoids, whom they call \"longshanks.\"</p>\n<p>Goblins are superstitious, with an intense awe of magic and a fascination with fire; goblins who master magic or fire earn great respect from their kin. Most other humanoids find it difficult to understand goblins' outlook: they hate canines but eagerly share their lairs with so-called \"goblin dogs,\" they fearlessly attack larger creatures but are terrified of horses, and they despise vegetables yet consider pickles a delicacy. To a goblin, of course, these are all perfectly sensible life choices.</p>",
+            "source": {
+                "value": "Pathfinder Society Scenario #1-01: The Absalom Initiation"
+            }
+        },
+        "resources": {},
+        "saves": {
+            "fortitude": {
+                "saveDetail": "",
+                "value": 5
+            },
+            "reflex": {
+                "saveDetail": "",
+                "value": 7
+            },
+            "will": {
+                "saveDetail": "",
+                "value": 3
+            }
+        },
+        "traits": {
+            "attitude": {
+                "value": "hostile"
+            },
+            "ci": [],
+            "di": {
+                "custom": "",
+                "value": []
+            },
+            "dr": [],
+            "dv": [],
+            "languages": {
+                "custom": "",
+                "selected": [],
+                "value": [
+                    "common",
+                    "goblin"
+                ]
+            },
+            "rarity": "common",
+            "senses": {
+                "value": "darkvision"
+            },
+            "size": {
+                "value": "sm"
+            },
+            "traits": {
+                "custom": "",
+                "value": [
+                    "goblin",
+                    "humanoid"
+                ]
+            }
+        }
+    },
+    "img": "systems/pf2e/icons/default-icons/npc.svg",
+    "items": [
+        {
+            "_id": "mMD4kftdZOuc9fDs",
+            "data": {
+                "MAP": {
+                    "value": ""
+                },
+                "baseItem": "dogslicer",
+                "bonus": {
+                    "value": 0
+                },
+                "bonusDamage": {
+                    "value": 0
+                },
+                "category": "martial",
+                "containerId": null,
+                "damage": {
+                    "damageType": "slashing",
+                    "dice": 1,
+                    "die": "d6",
+                    "value": ""
+                },
+                "description": {
+                    "value": "<p>This short, curved, and crude makeshift blade often has holes drilled into it to reduce its weight. It's a favored weapon of goblins.</p>"
+                },
+                "equipped": {
+                    "carryType": "held",
+                    "handsHeld": 1,
+                    "invested": null
+                },
+                "equippedBulk": {
+                    "value": ""
+                },
+                "group": "sword",
+                "hardness": 0,
+                "hp": {
+                    "brokenThreshold": 0,
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "potencyRune": {
+                    "value": 0
+                },
+                "preciousMaterial": {
+                    "value": null
+                },
+                "preciousMaterialGrade": {
+                    "value": null
+                },
+                "price": {
+                    "value": {
+                        "sp": 1
+                    }
+                },
+                "property1": {
+                    "critDamage": "",
+                    "critDamageType": "",
+                    "critDice": null,
+                    "critDie": "",
+                    "criticalConditionType": "",
+                    "criticalConditionValue": null,
+                    "damageType": "",
+                    "dice": null,
+                    "die": "",
+                    "strikeConditionType": "",
+                    "strikeConditionValue": null,
+                    "value": ""
+                },
+                "propertyRune1": {
+                    "value": null
+                },
+                "propertyRune2": {
+                    "value": null
+                },
+                "propertyRune3": {
+                    "value": null
+                },
+                "propertyRune4": {
+                    "value": null
+                },
+                "quantity": 1,
+                "range": null,
+                "reload": {
+                    "value": ""
+                },
+                "rules": [],
+                "size": "sm",
+                "slug": "dogslicer",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "specific": {
+                    "value": false
+                },
+                "splashDamage": {
+                    "value": null
+                },
+                "stackGroup": null,
+                "strikingRune": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "uncommon",
+                    "value": [
+                        "agile",
+                        "backstabber",
+                        "finesse",
+                        "goblin"
+                    ]
+                },
+                "usage": {
+                    "value": "held-in-one-hand"
+                },
+                "weight": {
+                    "value": "L"
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.equipment-srd.olwngGXM3hpgoLEP"
+                }
+            },
+            "img": "systems/pf2e/icons/equipment/weapons/dogslicer.webp",
+            "name": "Dogslicer",
+            "sort": 100000,
+            "type": "weapon"
+        },
+        {
+            "_id": "IJpCpIMcnl9ZLZlp",
+            "data": {
+                "MAP": {
+                    "value": ""
+                },
+                "baseItem": "shortbow",
+                "bonus": {
+                    "value": 0
+                },
+                "bonusDamage": {
+                    "value": 0
+                },
+                "category": "martial",
+                "containerId": null,
+                "damage": {
+                    "damageType": "piercing",
+                    "dice": 1,
+                    "die": "d6",
+                    "value": ""
+                },
+                "description": {
+                    "value": "<p>This smaller bow is made of a single piece of wood and favored by skirmishers and cavalry.</p>"
+                },
+                "equipped": {
+                    "carryType": "held",
+                    "handsHeld": 1,
+                    "invested": null
+                },
+                "equippedBulk": {
+                    "value": ""
+                },
+                "group": "bow",
+                "hardness": 0,
+                "hp": {
+                    "brokenThreshold": 0,
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "potencyRune": {
+                    "value": 0
+                },
+                "preciousMaterial": {
+                    "value": null
+                },
+                "preciousMaterialGrade": {
+                    "value": null
+                },
+                "price": {
+                    "value": {
+                        "gp": 3
+                    }
+                },
+                "property1": {
+                    "critDamage": "",
+                    "critDamageType": "",
+                    "critDice": null,
+                    "critDie": "",
+                    "criticalConditionType": "",
+                    "criticalConditionValue": null,
+                    "damageType": "",
+                    "dice": null,
+                    "die": "",
+                    "strikeConditionType": "",
+                    "strikeConditionValue": null,
+                    "value": ""
+                },
+                "propertyRune1": {
+                    "value": null
+                },
+                "propertyRune2": {
+                    "value": null
+                },
+                "propertyRune3": {
+                    "value": null
+                },
+                "propertyRune4": {
+                    "value": null
+                },
+                "quantity": 1,
+                "range": 60,
+                "reload": {
+                    "value": "0"
+                },
+                "rules": [],
+                "size": "sm",
+                "slug": "shortbow",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "specific": {
+                    "value": false
+                },
+                "splashDamage": {
+                    "value": 0
+                },
+                "stackGroup": null,
+                "strikingRune": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "deadly-d10"
+                    ]
+                },
+                "usage": {
+                    "value": "held-in-one-plus-hands"
+                },
+                "weight": {
+                    "value": "1"
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.equipment-srd.hIgqLgH3YcLZBeoT"
+                }
+            },
+            "img": "systems/pf2e/icons/equipment/weapons/shortbow.webp",
+            "name": "Shortbow",
+            "sort": 200000,
+            "type": "weapon"
+        },
+        {
+            "_id": "WCcXHATq4Dp0GePS",
+            "data": {
+                "armor": {
+                    "value": 1
+                },
+                "baseItem": "leather-armor",
+                "category": "light",
+                "check": {
+                    "value": -1
+                },
+                "containerId": null,
+                "description": {
+                    "value": "<p>A mix of flexible and molded boiled leather, a suit of this type of armor provides some protection with maximum flexibility.</p>"
+                },
+                "dex": {
+                    "value": 4
+                },
+                "equipped": {
+                    "carryType": "worn",
+                    "inSlot": true,
+                    "invested": null
+                },
+                "equippedBulk": {
+                    "value": "1"
+                },
+                "group": "leather",
+                "hardness": 0,
+                "hp": {
+                    "brokenThreshold": 0,
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "potency": {},
+                "potencyRune": {
+                    "value": 0
+                },
+                "preciousMaterial": {
+                    "value": null
+                },
+                "preciousMaterialGrade": {
+                    "value": null
+                },
+                "price": {
+                    "value": {
+                        "gp": 2
+                    }
+                },
+                "propertyRune1": {
+                    "value": ""
+                },
+                "propertyRune2": {
+                    "value": ""
+                },
+                "propertyRune3": {
+                    "value": ""
+                },
+                "propertyRune4": {
+                    "value": ""
+                },
+                "quantity": 1,
+                "resiliencyRune": {
+                    "value": ""
+                },
+                "rules": [],
+                "size": "sm",
+                "slug": "leather-armor",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "speed": {
+                    "value": 0
+                },
+                "stackGroup": null,
+                "strength": {
+                    "value": 10
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "usage": {
+                    "value": "wornarmor"
+                },
+                "weight": {
+                    "value": "2"
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.equipment-srd.4tIVTg9wj56RrveA"
+                }
+            },
+            "img": "systems/pf2e/icons/equipment/armor/leather-armor.webp",
+            "name": "Leather Armor",
+            "sort": 300000,
+            "type": "armor"
+        },
+        {
+            "_id": "b5rXje1IafNc5Ey6",
+            "data": {
+                "activation": {
+                    "condition": "",
+                    "cost": 0,
+                    "type": ""
+                },
+                "autoDestroy": {
+                    "_deprecated": true,
+                    "value": true
+                },
+                "autoUse": {
+                    "_deprecated": true,
+                    "value": true
+                },
+                "baseItem": null,
+                "charges": {
+                    "_deprecated": true,
+                    "max": 0,
+                    "value": 0
+                },
+                "consumableType": {
+                    "value": "ammo"
+                },
+                "consume": {
+                    "_deprecated": true,
+                    "value": ""
+                },
+                "containerId": null,
+                "description": {
+                    "value": "<p>These projectiles are the ammunition for bows. The shaft of an arrow is made of wood. It is stabilized in flight by fletching at one end and bears a metal head on the other.</p>"
+                },
+                "duration": {
+                    "units": "",
+                    "value": null
+                },
+                "equipped": {
+                    "carryType": "held",
+                    "handsHeld": 1
+                },
+                "equippedBulk": {
+                    "value": ""
+                },
+                "hardness": 0,
+                "hp": {
+                    "brokenThreshold": 0,
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "preciousMaterial": {
+                    "value": ""
+                },
+                "preciousMaterialGrade": {
+                    "value": ""
+                },
+                "price": {
+                    "per": 10,
+                    "value": {
+                        "sp": 1
+                    }
+                },
+                "quantity": 10,
+                "range": {
+                    "long": null,
+                    "units": "",
+                    "value": null
+                },
+                "rules": [],
+                "size": "med",
+                "slug": "arrows",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "spell": {
+                    "data": null,
+                    "heightenedLevel": null
+                },
+                "stackGroup": "arrows",
+                "target": {
+                    "type": "",
+                    "units": "",
+                    "value": null
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "usage": {
+                    "value": "held-in-one-hand"
+                },
+                "uses": {
+                    "autoDestroy": true,
+                    "autoUse": true,
+                    "max": 0,
+                    "per": null,
+                    "value": 0
+                },
+                "weight": {
+                    "value": "L"
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.equipment-srd.w2ENw2VMPcsbif8g"
+                }
+            },
+            "img": "systems/pf2e/icons/equipment/weapons/arrows.webp",
+            "name": "Arrows",
+            "sort": 400000,
+            "type": "consumable"
+        },
+        {
+            "_id": "CnmgzGmi2Avq67QA",
+            "data": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "custom": "",
+                    "value": []
+                },
+                "bonus": {
+                    "value": 8
+                },
+                "damageRolls": {
+                    "ey6azuuwlybw1co71ts0": {
+                        "damage": "1d6",
+                        "damageType": "slashing"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "agile",
+                        "backstabber",
+                        "finesse"
+                    ]
+                },
+                "weaponType": {
+                    "value": "melee"
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Dogslicer",
+            "sort": 500000,
+            "type": "melee"
+        },
+        {
+            "_id": "4EXgRMqNIRLXxB1c",
+            "data": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "custom": "",
+                    "value": []
+                },
+                "bonus": {
+                    "value": 8
+                },
+                "damageRolls": {
+                    "ujtbajeebtfq2x6cn2d7": {
+                        "damage": "1d6",
+                        "damageType": "piercing"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "deadly-d10",
+                        "range-increment-60",
+                        "reload-0"
+                    ]
+                },
+                "weaponType": {
+                    "value": "ranged"
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Shortbow",
+            "sort": 600000,
+            "type": "melee"
+        },
+        {
+            "_id": "ZTPzGQcaC9zUdjD6",
+            "data": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Darkvision]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "darkvision",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.qCCLZhnp2HhP3Ex6"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Darkvision",
+            "sort": 700000,
+            "type": "action"
+        },
+        {
+            "_id": "czwGWW73rkPW7vBg",
+            "data": {
+                "actionCategory": {
+                    "value": "defensive"
+                },
+                "actionType": {
+                    "value": "reaction"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p><strong>Trigger</strong> A goblin ally ends a move action adjacent to the goblin.</p>\n<hr />\n<p><strong>Effect</strong> The goblin @Compendium[pf2e.actionspf2e.Step]{Steps}.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "goblin-goblin-scuttle",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-family-ability-glossary.EM6YZCt6vFCFhXmb"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Reaction.webp",
+            "name": "Goblin Scuttle",
+            "sort": 800000,
+            "type": "action"
+        },
+        {
+            "_id": "4IYKiAKdOPkrg58e",
+            "data": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 5
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Acrobatics",
+            "sort": 900000,
+            "type": "lore"
+        },
+        {
+            "_id": "hYUMQbjFFTteVyB3",
+            "data": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 2
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Athletics",
+            "sort": 1000000,
+            "type": "lore"
+        },
+        {
+            "_id": "uwmO8lb09eq8enNS",
+            "data": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 1
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Nature",
+            "sort": 1100000,
+            "type": "lore"
+        },
+        {
+            "_id": "eWNZ53Hfva4nIvHo",
+            "data": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 5
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Stealth",
+            "sort": 1200000,
+            "type": "lore"
+        }
+    ],
+    "name": "Goblin Warrior (PFS 1-01)",
+    "token": {
+        "disposition": -1,
+        "height": 1,
+        "img": "systems/pf2e/icons/default-icons/npc.svg",
+        "name": "Goblin Warrior",
+        "width": 1
+    },
+    "type": "npc"
+}

--- a/packs/data/pfs-season-1-bestiary.db/greater-shadow-wisp.json
+++ b/packs/data/pfs-season-1-bestiary.db/greater-shadow-wisp.json
@@ -63,7 +63,7 @@
             "privateNotes": "",
             "publicNotes": "",
             "source": {
-                "value": "Pathfinder Society: Season 1"
+                "value": "Pathfinder Society Scenario #1-01: The Absalom Initiation"
             }
         },
         "resources": {},
@@ -281,7 +281,7 @@
                     "value": 1
                 },
                 "description": {
-                    "value": "<p><strong>Requirements</strong> The shadow wisp's previous action was a hit against an adjacent creature with its shadow tendril Strike.</p>\n<hr />\n<p><strong>Effect</strong> The shadow wisp Steps into the creature's space and attempts an Acrobatics check against the target's Reflex DC to attach itself to the target's shadow.</p>\n<p>As long as it remains attached, it moves with the target and is @Compendium[pf2e.conditionitems.Flat-Footed]{Flat-Footed} to attacks from the target. The target can spend a move action on its turn to attempt a Reflex save against the wisp's Acrobatics DC to escape the shroud.</p>"
+                    "value": "<p><strong>Requirements</strong> The shadow wisp's previous action was a hit against an adjacent creature with its shadow tendril Strike.</p>\n<hr />\n<p><strong>Effect</strong> The shadow wisp Steps into the creature's space and attempts an @Check[type:acrobatics] check against the target's Reflex DC to attach itself to the target's shadow. As long as it remains attached, it moves with the target and is @Compendium[pf2e.conditionitems.Flat-Footed]{Flat-Footed} to attacks from the target. The target can spend a move action on its turn to attempt a Reflex save against the wisp's Acrobatics DC to escape the shroud.</p>"
                 },
                 "requirements": {
                     "value": ""

--- a/packs/data/pfs-season-1-bestiary.db/rending-hands.json
+++ b/packs/data/pfs-season-1-bestiary.db/rending-hands.json
@@ -9,9 +9,9 @@
             "hasHealth": true,
             "hp": {
                 "details": "",
-                "max": 10,
+                "max": 0,
                 "temp": 0,
-                "value": 10
+                "value": 0
             },
             "stealth": {
                 "details": "<p>(trained) to hear the scratching beneath the floorboards</p>",
@@ -21,7 +21,7 @@
         "creatureType": "",
         "details": {
             "description": "<p>Illusory hands tear from the floorboards, clawing at their victim's legs and leaving real wounds.</p>",
-            "disable": "<p>Religion DC 20 (trained) to exorcize the spirits</p>",
+            "disable": "<p>@Check[type:religion|dc:20](trained) to exorcize the spirits</p>",
             "isComplex": false,
             "level": {
                 "value": 4
@@ -44,7 +44,8 @@
             }
         },
         "source": {
-            "value": ""
+            "author": "",
+            "value": "Pathfinder Society Scenario #1-01: The Absalom Initiation"
         },
         "statusEffects": [],
         "traits": {

--- a/packs/data/pfs-season-1-bestiary.db/rending-hands.json
+++ b/packs/data/pfs-season-1-bestiary.db/rending-hands.json
@@ -21,7 +21,7 @@
         "creatureType": "",
         "details": {
             "description": "<p>Illusory hands tear from the floorboards, clawing at their victim's legs and leaving real wounds.</p>",
-            "disable": "<p>@Check[type:religion|dc:20](trained) to exorcize the spirits</p>",
+            "disable": "<p>@Check[type:religion|dc:20|name:Exorcize the Spirits](trained) to exorcize the spirits</p>",
             "isComplex": false,
             "level": {
                 "value": 4

--- a/packs/data/pfs-season-1-bestiary.db/scrabbling-hands.json
+++ b/packs/data/pfs-season-1-bestiary.db/scrabbling-hands.json
@@ -9,9 +9,9 @@
             "hasHealth": true,
             "hp": {
                 "details": "",
-                "max": 10,
+                "max": 0,
                 "temp": 0,
-                "value": 10
+                "value": 0
             },
             "stealth": {
                 "details": "<p>(trained) to hear the scratching beneath the floorboards</p>",
@@ -21,7 +21,7 @@
         "creatureType": "",
         "details": {
             "description": "<p>Illusory hands tear from the floorboards, clawing at their victim's legs and leaving real wounds.</p>",
-            "disable": "<p>Religion DC 16 (trained) to exorcize the spirits</p>",
+            "disable": "<p>@Check[type:religion|dc:16](trained) to exorcize the spirits</p>",
             "isComplex": false,
             "level": {
                 "value": 2
@@ -44,7 +44,8 @@
             }
         },
         "source": {
-            "value": ""
+            "author": "",
+            "value": "Pathfinder Society Scenario #1-01: The Absalom Initiation"
         },
         "statusEffects": [],
         "traits": {

--- a/packs/data/pfs-season-1-bestiary.db/scrabbling-hands.json
+++ b/packs/data/pfs-season-1-bestiary.db/scrabbling-hands.json
@@ -21,7 +21,7 @@
         "creatureType": "",
         "details": {
             "description": "<p>Illusory hands tear from the floorboards, clawing at their victim's legs and leaving real wounds.</p>",
-            "disable": "<p>@Check[type:religion|dc:16](trained) to exorcize the spirits</p>",
+            "disable": "<p>@Check[type:religion|dc:16|name:Exorcize the Spirits](trained) to exorcize the spirits</p>",
             "isComplex": false,
             "level": {
                 "value": 2

--- a/packs/data/pfs-season-1-bestiary.db/shadow-wisp.json
+++ b/packs/data/pfs-season-1-bestiary.db/shadow-wisp.json
@@ -63,7 +63,7 @@
             "privateNotes": "",
             "publicNotes": "",
             "source": {
-                "value": "Pathfinder Society: Season 1"
+                "value": "Pathfinder Society Scenario #1-01: The Absalom Initiation"
             }
         },
         "resources": {},
@@ -281,7 +281,7 @@
                     "value": 1
                 },
                 "description": {
-                    "value": "<p><strong>Requirements</strong> The shadow wisp's previous action was a hit against an adjacent creature with its shadow tendril Strike.</p>\n<hr />\n<p><strong>Effect</strong> The shadow wisp @Compendium[pf2e.actionspf2e.Step]{Steps} into the creature's space and attempts an Acrobatics check against the target's Reflex DC to attach itself to the target's shadow.</p>\n<p>As long as it remains attached, it moves with the target and is @Compendium[pf2e.conditionitems.Flat-Footed]{Flat-Footed} to attacks from the target. The target can spend a move action on its turn to attempt a Reflex save against the wisp's Acrobatics DC to escape the shroud.</p>"
+                    "value": "<p><strong>Requirements</strong> The shadow wisp's previous action was a hit against an adjacent creature with its shadow tendril Strike.</p>\n<hr />\n<p><strong>Effect</strong> The shadow wisp @Compendium[pf2e.actionspf2e.Step]{Steps} into the creature's space and attempts an @Check[type:acrobatics] check against the target's Reflex DC to attach itself to the target's shadow.</p>\n<p>As long as it remains attached, it moves with the target and is @Compendium[pf2e.conditionitems.Flat-Footed]{Flat-Footed} to attacks from the target. The target can spend a move action on its turn to attempt a Reflex save against the wisp's Acrobatics DC to escape the shroud.</p>"
                 },
                 "requirements": {
                     "value": ""

--- a/packs/data/pfs-season-1-bestiary.db/unkillable-zombie-brute-pfs-1-01.json
+++ b/packs/data/pfs-season-1-bestiary.db/unkillable-zombie-brute-pfs-1-01.json
@@ -58,7 +58,7 @@
             "privateNotes": "",
             "publicNotes": "<p>Necromantic augmentations have granted this zombie increased size and power.</p>\n<hr />\n<p>A zombie's only desire is to consume the living. Unthinking and ever-shambling harbingers of death, zombies stop only when they're destroyed.</p>",
             "source": {
-                "value": "Pathfinder Society: Season 1"
+                "value": "Pathfinder Society Scenario #1-01: The Absalom Initiation"
             }
         },
         "resources": {},
@@ -397,46 +397,6 @@
             "type": "action"
         },
         {
-            "_id": "V5U9d0DWWw5xvPxJ",
-            "data": {
-                "actionCategory": {
-                    "value": "defensive"
-                },
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "description": {
-                    "value": "<p>This zombie is nigh unkillable.</p>\n<p>The zombie loses its weakness to slashing and gains resistance 3 against all damage, and it gains weakness 6 to critical hits.</p>"
-                },
-                "requirements": {
-                    "value": ""
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                },
-                "trigger": {
-                    "value": ""
-                },
-                "weapon": {
-                    "value": ""
-                }
-            },
-            "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Unkillable",
-            "sort": 700000,
-            "type": "action"
-        },
-        {
             "_id": "lVjydvACaQe5413Q",
             "data": {
                 "actionCategory": {
@@ -449,7 +409,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>A zombie hulk can throw corpses at foes.</p>\n<p>While any Medium dead body will do, they sometimes throw @Compendium[pf2e.pathfinder-bestiary.Zombie Shambler]{Zombie Shamblers}, who take just as much damage from being thrown as the target they hit.</p>\n<p>A thrown shambler lands @Compendium[pf2e.conditionitems.Prone]{Prone}, but if it's not destroyed, it can rise and use other actions normally.</p>"
+                    "value": "<p>A zombie hulk can throw corpses at foes. While any Medium dead body will do, they sometimes throw @Compendium[pf2e.pathfinder-bestiary.Zombie Shambler]{Zombie Shamblers}, who take just as much damage from being thrown as the target they hit. A thrown shambler lands @Compendium[pf2e.conditionitems.Prone]{Prone}, but if it's not destroyed, it can rise and use other actions normally.</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -473,7 +433,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Corpse Throwing",
-            "sort": 800000,
+            "sort": 700000,
             "type": "action"
         },
         {
@@ -513,7 +473,7 @@
             },
             "img": "systems/pf2e/icons/actions/OneAction.webp",
             "name": "Wide Swing",
-            "sort": 900000,
+            "sort": 800000,
             "type": "action"
         },
         {
@@ -541,11 +501,11 @@
             },
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Athletics",
-            "sort": 1000000,
+            "sort": 900000,
             "type": "lore"
         }
     ],
-    "name": "Unkillable Zombie Brute",
+    "name": "Unkillable Zombie Brute (PFS 1-01)",
     "token": {
         "disposition": -1,
         "height": 2,

--- a/packs/data/pfs-season-1-bestiary.db/weak-ceustodaemon-pfs-1-01.json
+++ b/packs/data/pfs-season-1-bestiary.db/weak-ceustodaemon-pfs-1-01.json
@@ -1,0 +1,1389 @@
+{
+    "_id": "UjVrEU4MTBH2eZOq",
+    "data": {
+        "abilities": {
+            "cha": {
+                "mod": 3
+            },
+            "con": {
+                "mod": 4
+            },
+            "dex": {
+                "mod": 2
+            },
+            "int": {
+                "mod": 0
+            },
+            "str": {
+                "mod": 5
+            },
+            "wis": {
+                "mod": 2
+            }
+        },
+        "attributes": {
+            "ac": {
+                "details": "",
+                "value": 21
+            },
+            "allSaves": {
+                "value": ""
+            },
+            "hp": {
+                "details": "",
+                "max": 110,
+                "temp": 0,
+                "value": 110
+            },
+            "initiative": {
+                "ability": "perception"
+            },
+            "perception": {
+                "value": 12
+            },
+            "speed": {
+                "otherSpeeds": [],
+                "value": "25"
+            }
+        },
+        "details": {
+            "alignment": {
+                "value": "NE"
+            },
+            "blurb": "",
+            "creatureType": "Fiend",
+            "level": {
+                "value": 5
+            },
+            "privateNotes": "",
+            "publicNotes": "<p>Ceustodaemons are formed from the souls of vile mortals, particularly those who took efforts to hasten their own death, their willingness shaping them into daemonic servants. Their otherworldly senses make them useful for protecting vaults and similar locations on the Material Plane. Ceustodaemons are created to serve, but always seek ways to subvert their bindings, so they can rend their mortal summoners' flesh. The worst type of conjurer calls upon ceustodaemons merely to set them free into the world in hopes of currying favor with the powers of Abaddon.</p>\n<hr />\n<p>Denizens of the bleak and terrible plane of Abaddon, daemons are shaped by and devoted to the destruction of life in all its forms. They seek the death of every mortal being by the most painful and horrible means possible, all in service to the apocalyptic entities known as the Four Horsemen. Each kind of daemon represents a different way to die, and their powers are nearly always aimed at spreading that particular form of death. Through the use of these powers, they seek to drag all existence down into a pit of hopelessness and despair, and to commit all souls to oblivion.</p>\n<p>While those who summon daemons to the Material Plane usually seek to use the creatures' destructive and corrupting powers for their own ends, daemons always look for ways to spread fear, doubt, and despair wherever they go. Often, daemons disguise their plots as the workings of other fiends, knowing that such confusion compounds mortals' fear.</p>\n<p>While all fiends seek to tempt mortals into lives of evil to increase their own numbers and power on their native planes, daemons are further driven by a supernatural hunger for mortal souls and use a variety of methods-not least of which is the cacodaemons' soul gems-to entrap them. On Abaddon and in other forbidding places across the multiverse, souls are simultaneously a delicacy, a trade good, and a source of magical power, and the daemons are among the greatest gluttons, merchants, and abusers of this spiritual \"resource.\"</p>",
+            "source": {
+                "value": "Pathfinder Society Scenario #1-01: The Absalom Initiation"
+            }
+        },
+        "resources": {
+            "focus": {
+                "max": 1,
+                "value": 1
+            }
+        },
+        "saves": {
+            "fortitude": {
+                "saveDetail": "",
+                "value": 14
+            },
+            "reflex": {
+                "saveDetail": "",
+                "value": 10
+            },
+            "will": {
+                "saveDetail": "",
+                "value": 10
+            }
+        },
+        "traits": {
+            "attitude": {
+                "value": "hostile"
+            },
+            "ci": [],
+            "di": {
+                "custom": "",
+                "value": [
+                    "death-effects"
+                ]
+            },
+            "dr": [],
+            "dv": [
+                {
+                    "type": "good",
+                    "value": 10
+                }
+            ],
+            "languages": {
+                "custom": "Telepathy 100 feet",
+                "selected": [],
+                "value": [
+                    "common",
+                    "daemonic"
+                ]
+            },
+            "rarity": "common",
+            "senses": {
+                "value": "darkvision, see invisibility"
+            },
+            "size": {
+                "value": "lg"
+            },
+            "traits": {
+                "custom": "",
+                "value": [
+                    "daemon",
+                    "fiend"
+                ]
+            }
+        }
+    },
+    "img": "systems/pf2e/icons/default-icons/npc.svg",
+    "items": [
+        {
+            "_id": "q09mldN5OwQ33WsU",
+            "data": {
+                "autoHeightenLevel": {
+                    "value": null
+                },
+                "description": {
+                    "value": ""
+                },
+                "displayLevels": {},
+                "prepared": {
+                    "value": "innate"
+                },
+                "proficiency": {
+                    "value": 0
+                },
+                "rules": [],
+                "showSlotlessLevels": {
+                    "value": false
+                },
+                "showUnpreparedSpells": {
+                    "value": true
+                },
+                "slots": {
+                    "slot0": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot1": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot10": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot11": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot2": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot3": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot4": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot5": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot6": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot7": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot8": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot9": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    }
+                },
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "spelldc": {
+                    "dc": 21,
+                    "mod": 0,
+                    "value": 13
+                },
+                "tradition": {
+                    "value": "divine"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/spellcastingEntry.svg",
+            "name": "Divine Innate Spells",
+            "sort": 100000,
+            "type": "spellcastingEntry"
+        },
+        {
+            "_id": "o5Zxivy6gPz9uwu3",
+            "data": {
+                "ability": {
+                    "value": ""
+                },
+                "area": {
+                    "areaType": "",
+                    "value": ""
+                },
+                "areasize": {
+                    "value": ""
+                },
+                "category": {
+                    "value": "spell"
+                },
+                "components": {
+                    "focus": false,
+                    "material": false,
+                    "somatic": true,
+                    "verbal": true
+                },
+                "cost": {
+                    "value": ""
+                },
+                "damage": {
+                    "value": {}
+                },
+                "description": {
+                    "value": "<p>Opening a door that bypasses normal space, you instantly transport yourself and any items you're wearing and holding from your current space to a clear space within range you can see. If this would bring another creature with you-even if you're carrying it in an extradimensional container-the spell is lost.</p>\n<hr />\n<p><strong>Heightened (5th)</strong> The range increases to 1 mile. You don't need to be able to see your destination, as long as you have been there in the past and know its relative location and distance from you. You are temporarily immune for 1 hour.</p>"
+                },
+                "duration": {
+                    "value": ""
+                },
+                "hasCounteractCheck": {
+                    "value": false
+                },
+                "level": {
+                    "value": 4
+                },
+                "location": {
+                    "heightenedLevel": 4,
+                    "value": "q09mldN5OwQ33WsU"
+                },
+                "materials": {
+                    "value": ""
+                },
+                "prepared": {
+                    "value": ""
+                },
+                "primarycheck": {
+                    "value": ""
+                },
+                "range": {
+                    "value": "120 feet"
+                },
+                "rules": [],
+                "save": {
+                    "basic": "",
+                    "value": ""
+                },
+                "school": {
+                    "value": "conjuration"
+                },
+                "secondarycasters": {
+                    "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "dimension-door",
+                "source": {
+                    "value": ""
+                },
+                "spellType": {
+                    "value": "utility"
+                },
+                "sustained": {
+                    "value": false
+                },
+                "target": {
+                    "value": ""
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traditions": {
+                    "value": [
+                        "arcane",
+                        "occult"
+                    ]
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "teleportation"
+                    ]
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.VlNcjmYyu95vOUe8"
+                }
+            },
+            "img": "systems/pf2e/icons/spells/dimension-door.webp",
+            "name": "Dimension Door (At Will)",
+            "sort": 200000,
+            "type": "spell"
+        },
+        {
+            "_id": "g2DB6NpjUJNvoMdm",
+            "data": {
+                "ability": {
+                    "value": ""
+                },
+                "area": {
+                    "areaType": "",
+                    "value": null
+                },
+                "areasize": {
+                    "value": ""
+                },
+                "category": {
+                    "value": "spell"
+                },
+                "components": {
+                    "focus": false,
+                    "material": false,
+                    "somatic": true,
+                    "verbal": true
+                },
+                "cost": {
+                    "value": ""
+                },
+                "damage": {
+                    "value": {}
+                },
+                "description": {
+                    "value": "<p>The target can soar through the air, gaining a fly Speed equal to its Speed or 20 feet, whichever is greater.</p>\n<hr />\n<p><strong>Heightened (7th)</strong> The duration increases to 1 hour.</p>"
+                },
+                "duration": {
+                    "value": "5 minutes"
+                },
+                "hasCounteractCheck": {
+                    "value": false
+                },
+                "level": {
+                    "value": 4
+                },
+                "location": {
+                    "heightenedLevel": 7,
+                    "value": "q09mldN5OwQ33WsU"
+                },
+                "materials": {
+                    "value": ""
+                },
+                "prepared": {
+                    "value": ""
+                },
+                "primarycheck": {
+                    "value": ""
+                },
+                "range": {
+                    "value": "touch"
+                },
+                "rules": [],
+                "save": {
+                    "basic": "",
+                    "value": ""
+                },
+                "school": {
+                    "value": "transmutation"
+                },
+                "secondarycasters": {
+                    "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "fly",
+                "source": {
+                    "value": ""
+                },
+                "spellType": {
+                    "value": "utility"
+                },
+                "sustained": {
+                    "value": false
+                },
+                "target": {
+                    "value": "1 creature"
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traditions": {
+                    "value": [
+                        "arcane",
+                        "occult",
+                        "primal"
+                    ]
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.A2JfEKe6BZcTG1S8"
+                }
+            },
+            "img": "systems/pf2e/icons/spells/fly.webp",
+            "name": "Fly",
+            "sort": 300000,
+            "type": "spell"
+        },
+        {
+            "_id": "KJMRThMjh77BRoKl",
+            "data": {
+                "ability": {
+                    "value": ""
+                },
+                "area": {
+                    "areaType": "",
+                    "value": null
+                },
+                "areasize": {
+                    "value": ""
+                },
+                "category": {
+                    "value": "spell"
+                },
+                "components": {
+                    "focus": false,
+                    "material": false,
+                    "somatic": true,
+                    "verbal": true
+                },
+                "cost": {
+                    "value": ""
+                },
+                "damage": {
+                    "value": {}
+                },
+                "description": {
+                    "value": "<p>You block the target's motor impulses before they can leave its mind, threatening to freeze the target in place. The target must attempt a Will save.</p>\n<hr />\n<p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target is @Compendium[pf2e.conditionitems.Stunned]{Stunned 1}.</p>\n<p><strong>Failure</strong> The target is @Compendium[pf2e.conditionitems.Paralyzed]{Paralyzed} for 1 round.</p>\n<p><strong>Critical Failure</strong> The target is Paralyzed for 4 rounds. At the end of each of its turns, it can attempt a new Will save to reduce the remaining duration by 1 round, or end it entirely on a critical success.</p>\n<hr />\n<p><strong>Heightened (7th)</strong> You can target up to 10 creatures.</p>"
+                },
+                "duration": {
+                    "value": "varies"
+                },
+                "hasCounteractCheck": {
+                    "value": false
+                },
+                "level": {
+                    "value": 3
+                },
+                "location": {
+                    "heightenedLevel": 3,
+                    "value": "q09mldN5OwQ33WsU"
+                },
+                "materials": {
+                    "value": ""
+                },
+                "prepared": {
+                    "value": ""
+                },
+                "primarycheck": {
+                    "value": ""
+                },
+                "range": {
+                    "value": "30 feet"
+                },
+                "rules": [],
+                "save": {
+                    "basic": "",
+                    "value": "will"
+                },
+                "school": {
+                    "value": "enchantment"
+                },
+                "secondarycasters": {
+                    "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "paralyze",
+                "source": {
+                    "value": ""
+                },
+                "spellType": {
+                    "value": "save"
+                },
+                "sustained": {
+                    "value": false
+                },
+                "target": {
+                    "value": "1 creature"
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traditions": {
+                    "custom": "",
+                    "value": [
+                        "arcane",
+                        "occult"
+                    ]
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "incapacitation",
+                        "mental"
+                    ]
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.DCQHaLrYXMI37dvW"
+                }
+            },
+            "img": "systems/pf2e/icons/spells/paralyze.webp",
+            "name": "Paralyze",
+            "sort": 400000,
+            "type": "spell"
+        },
+        {
+            "_id": "g9WvIGvN03NY5UOq",
+            "data": {
+                "ability": {
+                    "value": ""
+                },
+                "area": {
+                    "areaType": "",
+                    "value": null
+                },
+                "areasize": {
+                    "value": ""
+                },
+                "category": {
+                    "value": "spell"
+                },
+                "components": {
+                    "focus": false,
+                    "material": false,
+                    "somatic": true,
+                    "verbal": true
+                },
+                "cost": {
+                    "value": ""
+                },
+                "damage": {
+                    "value": {}
+                },
+                "description": {
+                    "value": "<p>You unravel the magic behind a spell or effect. Attempt a counteract check against the target. If you successfully counteract a magic item, the item becomes a mundane item of its type for 10 minutes. This doesn't change the item's non-magical properties. If the target is an artifact or similar item, you automatically fail.</p>"
+                },
+                "duration": {
+                    "value": ""
+                },
+                "hasCounteractCheck": {
+                    "value": true
+                },
+                "level": {
+                    "value": 2
+                },
+                "location": {
+                    "heightenedLevel": 3,
+                    "uses": {
+                        "max": 2,
+                        "value": 2
+                    },
+                    "value": "q09mldN5OwQ33WsU"
+                },
+                "materials": {
+                    "value": ""
+                },
+                "prepared": {
+                    "value": ""
+                },
+                "primarycheck": {
+                    "value": ""
+                },
+                "range": {
+                    "value": "120 feet"
+                },
+                "rules": [],
+                "save": {
+                    "basic": "",
+                    "value": ""
+                },
+                "school": {
+                    "value": "abjuration"
+                },
+                "secondarycasters": {
+                    "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "dispel-magic",
+                "source": {
+                    "value": ""
+                },
+                "spellType": {
+                    "value": "utility"
+                },
+                "sustained": {
+                    "value": false
+                },
+                "target": {
+                    "value": "1 spell effect or unattended magic item"
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traditions": {
+                    "value": [
+                        "arcane",
+                        "divine",
+                        "occult",
+                        "primal"
+                    ]
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.9HpwDN4MYQJnW0LG"
+                }
+            },
+            "img": "systems/pf2e/icons/spells/dispel-magic.webp",
+            "name": "Dispel Magic",
+            "sort": 500000,
+            "type": "spell"
+        },
+        {
+            "_id": "7qE6PiM12QgkWctV",
+            "data": {
+                "ability": {
+                    "value": ""
+                },
+                "area": {
+                    "areaType": "",
+                    "value": ""
+                },
+                "areasize": {
+                    "value": ""
+                },
+                "category": {
+                    "value": "spell"
+                },
+                "components": {
+                    "focus": false,
+                    "material": false,
+                    "somatic": true,
+                    "verbal": true
+                },
+                "cost": {
+                    "value": ""
+                },
+                "damage": {
+                    "value": {}
+                },
+                "description": {
+                    "value": "<p>You can see @Compendium[pf2e.conditionitems.Invisible]{Invisible} creatures and objects. They appear to you as translucent shapes, and they are @Compendium[pf2e.conditionitems.Concealed]{Concealed} to you.</p>\n<hr />\n<p><strong>Heightened (5th)</strong> The spell has a duration of 8 hours.</p>"
+                },
+                "duration": {
+                    "value": "10 minutes"
+                },
+                "hasCounteractCheck": {
+                    "value": false
+                },
+                "level": {
+                    "value": 2
+                },
+                "location": {
+                    "heightenedLevel": 2,
+                    "value": "q09mldN5OwQ33WsU"
+                },
+                "materials": {
+                    "value": ""
+                },
+                "prepared": {
+                    "value": ""
+                },
+                "primarycheck": {
+                    "value": ""
+                },
+                "range": {
+                    "value": ""
+                },
+                "rules": [],
+                "save": {
+                    "basic": "",
+                    "value": ""
+                },
+                "school": {
+                    "value": "divination"
+                },
+                "secondarycasters": {
+                    "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "see-invisibility",
+                "source": {
+                    "value": ""
+                },
+                "spellType": {
+                    "value": "utility"
+                },
+                "sustained": {
+                    "value": false
+                },
+                "target": {
+                    "value": ""
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traditions": {
+                    "value": [
+                        "arcane",
+                        "divine",
+                        "occult"
+                    ]
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "revelation"
+                    ]
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.jwK43yKsHTkJQvQ9"
+                }
+            },
+            "img": "systems/pf2e/icons/spells/see-invisibility.webp",
+            "name": "See Invisibility (Constant)",
+            "sort": 600000,
+            "type": "spell"
+        },
+        {
+            "_id": "EnBhUXkHOrsrB0rH",
+            "data": {
+                "ability": {
+                    "value": ""
+                },
+                "area": {
+                    "areaType": "emanation",
+                    "value": "30"
+                },
+                "areasize": {
+                    "value": "30-foot emanation"
+                },
+                "category": {
+                    "value": "spell"
+                },
+                "components": {
+                    "focus": false,
+                    "material": false,
+                    "somatic": true,
+                    "verbal": true
+                },
+                "cost": {
+                    "value": ""
+                },
+                "damage": {
+                    "value": {}
+                },
+                "description": {
+                    "value": "<p>Your eyes glow as you sense aligned auras. Choose chaotic, evil, good, or lawful. You detect auras of that alignment. You receive no information beyond presence or absence. You can choose not to detect creatures or effects you're aware have that alignment.</p>\n<p>Only creatures of 6th level or higher-unless divine spellcasters, undead, or beings from the Outer Sphere-have alignment auras.</p>\n<hr />\n<p><strong>Heightened (2nd)</strong> You learn each aura's location and strength.</p>"
+                },
+                "duration": {
+                    "value": ""
+                },
+                "hasCounteractCheck": {
+                    "value": false
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": {
+                    "heightenedLevel": 1,
+                    "value": "q09mldN5OwQ33WsU"
+                },
+                "materials": {
+                    "value": ""
+                },
+                "prepared": {
+                    "value": ""
+                },
+                "primarycheck": {
+                    "value": ""
+                },
+                "range": {
+                    "value": ""
+                },
+                "rules": [],
+                "save": {
+                    "basic": "",
+                    "value": ""
+                },
+                "school": {
+                    "value": "divination"
+                },
+                "secondarycasters": {
+                    "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "detect-alignment",
+                "source": {
+                    "value": ""
+                },
+                "spellType": {
+                    "value": "utility"
+                },
+                "sustained": {
+                    "value": false
+                },
+                "target": {
+                    "value": ""
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traditions": {
+                    "value": [
+                        "divine",
+                        "occult"
+                    ]
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "uncommon",
+                    "value": [
+                        "detection"
+                    ]
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.QnTtGCAvdWRU4spv"
+                }
+            },
+            "img": "systems/pf2e/icons/spells/detect-alignment.webp",
+            "name": "Detect Alignment (At Will) (Good Only)",
+            "sort": 700000,
+            "type": "spell"
+        },
+        {
+            "_id": "O7YsO4EwyIY6RIDs",
+            "data": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "custom": "",
+                    "value": [
+                        "vicious-wounds"
+                    ]
+                },
+                "bonus": {
+                    "value": 16
+                },
+                "damageRolls": {
+                    "f7aysg1od1qm8tt7db6q": {
+                        "damage": "2d10+3",
+                        "damageType": "piercing"
+                    },
+                    "z05z88pykuk0rfwe1m3p": {
+                        "damage": "1d6",
+                        "damageType": "evil"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "evil",
+                        "reach-10"
+                    ]
+                },
+                "weaponType": {
+                    "value": "melee"
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Jaws",
+            "sort": 800000,
+            "type": "melee"
+        },
+        {
+            "_id": "daIbHqtjaWyJns1q",
+            "data": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Darkvision]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "darkvision",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.qCCLZhnp2HhP3Ex6"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Darkvision",
+            "sort": 900000,
+            "type": "action"
+        },
+        {
+            "_id": "hperRozJh0EXe7iX",
+            "data": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Telepathy]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "telepathy",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "aura",
+                        "divination",
+                        "magical"
+                    ]
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.kdhbPaBMK1d1fpbA"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Telepathy 100 feet",
+            "sort": 1000000,
+            "type": "action"
+        },
+        {
+            "_id": "zSXEX1BIW9Kopq1o",
+            "data": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.AtWillSpells]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "at-will-spells",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.2YRDYVnC1eljaXKK"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "At-Will Spells",
+            "sort": 1100000,
+            "type": "action"
+        },
+        {
+            "_id": "nxwLnaNtKUpRi5Rp",
+            "data": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.ConstantSpells]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "constant-spells",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.kakyXBG5WA8c6Zfd"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Constant Spells",
+            "sort": 1200000,
+            "type": "action"
+        },
+        {
+            "_id": "qf9VkXweMZaEf2DP",
+            "data": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "description": {
+                    "value": "<p>The ceustodaemon breathes flames in a @Template[type:cone|distance:30]. Creatures in the cone take [[/r {6d6}[fire]]]{6d6 fire damage} (@Check[type:reflex|dc:22|basic:true] save).</p>\n<p>The ceustodaemon and each creature that fails the save catch fire, taking [[/r {1d6}[persistent,fire]]]@Compendium[pf2e.conditionitems.Persistent Damage]{Persistent Fire Damage}.</p>\n<p>The breath weapon can't be used again for [[/br 1d4 #rounds]]{1d4 rounds}.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "divine",
+                        "evocation",
+                        "fire"
+                    ]
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Breath Weapon",
+            "sort": 1300000,
+            "type": "action"
+        },
+        {
+            "_id": "WI20ZnQYqmSIaz3B",
+            "data": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>When bringing a ceustodaemon to another plane with effects like a <em>@Compendium[pf2e.spells-srd.Planar Binding]{Planar Binding}</em> or <em>@Compendium[pf2e.spells-srd.Planar Ally]{Planar Ally}</em> ritual, the primary and secondary skill DCs are reduced by 5, and the ceustodaemon demands only half the normal cost for its service.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Drawn to Service",
+            "sort": 1400000,
+            "type": "action"
+        },
+        {
+            "_id": "5McIXOemuKXFd7Ep",
+            "data": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>On a successful jaws or claw Strike, the ceustodaemon viciously tears into its victim as similar wounds appear on its own body. The target takes an extra [[/r {1d6}]]{1d6 amount of damage}, and the ceustodaemon takes the same extra damage.</p>\n<p>If this extra damage to the target is doubled, due to a critical hit, the ceustodaemon takes double damage as well.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [
+                    {
+                        "diceNumber": 1,
+                        "dieSize": "d6",
+                        "key": "DamageDice",
+                        "selector": "strike-damage"
+                    }
+                ],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Vicious Wounds",
+            "sort": 1500000,
+            "type": "action"
+        },
+        {
+            "_id": "XiG0lbluOpyjxtSS",
+            "data": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 13
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Deception",
+            "sort": 1600000,
+            "type": "lore"
+        },
+        {
+            "_id": "B0skQV8cwnqigOEX",
+            "data": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 11
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Intimidation",
+            "sort": 1700000,
+            "type": "lore"
+        },
+        {
+            "_id": "j5ipJB3fExiWk57S",
+            "data": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 10
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Stealth",
+            "sort": 1800000,
+            "type": "lore"
+        },
+        {
+            "_id": "Bg0HDQ2k1BjsssJL",
+            "data": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 8
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Survival",
+            "sort": 1900000,
+            "type": "lore"
+        }
+    ],
+    "name": "Weak Ceustodaemon (PFS 1-01)",
+    "token": {
+        "disposition": -1,
+        "height": 2,
+        "img": "systems/pf2e/icons/default-icons/npc.svg",
+        "name": "Ceustodaemon",
+        "width": 2
+    },
+    "type": "npc"
+}

--- a/packs/data/pfs-season-1-bestiary.db/whispering-souls.json
+++ b/packs/data/pfs-season-1-bestiary.db/whispering-souls.json
@@ -9,9 +9,9 @@
             "hasHealth": true,
             "hp": {
                 "details": "",
-                "max": 10,
+                "max": 0,
                 "temp": 0,
-                "value": 10
+                "value": 0
             },
             "stealth": {
                 "details": "<p>(trained) to hear the whispers from a distance</p>",
@@ -21,10 +21,10 @@
         "creatureType": "",
         "details": {
             "description": "<p>Lost spirits whisper, reliving their last moments, ready to drag the living into their illusion.</p>",
-            "disable": "<p>Religion DC 19 (trained) to suppress the spirits or Performance DC 19 (trained) to drown them out</p>",
+            "disable": "<p>@Check[type:religion|dc:19](trained) to suppress the spirits or @Check[type:performance|dc:19](trained) to drown them out</p>",
             "isComplex": false,
             "level": {
-                "value": 2
+                "value": 4
             },
             "reset": "<p>The underlying spirits remain, resetting the haunt every midnight, until what truly happened here becomes public.</p>",
             "routine": ""
@@ -44,7 +44,8 @@
             }
         },
         "source": {
-            "value": ""
+            "author": "",
+            "value": "Pathfinder Society Scenario #1-01: The Absalom Initiation"
         },
         "statusEffects": [],
         "traits": {

--- a/packs/data/pfs-season-1-bestiary.db/whispering-souls.json
+++ b/packs/data/pfs-season-1-bestiary.db/whispering-souls.json
@@ -21,7 +21,7 @@
         "creatureType": "",
         "details": {
             "description": "<p>Lost spirits whisper, reliving their last moments, ready to drag the living into their illusion.</p>",
-            "disable": "<p>@Check[type:religion|dc:19](trained) to suppress the spirits or @Check[type:performance|dc:19](trained) to drown them out</p>",
+            "disable": "<p>@Check[type:religion|dc:19|name:Supress the Spirits](trained) to suppress the spirits or @Check[type:performance|dc:19|name:Drown Out the Spirits](trained) to drown them out</p>",
             "isComplex": false,
             "level": {
                 "value": 4

--- a/packs/data/pfs-season-1-bestiary.db/whispering-spirits.json
+++ b/packs/data/pfs-season-1-bestiary.db/whispering-spirits.json
@@ -9,9 +9,9 @@
             "hasHealth": true,
             "hp": {
                 "details": "",
-                "max": 10,
+                "max": 0,
                 "temp": 0,
-                "value": 10
+                "value": 0
             },
             "stealth": {
                 "details": "<p>(trained) to hear the whispers from a distance</p>",
@@ -21,7 +21,7 @@
         "creatureType": "",
         "details": {
             "description": "<p>Lost spirits whisper, reliving their last moments, ready to drag the living into their illusion.</p>",
-            "disable": "<p>Religion DC 16 (trained) to suppress the spirits or Performance DC 16 (trained) to drown them out</p>",
+            "disable": "<p>@Check[type:religion|dc:16](trained) to suppress the spirits or @Check[type:performance|dc:16](trained) to drown them out</p>",
             "isComplex": false,
             "level": {
                 "value": 2
@@ -44,7 +44,8 @@
             }
         },
         "source": {
-            "value": ""
+            "author": "",
+            "value": "Pathfinder Society Scenario #1-01: The Absalom Initiation"
         },
         "statusEffects": [],
         "traits": {

--- a/packs/data/pfs-season-1-bestiary.db/whispering-spirits.json
+++ b/packs/data/pfs-season-1-bestiary.db/whispering-spirits.json
@@ -21,7 +21,7 @@
         "creatureType": "",
         "details": {
             "description": "<p>Lost spirits whisper, reliving their last moments, ready to drag the living into their illusion.</p>",
-            "disable": "<p>@Check[type:religion|dc:16](trained) to suppress the spirits or @Check[type:performance|dc:16](trained) to drown them out</p>",
+            "disable": "<p>@Check[type:religion|dc:16|name:Supress the Spirits](trained) to suppress the spirits or @Check[type:performance|dc:16|name:Drown Out the Spirits](trained) to drown them out</p>",
             "isComplex": false,
             "level": {
                 "value": 2


### PR DESCRIPTION
Corrects B1 Goblin Pyro, which had its own strike block for torch (improvised, autogenerated one was incorrect).
Closes #1601 