### PR TITLE
Release Notes 4.0.0-beta3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Version 4.0.0 (Beta 3)
+
+### System Improvements
+* (LebombJames) Clear search bar in compendium browser when filters are cleared
+
+### Bugfixes
+* (stwlam) Restore damage types to spell sheet
+* (stwlam) Fix race condition causing kits to inflate with incorrect item quantities
+* (stwlam) Fix issue causing advanced alchemy formulas to not be removable
+* (Supe) Fix removing Elite/Weak adjustments
+
 ## Version 4.0.0 (Beta 2)
 
 ### Bugfixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
     "name": "foundry-pf2e",
-    "version": "4.0.0-beta2",
+    "version": "4.0.0-beta3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "name": "4.0.0-beta2",
+            "name": "4.0.0-beta3",
             "version": "3.13.5",
             "dependencies": {
                 "@codemirror/lang-json": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "foundry-pf2e",
-    "version": "4.0.0-beta2",
+    "version": "4.0.0-beta3",
     "description": "",
     "private": true,
     "scripts": {

--- a/system.json
+++ b/system.json
@@ -3,7 +3,7 @@
     "title": "Pathfinder 2nd Edition",
     "description": "A community contributed game system for Pathfinder Second Edition",
     "license": "./LICENSE",
-    "version": "4.0.0-beta2",
+    "version": "4.0.0-beta3",
     "compatibility": {
         "minimum": "10.284",
         "verified": "10.284",


### PR DESCRIPTION
### System Improvements
* (LebombJames) Clear search bar in compendium browser when filters are cleared

### Bugfixes
* (stwlam) Restore damage types to spell sheet
* (stwlam) Fix race condition causing kits to inflate with incorrect item quantities
* (stwlam) Fix issue causing advanced alchemy formulas to not be removable
* (Supe) Fix removing Elite/Weak adjustments