### PR TITLE
Fix certain item sidebar styling

### DIFF
--- a/src/module/item/sheet/base.ts
+++ b/src/module/item/sheet/base.ts
@@ -371,7 +371,7 @@ export class ItemSheetPF2e<TItem extends ItemPF2e> extends ItemSheet<TItem> {
         const sidebarHeader = this.element[0]?.querySelector<HTMLElement>(".sidebar-summary");
         const sidebar = this.element[0]?.querySelector<HTMLElement>(".sheet-sidebar");
         if (sidebarHeader && sidebar) {
-            const display = activeTab === "rules" ? "none" : "block";
+            const display = activeTab === "rules" ? "none" : "";
             sidebarHeader.style.display = sidebar.style.display = display;
         }
     }

--- a/src/styles/item/_index.scss
+++ b/src/styles/item/_index.scss
@@ -338,7 +338,6 @@
             flex-direction: row;
             align-items: center;
             justify-content: space-between;
-            font-size: var(--font-size-12);
 
             & > label {
                 display: flex;


### PR DESCRIPTION
This also removes the specific font size override on certain form elements in the item sheet. That font size override should be done more generally rather than being tied to a layout element, but we stand to change too much if we apply it globally so I just removed it for now. Sneaky fix for a sizing inconsistency in the flat modifier rule element form.