### PR TITLE
Move PC hit-point overage handling to base item class

### DIFF
--- a/src/module/item/abc/index.ts
+++ b/src/module/item/abc/index.ts
@@ -3,7 +3,6 @@ import type { AncestryData } from "@item/ancestry/data";
 import type { BackgroundData } from "@item/background/data";
 import type { ClassData } from "@item/class/data";
 import { FeatPF2e } from "@item/feat";
-import { UserPF2e } from "@module/user";
 
 /** Abstract base class representing a Pathfinder (A)ncestry, (B)ackground, or (C)lass */
 export abstract class ABCItemPF2e extends ItemPF2e {
@@ -23,29 +22,6 @@ export abstract class ABCItemPF2e extends ItemPF2e {
                 source: this.name,
             },
         ];
-    }
-
-    /** Increase HP by amount increased by new ABC item */
-    protected override async _preCreate(
-        data: PreDocumentId<this["data"]["_source"]>,
-        options: DocumentModificationContext<this>,
-        user: UserPF2e
-    ): Promise<void> {
-        if (this.actor?.isOfType("character")) {
-            const clone = this.actor.clone({
-                items: [...this.actor.toObject().items, this.toObject()],
-            });
-            const hpMaxDifference = clone.hitPoints.max - this.actor.hitPoints.max;
-            if (hpMaxDifference !== 0) {
-                const newHitPoints = this.actor.hitPoints.value + hpMaxDifference;
-                this.actor.update(
-                    { "data.attributes.hp.value": newHitPoints },
-                    { render: false, allowHPOverage: true }
-                );
-            }
-        }
-
-        return super._preCreate(data, options, user);
     }
 }
 


### PR DESCRIPTION
Besides ABC items, heritage and feats also need to be handled