### PR TITLE
Add warning message to `PackLoader` if a pack couldn't be loaded

### DIFF
--- a/src/module/apps/compendium-browser/index.ts
+++ b/src/module/apps/compendium-browser/index.ts
@@ -56,6 +56,9 @@ class PackLoader {
                         data = { pack, index };
                         this.loadedPacks[documentType][packId] = data;
                     } else {
+                        ui.notifications.warn(
+                            game.i18n.format("PF2E.BrowserWarnPackNotLoaded", { pack: pack.collection })
+                        );
                         continue;
                     }
                 } else {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1027,7 +1027,7 @@
         "BrowserSortyByLevelLabel": "Level",
         "BrowserSortyByPriceLabel": "Price",
         "BrowserSortyByNameLabel": "Name",
-        "BrowserWarnPackNotLoaded": "Compendium '{pack}' could not be loaded.",
+        "BrowserWarnPackNotLoaded": "Compendium \"{pack}\" could not be loaded.",
         "BulkCapacityLabel": "Holds Bulk Amount",
         "BulkLabel": "Carried Bulk",
         "BulkMaxLabel": "Max Bulk",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1027,6 +1027,7 @@
         "BrowserSortyByLevelLabel": "Level",
         "BrowserSortyByPriceLabel": "Price",
         "BrowserSortyByNameLabel": "Name",
+        "BrowserWarnPackNotLoaded": "Compendium '{pack}' could not be loaded.",
         "BulkCapacityLabel": "Holds Bulk Amount",
         "BulkLabel": "Carried Bulk",
         "BulkMaxLabel": "Max Bulk",


### PR DESCRIPTION
Closes #4123 (Maybe there will be an upstream fix)