### PR TITLE
Avoid double data preparation

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -1199,7 +1199,7 @@ class ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
         // If alliance has changed, reprepare token data to update the color of bounding boxes
         if (canvas.ready && changed.system?.details && "alliance" in changed.system.details) {
             for (const token of this.getActiveTokens(true, true)) {
-                token.prepareData();
+                token.reset();
             }
         }
     }

--- a/src/module/canvas/token/object.ts
+++ b/src/module/canvas/token/object.ts
@@ -328,7 +328,7 @@ class TokenPF2e extends Token<TokenDocumentPF2e> {
         if (!this.document.isLinked) {
             const source = this.document.toObject();
             const { width, height, texture } = source;
-            this.document.prepareData();
+            this.document.reset();
             // If any of the following changed, a full redraw should be performed
             const postChange = pick(this.document, ["width", "height", "texture"]);
             mergeObject(changed, diffObject({ width, height, texture }, postChange));

--- a/src/module/item/base.ts
+++ b/src/module/item/base.ts
@@ -582,7 +582,7 @@ class ItemPF2e extends Item<ActorPF2e> {
             const actorClone = this.actor.clone();
             const item = actorClone.items.get(this.id, { strict: true });
             item.updateSource(changed, options);
-            actorClone.prepareData();
+            actorClone.reset();
 
             const hpMaxDifference = actorClone.hitPoints.max - this.actor.hitPoints.max;
             if (hpMaxDifference !== 0) {
@@ -611,7 +611,7 @@ class ItemPF2e extends Item<ActorPF2e> {
         super._onCreate(data, options, userId);
 
         if (this.actor && game.user.id === userId) {
-            this.actor.prepareData();
+            this.actor.reset();
             const actorUpdates: Record<string, unknown> = {};
             for (const rule of this.rules) {
                 rule.onCreate?.(actorUpdates);

--- a/src/module/scene/token-document/document.ts
+++ b/src/module/scene/token-document/document.ts
@@ -282,7 +282,7 @@ class TokenDocumentPF2e<TActor extends ActorPF2e = ActorPF2e> extends TokenDocum
         if (!this.isLinked) return super._onUpdateBaseActor(updates, options);
 
         const currentData = this.toObject(false);
-        this.prepareData();
+        this.reset();
         const newData = this.toObject(false);
         const changed = diffObject<DeepPartial<foundry.data.TokenSource>>(currentData, newData);
 

--- a/src/module/system/effect-tracker.ts
+++ b/src/module/system/effect-tracker.ts
@@ -99,7 +99,7 @@ export class EffectTracker {
             }, []);
 
         for (const actor of updatedActors) {
-            actor.prepareData();
+            actor.reset();
             actor.sheet.render(false);
             if (actor.isOfType("creature")) {
                 for (const token of actor.getActiveTokens()) {

--- a/src/module/system/settings/automation.ts
+++ b/src/module/system/settings/automation.ts
@@ -30,11 +30,13 @@ export class AutomationSettings extends SettingsMenuPF2e {
                 default: true,
                 type: Boolean,
                 onChange: () => {
-                    game.actors.forEach((actor) => {
-                        actor.prepareData();
+                    for (const actor of game.actors) {
+                        actor.reset();
                         actor.sheet.render(false);
-                        actor.getActiveTokens().forEach((token) => token.drawEffects());
-                    });
+                        for (const token of actor.getActiveTokens()) {
+                            token.drawEffects();
+                        }
+                    }
                 },
             },
             removeExpiredEffects: {

--- a/src/scripts/hooks/migration-complete.ts
+++ b/src/scripts/hooks/migration-complete.ts
@@ -1,7 +1,7 @@
 export function listen() {
     Hooks.on("migrationComplete", () => {
         for (const actor of game.actors) {
-            actor.prepareData();
+            actor.reset();
         }
     });
 }


### PR DESCRIPTION
In V9, `document.prepareData()` called `document.reset()`, restoring the document's data to its source state. Now the relationship has been inverted (`document.reset()` resets and then calls `document.prepareData()`), meaning `document.prepareData()` can prepare over an already-prepared state.