### PR TITLE
Clear search bar in compendium browser when filters are cleared

### DIFF
--- a/src/module/apps/compendium-browser/tabs/base.ts
+++ b/src/module/apps/compendium-browser/tabs/base.ts
@@ -47,7 +47,7 @@ export abstract class CompendiumBrowserTab {
 
     /** Reset all filters */
     resetFilters(): void {
-        this.filterData = this.defaultFilterData;
+        this.filterData = deepClone(this.defaultFilterData);
     }
 
     /** Load and prepare the compendium index and set filter options */

--- a/src/module/apps/compendium-browser/tabs/base.ts
+++ b/src/module/apps/compendium-browser/tabs/base.ts
@@ -47,7 +47,7 @@ export abstract class CompendiumBrowserTab {
 
     /** Reset all filters */
     resetFilters(): void {
-        this.filterData = mergeObject(this.filterData, this.defaultFilterData, { inplace: false });
+        this.filterData = this.defaultFilterData;
     }
 
     /** Load and prepare the compendium index and set filter options */

--- a/src/module/apps/compendium-browser/tabs/base.ts
+++ b/src/module/apps/compendium-browser/tabs/base.ts
@@ -47,8 +47,7 @@ export abstract class CompendiumBrowserTab {
 
     /** Reset all filters */
     resetFilters(): void {
-        const { search } = this.filterData;
-        this.filterData = mergeObject(this.defaultFilterData, { search }, { inplace: false });
+        this.filterData = mergeObject(this.filterData, this.defaultFilterData, { inplace: false });
     }
 
     /** Load and prepare the compendium index and set filter options */


### PR DESCRIPTION
The params on `mergeObject` seemed to be backwards: the current `filterData` should be the object being overwritten by the default values. Plus there doesn't seem to be a reason to declare `filterData` as `{ search }` beforehand.