### PR TITLE
Fix features requiring agile/finesse/ranged weapons

### DIFF
--- a/packs/scripts/run-migration.ts
+++ b/packs/scripts/run-migration.ts
@@ -34,6 +34,7 @@ import { Migration771SpellVariantsToSystem } from "@module/migration/migrations/
 import { Migration772V10EmbeddedSpellData } from "@module/migration/migrations/772-v10-embedded-spell-data";
 import { Migration773ReligiousSymbolUsage } from "@module/migration/migrations/773-religious-symbol-usage";
 import { Migration774UnpersistCraftingEntries } from "@module/migration/migrations/774-unpersist-crafting-entries";
+import { Migration775AgileFinesseRanged } from "@module/migration/migrations/775-agile-finesse-ranged";
 // ^^^ don't let your IDE use the index in these imports. you need to specify the full path ^^^
 
 const { window } = new JSDOM();
@@ -70,6 +71,7 @@ const migrations: MigrationBase[] = [
     new Migration772V10EmbeddedSpellData(),
     new Migration773ReligiousSymbolUsage(),
     new Migration774UnpersistCraftingEntries(),
+    new Migration775AgileFinesseRanged(),
 ];
 
 global.deepClone = <T>(original: T): T => {

--- a/src/module/migration/migrations/index.ts
+++ b/src/module/migration/migrations/index.ts
@@ -172,3 +172,4 @@ export { Migration771SpellVariantsToSystem } from "./771-spell-variants-to-syste
 export { Migration772V10EmbeddedSpellData } from "./772-v10-embedded-spell-data";
 export { Migration773ReligiousSymbolUsage } from "./773-religious-symbol-usage";
 export { Migration774UnpersistCraftingEntries } from "./774-unpersist-crafting-entries";
+export { Migration775AgileFinesseRanged } from "./775-agile-finesse-ranged";

--- a/src/module/migration/runner/base.ts
+++ b/src/module/migration/runner/base.ts
@@ -14,7 +14,7 @@ interface CollectionDiff<T extends foundry.data.ActiveEffectSource | ItemSourceP
 export class MigrationRunnerBase {
     migrations: MigrationBase[];
 
-    static LATEST_SCHEMA_VERSION = 0.774;
+    static LATEST_SCHEMA_VERSION = 0.775;
 
     static MINIMUM_SAFE_VERSION = 0.618;
 


### PR DESCRIPTION
The system's alternate usages now classify thrown melee weapons as ranged weapons when thrown, requiring an adjustment to REs that predicate on them.

Closes #3605