### PR TITLE
Correct formatting errors for Oracle

### DIFF
--- a/packs/data/feats.db/basic-lesson.json
+++ b/packs/data/feats.db/basic-lesson.json
@@ -13,7 +13,7 @@
             "value": null
         },
         "description": {
-            "value": "<p>Your patron grants you a special lesson, revealing a hidden facet of its nature. Choose a Basic Lesson. You gain its associated hex, and your familiar learns the associated spell. Increase the number of Focus Points in your focus pool by 1.</p>\n<hr />"
+            "value": "<p>Your patron grants you a special lesson, revealing a hidden facet of its nature. Choose a Basic Lesson. You gain its associated hex, and your familiar learns the associated spell. Increase the number of Focus Points in your focus pool by 1.</p>"
         },
         "featType": {
             "value": "class"

--- a/packs/data/feats.db/glean-lore.json
+++ b/packs/data/feats.db/glean-lore.json
@@ -13,7 +13,7 @@
             "value": 1
         },
         "description": {
-            "value": "<p>You tap into the collected lore of the divine, accessing a variety of potentially useful information.</p>\n<p>Attempt a Religion check to understand the information you gain. The GM sets the DC (similar to the DC to @Compendium[pf2e.actionspf2e.Recall Knowledge (Lore)]{Recall Knowledge}), potentially adjusting the DC of the check for topics far removed from your mystery.</p>\n<hr />\n<p><strong>Critical Success</strong> You comprehend the lore accurately or gain a</p>\n<p>useful clue from the divine about your situation.</p>\n<p><strong>Success</strong> You learn two pieces of information about the topic,</p>\n<p>one true and one erroneous, but you don't know which is which.</p>\n<p><strong>Failure</strong> You recall incorrect information or gain an erroneous</p>\n<p>or misleading clue.</p>\n<p><strong>Critical Failure</strong> You recall two pieces of incorrect information</p>\n<p>or gain two erroneous or misleading clues.</p>"
+            "value": "<p>You tap into the collected lore of the divine, accessing a variety of potentially useful information.</p>\n<p>Attempt a @Check[type:religion] check to understand the information you gain. The GM sets the DC (similar to the DC to @Compendium[pf2e.actionspf2e.Recall Knowledge (Lore)]{Recall Knowledge}), potentially adjusting the DC of the check for topics far removed from your mystery.</p>\n<hr />\n<p><strong>Critical Success</strong> You comprehend the lore accurately or gain a useful clue from the divine about your situation.</p>\n<p><strong>Success</strong> You learn two pieces of information about the topic, one true and one erroneous, but you don't know which is which.</p>\n<p><strong>Failure</strong> You recall incorrect information or gain an erroneous or misleading clue.</p>\n<p><strong>Critical Failure</strong> You recall two pieces of incorrect information or gain two erroneous or misleading clues.</p>"
         },
         "featType": {
             "value": "class"
@@ -21,6 +21,7 @@
         "level": {
             "value": 1
         },
+        "location": null,
         "prerequisites": {
             "value": []
         },

--- a/packs/data/spells.db/breath-of-life.json
+++ b/packs/data/spells.db/breath-of-life.json
@@ -8,7 +8,7 @@
         },
         "area": {
             "areaType": "",
-            "value": null
+            "value": ""
         },
         "areasize": {
             "value": ""
@@ -17,6 +17,7 @@
             "value": "spell"
         },
         "components": {
+            "focus": false,
             "material": false,
             "somatic": false,
             "verbal": true
@@ -27,23 +28,24 @@
         "damage": {
             "value": {
                 "0": {
-                    "applyMod": true,
+                    "applyMod": "0",
                     "type": {
                         "categories": [],
-                        "value": "healing"
+                        "subtype": "",
+                        "value": ""
                     },
                     "value": "4d8"
                 }
             }
         },
         "description": {
-            "value": "<p><strong>Trigger</strong> A living creature within range would die.</p>\n<hr />\n<p>Your blessing revives a creature at the moment of its death. You prevent the target from @Compendium[pf2e.conditionitems.Dying]{Dying} and restore Hit Points to the target equal to 4d8 plus your spellcasting ability modifier. You can't use breath of life if the triggering effect was disintegrate or a death effect.</p>"
+            "value": "<p><strong>Trigger</strong> A living creature within range would die.</p>\n<hr />\n<p>Your blessing revives a creature at the moment of its death. You prevent the target from dying and restore Hit Points to the target equal to 4d8 plus your spellcasting ability modifier. You can't use breath of life if the triggering effect was <em>@Compendium[pf2e.spells-srd.Disintegrate]{Disintegrate}</em> or a death effect.</p>"
         },
         "duration": {
             "value": ""
         },
         "hasCounteractCheck": {
-            "value": false
+            "value": null
         },
         "level": {
             "value": 5

--- a/packs/data/spells.db/breath-of-life.json
+++ b/packs/data/spells.db/breath-of-life.json
@@ -39,7 +39,7 @@
             }
         },
         "description": {
-            "value": "<p><strong>Trigger</strong> A living creature within range would die.</p>\n<hr />\n<p>Your blessing revives a creature at the moment of its death. You prevent the target from dying and restore Hit Points to the target equal to 4d8 plus your spellcasting ability modifier. You can't use breath of life if the triggering effect was <em>@Compendium[pf2e.spells-srd.Disintegrate]{Disintegrate}</em> or a death effect.</p>"
+            "value": "<p><strong>Trigger</strong> A living creature within range would die.</p>\n<hr />\n<p>Your blessing revives a creature at the moment of its death. You prevent the target from dying and restore Hit Points to the target equal to 4d8 plus your spellcasting ability modifier. You can't use <em>breath of life</em> if the triggering effect was <em>@Compendium[pf2e.spells-srd.Disintegrate]{Disintegrate}</em> or a death effect.</p>"
         },
         "duration": {
             "value": ""

--- a/packs/data/spells.db/claim-undead.json
+++ b/packs/data/spells.db/claim-undead.json
@@ -17,6 +17,7 @@
             "value": "focus"
         },
         "components": {
+            "focus": false,
             "material": false,
             "somatic": true,
             "verbal": true
@@ -28,13 +29,13 @@
             "value": {}
         },
         "description": {
-            "value": "<p>You attempt to wrest control of a target undead or force it to recognize you as its master. If the target is controlled by another creature, that controller attempts a Will saving throw to retain control; otherwise, the target must attempt a Will save.</p>\n<hr />\n<p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target is @Compendium[pf2e.conditionitems.Stunned]{Stunned 1} as it fights off your commands.</p>\n<p><strong>Failure</strong> The target becomes @Compendium[pf2e.conditionitems.Controlled]{Controlled} by you and follows</p>\n<p>your orders. It (or the creature previously controlling it) can</p>\n<p>attempt a new Will save at the end of each of its turns,</p>\n<p>and the spell ends on a success. If you issue an obviously</p>\n<p>self-destructive order, the target doesn't act until you issue</p>\n<p>a new order.</p>\n<p><strong>Critical Failure</strong> As failure, but the target (or the creature</p>\n<p>previously controlling it) receives a new save only if you</p>\n<p>give it a new order that is against its nature.</p>"
+            "value": "<p>You attempt to wrest control of a target undead or force it to recognize you as its master. If the target is controlled by another creature, that controller attempts a Will saving throw to retain control; otherwise, the target must attempt a Will save.</p>\n<hr />\n<p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target is @Compendium[pf2e.conditionitems.Stunned]{Stunned 1} as it fights off your commands.</p>\n<p><strong>Failure</strong> The target becomes @Compendium[pf2e.conditionitems.Controlled]{Controlled} by you and follows your orders. It (or the creature previously controlling it) can attempt a new Will save at the end of each of its turns, and the spell ends on a success. If you issue an obviously self-destructive order, the target doesn't act until you issue a new order.</p>\n<p><strong>Critical Failure</strong> As failure, but the target (or the creature previously controlling it) receives a new save only if yo give it a new order that is against its nature.</p>"
         },
         "duration": {
             "value": "10 minutes"
         },
         "hasCounteractCheck": {
-            "value": false
+            "value": null
         },
         "level": {
             "value": 6

--- a/packs/data/spells.db/debilitating-dichotomy.json
+++ b/packs/data/spells.db/debilitating-dichotomy.json
@@ -17,6 +17,7 @@
             "value": "focus"
         },
         "components": {
+            "focus": false,
             "material": false,
             "somatic": true,
             "verbal": true
@@ -27,22 +28,24 @@
         "damage": {
             "value": {
                 "0": {
+                    "applyMod": null,
                     "type": {
                         "categories": [],
-                        "value": "mental"
+                        "subtype": "",
+                        "value": ""
                     },
                     "value": "9d6"
                 }
             }
         },
         "description": {
-            "value": "<p>You reveal a glimpse of the impossible conflicts between the</p>\n<p>divine anathema behind your curse, forcing you to reckon</p>\n<p>with another's conflicts as well.</p>\n<p>You and the target each take 9d6 mental damage with a basic Will save, and the target is @Compendium[pf2e.conditionitems.Stunned]{Stunned 1} if it critically fails its save. You get a degree of success one better than you rolled for your saving throw.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 3d6.</p>"
+            "value": "<p>You reveal a glimpse of the impossible conflicts between the divine anathema behind your curse, forcing you to reckon with another's conflicts as well.</p>\n<p>You and the target each take 9d6 mental damage with a basic Will save, and the target is @Compendium[pf2e.conditionitems.Stunned]{Stunned 1} if it critically fails its save. You get a degree of success one better than you rolled for your saving throw.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 3d6.</p>"
         },
         "duration": {
             "value": ""
         },
         "hasCounteractCheck": {
-            "value": false
+            "value": null
         },
         "heightening": {
             "damage": {

--- a/packs/data/spells.db/thunderburst.json
+++ b/packs/data/spells.db/thunderburst.json
@@ -28,24 +28,24 @@
         "damage": {
             "value": {
                 "0": {
-                    "applyMod": false,
+                    "applyMod": null,
                     "type": {
                         "categories": [],
                         "subtype": "",
-                        "value": "bludgeoning"
+                        "value": ""
                     },
                     "value": "2d6"
                 }
             }
         },
         "description": {
-            "value": "<p>You create a powerful blast of air and a loud peal of thunder, dealing 2d6 bludgeoning damage and 2d6 sonic damage. Each creature in the area must attempt a Fortitude save.</p>\n<hr />\n<p><strong>Critical Success</strong> The creature is unaffected<strong>.</strong></p>\n<p><strong>Success</strong> The creature takes half damage.</p>\n<p><strong>Failure</strong> The creature takes full damage and is @Compendium[pf2e.conditionitems.Deafened]{Deafened} for 1 minute.</p>\n<p><strong>Critical Failure</strong> The creature takes double damage and is</p>\n<p>Deafened for 1 hour.</p>\n<hr />\n<p><strong>Heightened (+2)</strong> Increase each type of damage by 2d6 and the area by 5 feet.</p>"
+            "value": "<p>You create a powerful blast of air and a loud peal of thunder, dealing 2d6 bludgeoning damage and 2d6 sonic damage. Each creature in the area must attempt a Fortitude save.</p>\n<hr />\n<p><strong>Critical Success</strong> The creature is unaffected<strong>.</strong></p>\n<p><strong>Success</strong> The creature takes half damage.</p>\n<p><strong>Failure</strong> The creature takes full damage and is @Compendium[pf2e.conditionitems.Deafened]{Deafened} for 1 minute.</p>\n<p><strong>Critical Failure</strong> The creature takes double damage and is Deafened for 1 hour.</p>\n<hr />\n<p><strong>Heightened (+2)</strong> Increase each type of damage by 2d6 and the area by 5 feet.</p>"
         },
         "duration": {
             "value": ""
         },
         "hasCounteractCheck": {
-            "value": false
+            "value": null
         },
         "heightening": {
             "damage": {


### PR DESCRIPTION
A few Oracle items had random new paragraphs, likely a result of copying straight from a PDF.

Also fixed Breath of Life, had an incorrect Dying link, and basic lesson, had a stray `<hr />`