### PR TITLE
Fix display of drag gap and mystified name (gm view) in encounter view popouts

### DIFF
--- a/src/styles/ui/_combat.scss
+++ b/src/styles/ui/_combat.scss
@@ -1,20 +1,10 @@
-#combat {
-    #combat-round {
-        .encounters {
-            h3 {
-                font-size: var(--font-size-16);
-                font-weight: 500;
-            }
-        }
+.combat-sidebar {
+    // The gap left by a combatant being dragged to a new position
+    .drag-gap {
+        visibility: hidden;
     }
-    #combat-tracker {
-        // The gap left by a combatant being dragged to a new position
-        .drag-gap {
-            visibility: hidden;
-        }
 
-        .hidden-name .token-name h4 {
-            color: var(--color-text-light-7);
-        }
+    .hidden-name .token-name h4 {
+        color: var(--color-text-light-7);
     }
 }


### PR DESCRIPTION
The h3 styling has not worked for v10, and even if changed the styling change is almost unnoticeable (the font size for the round is the same, the only change is the font weight, and only marginally). So I just removed it since it no longer really served a purpose.