### PR TITLE
Explicitly set the `async` option for all references to `enrichHTML`

### DIFF
--- a/src/module/actor/character/crafting/helpers.ts
+++ b/src/module/actor/character/crafting/helpers.ts
@@ -35,7 +35,7 @@ function prepStrings(costs: Costs, item: PhysicalItemPF2e) {
         lostMaterials: game.i18n.format("PF2E.Actions.Craft.Details.LostMaterials", {
             cost: costs.lostMaterials.toString(),
         }),
-        itemLink: game.pf2e.TextEditor.enrichHTML(item.link, { rollData }),
+        itemLink: game.pf2e.TextEditor.enrichHTML(item.link, { rollData, async: false }),
     };
 }
 

--- a/src/module/actor/sheet/item-summary-renderer.ts
+++ b/src/module/actor/sheet/item-summary-renderer.ts
@@ -139,7 +139,7 @@ export class ItemSummaryRendererPF2e<AType extends ActorPF2e> {
 
         const description = isItemSystemData(chatData)
             ? chatData.description.value
-            : game.pf2e.TextEditor.enrichHTML(item.description, { rollData: item.getRollData() });
+            : game.pf2e.TextEditor.enrichHTML(item.description, { rollData: item.getRollData(), async: false });
 
         $div.append($properties, $priceLabel, `<div class="item-description">${description}</div>`);
     }

--- a/src/module/chat-message/document.ts
+++ b/src/module/chat-message/document.ts
@@ -165,7 +165,7 @@ class ChatMessagePF2e extends ChatMessage<ActorPF2e> {
         super.prepareData();
 
         const rollData = { ...this.actor?.getRollData(), ...(this.item?.getRollData() ?? { actor: this.actor }) };
-        this.content = TextEditorPF2e.enrichHTML(this.content, { rollData });
+        this.content = TextEditorPF2e.enrichHTML(this.content, { rollData, async: false });
     }
 
     override async getHTML(): Promise<JQuery> {

--- a/src/module/item/base.ts
+++ b/src/module/item/base.ts
@@ -273,6 +273,7 @@ class ItemPF2e extends Item<ActorPF2e> {
         if (isItemSystemData(data)) {
             const chatData = duplicate(data);
             htmlOptions.rollData = mergeObject(this.getRollData(), htmlOptions.rollData ?? {});
+            htmlOptions.async = false;
             chatData.description.value = game.pf2e.TextEditor.enrichHTML(chatData.description.value, htmlOptions);
 
             return chatData;

--- a/src/module/item/spell/index.ts
+++ b/src/module/item/spell/index.ts
@@ -486,7 +486,7 @@ class SpellPF2e extends ItemPF2e {
         const localize: Localization["localize"] = game.i18n.localize.bind(game.i18n);
         const systemData: SpellSystemData = this.system;
 
-        const options = { ...htmlOptions, rollData };
+        const options = { ...htmlOptions, rollData, async: false };
         const description = game.pf2e.TextEditor.enrichHTML(this.description, options);
 
         const trickData = this.trickMagicEntry;

--- a/src/module/system/damage/roll-dialog.ts
+++ b/src/module/system/damage/roll-dialog.ts
@@ -152,7 +152,10 @@ export class DamageRollModifiersDialog extends Application {
         const noteRollData = context.self?.item?.getRollData();
         const notes = damage.notes
             .filter((note) => note.outcome.length === 0 || note.outcome.includes(outcome))
-            .map((note) => game.pf2e.TextEditor.enrichHTML(note.text, { rollData: noteRollData }))
+            .map(
+                async (note) =>
+                    await game.pf2e.TextEditor.enrichHTML(note.text, { rollData: noteRollData, async: true })
+            )
             .join("<br />");
         flavor += `${notes}`;
 

--- a/src/module/system/rolls.ts
+++ b/src/module/system/rolls.ts
@@ -277,7 +277,9 @@ class CheckPF2e {
                     }
                     return false;
                 })
-                .map((n) => game.pf2e.TextEditor.enrichHTML(n.text, { rollData: noteRollData }))
+                .map(
+                    async (n) => await game.pf2e.TextEditor.enrichHTML(n.text, { rollData: noteRollData, async: true })
+                )
                 .join("<br />") ?? "";
 
         const item = context.item ?? null;

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -13,7 +13,7 @@ class TextEditorPF2e extends TextEditor {
     static override enrichHTML(content?: string, options?: EnrichHTMLOptionsPF2e & { async: true }): Promise<string>;
     static override enrichHTML(content?: string, options?: EnrichHTMLOptionsPF2e): string;
     static override enrichHTML(content = "", options: EnrichHTMLOptionsPF2e = {}): string | Promise<string> {
-        const enriched = super.enrichHTML(this.enrichString(content, options), { async: false, ...options });
+        const enriched = super.enrichHTML(this.enrichString(content, options), options);
         if (typeof enriched === "string") {
             return this.#processUserVisibility(enriched, options);
         }

--- a/src/scripts/handlebars.ts
+++ b/src/scripts/handlebars.ts
@@ -133,7 +133,7 @@ export function registerHandlebarsHelpers() {
     Handlebars.registerHelper("enrichHTML", (html, options) => {
         const item: ItemPF2e = options?.hash.item;
         const rollData = item?.getRollData();
-        return game.pf2e.TextEditor.enrichHTML(html, { rollData, secrets: game.user.isGM });
+        return game.pf2e.TextEditor.enrichHTML(html, { rollData, secrets: game.user.isGM, async: false });
     });
 
     Handlebars.registerHelper("json", (html) => {

--- a/src/scripts/macros/hotbar.ts
+++ b/src/scripts/macros/hotbar.ts
@@ -77,7 +77,9 @@ export async function rollActionMacro(actorId: string, actionIndex: number, acti
                     actor,
                     strike: action,
                     strikeIndex: actionIndex,
-                    strikeDescription: game.pf2e.TextEditor.enrichHTML(game.i18n.localize(action.description)),
+                    strikeDescription: await game.pf2e.TextEditor.enrichHTML(game.i18n.localize(action.description), {
+                        async: true,
+                    }),
                 };
 
                 const content = await renderTemplate("systems/pf2e/templates/chat/strike-card.html", templateData);


### PR DESCRIPTION
Setting the default option in the super call makes the async handling of the override pointless.