### PR TITLE
Correct description of the Staff of Illusion Items

### DIFF
--- a/packs/data/equipment.db/staff-of-illusion-greater.json
+++ b/packs/data/equipment.db/staff-of-illusion-greater.json
@@ -20,7 +20,7 @@
             "value": ""
         },
         "description": {
-            "value": "<p>This staff is tapered at the base and carved into a gem-studded twist at the top. While wielding the staff, you gain a +2 circumstance bonus to checks to identify evocation magic.</p>\n<p><strong>Activate</strong> Cast a Spell</p>\n<hr />\n<p><strong>Effect</strong> You expend a number of charges from the staff to cast a spell from its list.</p>\n<ul>\n<li><strong>Cantrip</strong> <em>@Compendium[pf2e.spells-srd.Ghost Sound]{Ghost Sound}</em></li>\n<li><strong>1st</strong> <em>@Compendium[pf2e.spells-srd.Illusory Disguise]{Illusory Disguise}</em>, <em>@Compendium[pf2e.spells-srd.Illusory Object]{Illusory Object}</em></li>\n<li><strong>2nd</strong> <em>@Compendium[pf2e.spells-srd.Illusory Creature]{Illusory Creature}</em>, <em>@Compendium[pf2e.spells-srd.Item Facade]{Item Facade}</em></li>\n<li><strong>3rd</strong> <em>@Compendium[pf2e.spells-srd.Illusory Disguise]{Illusory Disguise}</em>, <em>@Compendium[pf2e.spells-srd.Item Facade]{Item Facade}</em></li>\n<li><strong>4th</strong> <em>@Compendium[pf2e.spells-srd.Illusory Creature]{Illusory Creature}</em>, <em>@Compendium[pf2e.spells-srd.Veil]{Veil}</em></li>\n</ul>\n<p><strong>Craft Requirements</strong> Supply one casting of all listed levels of all listed spells.</p>"
+            "value": "<p>This ornately designed metal staff shines with precious inlays of gold. When you Cast a Spell from the staff, the illusory image of something you desire flashes across its surface. While wielding the staff, you gain a +2 circumstance bonus to checks to identify illusion magic.</p>\n<p><strong>Activate</strong> Cast a Spell</p>\n<hr />\n<p><strong>Effect</strong> You expend a number of charges from the staff to cast a spell from its list.</p>\n<ul>\n<li><strong>Cantrip</strong> <em>@Compendium[pf2e.spells-srd.Ghost Sound]{Ghost Sound}</em></li>\n<li><strong>1st</strong> <em>@Compendium[pf2e.spells-srd.Illusory Disguise]{Illusory Disguise}</em>, <em>@Compendium[pf2e.spells-srd.Illusory Object]{Illusory Object}</em></li>\n<li><strong>2nd</strong> <em>@Compendium[pf2e.spells-srd.Illusory Creature]{Illusory Creature}</em>, <em>@Compendium[pf2e.spells-srd.Item Facade]{Item Facade}</em>, <em>@Compendium[pf2e.spells-srd.Ventriloquism]{Ventriloquism}</em></li>\n<li><strong>3rd</strong> <em>@Compendium[pf2e.spells-srd.Illusory Disguise]{Illusory Disguise}</em>, <em>@Compendium[pf2e.spells-srd.Item Facade]{Item Facade}</em></li>\n<li><strong>4th</strong> <em>@Compendium[pf2e.spells-srd.Illusory Creature]{Illusory Creature}</em>, <em>@Compendium[pf2e.spells-srd.Veil]{Veil}</em></li>\n</ul>\n<p><strong>Craft Requirements</strong> Supply one casting of all listed levels of all listed spells.</p>"
         },
         "equippedBulk": {
             "value": ""
@@ -39,13 +39,13 @@
             "value": "0"
         },
         "potencyRune": {
-            "value": null
+            "value": 0
         },
         "preciousMaterial": {
-            "value": ""
+            "value": null
         },
         "preciousMaterialGrade": {
-            "value": ""
+            "value": null
         },
         "price": {
             "value": {
@@ -67,16 +67,16 @@
             "value": ""
         },
         "propertyRune1": {
-            "value": ""
+            "value": null
         },
         "propertyRune2": {
-            "value": ""
+            "value": null
         },
         "propertyRune3": {
-            "value": ""
+            "value": null
         },
         "propertyRune4": {
-            "value": ""
+            "value": null
         },
         "quantity": 1,
         "range": null,
@@ -101,6 +101,9 @@
         "size": "med",
         "source": {
             "value": "Pathfinder Core Rulebook"
+        },
+        "specific": {
+            "value": false
         },
         "splashDamage": {
             "value": 0

--- a/packs/data/equipment.db/staff-of-illusion-major.json
+++ b/packs/data/equipment.db/staff-of-illusion-major.json
@@ -20,7 +20,7 @@
             "value": ""
         },
         "description": {
-            "value": "<p>This staff is tapered at the base and carved into a gem-studded twist at the top. While wielding the staff, you gain a +2 circumstance bonus to checks to identify evocation magic.</p>\n<p><strong>Activate</strong> Cast a Spell</p>\n<hr />\n<p><strong>Effect</strong> You expend a number of charges from the staff to cast a spell from its list.</p>\n<ul>\n<li><strong>Cantrip</strong> <em>@Compendium[pf2e.spells-srd.Ghost Sound]{Ghost Sound}</em></li>\n<li><strong>1st</strong> <em>@Compendium[pf2e.spells-srd.Illusory Disguise]{Illusory Disguise}</em>, <em>@Compendium[pf2e.spells-srd.Illusory Object]{Illusory Object}</em></li>\n<li><strong>2nd</strong> <em>@Compendium[pf2e.spells-srd.Illusory Creature]{Illusory Creature}</em>, <em>@Compendium[pf2e.spells-srd.Item Facade]{Item Facade}</em></li>\n<li><strong>3rd</strong> <em>@Compendium[pf2e.spells-srd.Illusory Disguise]{Illusory Disguise}</em>, <em>@Compendium[pf2e.spells-srd.Item Facade]{Item Facade}</em></li>\n<li><strong>4th</strong> <em>@Compendium[pf2e.spells-srd.Illusory Creature]{Illusory Creature}</em>, <em>@Compendium[pf2e.spells-srd.Veil]{Veil}</em></li>\n<li><strong>5th</strong> <em>@Compendium[pf2e.spells-srd.Illusory Scene]{Illusory Scene}</em>, <em>@Compendium[pf2e.spells-srd.Veil]{Veil}</em></li>\n<li><strong>6th</strong> <em>@Compendium[pf2e.spells-srd.Hallucination]{Hallucination}</em>, <em>@Compendium[pf2e.spells-srd.Mislead]{Mislead}</em></li>\n</ul>\n<p><strong>Craft Requirements</strong> Supply one casting of all listed levels of all listed spells.</p>"
+            "value": "<p>This ornately designed metal staff shines with precious inlays of gold. When you Cast a Spell from the staff, the illusory image of something you desire flashes across its surface. While wielding the staff, you gain a +2 circumstance bonus to checks to identify illusion magic.</p>\n<p><strong>Activate</strong> Cast a Spell</p>\n<hr />\n<p><strong>Effect</strong> You expend a number of charges from the staff to cast a spell from its list.</p>\n<ul>\n<li><strong>Cantrip</strong> <em>@Compendium[pf2e.spells-srd.Ghost Sound]{Ghost Sound}</em></li>\n<li><strong>1st</strong> <em>@Compendium[pf2e.spells-srd.Illusory Disguise]{Illusory Disguise}</em>, <em>@Compendium[pf2e.spells-srd.Illusory Object]{Illusory Object}</em></li>\n<li><strong>2nd</strong> <em>@Compendium[pf2e.spells-srd.Illusory Creature]{Illusory Creature}</em>, <em>@Compendium[pf2e.spells-srd.Item Facade]{Item Facade}</em>, <em>@Compendium[pf2e.spells-srd.Ventriloquism]{Ventriloquism}</em></li>\n<li><strong>3rd</strong> <em>@Compendium[pf2e.spells-srd.Illusory Disguise]{Illusory Disguise}</em>, <em>@Compendium[pf2e.spells-srd.Item Facade]{Item Facade}</em></li>\n<li><strong>4th</strong> <em>@Compendium[pf2e.spells-srd.Illusory Creature]{Illusory Creature}</em>, <em>@Compendium[pf2e.spells-srd.Veil]{Veil}</em></li>\n<li><strong>5th</strong> <em>@Compendium[pf2e.spells-srd.Illusory Scene]{Illusory Scene}</em>, <em>@Compendium[pf2e.spells-srd.Veil]{Veil}</em></li>\n<li><strong>6th</strong> <em>@Compendium[pf2e.spells-srd.Hallucination]{Hallucination}</em>, <em>@Compendium[pf2e.spells-srd.Mislead]{Mislead}</em></li>\n</ul>\n<p><strong>Craft Requirements</strong> Supply one casting of all listed levels of all listed spells.</p>"
         },
         "equippedBulk": {
             "value": ""
@@ -39,13 +39,13 @@
             "value": "0"
         },
         "potencyRune": {
-            "value": null
+            "value": 0
         },
         "preciousMaterial": {
-            "value": ""
+            "value": null
         },
         "preciousMaterialGrade": {
-            "value": ""
+            "value": null
         },
         "price": {
             "value": {
@@ -67,16 +67,16 @@
             "value": ""
         },
         "propertyRune1": {
-            "value": ""
+            "value": null
         },
         "propertyRune2": {
-            "value": ""
+            "value": null
         },
         "propertyRune3": {
-            "value": ""
+            "value": null
         },
         "propertyRune4": {
-            "value": ""
+            "value": null
         },
         "quantity": 1,
         "range": null,
@@ -101,6 +101,9 @@
         "size": "med",
         "source": {
             "value": "Pathfinder Core Rulebook"
+        },
+        "specific": {
+            "value": false
         },
         "splashDamage": {
             "value": 0

--- a/packs/data/equipment.db/staff-of-illusion.json
+++ b/packs/data/equipment.db/staff-of-illusion.json
@@ -20,7 +20,7 @@
             "value": ""
         },
         "description": {
-            "value": "<p>This staff is tapered at the base and carved into a gem-studded twist at the top. While wielding the staff, you gain a +2 circumstance bonus to checks to identify evocation magic.</p>\n<p><strong>Activate</strong> Cast a Spell</p>\n<hr />\n<p><strong>Effect</strong> You expend a number of charges from the staff to cast a spell from its list.</p>\n<ul>\n<li><strong>Cantrip</strong> <em>@Compendium[pf2e.spells-srd.Ghost Sound]{Ghost Sound}</em></li>\n<li><strong>1st</strong> <em>@Compendium[pf2e.spells-srd.Illusory Disguise]{Illusory Disguise}</em>, <em>@Compendium[pf2e.spells-srd.Illusory Object]{Illusory Object}</em></li>\n<li><strong>2nd</strong> <em>@Compendium[pf2e.spells-srd.Illusory Creature]{Illusory Creature}</em>, <em>@Compendium[pf2e.spells-srd.Item Facade]{Item Facade}</em></li>\n</ul>\n<p><strong>Craft Requirements</strong> Supply one casting of all listed levels of all listed spells.</p>"
+            "value": "<p>This ornately designed metal staff shines with precious inlays of gold. When you Cast a Spell from the staff, the illusory image of something you desire flashes across its surface. While wielding the staff, you gain a +2 circumstance bonus to checks to identify illusion magic.</p>\n<p><strong>Activate</strong> Cast a Spell</p>\n<hr />\n<p><strong>Effect</strong> You expend a number of charges from the staff to cast a spell from its list.</p>\n<ul>\n<li><strong>Cantrip</strong> <em>@Compendium[pf2e.spells-srd.Ghost Sound]{Ghost Sound}</em></li>\n<li><strong>1st</strong> <em>@Compendium[pf2e.spells-srd.Illusory Disguise]{Illusory Disguise}</em>, <em>@Compendium[pf2e.spells-srd.Illusory Object]{Illusory Object}</em></li>\n<li><strong>2nd</strong> <em>@Compendium[pf2e.spells-srd.Illusory Creature]{Illusory Creature}</em>, <em>@Compendium[pf2e.spells-srd.Item Facade]{Item Facade}</em>, <em>@Compendium[pf2e.spells-srd.Ventriloquism]{Ventriloquism}</em></li>\n</ul>\n<p><strong>Craft Requirements</strong> Supply one casting of all listed levels of all listed spells.</p>"
         },
         "equippedBulk": {
             "value": ""
@@ -39,13 +39,13 @@
             "value": "0"
         },
         "potencyRune": {
-            "value": null
+            "value": 0
         },
         "preciousMaterial": {
-            "value": ""
+            "value": null
         },
         "preciousMaterialGrade": {
-            "value": ""
+            "value": null
         },
         "price": {
             "value": {
@@ -67,16 +67,16 @@
             "value": ""
         },
         "propertyRune1": {
-            "value": ""
+            "value": null
         },
         "propertyRune2": {
-            "value": ""
+            "value": null
         },
         "propertyRune3": {
-            "value": ""
+            "value": null
         },
         "propertyRune4": {
-            "value": ""
+            "value": null
         },
         "quantity": 1,
         "range": null,
@@ -101,6 +101,9 @@
         "size": "med",
         "source": {
             "value": "Pathfinder Core Rulebook"
+        },
+        "specific": {
+            "value": false
         },
         "splashDamage": {
             "value": 0


### PR DESCRIPTION
Also adds Ventriloquism to the 2nd level spells provided by the Staffs; this is present in all three versions of the CRB.
Closes https://github.com/foundryvtt/pf2e/issues/3010.