### PR TITLE
Fix the range of sturzstromer tremorsense ability

### DIFF
--- a/packs/data/pathfinder-bestiary-3.db/sturzstromer.json
+++ b/packs/data/pathfinder-bestiary-3.db/sturzstromer.json
@@ -622,7 +622,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>A sturzstromer's tremorsense is a precise sense out to 120 feet and an imprecise sense out to 24 feet. A sturzstromer can't sense anything beyond the range of its tremorsense.</p>\n<hr />\n<p>@Localize[PF2E.NPC.Abilities.Glossary.Tremorsense]</p>"
+                    "value": "<p>A sturzstromer's tremorsense is a precise sense out to 120 feet and an imprecise sense out to 240 feet. A sturzstromer can't sense anything beyond the range of its tremorsense.</p>\n<hr />\n<p>@Localize[PF2E.NPC.Abilities.Glossary.Tremorsense]</p>"
                 },
                 "requirements": {
                     "value": ""


### PR DESCRIPTION
Fix a typo 240 feet instead of 24 feet