### PR TITLE
Add levels to actors in actor directory

### DIFF
--- a/src/module/apps/compendium-browser/index.ts
+++ b/src/module/apps/compendium-browser/index.ts
@@ -949,6 +949,14 @@ class CompendiumBrowser extends Application {
             ev.preventDefault();
             this.openTab("bestiary");
         });
+
+        // Add levels to actors.
+        $html.find(".actor").filter(":not([level-added])").each((_,actor) => {
+            const documentId = $(actor).attr("data-document-id");
+            $(actor).attr("level-added", "true");
+            const level = ui.actors.documents.find((actorDoc) => actorDoc.id === documentId)?.level;
+            if (level) $(actor).find(".document-name").append(`<span class="actor-level">Level ${level}</span>`);
+        });
     }
 
     override getData() {

--- a/src/styles/_globals.scss
+++ b/src/styles/_globals.scss
@@ -321,3 +321,14 @@ i[data-pf2-repost] {
 a[href]:hover {
     text-shadow: 0 0 8px var(--color-text-hyperlink);
 }
+
+/* ----------------------------------------- */
+/* Actor Directory                           */
+/* ----------------------------------------- */
+
+.directory-item.actor .actor-level {
+    display: flex;
+    line-height: normal;
+    margin-top: -16px;
+    font-size: x-small;
+}


### PR DESCRIPTION
Closes #3688 

This is how it looks right now..
![image](https://user-images.githubusercontent.com/1530996/189396552-8c7e50b8-3642-40d7-97a7-59f01b4756aa.png)

Doesn't work when popped out (looking into that) but wanted to start getting feedback on presentation. Thinking I should try to get it to where the name+level is vertically aligned to the center. Right now the name is, and the level is under, but that forces a pretty small font size. Maybe fine? Let me know how y'all feel.