### PR TITLE
Allow Choice Set homebrew drop when there are no valid default choices

### DIFF
--- a/src/module/rules/rule-element/choice-set/prompt.ts
+++ b/src/module/rules/rule-element/choice-set/prompt.ts
@@ -46,6 +46,7 @@ export class ChoiceSetPrompt extends PickAThingPrompt<string | number | object> 
             prompt: this.prompt,
             containsUUIDs: this.containsUUIDs,
             allowNoSelection: this.allowNoSelection,
+            allowedDrops: this.allowedDrops,
             selectMenu: this.choices.length > 9,
         };
     }
@@ -72,7 +73,7 @@ export class ChoiceSetPrompt extends PickAThingPrompt<string | number | object> 
         }
 
         // Exit early if there are no valid choices
-        if (this.choices.length === 0 && !this.containsUUIDs) {
+        if (this.choices.length === 0 && !this.containsUUIDs && !this.allowedDrops) {
             await this.close({ force: true });
             return null;
         }
@@ -160,4 +161,5 @@ interface ChoiceSetTemplateData extends PromptTemplateData {
     choices: PickableThing[];
     containsUUIDs: boolean;
     allowNoSelection: boolean;
+    allowedDrops: { label: string | null; predicate: PredicatePF2e };
 }

--- a/src/module/rules/rule-element/choice-set/prompt.ts
+++ b/src/module/rules/rule-element/choice-set/prompt.ts
@@ -7,7 +7,7 @@ import {
     PromptTemplateData,
 } from "@module/apps/pick-a-thing-prompt";
 import { PredicatePF2e } from "@system/predication";
-import { ErrorPF2e } from "@util";
+import { ErrorPF2e, sluggify } from "@util";
 
 /** Prompt the user for a selection among a set of options */
 export class ChoiceSetPrompt extends PickAThingPrompt<string | number | object> {
@@ -105,7 +105,10 @@ export class ChoiceSetPrompt extends PickAThingPrompt<string | number | object> 
         }
 
         // Drop accepted: Add to button list or select menu
-        const newChoice = { value: droppedItem.uuid, label: droppedItem.name };
+        const newChoice = {
+            value: this.containsUUIDs ? droppedItem.uuid : sluggify(droppedItem.name),
+            label: droppedItem.name,
+        };
         const choicesLength = this.choices.push(newChoice);
 
         const prompt = document.querySelector<HTMLElement>(`#${this.id}`);

--- a/static/templates/system/rules-elements/choice-set-prompt.html
+++ b/static/templates/system/rules-elements/choice-set-prompt.html
@@ -23,7 +23,7 @@
 </div>
 
 {{#*inline "dropZone"}}
-    {{#if @root.containsUUIDs}}
+    {{#if (any @root.containsUUIDs @root.allowedDrops )}}
         <div class="drop-zone with-image">
             <i class="fas fa-info-circle" title="{{localize "PF2E.UI.RuleElements.ChoiceSet.DragHomebrewItem"}}"></i>
             <span>{{localize "PF2E.UI.RuleElements.ChoiceSet.HomebrewItem"}}</span>


### PR DESCRIPTION
Currently, when a ChoiceSet has no valid choices, it says there are no suitable items, regardless of if there is an allowedDrops on the ChoiceSet. This change causes a homebrew drop box to appear in such a situation, allowing for allowedDrops to be used.

You can test this behaviour on Implement Adept. The choices are hardcoded to the existing implements, meaning if someone is using a homebrew implement, they have easy no way to set that implement as their adept, making automation predicated off that essentially impossible. With this change, the prompt window shows with a homebrew drop box.