### PR TITLE
Remove aura effects on token deletion

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -324,8 +324,10 @@ class ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
     async checkAreaEffects(): Promise<void> {
         if (!canvas.ready || game.user !== this.primaryUpdater) return;
 
+        const thisTokens = this.getActiveTokens(false, true);
         const toDelete: string[] = [];
         const toKeep: string[] = [];
+
         for (const effect of this.itemTypes.effect) {
             const auraData = effect.data.flags.pf2e.aura;
             if (!auraData?.removeOnExit) continue;
@@ -341,12 +343,17 @@ class ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
             })();
 
             const aura = auraToken?.auras.get(auraData.slug);
-            for (const thisToken of this.getActiveTokens(false, true)) {
-                if (aura?.containsToken(thisToken)) {
+            for (const token of thisTokens) {
+                if (aura?.containsToken(token)) {
                     toKeep.push(effect.id);
                 } else {
                     toDelete.push(effect.id);
                 }
+            }
+
+            // If no tokens for this actor remain in the scene, always remove the effect
+            if (thisTokens.length === 0) {
+                toDelete.push(effect.id);
             }
         }
 

--- a/src/module/scene/token-document/document.ts
+++ b/src/module/scene/token-document/document.ts
@@ -341,6 +341,15 @@ class TokenDocumentPF2e<TActor extends ActorPF2e = ActorPF2e> extends TokenDocum
             ui.combat.render();
         }
     }
+
+    /** Check area effects, removing any from this token's actor if the actor has no other tokens in the scene */
+    protected override _onDelete(options: DocumentModificationContext<this>, userId: string): void {
+        super._onDelete(options, userId);
+
+        if (this.isLinked && !this.scene?.tokens.some((t) => t.actor === this.actor)) {
+            this.actor?.checkAreaEffects();
+        }
+    }
 }
 
 interface TokenDocumentPF2e<TActor extends ActorPF2e = ActorPF2e> extends TokenDocument<TActor> {


### PR DESCRIPTION
Also adds a lock for `ScenePF2e#checkAuras` to prevent concurrent executions