### PR TITLE
Expand filter parameters for game.pf2e.compendiumBrowser.openTab()

### DIFF
--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -736,10 +736,27 @@ class CharacterSheetPF2e extends CreatureSheetPF2e<CharacterPF2e> {
     private async onClickBrowseFeatCompendia(event: JQuery.ClickEvent): Promise<void> {
         const maxLevel = Number($(event.currentTarget).attr("data-level")) || this.actor.level;
         const button: HTMLElement = event.currentTarget;
-        const filter = button.dataset.filter?.split(",").filter((f) => !!f) ?? [];
-        if (filter.includes("feattype-general")) filter.push("feattype-skill");
+        const checkboxesFilterCodes = button.dataset.filter?.split(",").filter((f) => !!f) ?? [];
+        if (checkboxesFilterCodes.includes("feattype-general")) checkboxesFilterCodes.push("feattype-skill");
 
-        await game.pf2e.compendiumBrowser.openTab("feat", filter, maxLevel);
+        const filter: Record<string, string[]> = {};
+        for (const filterCode of checkboxesFilterCodes) {
+            const splitValues = filterCode.split("-");
+            if (splitValues.length !== 2) {
+                console.error(
+                    `Invalid filter value for opening the compendium browser:\n'${JSON.stringify(
+                        checkboxesFilterCodes
+                    )}'`
+                );
+                return;
+            }
+
+            const [filterType, value] = splitValues;
+            const filterCategory = filter[filterType] ?? (filter[filterType] = []);
+            filterCategory.push(value);
+        }
+
+        await game.pf2e.compendiumBrowser.openTab("feat", Object.assign(filter, { levelRange: { max: maxLevel } }));
     }
 
     /** Handle changing of proficiency-rank via dropdown */

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -566,12 +566,29 @@ export abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorShee
         }
     }
 
-    private onClickBrowseEquipmentCompendia(event: JQuery.ClickEvent<HTMLElement>) {
-        const filter: string[] = [$(event.currentTarget).attr("data-filter")].filter(
+    private async onClickBrowseEquipmentCompendia(event: JQuery.ClickEvent<HTMLElement>): Promise<void> {
+        const checkboxesFilterCodes: string[] = [$(event.currentTarget).attr("data-filter")].filter(
             (element): element is string => !!element
         );
-        console.debug(`Filtering on: ${filter}`);
-        game.pf2e.compendiumBrowser.openTab("equipment", filter);
+
+        const filter: Record<string, string[]> = {};
+        for (const filterCode of checkboxesFilterCodes) {
+            const splitValues = filterCode.split("-");
+            if (splitValues.length !== 2) {
+                console.error(
+                    `Invalid filter value for opening the compendium browser:\n'${JSON.stringify(
+                        checkboxesFilterCodes
+                    )}'`
+                );
+                return;
+            }
+
+            const [filterType, value] = splitValues;
+            const filterCategory = filter[filterType] ?? (filter[filterType] = []);
+            filterCategory.push(value);
+        }
+
+        await game.pf2e.compendiumBrowser.openTab("equipment", filter);
     }
 
     protected override _canDragStart(selector: string): boolean {

--- a/src/module/apps/compendium-browser/data.ts
+++ b/src/module/apps/compendium-browser/data.ts
@@ -8,5 +8,7 @@ export type TabName = "action" | "bestiary" | "equipment" | "feat" | "hazard" | 
 export type TabType = InstanceType<typeof BrowserTab[keyof typeof BrowserTab]>;
 export type TabData<T> = Record<TabName, T | null>;
 
-export type SortByOption = "name" | "level" | "price";
+export type CommonSortByOption = "name" | "level";
+
+export type SortByOption = CommonSortByOption | "price";
 export type SortDirection = "asc" | "desc";

--- a/src/module/apps/compendium-browser/tabs/data.ts
+++ b/src/module/apps/compendium-browser/tabs/data.ts
@@ -1,5 +1,5 @@
 import { PhysicalItemTrait } from "@item/physical/data";
-import { SortDirection } from "../data";
+import { CommonSortByOption, SortByOption, SortDirection } from "../data";
 
 type CheckboxOptions = Record<string, { label: string; selected: boolean }>;
 interface CheckboxData {
@@ -98,6 +98,81 @@ interface SpellFilters extends BaseFilterData {
     selects: Record<"timefilter", SelectData>;
 }
 
+// Models used for initializing filters
+interface BaseInitialFilters {
+    searchText?: string;
+    orderBy?: SortByOption;
+    orderDirection?: SortDirection;
+}
+
+interface InitialActionFilters extends BaseInitialFilters {
+    traits?: string[];
+    source?: string[];
+    orderBy?: CommonSortByOption;
+}
+
+interface InitialBestiaryFilters extends BaseInitialFilters {
+    alignments?: string[];
+    rarity?: string[];
+    sizes?: string[];
+    source?: string[];
+    traits?: string[];
+    orderBy?: CommonSortByOption;
+}
+
+interface InitialEquipmentFilters extends BaseInitialFilters {
+    armorTypes?: string[];
+    weaponTypes?: string[];
+    itemtypes?: string[];
+    rarity?: string[];
+    source?: string[];
+    priceRange?: { min?: number | string; max?: number | string };
+    levelRange?: { min?: number; max?: number };
+    orderBy?: CommonSortByOption | "price";
+}
+
+interface InitialFeatFilters extends BaseInitialFilters {
+    ancestry?: string[];
+    classes?: string[];
+    feattype?: string[];
+    skills?: string[];
+    rarity?: string[];
+    source?: string[];
+    traits?: string[];
+    levelRange?: { min?: number; max?: number };
+    orderBy?: CommonSortByOption;
+}
+
+interface InitialHazardFilters extends BaseInitialFilters {
+    complexity?: string[];
+    rarity?: string[];
+    source?: string[];
+    traits?: string[];
+    levelRange?: { min?: number; max?: number };
+    orderBy?: CommonSortByOption;
+}
+
+interface InitialSpellFilters extends BaseInitialFilters {
+    timefilter?: string;
+    category?: string[];
+    classes?: string[];
+    level?: string[];
+    rarity?: string[];
+    school?: string[];
+    source?: string[];
+    traditions?: string[];
+    traits?: string[];
+    orderBy?: CommonSortByOption;
+}
+
+type InitialFilters =
+    | InitialActionFilters
+    | InitialBestiaryFilters
+    | InitialEquipmentFilters
+    | InitialFeatFilters
+    | InitialHazardFilters
+    | InitialSpellFilters;
+
 export {
     ActionFilters,
     BaseFilterData,
@@ -110,4 +185,11 @@ export {
     MultiselectData,
     RangesData,
     SpellFilters,
+    InitialFilters,
+    InitialActionFilters,
+    InitialBestiaryFilters,
+    InitialEquipmentFilters,
+    InitialFeatFilters,
+    InitialHazardFilters,
+    InitialSpellFilters,
 };


### PR DESCRIPTION
I would like to use the game.pf2e.compendiumBrowser.openTab function in macros to open the compendium browser with feats or spells of a particular level but it does not currently take a "minLevel" parameter.

To keep the function backwards compatible, I added the parameter in the last position with a default value. I would be happy to change it to something like levelFilter: { min: number; max: number; } if need be.