### PR TITLE
Fix rules json editor vertically overflowing with more lines

### DIFF
--- a/src/styles/item/_rules.scss
+++ b/src/styles/item/_rules.scss
@@ -54,6 +54,7 @@
         & > .cm-editor {
             flex: 1;
             background-color: white;
+            overflow: hidden;
 
             .cm-scroller {
                 @include scrollbar;


### PR DESCRIPTION
This bug also exists in the previous version