### PR TITLE
Fix PWoL variant not honoring untrained proficiency penalties

### DIFF
--- a/src/module/actor/character/index.ts
+++ b/src/module/actor/character/index.ts
@@ -556,7 +556,7 @@ class CharacterPF2e extends CreaturePF2e {
         // Perception
         {
             const domains = ["perception", "wis-based", "all"];
-            const proficiencyRank = systemData.attributes.perception.rank || 0;
+            const proficiencyRank = systemData.attributes.perception.rank;
             const modifiers = [
                 createAbilityModifier({ actor: this, ability: "wis", domains }),
                 ProficiencyModifier.fromLevelAndRank(this.level, proficiencyRank),
@@ -1469,7 +1469,7 @@ class CharacterPF2e extends CreaturePF2e {
             .filter((p): p is MartialProficiency => "definition" in p && p.definition.test(weaponProficiencyOptions))
             .map((p) => p.rank);
 
-        const proficiencyRank = Math.max(categoryRank, groupRank, baseWeaponRank, ...syntheticRanks);
+        const proficiencyRank = Math.max(categoryRank, groupRank, baseWeaponRank, ...syntheticRanks) as ZeroToFour;
         modifiers.push(ProficiencyModifier.fromLevelAndRank(this.level, proficiencyRank));
         weaponRollOptions.push(`weapon:proficiency:rank:${proficiencyRank}`);
 

--- a/src/module/actor/creature/index.ts
+++ b/src/module/actor/creature/index.ts
@@ -8,6 +8,7 @@ import {
     ensureProficiencyOption,
     ModifierPF2e,
     MODIFIER_TYPE,
+    MODIFIER_TYPES,
     RawModifier,
     StatisticModifier,
 } from "@actor/modifiers";
@@ -34,7 +35,7 @@ import { LocalizePF2e } from "@system/localize";
 import { PredicatePF2e, RawPredicate } from "@system/predication";
 import { CheckPF2e, CheckRollContext } from "@system/rolls";
 import { Statistic } from "@system/statistic";
-import { ErrorPF2e, objectHasKey, traitSlugToObject } from "@util";
+import { ErrorPF2e, objectHasKey, setHasElement, traitSlugToObject } from "@util";
 import {
     CreatureSkills,
     CreatureSpeeds,
@@ -599,7 +600,14 @@ export abstract class CreaturePF2e extends ActorPF2e {
         const customModifiers = this.toObject().system.customModifiers ?? {};
         const modifiers = customModifiers[stat] ?? [];
         if (!modifiers.some((m) => m.label === label)) {
-            const modifier = new ModifierPF2e({ label, modifier: value, type, predicate, custom: true }).toObject();
+            const modifierType = setHasElement(MODIFIER_TYPES, type) ? type : "untyped";
+            const modifier = new ModifierPF2e({
+                label,
+                modifier: value,
+                type: modifierType,
+                predicate,
+                custom: true,
+            }).toObject();
             if (damageType) {
                 modifier.damageType = damageType;
             }


### PR DESCRIPTION
This also addresses the bonuses being affected by the configurable variant values when the variant is disabled