### PR TITLE
Fix Blaze effect

### DIFF
--- a/packs/data/equipment-effects.db/effect-blaze.json
+++ b/packs/data/equipment-effects.db/effect-blaze.json
@@ -20,7 +20,7 @@
             {
                 "key": "FlatModifier",
                 "predicate": {
-                    "not": [
+                    "all": [
                         "fire"
                     ]
                 },


### PR DESCRIPTION
Fixed Blaze effect by replacing "not" with "all", in the predicate.