### PR TITLE
Add type definition for `fromUuidSync` helper function

### DIFF
--- a/types/foundry/client/collections/compendium-collection.d.ts
+++ b/types/foundry/client/collections/compendium-collection.d.ts
@@ -173,6 +173,23 @@ declare global {
     function fromUuid<T extends CompendiumDocument = CompendiumDocument>(uuid: CompendiumUUID): Promise<T | null>;
     function fromUuid<T extends ClientDocument = ClientDocument>(uuid: string): Promise<T | null>;
 
+    /**
+     * Retrieve a Document by its Universally Unique Identifier (uuid) synchronously. If the uuid resolves to a compendium
+     * document, that document's index entry will be returned instead.
+     * @param uuid The uuid of the Document to retrieve.
+     * @param {} [relative]  A document to resolve relative UUIDs against.
+     * @returns The Document or its index entry if it resides in a Compendium, otherwise null.
+     * @throws If the uuid resolves to a Document that cannot be retrieved synchronously.
+     */
+    function fromUuidSync(
+        uuid: WorldDocumentUUID,
+        relative?: ClientDocument | CompendiumIndexData | null
+    ): ClientDocument | null;
+    function fromUuidSync(
+        uuid: string,
+        relative?: ClientDocument | CompendiumIndexData | null
+    ): ClientDocument | CompendiumIndexData | null;
+
     interface CompendiumMetadata<T extends CompendiumDocument = CompendiumDocument> {
         readonly type: T["documentName"];
         name: string;
@@ -188,7 +205,7 @@ declare global {
         _id: string;
         type: string;
         name: string;
-        img?: ImagePath;
+        img: ImagePath;
         [key: string]: any;
     }
 


### PR DESCRIPTION
Also updates `CompendiumIndexData` to reflect that the `img` property is now always retrieved