### PR TITLE
Localize Skill Variant for Falrok (AoA)

### DIFF
--- a/packs/data/age-of-ashes-bestiary.db/falrok.json
+++ b/packs/data/age-of-ashes-bestiary.db/falrok.json
@@ -312,7 +312,7 @@
                     {
                         "domain": "all",
                         "key": "RollOption",
-                        "label": "In lazurite infused terrain",
+                        "label": "PF2E.NPCAbility.Falrok.LazuriteTerrainSwitch",
                         "option": "terrain:lazurite",
                         "toggleable": true
                     }

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -467,6 +467,9 @@
                 "AC": "Designated Prey attacks the Duskwalker",
                 "Checks": "Duskwalker rolls checks against his Designated Prey"
             },
+            "Falrok": {
+                "LazuriteTerrainSwitch": "In lazurite infused terrain"
+            },
             "GiantAnimatedStatueBrazier": "Brazier is alight",
             "HobgoblinFormationArea": "Formation vs. Area Effects",
             "LegionArchonFlameOfJustice": "Flame of Justice - Critical Hit",


### PR DESCRIPTION
Changed RuleElement of AoA: Falrok to use re-en.json