### PR TITLE
Fix overflow for long tag elements

### DIFF
--- a/src/styles/_tags.scss
+++ b/src/styles/_tags.scss
@@ -244,3 +244,13 @@ tags.pf2e-tagify, tags.tags.paizo-style {
         background: rgba(0, 0, 0, 0.05);
     }
 }
+
+// Ensure shadow fills the whole tag even if it wraps lines
+.tagify {
+    --tag-inset-shadow-size: 10em
+}
+
+// Ensure that remove button doesn't get covered up in when window is small
+.tagify__tag__removeBtn {
+    overflow: visible;
+}

--- a/src/styles/_tags.scss
+++ b/src/styles/_tags.scss
@@ -111,6 +111,10 @@ li.chat-message .tags .tag {
     padding: 0.05em;
     gap: 0;
 
+    select.tag {
+        height: 22px;
+    }
+
     tag, .tag, select.tag {
         border: 2px solid var(--color-border-trait);
         margin: 0;

--- a/src/styles/_tags.scss
+++ b/src/styles/_tags.scss
@@ -246,11 +246,13 @@ tags.pf2e-tagify, tags.tags.paizo-style {
 }
 
 // Ensure shadow fills the whole tag even if it wraps lines
+// Default from tagify module is 1.1em
 .tagify {
     --tag-inset-shadow-size: 10em
 }
 
-// Ensure that remove button doesn't get covered up in when window is small
+// Ensure that remove button doesn't get covered up when window is small
+// Default from tagify module is hidden
 .tagify__tag__removeBtn {
     overflow: visible;
 }

--- a/src/styles/_tags.scss
+++ b/src/styles/_tags.scss
@@ -114,7 +114,7 @@ li.chat-message .tags .tag {
     tag, .tag, select.tag {
         border: 2px solid var(--color-border-trait);
         margin: 0;
-        height: 22px;
+        min-height: 22px;
 
         x {
             align-items: start;

--- a/src/styles/_tags.scss
+++ b/src/styles/_tags.scss
@@ -17,7 +17,7 @@
         color: white;
         display: flex;
         font-weight: 500;
-        height: 1.5em;
+        min-height: 1.5em;
         padding: 0 0.33em;
 
         &.edit-btn {

--- a/src/styles/settings/_homebrew.scss
+++ b/src/styles/settings/_homebrew.scss
@@ -16,7 +16,6 @@
 
                 .homebrew {
                     --tag-text-color--edit: #111;
-                    --tag-inset-shadow-size: 1.35em;
                     --tag-pad: 0.2em 0.4em;
                     --tag-remove-bg: var(--tag-hover);
                     --tag-remove-btn-bg--hover: black;


### PR DESCRIPTION
Closes #2950
If a tag is longer than the width allows, currently the text overflows on the bottom but the border doesn't expand with it. This change makes the border expand so it looks right, only if the text requires it.
![image](https://user-images.githubusercontent.com/6468183/191854533-437229a2-0893-4534-a81e-2cd4a1f32516.png)