### PR TITLE
Add support for spell variants from consumable items

### DIFF
--- a/src/module/actor/sheet/item-summary-renderer.ts
+++ b/src/module/actor/sheet/item-summary-renderer.ts
@@ -1,5 +1,5 @@
-import { ActorPF2e, CharacterPF2e, CreaturePF2e } from "@actor";
-import { ConsumablePF2e, ItemPF2e, PhysicalItemPF2e, SpellPF2e } from "@item";
+import { ActorPF2e, CreaturePF2e } from "@actor";
+import { ItemPF2e, PhysicalItemPF2e } from "@item";
 import { ItemSummaryData } from "@item/data";
 import { isItemSystemData } from "@item/data/helpers";
 import { InlineRollLinks } from "@scripts/ui/inline-roll-links";
@@ -194,7 +194,7 @@ export class CreatureSheetItemRenderer<AType extends CreaturePF2e> extends ItemS
                     buttons.append(`<span>${save.label}</span>`);
                 }
 
-                if (actor instanceof CharacterPF2e) {
+                if (actor.isOfType("character")) {
                     if (Array.isArray(chatData.variants) && chatData.variants.length) {
                         const label = game.i18n.localize("PF2E.Item.Spell.Variants.SelectVariantLabel");
                         buttons.append(
@@ -217,7 +217,7 @@ export class CreatureSheetItemRenderer<AType extends CreaturePF2e> extends ItemS
 
                 break;
             case "consumable":
-                if (item instanceof ConsumablePF2e && item.charges.max > 0 && item.isIdentified) {
+                if (item.isOfType("consumable") && item.charges.max > 0 && item.isIdentified) {
                     const label = game.i18n.localize("PF2E.ConsumableUseLabel");
                     buttons.append(
                         `<span><button class="consume" data-action="consume">${label} ${item.name}</button></span>`
@@ -233,7 +233,7 @@ export class CreatureSheetItemRenderer<AType extends CreaturePF2e> extends ItemS
             event.preventDefault();
             event.stopPropagation();
 
-            const spell = item instanceof SpellPF2e ? item : item instanceof ConsumablePF2e ? item.embeddedSpell : null;
+            const spell = item.isOfType("spell") ? item : item.isOfType("consumable") ? item.embeddedSpell : null;
 
             // which function gets called depends on the type of button stored in the dataset attribute action
             switch (event.target.dataset.action) {
@@ -244,7 +244,7 @@ export class CreatureSheetItemRenderer<AType extends CreaturePF2e> extends ItemS
                     spell?.rollDamage(event);
                     break;
                 case "consume":
-                    if (item instanceof ConsumablePF2e) item.consume();
+                    if (item.isOfType("consumable")) item.consume();
                     break;
                 case "selectVariant":
                     spell?.toMessage();

--- a/src/module/chat-message/data.ts
+++ b/src/module/chat-message/data.ts
@@ -23,7 +23,7 @@ type ChatMessageFlagsPF2e = foundry.data.ChatMessageFlags & {
         modifierName?: string;
         modifiers?: RawModifier[];
         preformatted?: "flavor" | "content" | "both";
-        isFromConsumable?: boolean;
+        isFromConsumable?: ItemUUID;
         journalEntry?: DocumentUUID;
         spellVariant?: { overlayIds: string[] };
         [key: string]: unknown;

--- a/src/module/chat-message/document.ts
+++ b/src/module/chat-message/document.ts
@@ -116,7 +116,7 @@ class ChatMessagePF2e extends ChatMessage<ActorPF2e> {
         }
 
         const spellVariant = this.flags.pf2e.spellVariant;
-        if (spellVariant && item?.isOfType("spell")) {
+        if (spellVariant && item?.isOfType("spell") && !item.isFromConsumable) {
             return item.loadVariant({
                 overlayIds: spellVariant.overlayIds,
             });

--- a/src/module/chat-message/listeners/cards.ts
+++ b/src/module/chat-message/listeners/cards.ts
@@ -1,7 +1,7 @@
 import { craftSpellConsumable } from "@actor/character/crafting/helpers";
 import { StrikeData } from "@actor/data/base";
 import { SAVE_TYPES } from "@actor/values";
-import { ItemPF2e, PhysicalItemPF2e } from "@item";
+import { ConsumablePF2e, ItemPF2e, PhysicalItemPF2e, SpellPF2e } from "@item";
 import { isSpellConsumable } from "@item/consumable/spell-consumables";
 import { CoinsPF2e } from "@item/physical/helpers";
 import { eventToRollParams } from "@scripts/sheet-util";
@@ -88,7 +88,15 @@ export const ChatCards = {
                             }
                         }
                     } else if (originalId) {
-                        const originalSpell = actor.items.get(originalId, { strict: true });
+                        if (spell?.isFromConsumable) {
+                            const consumableItem = fromUuidSync<Embedded<ConsumablePF2e>>(spell.isFromConsumable);
+                            if (consumableItem?.embeddedSpell) {
+                                await message.delete();
+                                consumableItem.castEmbeddedSpell();
+                                return;
+                            }
+                        }
+                        const originalSpell = actor.items.get<Embedded<SpellPF2e>>(originalId, { strict: true });
                         const originalMessage = await originalSpell.toMessage(undefined, {
                             create: false,
                             data: { spellLvl: castLevel },

--- a/src/module/item/base.ts
+++ b/src/module/item/base.ts
@@ -124,7 +124,7 @@ class ItemPF2e extends Item<ActorPF2e> {
         const template = `systems/pf2e/templates/chat/${this.type}-card.html`;
         const token = this.actor.token;
         const nearestItem = event ? event.currentTarget.closest(".item") : {};
-        const contextualData = !isObjectEmpty(data) ? data : nearestItem.dataset || {};
+        const contextualData = !Object.keys(data).length ? data : nearestItem.dataset || {};
         const templateData = {
             actor: this.actor,
             tokenId: token ? `${token.parent?.id}.${token.id}` : null,

--- a/src/module/item/consumable/index.ts
+++ b/src/module/item/consumable/index.ts
@@ -41,7 +41,7 @@ class ConsumablePF2e extends PhysicalItemPF2e {
 
         return new SpellPF2e(spellData, {
             parent: this.actor,
-            fromConsumable: true,
+            fromConsumable: this.uuid,
         }) as Embedded<SpellPF2e>;
     }
 

--- a/types/foundry/client/collections/compendium-collection.d.ts
+++ b/types/foundry/client/collections/compendium-collection.d.ts
@@ -173,6 +173,8 @@ declare global {
     function fromUuid<T extends CompendiumDocument = CompendiumDocument>(uuid: CompendiumUUID): Promise<T | null>;
     function fromUuid<T extends ClientDocument = ClientDocument>(uuid: string): Promise<T | null>;
 
+    function fromUuidSync<T extends ClientDocument = ClientDocument>(uuid: string): T | null;
+
     interface CompendiumMetadata<T extends CompendiumDocument = CompendiumDocument> {
         readonly type: T["documentName"];
         name: string;


### PR DESCRIPTION
The `Select Other Variant` button on chat cards from consumable items deletes the original message instead of updating it because I didn't want make the whole thing even more janky. I probably should've renamed `isFromConsumable` but the name is technically still correct because it points at the consumable the spell is from. 😄 

Closes #3382 