### PR TITLE
Refocus tagify on re-render

### DIFF
--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -28,7 +28,7 @@ import {
     TAG_SELECTOR_TYPES,
     WeaknessSelector,
 } from "@system/tag-selector";
-import { ErrorPF2e, objectHasKey, tupleHasValue } from "@util";
+import { ErrorPF2e, htmlClosest, htmlQuery, objectHasKey, tupleHasValue } from "@util";
 import { ActorSheetDataPF2e, CoinageSummary, InventoryItem, SheetInventory } from "./data-types";
 import { ItemSummaryRendererPF2e } from "./item-summary-renderer";
 import { MoveLootPopup } from "./loot/move-loot-popup";
@@ -1206,6 +1206,18 @@ export abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorShee
         return this.itemRenderer.saveAndRestoreState(() => {
             return super._renderInner(data, options);
         });
+    }
+
+    /** Overridden to maintain focus on tagify elements */
+    protected override async _render(force?: boolean, options?: RenderOptions): Promise<void> {
+        const active = document.activeElement;
+        await super._render(force, options);
+        if (active?.classList.contains("tagify__input")) {
+            const name = htmlClosest(active, "tags")?.dataset.name;
+            if (name && this.element[0]) {
+                htmlQuery(this.element[0], `tags[data-name="${name}"] span[contenteditable]`)?.focus();
+            }
+        }
     }
 
     protected override _getSubmitData(updateData?: DocumentUpdateData<TActor>): Record<string, unknown> {

--- a/src/module/item/sheet/base.ts
+++ b/src/module/item/sheet/base.ts
@@ -11,7 +11,16 @@ import {
     TagSelectorBasic,
     TAG_SELECTOR_TYPES,
 } from "@system/tag-selector";
-import { ErrorPF2e, sluggify, sortStringRecord, tupleHasValue, objectHasKey, tagify } from "@util";
+import {
+    ErrorPF2e,
+    sluggify,
+    sortStringRecord,
+    tupleHasValue,
+    objectHasKey,
+    tagify,
+    htmlClosest,
+    htmlQuery,
+} from "@util";
 import Tagify from "@yaireo/tagify";
 import type * as TinyMCE from "tinymce";
 import { CodeMirror } from "./codemirror";
@@ -509,5 +518,17 @@ export class ItemSheetPF2e<TItem extends ItemPF2e> extends ItemSheet<TItem> {
         }
 
         return super._updateObject(event, flattenObject(expanded));
+    }
+
+    /** Overriden _render to maintain focus on tagify elements */
+    protected override async _render(force?: boolean, options?: RenderOptions): Promise<void> {
+        const active = document.activeElement;
+        await super._render(force, options);
+        if (active?.classList.contains("tagify__input")) {
+            const name = htmlClosest(active, "tags")?.dataset.name;
+            if (name && this.element[0]) {
+                htmlQuery(this.element[0], `tags[data-name="${name}"] span[contenteditable]`)?.focus();
+            }
+        }
     }
 }

--- a/src/util/tags.ts
+++ b/src/util/tags.ts
@@ -45,6 +45,11 @@ function tagify(input: HTMLInputElement | null, { whitelist, maxTags }: TagifyOp
         whitelist: whitelistTransformed,
     });
 
+    // Add the name to the tags html as an indicator for refreshing
+    if (input.name) {
+        tagify.DOM.scope.dataset.name = input.name;
+    }
+
     // Work around a tagify bug on Firefox
     // https://github.com/yairEO/tagify/issues/1115
     tagify.DOM.input.blur();


### PR DESCRIPTION
https://user-images.githubusercontent.com/1286721/188336177-0366a9ce-f5e7-4061-920e-7ece612d6c80.mp4

The only glitchiness seems to be if while the dropdown is open, you change windows, then come back. But that's tagify in general.