### PR TITLE
Extract notes in statistic rather than passing it in

### DIFF
--- a/src/module/actor/character/index.ts
+++ b/src/module/actor/character/index.ts
@@ -756,7 +756,6 @@ class CharacterPF2e extends CreaturePF2e {
                 ability: entry.ability,
                 rank,
                 modifiers: extractModifiers(synthetics, baseSelectors),
-                notes: extractNotes(rollNotes, [...baseSelectors, ...attackSelectors]),
                 domains: baseSelectors,
                 rollOptions: entry.getRollOptions("spellcasting"),
                 check: {
@@ -911,7 +910,6 @@ class CharacterPF2e extends CreaturePF2e {
     private prepareSaves(): void {
         const systemData = this.system;
         const { wornArmor } = this;
-        const { rollNotes } = this.synthetics;
 
         // Saves
         const saves: Partial<Record<SaveType, Statistic>> = {};
@@ -959,7 +957,6 @@ class CharacterPF2e extends CreaturePF2e {
                 label: saveName,
                 ability: save.ability,
                 rank: save.rank,
-                notes: extractNotes(rollNotes, selectors),
                 modifiers,
                 domains: selectors,
                 check: {

--- a/src/module/actor/creature/index.ts
+++ b/src/module/actor/creature/index.ts
@@ -78,7 +78,6 @@ export abstract class CreaturePF2e extends ActorPF2e {
                 check: { adjustments: skill.adjustments, type: "skill-check" },
                 dc: {},
                 modifiers: [...skill.modifiers],
-                notes: skill.notes,
             });
 
             if (shortForm !== longForm) {

--- a/src/module/actor/hazard/index.ts
+++ b/src/module/actor/hazard/index.ts
@@ -4,7 +4,7 @@ import { SaveType } from "@actor/types";
 import { SAVE_TYPES } from "@actor/values";
 import { ItemType } from "@item/data";
 import { Rarity } from "@module/data";
-import { extractModifiers, extractNotes } from "@module/rules/util";
+import { extractModifiers } from "@module/rules/util";
 import { Statistic } from "@system/statistic";
 import { HazardData } from "./data";
 
@@ -72,7 +72,6 @@ export class HazardPF2e extends ActorPF2e {
 
     protected prepareSaves(): { [K in SaveType]?: Statistic } {
         const { system } = this;
-        const { rollNotes } = this.synthetics;
 
         // Saving Throws
         return SAVE_TYPES.reduce((saves: { [K in SaveType]?: Statistic }, saveType) => {
@@ -89,7 +88,6 @@ export class HazardPF2e extends ActorPF2e {
             const stat = new Statistic(this, {
                 slug: saveType,
                 label: saveName,
-                notes: extractNotes(rollNotes, selectors),
                 domains: selectors,
                 modifiers: [
                     new ModifierPF2e("PF2E.BaseModifier", base, MODIFIER_TYPE.UNTYPED),

--- a/src/module/actor/npc/index.ts
+++ b/src/module/actor/npc/index.ts
@@ -731,7 +731,6 @@ class NPCPF2e extends CreaturePF2e {
             entry.statistic = new Statistic(this, {
                 slug: sluggify(entry.name),
                 label: CONFIG.PF2E.magicTraditions[tradition],
-                notes: extractNotes(rollNotes, [...baseSelectors, ...attackSelectors]),
                 domains: baseSelectors,
                 rollOptions: entry.getRollOptions("spellcasting"),
                 check: {
@@ -762,7 +761,7 @@ class NPCPF2e extends CreaturePF2e {
 
     prepareSaves(): void {
         const systemData = this.system;
-        const { modifierAdjustments, rollNotes } = this.synthetics;
+        const { modifierAdjustments } = this.synthetics;
 
         // Saving Throws
         const saves: Partial<Record<SaveType, Statistic>> = {};
@@ -776,7 +775,6 @@ class NPCPF2e extends CreaturePF2e {
             const stat = new Statistic(this, {
                 slug: saveType,
                 label: saveName,
-                notes: extractNotes(rollNotes, domains),
                 domains: domains,
                 modifiers: [
                     new ModifierPF2e({

--- a/src/module/actor/vehicle/index.ts
+++ b/src/module/actor/vehicle/index.ts
@@ -1,7 +1,7 @@
 import { ModifierPF2e } from "@actor/modifiers";
 import { ActorDimensions } from "@actor/types";
 import { ItemType } from "@item/data";
-import { extractModifiers, extractNotes } from "@module/rules/util";
+import { extractModifiers } from "@module/rules/util";
 import { UserPF2e } from "@module/user";
 import { TokenDocumentPF2e } from "@scene";
 import { Statistic } from "@system/statistic";
@@ -78,7 +78,6 @@ export class VehiclePF2e extends ActorPF2e {
         const fortitude = new Statistic(this, {
             slug: "fortitude",
             label: CONFIG.PF2E.saves.fortitude,
-            notes: extractNotes(synthetics.rollNotes, domains),
             modifiers,
             domains,
             check: {

--- a/src/module/system/statistic/data.ts
+++ b/src/module/system/statistic/data.ts
@@ -1,7 +1,6 @@
 import { ModifierPF2e, RawModifier } from "@actor/modifiers";
 import { AbilityString } from "@actor/types";
 import { ZeroToFour } from "@module/data";
-import { RollNotePF2e } from "@module/notes";
 import { DegreeOfSuccessAdjustment } from "@system/degree-of-success";
 import { CheckType } from "@system/rolls";
 
@@ -23,8 +22,6 @@ export interface StatisticDifficultyClassData {
 
 /**
  * The base type for statistic data, which is used to build the actual statistic object.
- * In general, the statistic data should be available in document data, but the actual statistic object
- * does not have to be.
  */
 export interface BaseStatisticData {
     /** An identifier such as "reflex" or "ac" or "deception" */
@@ -37,7 +34,6 @@ export interface BaseStatisticData {
     check?: StatisticCheckData;
     dc?: StatisticDifficultyClassData;
     modifiers?: ModifierPF2e[];
-    notes?: RollNotePF2e[];
     /** Base domains for fetching actor roll options */
     domains?: string[];
     /**

--- a/src/module/system/statistic/index.ts
+++ b/src/module/system/statistic/index.ts
@@ -11,7 +11,7 @@ import {
 import { AbilityString } from "@actor/types";
 import { ItemPF2e } from "@item";
 import { ZeroToFour } from "@module/data";
-import { extractRollSubstitutions, extractRollTwice } from "@module/rules/util";
+import { extractNotes, extractRollSubstitutions, extractRollTwice } from "@module/rules/util";
 import { eventToRollParams } from "@scripts/sheet-util";
 import { CheckRoll } from "@system/check/roll";
 import { CheckDC } from "@system/degree-of-success";
@@ -133,7 +133,6 @@ export class Statistic<T extends BaseStatisticData = StatisticData> {
             check: { adjustments: stat.adjustments, type },
             dc: {},
             modifiers: [...stat.modifiers],
-            notes: stat.notes,
         });
     }
 
@@ -344,7 +343,7 @@ class StatisticCheck {
             domains,
             target: rollContext?.target ?? null,
             dc: args.dc ?? rollContext?.dc,
-            notes: data.notes,
+            notes: extractNotes(actor.synthetics.rollNotes, this.domains),
             options,
             type: data.check.type,
             secret,

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -2,7 +2,7 @@ import { ActorPF2e } from "@actor";
 import { SKILL_DICTIONARY, SKILL_EXPANDED } from "@actor/values";
 import { ItemPF2e } from "@item";
 import { ItemSystemData } from "@item/data/base";
-import { extractModifiers, extractNotes } from "@module/rules/util";
+import { extractModifiers } from "@module/rules/util";
 import { UserVisibility, UserVisibilityPF2e } from "@scripts/ui/user-visibility";
 import { objectHasKey, sluggify } from "@util";
 import { Statistic } from "./statistic";
@@ -341,12 +341,10 @@ function getCheckDC(
         const getStatisticValue = (selectors: string[]): string => {
             if (item?.isOwned && params.immutable !== "true") {
                 const actor = item.actor!;
-                const { rollNotes } = actor.synthetics;
 
                 const stat = new Statistic(actor, {
                     slug: type,
                     label: name,
-                    notes: extractNotes(rollNotes, selectors),
                     domains: selectors,
                     modifiers: [...extractModifiers(actor.synthetics, selectors)],
                     dc: {


### PR DESCRIPTION
If we ever need to add additional roll notes, that can be a roll() argument or we can bring back the argument and make it behave accordingly depending on the use case.