### PR TITLE
Build out support for (most of) Righteous Might spell effect

### DIFF
--- a/packs/data/spell-effects.db/spell-effect-righteous-might.json
+++ b/packs/data/spell-effects.db/spell-effect-righteous-might.json
@@ -1,6 +1,7 @@
 {
     "_id": "W4lb3417rNDd9tCq",
     "data": {
+        "badge": null,
         "description": {
             "value": "<p>Granted By <em>@Compendium[pf2e.spells-srd.Righteous Might]{Righteous Might}</em></p>\n<p>You focus all your divine energy and transform yourself into a Medium battle form, similar to your normal form but armed with powerful divine armaments granted by your deity. While in this form, you gain the statistics and abilities listed below. You have hands in this battle form and can use manipulate actions. You can Dismiss the spell.</p>\n<p>You gain the following statistics and abilities:</p>\n<ul>\n<li>AC = 20 + your level. Ignore your armor's check penalty and Speed reduction.</li>\n<li>10 temporary Hit Points.</li>\n<li>Speed 40 feet.</li>\n<li>Resistance 3 against physical damage.</li>\n<li>Darkvision.</li>\n<li>A special attack with a righteous armament version of your favored weapon, which is the only attack you can use. Your attack modifier with the special weapon is +21, and your damage bonus is +8 (or +6 for a ranged attack). If your attack modifier with your deity's favored weapon is higher, you can use it instead. You deal three of your weapon's normal damage dice, or three damage dice of one size larger if your weapon is a simple weapon with a d4 or d6 damage die. The weapon has one of the following properties that matches your deity's alignment: <em>anarchic</em>, <em>axiomatic</em>, <em>holy</em>, <em>unholy</em>. If your deity is true neutral, you instead deal an extra 1d6 precision damage.</li>\n<li>Athletics modifier of +23, unless your own modifier is higher.</li>\n</ul>\n<hr />\n<p><strong>Heightened (8th)</strong> Your battle form is Large, and your attacks have 10-foot reach, or 15-foot reach if your deity's favored weapon has reach. You must have enough space to expand into or the spell is lost. You instead gain AC = 21 + your level, 15 temporary HP, resistance 4 against physical damage, attack modifier +28, damage bonus +15 (+12 for a ranged attack), and Athletics +29.</p>\n<hr />\n<p><em>Note: The special attack is not added at this time due to the large amount of player choice and missing deity automation. Additionally, the resistance and removal of armor penalties cannot be automated at present. Please apply these manually for the time being.</em></p>"
         },
@@ -15,88 +16,118 @@
         },
         "rules": [
             {
-                "key": "FixedProficiency",
-                "label": "Righteous Might",
-                "selector": "ac",
-                "type": "polymorph",
+                "key": "BattleForm",
+                "overrides": {
+                    "armorClass": {
+                        "modifier": "20 + @actor.level"
+                    },
+                    "resistances": [
+                        {
+                            "type": "physical",
+                            "value": "ternary(gte(@item.level, 8), 4, 3)"
+                        }
+                    ],
+                    "senses": {
+                        "darkvision": {}
+                    },
+                    "size": "med",
+                    "skills": {
+                        "ath": {
+                            "modifier": 23
+                        }
+                    },
+                    "speeds": {
+                        "land": 40
+                    },
+                    "strikes": {
+                        "favored-weapon": {
+                            "modifier": 21,
+                            "query": "{\"data.slug\":\"{actor|data.details.deities.primary.weapons.0}\"}"
+                        }
+                    },
+                    "tempHP": 10
+                },
+                "predicate": {
+                    "all": [
+                        "deity"
+                    ]
+                },
                 "value": {
                     "brackets": [
                         {
-                            "end": 7,
-                            "start": 6,
-                            "value": "20 + @actor.level"
-                        },
-                        {
                             "start": 8,
-                            "value": "21 + @actor.level"
+                            "value": {
+                                "armorClass": {
+                                    "modifier": "21 + @actor.level"
+                                },
+                                "skills": {
+                                    "ath": {
+                                        "modifier": 29
+                                    }
+                                },
+                                "strikes": {
+                                    "favored-weapon": {
+                                        "modifier": 28
+                                    }
+                                },
+                                "tempHP": 15
+                            }
                         }
                     ],
                     "field": "item|data.level.value"
                 }
             },
             {
-                "key": "TempHP",
-                "label": "Righteous Might",
-                "value": {
-                    "brackets": [
+                "key": "FlatModifier",
+                "selector": "favored-weapon-damage",
+                "value": "ternary(gte(@item.level,8),12,6)"
+            },
+            {
+                "key": "AdjustModifier",
+                "mode": "add",
+                "predicate": {
+                    "all": [
+                        "weapon:melee"
+                    ]
+                },
+                "selector": "favored-weapon-damage",
+                "value": "ternary(gte(@item.level,8),3,2)"
+            },
+            {
+                "key": "DamageDice",
+                "override": {
+                    "diceNumber": 3
+                },
+                "selector": "favored-weapon-damage"
+            },
+            {
+                "key": "DamageDice",
+                "override": {
+                    "upgrade": true
+                },
+                "predicate": {
+                    "all": [
+                        "weapon:category:simple",
                         {
-                            "end": 7,
-                            "start": 6,
-                            "value": 10
-                        },
-                        {
-                            "start": 8,
-                            "value": 15
+                            "or": [
+                                "weapon:damage:die:faces:4",
+                                "weapon:damage:die:faces:6"
+                            ]
                         }
-                    ],
-                    "field": "item|data.level.value"
-                }
+                    ]
+                },
+                "selector": "favored-weapon-damage"
             },
             {
-                "key": "Sense",
-                "label": "PF2E.SensesDarkvision",
-                "selector": "darkvision"
-            },
-            {
-                "key": "BaseSpeed",
-                "selector": "land-speed",
-                "value": 40
-            },
-            {
-                "key": "CreatureSize",
-                "value": {
-                    "brackets": [
-                        {
-                            "end": 7,
-                            "start": 6,
-                            "value": "med"
-                        },
-                        {
-                            "start": 8,
-                            "value": "lg"
-                        }
-                    ],
-                    "field": "item|data.level.value"
-                }
-            },
-            {
-                "key": "FixedProficiency",
-                "label": "Righteous Might",
-                "selector": "athletics",
-                "value": {
-                    "brackets": [
-                        {
-                            "end": 7,
-                            "start": 6,
-                            "value": 23
-                        },
-                        {
-                            "start": 8,
-                            "value": 29
-                        }
-                    ],
-                    "field": "item|data.level.value"
-                }
+                "damageType": "precision",
+                "dieSize": "d6",
+                "key": "DamageDice",
+                "predicate": {
+                    "all": [
+                        "deity:alignment:n"
+                    ]
+                },
+                "selector": "favored-weapon-damage"
             }
         ],
         "source": {

--- a/src/module/actor/character/data/types.ts
+++ b/src/module/actor/character/data/types.ts
@@ -347,7 +347,7 @@ interface CharacterDeities {
 }
 
 type DeityDetails = Pick<DeitySystemData, "alignment" | "skill"> & {
-    weapons: { option: string; label: string }[];
+    weapons: BaseWeaponType[];
 };
 
 interface CharacterAttributes extends CreatureAttributes {

--- a/src/module/actor/modifiers.ts
+++ b/src/module/actor/modifiers.ts
@@ -581,6 +581,9 @@ interface DamageDiceOverride {
 
     /** Override the damage type */
     damageType?: DamageType;
+
+    /** Override the number of damage dice */
+    diceNumber?: number;
 }
 
 /**

--- a/src/module/item/deity/document.ts
+++ b/src/module/item/deity/document.ts
@@ -1,3 +1,4 @@
+import { Alignment } from "@actor/creature/types";
 import { ALIGNMENTS } from "@actor/creature/values";
 import { ItemPF2e } from "@item";
 import { BaseWeaponType } from "@item/weapon/types";
@@ -7,18 +8,22 @@ import { DeitySheetPF2e } from "./sheet";
 
 class DeityPF2e extends ItemPF2e {
     get category(): "deity" | "pantheon" | "philosophy" {
-        return this.data.data.category;
+        return this.system.category;
+    }
+
+    get alignment(): Alignment | null {
+        return this.system.alignment.own;
     }
 
     get favoredWeapons(): BaseWeaponType[] {
-        return [...this.data.data.weapons];
+        return [...this.system.weapons];
     }
 
     override prepareBaseData(): void {
         super.prepareBaseData();
 
         if (this.category === "philosophy") {
-            const systemData = this.data.data;
+            const systemData = this.system;
             systemData.domains = { primary: [], alternate: [] };
             systemData.font = [];
             systemData.spells = {};
@@ -36,17 +41,15 @@ class DeityPF2e extends ItemPF2e {
         this.actor.deity = this;
 
         const { deities } = this.actor.data.data.details;
-        const systemData = this.data.data;
+        const systemData = this.system;
         deities.primary = {
             alignment: deepClone(systemData.alignment),
             skill: deepClone(systemData.skill),
-            weapons: systemData.weapons.flatMap((w) =>
-                w in CONFIG.PF2E.baseWeaponTypes ? { option: w, label: CONFIG.PF2E.baseWeaponTypes[w] } : []
-            ),
+            weapons: deepClone(systemData.weapons),
         };
 
         // Set available domains from this deity
-        for (const domain of this.data.data.domains.primary) {
+        for (const domain of this.system.domains.primary) {
             const label = CONFIG.PF2E.deityDomains[domain]?.label;
             deities.domains[domain] = label ?? domain;
         }
@@ -55,16 +58,21 @@ class DeityPF2e extends ItemPF2e {
         const slug = this.slug ?? sluggify(this.name);
         const prefix = "deity:primary";
         const actorRollOptions = this.actor.rollOptions;
+        actorRollOptions.all["deity"] = true;
         actorRollOptions.all[`${prefix}:${slug}`] = true;
 
         for (const baseType of this.favoredWeapons) {
             actorRollOptions.all[`${prefix}:favored-weapon:${baseType}`] = true;
         }
 
-        const alignments = (
-            this.data.data.alignment.follower.length > 0 ? this.data.data.alignment.follower : Array.from(ALIGNMENTS)
+        if (this.alignment) {
+            actorRollOptions.all[`${prefix}:alignment:${this.alignment.toLowerCase()}`] = true;
+        }
+
+        const followerAlignments = (
+            this.system.alignment.follower.length > 0 ? this.system.alignment.follower : Array.from(ALIGNMENTS)
         ).map((a) => a.toLowerCase());
-        for (const alignment of alignments) {
+        for (const alignment of followerAlignments) {
             actorRollOptions.all[`${prefix}:alignment:follower:${alignment}`] = true;
         }
 
@@ -76,9 +84,9 @@ class DeityPF2e extends ItemPF2e {
     setFavoredWeaponRank(this: Embedded<DeityPF2e>): void {
         if (!this.actor.isOfType("character")) return;
 
-        const favoredWeaponRank = this.actor.data.flags.pf2e.favoredWeaponRank;
+        const favoredWeaponRank = this.actor.flags.pf2e.favoredWeaponRank;
         if (favoredWeaponRank > 0) {
-            const proficiencies = this.actor.data.data.martial;
+            const proficiencies = this.actor.system.martial;
             for (const baseType of this.favoredWeapons) {
                 mergeObject(proficiencies, {
                     [`weapon-base-${baseType}`]: {

--- a/src/module/rules/rule-element/battle-form/types.ts
+++ b/src/module/rules/rule-element/battle-form/types.ts
@@ -7,7 +7,7 @@ import { BaseWeaponType, WeaponCategory, WeaponGroup, WeaponTrait } from "@item/
 import { Size } from "@module/data";
 import { BracketedValue, RuleElementSource } from "../";
 
-export interface BattleFormSource extends RuleElementSource {
+interface BattleFormSource extends RuleElementSource {
     overrides?: BattleFormOverrides;
     canCast?: boolean;
     canSpeak?: boolean;
@@ -17,7 +17,7 @@ export interface BattleFormSource extends RuleElementSource {
     ownUnarmed?: boolean;
 }
 
-export interface BattleFormOverrides {
+interface BattleFormOverrides {
     traits?: CreatureTrait[];
     armorClass?: BattleFormAC;
     tempHP?: number | null;
@@ -31,7 +31,7 @@ export interface BattleFormOverrides {
     resistances?: { type: ResistanceType; except?: ResistanceType; value: number | BracketedValue<number> }[];
 }
 
-export interface BattleFormAC {
+interface BattleFormAC {
     modifier?: string | number;
     ignoreCheckPenalty?: boolean;
     ignoreSpeedPenalty?: boolean;
@@ -46,17 +46,34 @@ interface BattleFormSkill {
     modifier: string | number;
     ownIfHigher?: boolean;
 }
-export type BattleFormSkills = { [K in SkillAbbreviation]?: BattleFormSkill };
 
-export interface BattleFormStrike {
+type BattleFormSkills = { [K in SkillAbbreviation]?: BattleFormSkill };
+
+interface BattleFormStrike {
     label: string;
     img?: ImagePath;
     ability: AbilityString;
     category: WeaponCategory;
-    group: WeaponGroup;
-    baseType?: BaseWeaponType;
+    group: WeaponGroup | null;
+    baseType?: BaseWeaponType | null;
     traits: WeaponTrait[];
     modifier: string | number;
     damage: WeaponDamage;
     ownIfHigher?: boolean;
 }
+
+interface BattleFormStrikeQuery {
+    pack: string;
+    query: string;
+    modifier: number;
+    ownIfHigher: boolean;
+}
+
+export {
+    BattleFormAC,
+    BattleFormOverrides,
+    BattleFormSkills,
+    BattleFormSource,
+    BattleFormStrike,
+    BattleFormStrikeQuery,
+};

--- a/src/module/rules/rule-element/damage-dice.ts
+++ b/src/module/rules/rule-element/damage-dice.ts
@@ -46,7 +46,11 @@ export class DamageDiceRuleElement extends RuleElementPF2e {
                     ((typeof override.upgrade === "boolean" && !("downgrade" in override)) ||
                         (typeof override.downgrade === "boolean" && !("upgrade" in override)) ||
                         setHasElement(DAMAGE_DIE_FACES, override.dieSize) ||
-                        setHasElement(DAMAGE_TYPES, override.damageType))
+                        setHasElement(DAMAGE_TYPES, override.damageType) ||
+                        (typeof override.diceNumber === "number" &&
+                            Number.isInteger(override.diceNumber) &&
+                            override.diceNumber > 0 &&
+                            override.diceNumber <= 10))
                 );
             };
 

--- a/src/module/rules/rule-element/iwr/base.ts
+++ b/src/module/rules/rule-element/iwr/base.ts
@@ -16,8 +16,7 @@ abstract class IWRRuleElement extends RuleElementPF2e {
     validate(value: unknown): boolean {
         return (
             this.data.type in this.dictionary &&
-            typeof value === "number" &&
-            value > 0 &&
+            ((typeof value === "number" && Number.isInteger(value) && value > 0) || typeof value === "string") &&
             (!this.data.except || typeof this.data.except === "string")
         );
     }

--- a/src/module/system/damage/weapon.ts
+++ b/src/module/system/damage/weapon.ts
@@ -576,12 +576,10 @@ export class WeaponDamagePF2e {
             (dm): dm is DiceModifierPF2e & { override: DamageDiceOverride } => !!(dm.enabled && dm.override)
         );
         for (const dm of enabledDiceModifiers) {
-            if (critical && dm.critical) {
+            if ((critical && dm.critical) || !dm.critical) {
                 base.dieSize = dm.override.dieSize ?? base.dieSize;
                 base.damageType = dm.override.damageType ?? base.damageType;
-            } else if (!dm.critical) {
-                base.dieSize = dm.override.dieSize ?? base.dieSize;
-                base.damageType = dm.override.damageType ?? base.damageType;
+                base.diceNumber = dm.override.diceNumber ?? base.diceNumber;
             }
         }
 


### PR DESCRIPTION
This will allow a Battle Form strike to be a compendium weapon query, which is pulled from the actor's deity.

Closes #2797