### PR TITLE
Add spell variants for heal, harm, heal animal, heal companion

### DIFF
--- a/packs/data/spells.db/harm.json
+++ b/packs/data/spells.db/harm.json
@@ -37,7 +37,7 @@
             }
         },
         "description": {
-            "value": "<p>You channel negative energy to harm the living or heal the undead. If the target is a living creature, you deal 1d8 negative damage to it, and it gets a basic Fortitude save. If the target is a willing undead creature, you restore that amount of Hit Points. The number of actions you spend when Casting this Spell determines its targets, range, area, and other parameters.</p>\n<p><span class=\"pf2-icon\">1</span> (somatic) The spell has a range of touch.</p>\n<p><span class=\"pf2-icon\">2</span> (verbal, somatic) The spell has a range of 30 feet. If you're healing an undead creature, increase the Hit Points restored by 8. [[/r (@item.level)d8[negative]+@item.level*8[healing]]]{2-Action Negative Healing}</p>\n<p><span class=\"pf2-icon\">3</span> (material, verbal, somatic) You disperse negative energy in a 30-foot emanation. This targets all living and undead creatures in the area.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The amount of healing or damage increases by 1d8, and the extra healing for the 2-action version increases by 8.</p>"
+            "value": "<p>You channel negative energy to harm the living or heal the undead. If the target is a living creature, you deal 1d8 negative damage to it, and it gets a basic Fortitude save. If the target is a willing undead creature, you restore that amount of Hit Points. The number of actions you spend when Casting this Spell determines its targets, range, area, and other parameters.</p>\n<p><span class=\"pf2-icon\">1</span> <strong>(somatic)</strong> The spell has a range of touch.</p>\n<p><span class=\"pf2-icon\">2</span> <strong>(verbal, somatic)</strong> The spell has a range of 30 feet. If you're healing an undead creature, increase the Hit Points restored by 8.</p>\n<p><span class=\"pf2-icon\">3</span> <strong>(material, verbal, somatic)</strong> You disperse negative energy in a 30-foot emanation. This targets all living and undead creatures in the area.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The amount of healing or damage increases by 1d8, and the extra healing for the 2-action version increases by 8.</p>"
         },
         "duration": {
             "value": ""
@@ -60,6 +60,119 @@
         },
         "materials": {
             "value": ""
+        },
+        "overlays": {
+            "4gyp3qlsv5ywdyjq": {
+                "_id": "4gyp3qlsv5ywdyjq",
+                "data": {
+                    "area": {
+                        "areaType": "",
+                        "value": ""
+                    },
+                    "components": {
+                        "somatic": true,
+                        "verbal": true
+                    },
+                    "damage": {
+                        "value": {
+                            "0": {
+                                "applyMod": true,
+                                "value": "1d8+8"
+                            }
+                        }
+                    },
+                    "heightening": {
+                        "damage": {
+                            "0": "1d8+8"
+                        }
+                    },
+                    "range": {
+                        "value": "30 feet"
+                    },
+                    "save": {
+                        "basic": "",
+                        "value": ""
+                    },
+                    "spellType": {
+                        "value": "heal"
+                    },
+                    "target": {
+                        "value": "1 willing undead creature"
+                    },
+                    "time": {
+                        "value": "2"
+                    }
+                },
+                "name": "Harm (vs. Undead)",
+                "overlayType": "override",
+                "sort": 3
+            },
+            "pq7cxntbz4s8g5ik": {
+                "_id": "pq7cxntbz4s8g5ik",
+                "data": {
+                    "area": {
+                        "areaType": "",
+                        "value": ""
+                    },
+                    "components": {
+                        "somatic": true
+                    },
+                    "range": {
+                        "value": "touch"
+                    },
+                    "time": {
+                        "value": "1"
+                    }
+                },
+                "overlayType": "override",
+                "sort": 1
+            },
+            "rvhoa43rqqqp8izn": {
+                "_id": "rvhoa43rqqqp8izn",
+                "data": {
+                    "components": {
+                        "material": true,
+                        "somatic": true,
+                        "verbal": true
+                    },
+                    "range": {
+                        "value": ""
+                    },
+                    "target": {
+                        "value": "all living and undead creatures"
+                    },
+                    "time": {
+                        "value": "3"
+                    }
+                },
+                "overlayType": "override",
+                "sort": 4
+            },
+            "z04svm1cvfcxtplb": {
+                "_id": "z04svm1cvfcxtplb",
+                "data": {
+                    "area": {
+                        "areaType": "",
+                        "value": ""
+                    },
+                    "components": {
+                        "somatic": true,
+                        "verbal": true
+                    },
+                    "range": {
+                        "value": "30 feet"
+                    },
+                    "target": {
+                        "value": "1 living creature"
+                    },
+                    "time": {
+                        "value": "2"
+                    }
+                },
+                "name": "Harm (vs. Living)",
+                "overlayType": "override",
+                "sort": 2
+            }
         },
         "prepared": {
             "value": ""

--- a/packs/data/spells.db/heal-animal.json
+++ b/packs/data/spells.db/heal-animal.json
@@ -6,7 +6,7 @@
         },
         "area": {
             "areaType": "",
-            "value": null
+            "value": ""
         },
         "areasize": {
             "value": ""
@@ -15,6 +15,7 @@
             "value": "focus"
         },
         "components": {
+            "focus": false,
             "material": false,
             "somatic": true,
             "verbal": false
@@ -25,8 +26,10 @@
         "damage": {
             "value": {
                 "0": {
+                    "applyMod": false,
                     "type": {
                         "categories": [],
+                        "subtype": "",
                         "value": "healing"
                     },
                     "value": "1d8"
@@ -34,7 +37,7 @@
             }
         },
         "description": {
-            "value": "<p>You heal an animal's wounds, restoring 1d8 Hit Points to the target. The number of actions spent Casting this Spell determines its effect.</p>\n<ul>\n<li><span class=\"pf2-icon\">1</span> <strong>somatic</strong> The spell has a range of touch.</li>\n<li><span class=\"pf2-icon\">2</span> <strong>somatic, verbal</strong> The spell has a range of 30 feet and restores an additional 8 Hit Points to the target.</li>\n</ul>\n<hr />\n<p><strong>Heightened (+1)</strong> The amount of healing increases by 1d8, and the additional healing for the 2-action version increases by 8.</p>"
+            "value": "<p>You heal an animal's wounds, restoring 1d8 Hit Points to the target. The number of actions spent Casting this Spell determines its effect.</p>\n<p><span class=\"pf2-icon\">1</span> <strong>(somatic)</strong> The spell has a range of touch.</p>\n<p><span class=\"pf2-icon\">2</span> <strong>(somatic, verbal)</strong> The spell has a range of 30 feet and restores an additional 8 Hit Points to the target.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The amount of healing increases by 1d8, and the additional healing for the 2-action version increases by 8.</p>"
         },
         "duration": {
             "value": ""
@@ -57,6 +60,69 @@
         },
         "materials": {
             "value": ""
+        },
+        "overlays": {
+            "b1ms5uwp9vwblhkq": {
+                "_id": "b1ms5uwp9vwblhkq",
+                "data": {
+                    "area": {
+                        "value": ""
+                    },
+                    "components": {
+                        "verbal": true
+                    },
+                    "damage": {
+                        "value": {
+                            "0": {
+                                "applyMod": false,
+                                "type": {
+                                    "subtype": ""
+                                },
+                                "value": "1d8+8"
+                            }
+                        }
+                    },
+                    "heightening": {
+                        "damage": {
+                            "0": "1d8+8"
+                        }
+                    },
+                    "range": {
+                        "value": "30 feet"
+                    },
+                    "time": {
+                        "value": "2"
+                    }
+                },
+                "overlayType": "override",
+                "sort": 2
+            },
+            "md8ss7iwxhth4y5f": {
+                "_id": "md8ss7iwxhth4y5f",
+                "data": {
+                    "area": {
+                        "value": ""
+                    },
+                    "damage": {
+                        "value": {
+                            "0": {
+                                "applyMod": false,
+                                "type": {
+                                    "subtype": ""
+                                }
+                            }
+                        }
+                    },
+                    "range": {
+                        "value": "touch"
+                    },
+                    "time": {
+                        "value": "1"
+                    }
+                },
+                "overlayType": "override",
+                "sort": 1
+            }
         },
         "prepared": {
             "value": ""

--- a/packs/data/spells.db/heal-companion.json
+++ b/packs/data/spells.db/heal-companion.json
@@ -37,7 +37,7 @@
             }
         },
         "description": {
-            "value": "<p>You harness positive energy to heal your animal companion's wounds. You restore [[/r 1d10]] Hit Points to your animal companion. The number of actions you spend @Compendium[pf2e.actionspf2e.Cast a Spell]{Casting this Spell} determines range and other parameters.</p>\n<ul>\n<li><span class=\"pf2-icon\">1</span> (somatic) The spell has a range of touch.</li>\n<li><span class=\"pf2-icon\">2</span> (somatic, verbal) The spell has a range of 30 feet and restores an additional 8 Hit Points to the target.</li>\n</ul>\n<hr />\n<p><strong>Heightened (+1)</strong> The amount of healing increases by [[/r 1d10]], and the additional healing for the 2-action version increases by 8.</p>"
+            "value": "<p>You harness positive energy to heal your animal companion's wounds. You restore 1d10 Hit Points to your animal companion. The number of actions you spend Casting this Spell determines range and other parameters.</p>\n<p><span class=\"pf2-icon\">1</span> <strong>(somatic)</strong> The spell has a range of touch.</p>\n<p><span class=\"pf2-icon\">2</span> <strong>(somatic, verbal)</strong> The spell has a range of 30 feet and restores an additional 8 Hit Points to the target.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The amount of healing increases by 1d10, and the additional healing for the 2-action version increases by 8.</p>"
         },
         "duration": {
             "value": ""
@@ -60,6 +60,59 @@
         },
         "materials": {
             "value": ""
+        },
+        "overlays": {
+            "0e58gcb5dwwddtze": {
+                "_id": "0e58gcb5dwwddtze",
+                "data": {
+                    "components": {
+                        "somatic": true,
+                        "verbal": true
+                    },
+                    "damage": {
+                        "value": {
+                            "0": {
+                                "value": "1d10+8"
+                            }
+                        }
+                    },
+                    "description": {
+                        "value": "<p>You harness positive energy to heal your animal companion's wounds. You restore [[/r 1d10]] Hit Points to your animal companion. The number of actions you spend @Compendium[pf2e.actionspf2e.Cast a Spell]{Casting this Spell} determines range and other parameters.</p>\n<ul>\n<li><span class=\"pf2-icon\">1</span> (somatic) The spell has a range of touch.</li>\n<li><span class=\"pf2-icon\">2</span> (somatic, verbal) The spell has a range of 30 feet and restores an additional 8 Hit Points to the target.</li>\n</ul>\n<hr />\n<p><strong>Heightened (+1)</strong> The amount of healing increases by [[/r 1d10]], and the additional healing for the 2-action version increases by 8.</p>"
+                    },
+                    "heightening": {
+                        "damage": {
+                            "0": "1d10+8"
+                        }
+                    },
+                    "range": {
+                        "value": "30 ft"
+                    },
+                    "time": {
+                        "value": "2"
+                    }
+                },
+                "overlayType": "override",
+                "sort": 2
+            },
+            "9klvzqocf0qn2pkm": {
+                "_id": "9klvzqocf0qn2pkm",
+                "data": {
+                    "components": {
+                        "somatic": true
+                    },
+                    "description": {
+                        "value": "<p>You harness positive energy to heal your animal companion's wounds. You restore [[/r 1d10]] Hit Points to your animal companion. The number of actions you spend @Compendium[pf2e.actionspf2e.Cast a Spell]{Casting this Spell} determines range and other parameters.</p>\n<ul>\n<li><span class=\"pf2-icon\">1</span> (somatic) The spell has a range of touch.</li>\n<li><span class=\"pf2-icon\">2</span> (somatic, verbal) The spell has a range of 30 feet and restores an additional 8 Hit Points to the target.</li>\n</ul>\n<hr />\n<p><strong>Heightened (+1)</strong> The amount of healing increases by [[/r 1d10]], and the additional healing for the 2-action version increases by 8.</p>"
+                    },
+                    "range": {
+                        "value": "touch"
+                    },
+                    "time": {
+                        "value": "1"
+                    }
+                },
+                "overlayType": "override",
+                "sort": 1
+            }
         },
         "prepared": {
             "value": ""

--- a/packs/data/spells.db/heal.json
+++ b/packs/data/spells.db/heal.json
@@ -37,7 +37,7 @@
             }
         },
         "description": {
-            "value": "<p>You channel positive energy to heal the living or damage the undead. If the target is a willing living creature, you restore 1d8 Hit Points. If the target is undead, you deal that amount of positive damage to it, and it gets a basic Fortitude save. The number of actions you spend when Casting this Spell determines its targets, range, area, and other parameters.</p>\n<p><span class=\"pf2-icon\">1</span> (somatic) The spell has a range of touch.</p>\n<p><span class=\"pf2-icon\">2</span> (verbal, somatic) The spell has a range of 30 feet. If you're healing a living creature, increase the Hit Points restored by 8. [[/r (@item.level)d8[positive]+@item.level*8[healing]]]{2-Action Healing}</p>\n<p><span class=\"pf2-icon\">3</span> (material, somatic, verbal) You disperse positive energy in a 30-foot emanation. This targets all living and undead creatures in the burst.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The amount of healing or damage increases by 1d8, and the extra healing for the 2-action version increases by 8.</p>"
+            "value": "<p>You channel positive energy to heal the living or damage the undead. If the target is a willing living creature, you restore 1d8 Hit Points. If the target is undead, you deal that amount of positive damage to it, and it gets a basic Fortitude save. The number of actions you spend when Casting this Spell determines its targets, range, area, and other parameters.</p>\n<p><span class=\"pf2-icon\">1</span> <strong>(somatic)</strong> The spell has a range of touch.</p>\n<p><span class=\"pf2-icon\">2</span> <strong>(verbal, somatic)</strong> The spell has a range of 30 feet. If you're healing a living creature, increase the Hit Points restored by 8</p>\n<p><span class=\"pf2-icon\">3</span> <strong>(material, somatic, verbal)</strong> You disperse positive energy in a 30-foot emanation. This targets all living and undead creatures in the burst.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The amount of healing or damage increases by 1d8, and the extra healing for the 2-action version increases by 8.</p>"
         },
         "duration": {
             "value": ""
@@ -60,6 +60,119 @@
         },
         "materials": {
             "value": ""
+        },
+        "overlays": {
+            "37gy7l19tik74o4s": {
+                "_id": "37gy7l19tik74o4s",
+                "data": {
+                    "area": {
+                        "areaType": "",
+                        "value": ""
+                    },
+                    "components": {
+                        "somatic": true,
+                        "verbal": true
+                    },
+                    "damage": {
+                        "value": {
+                            "0": {
+                                "value": "1d8+8"
+                            }
+                        }
+                    },
+                    "heightenedLevel": {},
+                    "heightening": {
+                        "damage": {
+                            "0": "1d8+8"
+                        }
+                    },
+                    "range": {
+                        "value": "30 feet"
+                    },
+                    "save": {
+                        "basic": "",
+                        "value": ""
+                    },
+                    "time": {
+                        "value": "2"
+                    }
+                },
+                "name": "Heal (vs. Living)",
+                "overlayType": "override",
+                "sort": 2
+            },
+            "7qdtetowq348s9oc": {
+                "_id": "7qdtetowq348s9oc",
+                "data": {
+                    "area": {
+                        "areaType": "",
+                        "value": ""
+                    },
+                    "components": {
+                        "somatic": true
+                    },
+                    "heightenedLevel": {},
+                    "range": {
+                        "value": "touch"
+                    },
+                    "time": {
+                        "value": "1"
+                    }
+                },
+                "overlayType": "override",
+                "sort": 1
+            },
+            "7vbvdrv2cl87sqta": {
+                "_id": "7vbvdrv2cl87sqta",
+                "data": {
+                    "components": {
+                        "material": true,
+                        "somatic": true,
+                        "verbal": true
+                    },
+                    "heightenedLevel": {},
+                    "range": {
+                        "value": ""
+                    },
+                    "target": {
+                        "value": "all living and undead creatures"
+                    },
+                    "time": {
+                        "value": "3"
+                    }
+                },
+                "overlayType": "override",
+                "sort": 4
+            },
+            "lfxcoz2d3f8j2zq1": {
+                "_id": "lfxcoz2d3f8j2zq1",
+                "data": {
+                    "area": {
+                        "areaType": "",
+                        "value": ""
+                    },
+                    "components": {
+                        "somatic": true,
+                        "verbal": true
+                    },
+                    "heightenedLevel": {},
+                    "range": {
+                        "value": "30 feet"
+                    },
+                    "spellType": {
+                        "value": "save"
+                    },
+                    "target": {
+                        "value": "1 undead"
+                    },
+                    "time": {
+                        "value": "2"
+                    }
+                },
+                "name": "Heal (vs. Undead)",
+                "overlayType": "override",
+                "sort": 3
+            }
         },
         "prepared": {
             "value": ""


### PR DESCRIPTION
Heal and harm have two versions of the 2 action, for a living/undead target, so that the bonus healing for the correct target can be added.

Formatting of the spells aligned to match CRB (i.e. **(somatic)** rather than (somatic) or **somatic**, and no bullet before action symbol).