### PR TITLE
Set `TokenDocumentPF2e#initialized` only once

### DIFF
--- a/src/module/rules/rule-element/token-light.ts
+++ b/src/module/rules/rule-element/token-light.ts
@@ -37,7 +37,8 @@ class TokenLightRuleElement extends RuleElementPF2e {
         if (!this.test()) return;
 
         const light = new foundry.data.LightData(this.data.value).toObject(false);
-        mergeObject(this.actor.overrides, { token: { light } });
+        const { overrides } = this.actor;
+        overrides.prototypeToken = mergeObject(overrides.prototypeToken ?? {}, { light });
     }
 }
 

--- a/src/module/scene/token-document/document.ts
+++ b/src/module/scene/token-document/document.ts
@@ -10,7 +10,7 @@ import { ActorSourcePF2e } from "@actor/data";
 
 class TokenDocumentPF2e<TActor extends ActorPF2e = ActorPF2e> extends TokenDocument<TActor> {
     /** Has this token gone through at least one cycle of data preparation? */
-    private initialized!: boolean;
+    private initialized?: boolean;
 
     auras!: Map<string, TokenAura>;
 
@@ -53,11 +53,8 @@ class TokenDocumentPF2e<TActor extends ActorPF2e = ActorPF2e> extends TokenDocum
     }
 
     protected override _initialize(): void {
-        this.initialized = false;
         this.auras = new Map();
-
         super._initialize();
-
         this.initialized = true;
     }
 
@@ -187,7 +184,7 @@ class TokenDocumentPF2e<TActor extends ActorPF2e = ActorPF2e> extends TokenDocum
         super.prepareDerivedData();
         if (!(this.initialized && this.actor && this.scene)) return;
 
-        // Temporary token image
+        // Merge token overrides from REs into this
         mergeObject(this, this.actor.overrides.prototypeToken ?? {}, { insertKeys: false });
 
         // Token dimensions from actor size


### PR DESCRIPTION
Foundry V10 now calls Document#_initialize every data preparation cycle, whereas it used to only call it during class construction.