### PR TITLE
Add craftableItems predicate to crafting entries

### DIFF
--- a/packs/data/classfeatures.db/advanced-alchemy.json
+++ b/packs/data/classfeatures.db/advanced-alchemy.json
@@ -36,11 +36,11 @@
                         "class:alchemist"
                     ]
                 },
-                "requiredTraits": [
-                    [
-                        "alchemical"
+                "craftableItems": {
+                    "all": [
+                        "item:trait:alchemical"
                     ]
-                ],
+                },
                 "selector": "alchemist"
             },
             {

--- a/packs/data/feats.db/alchemist-dedication.json
+++ b/packs/data/feats.db/alchemist-dedication.json
@@ -41,11 +41,11 @@
                 "isDailyPrep": true,
                 "key": "CraftingEntry",
                 "maxItemLevel": 1,
-                "requiredTraits": [
-                    [
-                        "alchemical"
+                "craftableItems": {
+                    "all": [
+                        "item:trait:alchemical"
                     ]
-                ],
+                },
                 "selector": "alchemist"
             },
             {

--- a/packs/data/feats.db/firework-technician-dedication.json
+++ b/packs/data/feats.db/firework-technician-dedication.json
@@ -36,11 +36,11 @@
                 "key": "CraftingEntry",
                 "label": "PF2E.SpecificRule.DedicationCraftingEntry.FireworkTechnician",
                 "maxItemLevel": 1,
-                "requiredTraits": [
-                    [
-                        "alchemical"
+                "craftableItems": {
+                    "all": [
+                        "item:trait:alchemical"
                     ]
-                ],
+                },
                 "selector": "fireworkTechnician"
             },
             {

--- a/packs/data/feats.db/gadget-specialist.json
+++ b/packs/data/feats.db/gadget-specialist.json
@@ -34,11 +34,11 @@
                 "isDailyPrep": true,
                 "key": "CraftingEntry",
                 "name": "Gadget Specialist",
-                "requiredTraits": [
-                    [
-                        "gadget"
+                "craftableItems": {
+                    "all": [
+                        "item:trait:gadget"
                     ]
-                ],
+                },
                 "selector": "gadgetSpecialist"
             },
             {

--- a/packs/data/feats.db/herbalist-dedication.json
+++ b/packs/data/feats.db/herbalist-dedication.json
@@ -45,12 +45,12 @@
                 "key": "CraftingEntry",
                 "label": "PF2E.SpecificRule.DedicationCraftingEntry.Herbalist",
                 "maxItemLevel": 1,
-                "requiredTraits": [
-                    [
-                        "alchemical",
-                        "healing"
+                "craftableItems": {
+                    "all": [
+                        "item:trait:alchemical",
+                        "item:trait:healing"
                     ]
-                ],
+                },
                 "selector": "herbalist"
             },
             {

--- a/packs/data/feats.db/munitions-crafter.json
+++ b/packs/data/feats.db/munitions-crafter.json
@@ -31,15 +31,15 @@
                 "isDailyPrep": true,
                 "key": "CraftingEntry",
                 "maxItemLevel": 1,
-                "requiredTraits": [
-                    [
-                        "alchemical",
-                        "bomb"
+                "craftableItems": {
+                    "all": [
+                        "item:trait:alchemical"
                     ],
-                    [
-                        "alchemical"
+                    "any": [
+                        "item:trait:bomb",
+                        "item:subtype:ammo"
                     ]
-                ],
+                },
                 "selector": "munitionsCrafter"
             },
             {

--- a/packs/data/feats.db/poisoner-dedication.json
+++ b/packs/data/feats.db/poisoner-dedication.json
@@ -35,12 +35,12 @@
                 "key": "CraftingEntry",
                 "label": "PF2E.SpecificRule.DedicationCraftingEntry.Poisoner",
                 "maxItemLevel": 1,
-                "requiredTraits": [
-                    [
-                        "alchemical",
-                        "poison"
+                "craftableItems": {
+                    "all": [
+                        "item:trait:alchemical",
+                        "item:trait:poison"
                     ]
-                ],
+                },
                 "selector": "poisoner"
             },
             {

--- a/packs/data/feats.db/snare-genius.json
+++ b/packs/data/feats.db/snare-genius.json
@@ -37,11 +37,11 @@
                 "isPrepared": true,
                 "key": "CraftingEntry",
                 "name": "Snare Crafting",
-                "requiredTraits": [
-                    [
-                        "snare"
+                "craftableItems": {
+                    "all": [
+                        "item:trait:snare"
                     ]
-                ],
+                },
                 "selector": "snareCrafting"
             },
             {

--- a/packs/data/feats.db/snare-specialist.json
+++ b/packs/data/feats.db/snare-specialist.json
@@ -37,11 +37,11 @@
                 "isPrepared": true,
                 "key": "CraftingEntry",
                 "name": "Snare Crafting",
-                "requiredTraits": [
-                    [
-                        "snare"
+                "craftableItems": {
+                    "all": [
+                        "item:trait:snare"
                     ]
-                ],
+                },
                 "selector": "snareCrafting"
             },
             {

--- a/packs/data/feats.db/snarecrafter-dedication.json
+++ b/packs/data/feats.db/snarecrafter-dedication.json
@@ -37,11 +37,11 @@
                 "isPrepared": true,
                 "key": "CraftingEntry",
                 "label": "PF2E.SpecificRule.DedicationCraftingEntry.Snarecrafter",
-                "requiredTraits": [
-                    [
-                        "snare"
+                "craftableItems": {
+                    "all": [
+                        "item:trait:snare"
                     ]
-                ],
+                },
                 "selector": "snareCrafting"
             },
             {

--- a/packs/data/feats.db/talisman-dabbler-dedication.json
+++ b/packs/data/feats.db/talisman-dabbler-dedication.json
@@ -30,11 +30,11 @@
                 "key": "CraftingEntry",
                 "label": "PF2E.SpecificRule.DedicationCraftingEntry.TalismanDabbler",
                 "maxSlots": 2,
-                "requiredTraits": [
-                    [
-                        "talisman"
+                "craftableItems": {
+                    "all": [
+                        "item:trait:talisman"
                     ]
-                ],
+                },
                 "selector": "talismanDabbler"
             },
             {

--- a/packs/data/feats.db/talisman-esoterica.json
+++ b/packs/data/feats.db/talisman-esoterica.json
@@ -31,11 +31,11 @@
                 "key": "CraftingEntry",
                 "label": "PF2E.SpecificRule.Thaumaturge.TalismanEsoterica",
                 "maxSlots": 2,
-                "requiredTraits": [
-                    [
-                        "talisman"
+                "craftableItems": {
+                    "all": [
+                        "item:trait:talisman"
                     ]
-                ],
+                },
                 "selector": "talismanEsoterica"
             },
             {

--- a/src/module/migration/migrations/772-predicate-on-crafting-entries.ts
+++ b/src/module/migration/migrations/772-predicate-on-crafting-entries.ts
@@ -1,0 +1,91 @@
+import { CraftingEntryData } from "@actor/character/crafting";
+import { ActorSourcePF2e } from "@actor/data";
+import { ItemSourcePF2e } from "@item/data";
+import { PhysicalItemTrait } from "@item/physical/data";
+import { RuleElementSource } from "@module/rules";
+import { RawPredicate } from "@system/predication";
+import { MigrationBase } from "../base";
+
+/** Convert crafting entry `requiredTrait` properties to be predicates */
+export class Migration772PredicateOnCraftingEntries extends MigrationBase {
+    static override version = 0.772;
+
+    munitionsCrafterPredicate: RawPredicate = {
+        all: ["item:trait:alchemical"],
+        any: ["item:trait:bomb", "item:subtype:ammo"],
+    };
+
+    override async updateActor(actorData: ActorSourcePF2e) {
+        if (actorData.type === "character") {
+            const craftingEntries: Record<string, Partial<MaybeWithRequiredTraits>> = actorData.system.crafting.entries;
+            for (const key in craftingEntries) {
+                const entry = craftingEntries[key];
+                const requiredTraits = entry["requiredTraits"];
+                if (requiredTraits) {
+                    entry.craftableItems =
+                        entry.selector === "munitionsCrafter"
+                            ? this.munitionsCrafterPredicate
+                            : this.generatePredicateFromRequiredTraits(requiredTraits);
+                    entry["-=requiredTraits"] = null;
+                }
+            }
+        }
+    }
+
+    override async updateItem(itemSource: ItemSourcePF2e): Promise<void> {
+        itemSource.system.rules ??= [];
+        const rules = itemSource.system.rules;
+        const craftingEntryRules = itemSource.system.rules.filter(
+            (rule: Record<string, unknown>): rule is CraftingEntryRuleSourceOld =>
+                typeof rule.key === "string" &&
+                ["CraftingEntry", "PF2E.RuleElement.CraftingEntry"].includes(rule.key) &&
+                Array.isArray(rule["requiredTraits"])
+        );
+        const newEntries = craftingEntryRules.map(
+            (craftingEntryRule): CraftingEntryRuleSourceNew => ({
+                key: "CraftingEntry",
+                craftableItems:
+                    craftingEntryRule.selector === "munitionsCrafter"
+                        ? this.munitionsCrafterPredicate
+                        : this.generatePredicateFromRequiredTraits(craftingEntryRule.requiredTraits || []),
+            })
+        );
+        for (const craftingEntryRule of craftingEntryRules) {
+            const index = rules.indexOf(craftingEntryRule);
+            rules.splice(index, 1, newEntries.shift()!);
+            delete craftingEntryRule.requiredTraits;
+        }
+    }
+
+    generatePredicateFromRequiredTraits(requiredTraits: PhysicalItemTrait[][]): RawPredicate {
+        if (requiredTraits.length === 1)
+            return {
+                all: requiredTraits[0].map((trait) => {
+                    return "item:trait:" + trait;
+                }),
+            };
+        return {
+            any: requiredTraits.map((traits) => {
+                return {
+                    and: traits.map((trait) => {
+                        return "item:trait:" + trait;
+                    }),
+                };
+            }),
+        };
+    }
+}
+
+interface MaybeWithRequiredTraits extends CraftingEntryData {
+    requiredTraits?: PhysicalItemTrait[][];
+    "-=requiredTraits": null;
+}
+
+type CraftingEntryRuleSourceOld = RuleElementSource & {
+    key: "CraftingEntry";
+    requiredTraits?: PhysicalItemTrait[][];
+};
+
+type CraftingEntryRuleSourceNew = RuleElementSource & {
+    craftableItems: RawPredicate;
+};

--- a/src/module/rules/rule-element/crafting/entry.ts
+++ b/src/module/rules/rule-element/crafting/entry.ts
@@ -2,9 +2,9 @@ import { RuleElementPF2e, RuleElementData, RuleElementSource, RuleElementOptions
 import { CharacterPF2e } from "@actor";
 import { ActorType } from "@actor/data";
 import { ItemPF2e } from "@item";
-import { PhysicalItemTrait } from "@item/physical/data";
 import { CraftingEntryData } from "@actor/character/crafting/entry";
 import { sluggify } from "@util";
+import { PredicatePF2e, RawPredicate } from "@system/predication";
 
 /**
  * @category RuleElement
@@ -44,7 +44,7 @@ class CraftingEntryRuleElement extends RuleElementPF2e {
             isAlchemical: this.data.isAlchemical,
             isDailyPrep: this.data.isDailyPrep,
             isPrepared: this.data.isPrepared,
-            requiredTraits: this.data.requiredTraits,
+            craftableItems: PredicatePF2e.validate(this.data.craftableItems) ? this.data.craftableItems : {},
             maxItemLevel: this.data.maxItemLevel,
             maxSlots: this.data.maxSlots,
         };
@@ -77,9 +77,9 @@ interface CraftingEntryRuleData extends RuleElementData {
     isAlchemical?: boolean;
     isDailyPrep?: boolean;
     isPrepared?: boolean;
-    requiredTraits?: PhysicalItemTrait[][];
     maxItemLevel?: number;
     maxSlots?: number;
+    craftableItems?: RawPredicate;
 }
 
 interface CraftingEntryRuleSource extends RuleElementSource {
@@ -87,9 +87,9 @@ interface CraftingEntryRuleSource extends RuleElementSource {
     isAlchemical?: unknown;
     isDailyPrep?: unknown;
     isPrepared?: unknown;
-    requiredTraits?: PhysicalItemTrait[][];
     maxItemLevel?: unknown;
     maxSlots?: unknown;
+    craftableItems?: unknown;
 }
 
 export { CraftingEntryRuleElement };


### PR DESCRIPTION
To make https://github.com/foundryvtt/pf2e/pull/3353 easier.

- Changes `requiredTraits` on crafting entries to be `formulaPredicate` instead. 
- Migrates existing crafting entries to transform `requiredTraits` into predicates.