### PR TITLE
Support @ actor in roll macros

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -1031,6 +1031,11 @@ class ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
         return Array.from(toReturn).sort();
     }
 
+    /** This allows @actor.level and such to work for roll macros */
+    override getRollData(): Record<string, unknown> {
+        return { ...duplicate(super.getRollData()), actor: this };
+    }
+
     /* -------------------------------------------- */
     /* Conditions                                   */
     /* -------------------------------------------- */


### PR DESCRIPTION
We can break backwards compatibility if you'd rather to do that, but I'd like to at least support `@actor.level` for simple roll macros.