### PR TITLE
update elemental form to properly size non-medium creates.

### DIFF
--- a/packs/data/spell-effects.db/spell-effect-elemental-form-air.json
+++ b/packs/data/spell-effects.db/spell-effect-elemental-form-air.json
@@ -1,6 +1,7 @@
 {
     "_id": "DliizYpHcmBG130w",
     "data": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by <em>@Compendium[pf2e.spells-srd.Elemental Form]{Elemental Form}</em></p>\n<p>You call upon the power of the planes to transform into a Medium elemental battle form. While in this form, you gain the air trait and the elemental trait. You have hands in this battle form and can take manipulate actions. You can Dismiss the spell.</p>\n<p>You gain the following statistics and abilities regardless of which battle form you choose:</p>\n<ul>\n<li>AC = 19 + your level. Ignore your armor's check penalty and Speed reduction.</li>\n<li>10 temporary Hit Points.</li>\n<li>Darkvision.</li>\n<li>One or more unarmed melee attacks specific to the battle form you choose, which are the only attacks you can use. You're trained with them. Your attack modifier is +18, and your damage bonus is +9. These are Dexterity based. If your corresponding unarmed attack modifier is higher, you can use it instead.</li>\n<li>Acrobatics modifier of +20; ignore this change if your own modifier is higher.</li>\n</ul>\n<p>You also gain specific abilities based on the type of elemental you choose:</p>\n<ul>\n<li><strong>Air</strong>\n<ul>\n<li>fly Speed 80 feet, movement doesn't trigger reactions;</li>\n<li><strong>Melee</strong> <span class=\"pf2-icon\">1</span> gust, <strong>Damage</strong> 1d4 bludgeoning.</li>\n</ul>\n</li>\n</ul>\n<hr />\n<p><strong>Heightened (6th)</strong> Your battle form is Large and your attacks have 10-foot reach. You must have space to expand or the spell is lost. You instead gain AC = 22 + your level, 15 temporary HP, an attack modifier of +23, a damage bonus of +13, and Acrobatics or Athletics +23.</p>\n<p><strong>Heightened (7th)</strong> Your battle form is Huge and your attacks have 15-foot reach. You must have space to expand or the spell is lost. You instead gain AC = 22 + your level, 20 temporary HP, an attack modifier of +25, a damage bonus of +11, double the number of damage dice (including @Compendium[pf2e.conditionitems.Persistent Damage]{Persistent Damage}), and Acrobatics or Athletics +25.</p>"
         },
@@ -53,6 +54,7 @@
                                 "armorClass": {
                                     "modifier": "19 + @actor.level"
                                 },
+                                "size": "med",
                                 "skills": {
                                     "acr": {
                                         "modifier": 20

--- a/packs/data/spell-effects.db/spell-effect-elemental-form-earth.json
+++ b/packs/data/spell-effects.db/spell-effect-elemental-form-earth.json
@@ -1,6 +1,7 @@
 {
     "_id": "8eWLR0WCf5258z8X",
     "data": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by <em>@Compendium[pf2e.spells-srd.Elemental Form]{Elemental Form}</em></p>\n<p>You call upon the power of the planes to transform into a Medium elemental battle form. While in this form, you gain the earth trait and the elemental trait. You have hands in this battle form and can take manipulate actions. You can Dismiss the spell.</p>\n<p>You gain the following statistics and abilities regardless of which battle form you choose:</p>\n<ul>\n<li>AC = 19 + your level. Ignore your armor's check penalty and Speed reduction.</li>\n<li>10 temporary Hit Points.</li>\n<li>Darkvision.</li>\n<li>One or more unarmed melee attacks specific to the battle form you choose, which are the only attacks you can use. You're trained with them. Your attack modifier is +18, and your damage bonus is +9. These are Strength based. If your corresponding unarmed attack modifier is higher, you can use it instead.</li>\n<li>Athletics modifier of +20; ignore this change if your own modifier is higher.</li>\n</ul>\n<p>You also gain specific abilities based on the type of elemental you choose:</p>\n<ul>\n<li><strong>Earth</strong>\n<ul>\n<li>Speed 20 feet, burrow Speed 20 feet;</li>\n<li><strong>Melee</strong> <span class=\"pf2-icon\">1</span> fist, <strong>Damage</strong> 2d10 bludgeoning.</li>\n</ul>\n</li>\n</ul>\n<hr />\n<p><strong>Heightened (6th)</strong> Your battle form is Large and your attacks have 10-foot reach. You must have space to expand or the spell is lost. You instead gain AC = 22 + your level, 15 temporary HP, an attack modifier of +23, a damage bonus of +13, and Acrobatics or Athletics +23.</p>\n<p><strong>Heightened (7th)</strong> Your battle form is Huge and your attacks have 15-foot reach. You must have space to expand or the spell is lost. You instead gain AC = 22 + your level, 20 temporary HP, an attack modifier of +25, a damage bonus of +11, double the number of damage dice (including @Compendium[pf2e.conditionitems.Persistent Damage]{Persistent Damage}), and Acrobatics or Athletics +25.</p>"
         },
@@ -57,6 +58,7 @@
                                 "armorClass": {
                                     "modifier": "19 + @actor.level"
                                 },
+                                "size": "med",
                                 "skills": {
                                     "ath": {
                                         "modifier": 20

--- a/packs/data/spell-effects.db/spell-effect-elemental-form-fire.json
+++ b/packs/data/spell-effects.db/spell-effect-elemental-form-fire.json
@@ -1,6 +1,7 @@
 {
     "_id": "phIoucsDa3iplMm2",
     "data": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by <em>@Compendium[pf2e.spells-srd.Elemental Form]{Elemental Form}</em></p>\n<p>You call upon the power of the planes to transform into a Medium elemental battle form. While in this form, you gain the fire trait and the elemental trait. You have hands in this battle form and can take manipulate actions. You can Dismiss the spell.</p>\n<p>You gain the following statistics and abilities regardless of which battle form you choose:</p>\n<ul>\n<li>AC = 19 + your level. Ignore your armor's check penalty and Speed reduction.</li>\n<li>10 temporary Hit Points.</li>\n<li>Darkvision.</li>\n<li>One or more unarmed melee attacks specific to the battle form you choose, which are the only attacks you can use. You're trained with them. Your attack modifier is +18, and your damage bonus is +9. These are Dexterity based. If your corresponding unarmed attack modifier is higher, you can use it instead.</li>\n<li>Acrobatics modifier of +20; ignore this change if your own modifier is higher.</li>\n</ul>\n<p>You also gain specific abilities based on the type of elemental you choose:</p>\n<ul>\n<li><strong>Fire</strong>\n<ul>\n<li>Speed 50 feet; fire resistance 10, weakness 5 to cold and 5 to water;</li>\n<li><strong>Melee</strong> <span class=\"pf2-icon\">1</span> tendril, <strong>Damage</strong> 1d8 fire plus [[/r {1d4}[persistent,fire]]] @Compendium[pf2e.conditionitems.Persistent Damage]{Persistent Fire Damage}.</li>\n</ul>\n</li>\n</ul>\n<hr />\n<p><strong>Heightened (6th)</strong> Your battle form is Large and your attacks have 10-foot reach. You must have space to expand or the spell is lost. You instead gain AC = 22 + your level, 15 temporary HP, an attack modifier of +23, a damage bonus of +13, and Acrobatics or Athletics +23.</p>\n<p><strong>Heightened (7th)</strong> Your battle form is Huge and your attacks have 15-foot reach. You must have space to expand or the spell is lost. You instead gain AC = 22 + your level, 20 temporary HP, an attack modifier of +25, a damage bonus of +11, double the number of damage dice (including @Compendium[pf2e.conditionitems.Persistent Damage]{Persistent Damage}), and Acrobatics or Athletics +25.</p>"
         },
@@ -68,6 +69,7 @@
                                 "armorClass": {
                                     "modifier": "19 + @actor.level"
                                 },
+                                "size": "med",
                                 "skills": {
                                     "acr": {
                                         "modifier": 20

--- a/packs/data/spell-effects.db/spell-effect-elemental-form-water.json
+++ b/packs/data/spell-effects.db/spell-effect-elemental-form-water.json
@@ -1,6 +1,7 @@
 {
     "_id": "kxMBdANwCcF841uA",
     "data": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by <em>@Compendium[pf2e.spells-srd.Elemental Form]{Elemental Form}</em></p>\n<p>You call upon the power of the planes to transform into a Medium elemental battle form. While in this form, you gain the earth trait and the elemental trait. You have hands in this battle form and can take manipulate actions. You can Dismiss the spell.</p>\n<p>You gain the following statistics and abilities regardless of which battle form you choose:</p>\n<ul>\n<li>AC = 19 + your level. Ignore your armor's check penalty and Speed reduction.</li>\n<li>10 temporary Hit Points.</li>\n<li>Darkvision.</li>\n<li>One or more unarmed melee attacks specific to the battle form you choose, which are the only attacks you can use. You're trained with them. Your attack modifier is +18, and your damage bonus is +9. These are Strength based. If your corresponding unarmed attack modifier is higher, you can use it instead.</li>\n<li>Athletics modifier of +20; ignore this change if your own modifier is higher.</li>\n</ul>\n<p>You also gain specific abilities based on the type of elemental you choose:</p>\n<ul>\n<li><strong>Water</strong>\n<ul>\n<li>Speed 20 feet, swim Speed 60 feet; fire resistance 5;</li>\n<li><strong>Melee <span class=\"pf2-icon\">1</span></strong> wave, <strong>Damage</strong> 1d12 bludgeoning, and you can spend an action immediately after a hit to push the target 5 feet with the effects of a successful Shove.</li>\n</ul>\n</li>\n</ul>\n<hr />\n<p><strong>Heightened (6th)</strong> Your battle form is Large and your attacks have 10-foot reach. You must have space to expand or the spell is lost. You instead gain AC = 22 + your level, 15 temporary HP, an attack modifier of +23, a damage bonus of +13, and Acrobatics or Athletics +23.</p>\n<p><strong>Heightened (7th)</strong> Your battle form is Huge and your attacks have 15-foot reach. You must have space to expand or the spell is lost. You instead gain AC = 22 + your level, 20 temporary HP, an attack modifier of +25, a damage bonus of +11, double the number of damage dice (including @Compendium[pf2e.conditionitems.Persistent Damage]{Persistent Damage}), and Acrobatics or Athletics +25.</p>"
         },
@@ -59,6 +60,7 @@
                                 "armorClass": {
                                     "modifier": "19 + @actor.level"
                                 },
+                                "size": "med",
                                 "skills": {
                                     "ath": {
                                         "modifier": 20


### PR DESCRIPTION
Non-medium creates using 5th level elemental form would previously be left at their non-medium size even though the spell specifies that you become a medium elemental. Now the 5th level spell effect will properly set the token size to medium.