### PR TITLE
Add missing creature family abilities

### DIFF
--- a/packs/data/bestiary-family-ability-glossary.db/coven-contribute-spell.json
+++ b/packs/data/bestiary-family-ability-glossary.db/coven-contribute-spell.json
@@ -1,0 +1,37 @@
+{
+    "_id": "zkjsfsweJmsB66CS",
+    "img": "systems/pf2e/icons/actions/OneAction.webp",
+    "name": "(Coven) Contribute Spell",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "action"
+        },
+        "actions": {
+            "value": 1
+        },
+        "description": {
+            "value": "<p>The coven member contributes to the casting of a coven spell; this is a spellcasting action with the verbal trait. If two members of the coven perform this action, a third member can cast any coven spell with the normal spellcasting actions; this spell must be cast within one round of two coven members taking this action, and the creature Casting the Spell must be within 30 feet of them.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder #182: Graveclaw"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": [
+                "concentrate"
+            ]
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/coven-locate-coven.json
+++ b/packs/data/bestiary-family-ability-glossary.db/coven-locate-coven.json
@@ -1,0 +1,37 @@
+{
+    "_id": "Y7cRjlRkdo3siz5y",
+    "img": "systems/pf2e/icons/actions/OneAction.webp",
+    "name": "(Coven) Locate Coven",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "action"
+        },
+        "actions": {
+            "value": 1
+        },
+        "description": {
+            "value": "<p>The creature selects one other member of their coven; they can sense the location and conditions of that coven member regardless of distance, even if they're on different planes of existence.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder #182: Graveclaw"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": [
+                "concentrate"
+            ]
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/coven-share-senses.json
+++ b/packs/data/bestiary-family-ability-glossary.db/coven-share-senses.json
@@ -1,0 +1,37 @@
+{
+    "_id": "jsZZJDd4ZuYMlEVV",
+    "img": "systems/pf2e/icons/actions/TwoActions.webp",
+    "name": "(Coven) Share Senses",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "action"
+        },
+        "actions": {
+            "value": 2
+        },
+        "description": {
+            "value": "<p>The creature selects one other member of their coven; they can sense what the other member is sensing at that time regardless of distance, even if they're on different planes of existence.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder #182: Graveclaw"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": [
+                "concentrate"
+            ]
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/cryptid-experimental-augmented.json
+++ b/packs/data/bestiary-family-ability-glossary.db/cryptid-experimental-augmented.json
@@ -1,0 +1,49 @@
+{
+    "_id": "UsWJ13sDyOgOGWvm",
+    "img": "systems/pf2e/icons/actions/Passive.webp",
+    "name": "(Cryptid, Experimental) Augmented",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "description": {
+            "value": "<p>An experimental cryptid is partially artificial and designed in a way to specifically prevent biological afflictions and instant death. It gains a +2 circumstance bonus to saving throws against death effects, disease, and poison.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "predicate": {
+                    "any": [
+                        "death",
+                        "disease",
+                        "poison"
+                    ]
+                },
+                "selector": "saving-throw",
+                "type": "circumstance",
+                "value": 2
+            }
+        ],
+        "source": {
+            "value": "Pathfinder Dark Archive"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/cryptid-experimental-clobber.json
+++ b/packs/data/bestiary-family-ability-glossary.db/cryptid-experimental-clobber.json
@@ -1,0 +1,78 @@
+{
+    "_id": "uDjn2b2ZrZycQQyv",
+    "img": "systems/pf2e/icons/actions/TwoActions.webp",
+    "name": "(Cryptid, Experimental) Clobber",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "action"
+        },
+        "actions": {
+            "value": 2
+        },
+        "description": {
+            "value": "<p>The experimental cryptid Strikes a creature. On a hit, the creature is pushed 5 feet (10 feet on a critical hit) and knocked @Compendium[pf2e.conditionitems.Prone]{Prone}. If this causes the creature to collide with a solid object, the creature takes an additional [[/r 1d10]]{1d10 damage}. If the experimental cryptid is at least 5th level, this Strike deals one additional weapon damage die of damage, and if the experimental cryptid is at least 15th level, this Strike deals two additional weapon damage dice of damage.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [
+            {
+                "domain": "damage-roll",
+                "key": "RollOption",
+                "option": "clobber",
+                "predicate": {
+                    "all": [
+                        {
+                            "gte": [
+                                "self:level",
+                                5
+                            ]
+                        }
+                    ]
+                },
+                "toggleable": true
+            },
+            {
+                "key": "DamageDice",
+                "predicate": {
+                    "all": [
+                        "clobber"
+                    ]
+                },
+                "selector": "strike-damage",
+                "value": {
+                    "brackets": [
+                        {
+                            "end": 14,
+                            "start": 5,
+                            "value": {
+                                "diceNumber": 1
+                            }
+                        },
+                        {
+                            "start": 15,
+                            "value": {
+                                "diceNumber": 2
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "source": {
+            "value": "Pathfinder Dark Archive"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/cryptid-experimental-energy-wave.json
+++ b/packs/data/bestiary-family-ability-glossary.db/cryptid-experimental-energy-wave.json
@@ -1,0 +1,35 @@
+{
+    "_id": "qYVKpytVx46oBVox",
+    "img": "systems/pf2e/icons/actions/TwoActions.webp",
+    "name": "(Cryptid, Experimental) Energy Wave",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "action"
+        },
+        "actions": {
+            "value": 2
+        },
+        "description": {
+            "value": "<p>The experimental cryptid unleashes a @Template[type:line|distance:30] of energy of a type specific to the experimental cryptid (typically electricity or fire). Creatures in the area take 1d6 damage per level of the cryptid with a @Check[type:reflex|dc:|basic:true] save. The experimental cryptid can use this ability once every [[/r 1d4 #Energy Wave Recharge]]{1d4 rounds}. This action has the damage type's trait. If the experiments that reshaped the creature were magical, this action also has the evocation trait and the trait matching the magical tradition of the experiments (arcane, divine, occult, or primal).</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Dark Archive"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/cryptid-experimental-energy-wave.json
+++ b/packs/data/bestiary-family-ability-glossary.db/cryptid-experimental-energy-wave.json
@@ -13,7 +13,7 @@
             "value": 2
         },
         "description": {
-            "value": "<p>The experimental cryptid unleashes a @Template[type:line|distance:30] of energy of a type specific to the experimental cryptid (typically electricity or fire). Creatures in the area take 1d6 damage per level of the cryptid with a @Check[type:reflex|dc:|basic:true] save. The experimental cryptid can use this ability once every [[/r 1d4 #Energy Wave Recharge]]{1d4 rounds}. This action has the damage type's trait. If the experiments that reshaped the creature were magical, this action also has the evocation trait and the trait matching the magical tradition of the experiments (arcane, divine, occult, or primal).</p>"
+            "value": "<p>The experimental cryptid unleashes a @Template[type:line|distance:30] of energy of a type specific to the experimental cryptid (typically electricity or fire). Creatures in the area take [[/r {1d6}[damageType]]]{1d6 damage per level of the cryptid} with a @Check[type:reflex|dc:|basic:true] save. The experimental cryptid can use this ability once every [[/r 1d4 #Energy Wave Recharge]]{1d4 rounds}. This action has the damage type's trait. If the experiments that reshaped the creature were magical, this action also has the evocation trait and the trait matching the magical tradition of the experiments (arcane, divine, occult, or primal).</p>"
         },
         "requirements": {
             "value": ""

--- a/packs/data/bestiary-family-ability-glossary.db/cryptid-experimental-energy-wave.json
+++ b/packs/data/bestiary-family-ability-glossary.db/cryptid-experimental-energy-wave.json
@@ -23,9 +23,11 @@
             "value": "Pathfinder Dark Archive"
         },
         "traits": {
-            "custom": "",
+            "custom": "[damage type], [magical tradition]",
             "rarity": "common",
-            "value": []
+            "value": [
+                "evocation"
+            ]
         },
         "trigger": {
             "value": ""

--- a/packs/data/bestiary-family-ability-glossary.db/cryptid-experimental-operational-flaw.json
+++ b/packs/data/bestiary-family-ability-glossary.db/cryptid-experimental-operational-flaw.json
@@ -1,0 +1,35 @@
+{
+    "_id": "xxI7QpVWLiGjdu4B",
+    "img": "systems/pf2e/icons/actions/Passive.webp",
+    "name": "(Cryptid, Experimental) Operational Flaw",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "description": {
+            "value": "<p>An experimental cryptid has a flaw in its construction that can be identified with a successful Perception check to @Compendium[pf2e.actionspf2e.Seek]{Seek} against the hard DC of the creature's level. An experimental cryptid has weakness equal to its level to the attacks of any creature that has successfully located the experiment's operational flaw.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Dark Archive"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/cryptid-experimental-power-surge.json
+++ b/packs/data/bestiary-family-ability-glossary.db/cryptid-experimental-power-surge.json
@@ -1,0 +1,82 @@
+{
+    "_id": "uQ7cI0oerU7lDLhT",
+    "img": "systems/pf2e/icons/actions/OneAction.webp",
+    "name": "(Cryptid, Experimental) Power Surge",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "action"
+        },
+        "actions": {
+            "value": 1
+        },
+        "description": {
+            "value": "<p>The experimental cryptid draws on its augmentations to empower its attacks. It attempts a @Check[type:flat|dc:5]. On a success, the experimental cryptid deals 1d6 additional damage with its Strikes until the end of its turn. On a failure, the experimental cryptid takes that much damage instead. The damage and traits for Power Surge are the same as those of Energy Wave. This additional damage increases to 2d6 if the experimental cryptid is 9th level or higher, 3d6 if the experimental cryptid is 15th level or higher, and 4d6 if the experimental cryptid is 18th level or higher.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [
+            {
+                "dieSize": "d6",
+                "key": "DamageDice",
+                "predicate": {
+                    "all": [
+                        "power-surge"
+                    ]
+                },
+                "selector": "strike-damage",
+                "value": {
+                    "brackets": [
+                        {
+                            "end": 8,
+                            "value": {
+                                "diceNumber": 1
+                            }
+                        },
+                        {
+                            "end": "14",
+                            "start": 9,
+                            "value": {
+                                "diceNumber": 2
+                            }
+                        },
+                        {
+                            "end": "17",
+                            "start": 5,
+                            "value": {
+                                "diceNumber": 3
+                            }
+                        },
+                        {
+                            "start": 18,
+                            "value": {
+                                "diceNumber": 4
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "domain": "damage-roll",
+                "key": "RollOption",
+                "option": "power-surge",
+                "toggleable": true
+            }
+        ],
+        "source": {
+            "value": "Pathfinder Dark Archive"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/cryptid-mutant-explosive-end.json
+++ b/packs/data/bestiary-family-ability-glossary.db/cryptid-mutant-explosive-end.json
@@ -14,7 +14,7 @@
         },
         "deathNote": true,
         "description": {
-            "value": "<p>The mutant cryptid's death reveals one last surprise as it explodes into flame, acid, a pile of toxic goop, or something stranger still. Choose a damage type appropriate for the mutant cryptid. When it dies, it explodes, dealing 1d6 damage of the chosen type to each creature in a @Template[type:emanation|distance:10], with a @Check[type:reflex|dc:|basic:true] save against a standard DC of the creature's level. The damage increases by 1d6 at 3rd level and every odd level thereafter.</p>"
+            "value": "<p>The mutant cryptid's death reveals one last surprise as it explodes into flame, acid, a pile of toxic goop, or something stranger still. Choose a damage type appropriate for the mutant cryptid. When it dies, it explodes, dealing [[/r {1d6}[damageType]]]{1d6 damage of the chosen type} to each creature in a @Template[type:emanation|distance:10], with a @Check[type:reflex|dc:|basic:true] save against a standard DC of the creature's level. The damage increases by 1d6 at 3rd level and every odd level thereafter.</p>"
         },
         "requirements": {
             "value": ""

--- a/packs/data/bestiary-family-ability-glossary.db/cryptid-mutant-explosive-end.json
+++ b/packs/data/bestiary-family-ability-glossary.db/cryptid-mutant-explosive-end.json
@@ -1,0 +1,36 @@
+{
+    "_id": "cfqRc4clMniqQNsl",
+    "img": "systems/pf2e/icons/actions/Passive.webp",
+    "name": "(Cryptid, Mutant) Explosive End",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "deathNote": true,
+        "description": {
+            "value": "<p>The mutant cryptid's death reveals one last surprise as it explodes into flame, acid, a pile of toxic goop, or something stranger still. Choose a damage type appropriate for the mutant cryptid. When it dies, it explodes, dealing 1d6 damage of the chosen type to each creature in a @Template[type:emanation|distance:10], with a @Check[type:reflex|dc:|basic:true] save against a standard DC of the creature's level. The damage increases by 1d6 at 3rd level and every odd level thereafter.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Dark Archive"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/cryptid-mutant-marrowlance.json
+++ b/packs/data/bestiary-family-ability-glossary.db/cryptid-mutant-marrowlance.json
@@ -1,0 +1,35 @@
+{
+    "_id": "WLmFKSzR6Xz9RqAu",
+    "img": "systems/pf2e/icons/actions/Passive.webp",
+    "name": "(Cryptid, Mutant) Marrowlance",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "description": {
+            "value": "<p>The mutant cryptid can make wicked spears of bone erupt from its body. The creature can make marrowlance ranged unarmed attacks. Use the highest attack modifier from the creature's highest ranged Strike, as well as the damage from that Strike. If it has no ranged attacks, use moderate accuracy and low damage for the creature's level. Marrowlance unarmed attacks have a range of 60 feet and the versatile S trait.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Dark Archive"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/cryptid-mutant-shifting-iridescence.json
+++ b/packs/data/bestiary-family-ability-glossary.db/cryptid-mutant-shifting-iridescence.json
@@ -1,0 +1,38 @@
+{
+    "_id": "ZUxt6s54TMgydXoW",
+    "img": "systems/pf2e/icons/actions/Passive.webp",
+    "name": "(Cryptid, Mutant) Shifting Iridescence",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "description": {
+            "value": "<p>Whenever the mutant cryptid takes energy damage to which it isn't resistant or immune, after taking the damage normally, it gains resistance 5 to that damage type. If it had a resistance to a different damage type from shifting iridescence, it replaces the old resistance with the new resistance. The resistance increases to 10 at 9th level and 15 at 17th level.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Dark Archive"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": [
+                "abjuration",
+                "magical"
+            ]
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/cryptid-mutant-unusual-bane.json
+++ b/packs/data/bestiary-family-ability-glossary.db/cryptid-mutant-unusual-bane.json
@@ -1,0 +1,35 @@
+{
+    "_id": "SEU4K3QRAUHEMRl2",
+    "img": "systems/pf2e/icons/actions/Passive.webp",
+    "name": "(Cryptid, Mutant) Unusual Bane",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "description": {
+            "value": "<p>The mutant cryptid gains an unusual weakness to a specific bane-such as aversion to saffron or to the sound of children's laughter. The first time each round the creature comes within 15 feet of its bane or interacts with its bane (such as stepping over a line of saffron or hearing children laugh) it takes an amount of mental damage equal to its level and must attempt a @Check[type:will|dc:] save with a hard DC for its level. On a failure, it's @Compendium[pf2e.conditionitems.Stunned]{Stunned 1} (@Compendium[pf2e.conditionitems.Stunned]{Stunned 3} on a critical failure).</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Dark Archive"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/cryptid-primeval-broken-arsenal.json
+++ b/packs/data/bestiary-family-ability-glossary.db/cryptid-primeval-broken-arsenal.json
@@ -1,0 +1,35 @@
+{
+    "_id": "z9yqLBExOMk1y9cg",
+    "img": "systems/pf2e/icons/actions/Passive.webp",
+    "name": "(Cryptid, Primeval) Broken Arsenal",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "description": {
+            "value": "<p>Fragments of broken blades and spears, the remnants of countless failed attempts to fell the primeval cryptid, remain lodged in its flesh. When an adjacent creature hits the primeval cryptid with a melee attack or otherwise touches it, that creature takes piercing damage equal to half the primeval cryptid's level (minimum 1 damage).</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Dark Archive"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/cryptid-primeval-grasp-for-life.json
+++ b/packs/data/bestiary-family-ability-glossary.db/cryptid-primeval-grasp-for-life.json
@@ -12,6 +12,7 @@
         "actions": {
             "value": null
         },
+        "deathnote": true,
         "description": {
             "value": "<p><strong>Frequency</strong> once per week</p>\n<p><strong>Trigger</strong> The primeval cryptid would be reduced to 0 Hit Points</p>\n<hr />\n<p><strong>Effect</strong> The cryptid's will to live is second nature, and its second wind has allowed it to survive when others of its kind went extinct. The creature shrugs off death. Instead of being reduced to 0 Hit Points, its Hit Points become equal to four times its level (or 4 Hit Points for a level 0 creature).</p>"
         },

--- a/packs/data/bestiary-family-ability-glossary.db/cryptid-primeval-grasp-for-life.json
+++ b/packs/data/bestiary-family-ability-glossary.db/cryptid-primeval-grasp-for-life.json
@@ -1,0 +1,37 @@
+{
+    "_id": "R0tsWv6QHd2jbQON",
+    "img": "systems/pf2e/icons/actions/FreeAction.webp",
+    "name": "(Cryptid, Primeval) Grasp for Life",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "free"
+        },
+        "actions": {
+            "value": null
+        },
+        "description": {
+            "value": "<p><strong>Frequency</strong> once per week</p>\n<p><strong>Trigger</strong> The primeval cryptid would be reduced to 0 Hit Points</p>\n<hr />\n<p><strong>Effect</strong> The cryptid's will to live is second nature, and its second wind has allowed it to survive when others of its kind went extinct. The creature shrugs off death. Instead of being reduced to 0 Hit Points, its Hit Points become equal to four times its level (or 4 Hit Points for a level 0 creature).</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Dark Archive"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": [
+                "healing"
+            ]
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/cryptid-primeval-shockwave.json
+++ b/packs/data/bestiary-family-ability-glossary.db/cryptid-primeval-shockwave.json
@@ -1,0 +1,35 @@
+{
+    "_id": "l5FyTQQ0OfICCS1c",
+    "img": "systems/pf2e/icons/actions/TwoActions.webp",
+    "name": "(Cryptid, Primeval) Shockwave",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "action"
+        },
+        "actions": {
+            "value": 2
+        },
+        "description": {
+            "value": "<p>The primeval cryptid creates a shockwave by stomping on the ground, beating its tail on the ground, or making another similarly violent, percussive slam. Creatures on the ground within 30 feet of the primeval cryptid take [[/r {1d6}[bludgeoning]]]{1d6 bludgeoning damage} per level of the primeval cryptid (minimum 2d6 damage), with a @Check[type:reflex|dc:|basic:true]. On a critical failure, a creature is also knocked @Compendium[pf2e.conditionitems.Prone]{Prone}.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Dark Archive"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/cryptid-primeval-stench.json
+++ b/packs/data/bestiary-family-ability-glossary.db/cryptid-primeval-stench.json
@@ -1,0 +1,38 @@
+{
+    "_id": "7llQJrvVuCh7KjZO",
+    "img": "systems/pf2e/icons/actions/Passive.webp",
+    "name": "(Cryptid, Primeval) Stench",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "description": {
+            "value": "<p>@Template[type:emanation|distance:30] @Compendium[pf2e.bestiary-ability-glossary-srd.Aura]{Aura}</p>\n<hr />\n<p>A creature entering the emanation or starting its turn in the emanation must succeed at a @Check[type:fortitude|dc:] save against the standard DC for the creature's level or become @Compendium[pf2e.conditionitems.Sickened]{Sickened 1} (plus @Compendium[pf2e.conditionitems.Slowed]{Slowed 1} as long as it's sickened on a critical failure). While within the emanation, affected creatures take a -2 circumstance penalty to saves against diseases and to recover from the sickened condition. A creature that succeeds at its save is temporarily immune for 1 minute.</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.wX9L6fbqVMLP05hn]{Effect: Stench}</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Dark Archive"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": [
+                "aura",
+                "olfactory"
+            ]
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/cryptid-rumored-burning-eyes.json
+++ b/packs/data/bestiary-family-ability-glossary.db/cryptid-rumored-burning-eyes.json
@@ -1,0 +1,35 @@
+{
+    "_id": "Bqnh5wiXVymfDgTw",
+    "img": "systems/pf2e/icons/actions/Passive.webp",
+    "name": "(Cryptid, Rumored) Burning Eyes",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "description": {
+            "value": "<p>The cryptid's eyes are distinctive; perhaps they burn bright red in the dark night. The rumored cryptid gains darkvision. If the base creature already has darkvision, it gains greater darkvision.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Dark Archive"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/cryptid-rumored-creature-obscura.json
+++ b/packs/data/bestiary-family-ability-glossary.db/cryptid-rumored-creature-obscura.json
@@ -1,0 +1,35 @@
+{
+    "_id": "qfDwBrCXeIYp0W8T",
+    "img": "systems/pf2e/icons/actions/Passive.webp",
+    "name": "(Cryptid, Rumored) Creature Obscura",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "description": {
+            "value": "<p>The cryptid appears in so many urban legends, it can be identified using Society or a Lore skill connected to a nearby settlement, in addition to the normal skills. However, much of the information known about it is dubious. The DC to identify a rumored cryptid is incredibly hard (rather than very hard for most rare creatures), but all failures to identify a rumored cryptid gain the effects of the @Compendium[pf2e.feats-srd.Dubious Knowledge]{Dubious Knowledge} skill feat.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Dark Archive"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/cryptid-rumored-howl.json
+++ b/packs/data/bestiary-family-ability-glossary.db/cryptid-rumored-howl.json
@@ -1,0 +1,40 @@
+{
+    "_id": "KLMdplDgOfXSLh6g",
+    "img": "systems/pf2e/icons/actions/TwoActions.webp",
+    "name": "(Cryptid, Rumored) Howl",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "action"
+        },
+        "actions": {
+            "value": 2
+        },
+        "description": {
+            "value": "<p>The rumored cryptid calls out with a wretched sound no living creature should make. Each creature in a @Template[type:emanation|distance:30] must attempt a @Check[type:will|dc:] save. A creature that fails is @Compendium[pf2e.conditionitems.Frightened]{Frightened 1} (or @Compendium[pf2e.conditionitems.Frightened]{Frightened 2} on a critical failure). A creature that succeeds is temporarily immune for 1 minute. The DC is the high DC for a creature of the rumored cryptid's level.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Dark Archive"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": [
+                "auditory",
+                "emotion",
+                "fear",
+                "mental"
+            ]
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/cryptid-rumored-hybrid-form.json
+++ b/packs/data/bestiary-family-ability-glossary.db/cryptid-rumored-hybrid-form.json
@@ -1,0 +1,35 @@
+{
+    "_id": "a7SNHoP22SBoOAmA",
+    "img": "systems/pf2e/icons/actions/Passive.webp",
+    "name": "(Cryptid, Rumored) Hybrid Form",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "description": {
+            "value": "<p>The cryptid's form morphs to be like a specific animal as the tales get longer. The rumored cryptid gains either a burrow, climb, or swim Speed equal to its land Speed.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Dark Archive"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/cryptid-rumored-obscura-vulnerability.json
+++ b/packs/data/bestiary-family-ability-glossary.db/cryptid-rumored-obscura-vulnerability.json
@@ -1,0 +1,35 @@
+{
+    "_id": "l2ov5uPpfOAoyXAL",
+    "img": "systems/pf2e/icons/actions/Passive.webp",
+    "name": "(Cryptid, Rumored) Obscura Vulnerability",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "description": {
+            "value": "<p>The cryptid is weakened by those who seek its truth. Whenever a creature succeeds at a Recall Knowledge check to identify the rumored cryptid, the rumored cryptid becomes @Compendium[pf2e.conditionitems.Drained]{Drained 1} (or @Compendium[pf2e.conditionitems.Drained]{Drained 2} if the Recall Knowledge check was a critical success).</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Dark Archive"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/cryptid-rumored-shifting-form.json
+++ b/packs/data/bestiary-family-ability-glossary.db/cryptid-rumored-shifting-form.json
@@ -1,0 +1,35 @@
+{
+    "_id": "K0scCV18j5FzM2ei",
+    "img": "systems/pf2e/icons/actions/Passive.webp",
+    "name": "(Cryptid, Rumored) Shifting Form",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "description": {
+            "value": "<p>The cryptid is sustained by localized tales or reports from witnesses. As a result, its appearance morphs between different appearances. If all records of the rumored cryptid are destroyed or all witnesses die, the rumored cryptid ceases to exist.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Dark Archive"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/cryptid-rumored-stalk.json
+++ b/packs/data/bestiary-family-ability-glossary.db/cryptid-rumored-stalk.json
@@ -1,0 +1,35 @@
+{
+    "_id": "XpGCN9KJN0CCIlzU",
+    "img": "systems/pf2e/icons/actions/OneAction.webp",
+    "name": "(Cryptid, Rumored) Stalk",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "action"
+        },
+        "actions": {
+            "value": 1
+        },
+        "description": {
+            "value": "<p><strong>Requirements</strong> The rumored cryptid is undetected</p>\n<hr />\n<p><strong>Effect</strong> The rumored cryptid swiftly stalks prey from hiding. It Strides, then Strikes.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Dark Archive"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/cryptid-rumored-vanishing-escape.json
+++ b/packs/data/bestiary-family-ability-glossary.db/cryptid-rumored-vanishing-escape.json
@@ -1,0 +1,35 @@
+{
+    "_id": "N9OUII3LfRr6hNP8",
+    "img": "systems/pf2e/icons/actions/OneAction.webp",
+    "name": "(Cryptid, Rumored) Vanishing Escape",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "action"
+        },
+        "actions": {
+            "value": 1
+        },
+        "description": {
+            "value": "<p>The rumored cryptid breaks away and fades into the background. It Strides, then Hides.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Dark Archive"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/vampire-noferatu-overlord-air-of-sickness.json
+++ b/packs/data/bestiary-family-ability-glossary.db/vampire-noferatu-overlord-air-of-sickness.json
@@ -1,0 +1,37 @@
+{
+    "_id": "yDE3ZEoxRUqQmAsX",
+    "img": "systems/pf2e/icons/actions/Passive.webp",
+    "name": "(Vampire, Noferatu Overlord) Air of Sickness",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "description": {
+            "value": "<p>@Template[type:emanation|distance:30] @Compendium[pf2e.bestiary-ability-glossary-srd.Aura]{Aura}</p>\n<p>A creature entering or starting its turn in the aura must attempt a @Check[type:fortitude|dc:] save with a moderate DC for the nosferatu's level. On a failure, the creature is @Compendium[pf2e.conditionitems.Sickened]{Sickened 1} and takes a -2 status penalty to saves made to resist diseases and remove the sickened condition for 1 hour.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Bestiary 3"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": [
+                "aura"
+            ]
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/vampire-noferatu-overlord-paralytic-fear.json
+++ b/packs/data/bestiary-family-ability-glossary.db/vampire-noferatu-overlord-paralytic-fear.json
@@ -1,0 +1,41 @@
+{
+    "_id": "EsbdyB9DwvPvhCCC",
+    "img": "systems/pf2e/icons/actions/OneAction.webp",
+    "name": "(Vampire, Noferatu Overlord) Paralytic Fear",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "action"
+        },
+        "actions": {
+            "value": 1
+        },
+        "description": {
+            "value": "<p><strong>Requirements</strong> The nosferatu overlord's last action was a successful claw Strike</p>\n<hr />\n<p><strong>Effect</strong> The nosferatu drags the target of the Strike close and freezes its mind in terror. The target must attempt a @Check[type:will|dc:] save with a moderate DC for the nosferatu's level.</p>\n<hr />\n<p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target is @Compendium[pf2e.conditionitems.Immobilized]{Immobilized} by fear until the end of the nosferatu's next turn.</p>\n<p><strong>Failure</strong> The target is @Compendium[pf2e.conditionitems.Restrained]{Restrained} and takes a -2 circumstance penalty to its Fortitude DC against the nosferatu's Drink Blood ability until the end of the nosferatu's next turn.</p>\n<p><strong>Critical Failure</strong> As failure, and the target is @Compendium[pf2e.conditionitems.Frightened]{Frightened 2}.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Bestiary 3"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": [
+                "divine",
+                "emotion",
+                "fear",
+                "incapacitation",
+                "mental"
+            ]
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/vampire-noferatu-thrall-fast-healing.json
+++ b/packs/data/bestiary-family-ability-glossary.db/vampire-noferatu-thrall-fast-healing.json
@@ -1,0 +1,35 @@
+{
+    "_id": "2BjqIO36k0Y6tgZf",
+    "img": "systems/pf2e/icons/actions/Passive.webp",
+    "name": "(Vampire, Noferatu Thrall) Fast Healing",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "description": {
+            "value": "<p>A nosferatu thrall gains fast healing 5 from being sustained by their master's blood.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Bestiary 3"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/vampire-noferatu-thrall-mindbound.json
+++ b/packs/data/bestiary-family-ability-glossary.db/vampire-noferatu-thrall-mindbound.json
@@ -1,0 +1,35 @@
+{
+    "_id": "LKxsPOf0hAS32Sp8",
+    "img": "systems/pf2e/icons/actions/Passive.webp",
+    "name": "(Vampire, Noferatu Thrall) Mindbound",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "description": {
+            "value": "<p>A nosferatu master exerts a fierce hold over their thrall's mind. If any creature other than the thrall's master targets them with an effect that would give them the @Compendium[pf2e.conditionitems.Controlled]{Controlled} condition, the thrall's master rolls a counteract check against it using their Dominate DC - 10 as the counteract check modifier.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Bestiary 3"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/vampire-noferatu-thrall-mortal-shield.json
+++ b/packs/data/bestiary-family-ability-glossary.db/vampire-noferatu-thrall-mortal-shield.json
@@ -1,0 +1,35 @@
+{
+    "_id": "OQt7nHInDBAmHaG6",
+    "img": "systems/pf2e/icons/actions/Reaction.webp",
+    "name": "(Vampire, Noferatu Thrall) Mortal Shield",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "reaction"
+        },
+        "actions": {
+            "value": null
+        },
+        "description": {
+            "value": "<p><strong>Trigger</strong> The thrall's master would take damage from a Strike or spell attack and is in an adjacent square</p>\n<hr />\n<p><strong>Effect</strong> The thrall throws themself in front of their master, taking half the damage of the attack (before applying any weaknesses or resistances). The thrall's master takes the remaining damage, applying any weaknesses or resistances as normal.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Bestiary 3"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/vampire-noferatu-thrall-rally.json
+++ b/packs/data/bestiary-family-ability-glossary.db/vampire-noferatu-thrall-rally.json
@@ -1,0 +1,35 @@
+{
+    "_id": "IL8wtCi23ch62zXG",
+    "img": "systems/pf2e/icons/actions/Reaction.webp",
+    "name": "(Vampire, Noferatu Thrall) Rally",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "reaction"
+        },
+        "actions": {
+            "value": null
+        },
+        "description": {
+            "value": "<p><strong>Trigger</strong> The thrall ends their turn more than 30 feet away from their master</p>\n<hr />\n<p><strong>Effect</strong> The thrall Strides up to their Speed toward their master.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Bestiary 3"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/vampire-noferatu-thrall-weakness.json
+++ b/packs/data/bestiary-family-ability-glossary.db/vampire-noferatu-thrall-weakness.json
@@ -1,0 +1,41 @@
+{
+    "_id": "8MACWp05F4SacE7E",
+    "img": "systems/pf2e/icons/actions/Passive.webp",
+    "name": "(Vampire, Noferatu Thrall) Weakness",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "description": {
+            "value": "<p>The strain of being controlled wears on the nosferatu thrall's mind, giving them weakness 10 to mental damage.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [
+            {
+                "key": "Weakness",
+                "type": "mental",
+                "value": 10
+            }
+        ],
+        "source": {
+            "value": "Pathfinder Bestiary 3"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/vampire-nosferatu-change-shape.json
+++ b/packs/data/bestiary-family-ability-glossary.db/vampire-nosferatu-change-shape.json
@@ -13,7 +13,7 @@
             "value": 1
         },
         "description": {
-            "value": "<p>The nosferatu transforms into a swarm of pale-gray rats. They gain a land Speed of 30 feet and a climb Speed of 10 feet, and they become Large. Each enemy in the swarm's space takes [[/r {2d10}[piercing]]]{2d10 piercing damage} and must attempt a @Check[type:reflex|dc:|basic:true] save with a high DC for the creature's level. A creature that fails its save is exposed to plague of ancients (see below).</p>"
+            "value": "<p>The nosferatu transforms into a swarm of pale-gray rats. They gain a land Speed of 30 feet and a climb Speed of 10 feet, and they become Large. Each enemy in the swarm's space takes [[/r {2d10}[piercing]]]{2d10 piercing damage} and must attempt a @Check[type:reflex|dc:|basic:true] save with a high DC for the creature's level. A creature that fails its save is exposed to plague of ancients.</p>"
         },
         "requirements": {
             "value": ""

--- a/packs/data/bestiary-family-ability-glossary.db/vampire-nosferatu-change-shape.json
+++ b/packs/data/bestiary-family-ability-glossary.db/vampire-nosferatu-change-shape.json
@@ -1,0 +1,40 @@
+{
+    "_id": "DWku0nZzkqmYjrQ5",
+    "img": "systems/pf2e/icons/actions/OneAction.webp",
+    "name": "(Vampire, Nosferatu) Change Shape",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "action"
+        },
+        "actions": {
+            "value": 1
+        },
+        "description": {
+            "value": "<p>The nosferatu transforms into a swarm of pale-gray rats. They gain a land Speed of 30 feet and a climb Speed of 10 feet, and they become Large. Each enemy in the swarm's space takes [[/r {2d10}[piercing]]]{2d10 piercing damage} and must attempt a @Check[type:reflex|dc:|basic:true] save with a high DC for the creature's level. A creature that fails its save is exposed to plague of ancients (see below).</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Bestiary 3"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": [
+                "concentrate",
+                "divine",
+                "polymorph",
+                "transmutation"
+            ]
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/vampire-nosferatu-command-thrall.json
+++ b/packs/data/bestiary-family-ability-glossary.db/vampire-nosferatu-command-thrall.json
@@ -1,0 +1,39 @@
+{
+    "_id": "8UQWXpYfn9oE1ZHu",
+    "img": "systems/pf2e/icons/actions/FreeAction.webp",
+    "name": "(Vampire, Nosferatu) Command Thrall",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "free"
+        },
+        "actions": {
+            "value": null
+        },
+        "description": {
+            "value": "<p><strong>Requirements</strong> One of the nosferatu's thralls is present and can hear the nosferatu</p>\n<hr />\n<p><strong>Effect</strong> The nosferatu gives a single command to one of their thralls, which the thrall follows to the best of its ability during its next turn.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Bestiary 3"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": [
+                "auditory",
+                "divine",
+                "mental"
+            ]
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/vampire-nosferatu-divine-innate-spells.json
+++ b/packs/data/bestiary-family-ability-glossary.db/vampire-nosferatu-divine-innate-spells.json
@@ -1,0 +1,35 @@
+{
+    "_id": "EwhjPJGLSW9v1Fbb",
+    "img": "systems/pf2e/icons/actions/Passive.webp",
+    "name": "(Vampire, Nosferatu) Divine Innate Spells",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "description": {
+            "value": "<p>The nosferatu can cast <em>@Compendium[pf2e.spells-srd.Telekinetic Haul]{Telekinetic Haul}</em> (heightened to half their level rounded up) three times per day as a divine innate spell. They use a high DC for their level.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Bestiary 3"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/vampire-nosferatu-dominate.json
+++ b/packs/data/bestiary-family-ability-glossary.db/vampire-nosferatu-dominate.json
@@ -1,0 +1,41 @@
+{
+    "_id": "4B8O9QBJuDhJkVcz",
+    "img": "systems/pf2e/icons/actions/TwoActions.webp",
+    "name": "(Vampire, Nosferatu) Dominate",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "action"
+        },
+        "actions": {
+            "value": 2
+        },
+        "description": {
+            "value": "<p>The nosferatu can cast <em>@Compendium[pf2e.spells-srd.Dominate]{Dominate}</em> at will as a divine innate spell. Casting it requires staring into the target's eyes, giving the spell the visual trait (@Check[type:will|dc:]). The save DC uses a high DC for the nosferatu's level, and a creature that succeeds is temporarily immune to that nosferatu's Dominate for 24 hours. Fully destroying the nosferatu ends the domination, but merely reducing the nosferatu to 0 HP is insufficient to break the spell.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Bestiary 3"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": [
+                "divine",
+                "enchantment",
+                "incapacitation",
+                "mental",
+                "visual"
+            ]
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/vampire-nosferatu-drink-blood.json
+++ b/packs/data/bestiary-family-ability-glossary.db/vampire-nosferatu-drink-blood.json
@@ -1,0 +1,38 @@
+{
+    "_id": "GpKQH8hnSYWiyuQU",
+    "img": "systems/pf2e/icons/actions/OneAction.webp",
+    "name": "(Vampire, Nosferatu) Drink Blood",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "action"
+        },
+        "actions": {
+            "value": 1
+        },
+        "description": {
+            "value": "<p><strong>Requirements</strong> The nosferatu's last action was a successful fangs Strike</p>\n<hr />\n<p><strong>Effect</strong> The nosferatu sinks their fangs into the targeted creature to drink its blood. This requires an Athletics check against the creature's Fortitude DC. On a success, the creature becomes @Compendium[pf2e.conditionitems.Drained]{Drained 1}, and the nosferatu regains HP equal to 10% of their maximum HP, gaining any excess HP as temporary Hit Points. Drinking Blood from a creature that's already drained doesn't restore any HP to the nosferatu, but increases the creature's drained condition value by 1. A nosferatu can also consume blood that's been emptied into a vessel for sustenance, but they gain no HP from doing so.</p>\n<p>The target creature's drained condition value decreases by 1 per week. A blood transfusion, which requires a successful @Check[type:medicine|dc:20] check and sufficient blood or a blood donor, reduces the drained value by 1 after 10 minutes.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Bestiary 3"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": [
+                "divine",
+                "necromancy"
+            ]
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/vampire-nosferatu-nosferatu-vulnerabilities.json
+++ b/packs/data/bestiary-family-ability-glossary.db/vampire-nosferatu-nosferatu-vulnerabilities.json
@@ -1,0 +1,35 @@
+{
+    "_id": "Sj1IGDjUmlwFpC35",
+    "img": "systems/pf2e/icons/actions/Passive.webp",
+    "name": "(Vampire, Nosferatu) Nosferatu Vulnerabilities",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "description": {
+            "value": "<ul>\n<li><strong>Revulsion</strong> A nosferatu can't voluntarily come within 10 feet of brandished garlic or a brandished religious symbol of a non-evil deity. To brandish garlic or a religious symbol, a creature must Interact to do so for 1 round (similar to Raising a Shield). If the nosferatu involuntarily comes within 10 feet of an object of their revulsion, they gain the @Compendium[pf2e.conditionitems.Fleeing]{Fleeing} condition, running from the object of their revulsion until they end an action beyond 10 feet. After 1 round of being exposed to the subject of their revulsion, a nosferatu can attempt a @Check[type:will|dc:25|traits:concentrate] save as a single action, which has the concentrate trait. On a success, they overcome their revulsions for [[/r 1d6 #Overcome Revulsions]]{1d6 rounds} (or 1 hour on a critical success).</li>\n<li><strong>Stake</strong> A magical wooden stake (such as one affected by a weapon potency rune, magic weapon, or similar magic) driven through the nosferatu's heart drops the nosferatu to 0 HP and prevents them from healing above 0 HP, even in their coffin. Staking a nosferatu requires 3 actions and works only if the nosferatu is @Compendium[pf2e.conditionitems.Unconscious]{Unconscious}. If the stake is removed, the nosferatu can heal above 0 HP again, and if they're in their coffin, the 1-hour rest period begins once the stake is removed. If the nosferatu's head is severed and anointed with holy water while the stake is in place, the nosferatu is destroyed.</li>\n<li><strong>Sunlight</strong> If exposed to direct sunlight, a nosferatu immediately becomes @Compendium[pf2e.conditionitems.Slowed]{Slowed 1}. The slowed value increases by 1 each time the nosferatu ends their turn in sunlight, and the condition ends when they're no longer in sunlight. If the nosferatu loses all their actions in this way, they're destroyed.</li>\n</ul>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Bestiary 3"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/vampire-nosferatu-overlord-divine-innate-spells.json
+++ b/packs/data/bestiary-family-ability-glossary.db/vampire-nosferatu-overlord-divine-innate-spells.json
@@ -1,0 +1,35 @@
+{
+    "_id": "uMedzgKYui5X3Qtn",
+    "img": "systems/pf2e/icons/actions/Passive.webp",
+    "name": "(Vampire, Nosferatu Overlord) Divine Innate Spells",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "description": {
+            "value": "<p>The nosferatu can cast <em>@Compendium[pf2e.spells-srd.Telekinetic Haul]{Telekinetic Haul}</em> (heightened to half their level rounded up) three times per day and <em>@Compendium[pf2e.spells-srd.Vampiric Exsanguination]{Vampiric Exsanguination}</em> twice per day as a divine innate spell. They use a high DC for their level.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Bestiary 3"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/vampire-nosferatu-plague-of-ancients.json
+++ b/packs/data/bestiary-family-ability-glossary.db/vampire-nosferatu-plague-of-ancients.json
@@ -1,0 +1,38 @@
+{
+    "_id": "NgiwaeUqMPfkYvQq",
+    "img": "systems/pf2e/icons/actions/Passive.webp",
+    "name": "(Vampire, Nosferatu) Plague of Ancients",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "description": {
+            "value": "<p><strong>Saving Throw</strong> @Check[type:fortitude|dc:] (use a high DC for the nosferatu's level)</p>\n<hr />\n<p><strong>Onset</strong> 1 day</p>\n<p><strong>Stage 1</strong> @Compendium[pf2e.conditionitems.Drained]{Drained 1} (1 day)</p>\n<p><strong>Stage 2</strong> @Compendium[pf2e.conditionitems.Drained]{Drained 2} and @Compendium[pf2e.conditionitems.Enfeebled]{Enfeebled 2} (1 day)</p>\n<p><strong>Stage 3</strong> @Compendium[pf2e.conditionitems.Doomed]{Doomed 1}, @Compendium[pf2e.conditionitems.Drained]{Drained 3}, and @Compendium[pf2e.conditionitems.Enfeebled]{Enfeebled 3} (1 day)</p>\n<p><strong>Stage 4</strong> @Compendium[pf2e.conditionitems.Doomed]{Doomed 2}, drained 3, and enfeebled 3 (1 day)</p>\n<p><strong>Stage 5</strong> @Compendium[pf2e.conditionitems.Unconscious]{Unconscious} (1 day)</p>\n<p><strong>Stage 6</strong> death</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Bestiary 3"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": [
+                "disease",
+                "virulent"
+            ]
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/vampire-nosferatu-plagued-coffin-restoration.json
+++ b/packs/data/bestiary-family-ability-glossary.db/vampire-nosferatu-plagued-coffin-restoration.json
@@ -1,0 +1,39 @@
+{
+    "_id": "hOOXkWcTw9EFKJev",
+    "img": "systems/pf2e/icons/actions/Passive.webp",
+    "name": "(Vampire, Nosferatu) Plagued Coffin Restoration",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "description": {
+            "value": "<p>Unlike other undead, a nosferatu isn't destroyed at 0 HP. Instead, they disperse into an immense number of individual rats heading in every direction in an attempt to return to their coffin. If even a single rat reaches the coffin, the nosferatu can recover. A nosferatu regains their strength through resting in earth taken from the grave of a creature who died of plague. If their body rests in their earth-filled coffin for 1 hour, the nosferatu gains 1 HP, after which their fast healing begins to function normally. If the coffin doesn't contain this plagued grave dirt, they instead need to rest in their coffin for 1 day before they gain 1 HP and regain their fast healing.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Bestiary 3"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": [
+                "divine",
+                "necromancy",
+                "negative"
+            ]
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/zombie-ankle-biter.json
+++ b/packs/data/bestiary-family-ability-glossary.db/zombie-ankle-biter.json
@@ -1,0 +1,48 @@
+{
+    "_id": "CdjqkgAexKk8khbB",
+    "img": "systems/pf2e/icons/actions/Passive.webp",
+    "name": "(Zombie) Ankle Biter",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "description": {
+            "value": "<p>This zombie fights just as well on the ground as it does standing. While @Compendium[pf2e.conditionitems.Prone]{Prone}, the zombie isn't @Compendium[pf2e.conditionitems.Flat-Footed]{Flat-Footed}, it ignores the status penalty to its attack rolls, and it gains a +2 circumstance bonus to Athletics checks to @Compendium[pf2e.actionspf2e.Trip]{Trip}. The zombie can also move up to half its Speed when it Crawls.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "predicate": {
+                    "all": [
+                        "action:trip",
+                        "self:condition:prone"
+                    ]
+                },
+                "selector": "athletics",
+                "type": "circumstance",
+                "value": 2
+            }
+        ],
+        "source": {
+            "value": "Pathfinder Bestiary 3"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/zombie-persistent-limbs.json
+++ b/packs/data/bestiary-family-ability-glossary.db/zombie-persistent-limbs.json
@@ -1,0 +1,35 @@
+{
+    "_id": "qZnZriRRtjK7FtP8",
+    "img": "systems/pf2e/icons/actions/Passive.webp",
+    "name": "(Zombie) Persistent Limbs",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "description": {
+            "value": "<p>The first time the zombie is critically hit with a melee or ranged Strike, a limb falls off its body and continues to attack. The limb acts on the zombie's initiative; each round it can Stride up to half the zombie's Speed and make a Strike. The limb uses and contributes to the zombie's multiple attack penalty.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Bestiary 3"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/zombie-putrid-stench.json
+++ b/packs/data/bestiary-family-ability-glossary.db/zombie-putrid-stench.json
@@ -1,0 +1,38 @@
+{
+    "_id": "Ez8sVqv1EBcJuorK",
+    "img": "systems/pf2e/icons/actions/Passive.webp",
+    "name": "(Zombie) Putrid Stench",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "description": {
+            "value": "<p>@Template[type:emanation|distance:15] @Compendium[pf2e.bestiary-ability-glossary-srd.Aura]{Aura}</p>\n<p>The zombie's rotting flesh is particularly malodorous. A creature that enters the area must attempt a @Check[type:fortitude|dc:] save. On a failure, the creature is @Compendium[pf2e.conditionitems.Sickened]{Sickened 1}, and on a critical failure, the creature also takes a -5-foot status penalty to its Speeds for 1 round. While within the aura, the creature takes a -2 circumstance penalty to saves to recover from the sickened condition. A creature that succeeds at its save is temporarily immune to all zombies' putrid stenches for 1 minute.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Bestiary 3"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": [
+                "aura",
+                "olfactory"
+            ]
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/zombie-shock-arcing-strikes.json
+++ b/packs/data/bestiary-family-ability-glossary.db/zombie-shock-arcing-strikes.json
@@ -1,0 +1,37 @@
+{
+    "_id": "GD1ZD4Rl2hTPhvjL",
+    "img": "systems/pf2e/icons/actions/Passive.webp",
+    "name": "(Zombie, Shock) Arcing Strikes",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "description": {
+            "value": "<p>When a shock zombie hits a creature with a melee attack, an arc of lighting leaps to a second creature, dealing [[/r {1d12}[electricity]]]{1d12 electricity damage}. This secondary target must be within 10 feet of the shock zombie's original target and must be the creature closest to the original target (if multiple creatures are equidistant, the shock zombie chooses which to affect).</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder #180: The Smoking Gun"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": [
+                "electricity"
+            ]
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/zombie-shock-breath-weapon.json
+++ b/packs/data/bestiary-family-ability-glossary.db/zombie-shock-breath-weapon.json
@@ -1,0 +1,38 @@
+{
+    "_id": "4AN6IgzsbhjCPYIZ",
+    "img": "systems/pf2e/icons/actions/TwoActions.webp",
+    "name": "(Zombie, Shock) Breath Weapon",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "action"
+        },
+        "actions": {
+            "value": 2
+        },
+        "description": {
+            "value": "<p>The shock zombie breathes lightning, dealing [[/r {4d12}[electricity]]]{4d12 electricity damage} in a @Template[type:line|distance:40] (@Check[type:reflex|dc:24|basic:true]). It can't use its Breath Weapon again for 1 minute.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder #180: The Smoking Gun"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": [
+                "electricity",
+                "evocation"
+            ]
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/zombie-shock-electromechanical-phasing.json
+++ b/packs/data/bestiary-family-ability-glossary.db/zombie-shock-electromechanical-phasing.json
@@ -1,0 +1,37 @@
+{
+    "_id": "vOvzh8XCMmvtW0Ws",
+    "img": "systems/pf2e/icons/actions/TwoActions.webp",
+    "name": "(Zombie, Shock) Electromechanical Phasing",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "action"
+        },
+        "actions": {
+            "value": 2
+        },
+        "description": {
+            "value": "<p><strong>Frequency</strong> once per day</p>\n<hr />\n<p><strong>Effect</strong> The shock zombie activates its electromechanical components and begins phasing in and out of reality. The shock zombie casts <em>@Compendium[pf2e.spells-srd.Blink]{Blink}</em> as a 4th-level divine innate spell.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder #180: The Smoking Gun"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": [
+                "electricity"
+            ]
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/zombie-shock-lightning-rod.json
+++ b/packs/data/bestiary-family-ability-glossary.db/zombie-shock-lightning-rod.json
@@ -1,0 +1,37 @@
+{
+    "_id": "ii98NEWkpvIJXgFZ",
+    "img": "systems/pf2e/icons/actions/Reaction.webp",
+    "name": "(Zombie, Shock) Lightning Rod",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "reaction"
+        },
+        "actions": {
+            "value": null
+        },
+        "description": {
+            "value": "<p><strong>Trigger</strong> A spell or ability with the electricity trait is used within 30 feet of the shock zombie</p>\n<hr />\n<p><strong>Effect</strong> The shock zombie attempts to counteract the spell or ability (counteract level 3, counteract modifier [[/r 1d20+17 #Counteract]]{+17}), harmlessly redirecting the electricity into one of its electricity coils.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder #180: The Smoking Gun"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": [
+                "electricity"
+            ]
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}

--- a/packs/data/bestiary-family-ability-glossary.db/zombie-unholy-speed.json
+++ b/packs/data/bestiary-family-ability-glossary.db/zombie-unholy-speed.json
@@ -1,0 +1,35 @@
+{
+    "_id": "2k0X7JdI9MMt4pp0",
+    "img": "systems/pf2e/icons/actions/Passive.webp",
+    "name": "(Zombie) Unholy Speed",
+    "system": {
+        "actionCategory": {
+            "value": "offensive"
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "description": {
+            "value": "<p>The zombie gains a +10 status bonus to all its Speeds.</p>"
+        },
+        "requirements": {
+            "value": ""
+        },
+        "rules": [],
+        "source": {
+            "value": "Pathfinder Bestiary 3"
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        },
+        "trigger": {
+            "value": ""
+        }
+    },
+    "type": "action"
+}


### PR DESCRIPTION
Adds missing family abilities for zombies, shock zombies, nosferatu, covens, and cryptids.

Closes #3436 Closes #3437