### PR TITLE
Add target item traits as roll options for the Repair action

### DIFF
--- a/src/module/system/action-macros/crafting/repair.ts
+++ b/src/module/system/action-macros/crafting/repair.ts
@@ -37,6 +37,8 @@ async function repair(options: RepairActionOptions) {
             return;
         })();
 
+    const targetItemOptions = Array.from(item?.traits ?? []).map((trait) => `target:trait:${trait}`);
+
     ActionMacroHelpers.simpleRollActionCheck({
         actors: options.actors,
         statName: property,
@@ -54,7 +56,7 @@ async function repair(options: RepairActionOptions) {
         },
         modifiers: options.modifiers,
         rollOptions: ["all", checkType, stat, "action:repair"],
-        extraOptions: ["action:repair"],
+        extraOptions: ["action:repair", ...targetItemOptions],
         traits: ["exploration", "manipulate"],
         checkType,
         event: options.event,


### PR DESCRIPTION
For the Repair basic action, add all traits of the target item as roll options with the format "target:trait:xyz". This will allow situational modifiers to predicate on those traits.