### PR TITLE
Cascade pf2e styling to prosemirror editor sheet

### DIFF
--- a/src/module/journal-entry/sheet.ts
+++ b/src/module/journal-entry/sheet.ts
@@ -5,6 +5,20 @@ import type * as TinyMCE from "tinymce";
 import "../../styles/tinymce.scss";
 
 class JournalSheetPF2e<TJournalEntry extends JournalEntry = JournalEntry> extends JournalSheet<TJournalEntry> {
+    static get theme(): string | null {
+        return null;
+    }
+
+    /** Use the system-themed styling only if the setting is enabled (on by default) */
+    static override get defaultOptions(): DocumentSheetOptions {
+        const options = super.defaultOptions;
+        const { theme } = this;
+        if (theme) {
+            options.classes.push(theme);
+        }
+        return options;
+    }
+
     override activateListeners($html: JQuery): void {
         super.activateListeners($html);
         InlineRollLinks.listen($html);
@@ -16,11 +30,10 @@ class JournalSheetPF2e<TJournalEntry extends JournalEntry = JournalEntry> extend
 
         options = foundry.utils.mergeObject(editor.options, options);
         options.height = options.target?.offsetHeight;
-
-        const defaults = (this.constructor as typeof JournalSheetPF2e).defaultOptions.classes;
         TextEditorPF2e.create(options, initialContent || editor.initial).then((mce) => {
-            if (defaults.includes("pf2e")) {
-                mce.getBody().classList.add("pf2e");
+            const theme = (this.constructor as typeof JournalSheetPF2e).theme;
+            if (theme) {
+                mce.getBody().classList.add(theme);
             }
 
             editor.mce = mce;
@@ -33,11 +46,8 @@ class JournalSheetPF2e<TJournalEntry extends JournalEntry = JournalEntry> extend
 }
 
 class JournalSheetStyledPF2e extends JournalSheetPF2e {
-    /** Use the system-themed styling only if the setting is enabled (on by default) */
-    static override get defaultOptions(): DocumentSheetOptions {
-        const options = super.defaultOptions;
-        options.classes.push("pf2e");
-        return options;
+    static override get theme() {
+        return "pf2e";
     }
 }
 

--- a/src/scripts/hooks/index.ts
+++ b/src/scripts/hooks/index.ts
@@ -15,6 +15,7 @@ import { RenderCombatTrackerConfig } from "./render-combat-tracker-config";
 import { RenderDialog } from "./render-dialog";
 import { RenderSceneControls } from "./render-scene-controls";
 import { RenderSettings } from "./render-settings";
+import { RenderJournalPageSheet } from "./render-journal-page-sheet";
 import { Setup } from "./setup";
 import { UpdateWorldTime } from "./update-world-time";
 
@@ -38,6 +39,7 @@ export const HooksPF2e = {
             RenderDialog,
             RenderSceneControls,
             RenderSettings,
+            RenderJournalPageSheet,
             Setup,
             UpdateWorldTime,
         ];

--- a/src/scripts/hooks/render-journal-page-sheet.ts
+++ b/src/scripts/hooks/render-journal-page-sheet.ts
@@ -1,0 +1,14 @@
+export const RenderJournalPageSheet = {
+    listen: (): void => {
+        Hooks.on("renderJournalPageSheet", (sheet, render) => {
+            const entry = sheet.object.parent;
+            const parentSheetClass = entry?.sheet.constructor as { theme?: string } | undefined;
+            if (!parentSheetClass) return;
+
+            const theme = parentSheetClass.theme ? String(parentSheetClass.theme) : null;
+            if (theme && render.hasClass("sheet")) {
+                render.addClass(theme);
+            }
+        });
+    },
+};

--- a/src/styles/system/journal/_index.scss
+++ b/src/styles/system/journal/_index.scss
@@ -23,11 +23,9 @@
         }
     }
 
-    .journal-entry-page section {
+    .journal-entry-page section, .editor-content {
         --p-space: var(--space-l);
         --max-width: 570px;
-        display: flex;
-        flex-direction: column;
         font-size: 1.2em;
         line-height: 1.5;
         color: var(--body);

--- a/types/foundry/client/application/journal/journal-page-sheet.ts
+++ b/types/foundry/client/application/journal/journal-page-sheet.ts
@@ -1,0 +1,11 @@
+/**
+ * The Application responsible for displaying and editing a single JournalEntryPage document.
+ * @extends {DocumentSheet}
+ * @param {JournalEntryPage} object         The JournalEntryPage instance which is being edited.
+ * @param {DocumentSheetOptions} [options]  Application options.
+ */
+declare class JournalPageSheet<
+    TJournalEntryPage extends JournalEntryPage = JournalEntryPage
+> extends DocumentSheet<TJournalEntryPage> {
+    constructor(object: TJournalEntryPage, options?: DocumentSheetOptions);
+}

--- a/types/foundry/client/core/hooks.d.ts
+++ b/types/foundry/client/core/hooks.d.ts
@@ -81,6 +81,7 @@ declare global {
         static on(...args: HookParamsRender<SceneControls, "SceneControls">): number;
         static on(...args: HookParamsRender<Settings, "Settings">): number;
         static on(...args: HookParamsRender<TokenHUD, "TokenHUD">): number;
+        static on(...args: HookParamsRender<JournalPageSheet, "JournalPageSheet">): number;
         static on(...args: HookParamsUpdate<Combat, "Combat">): number;
         static on(...args: HookParamsUpdate<Scene, "Scene">): number;
         static on(...args: HookParamsUpdateWorldTime): number;

--- a/types/foundry/client/documents/constructors.d.ts
+++ b/types/foundry/client/documents/constructors.d.ts
@@ -30,6 +30,8 @@ export const ItemConstructor: ClientDocumentMixin<typeof foundry.documents.BaseI
 
 export const JournalEntryConstructor: ClientDocumentMixin<typeof foundry.documents.BaseJournalEntry>;
 
+export const JournalEntryPageConstructor: ClientDocumentMixin<typeof foundry.documents.BaseJournalEntryPage>;
+
 export const MacroConstructor: ClientDocumentMixin<typeof foundry.documents.BaseMacro>;
 
 export const MeasuredTemplateDocumentConstructor: CanvasDocumentMixin<

--- a/types/foundry/client/documents/journal-entry-page.d.ts
+++ b/types/foundry/client/documents/journal-entry-page.d.ts
@@ -1,0 +1,11 @@
+import { JournalEntryPageConstructor } from "./constructors";
+
+declare global {
+    class JournalEntryPage extends JournalEntryPageConstructor {
+        static slugifyHeading(heading: HTMLHeadingElement | string): string;
+    }
+
+    interface JournalEntryPage {
+        parent: JournalEntry | null;
+    }
+}

--- a/types/foundry/client/documents/journal-entry.d.ts
+++ b/types/foundry/client/documents/journal-entry.d.ts
@@ -59,4 +59,8 @@ declare global {
 
         override _onDelete(options: DocumentModificationContext, userId: string): void;
     }
+
+    interface JournalEntry {
+        get sheet(): JournalSheet<this>;
+    }
 }

--- a/types/foundry/common/data/data/index.d.ts
+++ b/types/foundry/common/data/data/index.d.ts
@@ -16,6 +16,7 @@ import "./fog-exploration-data";
 import "./folder-data";
 import "./item-data";
 import "./journal-entry-data";
+import "./journal-entry-page-data";
 import "./light-data";
 import "./macro-data";
 import "./measured-template-data";

--- a/types/foundry/common/data/data/journal-entry-data.d.ts
+++ b/types/foundry/common/data/data/journal-entry-data.d.ts
@@ -28,9 +28,12 @@ declare module foundry {
         }
 
         class JournalEntryData<
-            TDocument extends documents.BaseJournalEntry = documents.BaseJournalEntry
+            TDocument extends documents.BaseJournalEntry = documents.BaseJournalEntry,
+            TPage extends documents.BaseJournalEntryPage = documents.BaseJournalEntryPage
         > extends abstract.DocumentData<TDocument> {
             static override defineSchema(): abstract.DocumentSchema;
+
+            pages: abstract.EmbeddedCollection<TPage>;
         }
 
         interface JournalEntryData extends JournalEntrySource {

--- a/types/foundry/common/data/data/journal-entry-page-data.d.ts
+++ b/types/foundry/common/data/data/journal-entry-page-data.d.ts
@@ -1,0 +1,90 @@
+declare module foundry {
+    module data {
+        /**
+         * @typedef {object} JournalEntryPageImageData
+         * @property {string} [caption]  A caption for the image.
+         */
+        interface JournalEntryPageImageData {
+            caption?: string;
+        }
+
+        /**
+         * @typedef {object} JournalEntryPageTextData
+         * @property {string} [content]   The content of the JournalEntryPage in a format appropriate for its type.
+         * @property {string} [markdown]  The original markdown source, if applicable.
+         * @property {number} format      The format of the page's content, in {@link CONST.JOURNAL_ENTRY_PAGE_FORMATS}.
+         */
+        interface JournalEntryPageTextData {
+            content?: string;
+            markdown?: string;
+            format: number;
+        }
+
+        /**
+         * @typedef {object} JournalEntryPageVideoData
+         * @property {boolean} [loop]      Automatically loop the video?
+         * @property {boolean} [autoplay]  Should the video play automatically?
+         * @property {number} [volume]     The volume level of any audio that the video file contains.
+         * @property {number} [timestamp]  The starting point of the video, in seconds.
+         * @property {number} [width]      The width of the video, otherwise it will fill the available container width.
+         * @property {number} [height]     The height of the video, otherwise it will use the aspect ratio of the source video,
+         *                                 or 16:9 if that aspect ratio is not available.
+         */
+        interface JournalEntryPageVideoData {
+            loop?: boolean;
+            autoplay?: boolean;
+            volume?: number;
+            timestamp?: number;
+            width?: number;
+            height?: number;
+        }
+
+        /**
+         * @property {boolean} show  Whether to render the page's title in the overall journal view.
+         * @property {number} level  The heading level to render this page's title at in the overall journal view.
+         */
+        interface JournalEntryPageTitleData {
+            show: boolean;
+            level: number;
+        }
+
+        /**
+         * The data schema for a JournalEntryPage document.
+         * @property {string} _id          The _id which uniquely identifies this JournalEntryPage embedded document.
+         * @property {string} name         The text name of this page.
+         * @property {string} type         The type of this page, in {@link BaseJournalEntryPage.TYPES}.
+         * @property {JournalEntryPageTitleData} title  Data that control's the display of this page's title.
+         * @property {JournalEntryPageImageData} image  Data particular to image journal entry pages.
+         * @property {JournalEntryPageTextData} text    Data particular to text journal entry pages.
+         * @property {JournalEntryPageVideoData} video  Data particular to video journal entry pages.
+         * @property {string} [src]        The URI of the image or other external media to be used for this page.
+         * @property {object} system       System-specific data.
+         * @property {number} sort         The numeric sort value which orders this page relative to its siblings.
+         * @property {object} [ownership]  An object which configures the ownership of this page.
+         * @property {object} [flags]      An object of optional key/value flags.
+         */
+        interface JournalEntryPageSource {
+            _id: string;
+            name: string;
+            title: JournalEntryPageTitleData;
+            image: JournalEntryPageImageData;
+            text: JournalEntryPageTextData;
+            video: JournalEntryPageVideoData;
+            src?: string | null;
+            system: object; // will be filled out later
+            sort: number;
+            ownership?: Record<string, PermissionLevel>;
+            flags: object; // will be filled out later
+        }
+
+        class JournalEntryPageData<
+            TDocument extends documents.BaseJournalEntryPage
+        > extends abstract.DocumentData<TDocument> {
+            protected override _initializeSource(data: this["_source"]): this["_source"];
+        }
+
+        interface JournalEntryPageData<TDocument extends documents.BaseJournalEntryPage> {
+            readonly _source: JournalEntryPageSource;
+        }
+    }
+}

--- a/types/foundry/common/documents/base-journal-entry-page.d.ts
+++ b/types/foundry/common/documents/base-journal-entry-page.d.ts
@@ -1,0 +1,27 @@
+declare module foundry {
+    module documents {
+        /** The JournalEntryPage document model. */
+        class BaseJournalEntryPage extends abstract.Document {
+            static override get schema(): typeof data.JournalEntryPageData;
+
+            static override get metadata(): JournalEntryPageMetadata;
+        }
+
+        interface BaseJournalEntryPage {
+            readonly data: data.JournalEntryPageData<this>;
+
+            readonly parent: BaseJournalEntry | null;
+
+            get documentName(): typeof BaseJournalEntryPage["metadata"]["name"];
+        }
+    }
+
+    interface JournalEntryPageMetadata extends abstract.DocumentMetadata {
+        name: "JournalEntryPage";
+        collection: "pages";
+        indexed: true;
+        label: "DOCUMENT.JournalEntryPage";
+        labelPlural: "DOCUMENT.JournalEntryPages";
+        coreTypes: ["image", "pdf", "text", "video"];
+    }
+}

--- a/types/foundry/common/documents/base-journal-entry.d.ts
+++ b/types/foundry/common/documents/base-journal-entry.d.ts
@@ -5,6 +5,8 @@ declare module foundry {
             static override get schema(): typeof data.JournalEntryData;
 
             static override get metadata(): JournalEntryMetadata;
+
+            get pages(): this["data"]["pages"];
         }
 
         interface BaseJournalEntry {
@@ -19,7 +21,13 @@ declare module foundry {
     interface JournalEntryMetadata extends abstract.DocumentMetadata {
         name: "JournalEntry";
         collection: "journal";
+        indexed: true;
+        compendiumIndexFields: ["_id", "name", "sort"];
+        embedded: {
+            JournalEntryPage: typeof documents.BaseJournalEntryPage;
+        };
         label: "DOCUMENT.JournalEntry";
+        labelPlural: "DOCUMENT.JournalEntries";
         isPrimary: true;
         permissions: Omit<abstract.DocumentMetadata["permissions"], "create"> & {
             create: "JOURNAL_CREATE";

--- a/types/foundry/common/documents/index.d.ts
+++ b/types/foundry/common/documents/index.d.ts
@@ -11,6 +11,7 @@ import "./base-fog-exploration";
 import "./base-folder";
 import "./item";
 import "./base-journal-entry";
+import "./base-journal-entry-page";
 import "./base-macro";
 import "./measured-template";
 import "./base-note";


### PR DESCRIPTION
TinyMCE uses an iframe, so for that we'll need to subclass JournalTextPageSheet and replace it during sheet registration to inject the theme, or use setTimeout(blah, 0) to wait for the iframe to initialize and then inject it there as part of the hook.  We're waiting on an answer from Kim before merging.

I wouldn't mind the hacky hack the iframe approach since tinymce is apparently being phased out.