### PR TITLE
Make ChatMessage's strike getter semi-private in the meantime

### DIFF
--- a/src/module/chat-message/document.ts
+++ b/src/module/chat-message/document.ts
@@ -117,8 +117,8 @@ class ChatMessagePF2e extends ChatMessage<ActorPF2e> {
         return item;
     }
 
-    /** If this message was for a strike, return the strike */
-    get strike(): StrikeData | null {
+    /** If this message was for a strike, return the strike. Strikes will change in a future release */
+    get _strike(): StrikeData | null {
         const actor = this.actor;
         const altUsage = this.flags.pf2e.context?.altUsage ?? null;
         if (!actor?.isOfType("character", "npc")) return null;

--- a/src/module/chat-message/listeners/cards.ts
+++ b/src/module/chat-message/listeners/cards.ts
@@ -128,7 +128,7 @@ export const ChatCards = {
             } else if (actor.isOfType("character", "npc")) {
                 const strikeName = $card.attr("data-strike-name");
                 const altUsage = message.flags.pf2e.context?.altUsage;
-                const strikeAction = message.strike;
+                const strikeAction = message._strike;
 
                 if (strikeAction && strikeAction.name === strikeName) {
                     const options = actor.getRollOptions(["all", "attack-roll"]);


### PR DESCRIPTION
I'll rewrite chat message strike handling code after the next release, and then get item() will return the strike item. However I suspect that retrieving the strike from a message will still be needed for the chat message handling code regardless.