### PR TITLE
Get confirmation from user before replacing generated NPC attacks

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -178,7 +178,6 @@ declare global {
         get(module: "pf2e", setting: "enabledRulesUI"): boolean;
         get(module: "pf2e", setting: "identifyMagicNotMatchingTraditionModifier"): 0 | 2 | 5 | 10;
         get(module: "pf2e", setting: "nathMode"): boolean;
-        get(module: "pf2e", setting: "npcAttacksFromWeapons"): boolean;
         get(module: "pf2e", setting: "statusEffectType"): StatusEffectIconTheme;
         get(module: "pf2e", setting: "worldSchemaVersion"): number;
         get(module: "pf2e", setting: "worldSystemVersion"): string;

--- a/src/module/actor/npc/types.ts
+++ b/src/module/actor/npc/types.ts
@@ -105,7 +105,6 @@ interface NPCSheetData<T extends NPCPF2e = NPCPF2e> extends CreatureSheetData<T>
     hasShield?: boolean;
     hasHardness?: boolean;
     configLootableNpc?: boolean;
-    npcAttacksFromWeapons?: boolean;
 }
 
 type NPCSheetItemData<T extends ItemDataPF2e | RawObject<ItemDataPF2e> = ItemDataPF2e> = T & {

--- a/src/module/system/settings/index.ts
+++ b/src/module/system/settings/index.ts
@@ -227,14 +227,6 @@ export function registerSettings() {
         type: Boolean,
     });
 
-    game.settings.register("pf2e", "npcAttacksFromWeapons", {
-        name: "NPC Attacks From Weapons",
-        scope: "world",
-        config: false,
-        default: false,
-        type: Boolean,
-    });
-
     if (BUILD_MODE === "production") {
         registerWorldSchemaVersion();
     }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -738,6 +738,14 @@
                         "Lootable": "Lootable",
                         "NotLootable": "Not Lootable"
                     }
+                },
+                "GenerateAttack": {
+                    "Label": "Generate Attack",
+                    "Confirm": {
+                        "Title": "Regenerate attack",
+                        "Content": "An attack has already been generated for this weapon. Would you like to replace it?"
+                    },
+                    "Notification": "Generated NPC attack: {attack}"
                 }
             },
             "Plural": "Actors"

--- a/static/templates/actors/partials/item-line.html
+++ b/static/templates/actors/partials/item-line.html
@@ -61,8 +61,8 @@
                 {{#if (and isSellable (ne @root.actor.type "loot"))}}
                     <a class="item-control item-sell-treasure" title="{{localize "PF2E.ui.sell"}}"><i class="fas fa-coins"></i></a>
                 {{/if}}
-                {{#if (and @root.npcAttacksFromWeapons (eq item.type "weapon") (eq @root.actor.type "npc"))}}
-                    <a class="item-control" data-action="generate-attack" title="Generate Attack"><i class="fas fa-bolt"></i></a>
+                {{#if (and (eq item.type "weapon") (eq @root.actor.type "npc"))}}
+                    <a class="item-control" data-action="generate-attack" title="{{localize "PF2E.Actor.NPC.GenerateAttack.Label"}}"><i class="fas fa-bolt"></i></a>
                 {{/if}}
                 {{#if (or @root.user.isGM item.isIdentified)}}
                     <a class="item-control item-edit" title="{{localize "PF2E.EditItemTitle"}}"><i class="fas fa-edit"></i></a>


### PR DESCRIPTION
This is the last bit of polish for the initial feature release, so the PR also removes the secret setting that hid it.