### PR TITLE
Fix tagify refocus regression for npc embedded item traits

### DIFF
--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -11,7 +11,7 @@ import { DENOMINATIONS } from "@item/physical/values";
 import { SpellPreparationSheet } from "@item/spellcasting-entry/sheet";
 import { DropCanvasItemDataPF2e } from "@module/canvas/drop-canvas-data";
 import { RollOptionRuleElement } from "@module/rules/rule-element/roll-option";
-import { createSheetTags, processTagifyInSubmitData } from "@module/sheet/helpers";
+import { createSheetTags, maintainTagifyFocusInRender, processTagifyInSubmitData } from "@module/sheet/helpers";
 import { eventToRollParams } from "@scripts/sheet-util";
 import { InlineRollLinks } from "@scripts/ui/inline-roll-links";
 import { LocalizePF2e } from "@system/localize";
@@ -28,7 +28,7 @@ import {
     TAG_SELECTOR_TYPES,
     WeaknessSelector,
 } from "@system/tag-selector";
-import { ErrorPF2e, htmlClosest, htmlQuery, objectHasKey, tupleHasValue } from "@util";
+import { ErrorPF2e, objectHasKey, tupleHasValue } from "@util";
 import { ActorSheetDataPF2e, CoinageSummary, InventoryItem, SheetInventory } from "./data-types";
 import { ItemSummaryRendererPF2e } from "./item-summary-renderer";
 import { MoveLootPopup } from "./loot/move-loot-popup";
@@ -1208,16 +1208,9 @@ export abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorShee
         });
     }
 
-    /** Overridden to maintain focus on tagify elements */
+    /** Overriden _render to maintain focus on tagify elements */
     protected override async _render(force?: boolean, options?: RenderOptions): Promise<void> {
-        const active = document.activeElement;
-        await super._render(force, options);
-        if (active?.classList.contains("tagify__input")) {
-            const name = htmlClosest(active, "tags")?.dataset.name;
-            if (name && this.element[0]) {
-                htmlQuery(this.element[0], `tags[data-name="${name}"] span[contenteditable]`)?.focus();
-            }
-        }
+        await maintainTagifyFocusInRender(this, () => super._render(force, options));
     }
 
     /** Tagify sets an empty input field to "" instead of "[]", which later causes the JSON parse to throw an error */

--- a/src/module/item/sheet/base.ts
+++ b/src/module/item/sheet/base.ts
@@ -1,7 +1,7 @@
 import { ItemPF2e, LorePF2e } from "@item";
 import { ItemSourcePF2e } from "@item/data";
 import { RuleElements, RuleElementSource } from "@module/rules";
-import { createSheetTags, processTagifyInSubmitData } from "@module/sheet/helpers";
+import { createSheetTags, maintainTagifyFocusInRender, processTagifyInSubmitData } from "@module/sheet/helpers";
 import { InlineRollLinks } from "@scripts/ui/inline-roll-links";
 import { LocalizePF2e } from "@system/localize";
 import {
@@ -11,16 +11,7 @@ import {
     TagSelectorBasic,
     TAG_SELECTOR_TYPES,
 } from "@system/tag-selector";
-import {
-    ErrorPF2e,
-    sluggify,
-    sortStringRecord,
-    tupleHasValue,
-    objectHasKey,
-    tagify,
-    htmlClosest,
-    htmlQuery,
-} from "@util";
+import { ErrorPF2e, sluggify, sortStringRecord, tupleHasValue, objectHasKey, tagify } from "@util";
 import Tagify from "@yaireo/tagify";
 import type * as TinyMCE from "tinymce";
 import { CodeMirror } from "./codemirror";
@@ -511,13 +502,6 @@ export class ItemSheetPF2e<TItem extends ItemPF2e> extends ItemSheet<TItem> {
 
     /** Overriden _render to maintain focus on tagify elements */
     protected override async _render(force?: boolean, options?: RenderOptions): Promise<void> {
-        const active = document.activeElement;
-        await super._render(force, options);
-        if (active?.classList.contains("tagify__input")) {
-            const name = htmlClosest(active, "tags")?.dataset.name;
-            if (name && this.element[0]) {
-                htmlQuery(this.element[0], `tags[data-name="${name}"] span[contenteditable]`)?.focus();
-            }
-        }
+        await maintainTagifyFocusInRender(this, () => super._render(force, options));
     }
 }


### PR DESCRIPTION
This isn't broken in the 4.0.0-beta2, and only revealed itself once actor traits was unflattened. This adds an additional check to make sure its the same sheet, which is what it should have done in the beginning.