### PR TITLE
Fix styling of flat modifier form in certain cases

### DIFF
--- a/src/styles/item/_rules.scss
+++ b/src/styles/item/_rules.scss
@@ -4,6 +4,7 @@
     select {
         font-size: var(--font-size-12);
         height: 1.36rem;
+        width: auto;
         span {
             padding: 0;
         }


### PR DESCRIPTION
I suspect it was broken for non-embedded items, but I can't be sure.

![image](https://user-images.githubusercontent.com/1286721/193989916-812f0b64-c682-4088-93c2-057caf66d964.png)
