### PR TITLE
Add undetected condition to token HUD

### DIFF
--- a/src/scripts/config/index.ts
+++ b/src/scripts/config/index.ts
@@ -175,6 +175,7 @@ const tokenHUDConditions = {
     stunned: "PF2E.ConditionTypeStunned",
     stupefied: "PF2E.ConditionTypeStupefied",
     unconscious: "PF2E.ConditionTypeUnconscious",
+    undetected: "PF2E.ConditionTypeUndetected",
     wounded: "PF2E.ConditionTypeWounded",
 };
 
@@ -186,7 +187,6 @@ const conditionTypes: Record<ConditionSlug, string> = {
     hostile: "PF2E.ConditionTypeHostile",
     indifferent: "PF2E.ConditionTypeIndifferent",
     observed: "PF2E.ConditionTypeObserved",
-    undetected: "PF2E.ConditionTypeUndetected",
     unfriendly: "PF2E.ConditionTypeUnfriendly",
     unnoticed: "PF2E.ConditionTypeUnnoticed",
 };


### PR DESCRIPTION
An orderly grid:
![image](https://user-images.githubusercontent.com/106829671/191132380-6724b0b8-cd6a-4d8d-8c38-987885463649.png)
