### PR TITLE
Release Notes 4.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## Version 4.0.4
+
+### System Improvements
+* (stwlam) Hide damage buttons for not-damaging weapons (e.g., Tanglefoot Bag)
+* (Supe) Have ChatMessage#item return the strike weapon if available (for module usage)
+
+### Bugfixes
+* (In3luki) Fix distribute coin popup
+* (stwlam) Prevent context menu from appearing on right click in status effects menu for some OS/browser combinations
+* (stwlam) Include journal entries in compendium search
+* (stwlam) Fix issue causing post-to-chat button to not appear for @Check expressions in journal entry pages
+* (stwlam) Migrate weapon and spell resolvables in rule elements for V10 compatibility
+* (stwlam) Fix persistent damage icon path
+* (stwlam) Fix multiple issues causing roll notes to display with superfluous line breaks
+* (stwlam) Fix obscuring sender names on chat messages when feature is enabled
+* (stwlam) Fix functionality of greater darkvision with no standard darkvision
+
+### Data Updates
+* (avagdu) Update Advanced Synergy to be takable multiple times
+* (Dods) Add rule elements to Skill Mastery (Rogue archetype)
+* (Friz) Brushup Doblagub
+* (Friz) Fix rule elements on Terrified Retreat, Feverish Enzymes, and Hellknight Dedication feats
+* (SpartanCPA) Add book source citations to more feats and effects missing them
+* (stwlam) Restore Fledgling Flight feat
+* (Tikael) Add missing Dread runes
+* (Tikael) Data Entry World fixes for September 3 2022
+* (Timingila) Updated Despair aura of Khisisi
+* (Xdy) Fix All-Around Vision on several NPCs
+
 ## Version 4.0.3
 
 ### Bugfixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "foundry-pf2e",
-    "version": "4.0.3",
+    "version": "4.0.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "foundry-pf2e",
-            "version": "4.0.3",
+            "version": "4.0.4",
             "dependencies": {
                 "@codemirror/lang-json": "^6.0.0",
                 "@yaireo/tagify": "^4.16.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "foundry-pf2e",
-    "version": "4.0.3",
+    "version": "4.0.4",
     "description": "",
     "private": true,
     "scripts": {

--- a/system.json
+++ b/system.json
@@ -3,7 +3,7 @@
     "title": "Pathfinder 2nd Edition",
     "description": "A community contributed game system for Pathfinder Second Edition",
     "license": "./LICENSE",
-    "version": "4.0.3",
+    "version": "4.0.4",
     "compatibility": {
         "minimum": "10.285",
         "verified": "10.285",


### PR DESCRIPTION
### System Improvements
* (stwlam) Hide damage buttons for not-damaging weapons (e.g., Tanglefoot Bag)
* (Supe) Have ChatMessage#item return the strike weapon if available (for module usage)

### Bugfixes
* (In3luki) Fix distribute coin popup
* (stwlam) Prevent context menu from appearing on right click in status effects menu for some OS/browser combinations
* (stwlam) Include journal entries in compendium search
* (stwlam) Fix issue causing post-to-chat button to not appear for @<!-- -->Check expressions in journal entry pages
* (stwlam) Migrate weapon and spell resolvables in rule elements for V10 compatibility
* (stwlam) Fix persistent damage icon path
* (stwlam) Fix multiple issues causing roll notes to display with superfluous line breaks
* (stwlam) Fix obscuring sender names on chat messages when feature is enabled
* (stwlam) Fix functionality of greater darkvision with no standard darkvision

### Data Updates
* (avagdu) Update Advanced Synergy to be takable multiple times
* (Dods) Add rule elements to Skill Mastery (Rogue archetype)
* (Friz) Brushup Doblagub
* (Friz) Fix rule elements on Terrified Retreat, Feverish Enzymes, and Hellknight Dedication feats
* (SpartanCPA) Add book source citations to more feats and effects missing them
* (stwlam) Restore Fledgling Flight feat
* (Tikael) Add missing Dread runes
* (Tikael) Data Entry World fixes for September 3 2022
* (Timingila) Updated Despair aura of Khisisi
* (Xdy) Fix All-Around Vision on several NPCs
