### PR TITLE
Change Caterwaul Sling icon to Sling

### DIFF
--- a/packs/data/equipment.db/caterwaul-sling.json
+++ b/packs/data/equipment.db/caterwaul-sling.json
@@ -1,6 +1,6 @@
 {
     "_id": "2KNAip9W6IoBrfIU",
-    "img": "systems/pf2e/icons/equipment/weapons/specific-magic-weapons/caterwaul-sling.webp",
+    "img": "systems/pf2e/icons/equipment/weapons/sling.webp",
     "name": "Caterwaul Sling",
     "system": {
         "MAP": {


### PR DESCRIPTION
It had a specific icon before but it's not a slingshot, it's a sling.