### PR TITLE
Default spellcasting entries to invalid statistic

### DIFF
--- a/src/module/item/spellcasting-entry/index.ts
+++ b/src/module/item/spellcasting-entry/index.ts
@@ -6,7 +6,7 @@ import { MAGIC_TRADITIONS } from "@item/spell/values";
 import { goesToEleven, OneToFour, OneToTen } from "@module/data";
 import { UserPF2e } from "@module/user";
 import { Statistic } from "@system/statistic";
-import { ErrorPF2e } from "@util";
+import { ErrorPF2e, sluggify } from "@util";
 import { SpellCollection } from "./collection";
 import { SpellcastingAbilityData, SpellcastingEntry, SpellcastingEntryData, SpellcastingEntryListData } from "./data";
 
@@ -77,6 +77,15 @@ class SpellcastingEntryPF2e extends ItemPF2e implements SpellcastingEntry {
         super.prepareBaseData();
         // Spellcasting abilities are always at least trained
         this.system.proficiency.value = Math.max(1, this.system.proficiency.value) as OneToFour;
+
+        // assign a default "invalid" statistic (in case actor data preparation fails)
+        if (this.actor) {
+            this.statistic = new Statistic(this.actor, {
+                slug: sluggify(this.name),
+                label: "PF2E.Actor.Creature.Spellcasting.InvalidProficiency",
+                check: { type: "check" },
+            });
+        }
     }
 
     override prepareSiblingData(): void {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -723,7 +723,8 @@
                 },
                 "CriticalSpecialization": "Critical Specialization",
                 "Spellcasting": {
-                    "Cantrips": "Cantrips"
+                    "Cantrips": "Cantrips",
+                    "InvalidProficiency": "Invalid"
                 },
                 "SpellPreparation": {
                     "Title": "{actor}: Spell Preparation",


### PR DESCRIPTION
One source of sheet explody when data prep fails (also a better way to handle how the class dc pr does invalid statistics).