### PR TITLE
Move degree of success adjustments into synthetics

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -459,6 +459,7 @@ class ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
         this.synthetics = {
             criticalSpecalizations: { standard: [], alternate: [] },
             damageDice: { damage: [] },
+            degreeOfSuccessAdjustments: {},
             dexterityModifierCaps: [],
             modifierAdjustments: { all: [], damage: [] },
             movementTypes: {},

--- a/src/module/actor/character/index.ts
+++ b/src/module/actor/character/index.ts
@@ -61,6 +61,7 @@ import { ChatMessagePF2e } from "@module/chat-message";
 import { PROFICIENCY_RANKS, ZeroToFour, ZeroToThree } from "@module/data";
 import { RollNotePF2e } from "@module/notes";
 import {
+    extractDegreeOfSuccessAdjustments,
     extractModifierAdjustments,
     extractModifiers,
     extractNotes,
@@ -557,6 +558,7 @@ class CharacterPF2e extends CreaturePF2e {
                 systemData.attributes.perception,
                 { overwrite: false }
             );
+            stat.adjustments = extractDegreeOfSuccessAdjustments(synthetics, domains);
             stat.breakdown = stat.modifiers
                 .filter((m) => m.enabled)
                 .map((m) => `${m.label} ${m.modifier < 0 ? "" : "+"}${m.modifier}`)
@@ -1040,6 +1042,7 @@ class CharacterPF2e extends CreaturePF2e {
             const stat = mergeObject(new StatisticModifier(longForm, modifiers, this.getRollOptions(domains)), skill, {
                 overwrite: false,
             });
+            stat.adjustments = extractDegreeOfSuccessAdjustments(synthetics, domains);
             stat.breakdown = stat.modifiers
                 .filter((modifier) => modifier.enabled)
                 .map((modifier) => {
@@ -1124,6 +1127,7 @@ class CharacterPF2e extends CreaturePF2e {
                 loreSkill,
                 { overwrite: false }
             );
+            stat.adjustments = extractDegreeOfSuccessAdjustments(synthetics, domains);
             stat.label = loreItem.name;
             stat.ability = "int";
             stat.itemID = loreItem.id;
@@ -1614,6 +1618,7 @@ class CharacterPF2e extends CreaturePF2e {
         const rollOptions = [...this.getRollOptions(selectors), ...weaponRollOptions, ...weaponTraits, meleeOrRanged];
         const strikeStat = new StatisticModifier(weapon.name, modifiers, rollOptions);
         const altUsages = weapon.getAltUsages().map((w) => this.prepareStrike(w, { categories }));
+        strikeStat.adjustments = extractDegreeOfSuccessAdjustments(synthetics, selectors);
 
         const action: CharacterStrike = mergeObject(strikeStat, {
             imageUrl: weapon.img,

--- a/src/module/actor/familiar/index.ts
+++ b/src/module/actor/familiar/index.ts
@@ -4,7 +4,7 @@ import { ActorSizePF2e } from "@actor/data/size";
 import { applyStackingRules, CheckModifier, ModifierPF2e, MODIFIER_TYPE, StatisticModifier } from "@actor/modifiers";
 import { SaveType } from "@actor/types";
 import { SAVE_TYPES, SKILL_ABBREVIATIONS, SKILL_DICTIONARY, SKILL_EXPANDED } from "@actor/values";
-import { extractModifiers, extractRollTwice } from "@module/rules/util";
+import { extractDegreeOfSuccessAdjustments, extractModifiers, extractRollTwice } from "@module/rules/util";
 import { CheckRoll } from "@system/check/roll";
 import { CheckPF2e, RollParameters } from "@system/rolls";
 import { Statistic } from "@system/statistic";
@@ -167,7 +167,7 @@ export class FamiliarPF2e extends CreaturePF2e {
             const saveName = game.i18n.localize(CONFIG.PF2E.saves[saveType]);
             const source = save.modifiers.filter((modifier) => !["status", "circumstance"].includes(modifier.type));
             const totalMod = applyStackingRules(source);
-            const selectors = save.data.domains ?? [];
+            const selectors = [saveType, `${save.ability}-based`, "saving-throw", "all"];
             const stat = new Statistic(this, {
                 slug: saveType,
                 label: saveName,
@@ -195,15 +195,15 @@ export class FamiliarPF2e extends CreaturePF2e {
 
         // Attack
         {
-            const selectors = ["attack", "attack-roll", "all"];
+            const domains = ["attack", "attack-roll", "all"];
             const modifiers = [
                 new ModifierPF2e("PF2E.MasterLevel", masterLevel, MODIFIER_TYPE.UNTYPED),
-                ...extractModifiers(synthetics, selectors),
+                ...extractModifiers(synthetics, domains),
             ];
             const stat = mergeObject(new StatisticModifier("attack", modifiers), {
                 roll: async (params: RollParameters): Promise<Rolled<CheckRoll> | null> => {
                     const options = new Set(params.options ?? []);
-                    const rollTwice = extractRollTwice(this.synthetics.rollTwice, selectors, options);
+                    const rollTwice = extractRollTwice(this.synthetics.rollTwice, domains, options);
 
                     const roll = await CheckPF2e.roll(
                         new CheckModifier("Attack Roll", stat),
@@ -213,12 +213,13 @@ export class FamiliarPF2e extends CreaturePF2e {
                     );
 
                     for (const rule of this.rules.filter((r) => !r.ignored)) {
-                        await rule.afterRoll?.({ roll, selectors, domains: selectors, rollOptions: options });
+                        await rule.afterRoll?.({ roll, selectors: domains, domains, rollOptions: options });
                     }
 
                     return roll;
                 },
             });
+            stat.adjustments = extractDegreeOfSuccessAdjustments(synthetics, domains);
             stat.value = stat.totalModifier;
             stat.breakdown = stat.modifiers
                 .filter((m) => m.enabled)
@@ -229,7 +230,7 @@ export class FamiliarPF2e extends CreaturePF2e {
 
         // Perception
         {
-            const selectors = ["perception", "wis-based", "all"];
+            const domains = ["perception", "wis-based", "all"];
             const modifiers = [
                 new ModifierPF2e("PF2E.MasterLevel", masterLevel, MODIFIER_TYPE.UNTYPED),
                 new ModifierPF2e(
@@ -237,11 +238,12 @@ export class FamiliarPF2e extends CreaturePF2e {
                     spellcastingAbilityModifier,
                     MODIFIER_TYPE.UNTYPED
                 ),
-                ...extractModifiers(synthetics, selectors).filter(filterModifier),
+                ...extractModifiers(synthetics, domains).filter(filterModifier),
             ];
             const stat = mergeObject(new StatisticModifier("perception", modifiers), systemData.attributes.perception, {
                 overwrite: false,
             });
+            stat.adjustments = extractDegreeOfSuccessAdjustments(synthetics, domains);
             stat.value = stat.totalModifier;
             stat.breakdown = stat.modifiers
                 .filter((m) => m.enabled)
@@ -251,7 +253,7 @@ export class FamiliarPF2e extends CreaturePF2e {
             stat.roll = async (params: RollParameters): Promise<Rolled<CheckRoll> | null> => {
                 const label = game.i18n.localize("PF2E.PerceptionCheck");
                 const rollOptions = new Set(params.options ?? []);
-                const rollTwice = extractRollTwice(this.synthetics.rollTwice, selectors, rollOptions);
+                const rollTwice = extractRollTwice(this.synthetics.rollTwice, domains, rollOptions);
 
                 const roll = await CheckPF2e.roll(
                     new CheckModifier(label, stat),
@@ -261,7 +263,7 @@ export class FamiliarPF2e extends CreaturePF2e {
                 );
 
                 for (const rule of this.rules.filter((r) => !r.ignored)) {
-                    await rule.afterRoll?.({ roll, selectors, domains: selectors, rollOptions });
+                    await rule.afterRoll?.({ roll, selectors: domains, domains, rollOptions });
                 }
 
                 return roll;
@@ -283,11 +285,12 @@ export class FamiliarPF2e extends CreaturePF2e {
                 );
             }
             const ability = SKILL_EXPANDED[longForm].ability;
-            const selectors = [longForm, `${ability}-based`, "skill-check", "all"];
-            modifiers.push(...extractModifiers(synthetics, selectors).filter(filterModifier));
+            const domains = [longForm, `${ability}-based`, "skill-check", "all"];
+            modifiers.push(...extractModifiers(synthetics, domains).filter(filterModifier));
 
             const label = CONFIG.PF2E.skills[shortForm] ?? longForm;
             const stat = mergeObject(new StatisticModifier(longForm, modifiers), {
+                adjustments: extractDegreeOfSuccessAdjustments(synthetics, domains),
                 label,
                 ability,
                 value: 0,
@@ -296,7 +299,7 @@ export class FamiliarPF2e extends CreaturePF2e {
                         skillName: game.i18n.localize(CONFIG.PF2E.skills[shortForm]),
                     });
                     const rollOptions = new Set(params.options ?? []);
-                    const rollTwice = extractRollTwice(this.synthetics.rollTwice, selectors, rollOptions);
+                    const rollTwice = extractRollTwice(this.synthetics.rollTwice, domains, rollOptions);
 
                     const roll = await CheckPF2e.roll(
                         new CheckModifier(label, stat),
@@ -306,7 +309,7 @@ export class FamiliarPF2e extends CreaturePF2e {
                     );
 
                     for (const rule of this.rules.filter((r) => !r.ignored)) {
-                        await rule.afterRoll?.({ roll, selectors, domains: selectors, rollOptions });
+                        await rule.afterRoll?.({ roll, selectors: domains, domains, rollOptions });
                     }
 
                     return roll;

--- a/src/module/actor/npc/index.ts
+++ b/src/module/actor/npc/index.ts
@@ -9,7 +9,13 @@ import { SAVE_TYPES, SKILL_DICTIONARY, SKILL_EXPANDED, SKILL_LONG_FORMS } from "
 import { ItemPF2e, MeleePF2e } from "@item";
 import { ItemType } from "@item/data";
 import { RollNotePF2e } from "@module/notes";
-import { extractModifierAdjustments, extractModifiers, extractNotes, extractRollTwice } from "@module/rules/util";
+import {
+    extractDegreeOfSuccessAdjustments,
+    extractModifierAdjustments,
+    extractModifiers,
+    extractNotes,
+    extractRollTwice,
+} from "@module/rules/util";
 import { WeaponDamagePF2e } from "@module/system/damage";
 import { CheckPF2e, CheckRollContext, DamageRollPF2e } from "@module/system/rolls";
 import { CheckRoll } from "@system/check/roll";
@@ -273,6 +279,7 @@ class NPCPF2e extends CreaturePF2e {
                 system.attributes.perception,
                 { overwrite: false }
             );
+            stat.adjustments = extractDegreeOfSuccessAdjustments(synthetics, domains);
             stat.base = base;
             stat.notes = extractNotes(rollNotes, domains);
             stat.value = stat.totalModifier;
@@ -367,6 +374,7 @@ class NPCPF2e extends CreaturePF2e {
                 },
                 { overwrite: false }
             );
+            stat.adjustments = extractDegreeOfSuccessAdjustments(synthetics, domains);
             stat.value = stat.totalModifier;
             stat.breakdown = stat.modifiers
                 .filter((m) => m.enabled)
@@ -411,6 +419,7 @@ class NPCPF2e extends CreaturePF2e {
                     system.skills[shortform],
                     { overwrite: false }
                 );
+                stat.adjustments = extractDegreeOfSuccessAdjustments(synthetics, domains);
                 stat.notes = extractNotes(rollNotes, domains);
                 stat.itemID = item.id;
                 stat.base = base;
@@ -521,7 +530,7 @@ class NPCPF2e extends CreaturePF2e {
                 }
 
                 const statistic = new StatisticModifier(item.name, modifiers, baseOptions);
-
+                statistic.adjustments = extractDegreeOfSuccessAdjustments(synthetics, domains);
                 const traitObjects = Array.from(traits).map(
                     (t): TraitViewData => ({
                         name: t,

--- a/src/module/rules/synthetics.ts
+++ b/src/module/rules/synthetics.ts
@@ -6,14 +6,17 @@ import { MeleePF2e, WeaponPF2e } from "@item";
 import { ActionTrait } from "@item/action/data";
 import { WeaponMaterialEffect, WeaponPropertyRuneType } from "@item/weapon/types";
 import { RollNotePF2e } from "@module/notes";
+import { DegreeOfSuccessAdjustment } from "@system/degree-of-success";
 import { PredicatePF2e } from "@system/predication";
 
+/** Defines a list of data provided by rule elements that an actor can pull from during its data preparation lifecycle */
 interface RuleElementSynthetics {
     criticalSpecalizations: {
         standard: CritSpecSynthetic[];
         alternate: CritSpecSynthetic[];
     };
     damageDice: Record<string, DeferredDamageDice[]>;
+    degreeOfSuccessAdjustments: Record<string, DegreeOfSuccessAdjustment[]>;
     dexterityModifierCaps: DexterityModifierCapData[];
     modifierAdjustments: Record<string, ModifierAdjustment[]>;
     movementTypes: { [K in BaseSpeedType]?: DeferredMovementType[] };
@@ -29,7 +32,7 @@ interface RuleElementSynthetics {
     tokenOverrides: DeepPartial<Pick<foundry.data.TokenSource, "light" | "name" | "texture">>;
     weaponPotency: Record<string, PotencySynthetic[]>;
     preparationWarnings: {
-        /** Adds a new preparation warning to be printed when flushed */
+        /** Adds a new preparation warning to be printed when flushed. These warnings are de-duped. */
         add: (warning: string) => void;
         /** Prints all preparation warnings, but this printout is debounced to handle prep and off-prep cycles */
         flush: () => void;

--- a/src/module/rules/util.ts
+++ b/src/module/rules/util.ts
@@ -1,7 +1,8 @@
 import { DamageDicePF2e, DeferredValueParams, ModifierAdjustment, ModifierPF2e } from "@actor/modifiers";
 import { RollNotePF2e } from "@module/notes";
+import { DegreeOfSuccessAdjustment } from "@system/degree-of-success";
 import { RollTwiceOption } from "@system/rolls";
-import { isObject } from "@util";
+import { isObject, pick } from "@util";
 import { BracketedValue } from "./rule-element/data";
 import { DeferredDamageDice, RollSubstitution, RollTwiceSynthetic, RuleElementSynthetics } from "./synthetics";
 
@@ -68,12 +69,20 @@ function extractRollSubstitutions(
         .filter((s) => s.predicate?.test(rollOptions) ?? true);
 }
 
+function extractDegreeOfSuccessAdjustments(
+    synthetics: Pick<RuleElementSynthetics, "degreeOfSuccessAdjustments">,
+    selectors: string[]
+): DegreeOfSuccessAdjustment[] {
+    return Object.values(pick(synthetics.degreeOfSuccessAdjustments, selectors)).flat();
+}
+
 function isBracketedValue(value: unknown): value is BracketedValue {
     return isObject<{ brackets?: unknown }>(value) && Array.isArray(value.brackets);
 }
 
 export {
     extractDamageDice,
+    extractDegreeOfSuccessAdjustments,
     extractModifierAdjustments,
     extractModifiers,
     extractNotes,

--- a/src/module/system/statistic/data.ts
+++ b/src/module/system/statistic/data.ts
@@ -1,13 +1,11 @@
 import { ModifierPF2e, RawModifier } from "@actor/modifiers";
 import { AbilityString } from "@actor/types";
 import { ZeroToFour } from "@module/data";
-import { DegreeOfSuccessAdjustment } from "@system/degree-of-success";
 import { CheckType } from "@system/rolls";
 
 export interface StatisticCheckData {
     type: CheckType;
     label?: string;
-    adjustments?: DegreeOfSuccessAdjustment[];
     modifiers?: ModifierPF2e[];
     /** Additional domains for fetching actor roll options */
     domains?: string[];


### PR DESCRIPTION
Bonus: Statistic.data is now fully private.  I don't know if I caught all cases, but character saves adjust properly and those are the most important. Skills such as silvertongue mutagen work even with @xdy module, which is being extra naughty and using the deprecated StatisticModifier skill check functions. 

The "type" parameter in the AdjustDegreeOfSuccess rule element is no longer necessary (was it ever?), we can cull it from data with a migration later.