### PR TITLE
Restore raw note functionality to CheckPF2e

### DIFF
--- a/src/module/notes.ts
+++ b/src/module/notes.ts
@@ -18,7 +18,7 @@ class RollNotePF2e {
 
     constructor(params: RollNoteSource) {
         this.selector = params.selector;
-        this.predicate = new PredicatePF2e(...(params.predicate ?? []));
+        this.predicate = PredicatePF2e.create(params.predicate ?? []);
         this.outcome = [...(params.outcome ?? [])];
         this.visibility = params.visibility ?? null;
         this.#title = params.title ?? null;


### PR DESCRIPTION
I'm pretty tempted on eventually refactoring the note string filter but not today.

Marked as a bugfix since this was a loss of functionality in an unfortunately public facing thing with no substitute.