### PR TITLE
Review spells against Nethys

### DIFF
--- a/packs/data/spells.db/dancing-shield.json
+++ b/packs/data/spells.db/dancing-shield.json
@@ -84,7 +84,7 @@
         },
         "traits": {
             "custom": "",
-            "rarity": "common",
+            "rarity": "uncommon",
             "value": []
         }
     },

--- a/packs/data/spells.db/dividing-trench.json
+++ b/packs/data/spells.db/dividing-trench.json
@@ -70,7 +70,7 @@
             "value": ""
         },
         "time": {
-            "value": "2"
+            "value": "3"
         },
         "traditions": {
             "custom": "",

--- a/packs/data/spells.db/falling-sky.json
+++ b/packs/data/spells.db/falling-sky.json
@@ -68,7 +68,10 @@
             "value": "2"
         },
         "traditions": {
-            "value": []
+            "value": [
+                "arcane",
+                "occult"
+            ]
         },
         "traits": {
             "custom": "",

--- a/packs/data/spells.db/focusing-hum.json
+++ b/packs/data/spells.db/focusing-hum.json
@@ -80,9 +80,7 @@
         "traits": {
             "custom": "",
             "rarity": "common",
-            "value": [
-                "enchantment"
-            ]
+            "value": []
         }
     },
     "img": "systems/pf2e/icons/default-icons/spell.svg",

--- a/packs/data/spells.db/foresee-the-path.json
+++ b/packs/data/spells.db/foresee-the-path.json
@@ -80,7 +80,7 @@
         },
         "traits": {
             "custom": "",
-            "rarity": "common",
+            "rarity": "uncommon",
             "value": [
                 "cantrip",
                 "psychic"

--- a/packs/data/spells.db/frenzied-revelry.json
+++ b/packs/data/spells.db/frenzied-revelry.json
@@ -92,7 +92,7 @@
         },
         "traits": {
             "custom": "",
-            "rarity": "common",
+            "rarity": "rare",
             "value": [
                 "cleric",
                 "emotion",

--- a/packs/data/spells.db/ghostly-shift.json
+++ b/packs/data/spells.db/ghostly-shift.json
@@ -15,7 +15,7 @@
             "focus": false,
             "material": false,
             "somatic": false,
-            "verbal": false
+            "verbal": true
         },
         "cost": {
             "value": ""

--- a/packs/data/spells.db/isolation.json
+++ b/packs/data/spells.db/isolation.json
@@ -75,7 +75,7 @@
         },
         "traits": {
             "custom": "",
-            "rarity": "common",
+            "rarity": "rare",
             "value": [
                 "cleric"
             ]

--- a/packs/data/spells.db/pact-broker.json
+++ b/packs/data/spells.db/pact-broker.json
@@ -9,7 +9,7 @@
             "value": ""
         },
         "category": {
-            "value": "spell"
+            "value": "focus"
         },
         "components": {
             "focus": false,

--- a/packs/data/spells.db/rally-point.json
+++ b/packs/data/spells.db/rally-point.json
@@ -65,10 +65,13 @@
             "value": ""
         },
         "time": {
-            "value": "2"
+            "value": "3"
         },
         "traditions": {
-            "value": []
+            "value": [
+                "arcane",
+                "occult"
+            ]
         },
         "traits": {
             "custom": "",

--- a/packs/data/spells.db/scouring-pulse.json
+++ b/packs/data/spells.db/scouring-pulse.json
@@ -108,7 +108,10 @@
         "traits": {
             "custom": "",
             "rarity": "uncommon",
-            "value": []
+            "value": [
+                "light",
+                "positive"
+            ]
         }
     },
     "img": "systems/pf2e/icons/spells/scouring-pulse.webp",

--- a/packs/data/spells.db/shadow-zombie.json
+++ b/packs/data/spells.db/shadow-zombie.json
@@ -88,7 +88,9 @@
         "traits": {
             "custom": "",
             "rarity": "uncommon",
-            "value": []
+            "value": [
+                "shadow"
+            ]
         }
     },
     "img": "systems/pf2e/icons/spells/shadow-zombie.webp",

--- a/packs/data/spells.db/string-of-fate.json
+++ b/packs/data/spells.db/string-of-fate.json
@@ -65,7 +65,7 @@
             "value": "you and 1 ally"
         },
         "time": {
-            "value": "2"
+            "value": "1"
         },
         "traditions": {
             "custom": "",

--- a/packs/data/spells.db/time-skip.json
+++ b/packs/data/spells.db/time-skip.json
@@ -14,8 +14,8 @@
         "components": {
             "focus": false,
             "material": false,
-            "somatic": false,
-            "verbal": true
+            "somatic": true,
+            "verbal": false
         },
         "cost": {
             "value": ""

--- a/packs/data/spells.db/wall-of-virtue.json
+++ b/packs/data/spells.db/wall-of-virtue.json
@@ -92,7 +92,7 @@
             "value": ""
         },
         "time": {
-            "value": "2"
+            "value": "3"
         },
         "traditions": {
             "custom": "",


### PR DESCRIPTION
Review spells by pulling data from Archives of Nethys' Elasticsearch backend. All changes were manually reviewed against the original PDFs; except Shadow Zombie, which I do not own.