### PR TITLE
Remove redundant area-effect check on initial canvas-ready call

### DIFF
--- a/src/scripts/hooks/canvas-ready.ts
+++ b/src/scripts/hooks/canvas-ready.ts
@@ -10,6 +10,20 @@ export const CanvasReady = {
             for (const li of $("#chat-log").children("li")) {
                 SetAsInitiative.listen($(li));
             }
+
+            // Check area effects after the first canvas-ready call
+            Hooks.on("canvasReady", async () => {
+                const withAuraEffects = game.pf2e.effectTracker.auraEffects
+                    .filter(
+                        (e) =>
+                            e.actor.isOwner &&
+                            e.actor.getActiveTokens(false, true).some((t) => t.scene === canvas.scene)
+                    )
+                    .map((e) => e.actor);
+                for (const actor of new Set(withAuraEffects)) {
+                    actor.checkAreaEffects();
+                }
+            });
         });
 
         Hooks.on("canvasReady", () => {
@@ -24,13 +38,6 @@ export const CanvasReady = {
                     const { visible } = token;
                     await token.draw();
                     token.visible = visible;
-                }
-
-                // Recheck auras and aura effects when an active scene is (re)drawn
-                if (canvas.scene?.active) {
-                    for (const effect of game.pf2e.effectTracker.auraEffects) {
-                        await effect.actor.checkAreaEffects();
-                    }
                 }
             });
         });


### PR DESCRIPTION
Game initialization is such that ActorPF2e#checkAreaEffects is called twice, with the second from the canvasReady hook. If both calls find an effect to remove, they'll both send up a request to remove it get back an error from the server.