### PR TITLE
Fix remaining betterer warnings outside type definitions except one

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -5,32 +5,16 @@
 //
 exports[`too-much-lint`] = {
   value: `{
-    "src/module/actor/character/sheet.ts:1435820242": [
-      [131, 72, 3, "Unexpected any. Specify a different type.", "193409811"],
-      [131, 77, 3, "Unexpected any. Specify a different type.", "193409811"],
-      [136, 72, 3, "Unexpected any. Specify a different type.", "193409811"],
-      [136, 77, 3, "Unexpected any. Specify a different type.", "193409811"]
-    ],
-    "src/module/actor/modifiers.ts:446279157": [
-      [410, 19, 3, "Unexpected any. Specify a different type.", "193409811"]
-    ],
-    "src/module/actor/sheet/base.ts:833009595": [
-      [898, 20, 3, "Unexpected any. Specify a different type.", "193409811"]
-    ],
-    "src/module/actor/vehicle/sheet.ts:617235856": [
-      [21, 25, 3, "Unexpected any. Specify a different type.", "193409811"],
-      [34, 44, 3, "Unexpected any. Specify a different type.", "193409811"]
-    ],
-    "src/module/item/consumable/data.ts:4102190712": [
-      [29, 13, 3, "Unexpected any. Specify a different type.", "193409811"]
+    "src/module/actor/modifiers.ts:1519629089": [
+      [412, 19, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
     "types/foundry/client/application/form-application/document-sheet/actor-sheet.d.ts:4046500136": [
       [8, 15, 3, "Unexpected any. Specify a different type.", "193409811"],
       [9, 14, 3, "Unexpected any. Specify a different type.", "193409811"],
       [10, 15, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "types/foundry/client/collections/compendium-collection.d.ts:283791623": [
-      [209, 23, 3, "Unexpected any. Specify a different type.", "193409811"]
+    "types/foundry/client/collections/compendium-collection.d.ts:3957627828": [
+      [210, 23, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
     "types/foundry/client/documents/item.d.ts:2931579527": [
       [62, 45, 3, "Unexpected any. Specify a different type.", "193409811"]
@@ -48,8 +32,8 @@ exports[`too-much-lint`] = {
       [167, 21, 3, "Unexpected any. Specify a different type.", "193409811"],
       [305, 44, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "types/foundry/client/game.d.ts:3068083748": [
-      [179, 32, 3, "Unexpected any. Specify a different type.", "193409811"]
+    "types/foundry/client/game.d.ts:2501689875": [
+      [182, 32, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
     "types/foundry/client/pixi/placeables-layer/base.d.ts:3719149522": [
       [132, 20, 3, "Unexpected any. Specify a different type.", "193409811"],
@@ -83,7 +67,7 @@ exports[`too-much-lint`] = {
       [111, 31, 3, "Unexpected any. Specify a different type.", "193409811"],
       [113, 43, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "types/foundry/common/utils/helpers.d.ts:2775131225": [
+    "types/foundry/common/utils/helpers.d.ts:1865096411": [
       [12, 50, 3, "Unexpected any. Specify a different type.", "193409811"],
       [165, 63, 3, "Unexpected any. Specify a different type.", "193409811"]
     ]

--- a/src/module/actor/character/data/sheet.ts
+++ b/src/module/actor/character/data/sheet.ts
@@ -7,7 +7,8 @@ import { FlattenedCondition } from "@system/conditions";
 import { BonusFeat, CharacterSystemData, SlottedFeat } from ".";
 import { CreatureSheetData, SpellcastingSheetData } from "@actor/creature/types";
 import { CHARACTER_SHEET_TABS } from "./values";
-import { ClassDCData } from "./types";
+import { CharacterSaveData, ClassDCData } from "./types";
+import { SaveType } from "@actor/types";
 
 type CharacterSheetOptions = ActorSheetOptions;
 
@@ -27,6 +28,13 @@ type CharacterSystemSheetData = CharacterSystemData & {
             hover: string;
         };
     };
+    saves: Record<
+        SaveType,
+        CharacterSaveData & {
+            rankName?: string;
+            short?: string;
+        }
+    >;
 };
 
 export interface CraftingEntriesSheetData {

--- a/src/module/actor/character/data/types.ts
+++ b/src/module/actor/character/data/types.ts
@@ -454,6 +454,7 @@ export {
     CharacterProficiency,
     CharacterResources,
     CharacterSaves,
+    CharacterSaveData,
     CharacterSkillData,
     CharacterSource,
     CharacterStrike,

--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -133,12 +133,12 @@ class CharacterSheetPF2e extends CreatureSheetPF2e<CharacterPF2e> {
             reflex: sheetData.data.saves.reflex,
             will: sheetData.data.saves.will,
         };
-        for (const save of Object.values(sheetData.data.saves as Record<any, any>)) {
+        for (const save of Object.values(sheetData.data.saves)) {
             save.rankName = game.i18n.format(`PF2E.ProficiencyLevel${save.rank}`);
         }
 
         // limiting the amount of characters for the save labels
-        for (const save of Object.values(sheetData.data.saves as Record<any, any>)) {
+        for (const save of Object.values(sheetData.data.saves)) {
             save.short = game.i18n.format(`PF2E.Saves${save.label}Short`);
         }
 

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -894,7 +894,7 @@ export abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorShee
     private onClickCreateItem(event: JQuery.ClickEvent) {
         event.preventDefault();
         const header = event.currentTarget;
-        const data: any = duplicate(header.dataset);
+        const data = duplicate(header.dataset);
         data.img = `systems/pf2e/icons/default-icons/${data.type}.svg`;
 
         if (data.type === "action") {

--- a/src/module/actor/vehicle/data.ts
+++ b/src/module/actor/vehicle/data.ts
@@ -6,6 +6,7 @@ import {
     BaseHitPointsData,
     BaseTraitsData,
 } from "@actor/data/base";
+import { ActorSheetDataPF2e } from "@actor/sheet/data-types";
 import { ActorSizePF2e } from "@actor/data/size";
 import { StatisticTraceData } from "@system/statistic";
 import { VehiclePF2e } from ".";
@@ -65,6 +66,7 @@ interface VehicleFortitudeSaveData extends StatisticTraceData {
 }
 
 interface VehicleTraitsData extends BaseTraitsData<VehicleTrait> {
+    rarity: keyof ConfigPF2e["PF2E"]["rarityTraits"];
     size: ActorSizePF2e;
 }
 
@@ -73,4 +75,14 @@ interface TokenDimensions {
     height: number;
 }
 
-export { VehicleData, VehicleSource, VehicleTrait, TokenDimensions };
+interface VehicleSheetData extends ActorSheetDataPF2e<VehiclePF2e> {
+    actorRarities: typeof CONFIG.PF2E.rarityTraits;
+    actorRarity: string;
+    actorSizes: typeof CONFIG.PF2E.actorSizes;
+    actorSize: string;
+    data: {
+        traits: VehicleTraitsData;
+    };
+}
+
+export { VehicleData, VehicleSheetData, VehicleSource, VehicleTrait, TokenDimensions };

--- a/src/module/actor/vehicle/sheet.ts
+++ b/src/module/actor/vehicle/sheet.ts
@@ -2,6 +2,7 @@ import { ActorSheetPF2e } from "../sheet/base";
 import { VehiclePF2e } from "@actor/vehicle";
 import { ItemDataPF2e } from "@item/data";
 import { tupleHasValue } from "@util";
+import { VehicleSheetData } from "./data";
 
 export class VehicleSheetPF2e extends ActorSheetPF2e<VehiclePF2e> {
     static override get defaultOptions(): ActorSheetOptions {
@@ -18,8 +19,8 @@ export class VehicleSheetPF2e extends ActorSheetPF2e<VehiclePF2e> {
         return "systems/pf2e/templates/actors/vehicle/vehicle-sheet.html";
     }
 
-    override async getData() {
-        const sheetData: any = await super.getData();
+    override async getData(): Promise<VehicleSheetData> {
+        const sheetData = (await super.getData()) as VehicleSheetData;
 
         sheetData.actorSizes = CONFIG.PF2E.actorSizes;
         sheetData.actorSize = sheetData.actorSizes[sheetData.data.traits.size.value];
@@ -32,7 +33,7 @@ export class VehicleSheetPF2e extends ActorSheetPF2e<VehiclePF2e> {
         return sheetData;
     }
 
-    protected async prepareItems(sheetData: any): Promise<void> {
+    protected async prepareItems(sheetData: VehicleSheetData): Promise<void> {
         const actorData = sheetData.actor;
 
         // Actions

--- a/src/module/item/consumable/data.ts
+++ b/src/module/item/consumable/data.ts
@@ -1,5 +1,4 @@
 import {
-    ActivatedEffectData,
     BasePhysicalItemData,
     BasePhysicalItemSource,
     PhysicalItemTraits,
@@ -18,7 +17,7 @@ type ConsumableType = keyof ConfigPF2e["PF2E"]["consumableTypes"];
 type ConsumableTrait = keyof ConfigPF2e["PF2E"]["consumableTraits"];
 type ConsumableTraits = PhysicalItemTraits<ConsumableTrait>;
 
-interface ConsumableSystemSource extends PhysicalSystemSource, ActivatedEffectData {
+interface ConsumableSystemSource extends PhysicalSystemSource {
     traits: ConsumableTraits;
 
     consumableType: {
@@ -27,7 +26,7 @@ interface ConsumableSystemSource extends PhysicalSystemSource, ActivatedEffectDa
     uses: {
         value: number;
         max: number;
-        per: any;
+        per: keyof ConfigPF2e["PF2E"]["frequencies"];
         autoUse: boolean;
         autoDestroy: boolean;
     };


### PR DESCRIPTION
I have no idea why `ConsumableSystemData` was extending `ActivatedEffectData`. The new type for `uses.per` might be incorrect but it looks like it isn't used anywhere. Also, the only references to `ConsumablePF2e#system.uses` I could find where `uses.value` and `uses.max`. Removing the unused properties could eliminate a lot of lines from the pack data.

The one remaining `any` type is a `[key: string]: any` in `StatisticModifier`. Removing that blows up a lot of stuff and I'm not sure what the best way to fix it would be.