### PR TITLE
Run migration to remove duplicated image

### DIFF
--- a/src/module/migration/migrations/767-remove-camelCase-persistent-damage-images.ts
+++ b/src/module/migration/migrations/767-remove-camelCase-persistent-damage-images.ts
@@ -2,7 +2,8 @@ import { ItemSourcePF2e } from "@item/data";
 import { isObject } from "@util";
 import { MigrationBase } from "../base";
 
-export class Migration767RemoveCamelCasePersistentDamageImages extends MigrationBase{
+/** Removes any instances of persistentDamage.webp and replaces them with persistent-damage.webp **/
+export class Migration767RemoveCamelCasePersistentDamageImages extends MigrationBase {
     static override version = 0.767;
     override async updateItem(source: ItemSourcePF2e): Promise<void> {
         if (

--- a/src/module/migration/migrations/767-remove-camelCase-persistent-damage-images.ts
+++ b/src/module/migration/migrations/767-remove-camelCase-persistent-damage-images.ts
@@ -1,0 +1,17 @@
+import { ItemSourcePF2e } from "@item/data";
+import { isObject } from "@util";
+import { MigrationBase } from "../base";
+
+export class Migration767RemoveCamelCasePersistentDamageImages extends MigrationBase{
+    static override version = 0.767;
+    override async updateItem(source: ItemSourcePF2e): Promise<void> {
+        if (
+            (!("game" in globalThis) || source.flags.core?.sourceId.startsWith("Compendium.pf2e.")) &&
+            isObject<{ value: unknown }>(source.data.source) &&
+            typeof source.data.source.value === "string" &&
+            source.data.source.value.startsWith("persistentDamage.webp")
+        ) {
+            source.data.source.value = "persistent-damage.webp";
+        }
+    }
+}

--- a/src/module/migration/migrations/index.ts
+++ b/src/module/migration/migrations/index.ts
@@ -166,3 +166,4 @@ export { Migration763RestoreAnimalStrikeOptions } from "./763-restore-animal-str
 export { Migration764PanacheVivaciousREs } from "./764-panache-vivacious-res";
 export { Migration765ChoiceOwnedItemTypes } from "./765-choice-owned-item-types";
 export { Migration766WipeURLSources } from "./766-wipe-url-sources";
+export { Migration767RemoveCamelCasePersistentDamageImages } from "./767-remove-camelCase-persistent-damage-images";


### PR DESCRIPTION
If necessary to prevent any issues from https://github.com/foundryvtt/pf2e/pull/3115. Shamelessly copied from Migration 766. If not necessary, just kill it.