### PR TITLE
Brushup spell effect REs A-C

### DIFF
--- a/packs/data/spell-effects.db/spell-effect-amplifying-touch.json
+++ b/packs/data/spell-effects.db/spell-effect-amplifying-touch.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/spells/lay-on-hands.webp",
     "name": "Spell Effect: Amplifying Touch",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by <em>@Compendium[pf2e.spells-srd.Lay on Hands]{Lay on Hands}</em> if you have @Compendium[pf2e.feats-srd.Amplifying Touch]{Amplifying Touch}.</p>\n<p>If the target is one of your allies, they also gain a +2 status bonus to AC, a +1 status bonus to their attack rolls and deals 1 additional good damage on all their strikes until the end of their next turn.</p>"
         },
@@ -18,14 +19,12 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Lay on Hands",
                 "selector": "ac",
                 "type": "status",
                 "value": 2
             },
             {
                 "key": "FlatModifier",
-                "label": "Amplifying Touch",
                 "selector": "attack",
                 "type": "status",
                 "value": 1
@@ -33,7 +32,6 @@
             {
                 "damageType": "good",
                 "key": "FlatModifier",
-                "label": "Amplifying Touch",
                 "selector": "strike-damage",
                 "value": 1
             }

--- a/packs/data/spell-effects.db/spell-effect-armor-of-bones.json
+++ b/packs/data/spell-effects.db/spell-effect-armor-of-bones.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/spells/armor-of-bones.webp",
     "name": "Spell Effect: Armor of Bones",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by <em>@Compendium[pf2e.spells-srd.Armor of Bones]{Armor of Bones}</em></p>"
         },
@@ -19,22 +20,22 @@
             {
                 "key": "Resistance",
                 "type": "cold",
-                "value": "(@item.level)"
+                "value": "@item.level"
             },
             {
                 "key": "Resistance",
                 "type": "electricity",
-                "value": "(@item.level)"
+                "value": "@item.level"
             },
             {
                 "key": "Resistance",
                 "type": "fire",
-                "value": "(@item.level)"
+                "value": "@item.level"
             },
             {
                 "key": "Resistance",
                 "type": "piercing",
-                "value": "(@item.level)"
+                "value": "@item.level"
             },
             {
                 "key": "Resistance",

--- a/packs/data/spell-effects.db/spell-effect-bane.json
+++ b/packs/data/spell-effects.db/spell-effect-bane.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/spells/bane.webp",
     "name": "Spell Effect: Bane",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by <em>@Compendium[pf2e.spells-srd.Bane]{Bane}</em>.</p>\n<p>Doubt fills your mind. You take a -1 status penalty to attack rolls so long as you are in the area of Bane.</p>"
         },
@@ -18,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Bane",
                 "selector": "attack",
                 "type": "status",
                 "value": -1

--- a/packs/data/spell-effects.db/spell-effect-bathe-in-blood.json
+++ b/packs/data/spell-effects.db/spell-effect-bathe-in-blood.json
@@ -19,6 +19,11 @@
         "rules": [
             {
                 "key": "FlatModifier",
+                "predicate": {
+                    "all": [
+                        "action:make-an-impression"
+                    ]
+                },
                 "selector": "diplomacy",
                 "type": "circumstance",
                 "value": 1

--- a/packs/data/spell-effects.db/spell-effect-bless.json
+++ b/packs/data/spell-effects.db/spell-effect-bless.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/spells/bless.webp",
     "name": "Spell Effect: Bless",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by <em>@Compendium[pf2e.spells-srd.Bless]{Bless}</em></p>\n<p>Blessings from beyond help you strike true. You gain a +1 status bonus to attack rolls.</p>"
         },
@@ -18,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Bless",
                 "selector": "attack",
                 "type": "status",
                 "value": 1
@@ -28,6 +28,7 @@
             "value": "Pathfinder Core Rulebook"
         },
         "start": {
+            "initiative": null,
             "value": 0
         },
         "target": null,

--- a/packs/data/spell-effects.db/spell-effect-blood-ward.json
+++ b/packs/data/spell-effects.db/spell-effect-blood-ward.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/spells/blood-ward.webp",
     "name": "Spell Effect: Blood Ward",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by <em>@Compendium[pf2e.spells-srd.Blood Ward]{Blood Ward}</em></p>"
         },
@@ -25,38 +26,15 @@
             },
             {
                 "key": "FlatModifier",
-                "label": "Defending vs. target of Blood Ward",
                 "predicate": {
                     "all": [
                         "blood-ward"
                     ]
                 },
-                "selector": "ac",
-                "type": "status",
-                "value": {
-                    "brackets": [
-                        {
-                            "end": 4,
-                            "start": 1,
-                            "value": 1
-                        },
-                        {
-                            "start": 5,
-                            "value": 2
-                        }
-                    ],
-                    "field": "item|system.level.value"
-                }
-            },
-            {
-                "key": "FlatModifier",
-                "label": "Defending vs. target of Blood Ward",
-                "predicate": {
-                    "all": [
-                        "blood-ward"
-                    ]
-                },
-                "selector": "saving-throw",
+                "selector": [
+                    "ac",
+                    "saving-throw"
+                ],
                 "type": "status",
                 "value": {
                     "brackets": [

--- a/packs/data/spell-effects.db/spell-effect-blunt-the-final-blade-critical-success.json
+++ b/packs/data/spell-effects.db/spell-effect-blunt-the-final-blade-critical-success.json
@@ -19,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Blunt the Final Blade (Critical Success Boon)",
                 "predicate": {
                     "any": [
                         "death",

--- a/packs/data/spell-effects.db/spell-effect-bullhorn.json
+++ b/packs/data/spell-effects.db/spell-effect-bullhorn.json
@@ -19,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Bullhorn",
                 "predicate": {
                     "all": [
                         "auditory",
@@ -33,7 +32,6 @@
             },
             {
                 "key": "FlatModifier",
-                "label": "Bullhorn",
                 "predicate": {
                     "all": [
                         "action:coerce"

--- a/packs/data/spell-effects.db/spell-effect-call-to-arms.json
+++ b/packs/data/spell-effects.db/spell-effect-call-to-arms.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/spells/call-to-arms.webp",
     "name": "Spell Effect: Call to Arms",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by <em>@Compendium[pf2e.spells-srd.Call to Arms]{Call to Arms}</em>.</p>"
         },
@@ -18,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Call to Arms",
                 "selector": "initiative",
                 "type": "status",
                 "value": {

--- a/packs/data/spell-effects.db/spell-effect-calm-emotions.json
+++ b/packs/data/spell-effects.db/spell-effect-calm-emotions.json
@@ -19,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Calm Emotions",
                 "selector": "attack",
                 "type": "status",
                 "value": -1

--- a/packs/data/spell-effects.db/spell-effect-celestial-brand.json
+++ b/packs/data/spell-effects.db/spell-effect-celestial-brand.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/spells/celestial-brand.webp",
     "name": "Spell Effect: Celestial Brand",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by attacking a target under the effect of <em>@Compendium[pf2e.spells-srd.Celestial Brand]{Celestial Brand}</em></p>"
         },
@@ -25,32 +26,21 @@
             },
             {
                 "key": "FlatModifier",
-                "label": "Celestial Brand",
                 "predicate": {
                     "all": [
                         "celestial-brand"
                     ]
                 },
-                "selector": "attack",
-                "type": "status",
-                "value": 1
-            },
-            {
-                "key": "FlatModifier",
-                "label": "Celestial Brand",
-                "predicate": {
-                    "all": [
-                        "celestial-brand"
-                    ]
-                },
-                "selector": "skill-check",
+                "selector": [
+                    "attack",
+                    "skill-check"
+                ],
                 "type": "status",
                 "value": 1
             },
             {
                 "damagetype": "good",
                 "key": "FlatModifier",
-                "label": "Celestial Brand",
                 "predicate": {
                     "all": [
                         "celestial-brand"

--- a/packs/data/spell-effects.db/spell-effect-corrosive-body-heightened-9th.json
+++ b/packs/data/spell-effects.db/spell-effect-corrosive-body-heightened-9th.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/spells/corrosive-body.webp",
     "name": "Spell Effect: Corrosive Body (Heightened 9th)",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by <em>@Compendium[pf2e.spells-srd.Corrosive Body]{Corrosive Body}</em></p>\n<p>You exhale corrosive gas, and acidic secretions coat your skin as you transform into a being of living acid. You gain acid immunity. Any creature that touches you or damages you with an unarmed melee attack or non-reach melee weapon takes [[/r {4d6}[acid]]]{4d6 acid damage}, and your unarmed attacks deal 2d4 additional acid damage. The first time each round that you deal acid damage to a creature in this way, you gain [[/r 5d6 #Temporary Hit Points]]{5d6 temporary Hit Points} as your body digests the eroded material and transforms it into a protective acid. When the spell ends, any remaining temporary HP expires as well. Your acid spells deal one additional die of acid damage (of the same damage die the spell uses). You can cast acid splash as an innate spell; the splash damage affects all creatures within 15 feet instead of the normal 5 feet.</p>"
         },
@@ -36,8 +37,7 @@
                     ]
                 },
                 "selector": "strike-damage",
-                "text": "The first time each round that you deal acid damage to a creature in this way, you gain [[/r 5d6 #Temporary Hit Points]]{5d6 temporary Hit Points}",
-                "title": "Corrosive Body"
+                "text": "The first time each round that you deal acid damage to a creature in this way, you gain [[/r 5d6 #Temporary Hit Points]]{5d6 temporary Hit Points}"
             },
             {
                 "key": "Immunity",

--- a/packs/data/spell-effects.db/spell-effect-corrosive-body.json
+++ b/packs/data/spell-effects.db/spell-effect-corrosive-body.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/spells/corrosive-body.webp",
     "name": "Spell Effect: Corrosive Body",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by <em>@Compendium[pf2e.spells-srd.Corrosive Body]{Corrosive Body}</em></p>\n<p>You exhale corrosive gas, and acidic secretions coat your skin as you transform into a being of living acid. You gain acid immunity. Any creature that touches you or damages you with an unarmed melee attack or non-reach melee weapon takes [[/r {3d6}[acid]]]{3d6 acid damage}, and your unarmed attacks deal 1d4 additional acid damage. The first time each round that you deal acid damage to a creature in this way, you gain [[/r 3d6 #Temporary Hit Points]]{3d6 temporary Hit Points} as your body digests the eroded material and transforms it into a protective acid. When the spell ends, any remaining temporary HP expires as well. Your acid spells deal one additional die of acid damage (of the same damage die the spell uses). You can cast acid splash as an innate spell; the splash damage affects all creatures within 15 feet instead of the normal 5 feet.</p>"
         },
@@ -36,8 +37,7 @@
                     ]
                 },
                 "selector": "strike-damage",
-                "text": "The first time each round that you deal acid damage to a creature in this way, you gain [[/r 3d6 #Temporary Hit Points]]{3d6 temporary Hit Points}",
-                "title": "Corrosive Body"
+                "text": "The first time each round that you deal acid damage to a creature in this way, you gain [[/r 3d6 #Temporary Hit Points]]{3d6 temporary Hit Points}"
             },
             {
                 "key": "Immunity",

--- a/packs/data/spell-effects.db/spell-effect-heroism.json
+++ b/packs/data/spell-effects.db/spell-effect-heroism.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/spells/heroism.webp",
     "name": "Spell Effect: Heroism",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by <em>@Compendium[pf2e.spells-srd.Heroism]{Heroism}</em></p>\n<p>Tapping into your inner heroism, you get a +1 status bonus to attack rolls, Perception checks, saving throws, and skill checks.</p>"
         },
@@ -18,83 +19,12 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Heroism",
-                "selector": "attack",
-                "type": "status",
-                "value": {
-                    "brackets": [
-                        {
-                            "end": 5,
-                            "start": 3,
-                            "value": 1
-                        },
-                        {
-                            "end": 8,
-                            "start": 6,
-                            "value": 2
-                        },
-                        {
-                            "start": 9,
-                            "value": 3
-                        }
-                    ],
-                    "field": "item|system.level.value"
-                }
-            },
-            {
-                "key": "FlatModifier",
-                "label": "Heroism",
-                "selector": "perception",
-                "type": "status",
-                "value": {
-                    "brackets": [
-                        {
-                            "end": 5,
-                            "start": 3,
-                            "value": 1
-                        },
-                        {
-                            "end": 8,
-                            "start": 6,
-                            "value": 2
-                        },
-                        {
-                            "start": 9,
-                            "value": 3
-                        }
-                    ],
-                    "field": "item|system.level.value"
-                }
-            },
-            {
-                "key": "FlatModifier",
-                "label": "Heroism",
-                "selector": "saving-throw",
-                "type": "status",
-                "value": {
-                    "brackets": [
-                        {
-                            "end": 5,
-                            "start": 3,
-                            "value": 1
-                        },
-                        {
-                            "end": 8,
-                            "start": 6,
-                            "value": 2
-                        },
-                        {
-                            "start": 9,
-                            "value": 3
-                        }
-                    ],
-                    "field": "item|system.level.value"
-                }
-            },
-            {
-                "key": "FlatModifier",
-                "label": "Heroism",
-                "selector": "skill-check",
+                "selector": [
+                    "attack",
+                    "saving-throw",
+                    "skill-check",
+                    "perception"
+                ],
                 "type": "status",
                 "value": {
                     "brackets": [
@@ -121,6 +51,7 @@
             "value": "Pathfinder Core Rulebook"
         },
         "start": {
+            "initiative": null,
             "value": 0
         },
         "target": null,

--- a/packs/data/spell-effects.db/spell-effect-inspire-courage.json
+++ b/packs/data/spell-effects.db/spell-effect-inspire-courage.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/spells/inspire-courage.webp",
     "name": "Spell Effect: Inspire Courage",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by <em>@Compendium[pf2e.spells-srd.Inspire Courage]{Inspire Courage}</em></p>\n<p>You are inspired by words or tunes of encouragement. You gain a +1 status bonus to attack rolls, damage rolls, and saves against fear effects.</p>"
         },
@@ -18,19 +19,15 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "selector": "attack",
+                "selector": [
+                    "attack",
+                    "damage"
+                ],
                 "type": "status",
                 "value": 1
             },
             {
                 "key": "FlatModifier",
-                "selector": "damage",
-                "type": "status",
-                "value": 1
-            },
-            {
-                "key": "FlatModifier",
-                "label": "Inspire Courage (vs fear)",
                 "predicate": {
                     "all": [
                         "fear"
@@ -45,6 +42,7 @@
             "value": "Pathfinder Core Rulebook"
         },
         "start": {
+            "initiative": null,
             "value": 0
         },
         "target": null,


### PR DESCRIPTION
Remove unneeded labels and condense flat modifiers when possible to use multiple selectors.