### PR TITLE
Return false early when testing detection of GM-hidden placeable objects

### DIFF
--- a/src/module/canvas/perception/modes.ts
+++ b/src/module/canvas/perception/modes.ts
@@ -30,6 +30,18 @@ class VisionDetectionMode extends DetectionModeBasicSight {
         });
     }
 
+    /** Short-circuit test to false if token is GM-hidden */
+    override testVisibility(
+        visionSource: VisionSource<Token>,
+        mode: TokenDetectionMode,
+        config?: CanvasVisibilityTestConfig
+    ): boolean {
+        return (
+            !(config?.object instanceof PlaceableObject && config.object.document.hidden) &&
+            super.testVisibility(visionSource, mode, config)
+        );
+    }
+
     protected override _canDetect(visionSource: VisionSource<TokenPF2e>, target: PlaceableObject): boolean {
         if (!super._canDetect(visionSource, target)) return false;
         const targetIsUndetected =
@@ -54,6 +66,19 @@ class HearingDetectionMode extends DetectionMode {
         }));
         filter.thickness = 1;
         return filter;
+    }
+
+    /** Short-circuit test to false if token is GM-hidden */
+    override testVisibility(
+        visionSource: VisionSource<Token>,
+        mode: TokenDetectionMode,
+        config?: CanvasVisibilityTestConfig
+    ): boolean {
+        return (
+            config?.object instanceof TokenPF2e &&
+            !config.object.document.hidden &&
+            super.testVisibility(visionSource, mode, config)
+        );
     }
 
     protected override _canDetect(visionSource: VisionSource<TokenPF2e>, target: PlaceableObject): boolean {

--- a/types/foundry/client/documents/mixins/canvas-document-mixin.d.ts
+++ b/types/foundry/client/documents/mixins/canvas-document-mixin.d.ts
@@ -56,5 +56,6 @@ declare global {
     > extends ClientDocument<TDocument> {
         x: number;
         y: number;
+        hidden: boolean;
     }
 }

--- a/types/foundry/client/pixi/layers/effects/visibility.d.ts
+++ b/types/foundry/client/pixi/layers/effects/visibility.d.ts
@@ -3,7 +3,7 @@ export {};
 declare global {
     interface CanvasVisibilityTestConfig {
         /** The target object */
-        object: PlaceableObject;
+        object: PlaceableObject | DoorControl;
         /** An array of visibility tests */
         tests: CanvasVisibilityTest[];
     }


### PR DESCRIPTION
Closes #4359.

This leaves such placeables still visible to GMs but cuts out the unnecessary performance cost of full detection testing against them.