### PR TITLE
Fix inline rolls for class dcs

### DIFF
--- a/src/module/actor/character/index.ts
+++ b/src/module/actor/character/index.ts
@@ -643,7 +643,7 @@ class CharacterPF2e extends CreaturePF2e {
         this.classDCs = {};
         for (const [slug, classDC] of Object.entries(systemData.proficiencies.classDCs)) {
             const statistic = this.prepareClassDC(slug, classDC);
-            systemData.proficiencies.classDCs[slug] = mergeObject(classDC, statistic.getTraceData());
+            systemData.proficiencies.classDCs[slug] = mergeObject(classDC, statistic.getTraceData({ value: "dc" }));
             this.classDCs[slug] = statistic;
             if (classDC.primary) {
                 this.classDC = statistic;

--- a/src/module/system/statistic/data.ts
+++ b/src/module/system/statistic/data.ts
@@ -66,7 +66,7 @@ export interface StatisticChatData {
 export interface StatisticTraceData {
     slug: string;
     label: string;
-    /** Backwards compatibility with StatisticModifier (this is an alias for totalModifier) */
+    /** Either the totalModifier or the dc depending on what the data is for */
     value: number;
     totalModifier: number;
     dc: number;

--- a/src/module/system/statistic/index.ts
+++ b/src/module/system/statistic/index.ts
@@ -243,13 +243,14 @@ export class Statistic {
     }
 
     /** Returns data intended to be merged back into actor data */
-    getTraceData(this: Statistic, options: RollOptionParameters = {}): StatisticTraceData {
-        const { check, dc } = this.withRollOptions(options);
+    getTraceData(this: Statistic, options: { value?: "dc" | "mod" } = {}): StatisticTraceData {
+        const { check, dc } = this;
+        const valueProp = options.value ?? "mod";
 
         return {
             slug: this.slug,
             label: this.label,
-            value: check.mod,
+            value: valueProp === "mod" ? check.mod : dc.value,
             totalModifier: check.mod ?? 0,
             dc: dc.value,
             breakdown: check.breakdown ?? "",


### PR DESCRIPTION
Alternatively we can migrate all class dcs to point to .dc instead of .value, or to point to `@actor.classDCs.dc.value`.