### PR TITLE
Add campaign feat sections as a secret setting

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -40,6 +40,7 @@ import { TextEditorPF2e } from "@system/text-editor";
 import { sluggify } from "@util";
 import { CombatantPF2e, EncounterPF2e } from "./module/encounter";
 import { ConditionManager } from "./module/system/conditions";
+import { FeatCategoryOptions } from "@actor/character/feats";
 
 declare global {
     interface Game {
@@ -146,6 +147,7 @@ declare global {
         get(module: "pf2e", setting: "worldClock.worldCreatedOn"): string;
 
         get(module: "pf2e", setting: "campaignFeats"): boolean;
+        get(module: "pf2e", setting: "campaignFeatSections"): FeatCategoryOptions[];
 
         get(module: "pf2e", setting: "homebrew.weaponCategories"): HomebrewTag<"weaponCategories">[];
         get(module: "pf2e", setting: HomebrewSettingsKey): HomebrewTag[];

--- a/src/module/actor/character/feats.ts
+++ b/src/module/actor/character/feats.ts
@@ -326,4 +326,4 @@ class FeatCategory {
     }
 }
 
-export { CharacterFeats, FeatCategory, FeatSlotLevel };
+export { CharacterFeats, FeatCategory, FeatCategoryOptions, FeatSlotLevel };

--- a/src/module/actor/character/index.ts
+++ b/src/module/actor/character/index.ts
@@ -1213,6 +1213,12 @@ class CharacterPF2e extends CreaturePF2e {
         this.pfsBoons = [];
         this.deityBoonsCurses = [];
         this.feats = new CharacterFeats(this);
+
+        const campaignFeatSections = game.settings.get("pf2e", "campaignFeatSections");
+        for (const section of campaignFeatSections) {
+            this.feats.createCategory(section);
+        }
+
         this.feats.assignFeats();
 
         // These are not handled by character feats

--- a/src/module/system/settings/index.ts
+++ b/src/module/system/settings/index.ts
@@ -218,6 +218,15 @@ export function registerSettings() {
         type: Boolean,
     });
 
+    // Secret for now until the user side is complete and a UI is built
+    game.settings.register("pf2e", "campaignFeatSections", {
+        name: "Campaign Feat Sections",
+        scope: "world",
+        config: false,
+        default: [],
+        type: Array,
+    });
+
     // This only exists to not break existing macros (yet). We'll keep it for a few versions
     game.settings.register("pf2e", "RAI.TreatWoundsAltSkills", {
         name: "Treat Wounds Macro Compat",

--- a/types/foundry/common/types.d.ts
+++ b/types/foundry/common/types.d.ts
@@ -33,7 +33,13 @@ declare global {
         /** Indicates if this Setting should render in the Config application */
         config: boolean;
         /** The JS Type that the Setting is storing */
-        type: NumberConstructor | StringConstructor | BooleanConstructor | ObjectConstructor | FunctionConstructor;
+        type:
+            | NumberConstructor
+            | StringConstructor
+            | BooleanConstructor
+            | ObjectConstructor
+            | ArrayConstructor
+            | FunctionConstructor;
         /** For string Types, defines the allowable values */
         choices?: Record<string, string>;
         /** For numeric Types, defines the allowable range */


### PR DESCRIPTION
Will satisfy my needs in the short term without focusing a lot of dev work into it. Can be expanded later.

Future expansions in mind are:
- Character level overrides (name and level). This will make it useful for SoT
- Different styling, perhaps increased indentation so it looks like it belongs to Campaign Feats rather than being a new full section
- Actually allowing end users to configure it