### PR TITLE
Add a secret focus cap property that can be overwritten by REs/modules

### DIFF
--- a/src/module/actor/character/data/types.ts
+++ b/src/module/actor/character/data/types.ts
@@ -264,7 +264,7 @@ type CharacterArmorClass = StatisticModifier & Required<ArmorClassData>;
 
 interface CharacterResources {
     /** The current number of focus points and pool size */
-    focus: { value: number; max: number };
+    focus: { value: number; max: number; cap: number };
     /** The current and maximum number of hero points */
     heroPoints: { value: number; max: number };
     /** The current and maximum number of invested items */

--- a/src/module/actor/character/index.ts
+++ b/src/module/actor/character/index.ts
@@ -428,6 +428,7 @@ class CharacterPF2e extends CreaturePF2e {
 
         resources.focus = mergeObject({ value: 0, max: 0 }, resources.focus ?? {});
         resources.focus.max = 0;
+        resources.focus.cap = 3;
 
         resources.crafting = mergeObject({ infusedReagents: { value: 0, max: 0 } }, resources.crafting ?? {});
         resources.crafting.infusedReagents.max = 0;
@@ -828,7 +829,7 @@ class CharacterPF2e extends CreaturePF2e {
 
         // Resources
         const { focus, crafting } = this.data.data.resources;
-        focus.max = Math.clamped(focus.max, 0, 3);
+        focus.max = Math.clamped(focus.max, 0, focus.cap);
         crafting.infusedReagents.value = Math.clamped(crafting.infusedReagents.value, 0, crafting.infusedReagents.max);
         // Ensure the character has a focus pool of at least one point if they have a focus spellcasting entry
         if (focus.max === 0 && this.spellcasting.regular.some((entry) => entry.isFocusPool)) {


### PR DESCRIPTION
If left alone, it caps focus to 3, but if an AELike or module alters it, that becomes the new mechanical limit.