### PR TITLE
Link up system conditions to V10's status effect automation

### DIFF
--- a/src/module/item/condition/index.ts
+++ b/src/module/item/condition/index.ts
@@ -77,6 +77,10 @@ class ConditionPF2e extends AbstractEffectPF2e {
         if (this.system.references.parent?.type !== "condition") {
             this.actor?.getActiveTokens().shift()?.showFloatyText({ create: this });
         }
+
+        for (const token of this.actor?.getActiveTokens() ?? []) {
+            token._onApplyStatusEffect(this.rollOptionSlug, true);
+        }
     }
 
     protected override _onUpdate(
@@ -111,6 +115,10 @@ class ConditionPF2e extends AbstractEffectPF2e {
             const baseName = this.system.base;
             const change = { delete: { name: baseName } };
             this.actor?.getActiveTokens().shift()?.showFloatyText(change);
+        }
+
+        for (const token of this.actor?.getActiveTokens() ?? []) {
+            token._onApplyStatusEffect(this.rollOptionSlug, false);
         }
     }
 }

--- a/src/scripts/hooks/init.ts
+++ b/src/scripts/hooks/init.ts
@@ -55,6 +55,9 @@ export const Init = {
             CONFIG.ui.compendium = CompendiumDirectoryPF2e;
             CONFIG.ui.hotbar = HotbarPF2e;
 
+            // The condition in Pathfinder 2e is "blinded" rather than "blind"
+            CONFIG.specialStatusEffects.BLIND = "blinded";
+
             // Insert templates into DOM tree so Applications can render into
             if (document.querySelector("#ui-top") !== null) {
                 // Template element for effects-panel

--- a/types/foundry/client/config.d.ts
+++ b/types/foundry/client/config.d.ts
@@ -427,6 +427,14 @@ declare global {
         /** An array of status effect icons which can be applied to Tokens */
         statusEffects: string[];
 
+        /** A mapping of status effect IDs which provide some additional mechanical integration. */
+        specialStatusEffects: {
+            DEFEATED: string;
+            INVISIBLE: string;
+            BLIND: string;
+            [key: string]: string;
+        };
+
         /** A mapping of core audio effects used which can be replaced by systems or mods */
         sounds: {
             dice: AudioPath;

--- a/types/foundry/client/pixi/placeable-object/token.d.ts
+++ b/types/foundry/client/pixi/placeable-object/token.d.ts
@@ -325,6 +325,13 @@ declare global {
          */
         checkCollision(destination: Point): boolean;
 
+        /**
+         * Handle changes to Token behavior when a significant status effect is applied
+         * @param statusId The status effect ID being applied, from CONFIG.specialStatusEffects
+         * @param active   Is the special status effect now active?
+         */
+        _onApplyStatusEffect(statusId: string, active: boolean): void;
+
         protected override _onControl(options?: { releaseOthers?: boolean; pan?: boolean }): void;
 
         protected override _onRelease(options?: Record<string, unknown>): void;


### PR DESCRIPTION
Core randomly hooks up two status effects with vision: invisibility and blindness. It should still serve as a good basis for reimplementing RBV.