### PR TITLE
Allow ability score boosts at level 0

### DIFF
--- a/src/module/actor/character/index.ts
+++ b/src/module/actor/character/index.ts
@@ -275,7 +275,7 @@ class CharacterPF2e extends CreaturePF2e {
         const boostLevels = [1, 5, 10, 15, 20] as const;
         const allowedBoosts = boostLevels.reduce((result, level) => {
             const allowed = (() => {
-                if (this.level < 1) return 0;
+                if (this.level === 0 && level === 1) return 4;
                 if (isGradual) return 4 - Math.clamped(level - this.level, 0, 4);
                 return this.level >= level ? 4 : 0;
             })();


### PR DESCRIPTION
Fix for #3403 

Level 0 characters are [still allowed to take level 1 boosts](https://2e.aonprd.com/Rules.aspx?ID=1344)

Could also rename `Level 1` to `Initial`? But I think level 0 characters are niche enough to not warrant a change.