### PR TITLE
Migrate weapon and spell resolvables to use .system

### DIFF
--- a/packs/scripts/run-migration.ts
+++ b/packs/scripts/run-migration.ts
@@ -20,6 +20,7 @@ import { Migration781SuppressNoCrowbar } from "@module/migration/migrations/781-
 import { Migration782UnnestActorTraits } from "@module/migration/migrations/782-unnest-actor-traits";
 import { Migration783RemoveClassSkillAELikes } from "@module/migration/migrations/783-remove-class-skill-ae-likes";
 import { Migration785ABCKitItemUUIDs } from "@module/migration/migrations/785-abc-kit-items";
+import { Migration787ResolvablesToSystem } from "@module/migration/migrations/787-resolvables-to-system";
 // ^^^ don't let your IDE use the index in these imports. you need to specify the full path ^^^
 
 const { window } = new JSDOM();
@@ -42,6 +43,7 @@ const migrations: MigrationBase[] = [
     new Migration782UnnestActorTraits(),
     new Migration783RemoveClassSkillAELikes(),
     new Migration785ABCKitItemUUIDs(),
+    new Migration787ResolvablesToSystem(),
 ];
 
 global.deepClone = <T>(original: T): T => {

--- a/src/module/migration/migrations/787-resolvables-to-system.ts
+++ b/src/module/migration/migrations/787-resolvables-to-system.ts
@@ -1,0 +1,14 @@
+import { ItemSourcePF2e } from "@item/data";
+import { recursiveReplaceString } from "@util";
+import { MigrationBase } from "../base";
+
+/** Convert object paths of weapon and spell resolvables with <V10 `data` properties to use `system` */
+export class Migration787ResolvablesToSystem extends MigrationBase {
+    static override version = 0.787;
+
+    override async updateItem(source: ItemSourcePF2e): Promise<void> {
+        source.system = recursiveReplaceString(source.system, (value: string) =>
+            value.replace(/@(weapon|spell)\.data\.data./g, "@$1.system.").replace(/@(weapon|spell)\.data./g, "@$1.")
+        );
+    }
+}

--- a/src/module/migration/migrations/index.ts
+++ b/src/module/migration/migrations/index.ts
@@ -184,3 +184,4 @@ export { Migration783RemoveClassSkillAELikes } from "./783-remove-class-skill-ae
 export { Migration784CompBrowserPackSetting } from "./784-comp-browser-pack-setting";
 export { Migration785ABCKitItemUUIDs } from "./785-abc-kit-items";
 export { Migration786RemoveIdentifiedData } from "./786-remove-identified-data";
+export { Migration787ResolvablesToSystem } from "./787-resolvables-to-system";

--- a/src/module/migration/runner/base.ts
+++ b/src/module/migration/runner/base.ts
@@ -14,7 +14,7 @@ interface CollectionDiff<T extends foundry.data.ActiveEffectSource | ItemSourceP
 export class MigrationRunnerBase {
     migrations: MigrationBase[];
 
-    static LATEST_SCHEMA_VERSION = 0.786;
+    static LATEST_SCHEMA_VERSION = 0.787;
 
     static MINIMUM_SAFE_VERSION = 0.618;
 


### PR DESCRIPTION
I must have accidentally dropped this part from the migration while writing it, but not before having it run on compendium JSON. :\