### PR TITLE
Show the correct item name in parentheses when mystified

### DIFF
--- a/src/module/item/physical/index.ts
+++ b/src/module/item/physical/index.ts
@@ -234,15 +234,13 @@ abstract class PhysicalItemPF2e extends ItemPF2e {
         super.prepareDerivedData();
 
         const systemData = this.system;
-        if (!systemData.identification.identified) {
-            systemData.identification.identified = {
-                name: this.name,
-                img: this.img,
-                data: {
-                    description: { value: this.description },
-                },
-            };
-        }
+        systemData.identification.identified ??= {
+            name: this.name,
+            img: this.img,
+            data: {
+                description: { value: this.description },
+            },
+        };
 
         // If the item has an adjusted price, replace it if higher
         const adjustedPrice = this.computeAdjustedPrice?.();

--- a/src/module/item/physical/index.ts
+++ b/src/module/item/physical/index.ts
@@ -234,13 +234,15 @@ abstract class PhysicalItemPF2e extends ItemPF2e {
         super.prepareDerivedData();
 
         const systemData = this.system;
-        systemData.identification.identified = {
-            name: this.name,
-            img: this.img,
-            data: {
-                description: { value: this.description },
-            },
-        };
+        if (!systemData.identification.identified) {
+            systemData.identification.identified = {
+                name: this.name,
+                img: this.img,
+                data: {
+                    description: { value: this.description },
+                },
+            };
+        }
 
         // If the item has an adjusted price, replace it if higher
         const adjustedPrice = this.computeAdjustedPrice?.();


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1530996/189376278-a1ae33ab-5ee3-4809-83dd-a33d4ab61d06.png)

After:
![image](https://user-images.githubusercontent.com/1530996/189376712-d3c8b598-ec21-45d1-91e3-2194b9ed92d1.png)
