### PR TITLE
Fix detection of highest level for spell collection

### DIFF
--- a/src/module/item/spellcasting-entry/collection.ts
+++ b/src/module/item/spellcasting-entry/collection.ts
@@ -18,7 +18,9 @@ export class SpellCollection extends Collection<Embedded<SpellPF2e>> {
     }
 
     get highestLevel(): number {
-        return Math.max(...this.map((s) => s.level)) ?? 1;
+        const highestSpell = Math.max(...this.map((s) => s.level));
+        const actorSpellLevel = Math.ceil((this.actor?.level ?? 0) / 2);
+        return Math.min(10, Math.max(highestSpell, actorSpellLevel));
     }
 
     /**

--- a/src/module/item/spellcasting-entry/index.ts
+++ b/src/module/item/spellcasting-entry/index.ts
@@ -70,8 +70,7 @@ class SpellcastingEntryPF2e extends ItemPF2e implements SpellcastingEntry {
     }
 
     get highestLevel(): number {
-        const actorSpellLevel = Math.ceil((this.actor?.level ?? 0) / 2);
-        return Math.min(10, Math.max(this.spells?.highestLevel ?? 1, actorSpellLevel));
+        return this.spells?.highestLevel ?? 0;
     }
 
     override prepareBaseData(): void {


### PR DESCRIPTION
I was going to put a deprecation warning, but there isn't much sense doing so before we're done refactoring collections. That said I don't think anyone uses SpellcastingEntryPF2e#highestLevel