### PR TITLE
Fix use of Earn Income macro

### DIFF
--- a/src/module/system/rolls.ts
+++ b/src/module/system/rolls.ts
@@ -196,6 +196,7 @@ class CheckPF2e {
         const substitutions = context.substitutions ?? [];
 
         // Acquire the d20 roll expression and resolve fortune/misfortune effects
+        const rollOptionsArray = Array.from(rollOptions);
         const [dice, tagsFromDice] = ((): [string, string[]] => {
             const substitutions =
                 context.substitutions?.filter((s) => (!s.ignored && s.predicate?.test(rollOptions)) ?? true) ?? [];
@@ -213,7 +214,7 @@ class CheckPF2e {
             }
 
             const substitution = substitutions.at(-1);
-            if (rollOptions.has("fortune") && rollOptions.has("misfortune")) {
+            if (rollOptionsArray.includes("fortune") && rollOptionsArray.includes("misfortune")) {
                 return ["1d20", ["PF2E.TraitFortune", "PF2E.TraitMisfortune"]];
             } else if (substitution) {
                 const effectType = {
@@ -319,7 +320,7 @@ class CheckPF2e {
             return TextEditor.enrichHTML(flavor, { ...item?.getRollData(), async: true });
         })();
 
-        const secret = context.secret ?? rollOptions.has("secret");
+        const secret = context.secret ?? rollOptionsArray.includes("secret");
 
         const contextFlag: CheckRollContextFlag = {
             ...context,
@@ -328,7 +329,7 @@ class CheckPF2e {
             token: context.token?.id ?? null,
             domains: context.domains ?? [],
             target: context.target ? { actor: context.target.actor.uuid, token: context.target.token.uuid } : null,
-            options: Array.from(rollOptions).sort(),
+            options: rollOptionsArray.sort(),
             notes: (context.notes ?? []).filter((n) => PredicatePF2e.test(n.predicate, rollOptions)),
             secret,
             rollMode: secret ? "blindroll" : context.rollMode ?? game.settings.get("core", "rollMode"),


### PR DESCRIPTION
With this change the earnIncome macro works on master.
Expected result is a popup with options, followed by a chat message with the income earned.
Without this fix the popup is displayed, but no chat message.
I have to admit that I don't understand why this change is required, .has on a Set *should* work. There's probably a better solution.
To test it I used:
```
let pack = game.packs.get("pf2e.pf2e-macros");
await pack.getIndex().then((index) => {
	let id = index.find((e) => e.name === "Earn Income")?._id;
	if (id) {
		pack.getDocument(id).then((e) => e.execute());
	}
});
```
