### PR TITLE
Update Blade Ally Effects

### DIFF
--- a/packs/data/feat-effects.db/effect-blade-ally-anarchic-rune.json
+++ b/packs/data/feat-effects.db/effect-blade-ally-anarchic-rune.json
@@ -1,6 +1,7 @@
 {
     "_id": "xLXFK4mtzgAF4zvx",
     "data": {
+        "badge": null,
         "description": {
             "value": "<p>An <em>anarchic</em> rune is jagged and asymmetrical, channeling chaotic energy. A weapon with this rune deals an additional 1d6 chaotic damage against lawful targets. If you are lawful, you are @Compendium[pf2e.conditionitems.Enfeebled]{Enfeebled 2} while carrying or wielding this weapon.</p>\n<p>When you critically succeed at a Strike with this weapon against a lawful creature, roll 1d6. On a 1 or 2, you deal double minimum damage; on a 3 or 4, double your damage normally; on a 5 or 6, you deal double maximum damage.</p>\n<p><strong>Craft Requirements</strong> You are chaotic.</p>"
         },
@@ -22,12 +23,21 @@
                         "weapon"
                     ]
                 },
+                "flag": "weaponSelect",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
             {
                 "key": "Note",
-                "selector": "{item|flags.pf2e.rulesSelections.effectBladeAllyAnarchicRune}-damage",
+                "outcome": [
+                    "criticalSuccess"
+                ],
+                "predicate": {
+                    "all": [
+                        "target:trait:lawful"
+                    ]
+                },
+                "selector": "{item|flags.pf2e.rulesSelections.weaponSelect}-damage",
                 "text": "<strong>Anarchic</strong> When you critically succeed at a Strike with this weapon against a lawful creature, roll [[/r 1d6]]. On a 1 or 2, you deal double minimum damage; on a 3 or 4, double your damage normally; on a 5 or 6, you deal double maximum damage."
             },
             {
@@ -35,7 +45,20 @@
                 "diceNumber": 1,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "selector": "{item|flags.pf2e.rulesSelections.effectBladeAllyAnarchicRune}-damage"
+                "predicate": {
+                    "all": [
+                        "target:trait:lawful"
+                    ]
+                },
+                "selector": "{item|flags.pf2e.rulesSelections.weaponSelect}-damage"
+            },
+            {
+                "key": "CriticalSpecialization",
+                "predicate": {
+                    "all": [
+                        "weapon:id:{item|flags.pf2e.rulesSelections.weaponSelect}"
+                    ]
+                }
             }
         ],
         "source": {

--- a/packs/data/feat-effects.db/effect-blade-ally-anarchic-rune.json
+++ b/packs/data/feat-effects.db/effect-blade-ally-anarchic-rune.json
@@ -23,7 +23,7 @@
                         "weapon"
                     ]
                 },
-                "flag": "weaponSelect",
+                "flag": "weapon",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
@@ -37,7 +37,7 @@
                         "target:trait:lawful"
                     ]
                 },
-                "selector": "{item|flags.pf2e.rulesSelections.weaponSelect}-damage",
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-damage",
                 "text": "<strong>Anarchic</strong> When you critically succeed at a Strike with this weapon against a lawful creature, roll [[/r 1d6]]. On a 1 or 2, you deal double minimum damage; on a 3 or 4, double your damage normally; on a 5 or 6, you deal double maximum damage."
             },
             {
@@ -50,13 +50,13 @@
                         "target:trait:lawful"
                     ]
                 },
-                "selector": "{item|flags.pf2e.rulesSelections.weaponSelect}-damage"
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-damage"
             },
             {
                 "key": "CriticalSpecialization",
                 "predicate": {
                     "all": [
-                        "weapon:id:{item|flags.pf2e.rulesSelections.weaponSelect}"
+                        "weapon:id:{item|flags.pf2e.rulesSelections.weapon}"
                     ]
                 }
             }

--- a/packs/data/feat-effects.db/effect-blade-ally-axiomatic-rune.json
+++ b/packs/data/feat-effects.db/effect-blade-ally-axiomatic-rune.json
@@ -1,6 +1,7 @@
 {
     "_id": "ZzE6jPbCyUqEqhcb",
     "data": {
+        "badge": null,
         "description": {
             "value": "<p>Complex and symmetrical, an <em>axiomatic</em> rune imbues a weapon with lawful energy. A weapon with this rune deals an additional 1d6 lawful damage against chaotic targets. If you are chaotic, you are @Compendium[pf2e.conditionitems.Enfeebled]{Enfeebled 2} while carrying or wielding this weapon.</p>\n<p>When you critically succeed at an attack roll with this weapon against a chaotic creature, instead of rolling, count each weapon damage die as average damage rounded up (3 for d4, 4 for d6, 5 for d8, 6 for d10, 7 for d12).</p>\n<p><strong>Craft Requirements</strong> You are lawful.</p>"
         },
@@ -22,12 +23,21 @@
                         "weapon"
                     ]
                 },
+                "flag": "weaponSelect",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
             {
                 "key": "Note",
-                "selector": "{item|flags.pf2e.rulesSelections.effectBladeAllyAxiomaticRune}-damage",
+                "outcome": [
+                    "criticalSuccess"
+                ],
+                "predicate": {
+                    "all": [
+                        "target:trait:chaotic"
+                    ]
+                },
+                "selector": "{item|flags.pf2e.rulesSelections.weaponSelect}-damage",
                 "text": "<strong>Axiomatic</strong> When you critically succeed at an attack roll with this weapon against a chaotic creature, instead of rolling, count each weapon damage die as average damage rounded up (3 for d4, 4 for d6, 5 for d8, 6 for d10, 7 for d12)."
             },
             {
@@ -35,7 +45,20 @@
                 "diceNumber": 1,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "selector": "{item|flags.pf2e.rulesSelections.effectBladeAllyAxiomaticRune}-damage"
+                "predicate": {
+                    "all": [
+                        "target:trait:chaotic"
+                    ]
+                },
+                "selector": "{item|flags.pf2e.rulesSelections.weaponSelect}-damage"
+            },
+            {
+                "key": "CriticalSpecialization",
+                "predicate": {
+                    "all": [
+                        "weapon:id:{item|flags.pf2e.rulesSelections.weaponSelect}"
+                    ]
+                }
             }
         ],
         "source": {

--- a/packs/data/feat-effects.db/effect-blade-ally-axiomatic-rune.json
+++ b/packs/data/feat-effects.db/effect-blade-ally-axiomatic-rune.json
@@ -23,7 +23,7 @@
                         "weapon"
                     ]
                 },
-                "flag": "weaponSelect",
+                "flag": "weapon",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
@@ -37,7 +37,7 @@
                         "target:trait:chaotic"
                     ]
                 },
-                "selector": "{item|flags.pf2e.rulesSelections.weaponSelect}-damage",
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-damage",
                 "text": "<strong>Axiomatic</strong> When you critically succeed at an attack roll with this weapon against a chaotic creature, instead of rolling, count each weapon damage die as average damage rounded up (3 for d4, 4 for d6, 5 for d8, 6 for d10, 7 for d12)."
             },
             {
@@ -50,13 +50,13 @@
                         "target:trait:chaotic"
                     ]
                 },
-                "selector": "{item|flags.pf2e.rulesSelections.weaponSelect}-damage"
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-damage"
             },
             {
                 "key": "CriticalSpecialization",
                 "predicate": {
                     "all": [
-                        "weapon:id:{item|flags.pf2e.rulesSelections.weaponSelect}"
+                        "weapon:id:{item|flags.pf2e.rulesSelections.weapon}"
                     ]
                 }
             }

--- a/packs/data/feat-effects.db/effect-blade-ally-disrupting-rune-greater.json
+++ b/packs/data/feat-effects.db/effect-blade-ally-disrupting-rune-greater.json
@@ -23,7 +23,7 @@
                         "weapon"
                     ]
                 },
-                "flag": "weaponSelect",
+                "flag": "weapon",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
@@ -37,7 +37,7 @@
                         "target:trait:undead"
                     ]
                 },
-                "selector": "{item|flags.pf2e.rulesSelections.weaponSelect}-damage",
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-damage",
                 "text": "PF2E.WeaponPropertyRune.greaterDisrupting.Note.criticalSuccess"
             },
             {
@@ -50,13 +50,13 @@
                         "target:trait:undead"
                     ]
                 },
-                "selector": "{item|flags.pf2e.rulesSelections.weaponSelect}-damage"
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-damage"
             },
             {
                 "key": "CriticalSpecialization",
                 "predicate": {
                     "all": [
-                        "weapon:id:{item|flags.pf2e.rulesSelections.weaponSelect}"
+                        "weapon:id:{item|flags.pf2e.rulesSelections.weapon}"
                     ]
                 }
             }

--- a/packs/data/feat-effects.db/effect-blade-ally-disrupting-rune-greater.json
+++ b/packs/data/feat-effects.db/effect-blade-ally-disrupting-rune-greater.json
@@ -23,6 +23,7 @@
                         "weapon"
                     ]
                 },
+                "flag": "weaponSelect",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
@@ -36,7 +37,7 @@
                         "target:trait:undead"
                     ]
                 },
-                "selector": "{item|flags.pf2e.rulesSelections.effectBladeAllyDisruptingRuneGreater}-damage",
+                "selector": "{item|flags.pf2e.rulesSelections.weaponSelect}-damage",
                 "text": "PF2E.WeaponPropertyRune.greaterDisrupting.Note.criticalSuccess"
             },
             {
@@ -49,7 +50,15 @@
                         "target:trait:undead"
                     ]
                 },
-                "selector": "{item|flags.pf2e.rulesSelections.effectBladeAllyDisruptingRuneGreater}-damage"
+                "selector": "{item|flags.pf2e.rulesSelections.weaponSelect}-damage"
+            },
+            {
+                "key": "CriticalSpecialization",
+                "predicate": {
+                    "all": [
+                        "weapon:id:{item|flags.pf2e.rulesSelections.weaponSelect}"
+                    ]
+                }
             }
         ],
         "source": {

--- a/packs/data/feat-effects.db/effect-blade-ally-disrupting-rune.json
+++ b/packs/data/feat-effects.db/effect-blade-ally-disrupting-rune.json
@@ -23,7 +23,7 @@
                         "weapon"
                     ]
                 },
-                "flag": "weaponSelect",
+                "flag": "weapon",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
@@ -37,7 +37,7 @@
                         "target:trait:undead"
                     ]
                 },
-                "selector": "{item|flags.pf2e.rulesSelections.weaponSelect}-damage",
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-damage",
                 "text": "PF2E.WeaponPropertyRune.disrupting.Note.criticalSuccess"
             },
             {
@@ -50,13 +50,13 @@
                         "target:trait:undead"
                     ]
                 },
-                "selector": "{item|flags.pf2e.rulesSelections.weaponSelect}-damage"
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-damage"
             },
             {
                 "key": "CriticalSpecialization",
                 "predicate": {
                     "all": [
-                        "weapon:id:{item|flags.pf2e.rulesSelections.weaponSelect}"
+                        "weapon:id:{item|flags.pf2e.rulesSelections.weapon}"
                     ]
                 }
             }

--- a/packs/data/feat-effects.db/effect-blade-ally-disrupting-rune.json
+++ b/packs/data/feat-effects.db/effect-blade-ally-disrupting-rune.json
@@ -1,6 +1,7 @@
 {
     "_id": "eippbzuocVM6ftcj",
     "data": {
+        "badge": null,
         "description": {
             "value": "<p>A disrupting weapon pulses with positive energy, dealing an extra [[/r {1d6}[positive]]]{1d6 positive damage} to undead. On a critical hit, the undead is also @Compendium[pf2e.conditionitems.Enfeebled]{Enfeebled 1} until the end of your next turn.</p>"
         },
@@ -22,6 +23,7 @@
                         "weapon"
                     ]
                 },
+                "flag": "weaponSelect",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
@@ -35,8 +37,8 @@
                         "target:trait:undead"
                     ]
                 },
-                "selector": "{item|flags.pf2e.rulesSelections.effectBladeAllyDisruptingRune}-damage",
-                "text": "<strong>Disrupting</strong> On a critical hit, the undead is @Compendium[pf2e.conditionitems.Enfeebled]{Enfeebled 1} until the end of your next turn."
+                "selector": "{item|flags.pf2e.rulesSelections.weaponSelect}-damage",
+                "text": "PF2E.WeaponPropertyRune.disrupting.Note.criticalSuccess"
             },
             {
                 "damageType": "positive",
@@ -48,7 +50,15 @@
                         "target:trait:undead"
                     ]
                 },
-                "selector": "{item|flags.pf2e.rulesSelections.effectBladeAllyDisruptingRune}-damage"
+                "selector": "{item|flags.pf2e.rulesSelections.weaponSelect}-damage"
+            },
+            {
+                "key": "CriticalSpecialization",
+                "predicate": {
+                    "all": [
+                        "weapon:id:{item|flags.pf2e.rulesSelections.weaponSelect}"
+                    ]
+                }
             }
         ],
         "source": {

--- a/packs/data/feat-effects.db/effect-blade-ally-fearsome-rune.json
+++ b/packs/data/feat-effects.db/effect-blade-ally-fearsome-rune.json
@@ -20,7 +20,7 @@
                 "outcome": [
                     "criticalSuccess"
                 ],
-                "selector": "{item|flags.pf2e.rulesSelections.weaponSelect}-damage",
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-damage",
                 "text": "PF2E.WeaponPropertyRune.fearsome.Note.criticalSuccess"
             },
             {
@@ -31,7 +31,7 @@
                         "weapon"
                     ]
                 },
-                "flag": "weaponSelect",
+                "flag": "weapon",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
@@ -39,7 +39,7 @@
                 "key": "CriticalSpecialization",
                 "predicate": {
                     "all": [
-                        "weapon:id:{item|flags.pf2e.rulesSelections.weaponSelect}"
+                        "weapon:id:{item|flags.pf2e.rulesSelections.weapon}"
                     ]
                 }
             }

--- a/packs/data/feat-effects.db/effect-blade-ally-fearsome-rune.json
+++ b/packs/data/feat-effects.db/effect-blade-ally-fearsome-rune.json
@@ -20,7 +20,7 @@
                 "outcome": [
                     "criticalSuccess"
                 ],
-                "selector": "{item|flags.pf2e.rulesSelections.effectBladeAllyFearsomeRune}-damage",
+                "selector": "{item|flags.pf2e.rulesSelections.weaponSelect}-damage",
                 "text": "PF2E.WeaponPropertyRune.fearsome.Note.criticalSuccess"
             },
             {
@@ -31,8 +31,17 @@
                         "weapon"
                     ]
                 },
+                "flag": "weaponSelect",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
+            },
+            {
+                "key": "CriticalSpecialization",
+                "predicate": {
+                    "all": [
+                        "weapon:id:{item|flags.pf2e.rulesSelections.weaponSelect}"
+                    ]
+                }
             }
         ],
         "source": {

--- a/packs/data/feat-effects.db/effect-blade-ally-flaming-rune.json
+++ b/packs/data/feat-effects.db/effect-blade-ally-flaming-rune.json
@@ -20,7 +20,7 @@
                 "diceNumber": 1,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "selector": "{item|flags.pf2e.rulesSelections.effectBladeAllyFlamingRune}-damage"
+                "selector": "{item|flags.pf2e.rulesSelections.weaponSelect}-damage"
             },
             {
                 "choices": {
@@ -30,6 +30,7 @@
                         "weapon"
                     ]
                 },
+                "flag": "weaponSelect",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
@@ -38,8 +39,16 @@
                 "outcome": [
                     "criticalSuccess"
                 ],
-                "selector": "{item|flags.pf2e.rulesSelections.effectBladeAllyFlamingRune}-damage",
+                "selector": "{item|flags.pf2e.rulesSelections.weaponSelect}-damage",
                 "text": "PF2E.WeaponPropertyRune.flaming.Note.criticalSuccess"
+            },
+            {
+                "key": "CriticalSpecialization",
+                "predicate": {
+                    "all": [
+                        "weapon:id:{item|flags.pf2e.rulesSelections.weaponSelect}"
+                    ]
+                }
             }
         ],
         "source": {

--- a/packs/data/feat-effects.db/effect-blade-ally-flaming-rune.json
+++ b/packs/data/feat-effects.db/effect-blade-ally-flaming-rune.json
@@ -20,7 +20,7 @@
                 "diceNumber": 1,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "selector": "{item|flags.pf2e.rulesSelections.weaponSelect}-damage"
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-damage"
             },
             {
                 "choices": {
@@ -30,7 +30,7 @@
                         "weapon"
                     ]
                 },
-                "flag": "weaponSelect",
+                "flag": "weapon",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
@@ -39,14 +39,14 @@
                 "outcome": [
                     "criticalSuccess"
                 ],
-                "selector": "{item|flags.pf2e.rulesSelections.weaponSelect}-damage",
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-damage",
                 "text": "PF2E.WeaponPropertyRune.flaming.Note.criticalSuccess"
             },
             {
                 "key": "CriticalSpecialization",
                 "predicate": {
                     "all": [
-                        "weapon:id:{item|flags.pf2e.rulesSelections.weaponSelect}"
+                        "weapon:id:{item|flags.pf2e.rulesSelections.weapon}"
                     ]
                 }
             }

--- a/packs/data/feat-effects.db/effect-blade-ally-ghost-touch-rune.json
+++ b/packs/data/feat-effects.db/effect-blade-ally-ghost-touch-rune.json
@@ -23,7 +23,7 @@
                         "weapon"
                     ]
                 },
-                "flag": "weaponSelect",
+                "flag": "weapon",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
@@ -31,7 +31,7 @@
                 "key": "CriticalSpecialization",
                 "predicate": {
                     "all": [
-                        "weapon:id:{item|flags.pf2e.rulesSelections.weaponSelect}"
+                        "weapon:id:{item|flags.pf2e.rulesSelections.weapon}"
                     ]
                 }
             },
@@ -42,7 +42,7 @@
                         "target:trait:incorporeal"
                     ]
                 },
-                "selector": "{item|flags.pf2e.rulesSelections.weaponSelect}-damage",
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-damage",
                 "text": "PF2E.WeaponPropertyRune.ghostTouch.Note"
             }
         ],

--- a/packs/data/feat-effects.db/effect-blade-ally-ghost-touch-rune.json
+++ b/packs/data/feat-effects.db/effect-blade-ally-ghost-touch-rune.json
@@ -1,6 +1,7 @@
 {
     "_id": "Rgio0hasm2epEMfh",
     "data": {
+        "badge": null,
         "description": {
             "value": "<p>The weapon can harm creatures without physical form. A ghost touch weapon is particularly effective against incorporeal creatures, which almost always have a specific vulnerability to ghost touch weapons. Incorporeal creatures can touch, hold, and wield ghost touch weapons (unlike most physical objects).</p>"
         },
@@ -22,15 +23,27 @@
                         "weapon"
                     ]
                 },
+                "flag": "weaponSelect",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
             {
-                "key": "DamageDice",
-                "selector": "{item|flags.pf2e.rulesSelections.effectBladeAllyGhostTouchRune}-damage",
-                "traits": [
-                    "ghostTouch"
-                ]
+                "key": "CriticalSpecialization",
+                "predicate": {
+                    "all": [
+                        "weapon:id:{item|flags.pf2e.rulesSelections.weaponSelect}"
+                    ]
+                }
+            },
+            {
+                "key": "Note",
+                "predicate": {
+                    "all": [
+                        "target:trait:incorporeal"
+                    ]
+                },
+                "selector": "{item|flags.pf2e.rulesSelections.weaponSelect}-damage",
+                "text": "PF2E.WeaponPropertyRune.ghostTouch.Note"
             }
         ],
         "source": {

--- a/packs/data/feat-effects.db/effect-blade-ally-holy-rune.json
+++ b/packs/data/feat-effects.db/effect-blade-ally-holy-rune.json
@@ -23,7 +23,7 @@
                         "weapon"
                     ]
                 },
-                "flag": "weaponSelect",
+                "flag": "weapon",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
@@ -37,7 +37,7 @@
                         "target:trait:evil"
                     ]
                 },
-                "selector": "{item|flags.pf2e.rulesSelections.weaponSelect}-damage",
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-damage",
                 "text": "<strong>Holy</strong> <strong>Activate</strong> <span class=\"pf2-icon\">R</span> command</p>\n<p><strong>Frequency</strong> once per day</p>\n<p><strong>Trigger</strong> You critically succeed at an attack roll against an evil creature with the weapon</p>\n<hr />\n<p><strong>Effect</strong> You regain HP equal to double the evil creature's level. This is a good, positive, healing effect."
             },
             {
@@ -50,13 +50,13 @@
                         "target:trait:evil"
                     ]
                 },
-                "selector": "{item|flags.pf2e.rulesSelections.weaponSelect}-damage"
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-damage"
             },
             {
                 "key": "CriticalSpecialization",
                 "predicate": {
                     "all": [
-                        "weapon:id:{item|flags.pf2e.rulesSelections.weaponSelect}"
+                        "weapon:id:{item|flags.pf2e.rulesSelections.weapon}"
                     ]
                 }
             }

--- a/packs/data/feat-effects.db/effect-blade-ally-holy-rune.json
+++ b/packs/data/feat-effects.db/effect-blade-ally-holy-rune.json
@@ -1,6 +1,7 @@
 {
     "_id": "l98IthkklgLDJXIo",
     "data": {
+        "badge": null,
         "description": {
             "value": "<p><em>Holy</em> weapons command powerful celestial energy. A weapon with this rune deals an extra [[/r {1d6}[good]]]{1d6 good damage} against evil targets. If you are evil, you are @Compendium[pf2e.conditionitems.Enfeebled]{Enfeebled 2} while carrying or wielding this weapon.</p>\n<p><strong>Activate</strong> <span class=\"pf2-icon\">R</span> command</p>\n<p><strong>Frequency</strong> once per day</p>\n<p><strong>Trigger</strong> You critically succeed at an attack roll against an evil creature with the weapon</p>\n<hr />\n<p><strong>Effect</strong> You regain HP equal to double the evil creature's level. This is a good, positive, healing effect.</p>"
         },
@@ -22,12 +23,21 @@
                         "weapon"
                     ]
                 },
+                "flag": "weaponSelect",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
             {
                 "key": "Note",
-                "selector": "{item|flags.pf2e.rulesSelections.effectBladeAllyHolyRune}-damage",
+                "outcome": [
+                    "criticalSuccess"
+                ],
+                "predicate": {
+                    "all": [
+                        "target:trait:evil"
+                    ]
+                },
+                "selector": "{item|flags.pf2e.rulesSelections.weaponSelect}-damage",
                 "text": "<strong>Holy</strong> <strong>Activate</strong> <span class=\"pf2-icon\">R</span> command</p>\n<p><strong>Frequency</strong> once per day</p>\n<p><strong>Trigger</strong> You critically succeed at an attack roll against an evil creature with the weapon</p>\n<hr />\n<p><strong>Effect</strong> You regain HP equal to double the evil creature's level. This is a good, positive, healing effect."
             },
             {
@@ -35,7 +45,20 @@
                 "diceNumber": 1,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "selector": "{item|flags.pf2e.rulesSelections.effectBladeAllyHolyRune}-damage"
+                "predicate": {
+                    "all": [
+                        "target:trait:evil"
+                    ]
+                },
+                "selector": "{item|flags.pf2e.rulesSelections.weaponSelect}-damage"
+            },
+            {
+                "key": "CriticalSpecialization",
+                "predicate": {
+                    "all": [
+                        "weapon:id:{item|flags.pf2e.rulesSelections.weaponSelect}"
+                    ]
+                }
             }
         ],
         "source": {

--- a/packs/data/feat-effects.db/effect-blade-ally-keen-rune.json
+++ b/packs/data/feat-effects.db/effect-blade-ally-keen-rune.json
@@ -1,6 +1,7 @@
 {
     "_id": "Gf7h44DcTB43464h",
     "data": {
+        "badge": null,
         "description": {
             "value": "<p>The edges of a keen weapon are preternaturally sharp. Attacks with this weapon are a critical hit on a 19 on the die as long as that result is a success. This property has no effect on a 19 if the result would be a failure.</p>"
         },
@@ -22,13 +23,22 @@
                         "weapon"
                     ]
                 },
+                "flag": "weaponSelect",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
             {
                 "key": "Note",
-                "selector": "{item|flags.pf2e.rulesSelections.effectBladeAllyKeenRune}-attack",
-                "text": "<strong>Keen</strong> Attacks with this weapon are a critical hit on a 19 on the die as long as that result is a success. This property has no effect on a 19 if the result would be a failure."
+                "selector": "{item|flags.pf2e.rulesSelections.weaponSelect}-attack",
+                "text": "PF2E.WeaponPropertyRune.keen.Note"
+            },
+            {
+                "key": "CriticalSpecialization",
+                "predicate": {
+                    "all": [
+                        "weapon:id:{item|flags.pf2e.rulesSelections.weaponSelect}"
+                    ]
+                }
             }
         ],
         "source": {

--- a/packs/data/feat-effects.db/effect-blade-ally-keen-rune.json
+++ b/packs/data/feat-effects.db/effect-blade-ally-keen-rune.json
@@ -23,20 +23,20 @@
                         "weapon"
                     ]
                 },
-                "flag": "weaponSelect",
+                "flag": "weapon",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
             {
                 "key": "Note",
-                "selector": "{item|flags.pf2e.rulesSelections.weaponSelect}-attack",
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-attack",
                 "text": "PF2E.WeaponPropertyRune.keen.Note"
             },
             {
                 "key": "CriticalSpecialization",
                 "predicate": {
                     "all": [
-                        "weapon:id:{item|flags.pf2e.rulesSelections.weaponSelect}"
+                        "weapon:id:{item|flags.pf2e.rulesSelections.weapon}"
                     ]
                 }
             }

--- a/packs/data/feat-effects.db/effect-blade-ally-unholy-rune.json
+++ b/packs/data/feat-effects.db/effect-blade-ally-unholy-rune.json
@@ -1,6 +1,7 @@
 {
     "_id": "rGSc2PtvU3mgm18S",
     "data": {
+        "badge": null,
         "description": {
             "value": "<p>An <em>unholy</em> rune instills fiendish power into the etched weapon. A weapon with this rune deals an additional [[/r {1d6}[evil]]]{1d6 evil damage} when it hits a good target. If you are good, you are @Compendium[pf2e.conditionitems.Enfeebled]{Enfeebled 2} while carrying or wielding this weapon.</p>\n<p><strong>Activate</strong> <span class=\"pf2-icon\">R</span> command</p>\n<p><strong>Frequency</strong> once per day</p>\n<p><strong>Trigger</strong> You critically succeed at an attack roll against a good creature with the weapon</p>\n<hr />\n<p><strong>Effect</strong> The target takes @Localize[PF2E.PersistentDamage.Bleed1d8.success] per weapon damage die of the etched weapon.</p>"
         },
@@ -22,12 +23,21 @@
                         "weapon"
                     ]
                 },
+                "flag": "weaponSelect",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
             {
                 "key": "Note",
-                "selector": "{item|flags.pf2e.rulesSelections.effectBladeAllyUnholyRune}-damage",
+                "outcome": [
+                    "criticalSuccess"
+                ],
+                "predicate": {
+                    "all": [
+                        "target:trait:good"
+                    ]
+                },
+                "selector": "{item|flags.pf2e.rulesSelections.weaponSelect}-damage",
                 "text": "<strong>Unholy</strong> <strong>Activate</strong> <span class=\"pf2-icon\">R</span> command</p>\n<p><strong>Frequency</strong> once per day</p>\n<p><strong>Trigger</strong> You critically succeed at an attack roll against a good creature with the weapon</p>\n<hr />\n<p><strong>Effect</strong> The target takes @Localize[PF2E.PersistentDamage.Bleed1d8.success] per weapon damage die of the etched weapon."
             },
             {
@@ -35,7 +45,20 @@
                 "diceNumber": 1,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "selector": "{item|flags.pf2e.rulesSelections.effectBladeAllyUnholyRune}-damage"
+                "predicate": {
+                    "all": [
+                        "target:trait:good"
+                    ]
+                },
+                "selector": "{item|flags.pf2e.rulesSelections.weaponSelect}-damage"
+            },
+            {
+                "key": "CriticalSpecialization",
+                "predicate": {
+                    "all": [
+                        "weapon:id:{item|flags.pf2e.rulesSelections.weaponSelect}"
+                    ]
+                }
             }
         ],
         "source": {

--- a/packs/data/feat-effects.db/effect-blade-ally-unholy-rune.json
+++ b/packs/data/feat-effects.db/effect-blade-ally-unholy-rune.json
@@ -23,7 +23,7 @@
                         "weapon"
                     ]
                 },
-                "flag": "weaponSelect",
+                "flag": "weapon",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
@@ -37,7 +37,7 @@
                         "target:trait:good"
                     ]
                 },
-                "selector": "{item|flags.pf2e.rulesSelections.weaponSelect}-damage",
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-damage",
                 "text": "<strong>Unholy</strong> <strong>Activate</strong> <span class=\"pf2-icon\">R</span> command</p>\n<p><strong>Frequency</strong> once per day</p>\n<p><strong>Trigger</strong> You critically succeed at an attack roll against a good creature with the weapon</p>\n<hr />\n<p><strong>Effect</strong> The target takes @Localize[PF2E.PersistentDamage.Bleed1d8.success] per weapon damage die of the etched weapon."
             },
             {
@@ -50,13 +50,13 @@
                         "target:trait:good"
                     ]
                 },
-                "selector": "{item|flags.pf2e.rulesSelections.weaponSelect}-damage"
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-damage"
             },
             {
                 "key": "CriticalSpecialization",
                 "predicate": {
                     "all": [
-                        "weapon:id:{item|flags.pf2e.rulesSelections.weaponSelect}"
+                        "weapon:id:{item|flags.pf2e.rulesSelections.weapon}"
                     ]
                 }
             }


### PR DESCRIPTION
Closes #2867 
Adds Critical Specialization Rule Elements to `Effect: Blade Ally x`
Update ChoiceSet with `"flag":"weaponSelect"`
Updated all REs to use new flag.
Update Effect: Blade Ally Disrupting Rune note RE
Update several REs to predicate on correct traits (evil, good etc.)