### PR TITLE
Update Kelorbeyan Guard Longsword attack modifier.

### DIFF
--- a/packs/data/one-shot-bestiary.db/kelorbeyan-guard.json
+++ b/packs/data/one-shot-bestiary.db/kelorbeyan-guard.json
@@ -872,7 +872,7 @@
                     "value": []
                 },
                 "bonus": {
-                    "value": 0
+                    "value": 14
                 },
                 "damageRolls": {
                     "3vcwrt030ggwziwhn5n2": {


### PR DESCRIPTION
Corrects Kelorbeyan Guard Longsword attack modifier from +0 to +14 per Mark of the Mantis statblock.