### PR TITLE
Add strike getter to chat message for module use

### DIFF
--- a/src/module/chat-message/document.ts
+++ b/src/module/chat-message/document.ts
@@ -8,6 +8,8 @@ import { traditionSkills, TrickMagicItemEntry } from "@item/spellcasting-entry/t
 import { UserPF2e } from "@module/user";
 import { CheckRoll } from "@system/check/roll";
 import { ChatRollDetails } from "./chat-roll-details";
+import { htmlQuery } from "@util";
+import { StrikeData } from "@actor/data/base";
 
 class ChatMessagePF2e extends ChatMessage<ActorPF2e> {
     /** The chat log doesn't wait for data preparation before rendering, so set some data in the constructor */
@@ -113,6 +115,24 @@ class ChatMessagePF2e extends ChatMessage<ActorPF2e> {
         }
 
         return item;
+    }
+
+    /** If this message was for a strike, return the strike */
+    get strike(): StrikeData | null {
+        const actor = this.actor;
+        const altUsage = this.flags.pf2e.context?.altUsage ?? null;
+        if (!actor?.isOfType("character", "npc")) return null;
+
+        const messageHTML = htmlQuery(ui.chat.element[0], `li[data-message-id="${this.id}"]`);
+        const chatCard = htmlQuery(messageHTML, ".chat-card, .message-buttons");
+        if (!chatCard || chatCard.dataset.strikeIndex === undefined) return null;
+
+        const strikeIndex = Number(chatCard?.dataset.strikeIndex);
+        const action = actor.system.actions.at(strikeIndex) ?? null;
+
+        return altUsage
+            ? action?.altUsages?.find((w) => (altUsage === "thrown" ? w.item.isThrown : w.item.isMelee)) ?? null
+            : action;
     }
 
     /** Get stringified item source from the DOM-rendering of this chat message */

--- a/src/module/chat-message/listeners/cards.ts
+++ b/src/module/chat-message/listeners/cards.ts
@@ -126,17 +126,9 @@ export const ChatCards = {
                     ChatCards.rollActorSaves(event, item);
                 }
             } else if (actor.isOfType("character", "npc")) {
-                const strikeIndex = $card.attr("data-strike-index");
                 const strikeName = $card.attr("data-strike-name");
-                const altUsage = message.flags.pf2e.context?.altUsage ?? null;
-
-                const strikeAction = ((): StrikeData | null => {
-                    const action = actor.system.actions.at(Number(strikeIndex)) ?? null;
-                    return altUsage
-                        ? action?.altUsages?.find((w) => (altUsage === "thrown" ? w.item.isThrown : w.item.isMelee)) ??
-                              null
-                        : action;
-                })();
+                const altUsage = message.flags.pf2e.context?.altUsage;
+                const strikeAction = message.strike;
 
                 if (strikeAction && strikeAction.name === strikeName) {
                     const options = actor.getRollOptions(["all", "attack-roll"]);

--- a/src/util/dom.ts
+++ b/src/util/dom.ts
@@ -1,26 +1,31 @@
 /**  DOM helper functions that return HTMLElement(s) (or `null`) */
 
+import { Optional } from "./misc";
+
 function htmlQuery<K extends keyof HTMLElementTagNameMap>(
-    parent: Element | EventTarget,
+    parent: Optional<Element | EventTarget>,
     selectors: K
 ): HTMLElementTagNameMap[K] | null;
-function htmlQuery(parent: Element | EventTarget, selectors: string): HTMLElement | null;
-function htmlQuery<E extends HTMLElement = HTMLElement>(parent: Element | EventTarget, selectors: string): E | null;
-function htmlQuery(parent: Element | EventTarget, selectors: string): HTMLElement | null {
+function htmlQuery(parent: Optional<Element | EventTarget>, selectors: string): HTMLElement | null;
+function htmlQuery<E extends HTMLElement = HTMLElement>(
+    parent: Optional<Element | EventTarget>,
+    selectors: string
+): E | null;
+function htmlQuery(parent: Optional<Element | EventTarget>, selectors: string): HTMLElement | null {
     if (!(parent instanceof Element)) return null;
     return parent.querySelector<HTMLElement>(selectors);
 }
 
 function htmlQueryAll<K extends keyof HTMLElementTagNameMap>(
-    parent: Element | EventTarget,
+    parent: Optional<Element | EventTarget>,
     selectors: K
 ): HTMLElementTagNameMap[K][] | null;
-function htmlQueryAll(parent: Element | EventTarget, selectors: string): HTMLElement[];
+function htmlQueryAll(parent: Optional<Element | EventTarget>, selectors: string): HTMLElement[];
 function htmlQueryAll<E extends HTMLElement = HTMLElement>(
-    parent: Element | EventTarget,
+    parent: Optional<Element | EventTarget>,
     selectors: string
 ): E[] | null;
-function htmlQueryAll(parent: Element | EventTarget, selectors: string): HTMLElement[] {
+function htmlQueryAll(parent: Optional<Element | EventTarget>, selectors: string): HTMLElement[] {
     if (!(parent instanceof Element)) return [];
     return Array.from(parent.querySelectorAll<HTMLElement>(selectors));
 }


### PR DESCRIPTION
Seems to continue working for spells and strikes. Interestingly enough, the original logic resolved spells to unarmed strikes, so I had to add an extra check.