### PR TITLE
Fixed source value and separator for the Atheism deity

### DIFF
--- a/packs/data/deities.db/atheism.json
+++ b/packs/data/deities.db/atheism.json
@@ -17,7 +17,7 @@
         "rules": [],
         "skill": null,
         "source": {
-            "value": "Pathfindier Core Rulebook, Pathfinder Lost Omens: Gods & Magic"
+            "value": "Pathfinder Core Rulebook; Pathfinder Lost Omens: Gods & Magic"
         },
         "spells": {},
         "weapons": []

--- a/packs/data/deities.db/atheism.json
+++ b/packs/data/deities.db/atheism.json
@@ -17,7 +17,7 @@
         "rules": [],
         "skill": null,
         "source": {
-            "value": "Pathfinder Core Rulebook; Pathfinder Lost Omens: Gods & Magic"
+            "value": "Pathfinder Lost Omens: Gods & Magic"
         },
         "spells": {},
         "weapons": []


### PR DESCRIPTION
There is currently only one data entry with more than one source: the "Atheism" deity.

```
"source": {
    "value": "Pathfindier Core Rulebook, Pathfinder Lost Omens: Gods & Magic"
},
```

In addition to a spelling error ("Pathfindier" instead of "Pathfinder"), it uses "," as a separator. However, some sources such as "Pathfinder Lost Omens: Absalom, City of Lost Omens" use a "," in their name, invalidating the use of "," as a separator.

The future-proof way to solve this would be to change the data type to an array but that would mean changing every data entry. This is not ideal, especially for only one problematic entry.

As a compromise, I would only change the "," to ";" in this specific data entry (and all future data entries with mixed sources), hoping that Paizo will never release something with a ";" in its name...