### PR TITLE
Remove stored identified data on physical items

### DIFF
--- a/src/module/item/armor/data.ts
+++ b/src/module/item/armor/data.ts
@@ -58,10 +58,9 @@ interface ArmorSystemSource extends Investable<PhysicalSystemSource> {
 }
 
 interface ArmorSystemData
-    extends Omit<ArmorSystemSource, "price" | "temporary" | "usage">,
-        Investable<PhysicalSystemData> {
+    extends Omit<ArmorSystemSource, "identification" | "price" | "temporary" | "usage">,
+        Omit<Investable<PhysicalSystemData>, "traits"> {
     baseItem: BaseArmorType;
-    traits: ArmorTraits;
     runes: {
         potency: number;
         resilient: ZeroToThree;

--- a/src/module/item/consumable/data.ts
+++ b/src/module/item/consumable/data.ts
@@ -49,11 +49,10 @@ interface ConsumableSystemSource extends PhysicalSystemSource, ActivatedEffectDa
     spell: SpellSource | null;
 }
 
-type ConsumableSystemData = Omit<ConsumableSystemSource, "price"> &
-    PhysicalSystemData & {
-        equipped: {
-            invested?: never;
-        };
-    };
+interface ConsumableSystemData
+    extends Omit<ConsumableSystemSource, "identification" | "price" | "temporary" | "usage">,
+        PhysicalSystemData {
+    traits: ConsumableTraits;
+}
 
 export { ConsumableData, ConsumableSource, ConsumableTrait, ConsumableType };

--- a/src/module/item/container/data.ts
+++ b/src/module/item/container/data.ts
@@ -25,6 +25,8 @@ interface ContainerSystemSource extends Investable<PhysicalSystemSource> {
     collapsed: boolean;
 }
 
-type ContainerSystemData = Omit<ContainerSystemSource, "price"> & PhysicalSystemData;
+interface ContainerSystemData
+    extends Omit<ContainerSystemSource, "identification" | "price" | "temporary" | "usage">,
+        Omit<Investable<PhysicalSystemData>, "traits"> {}
 
 export { ContainerData, ContainerSource };

--- a/src/module/item/equipment/data.ts
+++ b/src/module/item/equipment/data.ts
@@ -19,7 +19,7 @@ interface EquipmentSystemSource extends Investable<PhysicalSystemSource> {
 }
 
 interface EquipmentSystemData
-    extends Omit<EquipmentSystemSource, "price" | "temporary" | "usage">,
+    extends Omit<EquipmentSystemSource, "identification" | "price" | "temporary" | "usage">,
         Investable<PhysicalSystemData> {
     traits: EquipmentTraits;
 }

--- a/src/module/item/physical/data.ts
+++ b/src/module/item/physical/data.ts
@@ -52,7 +52,7 @@ interface PhysicalSystemSource extends ItemSystemSource, ItemLevelData {
     };
     price: PartialPrice;
     equipped: EquippedData;
-    identification: IdentificationData;
+    identification: IdentificationSource;
     stackGroup: string | null;
     negateBulk: {
         value: string;
@@ -77,6 +77,7 @@ interface PhysicalSystemData extends PhysicalSystemSource, ItemSystemData {
     bulk: BulkData;
     traits: PhysicalItemTraits;
     temporary: boolean;
+    identification: IdentificationData;
     usage: UsageDetails;
 }
 
@@ -139,11 +140,14 @@ interface MystifiedData {
 
 type IdentifiedData = DeepPartial<MystifiedData>;
 
-interface IdentificationData {
+interface IdentificationSource {
     status: IdentificationStatus;
-    identified: MystifiedData;
     unidentified: MystifiedData;
     misidentified: {};
+}
+
+interface IdentificationData extends IdentificationSource {
+    identified: MystifiedData;
 }
 
 type EquippedData = {

--- a/src/module/item/weapon/data/types.ts
+++ b/src/module/item/weapon/data/types.ts
@@ -137,7 +137,9 @@ interface WeaponSystemSource extends Investable<PhysicalSystemSource> {
     selectedAmmoId: string | null;
 }
 
-interface WeaponSystemData extends Omit<WeaponSystemSource, "price" | "temporary">, Investable<PhysicalSystemData> {
+interface WeaponSystemData
+    extends Omit<WeaponSystemSource, "identification" | "price" | "temporary">,
+        Investable<PhysicalSystemData> {
     baseItem: BaseWeaponType | null;
     traits: WeaponTraits;
     maxRange: number | null;

--- a/src/module/migration/migrations/786-remove-identified-data.ts
+++ b/src/module/migration/migrations/786-remove-identified-data.ts
@@ -1,0 +1,24 @@
+import { ItemSourcePF2e } from "@item/data";
+import { isPhysicalData } from "@item/data/helpers";
+import { IdentificationStatus } from "@item/physical/data";
+import { MigrationBase } from "../base";
+
+/** Remove stored `system.identification.identified` properties on physical items */
+export class Migration786RemoveIdentifiedData extends MigrationBase {
+    static override version = 0.786;
+
+    override async updateItem(source: ItemSourcePF2e): Promise<void> {
+        if (!isPhysicalData(source)) return;
+
+        const identification: MaybeWithIdentifiedData = source.system.identification ?? {};
+        if (identification.identified) {
+            identification["-=identified"] = null;
+        }
+    }
+}
+
+interface MaybeWithIdentifiedData {
+    status: IdentificationStatus;
+    identified?: unknown;
+    "-=identified"?: null;
+}

--- a/src/module/migration/migrations/index.ts
+++ b/src/module/migration/migrations/index.ts
@@ -183,3 +183,4 @@ export { Migration782UnnestActorTraits } from "./782-unnest-actor-traits";
 export { Migration783RemoveClassSkillAELikes } from "./783-remove-class-skill-ae-likes";
 export { Migration784CompBrowserPackSetting } from "./784-comp-browser-pack-setting";
 export { Migration785ABCKitItemUUIDs } from "./785-abc-kit-items";
+export { Migration786RemoveIdentifiedData } from "./786-remove-identified-data";

--- a/src/module/migration/runner/base.ts
+++ b/src/module/migration/runner/base.ts
@@ -14,7 +14,7 @@ interface CollectionDiff<T extends foundry.data.ActiveEffectSource | ItemSourceP
 export class MigrationRunnerBase {
     migrations: MigrationBase[];
 
-    static LATEST_SCHEMA_VERSION = 0.785;
+    static LATEST_SCHEMA_VERSION = 0.786;
 
     static MINIMUM_SAFE_VERSION = 0.618;
 


### PR DESCRIPTION
No identification data is in compendium JSON, so no internal migration needed.