### PR TITLE
Fix Localize only returning first paragraph

### DIFF
--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -97,8 +97,8 @@ class TextEditorPF2e extends TextEditor {
         }
         const enriched = await TextEditor.enrichHTML(content, { ...options, async: true });
         const doc = new DOMParser().parseFromString(enriched, "text/html");
-        if (doc.body.firstElementChild instanceof HTMLElement) {
-            return doc.body.firstElementChild;
+        if (doc.body instanceof HTMLElement) {
+            return doc.body;
         }
         return null;
     }


### PR DESCRIPTION
The empty line is back regardless but by only returning the first child we lose the rest of the text.