### PR TITLE
Fix Drained Condition Health Removal

### DIFF
--- a/packs/data/conditionitems.db/drained.json
+++ b/packs/data/conditionitems.db/drained.json
@@ -48,7 +48,8 @@
             },
             {
                 "key": "LoseHitPoints",
-                "value": "@actor.level * @item.badge.value"
+                "value": "@actor.level * @item.badge.value",
+                "reevaluateOnUpdate": true
             }
         ],
         "source": {

--- a/src/module/item/base.ts
+++ b/src/module/item/base.ts
@@ -590,8 +590,6 @@ class ItemPF2e extends Item<ActorPF2e> {
         type WithPreUpdate = RuleElementPF2e & { preUpdate: NonNullable<RuleElementPF2e["preUpdate"]> };
         const rules = this.rules.filter((r): r is WithPreUpdate => !!r.preUpdate);
         if (rules.length > 0) {
-            const clone = this.clone(changed, { keepId: true });
-            this.data.flags.pf2e.rollOptions = clone.data.flags.pf2e.rollOptions;
             for (const rule of rules) {
                 await rule.preUpdate(changed);
             }

--- a/src/module/item/base.ts
+++ b/src/module/item/base.ts
@@ -587,12 +587,8 @@ class ItemPF2e extends Item<ActorPF2e> {
         }
 
         // Run preUpdateItem rule element callbacks
-        type WithPreUpdate = RuleElementPF2e & { preUpdate: NonNullable<RuleElementPF2e["preUpdate"]> };
-        const rules = this.rules.filter((r): r is WithPreUpdate => !!r.preUpdate);
-        if (rules.length > 0) {
-            for (const rule of rules) {
-                await rule.preUpdate(changed);
-            }
+        for (const rule of this.rules) {
+            await rule.preUpdate?.(changed);
         }
 
         await super._preUpdate(changed, options, user);

--- a/src/module/item/base.ts
+++ b/src/module/item/base.ts
@@ -585,6 +585,18 @@ class ItemPF2e extends Item<ActorPF2e> {
         if (changed.data?.description?.value === null) {
             changed.data.description.value = "";
         }
+
+        // Run preUpdateItem rule element callbacks
+        type WithPreUpdate = RuleElementPF2e & { preUpdate: NonNullable<RuleElementPF2e["preUpdate"]> };
+        const rules = this.rules.filter((r): r is WithPreUpdate => !!r.preUpdate);
+        if (rules.length > 0) {
+            const clone = this.clone(changed, { keepId: true });
+            this.data.flags.pf2e.rollOptions = clone.data.flags.pf2e.rollOptions;
+            for (const rule of rules) {
+                await rule.preUpdate(changed);
+            }
+        }
+
         await super._preUpdate(changed, options, user);
     }
 

--- a/src/module/rules/rule-element/base.ts
+++ b/src/module/rules/rule-element/base.ts
@@ -385,6 +385,10 @@ interface RuleElementPF2e {
     preDelete?({ pendingItems, context }: RuleElementPF2e.PreDeleteParams): Promise<void>;
 
     /**
+     * Runs before this rules element's parent item is updated */
+    preUpdate?(changes: DeepPartial<ItemSourcePF2e>): Promise<void>;
+
+    /**
      * Runs after an item holding this rule is added to an actor. If you modify or add the rule after the item
      * is already present on the actor, nothing will happen. Rules that add toggles won't work here since this method is
      * only called on item add.

--- a/src/module/rules/rule-element/lose-hit-points.ts
+++ b/src/module/rules/rule-element/lose-hit-points.ts
@@ -1,25 +1,48 @@
 import { CreaturePF2e } from "@actor";
 import { ItemPF2e } from "@item";
+import { ItemSourcePF2e } from "@item/data";
 import { RuleElementPF2e, RuleElementSource } from "./";
 import { RuleElementOptions } from "./base";
 
 /** Reduce current hit points without applying damage */
 export class LoseHitPointsRuleElement extends RuleElementPF2e {
-    constructor(data: RuleElementSource, item: Embedded<ItemPF2e>, options?: RuleElementOptions) {
+    /** Lost hitpoints should reevaluate on item update, with the parent actor losing the difference in HP between the new and old values */
+    protected reevaluateOnUpdate: boolean;
+
+    constructor(data: LoseHitPointsSource, item: Embedded<ItemPF2e>, options?: RuleElementOptions) {
         super(data, item, options);
         const actorIsCreature = this.actor instanceof CreaturePF2e;
         const valueIsValid = typeof data.value === "number" || typeof data.value === "string";
         if (!(actorIsCreature && valueIsValid)) this.ignored = true;
+        this.reevaluateOnUpdate = !!data.reevaluateOnUpdate;
     }
 
     override onCreate(actorUpdates: Record<string, unknown>): void {
         if (this.ignored) return;
         const value = Math.abs(Number(this.resolveValue()) || 0);
-        if (typeof value === "number") {
+        const currentHP = this.actor.data._source.data.attributes.hp.value;
+        actorUpdates["data.attributes.hp.value"] = Math.max(currentHP - value, 0);
+    }
+
+    override async preUpdate(changes: DeepPartial<ItemSourcePF2e>): Promise<void> {
+        if (!this.reevaluateOnUpdate || this.ignored) return;
+        const previousValue = Math.abs(Number(this.resolveValue()) || 0);
+        const newItem = this.item.clone(changes);
+        const rule = newItem.data.data.rules.find((r) => r.key === this.key);
+        const newValue = Math.abs(Number(this.resolveValue(rule?.value, 0, { resolvables: { item: newItem } })));
+        const valueChange = newValue - previousValue;
+        if (valueChange > 0) {
             const currentHP = this.actor.data._source.data.attributes.hp.value;
-            actorUpdates["data.attributes.hp.value"] = Math.max(currentHP - value, 0);
+            await this.actor.update(
+                { "data.attributes.hp.value": Math.max(currentHP - valueChange, 0) },
+                { render: false }
+            );
         }
     }
+}
+
+interface LoseHitPointsSource extends RuleElementSource {
+    reevaluateOnUpdate?: unknown;
 }
 
 export interface LoseHitPointsRuleElement extends RuleElementPF2e {


### PR DESCRIPTION
Potential fix for https://github.com/foundryvtt/pf2e/issues/2962

I hope there can be a neater solution to this but I struggled to find something that didn't resort to hard coding. The problems with drain are:
- Hooking into preUpdateActor won't work since the condition is being updated, not the actor
- Making a new preUpdateItem method could be promising but...
- Since we're incrementing a condition we need to know the previous value and new value, to avoid removing too much health

There were other issues but essentially I struggled to find a way to do this in a clean, generic way. This solution works but it most likely would be better somewhere else instead of on an RE. Happy to hear suggestions.