### PR TITLE
add missing crit success and fail notes to actions

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -5,13 +5,13 @@
 //
 exports[`too-much-lint`] = {
   value: `{
-    "src/module/actor/character/sheet.ts:407656718": [
-      [114, 72, 3, "Unexpected any. Specify a different type.", "193409811"],
-      [114, 77, 3, "Unexpected any. Specify a different type.", "193409811"],
-      [122, 72, 3, "Unexpected any. Specify a different type.", "193409811"],
-      [122, 77, 3, "Unexpected any. Specify a different type.", "193409811"],
-      [204, 64, 3, "Unexpected any. Specify a different type.", "193409811"],
-      [290, 30, 3, "Unexpected any. Specify a different type.", "193409811"]
+    "src/module/actor/character/sheet.ts:893223082": [
+      [118, 72, 3, "Unexpected any. Specify a different type.", "193409811"],
+      [118, 77, 3, "Unexpected any. Specify a different type.", "193409811"],
+      [126, 72, 3, "Unexpected any. Specify a different type.", "193409811"],
+      [126, 77, 3, "Unexpected any. Specify a different type.", "193409811"],
+      [212, 64, 3, "Unexpected any. Specify a different type.", "193409811"],
+      [298, 30, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
     "src/module/actor/hazard/sheet.ts:1273453349": [
       [58, 37, 3, "Unexpected any. Specify a different type.", "193409811"]
@@ -19,24 +19,24 @@ exports[`too-much-lint`] = {
     "src/module/actor/modifiers.ts:1819260910": [
       [441, 19, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "src/module/actor/sheet/base.ts:3763411753": [
-      [1033, 20, 3, "Unexpected any. Specify a different type.", "193409811"]
+    "src/module/actor/sheet/base.ts:872269999": [
+      [1017, 20, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
     "src/module/actor/vehicle/sheet.ts:3440049600": [
       [23, 25, 3, "Unexpected any. Specify a different type.", "193409811"],
       [36, 38, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "src/module/item/base.ts:287937855": [
-      [317, 24, 3, "Unexpected any. Specify a different type.", "193409811"]
+    "src/module/item/base.ts:2095124455": [
+      [320, 24, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
     "src/module/item/consumable/data.ts:2037414684": [
       [29, 13, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "src/module/item/sheet/base.ts:3371077888": [
-      [60, 25, 3, "Unexpected any. Specify a different type.", "193409811"]
+    "src/module/item/sheet/base.ts:3749762691": [
+      [58, 25, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "src/module/system/damage/weapon.ts:1956010729": [
-      [85, 16, 3, "Unexpected any. Specify a different type.", "193409811"]
+    "src/module/system/damage/weapon.ts:144394113": [
+      [86, 16, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
     "src/module/system/tag-selector/basic.ts:2559940787": [
       [127, 44, 3, "Unexpected any. Specify a different type.", "193409811"]
@@ -97,10 +97,10 @@ exports[`too-much-lint`] = {
       [167, 21, 3, "Unexpected any. Specify a different type.", "193409811"],
       [305, 44, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "types/foundry/client/game.d.ts:268476607": [
-      [163, 32, 3, "Unexpected any. Specify a different type.", "193409811"]
+    "types/foundry/client/game.d.ts:2392715649": [
+      [167, 32, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "types/foundry/client/pixi/placeables-layer/base.d.ts:2594726807": [
+    "types/foundry/client/pixi/placeables-layer/base.d.ts:140887940": [
       [132, 20, 3, "Unexpected any. Specify a different type.", "193409811"],
       [156, 20, 3, "Unexpected any. Specify a different type.", "193409811"],
       [162, 31, 3, "Unexpected any. Specify a different type.", "193409811"],

--- a/src/module/system/action-macros/acrobatics/maneuver-in-flight.ts
+++ b/src/module/system/action-macros/acrobatics/maneuver-in-flight.ts
@@ -17,6 +17,7 @@ export function maneuverInFlight(options: SkillActionOptions) {
         callback: options.callback,
         difficultyClass: options.difficultyClass,
         extraNotes: (selector: string) => [
+            ActionMacroHelpers.note(selector, "PF2E.Actions.ManeuverInFlight", "criticalSuccess"),
             ActionMacroHelpers.note(selector, "PF2E.Actions.ManeuverInFlight", "success"),
             ActionMacroHelpers.note(selector, "PF2E.Actions.ManeuverInFlight", "failure"),
             ActionMacroHelpers.note(selector, "PF2E.Actions.ManeuverInFlight", "criticalFailure"),

--- a/src/module/system/action-macros/acrobatics/tumble-through.ts
+++ b/src/module/system/action-macros/acrobatics/tumble-through.ts
@@ -18,8 +18,10 @@ export function tumbleThrough(options: SkillActionOptions) {
         difficultyClass: options.difficultyClass,
         difficultyClassStatistic: (target) => target.saves.reflex,
         extraNotes: (selector: string) => [
+            ActionMacroHelpers.note(selector, "PF2E.Actions.TumbleThrough", "criticalSuccess"),
             ActionMacroHelpers.note(selector, "PF2E.Actions.TumbleThrough", "success"),
             ActionMacroHelpers.note(selector, "PF2E.Actions.TumbleThrough", "failure"),
+            ActionMacroHelpers.note(selector, "PF2E.Actions.TumbleThrough", "criticalFailure"),
         ],
     });
 }

--- a/src/module/system/action-macros/athletics/long-jump.ts
+++ b/src/module/system/action-macros/athletics/long-jump.ts
@@ -17,6 +17,7 @@ export function longJump(options: SkillActionOptions) {
         callback: options.callback,
         difficultyClass: options.difficultyClass,
         extraNotes: (selector: string) => [
+            ActionMacroHelpers.note(selector, "PF2E.Actions.LongJump", "criticalSuccess"),
             ActionMacroHelpers.note(selector, "PF2E.Actions.LongJump", "success"),
             ActionMacroHelpers.note(selector, "PF2E.Actions.LongJump", "failure"),
             ActionMacroHelpers.note(selector, "PF2E.Actions.LongJump", "criticalFailure"),

--- a/src/module/system/action-macros/deception/create-a-diversion.ts
+++ b/src/module/system/action-macros/deception/create-a-diversion.ts
@@ -41,8 +41,10 @@ export function createADiversion(options: { variant: CreateADiversionVariant } &
         difficultyClass: options.difficultyClass,
         difficultyClassStatistic: (target) => target.perception,
         extraNotes: (selector: string) => [
+            ActionMacroHelpers.note(selector, "PF2E.Actions.CreateADiversion", "criticalSuccess"),
             ActionMacroHelpers.note(selector, "PF2E.Actions.CreateADiversion", "success"),
             ActionMacroHelpers.note(selector, "PF2E.Actions.CreateADiversion", "failure"),
+            ActionMacroHelpers.note(selector, "PF2E.Actions.CreateADiversion", "criticalFailure"),
         ],
     });
 }

--- a/src/module/system/action-macros/deception/impersonate.ts
+++ b/src/module/system/action-macros/deception/impersonate.ts
@@ -18,6 +18,7 @@ export function impersonate(options: SkillActionOptions) {
         difficultyClass: options.difficultyClass,
         difficultyClassStatistic: (target) => target.perception,
         extraNotes: (selector: string) => [
+            ActionMacroHelpers.note(selector, "PF2E.Actions.Impersonate", "criticalSuccess"),
             ActionMacroHelpers.note(selector, "PF2E.Actions.Impersonate", "success"),
             ActionMacroHelpers.note(selector, "PF2E.Actions.Impersonate", "failure"),
             ActionMacroHelpers.note(selector, "PF2E.Actions.Impersonate", "criticalFailure"),

--- a/src/module/system/action-macros/deception/lie.ts
+++ b/src/module/system/action-macros/deception/lie.ts
@@ -18,8 +18,10 @@ export function lie(options: SkillActionOptions) {
         difficultyClass: options.difficultyClass,
         difficultyClassStatistic: (target) => target.perception,
         extraNotes: (selector: string) => [
+            ActionMacroHelpers.note(selector, "PF2E.Actions.Lie", "criticalSuccess"),
             ActionMacroHelpers.note(selector, "PF2E.Actions.Lie", "success"),
             ActionMacroHelpers.note(selector, "PF2E.Actions.Lie", "failure"),
+            ActionMacroHelpers.note(selector, "PF2E.Actions.Lie", "criticalFailure"),
         ],
     });
 }

--- a/src/module/system/action-macros/diplomacy/gather-information.ts
+++ b/src/module/system/action-macros/diplomacy/gather-information.ts
@@ -17,6 +17,7 @@ export function gatherInformation(options: SkillActionOptions) {
         callback: options.callback,
         difficultyClass: options.difficultyClass,
         extraNotes: (selector: string) => [
+            ActionMacroHelpers.note(selector, "PF2E.Actions.GatherInformation", "criticalSuccess"),
             ActionMacroHelpers.note(selector, "PF2E.Actions.GatherInformation", "success"),
             ActionMacroHelpers.note(selector, "PF2E.Actions.GatherInformation", "criticalFailure"),
         ],

--- a/src/module/system/action-macros/exploration/avoid-notice.ts
+++ b/src/module/system/action-macros/exploration/avoid-notice.ts
@@ -16,6 +16,9 @@ export function avoidNotice(options: SkillActionOptions) {
         event: options.event,
         callback: options.callback,
         difficultyClass: options.difficultyClass,
-        extraNotes: (selector: string) => [ActionMacroHelpers.note(selector, "PF2E.Actions.AvoidNotice", "success")],
+        extraNotes: (selector: string) => [
+            ActionMacroHelpers.note(selector, "PF2E.Actions.AvoidNotice", "criticalSuccess"),
+            ActionMacroHelpers.note(selector, "PF2E.Actions.AvoidNotice", "success"),
+        ],
     });
 }

--- a/src/module/system/action-macros/exploration/track.ts
+++ b/src/module/system/action-macros/exploration/track.ts
@@ -18,6 +18,7 @@ export function track(options: SkillActionOptions) {
         callback: options.callback,
         difficultyClass: options.difficultyClass,
         extraNotes: (selector: string) => [
+            ActionMacroHelpers.note(selector, "PF2E.Actions.Track", "criticalSuccess"),
             ActionMacroHelpers.note(selector, "PF2E.Actions.Track", "success"),
             ActionMacroHelpers.note(selector, "PF2E.Actions.Track", "failure"),
             ActionMacroHelpers.note(selector, "PF2E.Actions.Track", "criticalFailure"),

--- a/src/module/system/action-macros/nature/command-an-animal.ts
+++ b/src/module/system/action-macros/nature/command-an-animal.ts
@@ -18,6 +18,7 @@ export function commandAnAnimal(options: SkillActionOptions) {
         difficultyClass: options.difficultyClass,
         difficultyClassStatistic: (target) => target.saves.will,
         extraNotes: (selector: string) => [
+            ActionMacroHelpers.note(selector, "PF2E.Actions.CommandAnAnimal", "criticalSuccess"),
             ActionMacroHelpers.note(selector, "PF2E.Actions.CommandAnAnimal", "success"),
             ActionMacroHelpers.note(selector, "PF2E.Actions.CommandAnAnimal", "failure"),
             ActionMacroHelpers.note(selector, "PF2E.Actions.CommandAnAnimal", "criticalFailure"),

--- a/src/module/system/action-macros/stealth/hide.ts
+++ b/src/module/system/action-macros/stealth/hide.ts
@@ -17,6 +17,9 @@ export function hide(options: SkillActionOptions) {
         callback: options.callback,
         difficultyClass: options.difficultyClass,
         difficultyClassStatistic: (target) => target.perception,
-        extraNotes: (selector: string) => [ActionMacroHelpers.note(selector, "PF2E.Actions.Hide", "success")],
+        extraNotes: (selector: string) => [
+            ActionMacroHelpers.note(selector, "PF2E.Actions.Hide", "criticalSuccess"),
+            ActionMacroHelpers.note(selector, "PF2E.Actions.Hide", "success"),
+        ],
     });
 }

--- a/src/module/system/action-macros/stealth/sneak.ts
+++ b/src/module/system/action-macros/stealth/sneak.ts
@@ -18,6 +18,7 @@ export function sneak(options: SkillActionOptions) {
         difficultyClass: options.difficultyClass,
         difficultyClassStatistic: (target) => target.perception,
         extraNotes: (selector: string) => [
+            ActionMacroHelpers.note(selector, "PF2E.Actions.Sneak", "criticalSuccess"),
             ActionMacroHelpers.note(selector, "PF2E.Actions.Sneak", "success"),
             ActionMacroHelpers.note(selector, "PF2E.Actions.Sneak", "failure"),
             ActionMacroHelpers.note(selector, "PF2E.Actions.Sneak", "criticalFailure"),

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -164,6 +164,7 @@
             },
             "AvoidNotice": {
                 "Notes": {
+                    "criticalSuccess": "<strong>Critical Success</strong> You're @Compendium[pf2e.conditionitems.VRSef5y1LmL2Hkjf]{undetected} by the creature during your movement and remain undetected by the creature at the end of it.<br/><br/>See the @Compendium[pf2e.actionspf2e.VMozDqMMuK5kpoX4]{Sneak} action for details.",
                     "success": "<strong>Success</strong> You're @Compendium[pf2e.conditionitems.VRSef5y1LmL2Hkjf]{undetected} by the creature during your movement and remain undetected by the creature at the end of it.<br/><br/>See the @Compendium[pf2e.actionspf2e.VMozDqMMuK5kpoX4]{Sneak} action for details."
                 },
                 "Title": "Avoid Notice"
@@ -244,6 +245,7 @@
             },
             "CommandAnAnimal": {
                 "Notes": {
+                    "criticalSuccess": "<strong>Critical Success</strong> The animal does as you command on its next turn.",
                     "success": "<strong>Success</strong> The animal does as you command on its next turn.",
                     "failure": "<strong>Failure</strong> The animal is hesitant or resistant, and it does nothing.",
                     "criticalFailure": "<strong>Critical Failure</strong> The animal misbehaves or misunderstands, and it takes some other action determined by the GM."
@@ -254,8 +256,10 @@
                 "DistractingWords": "Create a Diversion - Distracting Words",
                 "Gesture": "Create a Diversion - Gesture",
                 "Notes": {
+                    "criticalSuccess": "<strong>Critical Success</strong> You become @Compendium[pf2e.conditionitems.iU0fEDdBp3rXpTMC]{Hidden} to each creature whose Perception DC is less than or equal to your result. (The hidden condition allows you to @Compendium[pf2e.actionspf2e.VMozDqMMuK5kpoX4]{Sneak} away.) This lasts until the end of your turn or until you do anything except Step or use the @Compendium[pf2e.actionspf2e.XMcnh4cSI32tljXa]{Hide} or the @Compendium[pf2e.actionspf2e.VMozDqMMuK5kpoX4]{Sneak} action of the Stealth skill. If you Strike a creature, the creature remains @Compendium[pf2e.conditionitems.AJh5ex99aV6VTggg]{Flat-Footed} against that attack, and you then become @Compendium[pf2e.conditionitems.1wQY3JYyhMYeeV2G]{Observed}. If you do anything else, you become @Compendium[pf2e.conditionitems.1wQY3JYyhMYeeV2G]{Observed} just before you act unless the GM determines otherwise.",
                     "success": "<strong>Success</strong> You become @Compendium[pf2e.conditionitems.iU0fEDdBp3rXpTMC]{Hidden} to each creature whose Perception DC is less than or equal to your result. (The hidden condition allows you to @Compendium[pf2e.actionspf2e.VMozDqMMuK5kpoX4]{Sneak} away.) This lasts until the end of your turn or until you do anything except Step or use the @Compendium[pf2e.actionspf2e.XMcnh4cSI32tljXa]{Hide} or the @Compendium[pf2e.actionspf2e.VMozDqMMuK5kpoX4]{Sneak} action of the Stealth skill. If you Strike a creature, the creature remains @Compendium[pf2e.conditionitems.AJh5ex99aV6VTggg]{Flat-Footed} against that attack, and you then become @Compendium[pf2e.conditionitems.1wQY3JYyhMYeeV2G]{Observed}. If you do anything else, you become @Compendium[pf2e.conditionitems.1wQY3JYyhMYeeV2G]{Observed} just before you act unless the GM determines otherwise.",
-                    "failure": "<strong>Failure</strong> You don't divert the attention of any creatures whose Perception DC exceeds your result, and those creatures are aware you were trying to trick them."
+                    "failure": "<strong>Failure</strong> You don't divert the attention of any creatures whose Perception DC exceeds your result, and those creatures are aware you were trying to trick them.",
+                    "criticalFailure": "<strong>Critical Failure</strong> You don't divert the attention of any creatures whose Perception DC exceeds your result, and those creatures are aware you were trying to trick them."
                 },
                 "Trick": "Create a Diversion - Trick"
             },
@@ -313,6 +317,7 @@
             },
             "GatherInformation": {
                 "Notes": {
+                    "criticalSuccess": "<strong>Critical Success</strong> You collect information about the individual or topic. The GM determines the specifics.",
                     "success": "<strong>Success</strong> You collect information about the individual or topic. The GM determines the specifics.",
                     "criticalFailure": "<strong>Critical Failure</strong> You collect incorrect information about the individual or topic."
                 },
@@ -329,6 +334,7 @@
             },
             "Hide": {
                 "Notes": {
+                    "criticalSuccess": "<strong>Critical Success</strong> If the creature could see you, you're now @Compendium[pf2e.conditionitems.iU0fEDdBp3rXpTMC]{Hidden} from it instead of observed. If you were @Compendium[pf2e.conditionitems.iU0fEDdBp3rXpTMC]{Hidden} from or @Compendium[pf2e.conditionitems.VRSef5y1LmL2Hkjf]{Undetected} by the creature, you retain that condition.",
                     "success": "<strong>Success</strong> If the creature could see you, you're now @Compendium[pf2e.conditionitems.iU0fEDdBp3rXpTMC]{Hidden} from it instead of observed. If you were @Compendium[pf2e.conditionitems.iU0fEDdBp3rXpTMC]{Hidden} from or @Compendium[pf2e.conditionitems.VRSef5y1LmL2Hkjf]{Undetected} by the creature, you retain that condition."
                 },
                 "Title": "Hide"
@@ -380,6 +386,7 @@
             },
             "Impersonate": {
                 "Notes": {
+                    "criticalSuccess": "<strong>Critical Success</strong> You trick the creature into thinking you're the person you're disguised as. You might have to attempt a new check if your behavior changes.",
                     "success": "<strong>Success</strong> You trick the creature into thinking you're the person you're disguised as. You might have to attempt a new check if your behavior changes.",
                     "failure": "<strong>Failure</strong> The creature can tell you're not who you claim to be.",
                     "criticalFailure": "<strong>Critical Failure</strong> The creature can tell you're not who you claim to be, and it recognizes you if it would know you without a disguise."
@@ -388,13 +395,16 @@
             },
             "Lie": {
                 "Notes": {
+                    "criticalSuccess": "<strong>Critical Success</strong> The target believes your lie.",
                     "success": "<strong>Success</strong> The target believes your lie.",
-                    "failure": "<strong>Failure</strong> The target doesn't believe your lie and gains a +4 circumstance bonus against your attempts to Lie for the duration of your conversation. The target is also more likely to be suspicious of you in the future."
+                    "failure": "<strong>Failure</strong> The target doesn't believe your lie and gains a +4 circumstance bonus against your attempts to Lie for the duration of your conversation. The target is also more likely to be suspicious of you in the future.",
+                    "criticalFailure": "<strong>Critical Failure</strong> The target doesn't believe your lie and gains a +4 circumstance bonus against your attempts to Lie for the duration of your conversation. The target is also more likely to be suspicious of you in the future."
                 },
                 "Title": "Lie"
             },
             "LongJump": {
                 "Notes": {
+                    "criticalSuccess": "<strong>Critical Success</strong> Increase the maximum horizontal distance you @Compendium[pf2e.actionspf2e.d5I6018Mci2SWokk]{Leap} to the desired distance.",
                     "success": "<strong>Success</strong> Increase the maximum horizontal distance you @Compendium[pf2e.actionspf2e.d5I6018Mci2SWokk]{Leap} to the desired distance.",
                     "failure": "<strong>Failure</strong> You @Compendium[pf2e.actionspf2e.d5I6018Mci2SWokk]{Leap} normally.",
                     "criticalFailure": "<strong>Critical Failure</strong> You @Compendium[pf2e.actionspf2e.d5I6018Mci2SWokk]{Leap} normally, but then fall and land @Compendium[pf2e.conditionitems.j91X7x0XSomq8d60]{Prone}."
@@ -411,6 +421,7 @@
             },
             "ManeuverInFlight": {
                 "Notes": {
+                    "criticalSuccess": "<strong>Critical Success</strong> You succeed at the maneuver.",
                     "success": "<strong>Success</strong> You succeed at the maneuver.",
                     "failure": "<strong>Failure</strong> Your maneuver fails. The GM chooses if you simply can't move or if some other detrimental effect happens. The outcome should be appropriate for the maneuver you attempted (for instance, being blown off course if you were trying to fly against a strong wind).",
                     "criticalFailure": "<strong>Critical Failure</strong> As failure, but the consequence is more dire."
@@ -524,6 +535,7 @@
             },
             "Sneak": {
                 "Notes": {
+                    "criticalSuccess": "<strong>Critical Success</strong> You're undetected by the creature during your movement and remain undetected by the creature at the end of it.",
                     "success": "<strong>Success</strong> You're undetected by the creature during your movement and remain undetected by the creature at the end of it.",
                     "failure": "<strong>Failure</strong> A telltale sound or other sign gives your position away, though you still remain unseen. You're hidden from the creature throughout your movement and remain so",
                     "criticalFailure": "<strong>Critical Failure</strong> You're spotted! You're observed by the creature throughout your movement and remain so. If you're invisible and were hidden from the creature, instead of being observed you're hidden throughout your movement and remain so."
@@ -564,6 +576,7 @@
             },
             "Track": {
                 "Notes": {
+                    "criticalSuccess": "<strong>Critical Success</strong> You find the trail or continue to follow the one you're already following.",
                     "success": "<strong>Success</strong> You find the trail or continue to follow the one you're already following.",
                     "failure": "<strong>Failure</strong> You lose the trail but can try again after a 1-hour delay.",
                     "criticalFailure": "<strong>Critical Failure</strong> You lose the trail and can't try again for 24 hours."
@@ -596,8 +609,10 @@
             },
             "TumbleThrough": {
                 "Notes": {
+                    "criticalSuccess": "<strong>Critical Success</strong> You move through the enemy's space, treating the squares in its space as difficult terrain (every 5 feet costs 10 feet of movement). If you don't have enough Speed to move all the way through its space, you get the same effect as a failure.",
                     "success": "<strong>Success</strong> You move through the enemy's space, treating the squares in its space as difficult terrain (every 5 feet costs 10 feet of movement). If you don't have enough Speed to move all the way through its space, you get the same effect as a failure.",
-                    "failure": "<strong>Failure</strong> Your movement ends, and you trigger reactions as if you had moved out of the square you started in."
+                    "failure": "<strong>Failure</strong> Your movement ends, and you trigger reactions as if you had moved out of the square you started in.",
+                    "criticalFailure": "<strong>Critical Failure</strong> Your movement ends, and you trigger reactions as if you had moved out of the square you started in."
                 },
                 "Title": "Tumble Through"
             },


### PR DESCRIPTION
Potential fix for: https://github.com/foundryvtt/pf2e/issues/2973

Actions with a Success note but not Critical Success note or with a Failure note but no Critical Failure note won't display any note when rolling a Critical Success or Failure. 

Since the effect of an action in these cases is identical to the regular Success or Failure case, we can duplicate the notes instead of showing nothing. 