### PR TITLE
Support class dc for spellcasting features

### DIFF
--- a/src/module/actor/npc/index.ts
+++ b/src/module/actor/npc/index.ts
@@ -725,17 +725,11 @@ class NPCPF2e extends CreaturePF2e {
 
             // Check Modifiers, calculate using the user configured value
             const baseMod = Number(entry.system?.spelldc?.value ?? 0);
-            const attackModifiers = [
-                new ModifierPF2e("PF2E.ModifierTitle", baseMod, MODIFIER_TYPE.UNTYPED),
-                ...extractModifiers(this.synthetics, [...baseSelectors, ...attackSelectors]),
-            ];
+            const attackModifiers = [new ModifierPF2e("PF2E.ModifierTitle", baseMod, MODIFIER_TYPE.UNTYPED)];
 
             // Save Modifiers, reverse engineer using the user configured value - 10
             const baseDC = Number(entry.system?.spelldc?.dc ?? 0);
-            const saveModifiers = [
-                new ModifierPF2e("PF2E.ModifierTitle", baseDC - 10, MODIFIER_TYPE.UNTYPED),
-                ...extractModifiers(this.synthetics, [...baseSelectors, ...saveSelectors]),
-            ];
+            const saveModifiers = [new ModifierPF2e("PF2E.ModifierTitle", baseDC - 10, MODIFIER_TYPE.UNTYPED)];
 
             // Assign statistic data to the spellcasting entry
             entry.statistic = new Statistic(this, {

--- a/src/module/actor/sheet/spellcasting-dialog.ts
+++ b/src/module/actor/sheet/spellcasting-dialog.ts
@@ -70,6 +70,7 @@ class SpellcastingCreateAndEditDialog extends FormApplication<Embedded<Spellcast
         }
 
         this.object.updateSource(inputData);
+        this.object.reset();
 
         // If this wasn't a submit, only re-render and exit
         if (event.type !== "submit") {
@@ -103,7 +104,13 @@ class SpellcastingCreateAndEditDialog extends FormApplication<Embedded<Spellcast
             await this.actor.createEmbeddedDocuments("Item", [updateData]);
         } else {
             const actualEntry = this.actor.spellcasting.get(this.object.id);
-            const system = pick(updateData.system, ["prepared", "tradition", "ability", "autoHeightenLevel"]);
+            const system = pick(updateData.system, [
+                "prepared",
+                "tradition",
+                "ability",
+                "proficiency",
+                "autoHeightenLevel",
+            ]);
             await actualEntry?.update({ system });
         }
 

--- a/src/module/item/spellcasting-entry/data/types.ts
+++ b/src/module/item/spellcasting-entry/data/types.ts
@@ -3,7 +3,7 @@ import { AbilityString } from "@actor/types";
 import { SpellPF2e } from "@item";
 import { BaseItemDataPF2e, BaseItemSourcePF2e, ItemSystemData } from "@item/data/base";
 import { MagicTradition } from "@item/spell/types";
-import { OneToFour, OneToTen, ZeroToEleven } from "@module/data";
+import { OneToTen, ZeroToEleven, ZeroToFour } from "@module/data";
 import { RollNotePF2e } from "@module/notes";
 import { Statistic } from "@system/statistic";
 import { SpellcastingEntryPF2e } from "..";
@@ -79,7 +79,8 @@ interface SpellcastingEntrySystemData extends ItemSystemData {
         value: boolean;
     };
     proficiency: {
-        value: OneToFour;
+        slug: string;
+        value: ZeroToFour;
     };
     slots: Record<SlotKey, SpellSlotData>;
     autoHeightenLevel: {

--- a/src/module/system/statistic/data.ts
+++ b/src/module/system/statistic/data.ts
@@ -6,20 +6,22 @@ import { CheckType } from "@system/rolls";
 export interface StatisticCheckData {
     type: CheckType;
     label?: string;
-    modifiers?: ModifierPF2e[];
     /** Additional domains for fetching actor roll options */
     domains?: string[];
+    /** Any additional modifiers not already handled by fetching modifiers using domains as selectors */
+    modifiers?: ModifierPF2e[];
 }
 
 export interface StatisticDifficultyClassData {
     base?: number;
-    modifiers?: ModifierPF2e[];
     /** Additional domains for fetching actor roll options */
     domains?: string[];
+    /** Any additional modifiers not already handled by fetching modifiers using domains as selectors */
+    modifiers?: ModifierPF2e[];
 }
 
 /**
- * The base type for statistic data, which is used to build the actual statistic object.
+ * Used to build the actual statistic object.
  */
 export interface StatisticData {
     /** An identifier such as "reflex" or "ac" or "deception" */
@@ -31,9 +33,10 @@ export interface StatisticData {
     proficient?: boolean;
     check?: StatisticCheckData;
     dc?: StatisticDifficultyClassData;
-    modifiers?: ModifierPF2e[];
     /** Base domains for fetching actor roll options */
     domains?: string[];
+    /** Any additional modifiers not already handled by fetching modifiers using domains as selectors */
+    modifiers?: ModifierPF2e[];
     /**
      * Any static roll options that should be added to the list of roll options.
      * This does not include actor, rank, or basic item roll options.
@@ -45,6 +48,7 @@ export interface StatisticData {
 export interface StatisticChatData {
     slug: string;
     label: string;
+    rank: number | null;
     check: {
         label: string;
         mod: number;

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -723,7 +723,8 @@
                 },
                 "CriticalSpecialization": "Critical Specialization",
                 "Spellcasting": {
-                    "Cantrips": "Cantrips"
+                    "Cantrips": "Cantrips",
+                    "InvalidProficiency": "Invalid"
                 },
                 "SpellPreparation": {
                     "Title": "{actor}: Spell Preparation",

--- a/static/templates/actors/character/tabs/spellcasting.html
+++ b/static/templates/actors/character/tabs/spellcasting.html
@@ -58,10 +58,10 @@
                         {{/if}}
 
                         <section class="spell-ability">
-                            <span class="spell-tradition">{{localize (lookup @root.magicTraditions entry.tradition)}}</span>
+                            <span class="spell-tradition">{{localize entry.statistic.label}}</span>
                             <div class="spellcasting-prof button-group">
-                                <select class="skill-proficiency pf-rank adjust-item-stat-select" data-item-property="system.proficiency.value" value="{{entry.system.proficiency.value}}">
-                                    {{> "systems/pf2e/templates/actors/character/partials/proficiencylevels-dropdown.html" excludeUntrained=true proflevel=entry.system.proficiency.value}}
+                                <select class="skill-proficiency pf-rank adjust-item-stat-select" data-item-property="system.proficiency.value" value="{{entry.statistic.rank}}">
+                                    {{> "systems/pf2e/templates/actors/character/partials/proficiencylevels-dropdown.html" excludeUntrained=true proflevel=entry.statistic.rank}}
                                 </select>
                             </div>
                         </section>

--- a/static/templates/actors/spellcasting-dialog.html
+++ b/static/templates/actors/spellcasting-dialog.html
@@ -28,6 +28,20 @@
                 {{/select}}
                 </select>
             </div>
+            {{#if (eq actor.type "character")}}
+                <div class="form-group">
+                    <label>{{localize "PF2E.ProficiencyLabel"}}</label>
+                    <select name="system.proficiency.slug">
+                    {{#select data.proficiency.slug}}
+                        <option value="">{{localize "PF2E.MagicTraditionLabel"}}</option>
+                        <option value="classDC">{{localize "PF2E.Actor.Character.ClassDC.Label"}}</option>
+                        {{#each actor.classDCs as |classDC|}}
+                            <option value="{{classDC.slug}}">{{classDC.label}}</option>
+                        {{/each}}
+                    {{/select}}
+                    </select>
+                </div>
+            {{/if}}
             <div class="form-group">
                 <label>{{localize "PF2E.SpellAbilityLabel"}}</label>
                 <select name="system.ability.value">


### PR DESCRIPTION
Requires #4019. It also changes class dc to use statistic (all the inline rolls continue to work, as do automatic prof bumps). Modifiers are also automatically retrieved from the synthetics rather than injected.

This changes spellcasting to stem from a base tradition proficiency. This base tradition proficiency could also be extended with alternative domains to create a counteract statistic in the future (that would not gain a +1 from inspire courage). 

The extend's function signature is *gnarly*. Typescript doesn't seem capable of understanding that StatisticCheckData is an object for the purposes of DeepPartial. Perhaps a typescript update would allow a simpler type. Or maybe you have another idea.