### PR TITLE
Add Aspirational State Ritual from PFS 2-22

### DIFF
--- a/packs/data/spells.db/aspirational-state.json
+++ b/packs/data/spells.db/aspirational-state.json
@@ -1,0 +1,152 @@
+{
+    "_id": "wrm1zIiLyFD1Is6h",
+    "data": {
+        "ability": {
+            "value": ""
+        },
+        "area": {
+            "areaType": "",
+            "value": ""
+        },
+        "category": {
+            "value": "ritual"
+        },
+        "components": {
+            "focus": false,
+            "material": false,
+            "somatic": false,
+            "verbal": false
+        },
+        "cost": {
+            "value": "totems related to the associated goal"
+        },
+        "damage": {
+            "value": {}
+        },
+        "description": {
+            "value": "<p>The primary caster takes an ethereal form composed of the combined drive of every caster to exorcise a malevolent spirit. In this form the primary caster can automatically locate the target of this common goal, and they can orient the secondary casters to this location. The primary caster can't interact with physical objects in this form, but they can interfere with the abilities of other incorporeal creatures, including spirits possessing a physical body. The primary caster can also manifest the collective intent of the ritual's participants as shifts in reality that further the casters' goal. These shifts manifest as Aspiration Points, which the secondary casters can spend on the Material Plane to aid their cause. Using Aspiration Points is described on page 7.</p>\n<p>The magical feedback created by this ritual renders teleportation magic unstable. Any attempt by the casters or the target of the ritual to use an ability with the teleportation trait automatically fails while the ritual is in effect. When the duration expires, the primary caster must spend 1 Aspiration Point to return to the Material Plane; if insufficient Aspiration Points remain, then the primary caster becomes trapped in the Ethereal Plane.</p>\n<hr />\n<p><strong>Critical Success</strong> The PCs gain 8 Aspiration Points. The strong connection between all the casters gives the secondary casters resistance 5 to negative damage for the remainder of the adventure.</p>\n<p><strong>Success</strong> The PCs gain 6 Aspiration Points.</p>\n<p><strong>Failure</strong> The PCs gain 4 Aspiration Points. The tenuous connection between the casters makes them vulnerable to entropy, giving the secondary casters weakness 5 to negative damage for the remainder of the adventure.</p>"
+        },
+        "duration": {
+            "value": "up to 24 hours"
+        },
+        "hasCounteractCheck": {
+            "value": false
+        },
+        "level": {
+            "value": 5
+        },
+        "location": {
+            "value": ""
+        },
+        "materials": {
+            "value": ""
+        },
+        "overlays": {
+            "2ytogtmt6fuqt7ax": {
+                "_id": "2ytogtmt6fuqt7ax",
+                "data": {
+                    "primarycheck": {
+                        "value": "DC 34 Occultism (master)"
+                    },
+                    "secondarycasters": {
+                        "value": "2"
+                    },
+                    "secondarycheck": {
+                        "value": "DC 27 Arcana, Athletics, Nature, Occultism, Performance, Religion, or Society"
+                    }
+                },
+                "name": "Aspirational State (Level 9-10, 5 or fewer PCs)",
+                "overlayType": "override",
+                "sort": 2
+            },
+            "e2tir0ve6g4wtagu": {
+                "_id": "e2tir0ve6g4wtagu",
+                "data": {
+                    "primarycheck": {
+                        "value": "DC 32 Occultism (master)"
+                    },
+                    "secondarycasters": {
+                        "value": "3"
+                    },
+                    "secondarycheck": {
+                        "value": "DC 24 Arcana, Athletics, Nature, Occultism, Performance, Religion, or Society"
+                    }
+                },
+                "name": "Aspirational State (Level 7-8, 6 PCs)",
+                "overlayType": "override",
+                "sort": 1
+            },
+            "t43a3pt01ure0ngh": {
+                "_id": "t43a3pt01ure0ngh",
+                "data": {
+                    "primarycheck": {
+                        "value": "DC 34 Occultism (master)"
+                    },
+                    "secondarycasters": {
+                        "value": "3"
+                    },
+                    "secondarycheck": {
+                        "value": "DC 27 Arcana, Athletics, Nature, Occultism, Performance, Religion, or Society"
+                    }
+                },
+                "name": "Aspirational State (Level 9-10, 6 PCs)",
+                "overlayType": "override",
+                "sort": 3
+            }
+        },
+        "primarycheck": {
+            "value": "DC 32 Occultism (master; DC 34 for levels 9–10)"
+        },
+        "range": {
+            "value": ""
+        },
+        "rules": [],
+        "save": {
+            "basic": "",
+            "value": ""
+        },
+        "school": {
+            "value": "abjuration"
+        },
+        "secondarycasters": {
+            "value": "2 (3 for groups of 6 PCs)"
+        },
+        "secondarycheck": {
+            "value": "DC 24 Arcana, Athletics, Nature, Occultism, Performance, Religion, or Society (DC 27 for levels 9–10)"
+        },
+        "source": {
+            "value": "Pathfinder Society Scenario #2-22: Breaking the Storm: Excising Ruination"
+        },
+        "spellType": {
+            "value": "utility"
+        },
+        "sustained": {
+            "value": false
+        },
+        "target": {
+            "value": ""
+        },
+        "time": {
+            "value": "4 hours"
+        },
+        "traditions": {
+            "custom": "",
+            "value": [
+                "primal"
+            ]
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "rare",
+            "value": [
+                "abjuration",
+                "incorporeal",
+                "primal",
+                "transmutation"
+            ]
+        }
+    },
+    "img": "systems/pf2e/icons/spells/face-in-the-crowd.webp",
+    "name": "Aspirational State",
+    "type": "spell"
+}

--- a/src/scripts/config/traits.ts
+++ b/src/scripts/config/traits.ts
@@ -282,6 +282,7 @@ const spellOtherTraits = {
     hex: "PF2E.TraitHex",
     incapacitation: "PF2E.TraitIncapacitation",
     incarnate: "PF2E.TraitIncarnate",
+    incorporeal: "PF2E.TraitIncorporeal",
     inhaled: "PF2E.TraitInhaled",
     light: "PF2E.TraitLight",
     linguistic: "PF2E.TraitLinguistic",
@@ -346,6 +347,7 @@ const spellTraits = {
     ...damageTraits,
     ...elementalTraits,
     ...magicSchools,
+    ...magicTraditions,
     ...spellOtherTraits,
 };
 


### PR DESCRIPTION
With the fixes added previously to allow multiple schools to be added via Traits, this should work for resolving https://github.com/foundryvtt/pf2e/issues/2447 at this time.