### PR TITLE
Add async overloads to `TextEditor.enrichHTML` and `TextEditorPF2e.enrichHTML`

### DIFF
--- a/types/foundry/client/core/text-editor.d.ts
+++ b/types/foundry/client/core/text-editor.d.ts
@@ -38,7 +38,9 @@ declare global {
          * @param [options.rollData]       The data object providing context for inline rolls
          * @return The enriched HTML content
          */
-        static enrichHTML(content?: string, options?: EnrichHTMLOptions): string;
+        static enrichHTML(content?: string, options?: EnrichHTMLOptions & { async?: false }): string;
+        static enrichHTML(content?: string, options?: EnrichHTMLOptions & { async: true }): Promise<string>;
+        static enrichHTML(content?: string, options?: EnrichHTMLOptions): string | Promise<string>;
 
         /**
          * Preview an HTML fragment by constructing a substring of a given length from its inner text.


### PR DESCRIPTION
Based on `Roll#evaluate`.
The first overload in `TextEditorPF2e` was necessary to pass type checks, not sure why.