### PR TITLE
Remove lookbehind assertions

### DIFF
--- a/src/module/migration/migrations/653-aes-to-res.ts
+++ b/src/module/migration/migrations/653-aes-to-res.ts
@@ -43,7 +43,7 @@ export class Migration653AEstoREs extends MigrationBase {
         // Remove transferred ActiveEffects, some of which will be converted to RuleElements
         actorSource.effects = actorSource.effects.filter((effect) => {
             const origin = effect.origin ?? "";
-            const itemId = /(?<=Item\.)[a-z0-9]{16}$/i.exec(origin)?.[0];
+            const itemId = /\bItem\.([A-Za-z0-9]{16})$/.exec(origin)?.[1];
             const itemSource = actorSource.items.find((maybeSource) => maybeSource._id === itemId);
             return itemSource && !(["class", "effect", "feat"].includes(itemSource.type) && this.isRemovableAE(effect));
         });

--- a/src/module/rules/rule-element/ae-like.ts
+++ b/src/module/rules/rule-element/ae-like.ts
@@ -16,7 +16,7 @@ class AELikeRuleElement extends RuleElementPF2e {
      */
     static SKILL_LONG_FORM_PATH = ((): RegExp => {
         const skillLongForms = Array.from(SKILL_LONG_FORMS).join("|");
-        return new RegExp(String.raw`(?<=^data\.skills\.)(?:${skillLongForms})\b`);
+        return new RegExp(String.raw`^data\.skills\.(${skillLongForms})\b`);
     })();
 
     constructor(data: AELikeSource, item: Embedded<ItemPF2e>, options?: RuleElementOptions) {
@@ -90,7 +90,8 @@ class AELikeRuleElement extends RuleElementPF2e {
         // Convert long-form skill slugs in paths to short forms
         this.data.path = this.resolveInjectedProperties(this.data.path).replace(
             AELikeRuleElement.SKILL_LONG_FORM_PATH,
-            (match) => (objectHasKey(SKILL_EXPANDED, match) ? SKILL_EXPANDED[match].shortform : match)
+            (match, group) =>
+                objectHasKey(SKILL_EXPANDED, group) ? `data.skills.${SKILL_EXPANDED[group].shortform}` : match
         );
 
         // Do not proceed if injected-property resolution failed

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -122,8 +122,8 @@ const wordCharacter = String.raw`[\p{Alphabetic}\p{Mark}\p{Decimal_Number}\p{Joi
 const nonWordCharacter = String.raw`[^\p{Alphabetic}\p{Mark}\p{Decimal_Number}\p{Join_Control}]`;
 const nonWordCharacterRE = new RegExp(nonWordCharacter, "gu");
 
-const wordBoundary = String.raw`(?<=${wordCharacter})(?=${nonWordCharacter})|(?<=${nonWordCharacter})(?=${wordCharacter})`;
-const nonWordBoundary = String.raw`(?<=${wordCharacter})(?=${wordCharacter})`;
+const wordBoundary = String.raw`(?:${wordCharacter})(?=${nonWordCharacter})|(?:${nonWordCharacter})(?=${wordCharacter})`;
+const nonWordBoundary = String.raw`(?:${wordCharacter})(?=${wordCharacter})`;
 const lowerCaseLetter = String.raw`\p{Lowercase_Letter}`;
 const upperCaseLetter = String.raw`\p{Uppercase_Letter}`;
 const lowerCaseThenUpperCaseRE = new RegExp(`(${lowerCaseLetter})(${upperCaseLetter}${nonWordBoundary})`, "gu");


### PR DESCRIPTION
Retested each, including via running `extractPacks all` to confirm no JSON files are renamed.