### PR TITLE
Use fa-stack for heal button, enlarge labels slightly

### DIFF
--- a/src/styles/ui/sidebar/chat/_damage.scss
+++ b/src/styles/ui/sidebar/chat/_damage.scss
@@ -148,63 +148,46 @@
 > .message-content {
     .chat-damage-buttons {
         display: flex;
+        justify-content: center;
         margin-top: 3px;
 
         button {
             flex: 1 1 0;
             font-size: var(--font-size-18);
             line-height: 0.5em;
-            position: relative;
-            width: 52px;
 
-            > i {
-                left: 1px;
-                margin-right: 3px;
+            &.half-damage {
                 position: relative;
-                top: 1px;
-                vertical-align: top;
-            }
 
-             .transparent-half {
-                background: rgb(248, 247, 233);
-                display: block;
-                height: 24px;
-                left: 48%;
-                opacity: 0.6;
-                position: absolute;
-                top: 0px;
-                width: 16px;
-            }
-
-            .plus {
-                color: rgba(248, 247, 233);
-                font-size: var(--font-size-17);
-                font-weight: bold;
-                left: 40%;
-                position: absolute;
-                top: 6px;
+                .transparent-half {
+                    background: rgb(248, 247, 233);
+                    display: block;
+                    height: 24px;
+                    left: 49%;
+                    opacity: 0.6;
+                    position: absolute;
+                    top: 0px;
+                    width: 10px;
+                }
             }
 
             > img {
                 border: none;
-                height: 19px;
-                position: relative;
-                top: 2px;
+                height: var(--font-size-18);
+            }
+
+            &.heal-damage .fa-stack {
+                font-size: 0.5em;
+
+                i.fa-plus {
+                    font-size: var(--font-size-10);
+                }
             }
 
             .label {
-                font-size: 0.4em;
+                font-size: var(--font-size-9);
+                font-weight: 500;
                 text-transform: uppercase;
-            }
-        }
-
-        // Slightly reposition elements if the triple-damage button is in
-        &.includes-fumble {
-            > button.triple-damage > img {
-                left: -1px;
-            }
-            span.plus {
-                left: 16px;
             }
         }
     }

--- a/static/templates/chat/damage/buttons.html
+++ b/static/templates/chat/damage/buttons.html
@@ -1,10 +1,10 @@
 <div class="chat-damage-buttons{{#if showTripleDamage}} includes-fumble{{/if}}">
     <button type="button" class="full-damage" title="{{localize "PF2E.DamageButton.Full"}}">
-        <i class="fas fa-heart-broken"></i>
+        <i class="fa-solid fa-heart-broken fa-fw"></i>
         <span class="label">{{localize "PF2E.DamageButton.FullShort"}}</span>
     </button>
     <button type="button" class="half-damage" title="{{localize "PF2E.DamageButton.Half"}}">
-        <i class="fas fa-heart-broken"></i>
+        <i class="fa-solid fa-heart-broken fa-fw"></i>
         <span class="transparent-half"></span>
         <span class="label">{{localize "PF2E.DamageButton.HalfShort"}}</span>
     </button>
@@ -19,12 +19,14 @@
         </button>
     {{/if}}
     <button type="button" class="shield-block dice-total-shield-btn" title="{{localize "PF2E.DamageButton.ShieldBlock"}}">
-        <i class="fas fa-shield-alt"></i>
+        <i class="fa-solid fa-shield-alt fa-fw"></i>
         <span class="label">{{localize "PF2E.DamageButton.ShieldBlockShort"}}</span>
     </button>
     <button type="button" class="heal-damage" title="{{localize "PF2E.DamageButton.Healing"}}">
-        <i class="fas fa-heart"></i>
-        <span class="plus">+</span>
+        <span class="fa-stack fa-fw">
+            <i class="fa-solid fa-heart fa-stack-2x"></i>
+            <i class="fa-solid fa-plus fa-inverse fa-stack-1x"></i>
+        </span>
         <span class="label">{{localize "PF2E.DamageButton.HealingShort"}}</span>
     </button>
 </div>


### PR DESCRIPTION
The styling is much less finicky now.

Before:
![image](https://user-images.githubusercontent.com/106829671/193484890-ddbe6038-437f-4f09-85c9-70ed27abe87a.png)


After:
![image](https://user-images.githubusercontent.com/106829671/193485044-ce9ccd45-c194-49f5-b2c1-f3677419bdc1.png)
