### PR TITLE
Fix pair of regressions from V10 conversion work

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -552,7 +552,7 @@ class ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
         ].includes(this.prototypeToken.texture.src);
         const tokenImgIsActorImg = this.prototypeToken.texture.src === this.img;
         if (tokenImgIsDefault && !tokenImgIsActorImg) {
-            this.prototypeToken.update({ img: this.img });
+            this.prototypeToken.texture.src = this.img;
         }
 
         // Disable manually-configured vision settings on the prototype token
@@ -1149,10 +1149,7 @@ class ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
         this._source.prototypeToken = mergeObject(this._source.prototypeToken ?? {}, { texture: {} });
         if (this._source.img === ActorPF2e.DEFAULT_ICON) {
             this._source.img =
-                this._source.prototypeToken.texture.src =
-                data.img =
-                data.prototypeToken.texture.src =
-                    `systems/pf2e/icons/default-icons/${data.type}.svg`;
+                this._source.prototypeToken.texture.src = `systems/pf2e/icons/default-icons/${data.type}.svg`;
         }
 
         await super._preCreate(data, options, user);

--- a/src/module/item/base.ts
+++ b/src/module/item/base.ts
@@ -453,20 +453,19 @@ class ItemPF2e extends Item<ActorPF2e> {
             }
 
             for (const source of [...nonKits]) {
-                const itemSource = deepClone(source);
-                if (!itemSource.system?.rules) continue;
+                if (!source.system?.rules?.length) continue;
                 if (!(context.keepId || context.keepEmbeddedIds)) {
-                    delete itemSource._id; // Allow a random ID to be set by rule elements, which may toggle on `keepId`
+                    delete source._id; // Allow a random ID to be set by rule elements, which may toggle on `keepId`
                 }
 
-                const item = new ItemPF2e(itemSource, { parent: context.parent }) as Embedded<ItemPF2e>;
+                const item = new ItemPF2e(source, { parent: context.parent }) as Embedded<ItemPF2e>;
                 // Pre-load this item's self: roll options for predication by preCreate rule elements
                 item.prepareActorData?.();
 
                 const rules = item.prepareRuleElements({ suppressWarnings: true });
                 for (const rule of rules) {
-                    const ruleSource = itemSource.system.rules[rules.indexOf(rule)] as RuleElementSource;
-                    await rule.preCreate?.({ itemSource, ruleSource, pendingItems: nonKits, context });
+                    const ruleSource = source.system.rules[rules.indexOf(rule)] as RuleElementSource;
+                    await rule.preCreate?.({ itemSource: source, ruleSource, pendingItems: nonKits, context });
                 }
             }
 

--- a/src/module/rules/rule-element/grant-item/base.ts
+++ b/src/module/rules/rule-element/grant-item/base.ts
@@ -124,8 +124,7 @@ class GrantItemRuleElement extends RuleElementPF2e {
         flags.pf2e.itemGrants.push({ id: grantedSource._id });
 
         // The granted item records its granting item's ID at `flags.pf2e.grantedBy`
-        const grantedFlags = mergeObject(grantedSource.flags ?? {}, { pf2e: {} });
-        grantedFlags.pf2e.grantedBy = { id: itemSource._id };
+        grantedSource.flags = mergeObject(grantedSource.flags ?? {}, { pf2e: { grantedBy: { id: itemSource._id } } });
 
         // Run the granted item's preCreate callbacks unless this is a pre-actor-update reevaluation
         if (!args.reevaluation) {


### PR DESCRIPTION
- GrantItem RE was no longer operating on original item source
- `Actor#_preCreate` is passed incomplete actor source, causing unhandled exceptions in property lookups