### PR TITLE
Use newly available wand-magic-sparkles icon for PC spellcasting tab

### DIFF
--- a/static/templates/actors/character/sheet.html
+++ b/static/templates/actors/character/sheet.html
@@ -55,7 +55,7 @@
         </a>
 
         <a class="item{{#unless tabVisibility.spellcasting}} hidden{{/unless}}" data-tab="spellcasting" title="{{localize "PF2E.TabSpellbookLabel"}}">
-            <i class="fas fa-magic"></i>
+            <i class="fas fa-wand-magic-sparkles"></i>
         </a>
 
         <a class="item{{#unless tabVisibility.crafting}} hidden{{/unless}}" data-tab="crafting" title="{{localize "PF2E.TabCraftingLabel"}}">


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/106829671/183270350-a68b3dd0-4763-4160-8555-adb356cd442a.png)

After:
![image](https://user-images.githubusercontent.com/106829671/183270343-9c96caf2-cb70-4a7e-bb1e-9f41d8ba87b6.png)
