### PR TITLE
Fixed the healing bomb feat traits

### DIFF
--- a/packs/data/feats.db/healing-bomb.json
+++ b/packs/data/feats.db/healing-bomb.json
@@ -31,7 +31,7 @@
             "custom": "",
             "rarity": "common",
             "value": [
-                "additive 2",
+                "additive2",
                 "alchemist"
             ]
         }


### PR DESCRIPTION
The trait "Additive 2" does not appear in Foundry for the feat Healing Bomb. This is because it has the trait value "additive 2" instead of "additive2". 