### PR TITLE
Release Notes 4.0.0-beta2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Version 4.0.0 (Beta 2)
+
+### Bugfixes
+* (stwlam) Fix issue causing auras to not appear until after their source is removed
+* (stwlam) Fix issue causing some AE-like rule elements to not apply
+* (stwlam, Supe) Fix vision and detection modes not functioning when rules-based vision is disabled
+* (Supe) Fix display and deprecation warnings in vehicle biography tab
+* (Supe) Fix display of scrollbars in hazard sheet
+* (Supe) Fix UI error thrown when editing hazard traits
+
+### Data Updates
+* (Dooplan) Fix level of Icewyrm
+* (Shandyan) Automate strix feats
+
+
 ## Version 4.0.0 (Beta 1)
 
 ### New Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
     "name": "foundry-pf2e",
-    "version": "3.13.5",
+    "version": "4.0.0-beta2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "name": "foundry-pf2e",
+            "name": "4.0.0-beta2",
             "version": "3.13.5",
             "dependencies": {
                 "@codemirror/lang-json": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "foundry-pf2e",
-    "version": "3.13.5",
+    "version": "4.0.0-beta2",
     "description": "",
     "private": true,
     "scripts": {

--- a/system.json
+++ b/system.json
@@ -3,7 +3,7 @@
     "title": "Pathfinder 2nd Edition",
     "description": "A community contributed game system for Pathfinder Second Edition",
     "license": "./LICENSE",
-    "version": "4.0.0-beta1",
+    "version": "4.0.0-beta2",
     "compatibility": {
         "minimum": "10.284",
         "verified": "10.284",


### PR DESCRIPTION
### Bugfixes
* (stwlam) Fix issue causing auras to not appear until after their source is removed
* (stwlam) Fix issue causing some AE-like rule elements to not apply
* (stwlam, Supe) Fix vision and detection modes not functioning when rules-based vision is disabled
* (Supe) Fix display and deprecation warnings in vehicle biography tab
* (Supe) Fix display of scrollbars in hazard sheet
* (Supe) Fix UI error thrown when editing hazard traits

### Data Updates
* (Dooplan) Fix level of Icewyrm
* (Shandyan) Automate strix feats