### PR TITLE
Update TypeScript to 4.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
                 "ts-loader": "^9.3.1",
                 "ts-node": "^10.9.1",
                 "tsconfig-paths": "^4.1.0",
-                "typescript": "^4.5.5",
+                "typescript": "4.8",
                 "webpack": "^5.74.0",
                 "webpack-cli": "^4.10.0",
                 "webpack-dev-server": "^4.11.0",
@@ -11747,9 +11747,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.5.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-            "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+            "version": "4.8.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+            "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -22143,9 +22143,9 @@
             }
         },
         "typescript": {
-            "version": "4.5.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-            "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+            "version": "4.8.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+            "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
             "dev": true
         },
         "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
         "ts-loader": "^9.3.1",
         "ts-node": "^10.9.1",
         "tsconfig-paths": "^4.1.0",
-        "typescript": "^4.5.5",
+        "typescript": "4.8",
         "webpack": "^5.74.0",
         "webpack-cli": "^4.10.0",
         "webpack-dev-server": "^4.11.0",

--- a/src/module/encounter/combatant.ts
+++ b/src/module/encounter/combatant.ts
@@ -28,7 +28,7 @@ class CombatantPF2e<
         this: RolledCombatant<NonNullable<TParent>>,
         { than }: { than: RolledCombatant<NonNullable<TParent>> }
     ): boolean {
-        if (this.parent !== than.parent) {
+        if (this.parent.id !== than.parent.id) {
             throw ErrorPF2e("The initiative of Combatants from different combats cannot be compared");
         }
 

--- a/src/module/item/effect/document.ts
+++ b/src/module/item/effect/document.ts
@@ -2,7 +2,7 @@ import { AbstractEffectPF2e } from "@item/abstract-effect";
 import { EffectBadge } from "@item/abstract-effect/data";
 import { RuleElementOptions, RuleElementPF2e } from "@module/rules";
 import { UserPF2e } from "@module/user";
-import { isObject, sluggify } from "@util";
+import { isObject, objectHasKey, sluggify } from "@util";
 import { EffectData } from "./data";
 
 class EffectPF2e extends AbstractEffectPF2e {
@@ -158,7 +158,7 @@ class EffectPF2e extends AbstractEffectPF2e {
 
         // If the badge type changes, reset the value
         const badge = changed.system?.badge;
-        if (isObject<EffectBadge>(badge) && badge?.type && !("value" in badge)) {
+        if (isObject<EffectBadge>(badge) && badge?.type && !objectHasKey(badge, "value")) {
             badge.value = 1;
         }
 


### PR DESCRIPTION
Includes two fixes to make the update possible.
Both `this.parent` in `CombatantPF2e#hasHigherInitiative` and `badge` in `EffectPF2e#_preUpdate` were resolving to `never` after the checks.