### PR TITLE
Prevent 404 error from displaying an error when fetching art mappings.

### DIFF
--- a/src/scripts/register-module-art.ts
+++ b/src/scripts/register-module-art.ts
@@ -42,11 +42,15 @@ async function getArtMap(art: unknown): Promise<ModuleArtRecord | null> {
         // Instead of being in a module.json file, the art map is in a separate JSON file referenced by path
         try {
             const response = await fetch(art);
+            if (!response.ok) {
+                console.warn(`PF2e System | Failed loading art mapping file at ${art}`);
+                return null;
+            }
             const map = await response.json();
             return isModuleArt(map) ? map : null;
         } catch (error) {
             if (error instanceof Error) {
-                ui.notifications.error(error.message);
+                console.warn(`PF2e System | ${error.message}`);
             }
         }
     }


### PR DESCRIPTION
The use case for how pdf to foundry means that the art mapping is dynamic based on which modules have been imported, so it should live in a place that can't be populated by the installer before. Because of this, an error is displayed when the pdf to foundry module is enabled and its art mapping file hasn't been created yet