### PR TITLE
Fix display and deprecation warnings in vehicle biography screen

### DIFF
--- a/src/styles/actor/tabs/_bio.scss
+++ b/src/styles/actor/tabs/_bio.scss
@@ -120,6 +120,12 @@ hr {
             color: white;
         }
 
+        // When the editor is open, fill more space so the user has something to work with
+        .tox.tox-tinymce {
+            // !important to work around tox's limitations and a foundry issue where initial height is overwritten
+            height: 200px!important;
+        }
+
         .tox {
             .tox-editor-container {
                 .tox-editor-header {

--- a/static/templates/actors/vehicle/tabs/vehicle-description.html
+++ b/static/templates/actors/vehicle/tabs/vehicle-description.html
@@ -3,7 +3,7 @@
         <div class="biography-content">
             <label class="details-label">{{localize "PF2E.vehicle.DescriptionHeading"}}</label>
             <span class="biography-content" title="{{localize "PF2E.vehicle.DescriptionHeading"}}">
-                {{editor content=data.details.description target="system.details.description" button=true owner=owner editable=editable}}
+                {{editor data.details.description target="system.details.description" button=true owner=owner editable=editable}}
             </span>
         </div>
     </section>


### PR DESCRIPTION
The styles affect character sheets, by making the biography appearance editors slightly bigger when you start editing as well. I can only consider this a good thing.