### PR TITLE
Convert spell schools to traits to allow multiple

### DIFF
--- a/packs/data/iconics.db/ezren-level-5.json
+++ b/packs/data/iconics.db/ezren-level-5.json
@@ -2963,9 +2963,6 @@
                     "basic": "",
                     "value": ""
                 },
-                "school": {
-                    "value": "evocation"
-                },
                 "secondarycasters": {
                     "value": ""
                 },
@@ -3001,7 +2998,8 @@
                     "value": [
                         "attack",
                         "acid",
-                        "cantrip"
+                        "cantrip",
+                        "evocation"
                     ]
                 }
             },
@@ -3090,9 +3088,6 @@
                     "basic": "basic",
                     "value": "reflex"
                 },
-                "school": {
-                    "value": "evocation"
-                },
                 "secondarycasters": {
                     "value": ""
                 },
@@ -3125,7 +3120,8 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "fire"
+                        "fire",
+                        "evocation"
                     ]
                 }
             },
@@ -3199,9 +3195,6 @@
                     "basic": "",
                     "value": "will"
                 },
-                "school": {
-                    "value": "illusion"
-                },
                 "secondarycasters": {
                     "value": ""
                 },
@@ -3235,7 +3228,8 @@
                     "rarity": "common",
                     "value": [
                         "incapacitation",
-                        "visual"
+                        "visual",
+                        "illusion"
                     ]
                 }
             },
@@ -3309,9 +3303,6 @@
                     "basic": "",
                     "value": ""
                 },
-                "school": {
-                    "value": "divination"
-                },
                 "secondarycasters": {
                     "value": ""
                 },
@@ -3348,7 +3339,8 @@
                     "rarity": "common",
                     "value": [
                         "detection",
-                        "cantrip"
+                        "cantrip",
+                        "divination"
                     ]
                 }
             },
@@ -3438,9 +3430,6 @@
                     "basic": "basic",
                     "value": "reflex"
                 },
-                "school": {
-                    "value": "evocation"
-                },
                 "secondarycasters": {
                     "value": ""
                 },
@@ -3475,7 +3464,8 @@
                     "rarity": "common",
                     "value": [
                         "electricity",
-                        "cantrip"
+                        "cantrip",
+                        "evocation"
                     ]
                 }
             },
@@ -3549,9 +3539,6 @@
                     "basic": "",
                     "value": "reflex"
                 },
-                "school": {
-                    "value": "conjuration"
-                },
                 "secondarycasters": {
                     "value": ""
                 },
@@ -3583,7 +3570,9 @@
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "conjuration"
+                    ]
                 }
             },
             "flags": {
@@ -3656,9 +3645,6 @@
                     "basic": "",
                     "value": ""
                 },
-                "school": {
-                    "value": "evocation"
-                },
                 "secondarycasters": {
                     "value": ""
                 },
@@ -3695,7 +3681,8 @@
                     "rarity": "common",
                     "value": [
                         "light",
-                        "cantrip"
+                        "cantrip",
+                        "evocation"
                     ]
                 }
             },
@@ -3769,9 +3756,6 @@
                     "basic": "",
                     "value": ""
                 },
-                "school": {
-                    "value": "abjuration"
-                },
                 "secondarycasters": {
                     "value": ""
                 },
@@ -3803,7 +3787,9 @@
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "abjuration"
+                    ]
                 }
             },
             "flags": {
@@ -3884,9 +3870,6 @@
                     "basic": "",
                     "value": ""
                 },
-                "school": {
-                    "value": "evocation"
-                },
                 "secondarycasters": {
                     "value": ""
                 },
@@ -3919,7 +3902,8 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "force"
+                        "force",
+                        "evocation"
                     ]
                 }
             },
@@ -3993,9 +3977,6 @@
                     "basic": "",
                     "value": ""
                 },
-                "school": {
-                    "value": "illusion"
-                },
                 "secondarycasters": {
                     "value": ""
                 },
@@ -4032,7 +4013,8 @@
                         "auditory",
                         "cantrip",
                         "linguistic",
-                        "mental"
+                        "mental",
+                        "illusion"
                     ]
                 }
             },
@@ -4122,9 +4104,6 @@
                     "basic": "",
                     "value": ""
                 },
-                "school": {
-                    "value": "evocation"
-                },
                 "secondarycasters": {
                     "value": ""
                 },
@@ -4160,7 +4139,8 @@
                     "value": [
                         "attack",
                         "cold",
-                        "cantrip"
+                        "cantrip",
+                        "evocation"
                     ]
                 }
             },
@@ -4234,9 +4214,6 @@
                     "basic": "",
                     "value": ""
                 },
-                "school": {
-                    "value": "divination"
-                },
                 "secondarycasters": {
                     "value": ""
                 },
@@ -4273,7 +4250,8 @@
                     "rarity": "common",
                     "value": [
                         "detection",
-                        "cantrip"
+                        "cantrip",
+                        "divination"
                     ]
                 }
             },
@@ -4347,9 +4325,6 @@
                     "basic": "",
                     "value": ""
                 },
-                "school": {
-                    "value": "abjuration"
-                },
                 "secondarycasters": {
                     "value": ""
                 },
@@ -4384,7 +4359,8 @@
                     "rarity": "common",
                     "value": [
                         "cantrip",
-                        "force"
+                        "force",
+                        "abjuration"
                     ]
                 }
             },
@@ -4474,9 +4450,6 @@
                     "basic": "",
                     "value": ""
                 },
-                "school": {
-                    "value": "evocation"
-                },
                 "secondarycasters": {
                     "value": ""
                 },
@@ -4510,7 +4483,8 @@
                     "rarity": "common",
                     "value": [
                         "attack",
-                        "cantrip"
+                        "cantrip",
+                        "evocation"
                     ]
                 }
             },
@@ -5173,9 +5147,6 @@
                     "basic": "",
                     "value": ""
                 },
-                "school": {
-                    "value": "evocation"
-                },
                 "secondarycasters": {
                     "value": ""
                 },
@@ -5208,7 +5179,8 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "cantrip"
+                        "cantrip",
+                        "evocation"
                     ]
                 }
             },
@@ -5282,9 +5254,6 @@
                     "basic": "",
                     "value": ""
                 },
-                "school": {
-                    "value": "divination"
-                },
                 "secondarycasters": {
                     "value": ""
                 },
@@ -5317,7 +5286,8 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "fortune"
+                        "fortune",
+                        "divination"
                     ]
                 }
             },
@@ -5406,9 +5376,6 @@
                     "basic": "",
                     "value": ""
                 },
-                "school": {
-                    "value": "evocation"
-                },
                 "secondarycasters": {
                     "value": ""
                 },
@@ -5442,7 +5409,8 @@
                     "rarity": "common",
                     "value": [
                         "acid",
-                        "attack"
+                        "attack",
+                        "evocation"
                     ]
                 }
             },
@@ -5516,9 +5484,6 @@
                     "basic": "",
                     "value": ""
                 },
-                "school": {
-                    "value": "abjuration"
-                },
                 "secondarycasters": {
                     "value": ""
                 },
@@ -5552,7 +5517,9 @@
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "abjuration"
+                    ]
                 }
             },
             "flags": {
@@ -5640,9 +5607,6 @@
                     "basic": "",
                     "value": ""
                 },
-                "school": {
-                    "value": "evocation"
-                },
                 "secondarycasters": {
                     "value": ""
                 },
@@ -5676,7 +5640,8 @@
                     "rarity": "common",
                     "value": [
                         "attack",
-                        "electricity"
+                        "electricity",
+                        "evocation"
                     ]
                 }
             },
@@ -5862,9 +5827,6 @@
                     "basic": "",
                     "value": ""
                 },
-                "school": {
-                    "value": "evocation"
-                },
                 "secondarycasters": {
                     "value": ""
                 },
@@ -5895,7 +5857,8 @@
                     "rarity": "uncommon",
                     "value": [
                         "attack",
-                        "wizard"
+                        "wizard",
+                        "evocation"
                     ]
                 }
             },
@@ -6500,9 +6463,6 @@
                                 "basic": "",
                                 "value": ""
                             },
-                            "school": {
-                                "value": "abjuration"
-                            },
                             "secondarycasters": {
                                 "value": ""
                             },
@@ -6534,7 +6494,9 @@
                             "traits": {
                                 "custom": "",
                                 "rarity": "common",
-                                "value": []
+                                "value": [
+                                    "abjuration"
+                                ]
                             }
                         },
                         "flags": {
@@ -6737,9 +6699,6 @@
                                 "basic": "",
                                 "value": ""
                             },
-                            "school": {
-                                "value": "evocation"
-                            },
                             "secondarycasters": {
                                 "value": ""
                             },
@@ -6772,7 +6731,8 @@
                                 "custom": "",
                                 "rarity": "common",
                                 "value": [
-                                    "force"
+                                    "force",
+                                    "evocation"
                                 ]
                             }
                         },
@@ -6905,9 +6865,6 @@
                     "basic": "basic",
                     "value": "reflex"
                 },
-                "school": {
-                    "value": "evocation"
-                },
                 "secondarycasters": {
                     "value": ""
                 },
@@ -6940,7 +6897,8 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "fire"
+                        "fire",
+                        "evocation"
                     ]
                 }
             },
@@ -7014,9 +6972,6 @@
                     "basic": "",
                     "value": ""
                 },
-                "school": {
-                    "value": "transmutation"
-                },
                 "secondarycasters": {
                     "value": ""
                 },
@@ -7049,7 +7004,9 @@
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "transmutation"
+                    ]
                 }
             },
             "flags": {
@@ -7122,9 +7079,6 @@
                     "basic": "",
                     "value": ""
                 },
-                "school": {
-                    "value": "illusion"
-                },
                 "secondarycasters": {
                     "value": ""
                 },
@@ -7157,7 +7111,8 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "visual"
+                        "visual",
+                        "illusion"
                     ]
                 }
             },
@@ -7231,9 +7186,6 @@
                     "basic": "",
                     "value": "reflex"
                 },
-                "school": {
-                    "value": "evocation"
-                },
                 "secondarycasters": {
                     "value": ""
                 },
@@ -7265,7 +7217,9 @@
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "evocation"
+                    ]
                 }
             },
             "flags": {

--- a/packs/data/pathfinder-bestiary-2.db/aolaz.json
+++ b/packs/data/pathfinder-bestiary-2.db/aolaz.json
@@ -314,9 +314,6 @@
                     "basic": "",
                     "value": ""
                 },
-                "school": {
-                    "value": "transmutation"
-                },
                 "secondarycasters": {
                     "value": ""
                 },
@@ -349,7 +346,8 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "air"
+                        "air",
+                        "transmutation"
                     ]
                 }
             },
@@ -423,9 +421,6 @@
                     "basic": "",
                     "value": ""
                 },
-                "school": {
-                    "value": "transmutation"
-                },
                 "secondarycasters": {
                     "value": ""
                 },
@@ -458,7 +453,9 @@
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "transmutation"
+                    ]
                 }
             },
             "flags": {

--- a/packs/data/pathfinder-bestiary-2.db/brownie.json
+++ b/packs/data/pathfinder-bestiary-2.db/brownie.json
@@ -294,9 +294,6 @@
                     "basic": "",
                     "value": ""
                 },
-                "school": {
-                    "value": "conjuration"
-                },
                 "secondarycasters": {
                     "value": ""
                 },
@@ -329,7 +326,8 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "teleportation"
+                        "teleportation",
+                        "conjuration"
                     ]
                 }
             },
@@ -403,9 +401,6 @@
                     "basic": "",
                     "value": ""
                 },
-                "school": {
-                    "value": "evocation"
-                },
                 "secondarycasters": {
                     "value": ""
                 },
@@ -441,7 +436,8 @@
                     "rarity": "common",
                     "value": [
                         "light",
-                        "cantrip"
+                        "cantrip",
+                        "evocation"
                     ]
                 }
             },
@@ -516,9 +512,6 @@
                     "basic": "",
                     "value": ""
                 },
-                "school": {
-                    "value": "transmutation"
-                },
                 "secondarycasters": {
                     "value": ""
                 },
@@ -552,7 +545,9 @@
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "transmutation"
+                    ]
                 }
             },
             "flags": {
@@ -625,9 +620,6 @@
                     "basic": "",
                     "value": ""
                 },
-                "school": {
-                    "value": "evocation"
-                },
                 "secondarycasters": {
                     "value": ""
                 },
@@ -663,7 +655,8 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "cantrip"
+                        "cantrip",
+                        "evocation"
                     ]
                 }
             },
@@ -737,9 +730,6 @@
                     "basic": "",
                     "value": ""
                 },
-                "school": {
-                    "value": "illusion"
-                },
                 "secondarycasters": {
                     "value": ""
                 },
@@ -774,7 +764,8 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "auditory"
+                        "auditory",
+                        "illusion"
                     ]
                 }
             },

--- a/packs/data/spells.db/discern-secrets.json
+++ b/packs/data/spells.db/discern-secrets.json
@@ -68,9 +68,6 @@
             "basic": "",
             "value": ""
         },
-        "school": {
-            "value": "divination"
-        },
         "secondarycasters": {
             "value": ""
         },
@@ -101,7 +98,8 @@
             "value": [
                 "cantrip",
                 "witch",
-                "hex"
+                "hex",
+                "divination"
             ]
         }
     },

--- a/packs/data/spells.db/divine-lance.json
+++ b/packs/data/spells.db/divine-lance.json
@@ -73,9 +73,6 @@
             "basic": "",
             "value": ""
         },
-        "school": {
-            "value": "evocation"
-        },
         "secondarycasters": {
             "value": ""
         },
@@ -107,7 +104,8 @@
             "rarity": "common",
             "value": [
                 "attack",
-                "cantrip"
+                "cantrip",
+                "evocation"
             ]
         }
     },

--- a/packs/scripts/run-migration.ts
+++ b/packs/scripts/run-migration.ts
@@ -26,6 +26,7 @@ import { Migration763RestoreAnimalStrikeOptions } from "@module/migration/migrat
 import { Migration764PanacheVivaciousREs } from "@module/migration/migrations/764-panache-vivacious-res";
 import { Migration765ChoiceOwnedItemTypes } from "@module/migration/migrations/765-choice-owned-item-types";
 import { Migration766WipeURLSources } from "@module/migration/migrations/766-wipe-url-sources";
+import { Migration767SchoolIntoTraits } from "@module/migration/migrations/767-school-into-traits";
 // ^^^ don't let your IDE use the index in these imports. you need to specify the full path ^^^
 
 const { window } = new JSDOM();
@@ -54,6 +55,7 @@ const migrations: MigrationBase[] = [
     new Migration764PanacheVivaciousREs(),
     new Migration765ChoiceOwnedItemTypes(),
     new Migration766WipeURLSources(),
+    new Migration767SchoolIntoTraits(),
 ];
 
 global.deepClone = <T>(original: T): T => {

--- a/src/module/apps/compendium-browser/tabs/data.ts
+++ b/src/module/apps/compendium-browser/tabs/data.ts
@@ -91,10 +91,7 @@ interface HazardFilters extends BaseFilterData {
 }
 
 interface SpellFilters extends BaseFilterData {
-    checkboxes: Record<
-        "category" | "classes" | "level" | "rarity" | "school" | "source" | "traditions" | "traits",
-        CheckboxData
-    >;
+    checkboxes: Record<"category" | "classes" | "level" | "rarity" | "source" | "traditions" | "traits", CheckboxData>;
     selects: Record<"timefilter", SelectData>;
 }
 

--- a/src/module/apps/compendium-browser/tabs/spell.ts
+++ b/src/module/apps/compendium-browser/tabs/spell.ts
@@ -25,9 +25,10 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
             "data.category.value",
             "data.traditions.value",
             "data.time",
-            "data.school.value",
             "data.traits",
             "data.source.value",
+            // backwards compatibility
+            "data.school.value",
         ];
 
         const data = this.browser.packLoader.loadPacks("Item", this.browser.loadedPacks("spell"), indexFields);
@@ -76,6 +77,13 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
                         spellData.data.source.value = sluggify(source);
                     }
 
+                    // Backwards compatibility, schools used to not be in traits
+                    const traits = spellData.data.traits.value;
+                    const schoolOld = spellData.data.school?.value;
+                    if (typeof schoolOld === "string" && Array.isArray(traits)) {
+                        traits.push(schoolOld);
+                    }
+
                     spells.push({
                         _id: spellData._id,
                         type: spellData.type,
@@ -85,9 +93,8 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
                         level: spellData.data.level.value,
                         time: spellData.data.time,
                         category: spellData.data.category.value,
-                        school: spellData.data.school.value,
                         traditions: spellData.data.traditions.value,
-                        traits: spellData.data.traits.value,
+                        traits,
                         rarity: spellData.data.traits.rarity,
                         source: spellData.data.source.value,
                     });
@@ -112,7 +119,6 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
             };
         }
         this.filterData.checkboxes.classes.options = this.generateCheckboxOptions(CONFIG.PF2E.classTraits);
-        this.filterData.checkboxes.school.options = this.generateCheckboxOptions(CONFIG.PF2E.magicSchools);
         this.filterData.checkboxes.rarity.options = this.generateCheckboxOptions(CONFIG.PF2E.rarityTraits, false);
         this.filterData.checkboxes.traits.options = this.generateCheckboxOptions(CONFIG.PF2E.spellTraits);
         this.filterData.checkboxes.source.options = this.generateSourceCheckboxOptions(sources);
@@ -158,10 +164,6 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
             const combined = [...checkboxes.classes.selected, ...checkboxes.traits.selected];
             if (!this.arrayIncludes(combined, entry.traits)) return false;
         }
-        // School
-        if (checkboxes.school.selected.length) {
-            if (!checkboxes.school.selected.includes(entry.school)) return false;
-        }
         // Rarity
         if (checkboxes.rarity.selected.length) {
             if (!checkboxes.rarity.selected.includes(entry.rarity)) return false;
@@ -197,12 +199,6 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
                 classes: {
                     isExpanded: false,
                     label: "PF2E.BrowserFilterClass",
-                    options: {},
-                    selected: [],
-                },
-                school: {
-                    isExpanded: false,
-                    label: "PF2E.BrowserFilterSchools",
                     options: {},
                     selected: [],
                 },

--- a/src/module/item/sheet/data-types.ts
+++ b/src/module/item/sheet/data-types.ts
@@ -95,13 +95,13 @@ export interface SpellSheetData extends ItemSheetDataPF2e<SpellPF2e> {
     isFocusSpell: boolean;
     isRitual: boolean;
     isVariant: boolean;
+    schools: string;
     variants: {
         name: string;
         id: string;
         sort: number;
         actions: string;
     }[];
-    magicSchools: ConfigPF2e["PF2E"]["magicSchools"];
     spellCategories: ConfigPF2e["PF2E"]["spellCategories"];
     spellLevels: ConfigPF2e["PF2E"]["spellLevels"];
     spellTypes: ConfigPF2e["PF2E"]["spellTypes"];

--- a/src/module/item/spell/data/types.ts
+++ b/src/module/item/spell/data/types.ts
@@ -10,7 +10,7 @@ import {
 } from "@item/data/base";
 import { OneToTen, ValueAndMax, ValuesList } from "@module/data";
 import { DamageType } from "@system/damage";
-import { MagicSchool, MagicTradition, SpellComponent, SpellTrait } from "../types";
+import { MagicTradition, SpellComponent, SpellTrait } from "../types";
 
 type SpellSource = BaseItemSourcePF2e<"spell", SpellSystemSource>;
 
@@ -73,9 +73,6 @@ interface SpellSystemSource extends ItemSystemSource, ItemLevelData {
         value: keyof ConfigPF2e["PF2E"]["spellCategories"];
     };
     traditions: ValuesList<MagicTradition>;
-    school: {
-        value: MagicSchool;
-    };
     components: Record<SpellComponent, boolean>;
     materials: {
         value: string;

--- a/src/module/item/spell/index.ts
+++ b/src/module/item/spell/index.ts
@@ -25,6 +25,7 @@ import { ErrorPF2e, getActionIcon, objectHasKey, ordinal } from "@util";
 import { SpellData, SpellHeightenLayer, SpellOverlay, SpellOverlayType, SpellSource } from "./data";
 import { MagicSchool, MagicTradition, SpellComponent, SpellTrait } from "./types";
 import { SpellOverlayCollection } from "./overlay";
+import { MAGIC_SCHOOLS } from "./values";
 
 interface SpellConstructionContext extends ItemConstructionContextPF2e {
     fromConsumable?: boolean;
@@ -57,8 +58,9 @@ class SpellPF2e extends ItemPF2e {
         return new Set(this.data.data.traits.value);
     }
 
-    get school(): MagicSchool {
-        return this.data.data.school.value;
+    get schools(): MagicSchool[] {
+        const traits = this.traits;
+        return Array.from(MAGIC_SCHOOLS).filter((school) => traits.has(school));
     }
 
     get traditions(): Set<MagicTradition> {
@@ -357,7 +359,7 @@ class SpellPF2e extends ItemPF2e {
     }
 
     override prepareSiblingData(this: Embedded<SpellPF2e>): void {
-        this.data.data.traits.value.push(this.school, ...this.traditions);
+        this.data.data.traits.value.push(...this.traditions);
         if (this.spellcasting?.isInnate) {
             mergeObject(this.data.data.location, { uses: { value: 1, max: 1 } }, { overwrite: false });
         }

--- a/src/module/item/spell/sheet.ts
+++ b/src/module/item/spell/sheet.ts
@@ -45,17 +45,21 @@ export class SpellSheetPF2e extends ItemSheetPF2e<SpellPF2e> {
             }))
             .sort((variantA, variantB) => variantA.sort - variantB.sort);
 
+        const schoolsLocalized = this.item.schools.map((school) =>
+            game.i18n.localize(CONFIG.PF2E.magicSchools[school])
+        );
+
         return {
             ...sheetData,
             itemType,
             isCantrip,
             isFocusSpell,
             isRitual,
+            schools: schoolsLocalized.join(" / "),
             variants,
             isVariant: this.item.isVariant,
             spellCategories: CONFIG.PF2E.spellCategories,
             spellTypes: CONFIG.PF2E.spellTypes,
-            magicSchools: CONFIG.PF2E.magicSchools,
             spellLevels: CONFIG.PF2E.spellLevels,
             magicTraditions: createSheetTags(CONFIG.PF2E.magicTraditions, sheetData.data.traditions),
             damageSubtypes: CONFIG.PF2E.damageSubtypes,

--- a/src/module/migration/migrations/621-remove-config-spell-schools.ts
+++ b/src/module/migration/migrations/621-remove-config-spell-schools.ts
@@ -1,4 +1,6 @@
 import { ItemSourcePF2e } from "@item/data";
+import { SpellSystemData } from "@item/spell/data";
+import { MagicSchool } from "@item/spell/types";
 import { MAGIC_SCHOOLS } from "@item/spell/values";
 import { objectHasKey, setHasElement } from "@util";
 import { MigrationBase } from "../base";
@@ -30,12 +32,19 @@ export class Migration621RemoveConfigSpellSchools extends MigrationBase {
 
     override async updateItem(itemData: ItemSourcePF2e): Promise<void> {
         if (itemData.type === "spell") {
-            const school: { value: string } = itemData.data.school ?? { value: "evocation" };
+            const spellSystem: SpellSystemOld = itemData.data;
+            const school: { value: string } = spellSystem.school ?? { value: "evocation" };
             school.value = this.reassignSchool(school.value);
         } else if (itemData.type === "consumable" && itemData.data.spell?.data) {
-            const spell = itemData.data.spell.data;
-            const school: { value: string } = spell.data.school ?? { value: "evocation" };
+            const spell: SpellSystemOld = itemData.data.spell.data.data;
+            const school: { value: string } = spell.school ?? { value: "evocation" };
             school.value = this.reassignSchool(school.value);
         }
     }
+}
+
+interface SpellSystemOld extends SpellSystemData {
+    school?: {
+        value: MagicSchool;
+    };
 }

--- a/src/module/migration/migrations/767-school-into-traits.ts
+++ b/src/module/migration/migrations/767-school-into-traits.ts
@@ -1,0 +1,30 @@
+import { ItemSourcePF2e } from "@item/data";
+import { SpellSystemData } from "@item/spell/data";
+import { MagicSchool } from "@item/spell/types";
+import { MigrationBase } from "../base";
+
+/** More dual school spells got printed... */
+export class Migration767SchoolIntoTraits extends MigrationBase {
+    static override version = 0.767;
+    override async updateItem(item: ItemSourcePF2e) {
+        if (item.type !== "spell" && item.type !== "consumable") return;
+        const system: SpellSystemOld | undefined = item.type === "spell" ? item.data : item.data.spell.data?.data;
+        if (!system) return;
+
+        if (system.school) {
+            if (system.school.value) {
+                system.traits.value.push(system.school.value);
+            }
+
+            delete system.school;
+            system["-=school"] = null;
+        }
+    }
+}
+
+interface SpellSystemOld extends SpellSystemData {
+    school?: {
+        value: MagicSchool;
+    };
+    "-=school"?: null;
+}

--- a/src/module/migration/migrations/index.ts
+++ b/src/module/migration/migrations/index.ts
@@ -166,3 +166,4 @@ export { Migration763RestoreAnimalStrikeOptions } from "./763-restore-animal-str
 export { Migration764PanacheVivaciousREs } from "./764-panache-vivacious-res";
 export { Migration765ChoiceOwnedItemTypes } from "./765-choice-owned-item-types";
 export { Migration766WipeURLSources } from "./766-wipe-url-sources";
+export { Migration767SchoolIntoTraits } from "./767-school-into-traits";

--- a/src/module/migration/runner/base.ts
+++ b/src/module/migration/runner/base.ts
@@ -14,7 +14,7 @@ interface CollectionDiff<T extends foundry.data.ActiveEffectSource | ItemSourceP
 export class MigrationRunnerBase {
     migrations: MigrationBase[];
 
-    static LATEST_SCHEMA_VERSION = 0.766;
+    static LATEST_SCHEMA_VERSION = 0.767;
 
     static MINIMUM_SAFE_VERSION = 0.618;
 

--- a/src/module/system/settings/homebrew/cleanup-migration.ts
+++ b/src/module/system/settings/homebrew/cleanup-migration.ts
@@ -92,13 +92,6 @@ export function prepareCleanup(listKey: ConfigPF2eHomebrewRecord, deletions: str
                     }
                     break;
                 }
-                case "magicSchools": {
-                    if (itemData.type === "spell") {
-                        const school = itemData.data.school;
-                        school.value = deletions.includes(school.value ?? "") ? "evocation" : school.value;
-                    }
-                    break;
-                }
                 case "spellTraits": {
                     if (itemData.type === "spell") {
                         const traits = itemData.data.traits;

--- a/src/scripts/config/traits.ts
+++ b/src/scripts/config/traits.ts
@@ -337,6 +337,7 @@ const spellTraits = {
     ...alignmentTraits,
     ...classTraits,
     ...damageTraits,
+    ...magicSchools,
     ...elementalTraits,
     ...spellOtherTraits,
 };

--- a/static/template.json
+++ b/static/template.json
@@ -1004,9 +1004,6 @@
             "traditions": {
                 "value": []
             },
-            "school": {
-                "value": "evocation"
-            },
             "components": {
                 "focus": false,
                 "material": false,

--- a/static/templates/items/spell-details.html
+++ b/static/templates/items/spell-details.html
@@ -52,17 +52,6 @@
         </select>
     </div>
 
-    <div class="form-group">
-        <label>{{localize "PF2E.SpellSchoolLabel"}}</label>
-        <select name="data.school.value" data-dtype="String">
-            {{#select data.school.value}}
-                {{#each magicSchools as |name sch|}}
-                    <option value="{{sch}}">{{localize name}}</option>
-                {{/each}}
-            {{/select}}
-        </select>
-    </div>
-
     <div class="form-group scalable">
         <label>
             {{localize "PF2E.SpellTraditionsLabel"}}


### PR DESCRIPTION
Comes with sample migration.

![image](https://user-images.githubusercontent.com/1286721/179344767-5f68e88f-ec42-4afb-9b0e-aa247d57f20f.png)

I don't really care to bother with the appearance of more than 2 until it actually becomes relevant. 2 is a travesty as is.