### PR TITLE
Fix melee/ranged status of chakrams

### DIFF
--- a/packs/data/equipment.db/chakram.json
+++ b/packs/data/equipment.db/chakram.json
@@ -81,7 +81,7 @@
             "value": null
         },
         "quantity": 1,
-        "range": null,
+        "range": 20,
         "reload": {
             "value": "-"
         },
@@ -104,7 +104,7 @@
             "custom": "",
             "rarity": "common",
             "value": [
-                "thrown-20"
+                "thrown"
             ]
         },
         "usage": {

--- a/packs/data/equipment.db/tamchal-chakram.json
+++ b/packs/data/equipment.db/tamchal-chakram.json
@@ -104,7 +104,7 @@
                 "agile",
                 "deadly-d6",
                 "finesse",
-                "thrown"
+                "thrown-20"
             ]
         },
         "usage": {


### PR DESCRIPTION
Updating to adhere to specifics of Thrown trait:
> When this trait appears on a melee weapon, it also includes the range increment. Ranged weapons with this trait use the range increment specified in the weapon’s Range entry.