### PR TITLE
Refactor feat group assignment into feat categories

### DIFF
--- a/src/module/actor/character/data/sheet.ts
+++ b/src/module/actor/character/data/sheet.ts
@@ -4,7 +4,7 @@ import { MagicTradition } from "@item/spell/types";
 import { CraftingEntry } from "@actor/character/crafting/entry";
 import { CraftingFormula } from "@actor/character/crafting/formula";
 import { FlattenedCondition } from "@system/conditions";
-import { CharacterSystemData } from ".";
+import { BonusFeat, CharacterSystemData, SlottedFeat } from ".";
 import { CreatureSheetData, SpellcastingSheetData } from "@actor/creature/types";
 import { CHARACTER_SHEET_TABS } from "./values";
 
@@ -70,6 +70,15 @@ interface CharacterSheetData extends CreatureSheetData<CharacterPF2e> {
     showPFSTab: boolean;
     spellcastingEntries: SpellcastingSheetData[];
     tabVisibility: CharacterSheetTabVisibility;
+    feats: FeatCategorySheetData[];
 }
 
-export { CharacterSheetData, CharacterSheetTabVisibility };
+interface FeatCategorySheetData {
+    id: string;
+    label: string;
+    feats: (SlottedFeat | BonusFeat)[];
+    /** Will move to sheet data later */
+    featFilter?: string;
+}
+
+export { CharacterSheetData, CharacterSheetTabVisibility, FeatCategorySheetData };

--- a/src/module/actor/character/data/types.ts
+++ b/src/module/actor/character/data/types.ts
@@ -31,7 +31,6 @@ import { ArmorCategory } from "@item/armor/data";
 import { ProficiencyRank } from "@item/data";
 import { DeitySystemData } from "@item/deity/data";
 import { DeityDomain } from "@item/deity/types";
-import { FeatType } from "@item/feat/data";
 import { MagicTradition } from "@item/spell/types";
 import { BaseWeaponType, WeaponCategory, WeaponGroup } from "@item/weapon/types";
 import { ZeroToFour } from "@module/data";
@@ -439,15 +438,6 @@ interface BonusFeat {
     grants: GrantedFeat[];
 }
 
-interface FeatSlot {
-    label: string;
-    feats: (SlottedFeat | BonusFeat)[];
-    /** Whether the feats are slotted by level or free-form */
-    slotted?: boolean;
-    featFilter?: string;
-    supported: FeatType[] | "all";
-}
-
 export {
     AuxiliaryAction,
     BaseWeaponProficiencyKey,
@@ -465,7 +455,6 @@ export {
     CharacterStrike,
     CharacterSystemData,
     ClassDCData,
-    FeatSlot,
     GrantedFeat,
     LinkedProficiency,
     MagicTraditionProficiencies,

--- a/src/module/actor/character/feats.ts
+++ b/src/module/actor/character/feats.ts
@@ -1,0 +1,264 @@
+import { FeatPF2e, ItemPF2e } from "@item";
+import { ItemGrantData } from "@item/data/base";
+import { FeatType } from "@item/feat/data";
+import { CharacterPF2e } from ".";
+import { BonusFeat, GrantedFeat, SlottedFeat } from "./data";
+
+type FeatSlotLevel = number | { id: string; label: string };
+
+interface FeatCategoryOptions {
+    id: string;
+    label: string;
+    featFilter?: string;
+    supported?: FeatType[];
+    levels?: FeatSlotLevel[];
+}
+
+class CharacterFeats extends Collection<FeatCategory> {
+    unorganized = new Array<BonusFeat>();
+
+    constructor(private actor: CharacterPF2e) {
+        super();
+
+        const classFeatSlots = actor.class?.grantedFeatSlots;
+        this.createCategory({
+            id: "ancestryfeature",
+            label: "PF2E.FeaturesAncestryHeader",
+            supported: ["ancestryfeature"],
+        });
+        this.createCategory({
+            id: "classfeature",
+            label: "PF2E.FeaturesClassHeader",
+            supported: ["classfeature"],
+        });
+        this.createCategory({
+            id: "ancestry",
+            label: "PF2E.FeatAncestryHeader",
+            featFilter: "ancestry-" + actor.ancestry?.slug,
+            supported: ["ancestry"],
+            levels: classFeatSlots?.ancestry ?? [],
+        });
+        this.createCategory({
+            id: "class",
+            label: "PF2E.FeatClassHeader",
+            featFilter: "classes-" + actor.class?.slug,
+            supported: ["class"],
+            levels: classFeatSlots?.class ?? [],
+        });
+
+        const evenLevels = new Array(actor.level)
+            .fill(0)
+            .map((_, idx) => idx)
+            .filter((idx) => idx && idx % 2 === 0);
+
+        // Add dual class if active
+        if (game.settings.get("pf2e", "dualClassVariant")) {
+            this.createCategory({
+                id: "dualclass",
+                label: "PF2E.FeatDualClassHeader",
+                supported: ["class"],
+                levels: [1, ...evenLevels],
+            });
+        }
+
+        // Add free archetype (if active)
+        if (game.settings.get("pf2e", "freeArchetypeVariant")) {
+            this.createCategory({
+                id: "archetype",
+                label: "PF2E.FeatArchetypeHeader",
+                supported: ["class"],
+                levels: evenLevels,
+            });
+        }
+
+        this.createCategory({
+            id: "skill",
+            label: "PF2E.FeatSkillHeader",
+            supported: ["skill"],
+            levels: classFeatSlots?.skill ?? [],
+        });
+        this.createCategory({
+            id: "general",
+            label: "PF2E.FeatGeneralHeader",
+            supported: ["general", "skill"],
+            levels: classFeatSlots?.general ?? [],
+        });
+
+        // Add campaign feats if enabled
+        if (game.settings.get("pf2e", "campaignFeats")) {
+            this.createCategory({ id: "campaign", label: "PF2E.FeatCampaignHeader" });
+        }
+
+        // Add background skill feat slot
+        const background = actor.background;
+        if (background && Object.keys(background.data.data.items).length > 0) {
+            this.get("skill").feats.unshift({
+                id: background.id,
+                level: game.i18n.localize("PF2E.FeatBackgroundShort"),
+                grants: [],
+            });
+        }
+    }
+
+    createCategory(options: FeatCategoryOptions) {
+        this.set(options.id, new FeatCategory(options));
+    }
+
+    private combineGrants(feat: FeatPF2e) {
+        const getGrantedItems = (grants: ItemGrantData[]): GrantedFeat[] => {
+            return grants.flatMap((grant) => {
+                const item = this.actor.items.get(grant.id);
+                return item?.isOfType("feat") && !item.data.data.location
+                    ? { feat: item, grants: getGrantedItems(item.data.flags.pf2e.itemGrants) }
+                    : [];
+            });
+        };
+
+        return { feat, grants: getGrantedItems(feat.data.flags.pf2e.itemGrants) };
+    }
+
+    async insertFeat(feat: FeatPF2e, options: { categoryId: string; slotId?: string }): Promise<ItemPF2e[]> {
+        const { categoryId, slotId } = options;
+        const group = this.get(categoryId);
+        const location = group?.slotted ? slotId ?? "" : categoryId;
+        const isFeatValidInSlot = group?.isFeatValid(feat);
+        const alreadyHasFeat = this.actor.items.has(feat.id);
+        const existing = this.actor.itemTypes.feat.filter((x) => x.data.data.location === location);
+
+        // Handle case where its actually dragging away from a location
+        if (alreadyHasFeat && feat.data.data.location && !isFeatValidInSlot) {
+            return this.actor.updateEmbeddedDocuments("Item", [{ _id: feat.id, "data.location": "" }]);
+        }
+
+        const changed: ItemPF2e[] = [];
+
+        // If this is a new feat, create a new feat item on the actor first
+        if (!alreadyHasFeat && isFeatValidInSlot) {
+            const source = feat.toObject();
+            source.data.location = location;
+            changed.push(...(await this.actor.createEmbeddedDocuments("Item", [source])));
+        }
+
+        // Determine what feats we have to move around
+        const locationUpdates = group?.slotted ? existing.map((x) => ({ _id: x.id, "data.location": "" })) : [];
+        if (alreadyHasFeat && isFeatValidInSlot) {
+            locationUpdates.push({ _id: feat.id, "data.location": location });
+        }
+
+        if (locationUpdates.length > 0) {
+            changed.push(...(await this.actor.updateEmbeddedDocuments("Item", locationUpdates)));
+        }
+
+        return changed;
+    }
+
+    assignFeats() {
+        const slotted = this.contents.filter((category) => category.slotted);
+        const categoryBySlot = slotted.reduce((previous: Partial<Record<string, FeatCategory>>, current) => {
+            for (const slot of Object.keys(current.slots)) {
+                previous[slot] = current;
+            }
+            return previous;
+        }, {});
+
+        // put the feats in their feat slots
+        const feats = this.actor.itemTypes.feat.sort((f1, f2) => f1.data.sort - f2.data.sort);
+        for (const feat of feats) {
+            if (feat.data.flags.pf2e.grantedBy && !feat.data.data.location) {
+                const granter = this.actor.items.get(feat.data.flags.pf2e.grantedBy.id);
+                if (granter?.isOfType("feat")) continue;
+            }
+
+            // We don't handle certain feat types here
+            if (["pfsboon", "deityboon", "curse"].includes(feat.featType)) {
+                continue;
+            }
+
+            const base = this.combineGrants(feat);
+
+            const location = feat.data.data.location;
+            const categoryForSlot = categoryBySlot[location ?? ""];
+            const slot = categoryForSlot?.slots[location ?? ""];
+            if (slot && slot.feat) {
+                console.debug(`Foundry VTT | Multiple feats with same index: ${feat.name}, ${slot.feat.name}`);
+                this.unorganized.push(base);
+            } else if (slot) {
+                slot.feat = feat;
+                slot.grants = base.grants;
+                feat.category = categoryForSlot;
+            } else {
+                // Perhaps this belongs to a un-slotted group matched on the location or
+                // on the feat type. Failing that, it gets dumped into bonuses.
+                const group = this.get(feat.data.data.location ?? "") ?? this.get(feat.featType);
+                if (group && !group.slotted) {
+                    group.feats.push(base);
+                    feat.category = group;
+                } else {
+                    this.unorganized.push(base);
+                }
+            }
+        }
+
+        this.get("classfeature").feats.sort((a, b) => (a.feat?.level || 0) - (b.feat?.level || 0));
+    }
+}
+
+interface CharacterFeats {
+    get(key: "ancestryfeature"): FeatCategory;
+    get(key: "classfeature"): FeatCategory;
+    get(key: "ancestry"): FeatCategory;
+    get(key: "class"): FeatCategory;
+    get(key: "skill"): FeatCategory;
+    get(key: "general"): FeatCategory;
+    get(key: string): FeatCategory | undefined;
+}
+
+class FeatCategory {
+    id: string;
+    label: string;
+    feats: (SlottedFeat | BonusFeat)[] = [];
+    /** Whether the feats are slotted by level or free-form */
+    slotted = false;
+    /** Will move to sheet data later */
+    featFilter?: string;
+
+    /** Feat Types that are supported */
+    supported: FeatType[] = [];
+
+    /** Lookup for the slots themselves */
+    slots: Record<string, SlottedFeat> = {};
+
+    constructor(options: FeatCategoryOptions) {
+        this.id = options.id;
+        this.label = options.label;
+        this.supported = options.supported ?? [];
+        this.featFilter = options.featFilter;
+        if (options.levels) {
+            this.slotted = true;
+            for (const level of options.levels) {
+                const { id, label } = typeof level === "object" ? level : { id: `${this.id}-${level}`, label: level };
+                const slot = { id, level: label, grants: [] };
+                this.feats.push(slot);
+                this.slots[id] = slot;
+            }
+        }
+    }
+
+    isFeatValid(feat: FeatPF2e): boolean {
+        const resolvedFeatType = (() => {
+            if (feat.featType === "archetype") {
+                if (feat.data.data.traits.value.includes("skill")) {
+                    return "skill";
+                } else {
+                    return "class";
+                }
+            }
+
+            return feat.featType;
+        })();
+
+        return this.supported.length === 0 || this.supported.includes(resolvedFeatType);
+    }
+}
+
+export { CharacterFeats, FeatCategory, FeatSlotLevel };

--- a/src/module/item/class/index.ts
+++ b/src/module/item/class/index.ts
@@ -1,4 +1,5 @@
 import { CharacterPF2e } from "@actor";
+import { FeatSlotLevel } from "@actor/character/feats";
 import { SaveType } from "@actor/types";
 import { SAVE_TYPES } from "@actor/values";
 import { ABCItemPF2e, FeatPF2e } from "@item";
@@ -31,6 +32,28 @@ class ClassPF2e extends ABCItemPF2e {
 
     get savingThrows(): Record<SaveType, ZeroToFour> {
         return this.data.data.savingThrows;
+    }
+
+    get grantedFeatSlots() {
+        const actorLevel = this.actor?.level ?? 0;
+        const filterLevels = (levels: number[]) => levels.filter((level) => actorLevel >= level) ?? [];
+        const system = this.data.data;
+
+        const ancestryLevels: FeatSlotLevel[] = filterLevels(system.ancestryFeatLevels.value);
+        if (game.settings.get("pf2e", "ancestryParagonVariant")) {
+            ancestryLevels.unshift({ id: "ancestry-bonus", label: "1" });
+            for (let level = 3; level <= actorLevel; level += 4) {
+                const index = (level + 1) / 2;
+                ancestryLevels.splice(index, 0, level);
+            }
+        }
+
+        return {
+            ancestry: ancestryLevels,
+            class: filterLevels(system.classFeatLevels.value),
+            skill: filterLevels(system.skillFeatLevels.value),
+            general: filterLevels(system.generalFeatLevels.value),
+        };
     }
 
     /** Include all class features in addition to any with the expected location ID */

--- a/src/module/item/feat/index.ts
+++ b/src/module/item/feat/index.ts
@@ -3,8 +3,11 @@ import { FeatData, FeatSource, FeatTrait, FeatType } from "./data";
 import { OneToThree } from "@module/data";
 import { UserPF2e } from "@module/user";
 import { sluggify } from "@util";
+import { FeatCategory } from "@actor/character/feats";
 
 class FeatPF2e extends ItemPF2e {
+    category!: FeatCategory | null;
+
     get featType(): FeatType {
         return this.data.data.featType.value;
     }
@@ -47,6 +50,8 @@ class FeatPF2e extends ItemPF2e {
 
     override prepareBaseData(): void {
         super.prepareBaseData();
+
+        this.category = null;
 
         // Handle legacy data with empty-string locations
         this.data.data.location ||= null;

--- a/static/templates/actors/character/tabs/feats.html
+++ b/static/templates/actors/character/tabs/feats.html
@@ -1,22 +1,22 @@
 <div class="tab feats feats-pane" data-group="primary" data-tab="feats">
-    {{#each actor.featSlots as |section sid|}}
-        <div class="feat-section"  {{#unless section.slotted}}data-slot-id="{{sid}}" data-feat-type="{{sid}}"{{/unless}}>
+    {{#each feats as |section|}}
+        <div class="feat-section" data-category-id="{{section.id}}">
             <h3 class="header">
                 {{localize section.label}}
-                <button type="button" class="feat-browse" title="{{localize "PF2E.OpenFeatBrowserTitle"}}" data-type="feat" data-filter="feattype-{{sid}},{{section.featFilter}}">
+                <button type="button" class="feat-browse" title="{{localize "PF2E.OpenFeatBrowserTitle"}}" data-type="feat" data-filter="feattype-{{section.id}},{{section.featFilter}}">
                     <i class="fas fa-search"></i>{{localize "PF2E.BrowseLabel"}}
                 </button>
             </h3>
             <ol class="actions-list directory-list item-list">
             {{#each section.feats as |featSlot fid|}}
                 {{#if featSlot.feat}}
-                    <li class="item feat-item" data-item-id="{{featSlot.feat.id}}" data-slot-id="{{featSlot.id}}" data-feat-type="{{sid}}">
+                    <li class="item feat-item" data-item-id="{{featSlot.feat.id}}" data-slot-id="{{featSlot.id}}" data-category-id="{{section.id}}">
                         <div class="item-name rollable">
                             <div class="feat-slot-title">
                                 {{#if section.slotted}}
                                     {{featSlot.level}}
-                                {{else}}
-                                    {{#if featSlot.feat.data.level.value}}{{featSlot.feat.data.level.value}}{{/if}}
+                                {{else if featSlot.feat.level}}
+                                    {{featSlot.feat.level}}
                                 {{/if}}
                             </div>
                             <div class="item-image">
@@ -33,14 +33,14 @@
                         {{> "systems/pf2e/templates/actors/character/partials/granted-feat.html" feat=featSlot}}
                     </li>
                 {{else}}
-                    <li class="item feat-item" data-slot-id="{{featSlot.id}}" data-feat-type="{{sid}}">
+                    <li class="item feat-item" data-slot-id="{{featSlot.id}}" data-category-id="{{section.id}}">
                         <div class="item-name">
                             <div class="feat-slot-title">{{featSlot.level}}</div>
                             <div class="item-placeholder">{{localize "PF2E.EmptySlot"}}</div>
                         </div>
                         <div class="item-controls">
                             {{#if @root.editable}}
-                                <a class="item-control feat-browse" data-filter="feattype-{{sid}},{{section.featFilter}}", data-level="{{featSlot.level}}"><i class="fas fa-plus-circle"></i></a>
+                                <a class="item-control feat-browse" data-filter="feattype-{{section.id}},{{section.featFilter}}", data-level="{{featSlot.level}}"><i class="fas fa-plus-circle"></i></a>
                             {{/if}}
                         </div>
                     </li>


### PR DESCRIPTION
Should be easier to add new custom feat groups after this. However the way feats are assigned still bothers me, but I don't know a good way to handle that yet. If actor.items is sorted, I could do it in prepareActorData() and it might be cleaner?

After this, it should be easy to store bonus feat categories in actor flags or homebrew settings or whatever and construct them.