### PR TITLE
Add support for item drops on familiar tokens

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -1238,7 +1238,7 @@ interface ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
 
     _sheet: ActorSheetPF2e<this> | ActorSheet<this, ItemPF2e> | null;
 
-    get sheet(): ActorSheetPF2e<this> | ActorSheet<this, ItemPF2e>;
+    get sheet(): ActorSheetPF2e<this>;
 
     /** See implementation in class */
     createEmbeddedDocuments(

--- a/src/scripts/hooks/drop-canvas-data.ts
+++ b/src/scripts/hooks/drop-canvas-data.ts
@@ -1,23 +1,16 @@
-import { ActorSheetPF2e } from "@actor/sheet/base";
 import { DropCanvasItemDataPF2e } from "@module/canvas/drop-canvas-data";
 
 export const DropCanvasData = {
     listen: (): void => {
-        Hooks.on("dropCanvasData", (canvas, data) => {
+        Hooks.on("dropCanvasData", (_canvas, data) => {
             const dropTarget = canvas.tokens.placeables.find((token) => {
                 const maximumX = token.x + (token.hitArea?.right ?? 0);
                 const maximumY = token.y + (token.hitArea?.bottom ?? 0);
                 return data.x >= token.x && data.y >= token.y && data.x <= maximumX && data.y <= maximumY;
             });
 
-            const actor = dropTarget?.actor;
-            if (actor && data.type === "Item") {
-                if (
-                    ["character", "npc", "loot", "vehicle"].includes(actor.type) &&
-                    actor.sheet instanceof ActorSheetPF2e
-                ) {
-                    actor.sheet.onDropItem(data as DropCanvasItemDataPF2e);
-                }
+            if (dropTarget?.actor && data.type === "Item") {
+                dropTarget.actor.sheet.onDropItem(data as DropCanvasItemDataPF2e);
                 return false; // Prevent modules from doing anything further
             }
             return true;


### PR DESCRIPTION
This only became possible when familiar sheets were refactored to inherit from `ActorSheetPF2e`.