### PR TITLE
Fix AE-likes modifying crafting entries

### DIFF
--- a/packs/data/classfeatures.db/advanced-alchemy.json
+++ b/packs/data/classfeatures.db/advanced-alchemy.json
@@ -42,7 +42,7 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.crafting.entries.alchemist.maxItemLevel",
-                "phase": "afterDerived",
+                "phase": "beforeDerived",
                 "predicate": [
                     "class:alchemist",
                     "crafting:entry:alchemist"

--- a/packs/data/classfeatures.db/field-discovery-bomber.json
+++ b/packs/data/classfeatures.db/field-discovery-bomber.json
@@ -29,7 +29,7 @@
                 "key": "ActiveEffectLike",
                 "mode": "override",
                 "path": "system.crafting.entries.alchemist.fieldDiscovery",
-                "phase": "afterDerived",
+                "phase": "beforeDerived",
                 "value": "bomb"
             }
         ],

--- a/packs/data/classfeatures.db/field-discovery-chirurgeon.json
+++ b/packs/data/classfeatures.db/field-discovery-chirurgeon.json
@@ -29,7 +29,7 @@
                 "key": "ActiveEffectLike",
                 "mode": "override",
                 "path": "system.crafting.entries.alchemist.fieldDiscovery",
-                "phase": "afterDerived",
+                "phase": "beforeDerived",
                 "value": "elixir"
             }
         ],

--- a/packs/data/classfeatures.db/field-discovery-mutagenist.json
+++ b/packs/data/classfeatures.db/field-discovery-mutagenist.json
@@ -29,7 +29,7 @@
                 "key": "ActiveEffectLike",
                 "mode": "override",
                 "path": "system.crafting.entries.alchemist.fieldDiscovery",
-                "phase": "afterDerived",
+                "phase": "beforeDerived",
                 "value": "mutagen"
             }
         ],

--- a/packs/data/classfeatures.db/field-discovery-toxicologist.json
+++ b/packs/data/classfeatures.db/field-discovery-toxicologist.json
@@ -29,7 +29,7 @@
                 "key": "ActiveEffectLike",
                 "mode": "override",
                 "path": "system.crafting.entries.alchemist.fieldDiscovery",
-                "phase": "afterDerived",
+                "phase": "beforeDerived",
                 "value": "poison"
             }
         ],

--- a/packs/data/feats.db/deeper-dabbler.json
+++ b/packs/data/feats.db/deeper-dabbler.json
@@ -33,7 +33,7 @@
                 "key": "ActiveEffectLike",
                 "mode": "add",
                 "path": "system.crafting.entries.talismanDabbler.maxSlots",
-                "phase": "afterDerived",
+                "phase": "beforeDerived",
                 "value": 2
             }
         ],

--- a/packs/data/feats.db/efficient-alchemy-paragon.json
+++ b/packs/data/feats.db/efficient-alchemy-paragon.json
@@ -29,14 +29,14 @@
                 "key": "ActiveEffectLike",
                 "mode": "updgrade",
                 "path": "system.crafting.entries.alchemist.batchSize",
-                "phase": "afterDerived",
+                "phase": "beforeDerived",
                 "value": 3
             },
             {
                 "key": "ActiveEffectLike",
                 "mode": "updgrade",
                 "path": "system.crafting.entries.alchemist.fieldDiscoveryBatchSize",
-                "phase": "afterDerived",
+                "phase": "beforeDerived",
                 "value": 4
             }
         ],

--- a/packs/data/feats.db/elaborate-talisman-esoterica.json
+++ b/packs/data/feats.db/elaborate-talisman-esoterica.json
@@ -34,7 +34,7 @@
                 "key": "ActiveEffectLike",
                 "mode": "add",
                 "path": "system.crafting.entries.talismanEsoterica.maxSlots",
-                "phase": "afterDerived",
+                "phase": "beforeDerived",
                 "value": 2
             }
         ],

--- a/packs/data/feats.db/expert-alchemy.json
+++ b/packs/data/feats.db/expert-alchemy.json
@@ -32,11 +32,12 @@
             ]
         },
         "rules": [
+            {},
             {
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.crafting.entries.alchemist.maxItemLevel",
-                "phase": "afterDerived",
+                "phase": "beforeDerived",
                 "predicate": [
                     "crafting:entry:alchemist"
                 ],

--- a/packs/data/feats.db/expert-fireworks-crafter.json
+++ b/packs/data/feats.db/expert-fireworks-crafter.json
@@ -36,7 +36,7 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.crafting.entries.fireworkTechnician.maxItemLevel",
-                "phase": "afterDerived",
+                "phase": "beforeDerived",
                 "predicate": [
                     "crafting:entry:firework-technician"
                 ],

--- a/packs/data/feats.db/expert-herbalism.json
+++ b/packs/data/feats.db/expert-herbalism.json
@@ -36,7 +36,7 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.crafting.entries.herbalist.maxItemLevel",
-                "phase": "afterDerived",
+                "phase": "beforeDerived",
                 "predicate": [
                     "crafting:entry:herbalist"
                 ],

--- a/packs/data/feats.db/expert-poisoner.json
+++ b/packs/data/feats.db/expert-poisoner.json
@@ -36,7 +36,7 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.crafting.entries.poisoner.maxItemLevel",
-                "phase": "afterDerived",
+                "phase": "beforeDerived",
                 "predicate": [
                     "crafting:entry:poisoner"
                 ],

--- a/packs/data/feats.db/gadget-specialist.json
+++ b/packs/data/feats.db/gadget-specialist.json
@@ -42,7 +42,7 @@
                 "key": "ActiveEffectLike",
                 "mode": "add",
                 "path": "system.crafting.entries.gadgetSpecialist.maxSlots",
-                "phase": "afterDerived",
+                "phase": "beforeDerived",
                 "priority": 41,
                 "value": {
                     "brackets": [

--- a/packs/data/feats.db/master-alchemy.json
+++ b/packs/data/feats.db/master-alchemy.json
@@ -36,7 +36,7 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.crafting.entries.alchemist.maxItemLevel",
-                "phase": "afterDerived",
+                "phase": "beforeDerived",
                 "predicate": [
                     "crafting:entry:alchemist"
                 ],

--- a/packs/data/feats.db/munitions-machinist.json
+++ b/packs/data/feats.db/munitions-machinist.json
@@ -36,7 +36,7 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.crafting.entries.munitionsCrafter.maxItemLevel",
-                "phase": "afterDerived",
+                "phase": "beforeDerived",
                 "predicate": [
                     "crafting:entry:munitions-crafter"
                 ],

--- a/packs/data/feats.db/plentiful-snares.json
+++ b/packs/data/feats.db/plentiful-snares.json
@@ -33,7 +33,7 @@
                 "key": "ActiveEffectLike",
                 "mode": "add",
                 "path": "system.crafting.entries.snareCrafting.maxSlots",
-                "phase": "afterDerived",
+                "phase": "beforeDerived",
                 "value": {
                     "brackets": [
                         {

--- a/packs/data/feats.db/snare-genius.json
+++ b/packs/data/feats.db/snare-genius.json
@@ -46,7 +46,7 @@
                 "key": "ActiveEffectLike",
                 "mode": "add",
                 "path": "system.crafting.entries.snareCrafting.maxSlots",
-                "phase": "afterDerived",
+                "phase": "beforeDerived",
                 "value": {
                     "brackets": [
                         {

--- a/packs/data/feats.db/snare-specialist.json
+++ b/packs/data/feats.db/snare-specialist.json
@@ -46,7 +46,7 @@
                 "key": "ActiveEffectLike",
                 "mode": "add",
                 "path": "system.crafting.entries.snareCrafting.maxSlots",
-                "phase": "afterDerived",
+                "phase": "beforeDerived",
                 "value": {
                     "brackets": [
                         {

--- a/packs/data/feats.db/snarecrafter-dedication.json
+++ b/packs/data/feats.db/snarecrafter-dedication.json
@@ -46,7 +46,7 @@
                 "key": "ActiveEffectLike",
                 "mode": "add",
                 "path": "system.crafting.entries.snareCrafting.maxSlots",
-                "phase": "afterDerived",
+                "phase": "beforeDerived",
                 "value": {
                     "brackets": [
                         {

--- a/packs/data/feats.db/talisman-dabbler-dedication.json
+++ b/packs/data/feats.db/talisman-dabbler-dedication.json
@@ -39,7 +39,7 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.crafting.entries.talismanDabbler.maxItemLevel",
-                "phase": "afterDerived",
+                "phase": "beforeDerived",
                 "predicate": [
                     "crafting:entry:talisman-dabbler"
                 ],

--- a/packs/data/feats.db/talisman-esoterica.json
+++ b/packs/data/feats.db/talisman-esoterica.json
@@ -39,7 +39,7 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.crafting.entries.talismanEsoterica.maxItemLevel",
-                "phase": "afterDerived",
+                "phase": "beforeDerived",
                 "predicate": [
                     "crafting:entry:talisman-esoterica"
                 ],

--- a/packs/data/feats.db/ubiquitous-gadgets.json
+++ b/packs/data/feats.db/ubiquitous-gadgets.json
@@ -33,7 +33,7 @@
                 "key": "ActiveEffectLike",
                 "mode": "add",
                 "path": "system.crafting.entries.gadgetSpecialist.maxSlots",
-                "phase": "afterDerived",
+                "phase": "beforeDerived",
                 "value": 2
             }
         ],

--- a/packs/data/feats.db/ubiquitous-snares.json
+++ b/packs/data/feats.db/ubiquitous-snares.json
@@ -33,7 +33,7 @@
                 "key": "ActiveEffectLike",
                 "mode": "add",
                 "path": "system.crafting.entries.snareCrafting.maxSlots",
-                "phase": "afterDerived",
+                "phase": "beforeDerived",
                 "value": {
                     "brackets": [
                         {

--- a/packs/data/iconics.db/fumbus-level-1.json
+++ b/packs/data/iconics.db/fumbus-level-1.json
@@ -277,7 +277,7 @@
                         "key": "ActiveEffectLike",
                         "mode": "upgrade",
                         "path": "system.crafting.entries.alchemist.maxItemLevel",
-                        "phase": "afterDerived",
+                        "phase": "beforeDerived",
                         "predicate": [
                             "class:alchemist",
                             "crafting:entry:alchemist"

--- a/packs/data/iconics.db/fumbus-level-3.json
+++ b/packs/data/iconics.db/fumbus-level-3.json
@@ -281,7 +281,7 @@
                         "key": "ActiveEffectLike",
                         "mode": "upgrade",
                         "path": "system.crafting.entries.alchemist.maxItemLevel",
-                        "phase": "afterDerived",
+                        "phase": "beforeDerived",
                         "predicate": [
                             "class:alchemist",
                             "crafting:entry:alchemist"

--- a/packs/data/iconics.db/fumbus-level-5.json
+++ b/packs/data/iconics.db/fumbus-level-5.json
@@ -293,7 +293,7 @@
                         "key": "ActiveEffectLike",
                         "mode": "upgrade",
                         "path": "system.crafting.entries.alchemist.maxItemLevel",
-                        "phase": "afterDerived",
+                        "phase": "beforeDerived",
                         "predicate": [
                             "class:alchemist",
                             "crafting:entry:alchemist"
@@ -3041,7 +3041,7 @@
                         "key": "ActiveEffectLike",
                         "mode": "override",
                         "path": "system.crafting.entries.alchemist.fieldDiscovery",
-                        "phase": "afterDerived",
+                        "phase": "beforeDerived",
                         "value": "bomb"
                     }
                 ],

--- a/src/module/migration/migrations/774-unpersist-crafting-entries.ts
+++ b/src/module/migration/migrations/774-unpersist-crafting-entries.ts
@@ -59,7 +59,7 @@ export class Migration774UnpersistCraftingEntries extends MigrationBase {
             delete craftingEntryRule.requiredTraits;
         }
 
-        // Add "phase":"afterDerived" property to any AE-Likes targeting "system.crafting.entries"
+        // Add "phase":"beforeDerived" property to any AE-Likes targeting "system.crafting.entries"
         const craftingEntryAELikes: (RuleElementSource & { phase?: unknown })[] = rules.filter(
             (r: RuleElementSource & { path?: unknown }) =>
                 r.key === "ActiveEffectLike" &&
@@ -67,7 +67,7 @@ export class Migration774UnpersistCraftingEntries extends MigrationBase {
                 r.path.startsWith("system.crafting.entries.")
         );
         const newCraftingEntryAELikes = craftingEntryAELikes.map((craftingEntryAELike) => {
-            craftingEntryAELike.phase = "afterDerived";
+            craftingEntryAELike.phase = "beforeDerived";
             return craftingEntryAELike;
         });
         for (const craftingEntryAELike of craftingEntryAELikes) {


### PR DESCRIPTION
Closes #4189 

The AE-likes never needed to be set in the "afterDerived" phase, but it won't hurt anything that ones out in the wild do.