### PR TITLE
Refactor wands and scrolls to not require embedded spell data

### DIFF
--- a/src/module/actor/hazard/sheet.ts
+++ b/src/module/actor/hazard/sheet.ts
@@ -1,7 +1,7 @@
 import { ActorSheetPF2e } from "@actor/sheet/base";
 import { ActorSheetDataPF2e } from "@actor/sheet/data-types";
 import { SAVE_TYPES } from "@actor/values";
-import { ConsumablePF2e, SpellPF2e } from "@item";
+import { ConsumablePF2e } from "@item";
 import { ItemDataPF2e } from "@item/data";
 import { TextEditorPF2e } from "@system/text-editor";
 import { ErrorPF2e, tagify } from "@util";
@@ -211,7 +211,7 @@ export class HazardSheetPF2e extends ActorSheetPF2e<HazardPF2e> {
         });
 
         // NPC Weapon Rolling
-        $html.find("button").on("click", (event) => {
+        $html.find("button").on("click", async (event) => {
             event.preventDefault();
             event.stopPropagation();
 
@@ -220,7 +220,7 @@ export class HazardSheetPF2e extends ActorSheetPF2e<HazardPF2e> {
             if (!item) {
                 throw ErrorPF2e(`Item ${itemId} not found`);
             }
-            const spell = item instanceof SpellPF2e ? item : item instanceof ConsumablePF2e ? item.embeddedSpell : null;
+            const spell = item.isOfType("spell") ? item : item.isOfType("consumable") ? await item.embeddedSpell : null;
 
             // which function gets called depends on the type of button stored in the dataset attribute action
             switch (event.target.dataset.action) {

--- a/src/module/actor/sheet/item-summary-renderer.ts
+++ b/src/module/actor/sheet/item-summary-renderer.ts
@@ -1,5 +1,5 @@
-import { ActorPF2e, CharacterPF2e, CreaturePF2e } from "@actor";
-import { ConsumablePF2e, ItemPF2e, PhysicalItemPF2e, SpellPF2e } from "@item";
+import { ActorPF2e, CreaturePF2e } from "@actor";
+import { ItemPF2e, PhysicalItemPF2e } from "@item";
 import { ItemSummaryData } from "@item/data";
 import { isItemSystemData } from "@item/data/helpers";
 import { InlineRollLinks } from "@scripts/ui/inline-roll-links";
@@ -198,7 +198,7 @@ export class CreatureSheetItemRenderer<AType extends CreaturePF2e> extends ItemS
                     buttons.append(`<span>${save.label}</span>`);
                 }
 
-                if (actor instanceof CharacterPF2e) {
+                if (actor.isOfType("character")) {
                     if (Array.isArray(chatData.variants) && chatData.variants.length) {
                         const label = game.i18n.localize("PF2E.Item.Spell.Variants.SelectVariantLabel");
                         buttons.append(
@@ -221,7 +221,7 @@ export class CreatureSheetItemRenderer<AType extends CreaturePF2e> extends ItemS
 
                 break;
             case "consumable":
-                if (item instanceof ConsumablePF2e && item.uses.max > 0 && item.isIdentified) {
+                if (item.isOfType("consumable") && item.uses.max > 0 && item.isIdentified) {
                     const label = game.i18n.localize("PF2E.ConsumableUseLabel");
                     buttons.append(
                         `<span><button class="consume" data-action="consume">${label} ${item.name}</button></span>`
@@ -233,11 +233,11 @@ export class CreatureSheetItemRenderer<AType extends CreaturePF2e> extends ItemS
 
         $div.append(buttons);
 
-        buttons.find("button").on("click", (event) => {
+        buttons.find("button").on("click", async (event) => {
             event.preventDefault();
             event.stopPropagation();
 
-            const spell = item instanceof SpellPF2e ? item : item instanceof ConsumablePF2e ? item.embeddedSpell : null;
+            const spell = item.isOfType("spell") ? item : null;
 
             // which function gets called depends on the type of button stored in the dataset attribute action
             switch (event.target.dataset.action) {
@@ -248,7 +248,7 @@ export class CreatureSheetItemRenderer<AType extends CreaturePF2e> extends ItemS
                     spell?.rollDamage(event);
                     break;
                 case "consume":
-                    if (item instanceof ConsumablePF2e) item.consume();
+                    if (item.isOfType("consumable")) item.consume();
                     break;
                 case "selectVariant":
                     spell?.toMessage();

--- a/src/module/actor/sheet/popups/scroll-wand-popup.ts
+++ b/src/module/actor/sheet/popups/scroll-wand-popup.ts
@@ -39,7 +39,7 @@ export class ScrollWandPopup extends FormApplication<ActorPF2e> {
         }
 
         if (!this.spell.uuid.startsWith("Compendium.")) {
-            ui.notifications.warn(game.i18n.localize("PF2E.ScrollWandPopup.warning"));
+            ui.notifications.warn("PF2E.ScrollWandPopup.warning", { localize: true, permanent: true });
         }
 
         const minimumLevel = this.spell.baseLevel;

--- a/src/module/actor/sheet/popups/scroll-wand-popup.ts
+++ b/src/module/actor/sheet/popups/scroll-wand-popup.ts
@@ -31,10 +31,15 @@ export class ScrollWandPopup extends FormApplication<ActorPF2e> {
     }
 
     override async getData(): Promise<FormApplicationData<ActorPF2e>> {
-        const sheetData: FormApplicationData<ActorPF2e> & { validLevels?: number[] } = await super.getData();
+        const sheetData: FormApplicationData<ActorPF2e> & { validLevels?: number[]; fromWorldItem?: boolean } =
+            await super.getData();
 
         if (!this.spell) {
             throw ErrorPF2e("ScrollWandPopup | Could not read spelldata");
+        }
+
+        if (!this.spell.uuid.startsWith("Compendium.")) {
+            ui.notifications.warn(game.i18n.localize("PF2E.ScrollWandPopup.warning"));
         }
 
         const minimumLevel = this.spell.baseLevel;

--- a/src/module/actor/sheet/trick-magic-item-popup.ts
+++ b/src/module/actor/sheet/trick-magic-item-popup.ts
@@ -1,5 +1,5 @@
 import { calculateTrickMagicItemCheckDC, TrickMagicItemDifficultyData } from "@item/consumable/spell-consumables";
-import type { ConsumablePF2e, SpellPF2e } from "@item";
+import type { ConsumablePF2e } from "@item";
 import { CharacterPF2e } from "@actor";
 import { LocalizePF2e } from "@module/system/localize";
 import { ErrorPF2e } from "@util";
@@ -18,13 +18,12 @@ export class TrickMagicItemPopup {
 
     private translations = LocalizePF2e.translations.PF2E.TrickMagicItemPopup;
 
-    constructor(item: Embedded<ConsumablePF2e>, readonly spell: Embedded<SpellPF2e>) {
+    constructor(item: Embedded<ConsumablePF2e>) {
         if (!item.isOfType("consumable")) {
             throw ErrorPF2e("Unexpected item used for Trick Magic Item");
         }
 
         this.item = item;
-        this.spell = spell;
         this.checkDC = calculateTrickMagicItemCheckDC(item);
 
         if (!(item.actor instanceof CharacterPF2e)) {
@@ -69,6 +68,6 @@ export class TrickMagicItemPopup {
         });
 
         const trick = new TrickMagicItemEntry(this.actor, skill);
-        this.item.castEmbeddedSpell(this.spell, trick);
+        this.item.castEmbeddedSpell(trick);
     }
 }

--- a/src/module/actor/sheet/trick-magic-item-popup.ts
+++ b/src/module/actor/sheet/trick-magic-item-popup.ts
@@ -1,5 +1,5 @@
 import { calculateTrickMagicItemCheckDC, TrickMagicItemDifficultyData } from "@item/consumable/spell-consumables";
-import type { ConsumablePF2e } from "@item";
+import type { ConsumablePF2e, SpellPF2e } from "@item";
 import { CharacterPF2e } from "@actor";
 import { LocalizePF2e } from "@module/system/localize";
 import { ErrorPF2e } from "@util";
@@ -18,12 +18,13 @@ export class TrickMagicItemPopup {
 
     private translations = LocalizePF2e.translations.PF2E.TrickMagicItemPopup;
 
-    constructor(item: Embedded<ConsumablePF2e>) {
+    constructor(item: Embedded<ConsumablePF2e>, readonly spell: Embedded<SpellPF2e>) {
         if (!item.isOfType("consumable")) {
             throw ErrorPF2e("Unexpected item used for Trick Magic Item");
         }
 
         this.item = item;
+        this.spell = spell;
         this.checkDC = calculateTrickMagicItemCheckDC(item);
 
         if (!(item.actor instanceof CharacterPF2e)) {
@@ -68,6 +69,6 @@ export class TrickMagicItemPopup {
         });
 
         const trick = new TrickMagicItemEntry(this.actor, skill);
-        this.item.castEmbeddedSpell(trick);
+        this.item.castEmbeddedSpell(this.spell, trick);
     }
 }

--- a/src/module/actor/spellcasting.ts
+++ b/src/module/actor/spellcasting.ts
@@ -1,5 +1,5 @@
 import { ActorPF2e, CharacterPF2e, NPCPF2e } from "@actor";
-import { ConsumablePF2e, SpellcastingEntryPF2e } from "@item";
+import { SpellcastingEntryPF2e, SpellPF2e } from "@item";
 import { SpellCollection } from "@item/spellcasting-entry/collection";
 import { ErrorPF2e } from "@util";
 
@@ -24,8 +24,7 @@ export class ActorSpellcasting extends Collection<SpellcastingEntryPF2e> {
         return this.regular.filter((entry) => entry.isPrepared || entry.isSpontaneous);
     }
 
-    canCastConsumable(item: ConsumablePF2e): boolean {
-        const spell = item.embeddedSpell;
+    canCastConsumable(spell?: SpellPF2e): boolean {
         return !!spell && this.spellcastingFeatures.some((entry) => entry.canCastSpell(spell));
     }
 

--- a/src/module/actor/spellcasting.ts
+++ b/src/module/actor/spellcasting.ts
@@ -1,5 +1,5 @@
 import { ActorPF2e, CharacterPF2e, NPCPF2e } from "@actor";
-import { SpellcastingEntryPF2e, SpellPF2e } from "@item";
+import { ConsumablePF2e, SpellcastingEntryPF2e } from "@item";
 import { SpellCollection } from "@item/spellcasting-entry/collection";
 import { ErrorPF2e } from "@util";
 
@@ -24,7 +24,8 @@ export class ActorSpellcasting extends Collection<SpellcastingEntryPF2e> {
         return this.regular.filter((entry) => entry.isPrepared || entry.isSpontaneous);
     }
 
-    canCastConsumable(spell?: SpellPF2e): boolean {
+    async canCastConsumable(consumable: ConsumablePF2e): Promise<boolean> {
+        const spell = await consumable.embeddedSpell;
         return !!spell && this.spellcastingFeatures.some((entry) => entry.canCastSpell(spell));
     }
 

--- a/src/module/chat-message/data.ts
+++ b/src/module/chat-message/data.ts
@@ -4,7 +4,6 @@ import { RawModifier } from "@actor/modifiers";
 import { DegreeOfSuccessString } from "@system/degree-of-success";
 import { CheckRollContextFlag } from "@system/rolls";
 import { ChatMessagePF2e } from ".";
-import { TrickMagicItemSkill } from "@item/spellcasting-entry/trick";
 
 interface ChatMessageDataPF2e<TChatMessage extends ChatMessagePF2e = ChatMessagePF2e>
     extends foundry.data.ChatMessageData<TChatMessage> {
@@ -32,7 +31,6 @@ type ChatMessageFlagsPF2e = foundry.data.ChatMessageFlags & {
             spellUuid?: ItemUUID;
             data?: string | null;
             castLevel: number;
-            trickMagicItemSkill?: TrickMagicItemSkill;
         };
         journalEntry?: DocumentUUID;
         spellVariant?: { overlayIds: string[] };

--- a/src/module/chat-message/data.ts
+++ b/src/module/chat-message/data.ts
@@ -4,6 +4,7 @@ import { RawModifier } from "@actor/modifiers";
 import { DegreeOfSuccessString } from "@system/degree-of-success";
 import { CheckRollContextFlag } from "@system/rolls";
 import { ChatMessagePF2e } from ".";
+import { TrickMagicItemSkill } from "@item/spellcasting-entry/trick";
 
 interface ChatMessageDataPF2e<TChatMessage extends ChatMessagePF2e = ChatMessagePF2e>
     extends foundry.data.ChatMessageData<TChatMessage> {
@@ -24,6 +25,15 @@ type ChatMessageFlagsPF2e = foundry.data.ChatMessageFlags & {
         modifiers?: RawModifier[];
         preformatted?: "flavor" | "content" | "both";
         isFromConsumable?: boolean;
+        consumableData?: {
+            originalOwner?: string;
+            consumableUuid?: ItemUUID;
+            consumableType?: "wand" | "scroll";
+            spellUuid?: ItemUUID;
+            data?: string | null;
+            castLevel: number;
+            trickMagicItemSkill?: TrickMagicItemSkill;
+        };
         journalEntry?: DocumentUUID;
         spellVariant?: { overlayIds: string[] };
         [key: string]: unknown;

--- a/src/module/chat-message/data.ts
+++ b/src/module/chat-message/data.ts
@@ -4,6 +4,7 @@ import { RawModifier } from "@actor/modifiers";
 import { DegreeOfSuccessString } from "@system/degree-of-success";
 import { CheckRollContextFlag } from "@system/rolls";
 import { ChatMessagePF2e } from ".";
+import { OneToTen } from "@module/data";
 
 interface ChatMessageDataPF2e<TChatMessage extends ChatMessagePF2e = ChatMessagePF2e>
     extends foundry.data.ChatMessageData<TChatMessage> {
@@ -30,7 +31,7 @@ type ChatMessageFlagsPF2e = foundry.data.ChatMessageFlags & {
             consumableType?: "wand" | "scroll";
             spellUuid?: ItemUUID;
             data?: string | null;
-            castLevel: number;
+            castLevel: OneToTen;
         };
         journalEntry?: DocumentUUID;
         spellVariant?: { overlayIds: string[] };

--- a/src/module/chat-message/document.ts
+++ b/src/module/chat-message/document.ts
@@ -104,7 +104,7 @@ class ChatMessagePF2e extends ChatMessage<ActorPF2e> {
 
                 const origin = this.flags.pf2e?.origin ?? null;
                 if (origin?.uuid) {
-                    return fromUuidSync<Embedded<ItemPF2e>>(origin.uuid);
+                    return fromUuidSync(origin.uuid) as Embedded<ItemPF2e> | null;
                 }
                 return null;
             })();

--- a/src/module/chat-message/listeners/cards.ts
+++ b/src/module/chat-message/listeners/cards.ts
@@ -24,7 +24,7 @@ export const ChatCards = {
             const action = $button.attr("data-action");
 
             // Get the actor and item from the chat message
-            const item = message.item ? message.item : await ConsumablePF2e.spellFromChatMessage(message);
+            const item = await message.item;
             const actor = item?.actor ?? message.actor;
             if (!actor) return;
 
@@ -89,18 +89,20 @@ export const ChatCards = {
                     } else if (originalId || spell?.isFromConsumable) {
                         const originalSpell = await (async () => {
                             if (spell?.isFromConsumable) {
-                                return ConsumablePF2e.spellFromChatMessage(message, true);
+                                return ConsumablePF2e.spellFromChatMessage(message);
                             }
                             return actor.items.get(originalId, { strict: true });
                         })();
                         if (!originalSpell) return;
 
-                        const originalMessage = await originalSpell.toMessage(undefined, {
-                            create: false,
-                            data: { castLevel },
-                        });
-                        if (originalMessage) {
-                            await message.update(originalMessage.toObject());
+                        const content = (
+                            await originalSpell.toMessage(undefined, {
+                                create: false,
+                                data: { castLevel },
+                            })
+                        )?.content;
+                        if (content) {
+                            await message.update({ content });
                         }
                     }
                 }

--- a/src/module/item/consumable/data.ts
+++ b/src/module/item/consumable/data.ts
@@ -7,6 +7,7 @@ import {
     PhysicalSystemSource,
 } from "@item/physical/data";
 import { SpellSource } from "@item/spell/data";
+import { OneToTen } from "@module/data";
 import type { ConsumablePF2e } from ".";
 
 type ConsumableSource = BasePhysicalItemSource<"consumable", ConsumableSystemSource>;
@@ -47,6 +48,10 @@ interface ConsumableSystemSource extends PhysicalSystemSource, ActivatedEffectDa
         _deprecated: boolean;
     };
     spell: SpellSource | null;
+    spellData?: {
+        uuid: ItemUUID;
+        heightenedLevel: OneToTen;
+    };
 }
 
 type ConsumableSystemData = Omit<ConsumableSystemSource, "price"> &

--- a/src/module/item/consumable/index.ts
+++ b/src/module/item/consumable/index.ts
@@ -64,7 +64,10 @@ class ConsumablePF2e extends PhysicalItemPF2e {
                     if (entry) {
                         embeddedSpell.system.location.value = entry.id;
                     }
-                    this.#spell = embeddedSpell;
+                    if (uuid.startsWith("Compendium")) {
+                        // Cache the spell if it came from a compendium
+                        this.#spell = embeddedSpell;
+                    }
                     return embeddedSpell;
                 }
                 throw ErrorPF2e(`Could not find Spell with UUID "${uuid}"!`);
@@ -247,7 +250,7 @@ class ConsumablePF2e extends PhysicalItemPF2e {
 
         // New item with a consumable Uuid
         if (consumableUuid) {
-            const consumable = fromUuidSync<Embedded<ConsumablePF2e>>(consumableUuid);
+            const consumable = fromUuidSync(consumableUuid) as Embedded<ConsumablePF2e> | null;
             if (consumable) {
                 return consumable.embeddedSpell;
             }

--- a/src/module/item/consumable/spell-consumables.ts
+++ b/src/module/item/consumable/spell-consumables.ts
@@ -66,7 +66,7 @@ async function createConsumableFromSpell(
     consumableSource.name = getNameForSpellConsumable(type, spell.name, heightenedLevel);
     const description = consumableSource.system.description.value;
     consumableSource.system.description.value = `@UUID[${spell.uuid}]` + `\n<hr/>${description}`;
-    consumableSource.system.spell = {
+    consumableSource.system.spellData = {
         uuid: spell.uuid,
         heightenedLevel,
     };

--- a/src/module/item/consumable/spell-consumables.ts
+++ b/src/module/item/consumable/spell-consumables.ts
@@ -65,10 +65,11 @@ async function createConsumableFromSpell(
     consumableSource.system.traits.value.push(...spell.traditions);
     consumableSource.name = getNameForSpellConsumable(type, spell.name, heightenedLevel);
     const description = consumableSource.system.description.value;
-    consumableSource.system.description.value =
-        (spell.sourceId ? "@" + spell.sourceId.replace(".", "[") + "]" : spell.description) + `\n<hr />${description}`;
-    consumableSource.system.spell = spell.clone({ "system.location.heightenedLevel": heightenedLevel }).toObject();
-
+    consumableSource.system.description.value = `@UUID[${spell.uuid}]` + `\n<hr/>${description}`;
+    consumableSource.system.spell = {
+        uuid: spell.uuid,
+        heightenedLevel,
+    };
     return consumableSource;
 }
 

--- a/src/module/item/data/base.ts
+++ b/src/module/item/data/base.ts
@@ -47,6 +47,12 @@ interface ItemFlagsPF2e extends foundry.data.ItemFlags {
         rulesSelections: Record<string, string | number | object>;
         itemGrants: ItemGrantData[];
         grantedBy: ItemGrantData | null;
+        consumableData?: {
+            uuid: ItemUUID;
+            spellUuid: ItemUUID;
+            type: "scroll" | "wand";
+            fromData?: boolean;
+        };
         [key: string]: unknown;
     };
 }

--- a/src/module/item/spell/index.ts
+++ b/src/module/item/spell/index.ts
@@ -447,7 +447,7 @@ class SpellPF2e extends ItemPF2e {
                 consumableUuid: uuid,
                 consumableType: type,
                 spellUuid: spellUuid,
-                castLevel: this.level,
+                castLevel: this.level as OneToTen,
                 // This is only set for spells from old consumables with embedded data
                 data: fromData
                     ? this.isVariant

--- a/src/module/item/spell/index.ts
+++ b/src/module/item/spell/index.ts
@@ -448,7 +448,6 @@ class SpellPF2e extends ItemPF2e {
                 consumableType: type,
                 spellUuid: spellUuid,
                 castLevel: this.level,
-                trickMagicItemSkill: this.trickMagicEntry?.skill,
                 // This is only set for spells from old consumables with embedded data
                 data: fromData
                     ? this.isVariant

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2919,7 +2919,8 @@
             "spellLevelLabel": "Heightened Level: ",
             "submit": "Create item",
             "title": "Create a scroll or wand",
-            "wand": "Wand"
+            "wand": "Wand",
+            "warning": "Items created with a spell from the world will stop working if that spell is deleted. Consider using a spell directly from the compendium."
         },
         "SelectLabel": "Select",
         "SellAllTreasureTitle": "Sell All Treasure",


### PR DESCRIPTION
Newly created wands and spells will only have a UUID and some information about the embedded spell.
Old items with embedded spell data are still fully supported but will show a warning in the console that that will change in a future system version. Spell variants also work with the old items now. No migration needed. 

Only old spell cards with the spell data embedded in the DOM will no longer work.

Closes #3382 