### PR TITLE
Fix empty gap created by @Localize and use all sub-elements

### DIFF
--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -95,12 +95,9 @@ class TextEditorPF2e extends TextEditor {
             ui.notifications.error(`Failed to localize ${paramString}!`);
             return null;
         }
-        const enriched = await TextEditor.enrichHTML(content, { ...options, async: true });
-        const doc = new DOMParser().parseFromString(enriched, "text/html");
-        if (doc.body.firstElementChild instanceof HTMLElement) {
-            return doc.body.firstElementChild;
-        }
-        return null;
+        const result = document.createElement("span");
+        result.innerHTML = await TextEditor.enrichHTML(content, { ...options, async: true });
+        return result;
     }
 
     /** Create inline template button from @template command */

--- a/src/styles/legacy/_chat.scss
+++ b/src/styles/legacy/_chat.scss
@@ -40,6 +40,7 @@
 
         p {
             margin: 4px 0;
+            min-height: unset;
         }
     }
 

--- a/src/styles/mixins/_tinymce.scss
+++ b/src/styles/mixins/_tinymce.scss
@@ -9,6 +9,12 @@
     --space-2xl: 2em;
     --radius: 3px;
 
+    // Override so that empty <p> (and <p>s with empty <span>) do not take space
+    // This comes up for @Localize
+    p {
+        min-height: unset;
+    }
+
     // Redeclared so that popout journals pages match embedded journal pages and item summaries
     :is(h1, h2, h3, h4, h5, h6):not(:first-child) {
         margin-top: 1em;


### PR DESCRIPTION
Turns out those empty `<p>` tags have always existed, but in foundry v10 they all have a minimum height now.