### PR TITLE
Expand choice set owned items to non-weapons

### DIFF
--- a/packs/scripts/run-migration.ts
+++ b/packs/scripts/run-migration.ts
@@ -24,6 +24,7 @@ import { Migration761ShotRules } from "@module/migration/migrations/761-update-s
 import { Migration762UpdateBackgroundItems } from "@module/migration/migrations/762-update-background-items";
 import { Migration763RestoreAnimalStrikeOptions } from "@module/migration/migrations/763-restore-animal-strike-options";
 import { Migration764PanacheVivaciousREs } from "@module/migration/migrations/764-panache-vivacious-res";
+import { Migration765ChoiceOwnedItemTypes } from "@module/migration/migrations/765-choice-owned-item-types";
 // ^^^ don't let your IDE use the index in these imports. you need to specify the full path ^^^
 
 const { window } = new JSDOM();
@@ -50,6 +51,7 @@ const migrations: MigrationBase[] = [
     new Migration762UpdateBackgroundItems(),
     new Migration763RestoreAnimalStrikeOptions(),
     new Migration764PanacheVivaciousREs(),
+    new Migration765ChoiceOwnedItemTypes(),
 ];
 
 global.deepClone = <T>(original: T): T => {

--- a/src/module/item/base.ts
+++ b/src/module/item/base.ts
@@ -65,6 +65,9 @@ class ItemPF2e extends Item<ActorPF2e> {
     /** Check this item's type (or whether it's one among multiple types) without a call to `instanceof` */
     isOfType(type: "physical"): this is PhysicalItemPF2e;
     isOfType<T extends ItemType>(...types: T[]): this is InstanceType<ConfigPF2e["PF2E"]["Item"]["documentClasses"][T]>;
+    isOfType<T extends "physical" | ItemType>(
+        ...types: T[]
+    ): this is PhysicalItemPF2e | InstanceType<ConfigPF2e["PF2E"]["Item"]["documentClasses"][Exclude<T, "physical">]>;
     isOfType(...types: (ItemType | "physical")[]): boolean {
         return types.some((t) => (t === "physical" ? setHasElement(PHYSICAL_ITEM_TYPES, this.type) : this.type === t));
     }

--- a/src/module/migration/migrations/765-choice-owned-item-types.ts
+++ b/src/module/migration/migrations/765-choice-owned-item-types.ts
@@ -1,0 +1,21 @@
+import { ItemSourcePF2e } from "@item/data";
+import { ChoiceSetOwnedItems, ChoiceSetSource } from "@module/rules/rule-element/choice-set/data";
+import { isObject } from "@util";
+import { MigrationBase } from "../base";
+
+/** The types choices was never enforced when it only worked for weapons */
+export class Migration765ChoiceOwnedItemTypes extends MigrationBase {
+    static override version = 0.765;
+    override async updateItem(source: ItemSourcePF2e): Promise<void> {
+        for (const rule of source.data.rules) {
+            if (rule.key !== "ChoiceSet") continue;
+
+            const data: ChoiceSetSource = rule;
+            if (isObject<ChoiceSetOwnedItems>(data.choices)) {
+                if (data.choices.ownedItems && !data.choices.types) {
+                    data.choices.types = ["weapon"];
+                }
+            }
+        }
+    }
+}

--- a/src/module/migration/migrations/index.ts
+++ b/src/module/migration/migrations/index.ts
@@ -164,3 +164,4 @@ export { Migration761ShotRules } from "./761-update-shot-rules";
 export { Migration762UpdateBackgroundItems } from "./762-update-background-items";
 export { Migration763RestoreAnimalStrikeOptions } from "./763-restore-animal-strike-options";
 export { Migration764PanacheVivaciousREs } from "./764-panache-vivacious-res";
+export { Migration765ChoiceOwnedItemTypes } from "./765-choice-owned-item-types";

--- a/src/module/migration/runner/base.ts
+++ b/src/module/migration/runner/base.ts
@@ -14,7 +14,7 @@ interface CollectionDiff<T extends foundry.data.ActiveEffectSource | ItemSourceP
 export class MigrationRunnerBase {
     migrations: MigrationBase[];
 
-    static LATEST_SCHEMA_VERSION = 0.764;
+    static LATEST_SCHEMA_VERSION = 0.765;
 
     static MINIMUM_SAFE_VERSION = 0.618;
 

--- a/src/module/rules/rule-element/choice-set/data.ts
+++ b/src/module/rules/rule-element/choice-set/data.ts
@@ -49,16 +49,14 @@ interface ChoiceSetSource extends RuleElementSource {
 }
 
 interface ChoiceSetOwnedItems {
-    /**
-     * The item type(s) and/or unarmed attacks forming the basis of the choices: currently only weapons and unarmed
-     * attacks are supported.
-     */
+    /** Whether the choices should pull from items on the actor. */
     ownedItems: boolean;
     /** Whether the choices should include handwraps of mighty blows in addition to weapons */
     includeHandwraps?: boolean;
     /** The filter to apply the actor's own weapons/unarmed attacks */
     predicate?: PredicatePF2e;
     unarmedAttacks?: never;
+    types: (ItemType | "physical")[];
 }
 
 interface ChoiceSetUnarmedAttacks {

--- a/src/module/rules/rule-element/choice-set/rule-element.ts
+++ b/src/module/rules/rule-element/choice-set/rule-element.ts
@@ -4,7 +4,7 @@ import { PickableThing } from "@module/apps/pick-a-thing-prompt";
 import { PredicatePF2e } from "@system/predication";
 import { ErrorPF2e, isObject, objectHasKey, sluggify } from "@util";
 import { fromUUIDs, isItemUUID } from "@util/from-uuids";
-import { ChoiceSetData, ChoiceSetPackQuery, ChoiceSetSource } from "./data";
+import { ChoiceSetData, ChoiceSetOwnedItems, ChoiceSetPackQuery, ChoiceSetSource } from "./data";
 import { ChoiceSetPrompt } from "./prompt";
 import { ItemType } from "@item/data";
 import { CharacterStrike } from "@actor/character/data";
@@ -64,6 +64,17 @@ class ChoiceSetRuleElement extends RuleElementPF2e {
 
         const predicate = this.resolveInjectedProperties(this.data.predicate ?? new PredicatePF2e({}));
         if (!predicate.test(rollOptions)) return;
+
+        if (isObject(this.data.choices)) {
+            const choices = this.data.choices;
+            if ("ownedItems" in choices && choices.ownedItems && !choices.types?.length) {
+                console.warn(
+                    "PF2E System | Failure during ChoiceSet preCreate, types is required if ownedItems is set"
+                );
+                ruleSource.ignored = true;
+                return;
+            }
+        }
 
         this.setDefaultFlag(ruleSource);
 
@@ -127,7 +138,7 @@ class ChoiceSetRuleElement extends RuleElementPF2e {
             ? this.data.choices // Static choices from RE constructor data
             : isObject(this.data.choices) // ChoiceSetAttackQuery or ChoiceSetItemQuery
             ? this.data.choices.ownedItems
-                ? this.choicesFromOwnedItems(this.data.choices.predicate, this.data.choices.includeHandwraps)
+                ? this.choicesFromOwnedItems(this.data.choices)
                 : this.data.choices.unarmedAttacks
                 ? this.choicesFromUnarmedAttacks(this.data.choices.predicate)
                 : "query" in this.data.choices && typeof this.data.choices.query === "string"
@@ -183,10 +194,13 @@ class ChoiceSetRuleElement extends RuleElementPF2e {
         return [];
     }
 
-    private choicesFromOwnedItems(predicate = new PredicatePF2e(), includeHandwraps = false): PickableThing<string>[] {
-        const weapons = this.actor.itemTypes.weapon;
-        const choices = weapons
-            .filter((i) => i.category !== "unarmed" && predicate.test(i.getRollOptions("item")))
+    private choicesFromOwnedItems(options: ChoiceSetOwnedItems): PickableThing<string>[] {
+        const predicate = options.predicate ?? new PredicatePF2e();
+        const { includeHandwraps, types } = options;
+
+        const choices = this.actor.items
+            .filter((i) => i.isOfType(...types) && predicate.test(i.getRollOptions("item")))
+            .filter((i) => !i.isOfType("weapon") || i.category !== "unarmed")
             .map(
                 (i): PickableThing<string> => ({
                     img: i.img,
@@ -197,7 +211,7 @@ class ChoiceSetRuleElement extends RuleElementPF2e {
 
         if (includeHandwraps) {
             choices.push(
-                ...weapons
+                ...this.actor.itemTypes.weapon
                     .filter((i) => i.slug === "handwraps-of-mighty-blows")
                     .map((h) => ({ img: h.img, label: h.name, value: "unarmed" }))
             );


### PR DESCRIPTION
Existing ones should still pick weapons, but the types array will allow non-spells. There is a migration, but it doesn't affect our compendium at all.