### PR TITLE
Data Entry World fixes for September 3 2022

### DIFF
--- a/packs/data/extinction-curse-bestiary.db/doblagub.json
+++ b/packs/data/extinction-curse-bestiary.db/doblagub.json
@@ -112,96 +112,15 @@
             "type": "spellcastingEntry"
         },
         {
-            "_id": "3VOyDvwPYul2WbJk",
-            "img": "systems/pf2e/icons/default-icons/spell.svg",
-            "name": "crushing despair",
-            "sort": 200000,
-            "system": {
-                "ability": {
-                    "value": ""
-                },
-                "area": {
-                    "value": ""
-                },
-                "category": {
-                    "value": "spell"
-                },
-                "components": {
-                    "focus": false,
-                    "material": false,
-                    "somatic": false,
-                    "verbal": false
-                },
-                "cost": {
-                    "value": ""
-                },
-                "damage": {
-                    "value": {}
-                },
-                "description": {
-                    "value": ""
-                },
-                "duration": {
-                    "value": ""
-                },
-                "hasCounteractCheck": {
-                    "value": false
-                },
-                "level": {
-                    "value": 6
-                },
-                "location": {
-                    "value": "1ezhm0ODqaxXqUZb"
-                },
-                "materials": {
-                    "value": ""
-                },
-                "prepared": {
-                    "value": ""
-                },
-                "range": {
-                    "value": ""
-                },
-                "rules": [],
-                "save": {
-                    "basic": "",
-                    "value": ""
-                },
-                "school": {
-                    "value": "evocation"
-                },
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "spellType": {
-                    "value": ""
-                },
-                "sustained": {
-                    "value": false
-                },
-                "target": {
-                    "value": ""
-                },
-                "time": {
-                    "value": ""
-                },
-                "traditions": {
-                    "value": []
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
+            "_id": "v2ov1hPXLNCnQj1i",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.OsOhx3TGIZ7AhD0P"
                 }
             },
-            "type": "spell"
-        },
-        {
-            "_id": "i9Ykaw2pgNFhj9KD",
             "img": "systems/pf2e/icons/spells/dominate.webp",
             "name": "Dominate",
-            "sort": 300000,
+            "sort": 200000,
             "system": {
                 "ability": {
                     "value": ""
@@ -209,6 +128,9 @@
                 "area": {
                     "areaType": "",
                     "value": null
+                },
+                "areasize": {
+                    "value": ""
                 },
                 "category": {
                     "value": "spell"
@@ -226,7 +148,7 @@
                     "value": {}
                 },
                 "description": {
-                    "value": "<p>You take command of the target, forcing it to obey your orders. If you issue an obviously self-destructive order, the target doesn't act until you issue a new order. The effect depends on its Will save.</p>\n<hr /><strong>Critical Success</strong> The target is unaffected.\n<p><strong>Success</strong> The target is @Compendium[pf2e.conditionitems.Stunned]{Stunned 1} as it fights off your commands.</p>\n<p><strong>Failure</strong> The target follows your orders but can attempt a Will save at the end of each of its turns. On a success, the spell ends.</p>\n<p><strong>Critical Failure</strong> As a failure, but the target receives a new save only if you give it a new order that is against its nature, such as killing its allies.</p>\n<hr /><strong>Heightened</strong> The duration is unlimited."
+                    "value": "<p>You take command of the target, forcing it to obey your orders. If you issue an obviously self-destructive order, the target doesn't act until you issue a new order. The effect depends on its Will save.</p>\n<hr />\n<p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target is @Compendium[pf2e.conditionitems.Stunned]{Stunned 1} as it fights off your commands.</p>\n<p><strong>Failure</strong> You control the target. It gains the @Compendium[pf2e.conditionitems.Controlled]{Controlled} condition, but it can attempt a Will save at the end of each of its turns. On a success, the spell ends.</p>\n<p><strong>Critical Failure</strong> As a failure, but the target receives a new save only if you give it a new order that is against its nature, such as killing its allies.</p>\n<hr />\n<p><strong>Heightened (10th)</strong> The duration is unlimited.</p>"
                 },
                 "duration": {
                     "value": "until the next time you make your daily preparations"
@@ -238,6 +160,7 @@
                     "value": 6
                 },
                 "location": {
+                    "heightenedLevel": 6,
                     "value": "1ezhm0ODqaxXqUZb"
                 },
                 "materials": {
@@ -246,20 +169,29 @@
                 "prepared": {
                     "value": ""
                 },
+                "primarycheck": {
+                    "value": ""
+                },
                 "range": {
                     "value": "30 feet"
                 },
                 "rules": [],
                 "save": {
                     "basic": "",
-                    "value": ""
+                    "value": "will"
                 },
                 "school": {
                     "value": "enchantment"
                 },
-                "slug": null,
-                "source": {
+                "secondarycasters": {
                     "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "dominate",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
                 },
                 "spellType": {
                     "value": "save"
@@ -281,7 +213,7 @@
                 },
                 "traits": {
                     "custom": "",
-                    "rarity": "common",
+                    "rarity": "uncommon",
                     "value": [
                         "incapacitation",
                         "mental"
@@ -293,15 +225,15 @@
         {
             "_id": "KMxn9xEYN5pNubae",
             "img": "systems/pf2e/icons/spells/true-seeing.webp",
-            "name": "True Seeing",
-            "sort": 400000,
+            "name": "True Seeing (Constant)",
+            "sort": 300000,
             "system": {
                 "ability": {
                     "value": ""
                 },
                 "area": {
                     "areaType": "",
-                    "value": null
+                    "value": ""
                 },
                 "category": {
                     "value": "spell"
@@ -352,7 +284,7 @@
                 },
                 "slug": null,
                 "source": {
-                    "value": ""
+                    "value": "https://2e.aonprd.com/Spells.aspx?ID=344"
                 },
                 "spellType": {
                     "value": "utility"
@@ -385,17 +317,25 @@
             "type": "spell"
         },
         {
-            "_id": "gxUs6AfvKjmNj0Qg",
-            "img": "systems/pf2e/icons/spells/confusion.webp",
-            "name": "Confusion",
-            "sort": 500000,
+            "_id": "mXLezV2TkqKWq5HZ",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.GaRQlC9Yw1BGKHfN"
+                }
+            },
+            "img": "systems/pf2e/icons/spells/chrusing-dispair.webp",
+            "name": "Crushing Despair",
+            "sort": 400000,
             "system": {
                 "ability": {
                     "value": ""
                 },
                 "area": {
-                    "areaType": "",
-                    "value": null
+                    "areaType": "cone",
+                    "value": "30"
+                },
+                "areasize": {
+                    "value": "30-foot cone"
                 },
                 "category": {
                     "value": "spell"
@@ -413,18 +353,30 @@
                     "value": {}
                 },
                 "description": {
-                    "value": "<p>You befuddle your target with strange impulses, causing it to act randomly. The effects are determined by the target's Will save. You can Dismiss the spell.</p>\n<hr /><strong>Critical Success</strong> The target is unaffected.\n<p><strong>Success</strong> The target babbles incoherently and is @Compendium[pf2e.conditionitems.Stunned]{Stunned 1}.</p>\n<p><strong>Failure</strong> The target is @Compendium[pf2e.conditionitems.Confused]{Confused} for 1 minute. It can attempt a new save at the end of each of its turns to end the confusion.</p>\n<p><strong>Critical Failure</strong> The target is @Compendium[pf2e.conditionitems.Confused]{Confused} for 1 minute, with no save to end early.</p>\n<hr /><strong>Heightened</strong> You can target up to 10 creatures."
+                    "value": "<p>You inflict despair on creatures in the area. The effects for each creature are determined by its Will save.</p>\n<hr />\n<p><strong>Critical Success</strong> The creature is unaffected.</p>\n<p><strong>Success</strong> For 1 round, the creature can't use reactions and must attempt another save at the start of its turn; on a failure, it is @Compendium[pf2e.conditionitems.Slowed]{Slowed 1} for that turn as it sobs uncontrollably.</p>\n<p><strong>Failure</strong> As success, but the duration is 1 minute.</p>\n<p><strong>Critical Failure</strong> As failure, and the creature is automatically @Compendium[pf2e.conditionitems.Slowed]{Slowed 1} for 1 minute.</p>\n<hr />\n<p><strong>Heightened (7th)</strong> The area increases to a 60-foot cone.</p>"
                 },
                 "duration": {
-                    "value": "1 minute"
+                    "value": "1 or more rounds"
                 },
                 "hasCounteractCheck": {
                     "value": false
+                },
+                "heightening": {
+                    "levels": {
+                        "7": {
+                            "area": {
+                                "areaType": "cone",
+                                "value": "60"
+                            }
+                        }
+                    },
+                    "type": "fixed"
                 },
                 "level": {
                     "value": 5
                 },
                 "location": {
+                    "heightenedLevel": 6,
                     "value": "1ezhm0ODqaxXqUZb"
                 },
                 "materials": {
@@ -433,20 +385,29 @@
                 "prepared": {
                     "value": ""
                 },
+                "primarycheck": {
+                    "value": ""
+                },
                 "range": {
-                    "value": "30 feet"
+                    "value": ""
                 },
                 "rules": [],
                 "save": {
                     "basic": "",
-                    "value": ""
+                    "value": "will"
                 },
                 "school": {
                     "value": "enchantment"
                 },
-                "slug": null,
-                "source": {
+                "secondarycasters": {
                     "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "crushing-despair",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
                 },
                 "spellType": {
                     "value": "save"
@@ -455,7 +416,7 @@
                     "value": false
                 },
                 "target": {
-                    "value": "1 creature"
+                    "value": ""
                 },
                 "time": {
                     "value": "2"
@@ -481,7 +442,7 @@
             "_id": "ujsPTlxDIf6lMOZJ",
             "img": "systems/pf2e/icons/spells/enthrall.webp",
             "name": "Enthrall",
-            "sort": 600000,
+            "sort": 500000,
             "system": {
                 "ability": {
                     "value": ""
@@ -543,7 +504,7 @@
                 },
                 "slug": null,
                 "source": {
-                    "value": ""
+                    "value": "https://2e.aonprd.com/Spells.aspx?ID=104"
                 },
                 "spellType": {
                     "value": "save"
@@ -577,15 +538,15 @@
         {
             "_id": "9XUmZ4qUBFoJyfKI",
             "img": "systems/pf2e/icons/spells/illusory-scene.webp",
-            "name": "Illusory Scene",
-            "sort": 700000,
+            "name": "Illusory Scene (At Will)",
+            "sort": 600000,
             "system": {
                 "ability": {
                     "value": ""
                 },
                 "area": {
                     "areaType": "",
-                    "value": null
+                    "value": ""
                 },
                 "category": {
                     "value": "spell"
@@ -636,7 +597,7 @@
                 },
                 "slug": null,
                 "source": {
-                    "value": ""
+                    "value": "https://2e.aonprd.com/Spells.aspx?ID=161"
                 },
                 "spellType": {
                     "value": "utility"
@@ -671,7 +632,7 @@
             "_id": "DGtPOc7CvdFtr0Zr",
             "img": "systems/pf2e/icons/spells/wall-of-stone.webp",
             "name": "Wall of Stone",
-            "sort": 800000,
+            "sort": 700000,
             "system": {
                 "ability": {
                     "value": ""
@@ -729,7 +690,7 @@
                 },
                 "slug": null,
                 "source": {
-                    "value": ""
+                    "value": "https://2e.aonprd.com/Spells.aspx?ID=365"
                 },
                 "spellType": {
                     "value": "utility"
@@ -763,7 +724,7 @@
             "_id": "PYLFUNANlbVoDKAu",
             "img": "systems/pf2e/icons/spells/charm.webp",
             "name": "Charm",
-            "sort": 900000,
+            "sort": 800000,
             "system": {
                 "ability": {
                     "value": ""
@@ -821,7 +782,7 @@
                 },
                 "slug": null,
                 "source": {
-                    "value": ""
+                    "value": "https://2e.aonprd.com/Spells.aspx?ID=34"
                 },
                 "spellType": {
                     "value": "save"
@@ -848,6 +809,127 @@
                     "value": [
                         "emotion",
                         "incapacitation",
+                        "mental"
+                    ]
+                }
+            },
+            "type": "spell"
+        },
+        {
+            "_id": "cQkF5yxLrCq2AsAz",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.LiGbewa9pO0yjbsY"
+                }
+            },
+            "img": "systems/pf2e/icons/spells/confusion.webp",
+            "name": "Confusion",
+            "sort": 900000,
+            "system": {
+                "ability": {
+                    "value": ""
+                },
+                "area": {
+                    "areaType": "",
+                    "value": ""
+                },
+                "areasize": {
+                    "value": ""
+                },
+                "category": {
+                    "value": "spell"
+                },
+                "components": {
+                    "focus": false,
+                    "material": false,
+                    "somatic": true,
+                    "verbal": true
+                },
+                "cost": {
+                    "value": ""
+                },
+                "damage": {
+                    "value": {}
+                },
+                "description": {
+                    "value": "<p>You befuddle your target with strange impulses, causing it to act randomly. The effects are determined by the target's Will save. You can Dismiss the spell.</p>\n<hr />\n<p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target babbles incoherently and is @Compendium[pf2e.conditionitems.Stunned]{Stunned 1}.</p>\n<p><strong>Failure</strong> The target is @Compendium[pf2e.conditionitems.Confused]{Confused} for 1 minute. It can attempt a new save at the end of each of its turns to end the confusion.</p>\n<p><strong>Critical Failure</strong> The target is Confused for 1 minute, with no save to end early.</p>\n<hr />\n<p><strong>Heightened (8th)</strong> You can target up to 10 creatures.</p>"
+                },
+                "duration": {
+                    "value": "1 minute"
+                },
+                "hasCounteractCheck": {
+                    "value": false
+                },
+                "heightening": {
+                    "levels": {
+                        "8": {
+                            "target": {
+                                "value": "10 creatures"
+                            }
+                        }
+                    },
+                    "type": "fixed"
+                },
+                "level": {
+                    "value": 4
+                },
+                "location": {
+                    "heightenedLevel": 5,
+                    "value": "1ezhm0ODqaxXqUZb"
+                },
+                "materials": {
+                    "value": ""
+                },
+                "prepared": {
+                    "value": ""
+                },
+                "primarycheck": {
+                    "value": ""
+                },
+                "range": {
+                    "value": "30 feet"
+                },
+                "rules": [],
+                "save": {
+                    "basic": "",
+                    "value": "will"
+                },
+                "school": {
+                    "value": "enchantment"
+                },
+                "secondarycasters": {
+                    "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "confusion",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "spellType": {
+                    "value": "save"
+                },
+                "sustained": {
+                    "value": false
+                },
+                "target": {
+                    "value": "1 creature"
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traditions": {
+                    "value": [
+                        "arcane",
+                        "occult"
+                    ]
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "emotion",
                         "mental"
                     ]
                 }
@@ -928,7 +1010,7 @@
                 },
                 "slug": null,
                 "source": {
-                    "value": ""
+                    "value": "https://2e.aonprd.com/Spells.aspx?ID=172"
                 },
                 "spellType": {
                     "value": "save"
@@ -1024,7 +1106,7 @@
                 },
                 "slug": null,
                 "source": {
-                    "value": ""
+                    "value": "https://2e.aonprd.com/Spells.aspx?ID=213"
                 },
                 "spellType": {
                     "value": "save"
@@ -1098,7 +1180,7 @@
                 "location": {
                     "uses": {
                         "max": 2,
-                        "value": 2
+                        "value": 1
                     },
                     "value": "1ezhm0ODqaxXqUZb"
                 },
@@ -1121,7 +1203,7 @@
                 },
                 "slug": null,
                 "source": {
-                    "value": ""
+                    "value": "https://2e.aonprd.com/Spells.aspx?ID=107"
                 },
                 "spellType": {
                     "value": "utility"
@@ -1155,7 +1237,7 @@
         {
             "_id": "PkPRBpSthtQAaHeA",
             "img": "systems/pf2e/icons/spells/fear.webp",
-            "name": "Fear",
+            "name": "Fear (At Will)",
             "sort": 1300000,
             "system": {
                 "ability": {
@@ -1163,7 +1245,7 @@
                 },
                 "area": {
                     "areaType": "",
-                    "value": null
+                    "value": ""
                 },
                 "category": {
                     "value": "spell"
@@ -1193,6 +1275,9 @@
                     "value": 3
                 },
                 "location": {
+                    "uses": {
+                        "value": 1
+                    },
                     "value": "1ezhm0ODqaxXqUZb"
                 },
                 "materials": {
@@ -1214,7 +1299,7 @@
                 },
                 "slug": null,
                 "source": {
-                    "value": ""
+                    "value": "https://2e.aonprd.com/Spells.aspx?ID=110"
                 },
                 "spellType": {
                     "value": "save"
@@ -1289,6 +1374,9 @@
                     "value": 3
                 },
                 "location": {
+                    "uses": {
+                        "value": 1
+                    },
                     "value": "1ezhm0ODqaxXqUZb"
                 },
                 "materials": {
@@ -1310,7 +1398,7 @@
                 },
                 "slug": null,
                 "source": {
-                    "value": ""
+                    "value": "https://2e.aonprd.com/Spells.aspx?ID=150"
                 },
                 "spellType": {
                     "value": "save"
@@ -1582,7 +1670,9 @@
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "reach-10"
+                    ]
                 },
                 "weaponType": {
                     "value": "melee"
@@ -1600,8 +1690,10 @@
                     "value": ""
                 },
                 "attackEffects": {
+                    "custom": "",
                     "value": [
-                        "grab"
+                        "grab",
+                        "magical-tongue"
                     ]
                 },
                 "bonus": {
@@ -1610,11 +1702,11 @@
                 "damageRolls": {
                     "unnje74zfapu55tanl47": {
                         "damage": "",
-                        "damageType": "Pull10feet"
+                        "damageType": "chaotic"
                     }
                 },
                 "description": {
-                    "value": ""
+                    "value": "<p>Grab and Pull 10ft.</p>"
                 },
                 "rules": [],
                 "slug": null,
@@ -1624,7 +1716,9 @@
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "reach-15"
+                    ]
                 },
                 "weaponType": {
                     "value": "melee"
@@ -1648,7 +1742,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>40 feet.</p>\n<p><strong>Requirements</strong> A doblagub has bonded with their current location by being called there via a ritual or by remaining in one place for 10 years</p>\n<hr />\n<p><strong>Effect</strong> The doblagub grows etheric fibers that they can use to psychically keep prey close. Any time a creature tries to move within this aura, it must succeed at a @Check[type:will|dc:30] save or the movement fails and the action is wasted.</p>"
+                    "value": "<p>@Template[type:emanation|distance:40]{40 feet} @Compendium[pf2e.bestiary-ability-glossary-srd.Aura]{Aura}</p>\n<p><strong>Requirements</strong> A doblagub has bonded with their current location by being called there via a ritual or by remaining in one place for 10 years</p>\n<hr />\n<p><strong>Effect</strong> The doblagub grows etheric fibers that they can use to psychically keep prey close. Any time a creature tries to move within this aura, it must succeed at a @Check[type:will|dc:30] save or the movement fails and the action is wasted.</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -1772,7 +1866,7 @@
                     "value": 1
                 },
                 "description": {
-                    "value": "<p>Medium, 4d10+8 bludgeoning, Rupture 24</p>"
+                    "value": "<p>Medium, [[/r {4d10+8}[bludgeoning]]]{2d8+3 bludgeoning damage }, Rupture 24</p>\n<hr style=\"border-top: 1px solid var(--color-border-light-primary); border-bottom: 1px solid var(--color-border-light-highlight);\">\n<p>@Localize[PF2E.NPC.Abilities.Glossary.SwallowWhole]</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -1799,10 +1893,47 @@
             "type": "action"
         },
         {
+            "_id": "ID4UBMeCzdTYwZJd",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Grab",
+            "sort": 2300000,
+            "system": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Grab]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": "Extinction Curse"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
             "_id": "UktcRGjrWtYFVDQY",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Athletics",
-            "sort": 2300000,
+            "sort": 2400000,
             "system": {
                 "description": {
                     "value": ""
@@ -1830,7 +1961,7 @@
             "_id": "54pGOqizDlhMpPWD",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Deception",
-            "sort": 2400000,
+            "sort": 2500000,
             "system": {
                 "description": {
                     "value": ""
@@ -1858,7 +1989,7 @@
             "_id": "SWxbeT0zKTRtc78B",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Intimidation",
-            "sort": 2500000,
+            "sort": 2600000,
             "system": {
                 "description": {
                     "value": ""
@@ -1886,7 +2017,7 @@
             "_id": "HGXRG7brWPJLrnbO",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Nature",
-            "sort": 2600000,
+            "sort": 2700000,
             "system": {
                 "description": {
                     "value": ""
@@ -1914,7 +2045,7 @@
             "_id": "TBmAFeGhZvwezm9a",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Survival",
-            "sort": 2700000,
+            "sort": 2800000,
             "system": {
                 "description": {
                     "value": ""

--- a/packs/data/extinction-curse-bestiary.db/doblagub.json
+++ b/packs/data/extinction-curse-bestiary.db/doblagub.json
@@ -1866,7 +1866,7 @@
                     "value": 1
                 },
                 "description": {
-                    "value": "<p>Medium, [[/r {4d10+8}[bludgeoning]]]{2d8+3 bludgeoning damage }, Rupture 24</p>\n<hr style=\"border-top: 1px solid var(--color-border-light-primary); border-bottom: 1px solid var(--color-border-light-highlight);\">\n<p>@Localize[PF2E.NPC.Abilities.Glossary.SwallowWhole]</p>"
+                    "value": "<p>Medium, [[/r {4d10+8}[bludgeoning]]]{2d8+3 bludgeoning damage }, Rupture 24</p>\n<hr />\n<p>@Localize[PF2E.NPC.Abilities.Glossary.SwallowWhole]</p>"
                 },
                 "requirements": {
                     "value": ""

--- a/packs/data/extinction-curse-bestiary.db/doblagub.json
+++ b/packs/data/extinction-curse-bestiary.db/doblagub.json
@@ -1702,7 +1702,7 @@
                 "damageRolls": {
                     "unnje74zfapu55tanl47": {
                         "damage": "",
-                        "damageType": "chaotic"
+                        "damageType": "bludgeoning"
                     }
                 },
                 "description": {

--- a/packs/data/feats.db/feverish-enzymes.json
+++ b/packs/data/feats.db/feverish-enzymes.json
@@ -33,7 +33,7 @@
             {
                 "key": "DamageDice",
                 "override": {
-                    "damagetype": "negative"
+                    "damageType": "negative"
                 },
                 "predicate": {
                     "all": [

--- a/packs/data/feats.db/hellknight-dedication.json
+++ b/packs/data/feats.db/hellknight-dedication.json
@@ -42,12 +42,11 @@
             {
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
-                "path": "system.skills.int.rank",
+                "path": "system.skills.intimidation.rank",
                 "value": 2
             },
             {
                 "key": "FlatModifier",
-                "label": "Wearing Hellknight Plate",
                 "predicate": {
                     "all": [
                         "wearing-hellplate"

--- a/packs/data/feats.db/skill-mastery-rogue.json
+++ b/packs/data/feats.db/skill-mastery-rogue.json
@@ -33,7 +33,340 @@
                 }
             ]
         },
-        "rules": [],
+        "rules": [
+            {
+                "choices": [
+                    {
+                        "label": "PF2E.SkillAcr",
+                        "predicate": {
+                            "all": [
+                                "skill:acr:rank:2"
+                            ]
+                        },
+                        "value": "acr"
+                    },
+                    {
+                        "label": "PF2E.SkillArc",
+                        "predicate": {
+                            "all": [
+                                "skill:arc:rank:2"
+                            ]
+                        },
+                        "value": "arc"
+                    },
+                    {
+                        "label": "PF2E.SkillAth",
+                        "predicate": {
+                            "all": [
+                                "skill:ath:rank:2"
+                            ]
+                        },
+                        "value": "ath"
+                    },
+                    {
+                        "label": "PF2E.SkillCra",
+                        "predicate": {
+                            "all": [
+                                "skill:cra:rank:2"
+                            ]
+                        },
+                        "value": "cra"
+                    },
+                    {
+                        "label": "PF2E.SkillDec",
+                        "predicate": {
+                            "all": [
+                                "skill:dec:rank:2"
+                            ]
+                        },
+                        "value": "dec"
+                    },
+                    {
+                        "label": "PF2E.SkillDip",
+                        "predicate": {
+                            "all": [
+                                "skill:dip:rank:2"
+                            ]
+                        },
+                        "value": "dip"
+                    },
+                    {
+                        "label": "PF2E.SkillItm",
+                        "predicate": {
+                            "all": [
+                                "skill:itm:rank:2"
+                            ]
+                        },
+                        "value": "itm"
+                    },
+                    {
+                        "label": "PF2E.SkillMed",
+                        "predicate": {
+                            "all": [
+                                "skill:med:rank:2"
+                            ]
+                        },
+                        "value": "med"
+                    },
+                    {
+                        "label": "PF2E.SkillNat",
+                        "predicate": {
+                            "all": [
+                                "skill:nat:rank:2"
+                            ]
+                        },
+                        "value": "nat"
+                    },
+                    {
+                        "label": "PF2E.SkillOcc",
+                        "predicate": {
+                            "all": [
+                                "skill:occ:rank:2"
+                            ]
+                        },
+                        "value": "occ"
+                    },
+                    {
+                        "label": "PF2E.SkillPrf",
+                        "predicate": {
+                            "all": [
+                                "skill:prf:rank:2"
+                            ]
+                        },
+                        "value": "prf"
+                    },
+                    {
+                        "label": "PF2E.SkillRel",
+                        "predicate": {
+                            "all": [
+                                "skill:rel:rank:2"
+                            ]
+                        },
+                        "value": "rel"
+                    },
+                    {
+                        "label": "PF2E.SkillSoc",
+                        "predicate": {
+                            "all": [
+                                "skill:soc:rank:2"
+                            ]
+                        },
+                        "value": "soc"
+                    },
+                    {
+                        "label": "PF2E.SkillSte",
+                        "predicate": {
+                            "all": [
+                                "skill:ste:rank:2"
+                            ]
+                        },
+                        "value": "ste"
+                    },
+                    {
+                        "label": "PF2E.SkillSur",
+                        "predicate": {
+                            "all": [
+                                "skill:sur:rank:2"
+                            ]
+                        },
+                        "value": "sur"
+                    },
+                    {
+                        "label": "PF2E.SkillThi",
+                        "predicate": {
+                            "all": [
+                                "skill:thi:rank:2"
+                            ]
+                        },
+                        "value": "thi"
+                    }
+                ],
+                "flag": "skillMaster",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.skillMastery.MasterPrompt"
+            },
+            {
+                "choices": [
+                    {
+                        "label": "PF2E.SkillAcr",
+                        "predicate": {
+                            "all": [
+                                "skill:acr:rank:1"
+                            ]
+                        },
+                        "value": "acr"
+                    },
+                    {
+                        "label": "PF2E.SkillArc",
+                        "predicate": {
+                            "all": [
+                                "skill:arc:rank:1"
+                            ]
+                        },
+                        "value": "arc"
+                    },
+                    {
+                        "label": "PF2E.SkillAth",
+                        "predicate": {
+                            "all": [
+                                "skill:ath:rank:1"
+                            ]
+                        },
+                        "value": "ath"
+                    },
+                    {
+                        "label": "PF2E.SkillCra",
+                        "predicate": {
+                            "all": [
+                                "skill:cra:rank:1"
+                            ]
+                        },
+                        "value": "cra"
+                    },
+                    {
+                        "label": "PF2E.SkillDec",
+                        "predicate": {
+                            "all": [
+                                "skill:dec:rank:1"
+                            ]
+                        },
+                        "value": "dec"
+                    },
+                    {
+                        "label": "PF2E.SkillDip",
+                        "predicate": {
+                            "all": [
+                                "skill:dip:rank:1"
+                            ]
+                        },
+                        "value": "dip"
+                    },
+                    {
+                        "label": "PF2E.SkillItm",
+                        "predicate": {
+                            "all": [
+                                "skill:itm:rank:1"
+                            ]
+                        },
+                        "value": "itm"
+                    },
+                    {
+                        "label": "PF2E.SkillMed",
+                        "predicate": {
+                            "all": [
+                                "skill:med:rank:1"
+                            ]
+                        },
+                        "value": "med"
+                    },
+                    {
+                        "label": "PF2E.SkillNat",
+                        "predicate": {
+                            "all": [
+                                "skill:nat:rank:1"
+                            ]
+                        },
+                        "value": "nat"
+                    },
+                    {
+                        "label": "PF2E.SkillOcc",
+                        "predicate": {
+                            "all": [
+                                "skill:occ:rank:1"
+                            ]
+                        },
+                        "value": "occ"
+                    },
+                    {
+                        "label": "PF2E.SkillPrf",
+                        "predicate": {
+                            "all": [
+                                "skill:prf:rank:1"
+                            ]
+                        },
+                        "value": "prf"
+                    },
+                    {
+                        "label": "PF2E.SkillRel",
+                        "predicate": {
+                            "all": [
+                                "skill:rel:rank:1"
+                            ]
+                        },
+                        "value": "rel"
+                    },
+                    {
+                        "label": "PF2E.SkillSoc",
+                        "predicate": {
+                            "all": [
+                                "skill:soc:rank:1"
+                            ]
+                        },
+                        "value": "soc"
+                    },
+                    {
+                        "label": "PF2E.SkillSte",
+                        "predicate": {
+                            "all": [
+                                "skill:ste:rank:1"
+                            ]
+                        },
+                        "value": "ste"
+                    },
+                    {
+                        "label": "PF2E.SkillSur",
+                        "predicate": {
+                            "all": [
+                                "skill:sur:rank:1"
+                            ]
+                        },
+                        "value": "sur"
+                    },
+                    {
+                        "label": "PF2E.SkillThi",
+                        "predicate": {
+                            "all": [
+                                "skill:thi:rank:1"
+                            ]
+                        },
+                        "value": "thi"
+                    }
+                ],
+                "flag": "skillExpert",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.skillMastery.ExpertPrompt"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "system.skills.{item|flags.pf2e.rulesSelections.skillExpert}.rank",
+                "value": 2
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "system.skills.{item|flags.pf2e.rulesSelections.skillMaster}.rank",
+                "value": 3
+            },
+            {
+                "adjustName": false,
+                "allowedDrops": {
+                    "all": [
+                        "item:trait:skill"
+                    ],
+                    "label": "PF2E.SpecificRule.SkillMastery.AllowedDrops"
+                },
+                "choices": {
+                    "query": "{\"system.traits.value\":{\"$elemMatch\":\"skill\"}}"
+                },
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.SkillFeat"
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "{item|flags.pf2e.rulesSelections.skillMasteryRogue}"
+            }
+        ],
         "source": {
             "value": "Pathfinder Core Rulebook"
         },

--- a/packs/data/feats.db/skill-mastery-rogue.json
+++ b/packs/data/feats.db/skill-mastery-rogue.json
@@ -334,7 +334,7 @@
                 ],
                 "flag": "skillExpert",
                 "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.skillMastery.ExpertPrompt"
+                "prompt": "PF2E.SpecificRule.SkillMastery.ExpertPrompt"
             },
             {
                 "key": "ActiveEffectLike",

--- a/packs/data/feats.db/skill-mastery-rogue.json
+++ b/packs/data/feats.db/skill-mastery-rogue.json
@@ -183,7 +183,7 @@
                 ],
                 "flag": "skillMaster",
                 "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.skillMastery.MasterPrompt"
+                "prompt": "PF2E.SpecificRule.SkillMastery.MasterPrompt"
             },
             {
                 "choices": [

--- a/packs/data/feats.db/terrified-retreat.json
+++ b/packs/data/feats.db/terrified-retreat.json
@@ -13,7 +13,7 @@
             "value": null
         },
         "description": {
-            "value": "<p>When you critically succeed at the Demoralize action, if the target's level is lower than yours, the target is fleeing for 1 round.</p>"
+            "value": "<p>When you critically succeed at the Demoralize action, if the target's level is lower than yours, the target is @Compendium[pf2e.conditionitems.Fleeing]{Fleeing} for 1 round.</p>"
         },
         "featType": {
             "value": "skill"
@@ -32,13 +32,22 @@
         "rules": [
             {
                 "key": "Note",
+                "outcome": [
+                    "criticalSuccess"
+                ],
                 "predicate": {
                     "all": [
-                        "action:demoralize"
+                        "action:demoralize",
+                        {
+                            "gt": [
+                                "self:level",
+                                "target:level"
+                            ]
+                        }
                     ]
                 },
                 "selector": "intimidation",
-                "text": "When you critically succeed at the Demoralize action, if the target's level is lower than yours, the target is fleeing for 1 round.",
+                "text": "{item|system.description.value}",
                 "title": "{item|name}"
             }
         ],

--- a/packs/data/outlaws-of-alkenstar-bestiary.db/slick.json
+++ b/packs/data/outlaws-of-alkenstar-bestiary.db/slick.json
@@ -213,7 +213,12 @@
             "type": "action"
         },
         {
-            "_id": "iF2j8ZpPVcS7dRD7",
+            "_id": "WDONBDlJ0RK57L6E",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.9qV49KjZujZnSp6w"
+                }
+            },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "All-Around Vision",
             "sort": 600000,
@@ -233,10 +238,17 @@
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
-                "slug": null,
+                "rules": [
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "system.attributes.flanking.flankable",
+                        "value": false
+                    }
+                ],
+                "slug": "all-around-vision",
                 "source": {
-                    "value": ""
+                    "value": "Pathfinder Bestiary"
                 },
                 "traits": {
                     "custom": "",

--- a/packs/data/pathfinder-bestiary-2.db/froghemoth.json
+++ b/packs/data/pathfinder-bestiary-2.db/froghemoth.json
@@ -225,7 +225,12 @@
             "type": "action"
         },
         {
-            "_id": "r9UN2dDmxrL8ACPX",
+            "_id": "XPEavSJTuusA8TlU",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.9qV49KjZujZnSp6w"
+                }
+            },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "All-Around Vision",
             "sort": 600000,
@@ -245,10 +250,17 @@
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
-                "slug": null,
+                "rules": [
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "system.attributes.flanking.flankable",
+                        "value": false
+                    }
+                ],
+                "slug": "all-around-vision",
                 "source": {
-                    "value": ""
+                    "value": "Pathfinder Bestiary"
                 },
                 "traits": {
                     "custom": "",

--- a/packs/data/pathfinder-bestiary-2.db/giant-chameleon.json
+++ b/packs/data/pathfinder-bestiary-2.db/giant-chameleon.json
@@ -171,7 +171,12 @@
             "type": "action"
         },
         {
-            "_id": "iF2j8ZpPVcS7dRD7",
+            "_id": "eDciSvI59Etta4Vh",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.9qV49KjZujZnSp6w"
+                }
+            },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "All-Around Vision",
             "sort": 500000,
@@ -191,10 +196,17 @@
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
-                "slug": null,
+                "rules": [
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "system.attributes.flanking.flankable",
+                        "value": false
+                    }
+                ],
+                "slug": "all-around-vision",
                 "source": {
-                    "value": ""
+                    "value": "Pathfinder Bestiary"
                 },
                 "traits": {
                     "custom": "",

--- a/packs/data/pfs-season-3-bestiary.db/khisisi-5-6.json
+++ b/packs/data/pfs-season-3-bestiary.db/khisisi-5-6.json
@@ -158,7 +158,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>@Template[type:emanation|distance:30]{30 feet} @Compendium[pf2e.bestiary-ability-glossary-srd.Aura]{Aura}</p>\n<hr />\n<p>Living creatures are @Compendium[pf2e.conditionitems.Frightened]{Frightened 1} while in a mummy guardian's despair aura. They can't naturally recover from this fear while in the area but recover instantly once they leave the area. When a creature first enters the area, it must succeed at a @Check[type:will|dc:24] save (after taking the penalty from being frightened) or be @Compendium[pf2e.conditionitems.Paralyzed]{Paralyzed} for 1 round. The creature is then temporarily immune for 24 hours.</p>"
+                    "value": "<p>@Template[type:emanation|distance:30]{30 feet} @Compendium[pf2e.bestiary-ability-glossary-srd.Aura]{Aura}</p>\n<hr />\n<p>Living creatures are @Compendium[pf2e.conditionitems.Frightened]{Frightened 1} while in a mummy guardian's despair aura. They can't naturally recover from this fear while in the area but recover instantly once they leave the area. When a creature first enters the area, it must succeed at a @Check[type:will|dc:22] save (after taking the penalty from being frightened) or be @Compendium[pf2e.conditionitems.Paralyzed]{Paralyzed} for 1 round. The creature is then temporarily immune for 24 hours.</p>"
                 },
                 "requirements": {
                     "value": ""

--- a/packs/data/pfs-season-3-bestiary.db/khisisi-7-8.json
+++ b/packs/data/pfs-season-3-bestiary.db/khisisi-7-8.json
@@ -386,7 +386,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>@Template[type:emanation|distance:30]{30 feet} @Compendium[pf2e.bestiary-ability-glossary-srd.Aura]{Aura}</p>\n<hr />\n<p>Living creatures are @Compendium[pf2e.conditionitems.Frightened]{Frightened 1} while in a mummy pharaoh's despair aura. They can't naturally recover from this fear while in the area but recover instantly once they leave the area. When a creature first enters the area, it must succeed at a @Check[type:will|dc:26] save (after taking the penalty from being frightened) or be @Compendium[pf2e.conditionitems.Paralyzed]{Paralyzed} for [[/br 1d4 #Paralyze Duration]]{1d4 rounds}. The creature is then temporarily immune for 24 hours.</p>"
+                    "value": "<p>@Template[type:emanation|distance:30]{30 feet} @Compendium[pf2e.bestiary-ability-glossary-srd.Aura]{Aura}</p>\n<hr />\n<p>Living creatures are @Compendium[pf2e.conditionitems.Frightened]{Frightened 1} while in a mummy pharaoh's despair aura. They can't naturally recover from this fear while in the area but recover instantly once they leave the area. When a creature first enters the area, it must succeed at a @Check[type:will|dc:25] save (after taking the penalty from being frightened) or be @Compendium[pf2e.conditionitems.Paralyzed]{Paralyzed} for 1 round. The creature is then temporarily immune for 24 hours.</p>"
                 },
                 "requirements": {
                     "value": ""

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -1457,6 +1457,11 @@
                     "Note": "If you roll a success on an attempt to Grab an Edge, you get a critical success instead; if you roll a critical failure, you get a failure instead."
                 }
             },
+            "SkillMastery": {
+                "AllowedDrops": "Skill Feats",
+                "ExpertPrompt": "Select a skill to become expert in.",
+                "MasterPrompt": "Select a skill to become master in."
+            },
             "SneakAttack": "Sneak Attack",
             "SnipersAim": {
                 "Note": "Ignore the target's Concealed condition."


### PR DESCRIPTION
- (Dods) Add automation to Skill Mastery (Rogue)

- (Friz) Fix rule elements on Terrified Retreat, Feverish Enzymes, and Hellknight Dedication feats

- (Friz) Brushup Doblagub

- (Timingila) Updated Despair aura of Khisisi

- (Xdy) Fix All-Around Vision on several NPCs