### PR TITLE
Fix rarity tag height in the Compendium Browser

### DIFF
--- a/src/styles/packs/_tab.scss
+++ b/src/styles/packs/_tab.scss
@@ -140,8 +140,7 @@
                 max-width: 6em;
 
                 .tag {
-                    color: var(--color-text-trait);
-                    font-size: var(--font-size-10);
+                    line-height: var(--font-size-10);
                 }
             }
 


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/41452412/192100224-6c0a9ba3-8264-46fa-ba90-6053ff0ef2ba.png)

After:
![after](https://user-images.githubusercontent.com/41452412/192100829-7010eec6-002f-4593-a6da-130d5adc4d14.png)

