### PR TITLE
Set default for custom check modifiers equal to the placeholder (+1)

### DIFF
--- a/src/module/system/check-modifiers-dialog.ts
+++ b/src/module/system/check-modifiers-dialog.ts
@@ -145,7 +145,7 @@ export class CheckModifiersDialog extends Application {
 
     async onAddModifier(event: JQuery.ClickEvent): Promise<void> {
         const parent = $(event.currentTarget).parents(".add-modifier-panel");
-        const value = Number(parent.find(".add-modifier-value").val());
+        const value = Number(parent.find(".add-modifier-value").val() || 1);
         const type = `${parent.find(".add-modifier-type").val()}`;
         let name = `${parent.find(".add-modifier-name").val()}`;
         const errors: string[] = [];

--- a/static/templates/chat/check-modifiers-dialog.html
+++ b/static/templates/chat/check-modifiers-dialog.html
@@ -48,7 +48,7 @@
             <option value="ability">{{localize "PF2E.ModifierType.ability"}}</option>
             <option value="proficiency">{{localize "PF2E.ModifierType.proficiency"}}</option>
         </select>
-        <input type="text" class="add-modifier-value" placeholder="+1">
+        <input type="number" class="add-modifier-value" placeholder="+1">
         <button type="button" class="add-modifier">+{{localize "PF2E.Roll.Add"}}</button>
     </div>
     <hr/>


### PR DESCRIPTION
Clicking add when the value box is empty now adds a +1 modifier. I get caught by this every so often, so I suspect its a semi-common issue no one raises an issue about because they go "oh" at the prompt.

![image](https://user-images.githubusercontent.com/1286721/192904238-212441df-8dd2-4ddd-8902-669b22df60fa.png)
