### PR TITLE
Release notes 4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Version 4.1.1
+
+### Bugfixes
+* (stwlam) Fix extraction of predicated damage dice
+* (stwlam) Fix localization of non-land speeds
+* (Supe) Fix detection of highest level for spell collection
+
+### Data Updates
+* (stwlam) Restore iconics' prototype tokens
+* (stwlam) Fix language known by Uthuls (bestiary 1)
+
+
 ## Version 4.1.0
 
 ### System Improvements

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "foundry-pf2e",
-    "version": "4.1.0",
+    "version": "4.1.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "foundry-pf2e",
-            "version": "4.1.0",
+            "version": "4.1.1",
             "dependencies": {
                 "@codemirror/lang-json": "^6.0.0",
                 "@yaireo/tagify": "^4.16.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "foundry-pf2e",
-    "version": "4.1.0",
+    "version": "4.1.1",
     "description": "",
     "private": true,
     "scripts": {

--- a/system.json
+++ b/system.json
@@ -3,7 +3,7 @@
     "title": "Pathfinder 2nd Edition",
     "description": "A community contributed game system for Pathfinder Second Edition",
     "license": "./LICENSE",
-    "version": "4.1.0",
+    "version": "4.1.1",
     "compatibility": {
         "minimum": "10.286",
         "verified": "10.286",


### PR DESCRIPTION
### Bugfixes
* (stwlam) Fix extraction of predicated damage dice
* (stwlam) Fix localization of non-land speeds
* (Supe) Fix detection of highest level for spell collection

### Data Updates
* (stwlam) Restore iconics' prototype tokens
* (stwlam) Fix language known by Uthuls (bestiary 1)
