### PR TITLE
Implement option to disable sorting on ChoiceSet

### DIFF
--- a/src/module/rules/rule-element/choice-set/data.ts
+++ b/src/module/rules/rule-element/choice-set/data.ts
@@ -36,6 +36,7 @@ interface ChoiceSetSource extends RuleElementSource {
     allowedDrops?: unknown;
     allowNoSelection?: unknown;
     rollOption?: unknown;
+    sort?: unknown;
 }
 
 interface ChoiceSetOwnedItems {

--- a/src/module/rules/rule-element/choice-set/rule-element.ts
+++ b/src/module/rules/rule-element/choice-set/rule-element.ts
@@ -32,6 +32,9 @@ class ChoiceSetRuleElement extends RuleElementPF2e {
     /** An optional roll option to be set from the selection */
     private rollOption: string | null;
 
+    /** Should the options on the prompt be sorted alphabetically? */
+    private sort: boolean;
+
     constructor(data: ChoiceSetSource, item: Embedded<ItemPF2e>, options?: RuleElementOptions) {
         super(data, item, options);
 
@@ -42,6 +45,7 @@ class ChoiceSetRuleElement extends RuleElementPF2e {
         this.allowedDrops = isObject(data.allowedDrops) ? new PredicatePF2e(data.allowedDrops) : new PredicatePF2e();
         this.allowNoSelection = !!data.allowNoSelection;
         this.rollOption = typeof data.rollOption === "string" && data.rollOption ? data.rollOption : null;
+        this.sort = !!(data.sort ?? true);
         if (isObject(this.data.choices) && "predicate" in this.data.choices) {
             this.data.choices.predicate = new PredicatePF2e(this.data.choices.predicate);
         }
@@ -143,7 +147,7 @@ class ChoiceSetRuleElement extends RuleElementPF2e {
     }
 
     /**
-     * If an array was passed, localize & sort the labels and return. If a string, look it up in CONFIG.PF2E and
+     * If an array was passed, localize the labels and sort if necessary, then return. If a string, look it up in CONFIG.PF2E and
      * create an array of choices.
      */
     private async inflateChoices(): Promise<PickableThing<string | number | object>[]> {
@@ -182,11 +186,11 @@ class ChoiceSetRuleElement extends RuleElementPF2e {
 
         try {
             return choices
-                .map((c) => ({
+                .map((c, index) => ({
                     value: c.value,
                     label: game.i18n.localize(c.label),
                     img: c.img,
-                    sort: c.sort,
+                    sort: this.sort ? c.sort : index + 1,
                     predicate: c.predicate ? new PredicatePF2e(c.predicate) : undefined,
                 }))
                 .sort((a, b) => a.label.localeCompare(b.label));

--- a/src/module/rules/rule-element/choice-set/rule-element.ts
+++ b/src/module/rules/rule-element/choice-set/rule-element.ts
@@ -45,7 +45,7 @@ class ChoiceSetRuleElement extends RuleElementPF2e {
         this.allowedDrops = isObject(data.allowedDrops) ? new PredicatePF2e(data.allowedDrops) : new PredicatePF2e();
         this.allowNoSelection = !!data.allowNoSelection;
         this.rollOption = typeof data.rollOption === "string" && data.rollOption ? data.rollOption : null;
-        this.sort = !!(data.sort ?? true);
+        this.sort = !!data.sort;
         if (isObject(this.data.choices) && "predicate" in this.data.choices) {
             this.data.choices.predicate = new PredicatePF2e(this.data.choices.predicate);
         }


### PR DESCRIPTION
Currently, ChoiceSets always sort choices, which is fine most of the time, but sometimes you want an arbitrary order. A good example of this is Oracle Curses - it would make more sense if they were sorted Minor -> Extreme.

This merge adds a `"sort"` boolean to the ChoiceSet RE, which defaults to true. When set to false, the prompt will follow the order declared in the ChoiceSet RE itself.

Left is `"sort": true` (or omitted), right is `"sort": false`

![image](https://user-images.githubusercontent.com/77904738/187097534-9d31ed09-fcfb-49a5-9f2a-cd2e5b5a8ec3.png)

(First real code merge, hope I haven't broken anything 🙏)
