### PR TITLE
Add spiritsense to types of senses

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -5,26 +5,23 @@
 //
 exports[`too-much-lint`] = {
   value: `{
-    "src/module/actor/character/sheet.ts:3233353492": [
-      [119, 72, 3, "Unexpected any. Specify a different type.", "193409811"],
-      [119, 77, 3, "Unexpected any. Specify a different type.", "193409811"],
-      [127, 72, 3, "Unexpected any. Specify a different type.", "193409811"],
-      [127, 77, 3, "Unexpected any. Specify a different type.", "193409811"]
+    "src/module/actor/character/sheet.ts:2754345904": [
+      [118, 72, 3, "Unexpected any. Specify a different type.", "193409811"],
+      [118, 77, 3, "Unexpected any. Specify a different type.", "193409811"],
+      [126, 72, 3, "Unexpected any. Specify a different type.", "193409811"],
+      [126, 77, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "src/module/actor/modifiers.ts:4143541466": [
-      [451, 19, 3, "Unexpected any. Specify a different type.", "193409811"]
+    "src/module/actor/modifiers.ts:2971529394": [
+      [409, 19, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "src/module/actor/sheet/base.ts:417099451": [
-      [1020, 20, 3, "Unexpected any. Specify a different type.", "193409811"]
+    "src/module/actor/sheet/base.ts:833009595": [
+      [898, 20, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
     "src/module/actor/vehicle/sheet.ts:617235856": [
       [21, 25, 3, "Unexpected any. Specify a different type.", "193409811"],
       [34, 44, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "src/module/item/base.ts:1096966691": [
-      [338, 24, 3, "Unexpected any. Specify a different type.", "193409811"]
-    ],
-    "src/module/item/consumable/data.ts:1360495826": [
+    "src/module/item/consumable/data.ts:4102190712": [
       [29, 13, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
     "types/foundry/client/application/form-application/document-sheet/actor-sheet.d.ts:4046500136": [
@@ -32,8 +29,8 @@ exports[`too-much-lint`] = {
       [9, 14, 3, "Unexpected any. Specify a different type.", "193409811"],
       [10, 15, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "types/foundry/client/collections/compendium-collection.d.ts:31827583": [
-      [208, 23, 3, "Unexpected any. Specify a different type.", "193409811"]
+    "types/foundry/client/collections/compendium-collection.d.ts:283791623": [
+      [209, 23, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
     "types/foundry/client/documents/item.d.ts:2931579527": [
       [62, 45, 3, "Unexpected any. Specify a different type.", "193409811"]
@@ -51,8 +48,8 @@ exports[`too-much-lint`] = {
       [167, 21, 3, "Unexpected any. Specify a different type.", "193409811"],
       [305, 44, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "types/foundry/client/game.d.ts:3610878987": [
-      [174, 32, 3, "Unexpected any. Specify a different type.", "193409811"]
+    "types/foundry/client/game.d.ts:3068083748": [
+      [179, 32, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
     "types/foundry/client/pixi/placeables-layer/base.d.ts:3719149522": [
       [132, 20, 3, "Unexpected any. Specify a different type.", "193409811"],
@@ -82,7 +79,7 @@ exports[`too-much-lint`] = {
     "types/foundry/common/abstract/document.d.ts:3086286863": [
       [572, 29, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "types/foundry/common/utils/collection.d.ts:738862421": [
+    "types/foundry/common/utils/collection.d.ts:3114157620": [
       [111, 31, 3, "Unexpected any. Specify a different type.", "193409811"],
       [113, 43, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],

--- a/src/module/actor/creature/sense.ts
+++ b/src/module/actor/creature/sense.ts
@@ -80,6 +80,7 @@ export const SENSE_TYPES = new Set([
     "motionsense",
     "scent",
     "seeInvisibility",
+    "spiritsense",
     "tremorsense",
     "wavesense",
 ] as const);

--- a/src/scripts/config/index.ts
+++ b/src/scripts/config/index.ts
@@ -88,6 +88,7 @@ const senses: Record<SenseType, string> = {
     motionsense: "PF2E.Actor.Creature.Sense.Type.Motionsense",
     scent: "PF2E.Actor.Creature.Sense.Type.Scent",
     seeInvisibility: "PF2E.Actor.Creature.Sense.Type.SeeInvisibility",
+    spiritsense: "PF2E.Actor.Creature.Sense.Type.Spiritsense",
     tremorsense: "PF2E.Actor.Creature.Sense.Type.Tremorsense",
     wavesense: "PF2E.Actor.Creature.Sense.Type.Wavesense",
 };

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -746,9 +746,9 @@
                         "Motionsense": "Motionsense",
                         "Scent": "Scent",
                         "SeeInvisibility": "See Invisibility",
+                        "Spiritsense": "Spiritsense",
                         "Tremorsense": "Tremorsense",
-                        "Wavesense": "Wavesense",
-                        "Spiritsense": "Spiritsense"
+                        "Wavesense": "Wavesense"                        
                     },
                     "WithAcuity": "{sense} ({acuity})",
                     "WithAcuityAndRange": "{sense} ({acuity} {range} Ft)"

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -747,7 +747,8 @@
                         "Scent": "Scent",
                         "SeeInvisibility": "See Invisibility",
                         "Tremorsense": "Tremorsense",
-                        "Wavesense": "Wavesense"
+                        "Wavesense": "Wavesense",
+                        "Spiritsense": "Spiritsense"
                     },
                     "WithAcuity": "{sense} ({acuity})",
                     "WithAcuityAndRange": "{sense} ({acuity} {range} Ft)"

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -748,7 +748,7 @@
                         "SeeInvisibility": "See Invisibility",
                         "Spiritsense": "Spiritsense",
                         "Tremorsense": "Tremorsense",
-                        "Wavesense": "Wavesense"                        
+                        "Wavesense": "Wavesense"
                     },
                     "WithAcuity": "{sense} ({acuity})",
                     "WithAcuityAndRange": "{sense} ({acuity} {range} Ft)"


### PR DESCRIPTION
WIP PR: 
I'm working on adding spiritsense to the list of senses in the system (re: issue #3942), and I've added it to src\scripts\config\index.ts Record of senses and to the src\module\actor\creature\sense.ts Set of SENSE_TYPES. 

I'm not getting the validation error any more, but in the list of available senses I'm not getting the nice label (I'm not great at style/html stuff) 

I've checked in static\templates\system\tag-selector\senses.html, but I can't find anything there that would make spiritsense any different from say motionsense or lifesense
![bad label](https://user-images.githubusercontent.com/32139677/190920998-41a7b78e-3b22-4cc2-8991-5623ce6dba6a.png)
