### PR TITLE
Optional-ize Spell collection

### DIFF
--- a/src/module/actor/creature/sheet.ts
+++ b/src/module/actor/creature/sheet.ts
@@ -398,9 +398,9 @@ export abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends Act
         $html.find("button[data-action=cast-spell]").on("click", (event) => {
             const $spellEl = $(event.currentTarget).closest(".item");
             const { itemId, slotLevel, slotId, entryId } = $spellEl.data();
-            const entry = this.actor.spellcasting.get(entryId, { strict: true });
-            const spell = entry.spells.get(itemId, { strict: true });
-            entry.cast(spell, { slot: slotId, level: slotLevel });
+            const collection = this.actor.spellcasting.collections.get(entryId, { strict: true });
+            const spell = collection.get(itemId, { strict: true });
+            collection.entry.cast(spell, { slot: slotId, level: slotLevel });
         });
 
         // Regenerating spell slots and spell uses

--- a/src/module/actor/creature/spell-preparation-sheet.ts
+++ b/src/module/actor/creature/spell-preparation-sheet.ts
@@ -2,8 +2,8 @@ import { ActorPF2e } from "@actor";
 import { ItemSummaryRendererPF2e } from "@actor/sheet/item-summary-renderer";
 import { ItemPF2e, SpellPF2e } from "@item";
 import { ItemSourcePF2e, SpellSource } from "@item/data";
+import { SpellcastingAbilityData } from "@item/spellcasting-entry/data";
 import { SpellcastingEntryPF2e } from "../../item/spellcasting-entry";
-import { SpellcastingEntryListData } from "../../item/spellcasting-entry/data";
 
 /**
  * Sheet used to render the the spell list for prepared casting.
@@ -135,7 +135,7 @@ class SpellPreparationSheet extends ActorSheet<ActorPF2e, ItemPF2e> {
 
         const spell = this.actor.items.get(itemData._id);
         if (itemData.system.location.value !== this.item.id && spell?.isOfType("spell")) {
-            const addedSpell = await this.item.spells.addSpell(spell);
+            const addedSpell = await this.item.spells?.addSpell(spell);
             return [addedSpell ?? []].flat();
         }
 
@@ -153,7 +153,7 @@ class SpellPreparationSheet extends ActorSheet<ActorPF2e, ItemPF2e> {
 interface SpellPreparationSheetData extends ActorSheetData<ActorPF2e> {
     actor: ActorPF2e;
     owner: boolean;
-    entry: SpellcastingEntryListData;
+    entry: SpellcastingAbilityData;
 }
 
 export { SpellPreparationSheet };

--- a/src/module/actor/creature/types.ts
+++ b/src/module/actor/creature/types.ts
@@ -2,7 +2,7 @@ import { ActorPF2e } from "@actor";
 import { ActorSheetDataPF2e } from "@actor/sheet/data-types";
 import { MeleePF2e, SpellPF2e, WeaponPF2e } from "@item";
 import { SpellcastingEntryData } from "@item/data";
-import { SpellcastingEntryListData } from "@item/spellcasting-entry/data";
+import { SpellcastingAbilityData } from "@item/spellcasting-entry/data";
 import { ModifierPF2e } from "@actor/modifiers";
 import { TokenDocumentPF2e } from "@scene";
 import { CheckDC } from "@system/degree-of-success";
@@ -88,7 +88,7 @@ interface CreatureSheetData<TActor extends CreaturePF2e = CreaturePF2e> extends 
     };
 }
 
-type SpellcastingSheetData = RawObject<SpellcastingEntryData> & SpellcastingEntryListData;
+type SpellcastingSheetData = RawObject<SpellcastingEntryData> & SpellcastingAbilityData;
 
 export {
     Alignment,

--- a/src/module/actor/spellcasting.ts
+++ b/src/module/actor/spellcasting.ts
@@ -58,7 +58,7 @@ export class ActorSpellcasting extends Collection<SpellcastingEntryPF2e> {
 
         const itemUpdates = this.contents.flatMap((entry): SpellcastingUpdate => {
             if (!(entry instanceof SpellcastingEntryPF2e)) return [];
-            if (entry.isFocusPool) return [];
+            if (entry.isFocusPool || !entry.spells) return [];
 
             // Innate spells should refresh uses instead
             if (entry.isInnate) {

--- a/src/module/item/spellcasting-entry/collection.ts
+++ b/src/module/item/spellcasting-entry/collection.ts
@@ -1,10 +1,11 @@
 import { SpellPF2e } from "@item";
-import { ErrorPF2e, ordinal } from "@util";
+import { OneToTen, ZeroToTen } from "@module/data";
+import { ErrorPF2e, groupBy, ordinal } from "@util";
 import { SpellcastingEntryPF2e } from ".";
-import { SlotKey } from "./data";
+import { ActiveSpell, SlotKey, SpellcastingSlotLevel, SpellPrepEntry } from "./data";
 
 export class SpellCollection extends Collection<Embedded<SpellPF2e>> {
-    constructor(private entry: Embedded<SpellcastingEntryPF2e>) {
+    constructor(public entry: Embedded<SpellcastingEntryPF2e>) {
         super();
     }
 
@@ -14,6 +15,10 @@ export class SpellCollection extends Collection<Embedded<SpellPF2e>> {
 
     get actor() {
         return this.entry.actor;
+    }
+
+    get highestLevel(): number {
+        return Math.max(...this.map((s) => s.level)) ?? 1;
     }
 
     /**
@@ -124,5 +129,167 @@ export class SpellCollection extends Collection<Embedded<SpellPF2e>> {
     setSlotExpendedState(slotLevel: number, spellSlot: number, isExpended: boolean): Promise<SpellcastingEntryPF2e> {
         const key = `system.slots.slot${slotLevel}.prepared.${spellSlot}.expended`;
         return this.entry.update({ [key]: isExpended });
+    }
+
+    async getSpellData() {
+        const { actor } = this.entry;
+        if (!actor.isOfType("character", "npc")) {
+            throw ErrorPF2e("Spellcasting entries can only exist on characters and npcs");
+        }
+
+        const results: SpellcastingSlotLevel[] = [];
+        const spells = this.contents.sort((s1, s2) => (s1.sort || 0) - (s2.sort || 0));
+        const signatureSpells = spells.filter((s) => s.system.location.signature);
+
+        const isFlexible = this.entry.isFlexible;
+
+        if (this.entry.isPrepared) {
+            // Prepared Spells. Active spells are what's been prepped.
+            for (let level = 0; level <= this.highestLevel; level++) {
+                const data = this.entry.system.slots[`slot${level}` as SlotKey];
+
+                // Detect which spells are active. If flexible, it will be set later via signature spells
+                const active: (ActiveSpell | null)[] = [];
+                const showLevel = this.entry.system.showSlotlessLevels.value || data.max > 0;
+                if (showLevel && (level === 0 || !isFlexible)) {
+                    const maxPrepared = Math.max(data.max, 0);
+                    active.push(...Array(maxPrepared).fill(null));
+                    for (const [key, value] of Object.entries(data.prepared)) {
+                        const spell = value.id ? this.get(value.id) : null;
+                        if (spell) {
+                            active[Number(key)] = {
+                                spell,
+                                chatData: await spell.getChatData(),
+                                expended: !!value.expended,
+                            };
+                        }
+                    }
+                }
+
+                results.push({
+                    label: level === 0 ? "PF2E.TraitCantrip" : CONFIG.PF2E.spellLevels[level as OneToTen],
+                    level: level as ZeroToTen,
+                    uses: {
+                        value: level > 0 && isFlexible ? data.value || 0 : undefined,
+                        max: data.max,
+                    },
+                    isCantrip: level === 0,
+                    active,
+                });
+            }
+        } else if (this.entry.isFocusPool) {
+            // Focus Spells. All non-cantrips are grouped together as they're auto-scaled
+            const cantrips = spells.filter((spell) => spell.isCantrip);
+            const leveled = spells.filter((spell) => !spell.isCantrip);
+
+            if (cantrips.length) {
+                const active = await Promise.all(
+                    cantrips.map(async (spell) => ({ spell, chatData: await spell.getChatData() }))
+                );
+                results.push({
+                    label: "PF2E.Actor.Creature.Spellcasting.Cantrips",
+                    level: 0,
+                    isCantrip: true,
+                    active,
+                });
+            }
+
+            if (leveled.length) {
+                const active = await Promise.all(
+                    leveled.map(async (spell) => ({ spell, chatData: await spell.getChatData() }))
+                );
+                results.push({
+                    label: actor.isOfType("character") ? "PF2E.Focus.Spells" : "PF2E.Focus.Pool",
+                    level: Math.max(1, Math.ceil(actor.level / 2)) as OneToTen,
+                    isCantrip: false,
+                    uses: actor.system.resources.focus ?? { value: 0, max: 0 },
+                    active,
+                });
+            }
+        } else {
+            // Everything else (Innate/Spontaneous/Ritual)
+            const alwaysShowHeader = !this.entry.isRitual;
+            const spellsByLevel = groupBy(spells, (spell) => (spell.isCantrip ? 0 : spell.level));
+            for (let level = 0; level <= this.highestLevel; level++) {
+                const data = this.entry.system.slots[`slot${level}` as SlotKey];
+                const spells = spellsByLevel.get(level) ?? [];
+                if (alwaysShowHeader || spells.length) {
+                    const uses =
+                        this.entry.isSpontaneous && level !== 0 ? { value: data.value, max: data.max } : undefined;
+                    const active = await Promise.all(
+                        spells.map(async (spell) => ({
+                            spell,
+                            chatData: await spell.getChatData(),
+                            expended: this.entry.isInnate && !spell.system.location.uses?.value,
+                            uses: this.entry.isInnate && !spell.unlimited ? spell.system.location.uses : undefined,
+                        }))
+                    );
+
+                    // These entries hide if there are no active spells at that level, or if there are no spell slots
+                    const hideForSpontaneous = this.entry.isSpontaneous && uses?.max === 0 && active.length === 0;
+                    const hideForInnate = this.entry.isInnate && active.length === 0;
+                    if (!this.entry.system.showSlotlessLevels.value && (hideForSpontaneous || hideForInnate)) continue;
+
+                    results.push({
+                        label: level === 0 ? "PF2E.TraitCantrip" : CONFIG.PF2E.spellLevels[level as OneToTen],
+                        level: level as ZeroToTen,
+                        isCantrip: level === 0,
+                        uses,
+                        active,
+                    });
+                }
+            }
+        }
+
+        // Handle signature spells, we need to add signature spells to each spell level
+        if (this.entry.isSpontaneous || isFlexible) {
+            for (const spell of signatureSpells) {
+                for (const result of results) {
+                    if (spell.baseLevel > result.level) continue;
+                    if (!this.entry.system.showSlotlessLevels.value && result.uses?.max === 0) continue;
+
+                    const existing = result.active.find((a) => a?.spell.id === spell.id);
+                    if (existing) {
+                        existing.signature = true;
+                    } else {
+                        const chatData = await spell.getChatData({}, { castLevel: result.level });
+                        result.active.push({ spell, chatData, signature: true, virtual: true });
+                    }
+                }
+            }
+        }
+
+        // If flexible, the limit is the number of slots, we need to notify the user
+        const flexibleAvailable = (() => {
+            if (!isFlexible) return undefined;
+            const totalSlots = results
+                .filter((result) => !result.isCantrip)
+                .map((level) => level.uses?.max || 0)
+                .reduce((first, second) => first + second, 0);
+            return { value: signatureSpells.length, max: totalSlots };
+        })();
+
+        return {
+            levels: results,
+            flexibleAvailable,
+            spellPrepList: this.getSpellPrepList(spells),
+        };
+    }
+
+    private getSpellPrepList(spells: Embedded<SpellPF2e>[]) {
+        if (!this.entry.isPrepared) return {};
+
+        const spellPrepList: Record<number, SpellPrepEntry[]> = {};
+        const spellsByLevel = groupBy(spells, (spell) => (spell.isCantrip ? 0 : spell.baseLevel));
+        for (let level = 0; level <= this.highestLevel; level++) {
+            // Build the prep list
+            spellPrepList[level] =
+                spellsByLevel.get(level as ZeroToTen)?.map((spell) => ({
+                    spell,
+                    signature: this.entry.isFlexible && spell.system.location.signature,
+                })) ?? [];
+        }
+
+        return Object.values(spellPrepList).some((s) => !!s.length) ? spellPrepList : null;
     }
 }

--- a/src/module/item/spellcasting-entry/data/sheet.ts
+++ b/src/module/item/spellcasting-entry/data/sheet.ts
@@ -4,15 +4,10 @@ import { ZeroToTen } from "@module/data";
 import { StatisticChatData } from "@system/statistic";
 import { PreparationType } from ".";
 
-/** Final render data used for showing a spell list  */
-export interface SpellListData {
+/** Final render data used for showing a spellcasting ability  */
+export interface SpellcastingAbilityData {
     id: string;
     name: string;
-    levels: SpellcastingSlotLevel[];
-}
-
-/** Spell list render data for a SpellcastingEntryPF2e */
-export interface SpellcastingEntryListData extends SpellListData {
     statistic: StatisticChatData;
     tradition: MagicTradition;
     castingType: PreparationType;
@@ -22,7 +17,13 @@ export interface SpellcastingEntryListData extends SpellListData {
     isInnate?: boolean;
     isFocusPool?: boolean;
     isRitual?: boolean;
+    hasCollection: boolean;
+}
+
+/** Spell list render data for a SpellcastingEntryPF2e */
+export interface SpellcastingEntryListData extends SpellcastingAbilityData {
     flexibleAvailable?: { value: number; max: number };
+    levels: SpellcastingSlotLevel[];
     spellPrepList: Record<number, SpellPrepEntry[]> | null;
 }
 

--- a/src/module/item/spellcasting-entry/index.ts
+++ b/src/module/item/spellcasting-entry/index.ts
@@ -3,23 +3,15 @@ import { AbilityString } from "@actor/types";
 import { ItemPF2e, SpellPF2e } from "@item";
 import { MagicTradition } from "@item/spell/types";
 import { MAGIC_TRADITIONS } from "@item/spell/values";
-import { goesToEleven, OneToFour, OneToTen, ZeroToTen } from "@module/data";
+import { goesToEleven, OneToFour, OneToTen } from "@module/data";
 import { UserPF2e } from "@module/user";
 import { Statistic } from "@system/statistic";
-import { ErrorPF2e, groupBy } from "@util";
+import { ErrorPF2e } from "@util";
 import { SpellCollection } from "./collection";
-import {
-    ActiveSpell,
-    SlotKey,
-    SpellcastingEntry,
-    SpellcastingEntryData,
-    SpellcastingEntryListData,
-    SpellcastingSlotLevel,
-    SpellPrepEntry,
-} from "./data";
+import { SpellcastingAbilityData, SpellcastingEntry, SpellcastingEntryData, SpellcastingEntryListData } from "./data";
 
 class SpellcastingEntryPF2e extends ItemPF2e implements SpellcastingEntry {
-    spells!: SpellCollection;
+    spells!: SpellCollection | null;
 
     /** Spellcasting attack and dc data created during actor preparation */
     statistic!: Statistic;
@@ -78,9 +70,8 @@ class SpellcastingEntryPF2e extends ItemPF2e implements SpellcastingEntry {
     }
 
     get highestLevel(): number {
-        const highestSpell = Math.max(...this.spells.map((s) => s.level));
         const actorSpellLevel = Math.ceil((this.actor?.level ?? 0) / 2);
-        return Math.min(10, Math.max(highestSpell, actorSpellLevel));
+        return Math.min(10, Math.max(this.spells?.highestLevel ?? 1, actorSpellLevel));
     }
 
     override prepareBaseData(): void {
@@ -162,7 +153,7 @@ class SpellcastingEntryPF2e extends ItemPF2e implements SpellcastingEntry {
 
         const levelLabel = game.i18n.localize(CONFIG.PF2E.spellLevels[level as OneToTen]);
         const slotKey = goesToEleven(level) ? (`slot${level}` as const) : "slot0";
-        if (this.system.slots === null) {
+        if (this.system.slots === null || !this.spells) {
             return false;
         }
 
@@ -216,159 +207,33 @@ class SpellcastingEntryPF2e extends ItemPF2e implements SpellcastingEntry {
      * or creating a new spell if its not.
      */
     async addSpell(spell: SpellPF2e, options?: { slotLevel?: number }): Promise<SpellPF2e | null> {
-        return this.spells.addSpell(spell, options);
+        return this.spells?.addSpell(spell, options) ?? null;
     }
 
     /** Saves the prepared spell slot data to the spellcasting entry  */
-    async prepareSpell(spell: SpellPF2e, slotLevel: number, spellSlot: number): Promise<SpellcastingEntryPF2e> {
-        return this.spells.prepareSpell(spell, slotLevel, spellSlot);
+    async prepareSpell(spell: SpellPF2e, slotLevel: number, spellSlot: number): Promise<SpellcastingEntryPF2e | null> {
+        return this.spells?.prepareSpell(spell, slotLevel, spellSlot) ?? null;
     }
 
     /** Removes the spell slot and updates the spellcasting entry */
-    unprepareSpell(spellLevel: number, slotLevel: number): Promise<SpellcastingEntryPF2e> {
-        return this.spells.unprepareSpell(spellLevel, slotLevel);
+    async unprepareSpell(spellLevel: number, slotLevel: number): Promise<SpellcastingEntryPF2e | null> {
+        return this.spells?.unprepareSpell(spellLevel, slotLevel) ?? null;
     }
 
     /** Sets the expended state of a spell slot and updates the spellcasting entry */
-    setSlotExpendedState(slotLevel: number, spellSlot: number, isExpended: boolean): Promise<SpellcastingEntryPF2e> {
-        return this.spells.setSlotExpendedState(slotLevel, spellSlot, isExpended);
+    async setSlotExpendedState(
+        slotLevel: number,
+        spellSlot: number,
+        isExpended: boolean
+    ): Promise<SpellcastingEntryPF2e | null> {
+        return this.spells?.setSlotExpendedState(slotLevel, spellSlot, isExpended) ?? null;
     }
 
     /** Returns rendering data to display the spellcasting entry in the sheet */
-    async getSpellData(): Promise<SpellcastingEntryListData> {
-        const { actor } = this;
-        if (!(actor instanceof CharacterPF2e || actor instanceof NPCPF2e)) {
+    async getSpellData(): Promise<SpellcastingAbilityData | SpellcastingEntryListData> {
+        if (!this.actor?.isOfType("character", "npc")) {
             throw ErrorPF2e("Spellcasting entries can only exist on characters and npcs");
         }
-
-        const results: SpellcastingSlotLevel[] = [];
-        const spells = this.spells.contents.sort((s1, s2) => (s1.sort || 0) - (s2.sort || 0));
-        const signatureSpells = spells.filter((s) => s.system.location.signature);
-
-        if (this.isPrepared) {
-            // Prepared Spells. Active spells are what's been prepped.
-            for (let level = 0; level <= this.highestLevel; level++) {
-                const data = this.system.slots[`slot${level}` as SlotKey];
-
-                // Detect which spells are active. If flexible, it will be set later via signature spells
-                const active: (ActiveSpell | null)[] = [];
-                const showLevel = this.system.showSlotlessLevels.value || data.max > 0;
-                if (showLevel && (level === 0 || !this.isFlexible)) {
-                    const maxPrepared = Math.max(data.max, 0);
-                    active.push(...Array(maxPrepared).fill(null));
-                    for (const [key, value] of Object.entries(data.prepared)) {
-                        const spell = value.id ? this.spells.get(value.id) : null;
-                        if (spell) {
-                            active[Number(key)] = {
-                                spell,
-                                chatData: await spell.getChatData(),
-                                expended: !!value.expended,
-                            };
-                        }
-                    }
-                }
-
-                results.push({
-                    label: level === 0 ? "PF2E.TraitCantrip" : CONFIG.PF2E.spellLevels[level as OneToTen],
-                    level: level as ZeroToTen,
-                    uses: {
-                        value: level > 0 && this.isFlexible ? data.value || 0 : undefined,
-                        max: data.max,
-                    },
-                    isCantrip: level === 0,
-                    active,
-                });
-            }
-        } else if (this.isFocusPool) {
-            // Focus Spells. All non-cantrips are grouped together as they're auto-scaled
-            const cantrips = spells.filter((spell) => spell.isCantrip);
-            const leveled = spells.filter((spell) => !spell.isCantrip);
-
-            if (cantrips.length) {
-                const active = await Promise.all(
-                    cantrips.map(async (spell) => ({ spell, chatData: await spell.getChatData() }))
-                );
-                results.push({
-                    label: "PF2E.Actor.Creature.Spellcasting.Cantrips",
-                    level: 0,
-                    isCantrip: true,
-                    active,
-                });
-            }
-
-            if (leveled.length) {
-                const active = await Promise.all(
-                    leveled.map(async (spell) => ({ spell, chatData: await spell.getChatData() }))
-                );
-                results.push({
-                    label: actor.isOfType("character") ? "PF2E.Focus.Spells" : "PF2E.Focus.Pool",
-                    level: Math.max(1, Math.ceil(actor.level / 2)) as OneToTen,
-                    isCantrip: false,
-                    uses: actor.system.resources.focus ?? { value: 0, max: 0 },
-                    active,
-                });
-            }
-        } else {
-            // Everything else (Innate/Spontaneous/Ritual)
-            const alwaysShowHeader = !this.isRitual;
-            const spellsByLevel = groupBy(spells, (spell) => (spell.isCantrip ? 0 : spell.level));
-            for (let level = 0; level <= this.highestLevel; level++) {
-                const data = this.system.slots[`slot${level}` as SlotKey];
-                const spells = spellsByLevel.get(level) ?? [];
-                if (alwaysShowHeader || spells.length) {
-                    const uses = this.isSpontaneous && level !== 0 ? { value: data.value, max: data.max } : undefined;
-                    const active = await Promise.all(
-                        spells.map(async (spell) => ({
-                            spell,
-                            chatData: await spell.getChatData(),
-                            expended: this.isInnate && !spell.system.location.uses?.value,
-                            uses: this.isInnate && !spell.unlimited ? spell.system.location.uses : undefined,
-                        }))
-                    );
-
-                    // These entries hide if there are no active spells at that level, or if there are no spell slots
-                    const hideForSpontaneous = this.isSpontaneous && uses?.max === 0 && active.length === 0;
-                    const hideForInnate = this.isInnate && active.length === 0;
-                    if (!this.system.showSlotlessLevels.value && (hideForSpontaneous || hideForInnate)) continue;
-
-                    results.push({
-                        label: level === 0 ? "PF2E.TraitCantrip" : CONFIG.PF2E.spellLevels[level as OneToTen],
-                        level: level as ZeroToTen,
-                        isCantrip: level === 0,
-                        uses,
-                        active,
-                    });
-                }
-            }
-        }
-
-        // Handle signature spells, we need to add signature spells to each spell level
-        if (this.isSpontaneous || this.isFlexible) {
-            for (const spell of signatureSpells) {
-                for (const result of results) {
-                    if (spell.baseLevel > result.level) continue;
-                    if (!this.system.showSlotlessLevels.value && result.uses?.max === 0) continue;
-
-                    const existing = result.active.find((a) => a?.spell.id === spell.id);
-                    if (existing) {
-                        existing.signature = true;
-                    } else {
-                        const chatData = await spell.getChatData({}, { castLevel: result.level });
-                        result.active.push({ spell, chatData, signature: true, virtual: true });
-                    }
-                }
-            }
-        }
-
-        // If flexible, the limit is the number of slots, we need to notify the user
-        const flexibleAvailable = (() => {
-            if (!this.isFlexible) return undefined;
-            const totalSlots = results
-                .filter((result) => !result.isCantrip)
-                .map((level) => level.uses?.max || 0)
-                .reduce((first, second) => first + second, 0);
-            return { value: signatureSpells.length, max: totalSlots };
-        })();
 
         return {
             id: this.id,
@@ -382,27 +247,9 @@ class SpellcastingEntryPF2e extends ItemPF2e implements SpellcastingEntry {
             isInnate: this.isInnate,
             isFocusPool: this.isFocusPool,
             isRitual: this.isRitual,
-            flexibleAvailable,
-            levels: results,
-            spellPrepList: this.getSpellPrepList(spells),
+            hasCollection: !!this.spells,
+            ...(await this.spells?.getSpellData()),
         };
-    }
-
-    private getSpellPrepList(spells: Embedded<SpellPF2e>[]) {
-        if (!this.isPrepared) return {};
-
-        const spellPrepList: Record<number, SpellPrepEntry[]> = {};
-        const spellsByLevel = groupBy(spells, (spell) => (spell.isCantrip ? 0 : spell.baseLevel));
-        for (let level = 0; level <= this.highestLevel; level++) {
-            // Build the prep list
-            spellPrepList[level] =
-                spellsByLevel.get(level as ZeroToTen)?.map((spell) => ({
-                    spell,
-                    signature: this.isFlexible && spell.system.location.signature,
-                })) ?? [];
-        }
-
-        return Object.values(spellPrepList).some((s) => !!s.length) ? spellPrepList : null;
     }
 
     override getRollOptions(prefix = this.type): string[] {

--- a/static/templates/actors/character/tabs/spellcasting.html
+++ b/static/templates/actors/character/tabs/spellcasting.html
@@ -1,7 +1,7 @@
 <div class="tab spellcasting spellbook-pane" data-group="primary" data-tab="spellcasting">
     <ol class="spellcastingEntry-list directory-list">
         {{#each spellcastingEntries as |entry eid|}}
-            <li class="item item-container spellcasting-entry" data-container-type="spellcastingEntry" data-item-id="{{entry.id}}" data-container-id="{{entry.id}}">
+            <li class="item item-container spellcasting-entry" data-item-id="{{entry.id}}" {{#if entry.hasCollection}}data-container-type="spellcastingEntry" data-container-id="{{entry.id}}"{{/if}}>
                 <div class="action-header">
                     <a class="drag-handle"><i class="fas fa-bars"></i></a>
 
@@ -63,8 +63,9 @@
                         </li>
                     </ol>
                 {{/unless}}
-
-                {{> "systems/pf2e/templates/actors/spellcasting-spell-list.html" entry=entry}}
+                {{#if entry.hasCollection}}
+                    {{> "systems/pf2e/templates/actors/spellcasting-spell-list.html" entry=entry}}
+                {{/if}}
             </li>
         {{/each}}
 

--- a/static/templates/actors/npc/tabs/spells.html
+++ b/static/templates/actors/npc/tabs/spells.html
@@ -1,7 +1,7 @@
 <div class="tab spells" data-group="primary" data-tab="spells">
     <ol class="entries-list">
         {{#each spellcastingEntries as |entry eid|}}
-            <li class="spellcasting-entry item item-container" data-container-type="spellcastingEntry" data-item-id="{{entry.id}}" data-container-id="{{entry.id}}">
+            <li class="spellcasting-entry item item-container" data-item-id="{{entry.id}}" {{#if entry.hasCollection}}data-container-type="spellcastingEntry" data-container-id="{{entry.id}}"{{/if}}>
                 <div class="header">
                     <a class="drag-handle"><i class="fas fa-bars"></i></a>
                     {{#if entry.isPrepared}}
@@ -56,9 +56,11 @@
                         </div>
                     {{/if}}
                 </div>
-                <div class="body">
-                    {{> systems/pf2e/templates/actors/spellcasting-spell-list.html entry=entry}}
-                </div>
+                {{#if entry.hasCollection}}
+                    <div class="body">
+                        {{> systems/pf2e/templates/actors/spellcasting-spell-list.html entry=entry}}
+                    </div>
+                {{/if}}
             </li>
 
         {{/each}}


### PR DESCRIPTION
Everything should still work the same since nothing actually sets the spell collection to null currently. The structure of the result of getSpellData() is starting to get creaky at the seams, but I'd rather not break compatibility with TAH for no good reason.