### PR TITLE
Add shortforms to skill selectors

### DIFF
--- a/src/module/actor/character/index.ts
+++ b/src/module/actor/character/index.ts
@@ -992,7 +992,7 @@ class CharacterPF2e extends CreaturePF2e {
             const skill = systemData.skills[shortForm];
             const longForm = SKILL_DICTIONARY[shortForm];
 
-            const domains = [longForm, `${skill.ability}-based`, "skill-check", `${skill.ability}-skill-check`, "all"];
+            const domains = [longForm, shortForm, `${skill.ability}-based`, "skill-check", `${skill.ability}-skill-check`, "all"];
             const modifiers = [
                 createAbilityModifier({ actor: this, ability: skill.ability, domains }),
                 ProficiencyModifier.fromLevelAndRank(this.level, skill.rank),

--- a/src/module/actor/creature/index.ts
+++ b/src/module/actor/creature/index.ts
@@ -67,7 +67,7 @@ export abstract class CreaturePF2e extends ActorPF2e {
             if (!objectHasKey(this.system.skills, shortForm)) return current;
             const longForm = skill.name;
             const skillName = game.i18n.localize(skill.label ?? CONFIG.PF2E.skills[shortForm]) || skill.name;
-            const domains = ["all", "skill-check", longForm, `${skill.ability}-based`, `${skill.ability}-skill-check`];
+            const domains = ["all", "skill-check", longForm, shortForm, `${skill.ability}-based`, `${skill.ability}-skill-check`];
 
             current[longForm] = new Statistic(this, {
                 slug: longForm,

--- a/src/module/actor/familiar/index.ts
+++ b/src/module/actor/familiar/index.ts
@@ -286,7 +286,7 @@ export class FamiliarPF2e extends CreaturePF2e {
                 );
             }
             const ability = SKILL_EXPANDED[longForm].ability;
-            const selectors = [longForm, `${ability}-based`, "skill-check", "all"];
+            const selectors = [longForm, shortForm, `${ability}-based`, "skill-check", "all"];
             modifiers.push(...extractModifiers(synthetics, selectors).filter(filterModifier));
 
             const label = CONFIG.PF2E.skills[shortForm] ?? longForm;

--- a/src/module/actor/npc/index.ts
+++ b/src/module/actor/npc/index.ts
@@ -322,7 +322,7 @@ class NPCPF2e extends CreaturePF2e {
         system.skills = {};
         for (const skill of SKILL_LONG_FORMS) {
             const { ability, shortform } = SKILL_EXPANDED[skill];
-            const domains = [skill, `${ability}-based`, "skill-check", `${ability}-skill-check`, "all"];
+            const domains = [skill, shortform, `${ability}-based`, "skill-check", `${ability}-skill-check`, "all"];
             const modifiers = [
                 new ModifierPF2e({
                     slug: "base",


### PR DESCRIPTION
I'm sure I missed some selectors somewhere since these are scattered around and not made using consistent code.  This is needed to simplify REs for certain effects.