### PR TITLE
Add a way to catch up embedded item source data to the current DataModel

### DIFF
--- a/types/foundry/common/abstract/document.d.ts
+++ b/types/foundry/common/abstract/document.d.ts
@@ -84,6 +84,13 @@ declare global {
                 static canUserCreate(user: documents.BaseUser): boolean;
 
                 /**
+                 * Migrate candidate source data for this DataModel which may require initial cleaning or transformations.
+                 * @param source           The candidate source data from which the model will be constructed
+                 * @returns                Migrated source data, if necessary
+                 */
+                static migrateData<TSource extends DocumentSource>(source: TSource): TSource;
+
+                /**
                  * Update the DataModel locally by applying an object of changes to its source data.
                  * The provided changes are cleaned, validated, and stored to the source data object for this model.
                  * The source data is then re-initialized to apply those changes to the prepared data.


### PR DESCRIPTION
`Item.migratedData` removes `data` and adds `system` but does not update the database so the item has both after the migration but I believe that shouldn't be a problem.