### PR TITLE
Fix start of turn status message

### DIFF
--- a/src/module/canvas/status-effects.ts
+++ b/src/module/canvas/status-effects.ts
@@ -306,7 +306,7 @@ export class StatusEffects {
             <div class="dice-roll">
                 <div class="dice-result">
                     <div class="dice-total statuseffect-message">
-                        <ul>${statusEffectList.join(", ")}</ul>
+                        <ul>${statusEffectList.join("")}</ul>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Before and after between different loads 

![image](https://user-images.githubusercontent.com/1286721/193765891-4c9581cb-ed11-4b90-a5a0-b0caaa6c760c.png)
