### PR TITLE
fix DC visibility in reposts from journals

### DIFF
--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -37,7 +37,8 @@ class TextEditorPF2e extends TextEditor {
     static processUserVisibility(content: string, options: EnrichHTMLOptionsPF2e): string {
         const $html = $("<div>").html(content);
         const actor = options.rollData?.actor ?? null;
-        UserVisibilityPF2e.process($html, { actor });
+        const journalEntry = options.relativeTo ?? null;
+        UserVisibilityPF2e.process($html, { actor, journalEntry });
 
         return $html.html();
     }
@@ -389,6 +390,7 @@ interface EnrichHTMLOptionsPF2e extends EnrichHTMLOptions {
         mod?: number;
         [key: string]: unknown;
     };
+    relativeTo?: JournalEntryPage;
 }
 
 interface ConvertXMLNodeOptions {

--- a/src/scripts/ui/user-visibility.ts
+++ b/src/scripts/ui/user-visibility.ts
@@ -30,7 +30,8 @@ class UserVisibilityPF2e {
             }
         }
 
-        const hasOwnership = document?.isOwner ?? game.user.isGM;
+        const { journalEntry } = options;
+        const hasOwnership = document?.isOwner ?? journalEntry?.isOwner ?? game.user.isGM;
         // Hide DC for explicit save buttons (such as in spell cards)
         const dcSetting = game.settings.get("pf2e", "metagame.showDC");
         const $saveButtons = $html.find("button[data-action=save]");
@@ -100,6 +101,7 @@ type UserVisibility = "all" | "owner" | "gm" | "none";
 interface ProcessOptions {
     message?: ChatMessagePF2e;
     actor?: ActorPF2e | null;
+    journalEntry?: JournalEntryPage | null;
 }
 
 export { UserVisibilityPF2e, UserVisibility };

--- a/src/scripts/ui/user-visibility.ts
+++ b/src/scripts/ui/user-visibility.ts
@@ -68,6 +68,12 @@ class UserVisibilityPF2e {
                 element.remove();
             }
         }
+        // Remove visibility=owner elements if the user is not the owner
+        if (!hasOwnership) {
+            for (const element of visibilityElements.filter((e) => e.dataset.visibility === "owner")) {
+                element.remove();
+            }
+        }
     }
 
     static processMessageSender(message: ChatMessagePF2e, html: HTMLElement): void {


### PR DESCRIPTION
This PR fixes DCs from reposts from journlas being visible by players. #2323

To work around this GMs could have a token selected before sending the post or they can give themselves a character in their user configuration. 

Implementing the first commit in this PR introduces a slight bug that is fixed by the second commit. After the first commit journals owned by a player will no longer show the DC of inline checks. Before the commit journals always showed the DC, which is also incorrect behavior. After the second commit DCs are only showed in journals if the player is an owner. 

I just started using this system recently with the beginner box so there might be systems that my changes affect that I'm unaware of. I tried to change as little code as possible to get it working. My limited testing shows no regressions with reposts from journals, items, or npcs. 