### PR TITLE
Update spell variant implementation

### DIFF
--- a/src/module/actor/sheet/item-summary-renderer.ts
+++ b/src/module/actor/sheet/item-summary-renderer.ts
@@ -247,7 +247,7 @@ export class CreatureSheetItemRenderer<AType extends CreaturePF2e> extends ItemS
                     if (item instanceof ConsumablePF2e) item.consume();
                     break;
                 case "selectVariant":
-                    spell?.variantPrompt().then((variant) => variant?.toMessage());
+                    spell?.toMessage();
                     break;
             }
         });

--- a/src/module/chat-message/index.ts
+++ b/src/module/chat-message/index.ts
@@ -170,6 +170,11 @@ class ChatMessagePF2e extends ChatMessage<ActorPF2e> {
         // Show/Hide GM only sections, DCs, and other such elements
         UserVisibilityPF2e.process($html, { message: this });
 
+        // Remove spell card owner buttons if the user is not the owner of the spell
+        if (this.item?.isOfType("spell") && !this.item.isOwner) {
+            $html.find("section.owner-buttons").remove();
+        }
+
         // Remove entire .target-dc and .dc-result elements if they are empty after user-visibility processing
         const targetDC = $html[0].querySelector(".target-dc");
         if (targetDC?.innerHTML.trim() === "") targetDC.remove();

--- a/src/module/chat-message/listeners/cards.ts
+++ b/src/module/chat-message/listeners/cards.ts
@@ -70,7 +70,34 @@ export const ChatCards = {
                 else if (action === "spellDamage") spell?.rollDamage(event);
                 else if (action === "spellCounteract") spell?.rollCounteract(event);
                 else if (action === "spellTemplate") spell?.placeTemplate();
-                else if (action === "selectVariant") (await spell?.variantPrompt())?.toMessage();
+                else if (action === "selectVariant") {
+                    const spellLvl = Number($html.find<HTMLDivElement>("div.chat-card").attr("data-spell-lvl")) || 1;
+                    const overlayIdString = $button.attr("data-overlay-ids");
+                    const originalId = $button.attr("data-original-id") ?? "";
+                    if (overlayIdString) {
+                        const overlayIds = overlayIdString.split(",").map((id) => id.trim());
+                        const variantSpell = spell?.loadVariant({ overlayIds, castLevel: spellLvl });
+                        if (variantSpell) {
+                            const variantMessage = await variantSpell.toMessage(undefined, {
+                                create: false,
+                                data: { spellLvl },
+                            });
+                            if (variantMessage) {
+                                const messageSource = variantMessage.toObject();
+                                await message.update(messageSource);
+                            }
+                        }
+                    } else if (originalId) {
+                        const originalSpell = actor.items.get(originalId, { strict: true });
+                        const originalMessage = await originalSpell.toMessage(undefined, {
+                            create: false,
+                            data: { spellLvl },
+                        });
+                        if (originalMessage) {
+                            await message.update(originalMessage.toObject());
+                        }
+                    }
+                }
                 // Consumable usage
                 else if (action === "consume") {
                     if (item instanceof ConsumablePF2e) {

--- a/src/module/item/spell/overlay.ts
+++ b/src/module/item/spell/overlay.ts
@@ -1,4 +1,3 @@
-import { PickAThingPrompt, PickAThingConstructorArgs, PickableThing } from "@module/apps/pick-a-thing-prompt";
 import { SpellOverlay, SpellOverlayType, SpellSource } from "./data";
 import { ErrorPF2e } from "@util";
 import { SpellPF2e } from ".";
@@ -102,27 +101,4 @@ class SpellOverlayCollection extends Collection<SpellOverlay> {
     }
 }
 
-class SpellVariantPrompt extends PickAThingPrompt<Embedded<SpellPF2e>> {
-    constructor(data: PickAThingConstructorArgs<Embedded<SpellPF2e>>) {
-        super(data);
-        this.choices = data.choices ?? [];
-    }
-
-    static override get defaultOptions(): ApplicationOptions {
-        return {
-            ...super.defaultOptions,
-            width: "auto",
-            classes: ["choice-set-prompt"],
-        };
-    }
-
-    override get template(): string {
-        return "systems/pf2e/templates/items/spell-variant-prompt.html";
-    }
-
-    protected override getChoices(): PickableThing<Embedded<SpellPF2e>>[] {
-        return this.choices;
-    }
-}
-
-export { SpellOverlayCollection, SpellVariantPrompt };
+export { SpellOverlayCollection };

--- a/src/module/item/spell/sheet.ts
+++ b/src/module/item/spell/sheet.ts
@@ -308,7 +308,7 @@ export class SpellSheetPF2e extends ItemSheetPF2e<SpellPF2e> {
                             sortBefore: true,
                         });
                         for (const s of sorting) {
-                            await s.target.update({ sort: s.update.sort }, { render: false });
+                            await this.item.overlays.updateOverride(s.target, s.update, { render: false });
                         }
                         this.render(true);
                     }

--- a/src/module/item/spellcasting-entry/index.ts
+++ b/src/module/item/spellcasting-entry/index.ts
@@ -129,14 +129,6 @@ class SpellcastingEntryPF2e extends ItemPF2e implements SpellcastingEntry {
         spell: Embedded<SpellPF2e>,
         options: { slot?: number; level?: number; consume?: boolean; message?: boolean } = {}
     ): Promise<void> {
-        if (spell.hasVariants) {
-            const variant = await spell.variantPrompt();
-            if (variant) {
-                spell = variant;
-            } else {
-                return;
-            }
-        }
         const consume = options.consume ?? true;
         const message = options.message ?? true;
         const level = options.level ?? spell.level;

--- a/src/styles/legacy/_chat.scss
+++ b/src/styles/legacy/_chat.scss
@@ -58,6 +58,22 @@
 
         button {
             margin: 2px 0;
+
+            &.with-image {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+
+                img {
+                    border: none;
+                    height: 2em;
+                    margin-right: 0.5em;
+                }
+
+                span {
+                    border: none;
+                }
+            }
         }
 
         .owner-buttons {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1822,6 +1822,7 @@
                     "DeleteDialogText": "Are you sure you want to delete '{variantName}'?",
                     "LabelPlural": "Spell Variants",
                     "SelectVariantLabel": "Select Variant",
+                    "SelectOtherVariantLabel": "Select Other Variant",
                     "SheetTitle": "{originalName} (Variant)"
                 }
             },

--- a/static/templates/actors/spellcasting-spell-list.html
+++ b/static/templates/actors/spellcasting-spell-list.html
@@ -122,7 +122,7 @@
                             </div>
 
                             {{#if @root.options.editable}}
-                                <button type="button" class="cast-spell" data-action="cast-spell">{{#if spell.hasVariants}}{{localize "PF2E.SelectLabel"}}{{else}}{{localize "PF2E.CastLabel"}}{{/if}}</button>
+                                <button type="button" class="cast-spell" data-action="cast-spell">{{localize "PF2E.CastLabel"}}</button>
                                 {{#unless (and entry.isFlexible (not section.isCantrip))}}
                                     <div class="item-controls">
                                         {{#if entry.isPrepared}}

--- a/static/templates/chat/spell-card.html
+++ b/static/templates/chat/spell-card.html
@@ -19,14 +19,19 @@
     </section>
 
     <section class="card-buttons">
-        {{#if item.hasVariants}}
-            <button type="button" data-action="selectVariant">{{localize "PF2E.Item.Spell.Variants.SelectVariantLabel"}}</button>
-        {{else}}
-            {{#if data.isSave}}
-                <button type="button" data-action="save" data-save="{{data.save.type}}" data-dc="{{data.save.value}}" data-owner-title="{{data.save.breakdown}}">{{data.save.label}}</button>
-            {{/if}}
-            {{#if (or data.check data.hasDamage data.hasCounteractCheck.value data.area.areaType)}}
-                <section class="owner-buttons" data-visibility="owner">
+        {{#if data.isSave}}
+            <button type="button" data-action="save" data-save="{{data.save.type}}" data-dc="{{data.save.value}}" data-owner-title="{{data.save.breakdown}}">{{data.save.label}}</button>
+        {{/if}}
+        {{#if (or data.check data.hasDamage data.hasCounteractCheck.value data.area.areaType)}}
+            <section class="owner-buttons">
+                {{#if item.hasVariants}}
+                    {{#each data.variants as |variant|}}
+                        <button type="button" data-action="selectVariant" data-overlay-ids="{{variant.overlayIds}}"{{#if variant.actions}} class="with-image"{{/if}}>
+                            {{#if variant.actions}}<img src="{{variant.actions}}" />{{/if}}
+                            <span>{{variant.name}}</span>
+                        </button>
+                    {{/each}}
+                {{else}}
                     {{#if data.check}}
                         <div class="spell-attack-buttons">
                             <button type="button" data-action="spellAttack">{{localize "PF2E.AttackLabel"}}</button>
@@ -49,8 +54,11 @@
                             <button type="button" data-action="spellTemplate">{{localize "PF2E.Item.Spell.PlaceMeasuredTemplate" shape=data.areaType size=data.areaSize unit=data.areaUnit}}</button>
                         </div>
                     {{/if}}
-                </section>
-            {{/if}}
+                    {{#if item.isVariant}}
+                        <button type="button" data-action="selectVariant" data-original-id="{{item.original.id}}">{{localize "PF2E.Item.Spell.Variants.SelectOtherVariantLabel"}}</button>
+                    {{/if}}
+                {{/if}}
+            </section>
         {{/if}}
     </section>
 

--- a/static/templates/items/item-sheet.html
+++ b/static/templates/items/item-sheet.html
@@ -52,7 +52,11 @@
 
             <!-- Item Description -->
             <div class="tab item-description" data-tab="description">
-                {{editor content=(enrichHTML data.description.value item=document) target="data.description.value" button=true owner=owner editable=editable}}
+                {{#if (not isVariant)}}
+                    {{editor content=(enrichHTML data.description.value item=document) target="data.description.value" button=true owner=owner editable=editable}}
+                {{else}}
+                    {{{enrichHTML data.description.value}}}
+                {{/if}}
             </div>
 
             <!-- Item Details -->


### PR DESCRIPTION
- Remove the SpellVariantPrompt class.
- Show spell variants as inline buttons on the spell chat card.
- Update the existing chat card with the selected variant data.
- Add a button to variant spell chat cards that allows the selection of another variant.
- Disable editing the description of spell variants.
- Remove spell chat buttons for users that are not the owner of that spell.

![Recording 2022-07-07 at 23 15 14](https://user-images.githubusercontent.com/41452412/177874267-6f6203a7-8b7c-4e7e-90c5-46e17fb8ef11.gif)
