### PR TITLE
Fix error when enriching null strings

### DIFF
--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -16,10 +16,10 @@ class TextEditorPF2e extends TextEditor {
     static override enrichHTML(content?: string, options?: EnrichHTMLOptionsPF2e): string;
     static override enrichHTML(
         this: typeof TextEditor,
-        content = "",
+        content?: string,
         options: EnrichHTMLOptionsPF2e = {}
     ): string | Promise<string> {
-        if (content.startsWith("<p>@Localize")) {
+        if (content?.startsWith("<p>@Localize")) {
             // Remove tags
             content = content.substring(3, content.length - 4);
         }

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -11,12 +11,15 @@ const superEnrichHTML = TextEditor.enrichHTML;
 
 /** Censor enriched HTML according to metagame knowledge settings */
 class TextEditorPF2e extends TextEditor {
-    static override enrichHTML(content?: string, options?: EnrichHTMLOptionsPF2e & { async?: false }): string;
-    static override enrichHTML(content?: string, options?: EnrichHTMLOptionsPF2e & { async: true }): Promise<string>;
-    static override enrichHTML(content?: string, options?: EnrichHTMLOptionsPF2e): string;
+    static override enrichHTML(content: string | null, options?: EnrichHTMLOptionsPF2e & { async?: false }): string;
+    static override enrichHTML(
+        content: string | null,
+        options?: EnrichHTMLOptionsPF2e & { async: true }
+    ): Promise<string>;
+    static override enrichHTML(content: string | null, options?: EnrichHTMLOptionsPF2e): string;
     static override enrichHTML(
         this: typeof TextEditor,
-        content?: string,
+        content: string | null,
         options: EnrichHTMLOptionsPF2e = {}
     ): string | Promise<string> {
         if (content?.startsWith("<p>@Localize")) {

--- a/types/foundry/client/core/text-editor.d.ts
+++ b/types/foundry/client/core/text-editor.d.ts
@@ -38,9 +38,9 @@ declare global {
          * @param [options.rollData]       The data object providing context for inline rolls
          * @return The enriched HTML content
          */
-        static enrichHTML(content?: string, options?: EnrichHTMLOptions & { async?: false }): string;
-        static enrichHTML(content?: string, options?: EnrichHTMLOptions & { async: true }): Promise<string>;
-        static enrichHTML(content?: string, options?: EnrichHTMLOptions): string | Promise<string>;
+        static enrichHTML(content: string | null, options?: EnrichHTMLOptions & { async?: false }): string;
+        static enrichHTML(content: string | null, options?: EnrichHTMLOptions & { async: true }): Promise<string>;
+        static enrichHTML(content: string | null, options?: EnrichHTMLOptions): string | Promise<string>;
 
         /**
          * Preview an HTML fragment by constructing a substring of a given length from its inner text.


### PR DESCRIPTION
The built in text editor enrich is able to handle null. Our override was not. Fixes #3873 

Though I'm uncertain if we even need this bit of code here.