### PR TITLE
Allow scrolls/wands for entries that contain the spell

### DIFF
--- a/src/module/actor/spellcasting.ts
+++ b/src/module/actor/spellcasting.ts
@@ -1,7 +1,7 @@
 import { ActorPF2e, CharacterPF2e, NPCPF2e } from "@actor";
 import { ConsumablePF2e, SpellcastingEntryPF2e } from "@item";
 import { SpellCollection } from "@item/spellcasting-entry/collection";
-import { ErrorPF2e, tupleHasValue } from "@util";
+import { ErrorPF2e } from "@util";
 
 export class ActorSpellcasting extends Collection<SpellcastingEntryPF2e> {
     /** All available spell lists on this actor */
@@ -25,11 +25,8 @@ export class ActorSpellcasting extends Collection<SpellcastingEntryPF2e> {
     }
 
     canCastConsumable(item: ConsumablePF2e): boolean {
-        const spellData = item.system.spell?.data?.data;
-        return (
-            !!spellData &&
-            this.spellcastingFeatures.some((entry) => tupleHasValue(spellData.traditions.value, entry.tradition))
-        );
+        const spell = item.embeddedSpell;
+        return !!spell && this.spellcastingFeatures.some((entry) => entry.canCastSpell(spell));
     }
 
     refocus(options: { all?: boolean } = {}) {

--- a/src/module/item/consumable/index.ts
+++ b/src/module/item/consumable/index.ts
@@ -36,7 +36,7 @@ class ConsumablePF2e extends PhysicalItemPF2e {
 
         const heightenedLevel = this.system.spell.heightenedLevel;
         if (typeof heightenedLevel === "number") {
-            spellData.data.location.heightenedLevel = heightenedLevel;
+            spellData.system.location.heightenedLevel = heightenedLevel;
         }
 
         return new SpellPF2e(spellData, {
@@ -171,7 +171,7 @@ class ConsumablePF2e extends PhysicalItemPF2e {
             if (trickMagicItemData) return trickMagicItemData;
 
             const spellcastingEntries = actor.spellcasting.spellcastingFeatures.filter((entry) =>
-                spell.traditions.has(entry.tradition)
+                entry.canCastSpell(spell)
             );
 
             let maxBonus = 0;

--- a/src/module/item/spellcasting-entry/index.ts
+++ b/src/module/item/spellcasting-entry/index.ts
@@ -114,6 +114,15 @@ class SpellcastingEntryPF2e extends ItemPF2e implements SpellcastingEntry {
         }
     }
 
+    /** Returns if the spell is valid to cast by this spellcasting entry */
+    canCastSpell(spell: SpellPF2e): boolean {
+        if (spell.traditions.has(this.tradition)) {
+            return true;
+        }
+
+        return this.collection.some((s) => s.slug === spell.slug);
+    }
+
     /** Casts the given spell as if it was part of this spellcasting entry */
     async cast(
         spell: Embedded<SpellPF2e>,


### PR DESCRIPTION
Basic oscillating wave using items support, but not oscillating wave archetype using items support. The latter is more complicated.

Also updates consumables for v10, but only for new consumables. We need migrations for the old ones.