### PR TITLE
Set correct ability when class dcs are picked

### DIFF
--- a/src/module/actor/character/index.ts
+++ b/src/module/actor/character/index.ts
@@ -758,11 +758,12 @@ class CharacterPF2e extends CreaturePF2e {
             }
 
             // Spellcasting entries extend other statistics, usually a tradition, but sometimes class dc
-            const stat = this.getProficiencyStatistic(entry.system.proficiency.slug);
-            if (!stat) continue;
+            const baseStat = this.getProficiencyStatistic(entry.system.proficiency.slug);
+            if (!baseStat) continue;
 
-            entry.system.proficiency.value = Math.max(entry.rank, stat.rank ?? 0) as ZeroToFour;
-            entry.statistic = stat.extend({
+            entry.system.ability.value = baseStat.ability ?? entry.system.ability.value;
+            entry.system.proficiency.value = Math.max(entry.rank, baseStat.rank ?? 0) as ZeroToFour;
+            entry.statistic = baseStat.extend({
                 slug: entry.slug ?? sluggify(entry.name),
                 ability: entry.ability,
                 rank: entry.rank,

--- a/src/module/actor/sheet/spellcasting-dialog.ts
+++ b/src/module/actor/sheet/spellcasting-dialog.ts
@@ -47,7 +47,7 @@ class SpellcastingCreateAndEditDialog extends FormApplication<Embedded<Spellcast
         return {
             ...(await super.getData()),
             actor: this.actor,
-            data: this.object.toObject(true).system,
+            data: this.object.toObject().system,
             magicTraditions: CONFIG.PF2E.magicTraditions,
             spellcastingTypes: CONFIG.PF2E.preparationType,
             abilities: CONFIG.PF2E.abilities,

--- a/src/module/actor/sheet/spellcasting-dialog.ts
+++ b/src/module/actor/sheet/spellcasting-dialog.ts
@@ -47,11 +47,19 @@ class SpellcastingCreateAndEditDialog extends FormApplication<Embedded<Spellcast
         return {
             ...(await super.getData()),
             actor: this.actor,
-            data: this.object.toObject(false).system,
+            data: this.object.toObject(true).system,
             magicTraditions: CONFIG.PF2E.magicTraditions,
             spellcastingTypes: CONFIG.PF2E.preparationType,
             abilities: CONFIG.PF2E.abilities,
+            hasAbility: this.#canSetAbility(),
         };
+    }
+
+    /** Returns whether or not the spellcasting data can include an ability */
+    #canSetAbility(): boolean {
+        const slug = this.object._source.system.proficiency.slug;
+        const baseStat = this.actor.isOfType("character") ? this.actor.getProficiencyStatistic(slug) : null;
+        return !slug || (!!baseStat && !baseStat.ability);
     }
 
     protected override async _updateObject(event: Event, formData: Record<string, unknown>): Promise<void> {
@@ -59,22 +67,29 @@ class SpellcastingCreateAndEditDialog extends FormApplication<Embedded<Spellcast
 
         // Unflatten the form data, so that we may make some modifications
         const inputData: DeepPartial<SpellcastingEntrySource> = expandObject(formData);
-        const system = inputData.system;
 
         // We may disable certain form data, so reinject it
-        inputData.system = mergeObject(
+        const system = mergeObject(
             inputData.system ?? {},
             {
                 prepared: {
                     value: this.object.system.prepared.value,
                 },
+                ability: { value: "cha" },
             },
             { overwrite: false }
         );
 
-        // When swapping to innate, convert to cha, but don't force it
-        if (system?.prepared?.value === "innate" && !wasInnate && system?.ability) {
+        inputData.system = system;
+
+        // When swapping to innate convert to cha, but allow changes after
+        if (system.prepared.value === "innate" && !wasInnate) {
             system.ability.value = "cha";
+        }
+
+        // If the proficiency is being set to a value, remove the selected ability
+        if (system.proficiency?.slug) {
+            system.ability.value = "";
         }
 
         if (system?.autoHeightenLevel) {
@@ -141,6 +156,7 @@ interface SpellcastingCreateAndEditDialogSheetData extends FormApplicationData<E
     magicTraditions: ConfigPF2e["PF2E"]["magicTraditions"];
     spellcastingTypes: ConfigPF2e["PF2E"]["preparationType"];
     abilities: ConfigPF2e["PF2E"]["abilities"];
+    hasAbility: boolean;
 }
 
 export async function createSpellcastingDialog(event: MouseEvent, object: ActorPF2e | Embedded<SpellcastingEntryPF2e>) {

--- a/static/templates/actors/spellcasting-dialog.html
+++ b/static/templates/actors/spellcasting-dialog.html
@@ -59,16 +59,18 @@
                     </select>
                 </div>
             {{/if}}
-            <div class="form-group">
-                <label>{{localize "PF2E.SpellAbilityLabel"}}</label>
-                <select name="system.ability.value">
-                    {{#select data.ability.value}}
-                        {{#each abilities as |label key|}}
-                            <option value="{{key}}">{{localize label}}</option>
-                        {{/each}}
-                    {{/select}}
-                </select>
-            </div>
+            {{#if hasAbility}}
+                <div class="form-group">
+                    <label>{{localize "PF2E.SpellAbilityLabel"}}</label>
+                    <select name="system.ability.value">
+                        {{#select data.ability.value}}
+                            {{#each abilities as |label key|}}
+                                <option value="{{key}}">{{localize label}}</option>
+                            {{/each}}
+                        {{/select}}
+                    </select>
+                </div>
+            {{/if}}
             {{#if (eq actor.type "npc")}}
             <div class="form-group">
                 <label>{{localize "PF2E.SpellcastingSettings.AutoHeightenLabel"}}</label>


### PR DESCRIPTION
This hides the ability selection as well when the proficiency is set to anything other than class tradition. Base tradition statistics do not have set abilities, and thus its safe to prioritize the base statistic's ability over the entry's.