### PR TITLE
Fix display of class features in the class item sheet details tab

### DIFF
--- a/static/templates/items/class-details.html
+++ b/static/templates/items/class-details.html
@@ -261,6 +261,12 @@
     </ul>
 </div>
 
+<div class="form-group-stacked item-ref-group" data-valid-drops="classfeature">
+    <label for="data.traits">{{localize "PF2E.ClassFeatures"}}</label>
+    {{#> abcItems}}{{/abcItems}}
+    {{#unless data.items}}{{localize PF2E.DragDropFeats}}{{/unless}}
+</div>
+
 {{~#*inline "abcItem"~}}
     <li data-pack-id="{{item.pack}}" data-index="{{i}}" data-item-uuid="{{item.uuid}}">
         <img src="{{item.img}}">
@@ -279,14 +285,8 @@
 
 {{~#*inline "abcItems"~}}
 <ul class="item-refs">
-    {{#each items}}
+    {{#each features}}
         {{#> abcItem item=this.item i=this.key}}{{@partial-block}}{{/abcItem}}
     {{/each}}
 </ul>
 {{~/inline~}}
-
-<div class="form-group-stacked item-ref-group" data-valid-drops="classfeature">
-    <label for="data.traits">{{localize "PF2E.ClassFeatures"}}</label>
-    {{#> abcItems}}{{/abcItems}}
-    {{#unless data.items}}{{localize PF2E.DragDropFeats}}{{/unless}}
-</div>


### PR DESCRIPTION
I've also moved the class feature block before the inline template declarations.

![image](https://user-images.githubusercontent.com/41452412/190381205-20eb06f6-d786-46a9-a630-40af4daf0a67.png)
