### PR TITLE
Remove last explicit any type

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -5,9 +5,6 @@
 //
 exports[`too-much-lint`] = {
   value: `{
-    "src/module/actor/modifiers.ts:1519629089": [
-      [412, 19, 3, "Unexpected any. Specify a different type.", "193409811"]
-    ],
     "types/foundry/client/application/form-application/document-sheet/actor-sheet.d.ts:4046500136": [
       [8, 15, 3, "Unexpected any. Specify a different type.", "193409811"],
       [9, 14, 3, "Unexpected any. Specify a different type.", "193409811"],

--- a/src/module/actor/character/data/sheet.ts
+++ b/src/module/actor/character/data/sheet.ts
@@ -13,6 +13,11 @@ import { SaveType } from "@actor/types";
 type CharacterSheetOptions = ActorSheetOptions;
 
 type CharacterSystemSheetData = CharacterSystemData & {
+    attributes: {
+        perception: {
+            rankName: string;
+        };
+    };
     details: CharacterSystemData["details"] & {
         keyability: {
             value: keyof typeof CONFIG.PF2E.abilities;

--- a/src/module/actor/character/data/types.ts
+++ b/src/module/actor/character/data/types.ts
@@ -71,6 +71,8 @@ interface CharacterSkillData extends SkillData {
     rank: ZeroToFour;
     /** Whether this skill is subject to an armor check penalty */
     armor: boolean;
+    /** Is this skill a Lore skill? */
+    lore?: boolean;
 }
 
 /** The raw information contained within the actor data object for characters. */

--- a/src/module/actor/character/index.ts
+++ b/src/module/actor/character/index.ts
@@ -1141,16 +1141,19 @@ class CharacterPF2e extends CreaturePF2e {
                 loreSkill,
                 { overwrite: false }
             );
+            const additionalData = {
+                itemID: loreItem.id,
+                shortform: shortForm,
+                expanded: loreItem,
+                lore: true,
+            };
+
             stat.adjustments = extractDegreeOfSuccessAdjustments(synthetics, domains);
             stat.label = loreItem.name;
             stat.ability = "int";
-            stat.itemID = loreItem.id;
             stat.notes = extractNotes(synthetics.rollNotes, domains);
             stat.rank = rank ?? 0;
-            stat.shortform = shortForm;
-            stat.expanded = loreItem;
             stat.value = stat.totalModifier;
-            stat.lore = true;
             stat.breakdown = stat.modifiers
                 .filter((m) => m.enabled)
                 .map((m) => `${m.label} ${m.modifier < 0 ? "" : "+"}${m.modifier}`)
@@ -1194,7 +1197,7 @@ class CharacterPF2e extends CreaturePF2e {
                 return roll;
             };
 
-            skills[shortForm] = stat;
+            skills[shortForm] = mergeObject(stat, additionalData);
         }
 
         return skills;

--- a/src/module/actor/creature/data.ts
+++ b/src/module/actor/creature/data.ts
@@ -72,6 +72,8 @@ type CreatureDetails = {
 };
 
 interface CreatureSystemData extends CreatureSystemSource, ActorSystemData {
+    abilities?: Abilities;
+
     details: CreatureDetails;
 
     /** Traits, languages, and other information. */
@@ -173,6 +175,7 @@ type MovementType = "land" | "burrow" | "climb" | "fly" | "swim";
 interface LabeledSpeed extends Omit<LabeledNumber, "exceptions"> {
     type: Exclude<MovementType, "land">;
     source?: string;
+    total?: number;
 }
 
 type UnlabeledSpeed = Omit<LabeledSpeed, "label">;

--- a/src/module/actor/creature/sheet.ts
+++ b/src/module/actor/creature/sheet.ts
@@ -22,7 +22,6 @@ import {
 } from "@util";
 import { ActorSheetPF2e } from "../sheet/base";
 import { CreatureConfig } from "./config";
-import { SkillData } from "./data";
 import { SpellPreparationSheet } from "./spell-preparation-sheet";
 import { CreatureSheetData, SpellcastingSheetData } from "./types";
 
@@ -37,7 +36,7 @@ export abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends Act
     protected abstract readonly actorConfigClass: ConstructorOf<CreatureConfig<CreaturePF2e>> | null;
 
     override async getData(options?: ActorSheetOptions): Promise<CreatureSheetData<TActor>> {
-        const sheetData = await super.getData(options);
+        const sheetData = (await super.getData(options)) as CreatureSheetData<TActor>;
         const { actor } = this;
 
         // Update save labels
@@ -68,13 +67,12 @@ export abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends Act
 
         // Update skill labels
         if (sheetData.data.skills) {
-            const skills: Record<string, SkillData & Record<string, string>> = sheetData.data.skills;
-            const mainSkills: Record<string, string> = CONFIG.PF2E.skills;
-            for (const key in skills) {
-                const skill = skills[key];
+            const skills = sheetData.data.skills;
+            for (const [key, skill] of Object.entries(skills)) {
+                const label = objectHasKey(CONFIG.PF2E.skills, key) ? CONFIG.PF2E.skills[key] : null;
                 skill.icon = this.getProficiencyIcon(skill.rank);
                 skill.hover = CONFIG.PF2E.proficiencyLevels[skill.rank];
-                skill.label = skill.label ?? mainSkills[key];
+                skill.label = skill.label ?? label ?? "";
             }
         }
 

--- a/src/module/actor/creature/types.ts
+++ b/src/module/actor/creature/types.ts
@@ -12,6 +12,9 @@ import { ALIGNMENTS, ALIGNMENT_TRAITS } from "./values";
 import { TraitViewData } from "@actor/data/base";
 import { FlattenedCondition } from "@system/conditions";
 import { ActorUpdateContext } from "@actor/base";
+import { AbilityData, CreatureSystemData, SaveData, SkillData } from "./data";
+import { ZeroToFour } from "@module/data";
+import { AbilityString, SaveType } from "@actor/types";
 
 type Alignment = SetElement<typeof ALIGNMENTS>;
 type AlignmentTrait = SetElement<typeof ALIGNMENT_TRAITS>;
@@ -73,7 +76,17 @@ interface CreatureUpdateContext<T extends CreaturePF2e> extends ActorUpdateConte
     allowHPOverage?: boolean;
 }
 
+type WithRank = { icon?: string; hover?: string; rank: ZeroToFour };
+
 interface CreatureSheetData<TActor extends CreaturePF2e = CreaturePF2e> extends ActorSheetDataPF2e<TActor> {
+    data: CreatureSystemData & {
+        abilities: Record<AbilityString, AbilityData & { label?: string }>;
+        attributes: {
+            perception: CreatureSystemData["attributes"]["perception"] & WithRank;
+        };
+        saves: Record<SaveType, SaveData & WithRank>;
+        skills: Record<string, SkillData & WithRank>;
+    };
     languages: SheetOptions;
     abilities: ConfigPF2e["PF2E"]["abilities"];
     skills: ConfigPF2e["PF2E"]["skills"];

--- a/src/module/actor/familiar/data.ts
+++ b/src/module/actor/familiar/data.ts
@@ -62,7 +62,7 @@ interface FamiliarAttributes extends CreatureAttributes {
 }
 
 type FamiliarPerception = { value: number } & StatisticModifier & Rollable;
-type FamiliarSkill = StatisticModifier & Rollable & { value: number };
+type FamiliarSkill = StatisticModifier & Rollable & { value: number; ability: AbilityString; visible?: boolean };
 type FamiliarSkills = Record<SkillAbbreviation, FamiliarSkill>;
 
 interface FamiliarTraitsData extends CreatureTraitsData {

--- a/src/module/actor/familiar/index.ts
+++ b/src/module/actor/familiar/index.ts
@@ -219,12 +219,11 @@ export class FamiliarPF2e extends CreaturePF2e {
                 },
             });
             stat.adjustments = extractDegreeOfSuccessAdjustments(synthetics, domains);
-            stat.value = stat.totalModifier;
             stat.breakdown = stat.modifiers
                 .filter((m) => m.enabled)
                 .map((m) => `${m.label} ${m.modifier < 0 ? "" : "+"}${m.modifier}`)
                 .join(", ");
-            systemData.attack = stat;
+            systemData.attack = mergeObject(stat, { value: stat.totalModifier });
         }
 
         // Perception

--- a/src/module/actor/hazard/index.ts
+++ b/src/module/actor/hazard/index.ts
@@ -64,14 +64,13 @@ export class HazardPF2e extends ActorPF2e {
             const stat = mergeObject(new StatisticModifier("ac", modifiers), system.attributes.ac, {
                 overwrite: false,
             });
-            stat.base = base;
             stat.value = stat.totalModifier;
             stat.breakdown = stat.modifiers
                 .filter((m) => m.enabled)
                 .map((m) => `${m.label} ${m.modifier < 0 ? "" : "+"}${m.modifier}`)
                 .join(", ");
 
-            system.attributes.ac = stat;
+            system.attributes.ac = mergeObject(stat, { base });
         }
 
         this.saves = this.prepareSaves();

--- a/src/module/actor/modifiers.ts
+++ b/src/module/actor/modifiers.ts
@@ -409,8 +409,6 @@ class StatisticModifier {
     notes?: RollNotePF2e[];
 
     adjustments?: DegreeOfSuccessAdjustment[];
-    /** Allow decorating this object with any needed extra fields. <-- ಠ_ಠ */
-    [key: string]: any;
 
     /**
      * @param slug The name of this collection of statistic modifiers.

--- a/src/module/actor/npc/data.ts
+++ b/src/module/actor/npc/data.ts
@@ -199,6 +199,7 @@ interface NPCHitPoints extends CreatureHitPoints {
 
 /** Perception data with an additional "base" value */
 interface NPCPerception extends PerceptionData {
+    rank?: number;
     base?: number;
 }
 
@@ -206,6 +207,8 @@ interface NPCPerception extends PerceptionData {
 interface NPCSkillData extends SkillData {
     base?: number;
     visible?: boolean;
+    isLore?: boolean;
+    itemID?: string;
     ability: AbilityString;
     label: string;
     expanded: string;

--- a/src/module/actor/npc/index.ts
+++ b/src/module/actor/npc/index.ts
@@ -419,14 +419,16 @@ class NPCPF2e extends CreaturePF2e {
                     system.skills[shortform],
                     { overwrite: false }
                 );
+                const additionalData = {
+                    itemID: item.id,
+                    lore: !objectHasKey(SKILL_EXPANDED, skill),
+                    rank: 1,
+                };
                 stat.adjustments = extractDegreeOfSuccessAdjustments(synthetics, domains);
                 stat.notes = extractNotes(rollNotes, domains);
-                stat.itemID = item.id;
                 stat.base = base;
                 stat.expanded = skill;
                 stat.label = item.name;
-                stat.lore = !objectHasKey(SKILL_EXPANDED, skill);
-                stat.rank = 1; // default to trained
                 stat.value = stat.totalModifier;
                 stat.visible = true;
                 stat.breakdown = stat.modifiers
@@ -463,15 +465,7 @@ class NPCPF2e extends CreaturePF2e {
                     return roll;
                 };
 
-                const variants = item.system.variants;
-                if (variants && Object.keys(variants).length) {
-                    stat.variants = [];
-                    for (const [, variant] of Object.entries(variants)) {
-                        stat.variants.push(variant);
-                    }
-                }
-
-                system.skills[shortform] = stat;
+                system.skills[shortform] = mergeObject(stat, additionalData);
             } else if (item.isOfType("melee")) {
                 const { ability, traits, isMelee, isThrown } = item;
 

--- a/src/module/actor/npc/sheet.ts
+++ b/src/module/actor/npc/sheet.ts
@@ -92,7 +92,7 @@ export class NPCSheetPF2e<TActor extends NPCPF2e> extends CreatureSheetPF2e<TAct
     }
 
     override async getData(): Promise<NPCSheetData<TActor>> {
-        const sheetData: PrePrepSheetData<TActor> = await super.getData();
+        const sheetData = (await super.getData()) as PrePrepSheetData<TActor>;
 
         // Show the token's name as the actor's name if the user has limited permission or this NPC is dead and lootable
         if (this.actor.limited || this.isLootSheet) {

--- a/src/module/actor/npc/types.ts
+++ b/src/module/actor/npc/types.ts
@@ -2,6 +2,7 @@ import { CreatureSheetData, SpellcastingSheetData } from "@actor/creature/types"
 import { HitPointsData, PerceptionData } from "@actor/data/base";
 import { SaveType } from "@actor/types";
 import { ActionItemData, EffectData, ItemDataPF2e } from "@item/data";
+import { ZeroToFour } from "@module/data";
 import { IdentifyCreatureData } from "@module/recall-knowledge";
 import { NPCPF2e } from ".";
 import {
@@ -53,11 +54,13 @@ interface VariantCloneParams {
     keepId?: boolean;
 }
 
+type WithRank = { icon?: string; hover?: string; rank: ZeroToFour };
+
 interface NPCSystemSheetData extends NPCSystemData {
     attributes: NPCAttributes & {
         ac: NPCArmorClass & WithAdjustments;
         hp: HitPointsData & WithAdjustments;
-        perception: PerceptionData & WithAdjustments;
+        perception: PerceptionData & WithAdjustments & WithRank;
     };
     details: NPCSystemData["details"] & {
         level: NPCSystemData["details"]["level"] & WithAdjustments;
@@ -66,7 +69,8 @@ interface NPCSystemSheetData extends NPCSystemData {
         };
     };
     sortedSkills: Record<string, NPCSkillData & WithAdjustments>;
-    saves: Record<SaveType, NPCSaveData & WithAdjustments & { labelShort?: string }>;
+    saves: Record<SaveType, NPCSaveData & WithAdjustments & WithRank & { labelShort?: string }>;
+    skills: Record<string, NPCSkillData & WithAdjustments & WithRank>;
     traits: NPCTraitsData & {
         size: {
             localizedName?: string;

--- a/src/module/system/action-macros/helpers.ts
+++ b/src/module/system/action-macros/helpers.ts
@@ -119,7 +119,7 @@ export class ActionMacroHelpers {
             })();
             combinedOptions.push(...(weapon?.getRollOptions("weapon") ?? []));
 
-            const stat = getProperty(selfActor, options.statName) as StatisticModifier;
+            const stat = getProperty(selfActor, options.statName) as StatisticModifier & { rank?: number };
             const itemBonus =
                 weapon && weapon.slug !== "basic-unarmed" ? this.getWeaponPotencyModifier(weapon, stat.slug) : null;
 


### PR DESCRIPTION
The removed `varaints` are `Lore` variants that are not used anywhere else in the code as far is I can tell. Also the `New Skill Variant` button on the lore item sheet is non-functional.