### PR TITLE
Fix damage dice validation for damageType and dieSize overrides

### DIFF
--- a/src/module/rules/rule-element/damage-dice.ts
+++ b/src/module/rules/rule-element/damage-dice.ts
@@ -150,6 +150,8 @@ class DamageDiceRuleElement extends RuleElementPF2e {
             isObject<DamageDiceOverride>(override) &&
             ((typeof override.upgrade === "boolean" && !("downgrade" in override)) ||
                 (typeof override.downgrade === "boolean" && !("upgrade" in override)) ||
+                typeof override.damageType === "string" ||
+                typeof override.dieSize === "string" ||
                 (typeof override.diceNumber === "number" &&
                     Number.isInteger(override.diceNumber) &&
                     override.diceNumber > 0 &&


### PR DESCRIPTION
The recent fix (#4350) removed the part of the damage dice validation that looked for the existence of the `damageType` or `dieSize` fields in the DamageDice `override` field. As a result, any override with _only_ these fields would be classed as invalid.

I've re-added these fields to the validation, merely testing that they are strings. The validity of the string is checked later, after resolving properties.