### PR TITLE
Fix the timefilter select behavior in the spell compendium browser

### DIFF
--- a/static/templates/compendium-browser/filters.html
+++ b/static/templates/compendium-browser/filters.html
@@ -28,13 +28,13 @@
                 </a>
             </dd>
         </dl>
-        {{#each filterData.selects as |select type|}}
+        {{#each filterData.selects as |selectData type|}}
             <dl class="{{type}}">
-                <dt>{{localize select.label}}:</dt>
+                <dt>{{localize selectData.label}}:</dt>
                 <dd><select name="{{type}}">
-                    {{#select select.selected}}
-                        <option value="" selected>-</option>
-                        {{#each select.options as |option key|}}
+                    {{#select selectData.selected}}
+                        <option value="">-</option>
+                        {{#each selectData.options as |option key|}}
                             <option value="{{key}}">{{option}}</option>
                         {{/each}}
                     {{/select}}
@@ -45,10 +45,10 @@
     <button type="button" class="clear-filters">{{localize "PF2E.BrowserClearFilters"}}</button>
     {{#each filterData.checkboxes as |checkbox name|}}
         {{#if (eq @index 1)}}
-            {{#each ../filterData.multiselects as |select type|}}
+            {{#each ../filterData.multiselects as |selectData type|}}
                 <div class="filtercontainer" data-filter-type="multiselects" data-filter-name="{{type}}">
-                    <h3>{{localize select.label}}</h3>
-                    <input class="tags paizo-style" name="{{type}}" data-tagify-select="true" spellcheck="false" value="{{json select.selected}}" />
+                    <h3>{{localize selectData.label}}</h3>
+                    <input class="tags paizo-style" name="{{type}}" data-tagify-select="true" spellcheck="false" value="{{json selectData.selected}}" />
                 </div>
             {{/each}}
         {{/if}}


### PR DESCRIPTION
In the "Spells" tab of the compendium browser, the "Casting time" select element has a weird behavior where selecting a value correctly filters the data but the option displayed by the select element does not change.

It is because a local variable in the handlebars template has the same name as the handlebars helper "select". Changing the name of the variable fixes the issue.

I also renamed an other "select" variable for consistency.