### PR TITLE
B3 - Add countered by and fed by effects to imperial dragons

### DIFF
--- a/packs/data/bestiary-effects.db/effect-countered-by-fire.json
+++ b/packs/data/bestiary-effects.db/effect-countered-by-fire.json
@@ -1,0 +1,57 @@
+{
+    "_id": "a4bZrBNL17zPjDiH",
+    "data": {
+        "badge": null,
+        "description": {
+            "value": "<p>The creature takes a -1 circumstance penalty to attack rolls and AC, and its jaws Strike doesn’t deal electricity damage.</p>"
+        },
+        "duration": {
+            "expiry": "turn-end",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "selector": "attack",
+                "type": "circumstance",
+                "value": -1
+            },
+            {
+                "key": "FlatModifier",
+                "selector": "ac",
+                "type": "circumstance",
+                "value": -1
+            },
+            {
+                "domain": "damage-roll",
+                "key": "RollOption",
+                "option": "countered-by-fire",
+                "value": true
+            }
+        ],
+        "source": {
+            "value": "Pathfinder Bestiary 3"
+        },
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "target": null,
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        }
+    },
+    "img": "systems/pf2e/icons/spells/wall-of-fire.webp",
+    "name": "Effect: Countered by Fire",
+    "type": "effect"
+}

--- a/packs/data/bestiary-effects.db/effect-countered-by-fire.json
+++ b/packs/data/bestiary-effects.db/effect-countered-by-fire.json
@@ -3,7 +3,7 @@
     "data": {
         "badge": null,
         "description": {
-            "value": "<p>The creature takes a -1 circumstance penalty to attack rolls and AC, and its jaws Strike doesn’t deal electricity damage.</p>"
+            "value": "<p>The creature takes a -1 circumstance penalty to attack rolls and AC, and its jaws Strike doesn't deal electricity damage.</p>"
         },
         "duration": {
             "expiry": "turn-end",

--- a/packs/data/bestiary-effects.db/effect-countered-by-water.json
+++ b/packs/data/bestiary-effects.db/effect-countered-by-water.json
@@ -3,7 +3,7 @@
     "data": {
         "badge": null,
         "description": {
-            "value": "<p>The creature takes a -1 circumstance penalty to attack rolls, and its jaws Strike doesn’t deal fire damage.</p>"
+            "value": "<p>The creature takes a -1 circumstance penalty to attack rolls, and its jaws Strike doesn't deal fire damage.</p>"
         },
         "duration": {
             "expiry": "turn-end",

--- a/packs/data/bestiary-effects.db/effect-countered-by-water.json
+++ b/packs/data/bestiary-effects.db/effect-countered-by-water.json
@@ -1,0 +1,51 @@
+{
+    "_id": "81XYZZ3H0GL8thdQ",
+    "data": {
+        "badge": null,
+        "description": {
+            "value": "<p>The creature takes a -1 circumstance penalty to attack rolls, and its jaws Strike doesn’t deal fire damage.</p>"
+        },
+        "duration": {
+            "expiry": "turn-end",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "selector": "attack",
+                "type": "circumstance",
+                "value": -1
+            },
+            {
+                "domain": "damage-roll",
+                "key": "RollOption",
+                "option": "countered-by-water",
+                "value": true
+            }
+        ],
+        "source": {
+            "value": "Pathfinder Bestiary 3"
+        },
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "target": null,
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        }
+    },
+    "img": "systems/pf2e/icons/spells/water-walk.webp",
+    "name": "Effect: Countered by Water",
+    "type": "effect"
+}

--- a/packs/data/bestiary-effects.db/effect-fed-by-wood.json
+++ b/packs/data/bestiary-effects.db/effect-fed-by-wood.json
@@ -3,7 +3,7 @@
     "data": {
         "badge": null,
         "description": {
-            "value": "<p>The fire damage from the creature’s jaws increases by one die.</p>"
+            "value": "<p>The fire damage from the creature's jaws increases by one die.</p>"
         },
         "duration": {
             "expiry": "turn-end",

--- a/packs/data/bestiary-effects.db/effect-fed-by-wood.json
+++ b/packs/data/bestiary-effects.db/effect-fed-by-wood.json
@@ -1,0 +1,46 @@
+{
+    "_id": "4FMFRlEC923CnLI7",
+    "data": {
+        "badge": null,
+        "description": {
+            "value": "<p>The fire damage from the creature’s jaws increases by one die.</p>"
+        },
+        "duration": {
+            "expiry": "turn-end",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "rules": [
+            {
+                "damageType": "fire",
+                "diceNumber": 1,
+                "dieSize": "d6",
+                "key": "DamageDice",
+                "selector": "jaws-damage"
+            }
+        ],
+        "source": {
+            "value": "Pathfinder Bestiary 3"
+        },
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "target": null,
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        }
+    },
+    "img": "systems/pf2e/icons/spells/shape-wood.webp",
+    "name": "Effect: Fed by Wood",
+    "type": "effect"
+}

--- a/packs/data/pathfinder-bestiary-3.db/adult-sky-dragon-spellcaster.json
+++ b/packs/data/pathfinder-bestiary-3.db/adult-sky-dragon-spellcaster.json
@@ -4258,43 +4258,12 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>If the sky dragon takes fire damage, the elemental magic of metal within them is tempered. Until the end of their next turn, they take a -1 circumstance penalty to attack rolls and AC, and their jaws Strikes don't deal electricity damage. This limitation ends if the dragon uses Breath Weapon.</p>"
+                    "value": "<p>If the sky dragon takes fire damage, the elemental magic of metal within them is tempered. Until the end of their next turn, they take a -1 circumstance penalty to attack rolls and AC, and their jaws Strikes don't deal electricity damage. This limitation ends if the dragon uses Breath Weapon.</p>\n<hr />\n<p>@Compendium[pf2e.bestiary-effects.Effect: Countered by Fire]{Effect: Countered by Fire}</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
-                "rules": [
-                    {
-                        "domain": "all",
-                        "key": "RollOption",
-                        "option": "countered-by-fire",
-                        "priority": 50,
-                        "toggleable": true,
-                        "value": false
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "predicate": {
-                            "all": [
-                                "countered-by-fire"
-                            ]
-                        },
-                        "selector": "attack",
-                        "type": "circumstance",
-                        "value": -1
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "predicate": {
-                            "all": [
-                                "countered-by-fire"
-                            ]
-                        },
-                        "selector": "ac",
-                        "type": "circumstance",
-                        "value": -1
-                    }
-                ],
+                "rules": [],
                 "slug": null,
                 "source": {
                     "value": ""

--- a/packs/data/pathfinder-bestiary-3.db/adult-sky-dragon.json
+++ b/packs/data/pathfinder-bestiary-3.db/adult-sky-dragon.json
@@ -1030,43 +1030,12 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>If the sky dragon takes fire damage, the elemental magic of metal within them is tempered. Until the end of their next turn, they take a -1 circumstance penalty to attack rolls and AC, and their jaws Strikes don't deal electricity damage. This limitation ends if the dragon uses Breath Weapon.</p>"
+                    "value": "<p>If the sky dragon takes fire damage, the elemental magic of metal within them is tempered. Until the end of their next turn, they take a -1 circumstance penalty to attack rolls and AC, and their jaws Strikes don't deal electricity damage. This limitation ends if the dragon uses Breath Weapon.</p>\n<hr />\n<p>@Compendium[pf2e.bestiary-effects.Effect: Countered by Fire]{Effect: Countered by Fire}</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
-                "rules": [
-                    {
-                        "domain": "all",
-                        "key": "RollOption",
-                        "option": "countered-by-fire",
-                        "priority": 50,
-                        "toggleable": true,
-                        "value": false
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "predicate": {
-                            "all": [
-                                "countered-by-fire"
-                            ]
-                        },
-                        "selector": "attack",
-                        "type": "circumstance",
-                        "value": -1
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "predicate": {
-                            "all": [
-                                "countered-by-fire"
-                            ]
-                        },
-                        "selector": "ac",
-                        "type": "circumstance",
-                        "value": -1
-                    }
-                ],
+                "rules": [],
                 "slug": null,
                 "source": {
                     "value": ""

--- a/packs/data/pathfinder-bestiary-3.db/adult-underworld-dragon-spellcaster.json
+++ b/packs/data/pathfinder-bestiary-3.db/adult-underworld-dragon-spellcaster.json
@@ -3421,31 +3421,12 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>If the underworld dragon takes damage from a spell with the cold or water trait, the elemental magic of fire within them is momentarily dampened.</p>\n<p>Until the end of their next turn, they take a -1 circumstance penalty to attack rolls, and their jaws Strikes don't deal fire damage, and they lose their sweltering heat aura.</p>\n<p>This limitation ends if the dragon uses Breath Weapon.</p>"
+                    "value": "<p>If the underworld dragon takes damage from a spell with the cold or water trait, the elemental magic of fire within them is momentarily dampened.</p>\n<p>Until the end of their next turn, they take a -1 circumstance penalty to attack rolls, and their jaws Strikes don't deal fire damage, and they lose their sweltering heat aura.</p>\n<p>This limitation ends if the dragon uses Breath Weapon.</p>\n<hr />\n<p>@Compendium[pf2e.bestiary-effects.Effect: Countered by Water]{Effect: Countered by Water}</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
-                "rules": [
-                    {
-                        "domain": "all",
-                        "key": "RollOption",
-                        "option": "countered-by-water",
-                        "toggleable": true,
-                        "value": false
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "predicate": {
-                            "all": [
-                                "countered-by-water"
-                            ]
-                        },
-                        "selector": "attack",
-                        "type": "circumstance",
-                        "value": -1
-                    }
-                ],
+                "rules": [],
                 "slug": null,
                 "source": {
                     "value": ""
@@ -3480,32 +3461,12 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>When an underworld dragon is struck by a weapon made primarily of wood or affected by a spell with the plant trait, the dragon's internal fiery essences are stoked with the added fuel. Their breath weapon recharges, and the fire damage from the dragon's jaws increases by one die until the end of the dragon's next turn.</p>"
+                    "value": "<p>When an underworld dragon is struck by a weapon made primarily of wood or affected by a spell with the plant trait, the dragon's internal fiery essences are stoked with the added fuel. Their breath weapon recharges, and the fire damage from the dragon's jaws increases by one die until the end of the dragon's next turn.</p>\n<hr />\n<p>@Compendium[pf2e.bestiary-effects.Effect: Fed by Wood]{Effect: Fed by Wood}</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
-                "rules": [
-                    {
-                        "domain": "all",
-                        "key": "RollOption",
-                        "option": "fed-by-wood",
-                        "toggleable": true,
-                        "value": false
-                    },
-                    {
-                        "damageType": "fire",
-                        "diceNumber": 1,
-                        "dieSize": "d6",
-                        "key": "DamageDice",
-                        "predicate": {
-                            "all": [
-                                "fed-by-wood"
-                            ]
-                        },
-                        "selector": "jaws-damage"
-                    }
-                ],
+                "rules": [],
                 "slug": null,
                 "source": {
                     "value": ""

--- a/packs/data/pathfinder-bestiary-3.db/adult-underworld-dragon.json
+++ b/packs/data/pathfinder-bestiary-3.db/adult-underworld-dragon.json
@@ -942,31 +942,12 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>If the underworld dragon takes damage from a spell with the cold or water trait, the elemental magic of fire within them is momentarily dampened.</p>\n<p>Until the end of their next turn, they take a -1 circumstance penalty to attack rolls, and their jaws Strikes don't deal fire damage, and they lose their sweltering heat aura.</p>\n<p>This limitation ends if the dragon uses Breath Weapon.</p>"
+                    "value": "<p>If the underworld dragon takes damage from a spell with the cold or water trait, the elemental magic of fire within them is momentarily dampened.</p>\n<p>Until the end of their next turn, they take a -1 circumstance penalty to attack rolls, and their jaws Strikes don't deal fire damage, and they lose their sweltering heat aura.</p>\n<p>This limitation ends if the dragon uses Breath Weapon.</p>\n<hr />\n<p>@Compendium[pf2e.bestiary-effects.Effect: Countered by Water]{Effect: Countered by Water}</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
-                "rules": [
-                    {
-                        "domain": "all",
-                        "key": "RollOption",
-                        "option": "countered-by-water",
-                        "toggleable": true,
-                        "value": false
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "predicate": {
-                            "all": [
-                                "countered-by-water"
-                            ]
-                        },
-                        "selector": "attack",
-                        "type": "circumstance",
-                        "value": -1
-                    }
-                ],
+                "rules": [],
                 "slug": null,
                 "source": {
                     "value": ""
@@ -1001,32 +982,12 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>When an underworld dragon is struck by a weapon made primarily of wood or affected by a spell with the plant trait, the dragon's internal fiery essences are stoked with the added fuel. Their breath weapon recharges, and the fire damage from the dragon's jaws increases by one die until the end of the dragon's next turn.</p>"
+                    "value": "<p>When an underworld dragon is struck by a weapon made primarily of wood or affected by a spell with the plant trait, the dragon's internal fiery essences are stoked with the added fuel. Their breath weapon recharges, and the fire damage from the dragon's jaws increases by one die until the end of the dragon's next turn.</p>\n<hr />\n<p>@Compendium[pf2e.bestiary-effects.Effect: Fed by Wood]{Effect: Fed by Wood}</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
-                "rules": [
-                    {
-                        "domain": "all",
-                        "key": "RollOption",
-                        "option": "fed-by-wood",
-                        "toggleable": true,
-                        "value": false
-                    },
-                    {
-                        "damageType": "fire",
-                        "diceNumber": 1,
-                        "dieSize": "d6",
-                        "key": "DamageDice",
-                        "predicate": {
-                            "all": [
-                                "fed-by-wood"
-                            ]
-                        },
-                        "selector": "jaws-damage"
-                    }
-                ],
+                "rules": [],
                 "slug": null,
                 "source": {
                     "value": ""

--- a/packs/data/pathfinder-bestiary-3.db/ancient-sky-dragon-spellcaster.json
+++ b/packs/data/pathfinder-bestiary-3.db/ancient-sky-dragon-spellcaster.json
@@ -4954,43 +4954,12 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>If the sky dragon takes fire damage, the elemental magic of metal within them is tempered. Until the end of their next turn, they take a -1 circumstance penalty to attack rolls and AC, and their jaws Strikes don't deal electricity damage. This limitation ends if the dragon uses Breath Weapon.</p>"
+                    "value": "<p>If the sky dragon takes fire damage, the elemental magic of metal within them is tempered. Until the end of their next turn, they take a -1 circumstance penalty to attack rolls and AC, and their jaws Strikes don't deal electricity damage. This limitation ends if the dragon uses Breath Weapon.</p>\n<hr />\n<p>@Compendium[pf2e.bestiary-effects.Effect: Countered by Fire]{Effect: Countered by Fire}</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
-                "rules": [
-                    {
-                        "domain": "all",
-                        "key": "RollOption",
-                        "option": "countered-by-fire",
-                        "priority": 50,
-                        "toggleable": true,
-                        "value": false
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "predicate": {
-                            "all": [
-                                "countered-by-fire"
-                            ]
-                        },
-                        "selector": "attack",
-                        "type": "circumstance",
-                        "value": -1
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "predicate": {
-                            "all": [
-                                "countered-by-fire"
-                            ]
-                        },
-                        "selector": "ac",
-                        "type": "circumstance",
-                        "value": -1
-                    }
-                ],
+                "rules": [],
                 "slug": null,
                 "source": {
                     "value": ""

--- a/packs/data/pathfinder-bestiary-3.db/ancient-sky-dragon.json
+++ b/packs/data/pathfinder-bestiary-3.db/ancient-sky-dragon.json
@@ -923,43 +923,12 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>If the sky dragon takes fire damage, the elemental magic of metal within them is tempered. Until the end of their next turn, they take a -1 circumstance penalty to attack rolls and AC, and their jaws Strikes don't deal electricity damage. This limitation ends if the dragon uses Breath Weapon.</p>"
+                    "value": "<p>If the sky dragon takes fire damage, the elemental magic of metal within them is tempered. Until the end of their next turn, they take a -1 circumstance penalty to attack rolls and AC, and their jaws Strikes don't deal electricity damage. This limitation ends if the dragon uses Breath Weapon.</p>\n<hr />\n<p>@Compendium[pf2e.bestiary-effects.Effect: Countered by Fire]{Effect: Countered by Fire}</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
-                "rules": [
-                    {
-                        "domain": "all",
-                        "key": "RollOption",
-                        "option": "countered-by-fire",
-                        "priority": 50,
-                        "toggleable": true,
-                        "value": false
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "predicate": {
-                            "all": [
-                                "countered-by-fire"
-                            ]
-                        },
-                        "selector": "attack",
-                        "type": "circumstance",
-                        "value": -1
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "predicate": {
-                            "all": [
-                                "countered-by-fire"
-                            ]
-                        },
-                        "selector": "ac",
-                        "type": "circumstance",
-                        "value": -1
-                    }
-                ],
+                "rules": [],
                 "slug": null,
                 "source": {
                     "value": ""

--- a/packs/data/pathfinder-bestiary-3.db/ancient-underworld-dragon-spellcaster.json
+++ b/packs/data/pathfinder-bestiary-3.db/ancient-underworld-dragon-spellcaster.json
@@ -4222,31 +4222,12 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>If the underworld dragon takes damage from a spell with the cold or water trait, the elemental magic of fire within them is momentarily dampened.</p>\n<p>Until the end of their next turn, they take a -1 circumstance penalty to attack rolls, and their jaws Strikes don't deal fire damage, and they lose their sweltering heat aura.</p>\n<p>This limitation ends if the dragon uses Breath Weapon.</p>"
+                    "value": "<p>If the underworld dragon takes damage from a spell with the cold or water trait, the elemental magic of fire within them is momentarily dampened.</p>\n<p>Until the end of their next turn, they take a -1 circumstance penalty to attack rolls, and their jaws Strikes don't deal fire damage, and they lose their sweltering heat aura.</p>\n<p>This limitation ends if the dragon uses Breath Weapon.</p>\n<hr />\n<p>@Compendium[pf2e.bestiary-effects.Effect: Countered by Water]{Effect: Countered by Water}</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
-                "rules": [
-                    {
-                        "domain": "all",
-                        "key": "RollOption",
-                        "option": "countered-by-water",
-                        "toggleable": true,
-                        "value": false
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "predicate": {
-                            "all": [
-                                "countered-by-water"
-                            ]
-                        },
-                        "selector": "attack",
-                        "type": "circumstance",
-                        "value": -1
-                    }
-                ],
+                "rules": [],
                 "slug": null,
                 "source": {
                     "value": ""
@@ -4281,32 +4262,12 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>When an underworld dragon is struck by a weapon made primarily of wood or affected by a spell with the plant trait, the dragon's internal fiery essences are stoked with the added fuel. Their breath weapon recharges, and the fire damage from the dragon's jaws increases by one die until the end of the dragon's next turn.</p>"
+                    "value": "<p>When an underworld dragon is struck by a weapon made primarily of wood or affected by a spell with the plant trait, the dragon's internal fiery essences are stoked with the added fuel. Their breath weapon recharges, and the fire damage from the dragon's jaws increases by one die until the end of the dragon's next turn.</p>\n<hr />\n<p>@Compendium[pf2e.bestiary-effects.Effect: Fed by Wood]{Effect: Fed by Wood}</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
-                "rules": [
-                    {
-                        "domain": "all",
-                        "key": "RollOption",
-                        "option": "fed-by-wood",
-                        "toggleable": true,
-                        "value": false
-                    },
-                    {
-                        "damageType": "fire",
-                        "diceNumber": 1,
-                        "dieSize": "d6",
-                        "key": "DamageDice",
-                        "predicate": {
-                            "all": [
-                                "fed-by-wood"
-                            ]
-                        },
-                        "selector": "jaws-damage"
-                    }
-                ],
+                "rules": [],
                 "slug": null,
                 "source": {
                     "value": ""

--- a/packs/data/pathfinder-bestiary-3.db/ancient-underworld-dragon.json
+++ b/packs/data/pathfinder-bestiary-3.db/ancient-underworld-dragon.json
@@ -945,31 +945,12 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>If the underworld dragon takes damage from a spell with the cold or water trait, the elemental magic of fire within them is momentarily dampened.</p>\n<p>Until the end of their next turn, they take a -1 circumstance penalty to attack rolls, and their jaws Strikes don't deal fire damage, and they lose their sweltering heat aura.</p>\n<p>This limitation ends if the dragon uses Breath Weapon.</p>"
+                    "value": "<p>If the underworld dragon takes damage from a spell with the cold or water trait, the elemental magic of fire within them is momentarily dampened.</p>\n<p>Until the end of their next turn, they take a -1 circumstance penalty to attack rolls, and their jaws Strikes don't deal fire damage, and they lose their sweltering heat aura.</p>\n<p>This limitation ends if the dragon uses Breath Weapon.</p>\n<hr />\n<p>@Compendium[pf2e.bestiary-effects.Effect: Countered by Water]{Effect: Countered by Water}</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
-                "rules": [
-                    {
-                        "domain": "all",
-                        "key": "RollOption",
-                        "option": "countered-by-water",
-                        "toggleable": true,
-                        "value": false
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "predicate": {
-                            "all": [
-                                "countered-by-water"
-                            ]
-                        },
-                        "selector": "attack",
-                        "type": "circumstance",
-                        "value": -1
-                    }
-                ],
+                "rules": [],
                 "slug": null,
                 "source": {
                     "value": ""
@@ -1004,32 +985,12 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>When an underworld dragon is struck by a weapon made primarily of wood or affected by a spell with the plant trait, the dragon's internal fiery essences are stoked with the added fuel. Their breath weapon recharges, and the fire damage from the dragon's jaws increases by one die until the end of the dragon's next turn.</p>"
+                    "value": "<p>When an underworld dragon is struck by a weapon made primarily of wood or affected by a spell with the plant trait, the dragon's internal fiery essences are stoked with the added fuel. Their breath weapon recharges, and the fire damage from the dragon's jaws increases by one die until the end of the dragon's next turn.</p>\n<hr />\n<p>@Compendium[pf2e.bestiary-effects.Effect: Fed by Wood]{Effect: Fed by Wood}</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
-                "rules": [
-                    {
-                        "domain": "all",
-                        "key": "RollOption",
-                        "option": "fed-by-wood",
-                        "toggleable": true,
-                        "value": false
-                    },
-                    {
-                        "damageType": "fire",
-                        "diceNumber": 1,
-                        "dieSize": "d6",
-                        "key": "DamageDice",
-                        "predicate": {
-                            "all": [
-                                "fed-by-wood"
-                            ]
-                        },
-                        "selector": "jaws-damage"
-                    }
-                ],
+                "rules": [],
                 "slug": null,
                 "source": {
                     "value": ""

--- a/packs/data/pathfinder-bestiary-3.db/young-sky-dragon-spellcaster.json
+++ b/packs/data/pathfinder-bestiary-3.db/young-sky-dragon-spellcaster.json
@@ -3269,43 +3269,12 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>If the sky dragon takes fire damage, the elemental magic of metal within them is tempered. Until the end of their next turn, they take a -1 circumstance penalty to attack rolls and AC, and their jaws Strikes don't deal electricity damage. This limitation ends if the dragon uses Breath Weapon.</p>"
+                    "value": "<p>If the sky dragon takes fire damage, the elemental magic of metal within them is tempered. Until the end of their next turn, they take a -1 circumstance penalty to attack rolls and AC, and their jaws Strikes don't deal electricity damage. This limitation ends if the dragon uses Breath Weapon.</p>\n<hr />\n<p>@Compendium[pf2e.bestiary-effects.Effect: Countered by Fire]{Effect: Countered by Fire}</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
-                "rules": [
-                    {
-                        "domain": "all",
-                        "key": "RollOption",
-                        "option": "countered-by-fire",
-                        "priority": 50,
-                        "toggleable": true,
-                        "value": false
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "predicate": {
-                            "all": [
-                                "countered-by-fire"
-                            ]
-                        },
-                        "selector": "attack",
-                        "type": "circumstance",
-                        "value": -1
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "predicate": {
-                            "all": [
-                                "countered-by-fire"
-                            ]
-                        },
-                        "selector": "ac",
-                        "type": "circumstance",
-                        "value": -1
-                    }
-                ],
+                "rules": [],
                 "slug": null,
                 "source": {
                     "value": ""

--- a/packs/data/pathfinder-bestiary-3.db/young-sky-dragon.json
+++ b/packs/data/pathfinder-bestiary-3.db/young-sky-dragon.json
@@ -849,43 +849,12 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>If the sky dragon takes fire damage, the elemental magic of metal within them is tempered. Until the end of their next turn, they take a -1 circumstance penalty to attack rolls and AC, and their jaws Strikes don't deal electricity damage. This limitation ends if the dragon uses Breath Weapon.</p>"
+                    "value": "<p>If the sky dragon takes fire damage, the elemental magic of metal within them is tempered. Until the end of their next turn, they take a -1 circumstance penalty to attack rolls and AC, and their jaws Strikes don't deal electricity damage. This limitation ends if the dragon uses Breath Weapon.</p>\n<hr />\n<p>@Compendium[pf2e.bestiary-effects.Effect: Countered by Fire]{Effect: Countered by Fire}</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
-                "rules": [
-                    {
-                        "domain": "all",
-                        "key": "RollOption",
-                        "option": "countered-by-fire",
-                        "priority": 50,
-                        "toggleable": true,
-                        "value": false
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "predicate": {
-                            "all": [
-                                "countered-by-fire"
-                            ]
-                        },
-                        "selector": "attack",
-                        "type": "circumstance",
-                        "value": -1
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "predicate": {
-                            "all": [
-                                "countered-by-fire"
-                            ]
-                        },
-                        "selector": "ac",
-                        "type": "circumstance",
-                        "value": -1
-                    }
-                ],
+                "rules": [],
                 "slug": null,
                 "source": {
                     "value": ""

--- a/packs/data/pathfinder-bestiary-3.db/young-underworld-dragon-spellcaster.json
+++ b/packs/data/pathfinder-bestiary-3.db/young-underworld-dragon-spellcaster.json
@@ -2523,31 +2523,12 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>If the underworld dragon takes damage from a spell with the cold or water trait, the elemental magic of fire within them is momentarily dampened.</p>\n<p>Until the end of their next turn, they take a -1 circumstance penalty to attack rolls, and their jaws Strikes don't deal fire damage.</p>\n<p>This limitation ends if the dragon uses Breath Weapon.</p>"
+                    "value": "<p>If the underworld dragon takes damage from a spell with the cold or water trait, the elemental magic of fire within them is momentarily dampened.</p>\n<p>Until the end of their next turn, they take a -1 circumstance penalty to attack rolls, and their jaws Strikes don't deal fire damage.</p>\n<p>This limitation ends if the dragon uses Breath Weapon.</p>\n<hr />\n<p>@Compendium[pf2e.bestiary-effects.Effect: Countered by Water]{Effect: Countered by Water}</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
-                "rules": [
-                    {
-                        "domain": "all",
-                        "key": "RollOption",
-                        "option": "countered-by-water",
-                        "toggleable": true,
-                        "value": false
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "predicate": {
-                            "all": [
-                                "countered-by-water"
-                            ]
-                        },
-                        "selector": "attack",
-                        "type": "circumstance",
-                        "value": -1
-                    }
-                ],
+                "rules": [],
                 "slug": null,
                 "source": {
                     "value": ""
@@ -2582,32 +2563,12 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>When an underworld dragon is struck by a weapon made primarily of wood or affected by a spell with the plant trait, the dragon's internal fiery essences are stoked with the added fuel. Their breath weapon recharges, and the fire damage from the dragon's jaws increases by one die until the end of the dragon's next turn.</p>"
+                    "value": "<p>When an underworld dragon is struck by a weapon made primarily of wood or affected by a spell with the plant trait, the dragon's internal fiery essences are stoked with the added fuel. Their breath weapon recharges, and the fire damage from the dragon's jaws increases by one die until the end of the dragon's next turn.</p>\n<hr />\n<p>@Compendium[pf2e.bestiary-effects.Effect: Fed by Wood]{Effect: Fed by Wood}</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
-                "rules": [
-                    {
-                        "domain": "all",
-                        "key": "RollOption",
-                        "option": "fed-by-wood",
-                        "toggleable": true,
-                        "value": false
-                    },
-                    {
-                        "damageType": "fire",
-                        "diceNumber": 1,
-                        "dieSize": "d6",
-                        "key": "DamageDice",
-                        "predicate": {
-                            "all": [
-                                "fed-by-wood"
-                            ]
-                        },
-                        "selector": "jaws-damage"
-                    }
-                ],
+                "rules": [],
                 "slug": null,
                 "source": {
                     "value": ""

--- a/packs/data/pathfinder-bestiary-3.db/young-underworld-dragon.json
+++ b/packs/data/pathfinder-bestiary-3.db/young-underworld-dragon.json
@@ -753,31 +753,12 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>If the underworld dragon takes damage from a spell with the cold or water trait, the elemental magic of fire within them is momentarily dampened.</p>\n<p>Until the end of their next turn, they take a -1 circumstance penalty to attack rolls, and their jaws Strikes don't deal fire damage.</p>\n<p>This limitation ends if the dragon uses Breath Weapon.</p>"
+                    "value": "<p>If the underworld dragon takes damage from a spell with the cold or water trait, the elemental magic of fire within them is momentarily dampened.</p>\n<p>Until the end of their next turn, they take a -1 circumstance penalty to attack rolls, and their jaws Strikes don't deal fire damage.</p>\n<p>This limitation ends if the dragon uses Breath Weapon.</p>\n<hr />\n<p>@Compendium[pf2e.bestiary-effects.Effect: Countered by Water]{Effect: Countered by Water}</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
-                "rules": [
-                    {
-                        "domain": "all",
-                        "key": "RollOption",
-                        "option": "countered-by-water",
-                        "toggleable": true,
-                        "value": false
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "predicate": {
-                            "all": [
-                                "countered-by-water"
-                            ]
-                        },
-                        "selector": "attack",
-                        "type": "circumstance",
-                        "value": -1
-                    }
-                ],
+                "rules": [],
                 "slug": null,
                 "source": {
                     "value": ""
@@ -812,32 +793,12 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>When an underworld dragon is struck by a weapon made primarily of wood or affected by a spell with the plant trait, the dragon's internal fiery essences are stoked with the added fuel. Their breath weapon recharges, and the fire damage from the dragon's jaws increases by one die until the end of the dragon's next turn.</p>"
+                    "value": "<p>When an underworld dragon is struck by a weapon made primarily of wood or affected by a spell with the plant trait, the dragon's internal fiery essences are stoked with the added fuel. Their breath weapon recharges, and the fire damage from the dragon's jaws increases by one die until the end of the dragon's next turn.</p>\n<hr />\n<p>@Compendium[pf2e.bestiary-effects.Effect: Fed by Wood]{Effect: Fed by Wood}</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
-                "rules": [
-                    {
-                        "domain": "all",
-                        "key": "RollOption",
-                        "option": "fed-by-wood",
-                        "toggleable": true,
-                        "value": false
-                    },
-                    {
-                        "damageType": "fire",
-                        "diceNumber": 1,
-                        "dieSize": "d6",
-                        "key": "DamageDice",
-                        "predicate": {
-                            "all": [
-                                "fed-by-wood"
-                            ]
-                        },
-                        "selector": "jaws-damage"
-                    }
-                ],
+                "rules": [],
                 "slug": null,
                 "source": {
                     "value": ""


### PR DESCRIPTION
I realized I created some inconsistency for the imperial dragons, because some had effects for their "countered by ..." and "fed by ..." abilities while others were done with toggles. I changed all to effects for better duration tracking.