### PR TITLE
Expose DC module on game.pf2e

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -41,7 +41,7 @@ import { TextEditorPF2e } from "@system/text-editor";
 import { sluggify } from "@util";
 import { CombatantPF2e, EncounterPF2e } from "./module/encounter";
 import { ConditionManager } from "./module/system/conditions";
-
+import * as dc from "@module/dc";
 declare global {
     interface Game {
         pf2e: {
@@ -57,6 +57,7 @@ declare global {
                 calculateXP: typeof calculateXP;
                 launchTravelSheet: typeof launchTravelSheet;
             };
+            dc: typeof dc;
             system: {
                 moduleArt: Map<ActorUUID, ModuleArt>;
                 remigrate: typeof remigrate;

--- a/src/scripts/set-game-pf2e.ts
+++ b/src/scripts/set-game-pf2e.ts
@@ -25,6 +25,7 @@ import { ActorImporter } from "@system/importer/actor-importer";
 import { CheckPF2e } from "@system/rolls";
 import { TextEditorPF2e } from "@system/text-editor";
 import { sluggify } from "@util";
+import * as dc from "@module/dc";
 
 /** Expose public game.pf2e interface */
 export const SetGamePF2e = {
@@ -62,6 +63,7 @@ export const SetGamePF2e = {
             rollItemMacro,
             system: { moduleArt: new Map(), remigrate, sluggify },
             variantRules: { AutomaticBonusProgression },
+            dc: dc,
         };
 
         game.pf2e = mergeObject(game.pf2e ?? {}, initSafe);


### PR DESCRIPTION
This enables custom macros to access the functions for calculating DCs (eg level-based, modified by difficulty and/or rarity) in the module at runtime.
#3771 

Please let me know if there's a way to do this already.