### PR TITLE
Student of the staff deadly scaling

### DIFF
--- a/packs/data/classfeatures.db/arcane-cascade.json
+++ b/packs/data/classfeatures.db/arcane-cascade.json
@@ -28,6 +28,13 @@
             {
                 "key": "GrantItem",
                 "uuid": "Compendium.pf2e.actionspf2e.Arcane Cascade"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.arcaneCascade.damageType",
+                "priority": -100,
+                "value": ""
             }
         ],
         "source": {

--- a/packs/data/feats.db/student-of-the-staff.json
+++ b/packs/data/feats.db/student-of-the-staff.json
@@ -46,7 +46,39 @@
                 "key": "DamageDice",
                 "predicate": [
                     "weapon:base:staff",
-                    "self:effect:arcane-cascade"
+                    "self:effect:arcane-cascade",
+                    {
+                        "nor": [
+                            "weapon:damage-dice:3",
+                            "weapon:damage-dice:4"
+                        ]
+                    }
+                ],
+                "selector": "damage"
+            },
+            {
+                "critical": true,
+                "damageType": "{actor|flags.pf2e.arcaneCascade.damageType}",
+                "diceNumber": 2,
+                "dieSize": "d6",
+                "key": "DamageDice",
+                "predicate": [
+                    "weapon:base:staff",
+                    "self:effect:arcane-cascade",
+                    "weapon:damage-dice:3"
+                ],
+                "selector": "damage"
+            },
+            {
+                "critical": true,
+                "damageType": "{actor|flags.pf2e.arcaneCascade.damageType}",
+                "diceNumber": 3,
+                "dieSize": "d6",
+                "key": "DamageDice",
+                "predicate": [
+                    "weapon:base:staff",
+                    "self:effect:arcane-cascade",
+                    "weapon:damage-dice:4"
                 ],
                 "selector": "damage"
             }

--- a/packs/data/feats.db/student-of-the-staff.json
+++ b/packs/data/feats.db/student-of-the-staff.json
@@ -35,7 +35,7 @@
             {
                 "key": "CriticalSpecialization",
                 "predicate": [
-                    "weapon:group:club"
+                    "weapon:base:staff"
                 ]
             },
             {


### PR DESCRIPTION
This fixes some oversights in my initial implementation of Student of the Staff automation, avoiding console errors when not in arcane cascade and correctly scaling up the extra critical damage dice with the weapon striking runes as the deadly trait is meant to do.