### PR TITLE
Use merge declarations for actor embedded document types

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -1245,6 +1245,10 @@ class ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
 interface ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
     readonly data: ActorDataPF2e;
 
+    readonly items: foundry.abstract.EmbeddedCollection<ItemPF2e>;
+
+    readonly effects: foundry.abstract.EmbeddedCollection<ActiveEffectPF2e>;
+
     prototypeToken: PrototypeTokenPF2e;
 
     flags: ActorFlagsPF2e;

--- a/types/foundry/client/documents/actor.d.ts
+++ b/types/foundry/client/documents/actor.d.ts
@@ -176,6 +176,10 @@ declare global {
 
         readonly parent: TParent | null;
 
+        readonly items: foundry.abstract.EmbeddedCollection<Item>;
+
+        readonly effects: foundry.abstract.EmbeddedCollection<ActiveEffect>;
+
         prototypeToken: foundry.data.PrototypeToken;
 
         get collection(): Actors<this>;

--- a/types/foundry/common/documents/actor.d.ts
+++ b/types/foundry/common/documents/actor.d.ts
@@ -15,13 +15,11 @@ declare module foundry {
 
             static override get metadata(): ActorMetadata;
 
-            /**
-             * A reference to the Collection of embedded ActiveEffect instances in the Actor document, indexed by _id.
-             */
-            get effects(): this["data"]["effects"];
+            /** A Collection of Item embedded Documents */
+            readonly items: abstract.EmbeddedCollection<documents.BaseItem>;
 
-            /** A reference to the Collection of embedded Item instances in the Actor document, indexed by _id. */
-            get items(): this["data"]["items"];
+            /** A Collection of ActiveEffect embedded Documents */
+            readonly effects: abstract.EmbeddedCollection<documents.BaseActiveEffect>;
 
             /**
              * Migrate the system data object to conform to data model defined by the current system version.


### PR DESCRIPTION
This is to help move closer to V10 types by getting rid of some types pulled from `this["data"]`