### PR TITLE
Update TokenImage RE for V10

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -1227,7 +1227,7 @@ class ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
             await this.token?.object?.drawEffects();
             // Foundry doesn't determine whether a token needs to be redrawn when its actor's embedded items change
             for (const tokenDoc of this.getActiveTokens(true, true)) {
-                tokenDoc.onActorItemChange();
+                tokenDoc._onUpdateBaseActor();
             }
         });
 

--- a/src/module/rules/rule-element/token-image.ts
+++ b/src/module/rules/rule-element/token-image.ts
@@ -6,11 +6,11 @@ import { RuleElementPF2e } from "./";
  */
 export class TokenImageRuleElement extends RuleElementPF2e {
     override afterPrepareData(): void {
-        const img = this.resolveValue();
-        if (typeof img !== "string") return this.failValidation("Missing value field");
+        const src = this.resolveValue();
+        if (typeof src !== "string") return this.failValidation("Missing value field");
 
         if (!this.test()) return;
 
-        mergeObject(this.actor.overrides, { token: { img } });
+        this.actor.overrides = mergeObject(this.actor.overrides, { prototypeToken: { texture: { src } } });
     }
 }

--- a/src/module/scene/token-document/document.ts
+++ b/src/module/scene/token-document/document.ts
@@ -6,6 +6,7 @@ import { ChatMessagePF2e } from "@module/chat-message";
 import { CombatantPF2e, EncounterPF2e } from "@module/encounter";
 import { PrototypeTokenDataPF2e } from "@actor/data/base";
 import { TokenAura } from "./aura";
+import { ActorSourcePF2e } from "@actor/data";
 
 class TokenDocumentPF2e<TActor extends ActorPF2e = ActorPF2e> extends TokenDocument<TActor> {
     /** Has this token gone through at least one cycle of data preparation? */
@@ -265,8 +266,11 @@ class TokenDocumentPF2e<TActor extends ActorPF2e = ActorPF2e> extends TokenDocum
     /* -------------------------------------------- */
 
     /** Rerun token data preparation and possibly redraw token when the actor's embedded items change */
-    onActorItemChange(): void {
-        if (!this.isLinked) return; // Handled by upstream
+    override _onUpdateBaseActor(
+        updates?: DeepPartial<ActorSourcePF2e>,
+        options?: DocumentModificationContext<ActorPF2e>
+    ): void {
+        if (!this.isLinked) return super._onUpdateBaseActor(updates, options);
 
         const currentData = this.toObject(false);
         this.prepareData();
@@ -280,6 +284,8 @@ class TokenDocumentPF2e<TActor extends ActorPF2e = ActorPF2e> extends TokenDocum
             if (!canvas.tokens.kimsNaughtyModule) this.object.auras.draw();
             this.scene.checkAuras();
         }
+
+        super._onUpdateBaseActor(updates, options);
     }
 
     /** Toggle token hiding if this token's actor is a loot actor */

--- a/types/foundry/client/documents/token-document.d.ts
+++ b/types/foundry/client/documents/token-document.d.ts
@@ -147,7 +147,7 @@ declare global {
         ): void;
 
         /** When the base Actor for a TokenDocument changes, we may need to update its Actor instance */
-        protected _onUpdateBaseActor(update?: Record<string, unknown>): void;
+        _onUpdateBaseActor(update?: Record<string, unknown>, options?: DocumentModificationContext<Actor>): void;
 
         /** When the Actor data overrides change for an un-linked Token Actor, simulate the post-update process. */
         protected _onUpdateTokenActor(


### PR DESCRIPTION
`TokenDocument#_onUpdateBaseActor` is documented as being `@protected` but then called publicly in foundry.js