### PR TITLE
Allow ability scores below 8 and above 30 if manual

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -5,26 +5,23 @@
 //
 exports[`too-much-lint`] = {
   value: `{
-    "src/module/actor/character/sheet.ts:3233353492": [
-      [119, 72, 3, "Unexpected any. Specify a different type.", "193409811"],
-      [119, 77, 3, "Unexpected any. Specify a different type.", "193409811"],
-      [127, 72, 3, "Unexpected any. Specify a different type.", "193409811"],
-      [127, 77, 3, "Unexpected any. Specify a different type.", "193409811"]
+    "src/module/actor/character/sheet.ts:2754345904": [
+      [118, 72, 3, "Unexpected any. Specify a different type.", "193409811"],
+      [118, 77, 3, "Unexpected any. Specify a different type.", "193409811"],
+      [126, 72, 3, "Unexpected any. Specify a different type.", "193409811"],
+      [126, 77, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "src/module/actor/modifiers.ts:4143541466": [
-      [451, 19, 3, "Unexpected any. Specify a different type.", "193409811"]
+    "src/module/actor/modifiers.ts:2971529394": [
+      [409, 19, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "src/module/actor/sheet/base.ts:417099451": [
-      [1020, 20, 3, "Unexpected any. Specify a different type.", "193409811"]
+    "src/module/actor/sheet/base.ts:833009595": [
+      [898, 20, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
     "src/module/actor/vehicle/sheet.ts:617235856": [
       [21, 25, 3, "Unexpected any. Specify a different type.", "193409811"],
       [34, 44, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "src/module/item/base.ts:1096966691": [
-      [338, 24, 3, "Unexpected any. Specify a different type.", "193409811"]
-    ],
-    "src/module/item/consumable/data.ts:1360495826": [
+    "src/module/item/consumable/data.ts:4102190712": [
       [29, 13, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
     "types/foundry/client/application/form-application/document-sheet/actor-sheet.d.ts:4046500136": [
@@ -32,8 +29,8 @@ exports[`too-much-lint`] = {
       [9, 14, 3, "Unexpected any. Specify a different type.", "193409811"],
       [10, 15, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "types/foundry/client/collections/compendium-collection.d.ts:31827583": [
-      [208, 23, 3, "Unexpected any. Specify a different type.", "193409811"]
+    "types/foundry/client/collections/compendium-collection.d.ts:283791623": [
+      [209, 23, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
     "types/foundry/client/documents/item.d.ts:2931579527": [
       [62, 45, 3, "Unexpected any. Specify a different type.", "193409811"]
@@ -51,8 +48,8 @@ exports[`too-much-lint`] = {
       [167, 21, 3, "Unexpected any. Specify a different type.", "193409811"],
       [305, 44, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "types/foundry/client/game.d.ts:3610878987": [
-      [174, 32, 3, "Unexpected any. Specify a different type.", "193409811"]
+    "types/foundry/client/game.d.ts:3068083748": [
+      [179, 32, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
     "types/foundry/client/pixi/placeables-layer/base.d.ts:3719149522": [
       [132, 20, 3, "Unexpected any. Specify a different type.", "193409811"],
@@ -82,7 +79,7 @@ exports[`too-much-lint`] = {
     "types/foundry/common/abstract/document.d.ts:3086286863": [
       [572, 29, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "types/foundry/common/utils/collection.d.ts:738862421": [
+    "types/foundry/common/utils/collection.d.ts:3114157620": [
       [111, 31, 3, "Unexpected any. Specify a different type.", "193409811"],
       [113, 43, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],

--- a/foundryconfig.example.json
+++ b/foundryconfig.example.json
@@ -1,0 +1,4 @@
+{
+  "dataPath": "PATH_TO_DATA_FOLDER/FoundryVTT",
+  "foundryUri": "http://localhost:30001"
+}

--- a/foundryconfig.example.json
+++ b/foundryconfig.example.json
@@ -1,4 +1,0 @@
-{
-  "dataPath": "PATH_TO_DATA_FOLDER/FoundryVTT",
-  "foundryUri": "http://localhost:30001"
-}

--- a/src/module/actor/character/index.ts
+++ b/src/module/actor/character/index.ts
@@ -855,14 +855,13 @@ class CharacterPF2e extends CreaturePF2e {
         }
 
         // Enforce a minimum of 8 and a maximum of 30 for homebrew "mythic" mechanics if not using manual changes
-       
-            for (const ability of Object.values(this.system.abilities)) { 
-                if(!this.system.build.abilities.manual){           
-                ability.value = Math.clamped(ability.value, 8, 30);  }         
-                // Record base values: same as stored value if in manual mode, and prior to RE modifications otherwise
-                ability.base = ability.value;
+        for (const ability of Object.values(this.system.abilities)) {
+            if (!this.system.build.abilities.manual) {
+                ability.value = Math.clamped(ability.value, 8, 30);
             }
-   
+            // Record base values: same as stored value if in manual mode, and prior to RE modifications otherwise
+            ability.base = ability.value;
+        }
     }
 
     /** Set roll operations for ability scores, proficiency ranks, and number of hands free */

--- a/src/module/actor/character/index.ts
+++ b/src/module/actor/character/index.ts
@@ -854,12 +854,15 @@ class CharacterPF2e extends CreaturePF2e {
             details.keyability.value = build.abilities.boosts.class ?? "str";
         }
 
-        // Enforce a minimum of 8 and a maximum of 30 for homebrew "mythic" mechanics
-        for (const ability of Object.values(this.system.abilities)) {
-            ability.value = Math.clamped(ability.value, 8, 30);
-            // Record base values: same as stored value if in manual mode, and prior to RE modifications otherwise
-            ability.base = ability.value;
-        }
+        // Enforce a minimum of 8 and a maximum of 30 for homebrew "mythic" mechanics if not using manual changes
+       
+            for (const ability of Object.values(this.system.abilities)) { 
+                if(!this.system.build.abilities.manual){           
+                ability.value = Math.clamped(ability.value, 8, 30);  }         
+                // Record base values: same as stored value if in manual mode, and prior to RE modifications otherwise
+                ability.base = ability.value;
+            }
+   
     }
 
     /** Set roll operations for ability scores, proficiency ranks, and number of hands free */

--- a/src/module/actor/character/index.ts
+++ b/src/module/actor/character/index.ts
@@ -856,7 +856,9 @@ class CharacterPF2e extends CreaturePF2e {
 
         // Enforce a minimum of 8 and a maximum of 30 for homebrew "mythic" mechanics if not using manual changes
         for (const ability of Object.values(this.system.abilities)) {
-            if (!this.system.build.abilities.manual) {
+            if (this.system.build.abilities.manual) {
+                ability.value = Math.clamped(ability.value, 1, 99);
+            } else {
                 ability.value = Math.clamped(ability.value, 8, 30);
             }
             // Record base values: same as stored value if in manual mode, and prior to RE modifications otherwise


### PR DESCRIPTION
Fixes issue #3664, allowing ability scores below 8 and above 30 if Manual changes are allowed, but still bound when using the ability builder. 