### PR TITLE
Remove `TextEditorPF2e` class and move its methods to `EnrichContentPF2e`

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -45,7 +45,7 @@ import { EffectTracker } from "@system/effect-tracker";
 import { ActorImporter } from "@system/importer/actor-importer";
 import { CheckPF2e } from "@system/rolls";
 import type { HomebrewSettingsKey, HomebrewTag } from "@system/settings/homebrew";
-import { TextEditorPF2e } from "@system/text-editor";
+import { EnrichContentPF2e } from "@system/enrich-content";
 import { sluggify } from "@util";
 import { CombatantPF2e, EncounterPF2e } from "./module/encounter";
 import { ConditionManager } from "./module/system/conditions";
@@ -89,7 +89,7 @@ declare global {
             Check: typeof CheckPF2e;
             RuleElements: typeof RuleElements;
             RuleElement: typeof RuleElementPF2e;
-            TextEditor: typeof TextEditorPF2e;
+            TextEditor: typeof EnrichContentPF2e;
         };
     }
 

--- a/src/module/actor/character/crafting/helpers.ts
+++ b/src/module/actor/character/crafting/helpers.ts
@@ -35,7 +35,7 @@ async function prepStrings(costs: Costs, item: PhysicalItemPF2e) {
         lostMaterials: game.i18n.format("PF2E.Actions.Craft.Details.LostMaterials", {
             cost: costs.lostMaterials.toString(),
         }),
-        itemLink: await game.pf2e.TextEditor.enrichHTML(item.link, { rollData, async: true }),
+        itemLink: await game.pf2e.TextEditor.enrichHTML(item.link, { rollData }),
     };
 }
 

--- a/src/module/actor/creature/sheet.ts
+++ b/src/module/actor/creature/sheet.ts
@@ -8,7 +8,6 @@ import { ITEM_CARRY_TYPES } from "@item/data/values";
 import { goesToEleven, ZeroToFour } from "@module/data";
 import { createSheetTags } from "@module/sheet/helpers";
 import { eventToRollParams } from "@scripts/sheet-util";
-import { TextEditorPF2e } from "@system/text-editor";
 import { ErrorPF2e, fontAwesomeIcon, objectHasKey, setHasElement, tupleHasValue } from "@util";
 import { ActorSheetPF2e } from "../sheet/base";
 import { CreatureConfig } from "./config";
@@ -69,7 +68,7 @@ export abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends Act
 
         // Enrich condition data
         const enrich = async (content: string, rollData: Record<string, unknown>): Promise<string> => {
-            return TextEditorPF2e.enrichHTML(content, { rollData, async: true });
+            return game.pf2e.TextEditor.enrichHTML(content, { rollData });
         };
         const actorRollData = this.actor.getRollData();
         const conditions = game.pf2e.ConditionManager.getFlattenedConditions(actor.itemTypes.condition);

--- a/src/module/actor/hazard/sheet.ts
+++ b/src/module/actor/hazard/sheet.ts
@@ -3,7 +3,6 @@ import { ActorSheetDataPF2e } from "@actor/sheet/data-types";
 import { SAVE_TYPES } from "@actor/values";
 import { ConsumablePF2e, SpellPF2e } from "@item";
 import { ItemDataPF2e } from "@item/data";
-import { TextEditorPF2e } from "@system/text-editor";
 import { ErrorPF2e, tagify } from "@util";
 import { HazardPF2e } from ".";
 import { HazardSystemData } from "./data";
@@ -56,7 +55,7 @@ export class HazardSheetPF2e extends ActorSheetPF2e<HazardPF2e> {
         // Enrich content
         const rollData = this.actor.getRollData();
         const enrich = async (content: string): Promise<string> => {
-            return TextEditorPF2e.enrichHTML(content, { rollData, async: true });
+            return game.pf2e.TextEditor.enrichHTML(content, { rollData });
         };
         sheetData.enrichedContent = mergeObject(sheetData.enrichedContent, {
             stealthDetails: await enrich(systemData.attributes.stealth.details),
@@ -146,11 +145,12 @@ export class HazardSheetPF2e extends ActorSheetPF2e<HazardPF2e> {
                 // Enrich description
                 const item = this.actor.items.get(itemData._id);
                 const rollData = { ...this.actor.getRollData(), ...item?.getRollData() };
-                itemData.system.description.value = await TextEditorPF2e.enrichHTML(itemData.system.description.value, {
-                    rollData,
-                    async: true,
-                });
-
+                itemData.system.description.value = await game.pf2e.TextEditor.enrichHTML(
+                    itemData.system.description.value,
+                    {
+                        rollData,
+                    }
+                );
                 attacks.push(itemData);
             }
         }

--- a/src/module/actor/loot/sheet.ts
+++ b/src/module/actor/loot/sheet.ts
@@ -5,7 +5,6 @@ import { LootNPCsPopup } from "../sheet/loot/loot-npcs-popup";
 import { LootSheetDataPF2e } from "../sheet/data-types";
 import { ItemPF2e } from "@item";
 import { DropCanvasItemDataPF2e } from "@module/canvas/drop-canvas-data";
-import { TextEditorPF2e } from "@system/text-editor";
 
 export class LootSheetPF2e extends ActorSheetPF2e<LootPF2e> {
     static override get defaultOptions(): ActorSheetOptions {
@@ -35,9 +34,11 @@ export class LootSheetPF2e extends ActorSheetPF2e<LootPF2e> {
 
         // Enrich content
         const rollData = this.actor.getRollData();
-        sheetData.enrichedContent.description = await TextEditorPF2e.enrichHTML(
+        sheetData.enrichedContent.description = await game.pf2e.TextEditor.enrichHTML(
             sheetData.data.details.description.value,
-            { rollData, async: true }
+            {
+                rollData,
+            }
         );
 
         return { ...sheetData, isLoot };

--- a/src/module/actor/npc/index.ts
+++ b/src/module/actor/npc/index.ts
@@ -18,7 +18,6 @@ import { LocalizePF2e } from "@system/localize";
 import { PredicatePF2e } from "@system/predication";
 import { RollParameters } from "@system/rolls";
 import { Statistic } from "@system/statistic";
-import { TextEditorPF2e } from "@system/text-editor";
 import { ErrorPF2e, objectHasKey, sluggify } from "@util";
 import { NPCData, NPCFlags, NPCSource, NPCStrike } from "./data";
 import { NPCSheetPF2e } from "./sheet";
@@ -823,7 +822,7 @@ class NPCPF2e extends CreaturePF2e {
         const formatNoteText = async (itemName: string, item: ItemPF2e) => {
             // Call enrichHTML with the correct item context
             const rollData = item.getRollData();
-            const description = await TextEditorPF2e.enrichHTML(item.description, { rollData, async: true });
+            const description = await game.pf2e.TextEditor.enrichHTML(item.description, { rollData });
 
             return `<div style="display: inline-block; font-weight: normal; line-height: 1.3em;" data-visibility="gm"><div><strong>${itemName}</strong></div>${description}</div>`;
         };

--- a/src/module/actor/npc/sheet.ts
+++ b/src/module/actor/npc/sheet.ts
@@ -11,7 +11,6 @@ import { Size } from "@module/data";
 import { identifyCreature, IdentifyCreatureData } from "@module/recall-knowledge";
 import { DicePF2e } from "@scripts/dice";
 import { eventToRollParams } from "@scripts/sheet-util";
-import { TextEditorPF2e } from "@system/text-editor";
 import { ErrorPF2e, getActionGlyph, getActionIcon, objectHasKey, setHasElement } from "@util";
 import { RecallKnowledgePopup } from "../sheet/popups/recall-knowledge-popup";
 import { NPCConfig } from "./config";
@@ -172,14 +171,18 @@ export class NPCSheetPF2e<TActor extends NPCPF2e> extends CreatureSheetPF2e<TAct
 
         // Enrich content
         const rollData = this.actor.getRollData();
-        sheetData.enrichedContent.publicNotes = await TextEditorPF2e.enrichHTML(sheetData.data.details.publicNotes, {
-            rollData,
-            async: true,
-        });
-        sheetData.enrichedContent.privateNotes = await TextEditorPF2e.enrichHTML(sheetData.data.details.privateNotes, {
-            rollData,
-            async: true,
-        });
+        sheetData.enrichedContent.publicNotes = await game.pf2e.TextEditor.enrichHTML(
+            sheetData.data.details.publicNotes,
+            {
+                rollData,
+            }
+        );
+        sheetData.enrichedContent.privateNotes = await game.pf2e.TextEditor.enrichHTML(
+            sheetData.data.details.privateNotes,
+            {
+                rollData,
+            }
+        );
 
         // Return data for rendering
         return sheetData as NPCSheetData<TActor>;
@@ -427,9 +430,8 @@ export class NPCSheetPF2e<TActor extends NPCPF2e> extends CreatureSheetPF2e<TAct
         return Promise.all(
             sheetData.actions.map(async (attack) => {
                 const itemRollData = attack.item.getRollData();
-                attack.description = await TextEditorPF2e.enrichHTML(attack.description, {
+                attack.description = await game.pf2e.TextEditor.enrichHTML(attack.description, {
                     rollData: { ...actorRollData, ...itemRollData },
-                    async: true,
                 });
                 const traits = attack.traits
                     .map((strikeTrait) => ({

--- a/src/module/actor/sheet/item-summary-renderer.ts
+++ b/src/module/actor/sheet/item-summary-renderer.ts
@@ -137,9 +137,12 @@ export class ItemSummaryRendererPF2e<AType extends ActorPF2e> {
         const allTags = [$rarityTag, ...traitTags, ...properties].filter((tag): tag is JQuery => !!tag);
         const $properties = $('<div class="item-properties tags"></div>').append(...allTags);
 
-        const description = isItemSystemData(chatData)
-            ? chatData.description.value
-            : await game.pf2e.TextEditor.enrichHTML(item.description, { rollData: item.getRollData(), async: true });
+        const description = await (async () => {
+            const enriched = isItemSystemData(chatData)
+                ? chatData.description.value
+                : await game.pf2e.TextEditor.enrichHTML(item.description, { rollData: item.getRollData() });
+            return game.pf2e.TextEditor.processUserVisibility(enriched, { actor: item.actor });
+        })();
 
         $div.append($properties, $priceLabel, `<div class="item-description">${description}</div>`);
     }

--- a/src/module/apps/migration-summary.ts
+++ b/src/module/apps/migration-summary.ts
@@ -1,6 +1,5 @@
 import { MigrationRunner } from "@module/migration";
 import { LocalizePF2e } from "@system/localize";
-import { TextEditorPF2e } from "@system/text-editor";
 
 /** A summary window that opens after a system migration completes */
 export class MigrationSummary extends Application<MigrationSummaryOptions> {
@@ -49,9 +48,8 @@ export class MigrationSummary extends Application<MigrationSummaryOptions> {
         const canRemigrate =
             this.options.troubleshoot || actors.successful < actors.total || items.successful < items.total;
 
-        const helpResourcesText = await TextEditorPF2e.enrichHTML(
-            LocalizePF2e.translations.PF2E.Migrations.Summary.HelpResources,
-            { async: true }
+        const helpResourcesText = await game.pf2e.TextEditor.enrichHTML(
+            LocalizePF2e.translations.PF2E.Migrations.Summary.HelpResources
         );
 
         return {

--- a/src/module/chat-message/document.ts
+++ b/src/module/chat-message/document.ts
@@ -13,8 +13,8 @@ import { traditionSkills, TrickMagicItemEntry } from "@item/spellcasting-entry/t
 import { ErrorPF2e } from "@util";
 import { UserPF2e } from "@module/user";
 import { CheckRoll } from "@system/check/roll";
-import { TextEditorPF2e } from "@system/text-editor";
 import { ChatRollDetails } from "./chat-roll-details";
+import { UserVisibilityPF2e } from "@scripts/ui/user-visibility";
 
 class ChatMessagePF2e extends ChatMessage<ActorPF2e> {
     /** The chat log doesn't wait for data preparation before rendering, so set some data in the constructor */
@@ -164,7 +164,7 @@ class ChatMessagePF2e extends ChatMessage<ActorPF2e> {
         // Determine some metadata
         const data = this.toObject(false) as RawObject<ChatMessageDataPF2e>;
         const rollData = { ...this.actor?.getRollData(), ...(this.item?.getRollData() ?? { actor: this.actor }) };
-        data.content = await TextEditorPF2e.enrichHTML(this.content, { rollData, async: true });
+        data.content = await game.pf2e.TextEditor.enrichHTML(this.content, { rollData });
         const isWhisper = this.whisper.length;
 
         // Construct message data
@@ -209,6 +209,9 @@ class ChatMessagePF2e extends ChatMessage<ActorPF2e> {
         if (this.item?.isOfType("spell") && !this.item.isOwner) {
             $html.find("section.owner-buttons").remove();
         }
+
+        // Apply user visibility changes
+        UserVisibilityPF2e.process($html, { message: this });
 
         // Remove entire .target-dc and .dc-result elements if they are empty after user-visibility processing
         const targetDC = $html[0].querySelector(".target-dc");

--- a/src/module/item/base.ts
+++ b/src/module/item/base.ts
@@ -5,7 +5,7 @@ import { preImportJSON } from "@module/doc-helpers";
 import { MigrationList, MigrationRunner } from "@module/migration";
 import { UserPF2e } from "@module/user";
 import { DicePF2e } from "@scripts/dice";
-import { EnrichHTMLOptionsPF2e } from "@system/text-editor";
+import { EnrichHTMLOptionsPF2e } from "@system/enrich-content";
 import { ErrorPF2e, isObject, setHasElement, sluggify } from "@util";
 import { RuleElementOptions, RuleElementPF2e, RuleElements, RuleElementSource } from "../rules";
 import { ContainerPF2e } from "./container";
@@ -277,7 +277,6 @@ class ItemPF2e extends Item<ActorPF2e> {
             htmlOptions.rollData = mergeObject(this.getRollData(), htmlOptions.rollData ?? {});
             chatData.description.value = await game.pf2e.TextEditor.enrichHTML(chatData.description.value, {
                 ...htmlOptions,
-                async: true,
             });
 
             return chatData;

--- a/src/module/item/physical/sheet.ts
+++ b/src/module/item/physical/sheet.ts
@@ -4,7 +4,6 @@ import { ItemSheetDataPF2e, PhysicalItemSheetData } from "@item/sheet/data-types
 import { BasePhysicalItemSource, ItemActivation } from "./data";
 import { createSheetTags } from "@module/sheet/helpers";
 import { CoinsPF2e } from "@item/physical/helpers";
-import { TextEditorPF2e } from "@system/text-editor";
 
 export class PhysicalItemSheetPF2e<TItem extends PhysicalItemPF2e = PhysicalItemPF2e> extends ItemSheetPF2e<TItem> {
     /** Show the identified data for editing purposes */
@@ -21,9 +20,13 @@ export class PhysicalItemSheetPF2e<TItem extends PhysicalItemPF2e = PhysicalItem
 
         // Enrich content
         const rollData = { ...this.item.getRollData(), ...this.actor?.getRollData() };
-        sheetData.enrichedContent.unidentifiedDescription = await TextEditorPF2e.enrichHTML(
+        sheetData.enrichedContent.unidentifiedDescription = await game.pf2e.TextEditor.enrichHTML(
             sheetData.item.system.identification.unidentified.data.description.value,
-            { rollData, async: true }
+            { rollData }
+        );
+        sheetData.enrichedContent.unidentifiedDescription = game.pf2e.TextEditor.processUserVisibility(
+            sheetData.enrichedContent.unidentifiedDescription,
+            { actor: this.item.actor }
         );
 
         return {

--- a/src/module/item/sheet/base.ts
+++ b/src/module/item/sheet/base.ts
@@ -68,7 +68,9 @@ export class ItemSheetPF2e<TItem extends ItemPF2e> extends ItemSheet<TItem> {
         const rollData = { ...this.item.getRollData(), ...this.actor?.getRollData() };
         enrichedContent.description = await game.pf2e.TextEditor.enrichHTML(itemData.system.description.value, {
             rollData,
-            async: true,
+        });
+        enrichedContent.description = game.pf2e.TextEditor.processUserVisibility(enrichedContent.description, {
+            actor: this.item.actor,
         });
 
         return {

--- a/src/module/item/spell/index.ts
+++ b/src/module/item/spell/index.ts
@@ -20,7 +20,7 @@ import { eventToRollParams } from "@scripts/sheet-util";
 import { DamageCategorization, DamageType } from "@system/damage";
 import { CheckPF2e } from "@system/rolls";
 import { StatisticRollParameters } from "@system/statistic";
-import { EnrichHTMLOptionsPF2e } from "@system/text-editor";
+import { EnrichHTMLOptionsPF2e } from "@system/enrich-content";
 import { ErrorPF2e, getActionIcon, objectHasKey, ordinal, traitSlugToObject } from "@util";
 import {
     SpellData,
@@ -489,7 +489,7 @@ class SpellPF2e extends ItemPF2e {
         const systemData: SpellSystemData = this.system;
 
         const options = { ...htmlOptions, rollData };
-        const description = await game.pf2e.TextEditor.enrichHTML(this.description, { ...options, async: true });
+        const description = await game.pf2e.TextEditor.enrichHTML(this.description, { ...options });
 
         const trickData = this.trickMagicEntry;
         const spellcasting = this.spellcasting;

--- a/src/module/journal-entry/sheet.ts
+++ b/src/module/journal-entry/sheet.ts
@@ -1,5 +1,4 @@
 import { InlineRollLinks } from "@scripts/ui/inline-roll-links";
-import { TextEditorPF2e } from "@system/text-editor";
 import { ErrorPF2e } from "@util";
 import type * as TinyMCE from "tinymce";
 import "../../styles/tinymce.scss";
@@ -30,7 +29,7 @@ class JournalSheetPF2e<TJournalEntry extends JournalEntry = JournalEntry> extend
 
         options = foundry.utils.mergeObject(editor.options, options);
         options.height = options.target?.offsetHeight;
-        TextEditorPF2e.create(options, initialContent || editor.initial).then((mce) => {
+        TextEditor.create(options, initialContent || editor.initial).then((mce) => {
             const theme = (this.constructor as typeof JournalSheetPF2e).theme;
             if (theme) {
                 mce.getBody().classList.add(theme);

--- a/src/module/system/damage/roll-dialog.ts
+++ b/src/module/system/damage/roll-dialog.ts
@@ -153,10 +153,7 @@ export class DamageRollModifiersDialog extends Application {
         const damageNotes = await Promise.all(
             damage.notes
                 .filter((note) => note.outcome.length === 0 || note.outcome.includes(outcome))
-                .map(
-                    async (note) =>
-                        await game.pf2e.TextEditor.enrichHTML(note.text, { rollData: noteRollData, async: true })
-                )
+                .map(async (note) => await game.pf2e.TextEditor.enrichHTML(note.text, { rollData: noteRollData }))
         );
         const notes = damageNotes.join("<br />");
         flavor += `${notes}`;

--- a/src/module/system/rolls.ts
+++ b/src/module/system/rolls.ts
@@ -25,7 +25,7 @@ import {
 } from "./degree-of-success";
 import { LocalizePF2e } from "./localize";
 import { PredicatePF2e } from "./predication";
-import { TextEditorPF2e } from "./text-editor";
+import { EnrichContentPF2e } from "./enrich-content";
 
 interface RollDataPF2e extends RollData {
     rollerId?: string;
@@ -303,7 +303,7 @@ class CheckPF2e {
                 .flat()
                 .map((e) => (typeof e === "string" ? e : e.outerHTML))
                 .join("");
-            return TextEditorPF2e.enrichHTML(flavor, { ...item?.getRollData(), async: true });
+            return game.pf2e.TextEditor.enrichHTML(flavor, { rollData: item?.getRollData() });
         })();
 
         const secret = context.secret ?? context.options?.includes("secret") ?? false;
@@ -722,7 +722,7 @@ class CheckPF2e {
         });
 
         const html = parseHTML(rendered);
-        const { convertXMLNode } = TextEditorPF2e;
+        const { convertXMLNode } = EnrichContentPF2e;
 
         if (targetData) {
             convertXMLNode(html, "target", { visibility: targetData.visibility, whose: "target" });

--- a/src/scripts/hooks/init.ts
+++ b/src/scripts/hooks/init.ts
@@ -17,6 +17,7 @@ import { SetGamePF2e } from "@scripts/set-game-pf2e";
 import { Check } from "@system/check";
 import { registerSettings } from "@system/settings";
 import { PF2ECONFIG } from "@scripts/config";
+import { EnrichContentPF2e } from "@system/enrich-content";
 
 export const Init = {
     listen: (): void => {
@@ -134,7 +135,7 @@ export const Init = {
             // Register custom enricher
             CONFIG.TextEditor.enrichers.push({
                 pattern: new RegExp("@(Check|Localize|Template)\\[([^\\]]+)\\](?:{([^}]+)})?", "g"),
-                enricher: (match, options) => game.pf2e.TextEditor.enrichString(match, options),
+                enricher: (match, options) => EnrichContentPF2e.enrichString(match, options),
             });
 
             // Soft-set system-preferred core settings until they've been explicitly set by the GM

--- a/src/scripts/macros/hotbar.ts
+++ b/src/scripts/macros/hotbar.ts
@@ -77,9 +77,7 @@ export async function rollActionMacro(actorId: string, actionIndex: number, acti
                     actor,
                     strike: action,
                     strikeIndex: actionIndex,
-                    strikeDescription: await game.pf2e.TextEditor.enrichHTML(game.i18n.localize(action.description), {
-                        async: true,
-                    }),
+                    strikeDescription: await game.pf2e.TextEditor.enrichHTML(game.i18n.localize(action.description)),
                 };
 
                 const content = await renderTemplate("systems/pf2e/templates/chat/strike-card.html", templateData);

--- a/src/scripts/set-game-pf2e.ts
+++ b/src/scripts/set-game-pf2e.ts
@@ -29,7 +29,7 @@ import { ConditionManager } from "@system/conditions";
 import { EffectTracker } from "@system/effect-tracker";
 import { ActorImporter } from "@system/importer/actor-importer";
 import { CheckPF2e } from "@system/rolls";
-import { TextEditorPF2e } from "@system/text-editor";
+import { EnrichContentPF2e } from "@system/enrich-content";
 import { sluggify } from "@util";
 import { CoinsPF2e } from "@item/physical/helpers";
 
@@ -71,7 +71,7 @@ export const SetGamePF2e = {
             StatisticModifier: StatisticModifier,
             StatusEffects: StatusEffects,
             system: { moduleArt: new Map(), remigrate, sluggify },
-            TextEditor: TextEditorPF2e,
+            TextEditor: EnrichContentPF2e,
             variantRules: { AutomaticBonusProgression },
         };
 

--- a/src/scripts/ui/user-visibility.ts
+++ b/src/scripts/ui/user-visibility.ts
@@ -4,7 +4,7 @@ import { objectHasKey } from "@util";
 
 const UserVisibilityPF2e = {
     /** Edits HTML live based on permission settings. Used to hide certain blocks and values */
-    process: ($html: JQuery, options: ProcessOptions = {}) => {
+    process: ($html: JQuery, options: UserVisibilityProcessOptions = {}) => {
         const visibilityElements = Array.from($html[0].querySelectorAll<HTMLElement>("[data-visibility]"));
 
         // Remove all visibility=none elements
@@ -88,9 +88,9 @@ const UserVisibilityPF2e = {
 
 type UserVisibility = "all" | "owner" | "gm" | "none";
 
-interface ProcessOptions {
+interface UserVisibilityProcessOptions {
     message?: ChatMessagePF2e;
     actor?: ActorPF2e | null;
 }
 
-export { UserVisibilityPF2e, UserVisibility };
+export { UserVisibilityPF2e, UserVisibility, UserVisibilityProcessOptions };


### PR DESCRIPTION
I've kept `game.pf2e.TextEditor` for compatibility.

- Chat message visibility is handled in `ChatMessagePF2e#getHTML`.
- Item description visibility is handled in the base item sheet and the item summary renderer.

Alternatively we could also add a handlebars helper to handle visibility in the templates.