### PR TITLE
Add basic automation to Fang Sharpener feat

### DIFF
--- a/packs/data/feats.db/fang-sharpener.json
+++ b/packs/data/feats.db/fang-sharpener.json
@@ -19,6 +19,7 @@
         "level": {
             "value": 1
         },
+        "location": null,
         "prerequisites": {
             "value": [
                 {
@@ -26,7 +27,51 @@
                 }
             ]
         },
-        "rules": [],
+        "rules": [
+            {
+                "category": "unarmed",
+                "damage": {
+                    "base": {
+                        "damageType": "piercing",
+                        "dice": 1,
+                        "die": "d4"
+                    }
+                },
+                "group": "brawling",
+                "key": "Strike",
+                "label": "PF2E.Weapon.Base.jaws",
+                "predicate": {
+                    "all": [
+                        "self:heritage:irongut-goblin"
+                    ]
+                },
+                "range": null,
+                "traits": [
+                    "unarmed"
+                ]
+            },
+            {
+                "key": "DamageDice",
+                "override": {
+                    "dieSize": "d8"
+                },
+                "predicate": {
+                    "all": [
+                        "self:heritage:razortooth-goblin"
+                    ]
+                },
+                "selector": "jaws-damage"
+            },
+            {
+                "key": "Note",
+                "outcome": [
+                    "criticalSuccess"
+                ],
+                "selector": "jaws-damage",
+                "text": "@Localize[PF2E.SpecificRule.Goblin.FangSharpener.Note]",
+                "title": "{item|name}"
+            }
+        ],
         "source": {
             "value": "Pathfinder Lost Omens: Character Guide"
         },

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -1177,6 +1177,9 @@
                 "ExtraSquishy": {
                     "Note": "If you roll a success to Squeeze, you get a critical success instead."
                 },
+                "FangSharpener": {
+                    "Note": "Whenever you score a critical hit with your jaws unarmed attack, your target takes [[/r (1 + @weapon.data.data.runes.striking)[persistent,bleed]]] @Compendium[pf2e.conditionitems.lDVqvLKA6eF3Df60]{Persistent Bleed Damage}"
+                },
                 "RecklessAbandon": {
                     "Note": "If you roll a failure or critical failure on a saving throw against a harmful effect, you get a success instead."
                 },


### PR DESCRIPTION
We can't do the removal of the finesse trait just yet, there's a way we could cheat that by predicating the strike on the base goblin heritage on not having this feat then just add a new strike here but I'd rather just do an AdjustStrike when we have a remove mode.