### PR TITLE
Ensure statistic check/dc always exists + other misc changes

### DIFF
--- a/src/module/actor/character/index.ts
+++ b/src/module/actor/character/index.ts
@@ -948,11 +948,10 @@ class CharacterPF2e extends CreaturePF2e {
                 check: {
                     type: "saving-throw",
                 },
-                dc: {},
             });
 
             saves[saveType] = stat;
-            this.system.saves[saveType] = mergeObject(this.system.saves[saveType], stat.getCompatData());
+            this.system.saves[saveType] = mergeObject(this.system.saves[saveType], stat.getTraceData());
         }
 
         this.saves = saves as Record<SaveType, Statistic>;

--- a/src/module/actor/creature/data.ts
+++ b/src/module/actor/creature/data.ts
@@ -18,7 +18,7 @@ import type { CREATURE_ACTOR_TYPES } from "@actor/values";
 import { LabeledNumber, Size, ValueAndMax, ValuesList, ZeroToThree, ZeroToTwo } from "@module/data";
 import { CombatantPF2e } from "@module/encounter";
 import { RollDataPF2e, RollParameters } from "@system/rolls";
-import { Statistic, StatisticCompatData } from "@system/statistic";
+import { Statistic, StatisticTraceData } from "@system/statistic";
 import type { CreaturePF2e } from ".";
 import { CreatureSensePF2e, SenseAcuity, SenseType } from "./sense";
 import { Alignment, AlignmentTrait } from "./types";
@@ -129,7 +129,7 @@ interface CreatureTraitsData extends BaseTraitsData<CreatureTrait>, Omit<Creatur
 type SkillData = StatisticModifier & AbilityBasedStatistic & Rollable;
 
 /** The full save data for a character; including its modifiers and other details */
-type SaveData = StatisticCompatData & AbilityBasedStatistic & { saveDetail?: string };
+type SaveData = StatisticTraceData & AbilityBasedStatistic & { saveDetail?: string };
 
 type CreatureSaves = Record<SaveType, SaveData>;
 

--- a/src/module/actor/creature/index.ts
+++ b/src/module/actor/creature/index.ts
@@ -76,8 +76,7 @@ export abstract class CreaturePF2e extends ActorPF2e {
                 label: skillName,
                 proficient: skill.visible,
                 domains,
-                check: { adjustments: skill.adjustments, type: "skill-check" },
-                dc: {},
+                check: { type: "skill-check" },
                 modifiers: [...skill.modifiers],
             });
 

--- a/src/module/actor/familiar/index.ts
+++ b/src/module/actor/familiar/index.ts
@@ -179,14 +179,13 @@ export class FamiliarPF2e extends CreaturePF2e {
                 check: {
                     type: "saving-throw",
                 },
-                dc: {},
             });
 
             return { ...partialSaves, [saveType]: stat };
         }, {} as Record<SaveType, Statistic>);
 
         this.system.saves = SAVE_TYPES.reduce(
-            (partial, saveType) => ({ ...partial, [saveType]: this.saves[saveType].getCompatData() }),
+            (partial, saveType) => ({ ...partial, [saveType]: this.saves[saveType].getTraceData() }),
             {} as CreatureSaves
         );
 

--- a/src/module/actor/hazard/index.ts
+++ b/src/module/actor/hazard/index.ts
@@ -96,10 +96,9 @@ export class HazardPF2e extends ActorPF2e {
                 check: {
                     type: "saving-throw",
                 },
-                dc: {},
             });
 
-            mergeObject(this.system.saves[saveType], stat.getCompatData());
+            mergeObject(this.system.saves[saveType], stat.getTraceData());
 
             saves[saveType] = stat;
             return saves;

--- a/src/module/actor/npc/index.ts
+++ b/src/module/actor/npc/index.ts
@@ -798,11 +798,10 @@ class NPCPF2e extends CreaturePF2e {
                 check: {
                     type: "saving-throw",
                 },
-                dc: {},
             });
 
             saves[saveType] = stat;
-            mergeObject(this.system.saves[saveType], stat.getCompatData());
+            mergeObject(this.system.saves[saveType], stat.getTraceData());
             systemData.saves[saveType].base = base;
         }
 

--- a/src/module/actor/vehicle/data.ts
+++ b/src/module/actor/vehicle/data.ts
@@ -7,7 +7,7 @@ import {
     BaseTraitsData,
 } from "@actor/data/base";
 import { ActorSizePF2e } from "@actor/data/size";
-import { StatisticCompatData } from "@system/statistic";
+import { StatisticTraceData } from "@system/statistic";
 import { VehiclePF2e } from ".";
 import { VehicleTrait } from "./types";
 
@@ -60,7 +60,7 @@ interface VehicleSystemData extends ActorSystemData {
     traits: VehicleTraitsData;
 }
 
-interface VehicleFortitudeSaveData extends StatisticCompatData {
+interface VehicleFortitudeSaveData extends StatisticTraceData {
     saveDetail: string;
 }
 

--- a/src/module/actor/vehicle/index.ts
+++ b/src/module/actor/vehicle/index.ts
@@ -58,7 +58,7 @@ export class VehiclePF2e extends ActorPF2e {
         super.prepareDerivedData();
 
         this.saves = this.prepareSaves();
-        this.system.saves.fortitude = mergeObject(this.system.saves.fortitude, this.saves.fortitude.getCompatData());
+        this.system.saves.fortitude = mergeObject(this.system.saves.fortitude, this.saves.fortitude.getTraceData());
     }
 
     private prepareSaves(): { fortitude: Statistic } {
@@ -83,7 +83,6 @@ export class VehiclePF2e extends ActorPF2e {
             check: {
                 type: "saving-throw",
             },
-            dc: {},
         });
 
         return { fortitude };

--- a/src/module/system/action-macros/types.ts
+++ b/src/module/system/action-macros/types.ts
@@ -6,7 +6,7 @@ import { TokenDocumentPF2e } from "@scene";
 import { CheckRoll } from "@system/check/roll";
 import { CheckDC, DegreeOfSuccessString } from "@system/degree-of-success";
 import { CheckType } from "@system/rolls";
-import { Statistic, StatisticDataWithDC } from "@system/statistic";
+import { Statistic } from "@system/statistic";
 
 type ActionGlyph = "A" | "D" | "T" | "R" | "F" | "a" | "d" | "t" | "r" | "f" | 1 | 2 | 3 | "1" | "2" | "3";
 
@@ -31,7 +31,7 @@ interface SimpleRollActionCheckOptions {
     checkType: CheckType;
     event: JQuery.TriggeredEvent;
     difficultyClass?: CheckDC;
-    difficultyClassStatistic?: (creature: CreaturePF2e) => Statistic<StatisticDataWithDC>;
+    difficultyClassStatistic?: (creature: CreaturePF2e) => Statistic;
     extraNotes?: (selector: string) => RollNotePF2e[];
     callback?: (result: CheckResultCallback) => void;
     createMessage?: boolean;

--- a/src/module/system/statistic/data.ts
+++ b/src/module/system/statistic/data.ts
@@ -21,7 +21,7 @@ export interface StatisticDifficultyClassData {
 /**
  * The base type for statistic data, which is used to build the actual statistic object.
  */
-export interface BaseStatisticData {
+export interface StatisticData {
     /** An identifier such as "reflex" or "ac" or "deception" */
     slug: string;
     ability?: AbilityString;
@@ -41,34 +41,27 @@ export interface BaseStatisticData {
     rollOptions?: string[];
 }
 
-export type StatisticDataWithCheck = BaseStatisticData & { check: StatisticCheckData };
-export type StatisticDataWithDC = BaseStatisticData & { dc: StatisticDifficultyClassData };
-/** The complete form of statistic data, able to do used to build a statistic for anything */
-export type StatisticData = StatisticDataWithCheck & StatisticDataWithDC;
-
 /** Defines view data for chat message and sheet rendering */
-export interface StatisticChatData<T extends BaseStatisticData = StatisticData> {
-    name: string;
-    check: T["check"] extends object
-        ? {
-              label: string;
-              mod: number;
-              breakdown: string;
-              map1: number;
-              map2: number;
-          }
-        : undefined;
-    dc: T["dc"] extends object
-        ? {
-              value: number;
-              breakdown: string;
-          }
-        : undefined;
+export interface StatisticChatData {
+    slug: string;
+    label: string;
+    check: {
+        label: string;
+        mod: number;
+        breakdown: string;
+        map1: number;
+        map2: number;
+    };
+    dc: {
+        value: number;
+        breakdown: string;
+    };
 }
 
-export interface StatisticCompatData {
+/** Data intended to be merged back into actor data (usually for token attribute/RE purposes) */
+export interface StatisticTraceData {
     slug: string;
-    name: string;
+    label: string;
     totalModifier: number;
     value: number;
     breakdown: string;


### PR DESCRIPTION
This makes it so that statistic.check and statistic.dc always returns a value. After this, we can no longer have dc only and check only statistics. 

Also renames compat data to trace data and changes slug/name to match changes to StatisticModifier. 