### PR TITLE
Update 4 Stance Effects Duration

### DIFF
--- a/packs/data/feat-effects.db/effect-dread-marshal-stance.json
+++ b/packs/data/feat-effects.db/effect-dread-marshal-stance.json
@@ -8,7 +8,7 @@
         "duration": {
             "expiry": "turn-start",
             "sustained": false,
-            "unit": "unlimited",
+            "unit": "encounter",
             "value": -1
         },
         "level": {
@@ -21,12 +21,14 @@
                     "criticalSuccess"
                 ],
                 "selector": "strike-damage",
-                "text": "When you or an ally in the aura critically hits an enemy with a Strike, that enemy is @Compendium[pf2e.conditionitems.Frightened]{Frightened 1}."
+                "text": "When you or an ally in the aura critically hits an enemy with a Strike, that enemy is @Compendium[pf2e.conditionitems.Frightened]{Frightened 1}.",
+                "title": ""
             },
             {
                 "key": "Note",
                 "selector": "strike-damage",
-                "text": "The Marshal's aura grants you and allies a status bonus to damage rolls equal to the number of weapon damage dice of the unarmed attack or weapon you are wielding that has the most weapon damage dice"
+                "text": "The Marshal's aura grants you and allies a status bonus to damage rolls equal to the number of weapon damage dice of the unarmed attack or weapon you are wielding that has the most weapon damage dice",
+                "title": ""
             }
         ],
         "source": {

--- a/packs/data/feat-effects.db/effect-dread-marshal-stance.json
+++ b/packs/data/feat-effects.db/effect-dread-marshal-stance.json
@@ -26,8 +26,7 @@
             {
                 "key": "Note",
                 "selector": "strike-damage",
-                "text": "The Marshal's aura grants you and allies a status bonus to damage rolls equal to the number of weapon damage dice of the unarmed attack or weapon you are wielding that has the most weapon damage dice",
-                "title": ""
+                "text": "The Marshal's aura grants you and allies a status bonus to damage rolls equal to the number of weapon damage dice of the unarmed attack or weapon you are wielding that has the most weapon damage dice"
             }
         ],
         "source": {

--- a/packs/data/feat-effects.db/effect-dread-marshal-stance.json
+++ b/packs/data/feat-effects.db/effect-dread-marshal-stance.json
@@ -21,8 +21,7 @@
                     "criticalSuccess"
                 ],
                 "selector": "strike-damage",
-                "text": "When you or an ally in the aura critically hits an enemy with a Strike, that enemy is @Compendium[pf2e.conditionitems.Frightened]{Frightened 1}.",
-                "title": ""
+                "text": "When you or an ally in the aura critically hits an enemy with a Strike, that enemy is @Compendium[pf2e.conditionitems.Frightened]{Frightened 1}."
             },
             {
                 "key": "Note",

--- a/packs/data/feat-effects.db/effect-inspiring-marshal-stance.json
+++ b/packs/data/feat-effects.db/effect-inspiring-marshal-stance.json
@@ -1,13 +1,14 @@
 {
     "_id": "kzEPq4aczYb6OD2h",
     "data": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by @Compendium[pf2e.feats-srd.Inspiring Marshal Stance]{Inspiring Marshal Stance}</p>\n<p>Your marshal's aura grants you and allies a +1 status bonus to\nattack rolls and saves against mental effects.</p>"
         },
         "duration": {
             "expiry": "turn-start",
             "sustained": false,
-            "unit": "unlimited",
+            "unit": "encounter",
             "value": -1
         },
         "level": {

--- a/packs/data/feat-effects.db/effect-reflective-ripple-stance.json
+++ b/packs/data/feat-effects.db/effect-reflective-ripple-stance.json
@@ -7,8 +7,8 @@
         },
         "duration": {
             "expiry": "turn-start",
-            "sustained": true,
-            "unit": "unlimited",
+            "sustained": false,
+            "unit": "encounter",
             "value": -1
         },
         "level": {
@@ -74,7 +74,7 @@
         },
         "target": null,
         "tokenIcon": {
-            "show": false
+            "show": true
         },
         "traits": {
             "custom": "",

--- a/packs/data/feat-effects.db/stance-everstand-stance.json
+++ b/packs/data/feat-effects.db/stance-everstand-stance.json
@@ -8,7 +8,7 @@
         "duration": {
             "expiry": "turn-start",
             "sustained": false,
-            "unit": "unlimited",
+            "unit": "encounter",
             "value": -1
         },
         "level": {


### PR DESCRIPTION
Closes #3045
Changes Duration from Unlimites to "End of Encounter" on:

- Effect: Dread Marshal Stance
- Effect: Inspiring Marshal Stance
- Effect: Reflective Ripple Stance
- Effect: Everstand Stance

Removes "Sustained" from Effect: Reflective Ripple Stance.
Adds "Show Token icon" to Effect: Reflective Ripple Stance.