### PR TITLE
Sort item traits in sheet header

### DIFF
--- a/src/module/item/sheet/base.ts
+++ b/src/module/item/sheet/base.ts
@@ -81,6 +81,7 @@ export class ItemSheetPF2e<TItem extends ItemPF2e> extends ItemSheet<TItem> {
 
         const validTraits = this.validTraits;
         const hasRarity = !this.item.isOfType("action", "condition", "deity", "effect", "lore", "melee");
+        const traits = validTraits ? createSheetTags(validTraits, this.item.system.traits?.value ?? []) : null;
 
         // Activate rule element sub forms
         this.ruleElementForms = {};
@@ -111,7 +112,8 @@ export class ItemSheetPF2e<TItem extends ItemPF2e> extends ItemSheet<TItem> {
             user: { isGM: game.user.isGM },
             rarity: hasRarity ? this.item.system.traits?.rarity ?? "common" : null,
             rarities: CONFIG.PF2E.rarityTraits,
-            traits: validTraits ? createSheetTags(validTraits, this.item.system.traits?.value ?? []) : null,
+            traits,
+            traitSlugs: Object.keys(traits ?? {}),
             enabledRulesUI: game.settings.get("pf2e", "enabledRulesUI"),
             ruleEditing: !!this.editingRuleElement,
             rules: {

--- a/src/module/item/sheet/data-types.ts
+++ b/src/module/item/sheet/data-types.ts
@@ -33,6 +33,8 @@ export interface ItemSheetDataPF2e<TItem extends ItemPF2e> extends ItemSheetData
     rarity: Rarity | null;
     rarities: ConfigPF2e["PF2E"]["rarityTraits"];
     traits: SheetOptions | null;
+    /** The slugs of the item's value sorted trait list */
+    traitSlugs: string[];
     rules: {
         labels: {
             label: string;

--- a/static/templates/items/item-sheet.html
+++ b/static/templates/items/item-sheet.html
@@ -24,7 +24,7 @@
                 {{/if}}
             </template>
             {{#if showTraits}}
-                <input class="paizo-style tags" name="system.traits.value" value="{{json data.traits.value}}" data-dtype="JSON" />
+                <input class="paizo-style tags" name="system.traits.value" value="{{json traitSlugs}}" data-dtype="JSON" />
             {{else if rarity}}
                 <div class="paizo-style tags"></div>
             {{/if}}


### PR DESCRIPTION
There's a small delay where the traits visibly shift around after adding it, since tagify will add the new tag then foundry will update. I think that should be fine 🤷 .