### PR TITLE
Add rule elements to have Esoteric Lore checks use charisma

### DIFF
--- a/packs/data/classfeatures.db/esoteric-lore.json
+++ b/packs/data/classfeatures.db/esoteric-lore.json
@@ -25,6 +25,25 @@
         },
         "rules": [
             {
+                "ability": "cha",
+                "key": "FlatModifier",
+                "selector": "esoteric-lore",
+                "type": "ability"
+            },
+            {
+                "key": "AdjustModifier",
+                "predicate": {
+                    "all": [
+                        "modifier:type:ability"
+                    ],
+                    "not": [
+                        "modifier:ability:cha"
+                    ]
+                },
+                "selector": "esoteric-lore",
+                "suppress": true
+            },
+            {
                 "key": "GrantItem",
                 "uuid": "Compendium.pf2e.feats-srd.Dubious Knowledge"
             }


### PR DESCRIPTION
This will still require one to create a lore skill called "Esoteric Lore," but a better solution will have to wait until system version 4.