### PR TITLE
Show players the total bulk for Loot actors they own.

### DIFF
--- a/static/templates/actors/loot/sidebar.html
+++ b/static/templates/actors/loot/sidebar.html
@@ -5,6 +5,13 @@
     {{else}}
         <div class="description">{{{enrichedContent.description}}}</section>
     {{/if}}
+
+    {{#unless user.isGM}}
+        {{#if isLoot}}
+            <div class="bulk"><strong>{{localize "PF2E.BulkLabel"}}</strong> {{inventory.bulk.value}}</div>
+        {{/if}}
+    {{/unless}}
+
     {{#if user.isGM}}
         {{#if isLoot}}
             <section class="loot-distribution">


### PR DESCRIPTION
Before and after image:
![image](https://user-images.githubusercontent.com/246024/193832758-8e254856-6cf5-4763-9b9f-42ec03daaa28.png)


Fixes #3229