### PR TITLE
Minor corrections of Iconic sheets

### DIFF
--- a/packs/data/iconics.db/droogami-level-1.json
+++ b/packs/data/iconics.db/droogami-level-1.json
@@ -424,6 +424,7 @@
             }
         },
         "crafting": {
+            "entries": {},
             "formulas": []
         },
         "details": {
@@ -455,7 +456,7 @@
                 "value": ""
             },
             "gender": {
-                "value": ""
+                "value": "F/She/Her"
             },
             "height": {
                 "value": ""

--- a/packs/data/iconics.db/droogami-level-5.json
+++ b/packs/data/iconics.db/droogami-level-5.json
@@ -559,6 +559,7 @@
             }
         },
         "crafting": {
+            "entries": {},
             "formulas": []
         },
         "details": {
@@ -590,7 +591,7 @@
                 "value": ""
             },
             "gender": {
-                "value": ""
+                "value": "F/She/Her"
             },
             "height": {
                 "value": ""

--- a/packs/data/iconics.db/feiya-level-5.json
+++ b/packs/data/iconics.db/feiya-level-5.json
@@ -8681,6 +8681,7 @@
             }
         },
         "crafting": {
+            "entries": {},
             "formulas": []
         },
         "customModifiers": {},
@@ -8787,13 +8788,13 @@
                 "rank": 0
             },
             "med": {
-                "rank": 1
+                "rank": 2
             },
             "nat": {
                 "rank": 1
             },
             "occ": {
-                "rank": 0
+                "rank": 2
             },
             "prf": {
                 "rank": 0

--- a/packs/data/iconics.db/harsk-level-5.json
+++ b/packs/data/iconics.db/harsk-level-5.json
@@ -3224,7 +3224,7 @@
                 "level": {
                     "value": 4
                 },
-                "location": "class-2",
+                "location": "class-4",
                 "prerequisites": {
                     "value": []
                 },
@@ -3272,7 +3272,7 @@
                 "level": {
                     "value": 2
                 },
-                "location": "class-4",
+                "location": "class-2",
                 "prerequisites": {
                     "value": []
                 },
@@ -4004,6 +4004,7 @@
             }
         },
         "crafting": {
+            "entries": {},
             "formulas": []
         },
         "customModifiers": {},

--- a/packs/data/iconics.db/jirelle-level-5.json
+++ b/packs/data/iconics.db/jirelle-level-5.json
@@ -2965,7 +2965,7 @@
                 "level": {
                     "value": 4
                 },
-                "location": "class-2",
+                "location": "class-4",
                 "prerequisites": {
                     "value": []
                 },
@@ -3023,7 +3023,7 @@
                 "level": {
                     "value": 2
                 },
-                "location": "class-4",
+                "location": "class-2",
                 "prerequisites": {
                     "value": []
                 },
@@ -3952,6 +3952,7 @@
             }
         },
         "crafting": {
+            "entries": {},
             "formulas": []
         },
         "customModifiers": {},

--- a/packs/data/iconics.db/korakai-level-1.json
+++ b/packs/data/iconics.db/korakai-level-1.json
@@ -4346,6 +4346,7 @@
             }
         },
         "crafting": {
+            "entries": {},
             "formulas": []
         },
         "customModifiers": {},
@@ -4378,7 +4379,7 @@
                 "value": ""
             },
             "gender": {
-                "value": ""
+                "value": "M/He/Him"
             },
             "height": {
                 "value": ""

--- a/packs/data/iconics.db/korakai-level-5.json
+++ b/packs/data/iconics.db/korakai-level-5.json
@@ -6295,6 +6295,7 @@
             }
         },
         "crafting": {
+            "entries": {},
             "formulas": []
         },
         "customModifiers": {},
@@ -6327,7 +6328,7 @@
                 "value": ""
             },
             "gender": {
-                "value": ""
+                "value": "M/He/Him"
             },
             "height": {
                 "value": ""

--- a/packs/data/iconics.db/lem-level-5.json
+++ b/packs/data/iconics.db/lem-level-5.json
@@ -5763,6 +5763,7 @@
             }
         },
         "crafting": {
+            "entries": {},
             "formulas": []
         },
         "customModifiers": {},
@@ -5848,7 +5849,7 @@
         "saves": {},
         "skills": {
             "acr": {
-                "rank": 1
+                "rank": 2
             },
             "arc": {
                 "rank": 0
@@ -5878,7 +5879,7 @@
                 "rank": 0
             },
             "prf": {
-                "rank": 0
+                "rank": 2
             },
             "rel": {
                 "rank": 0

--- a/packs/data/iconics.db/lini-level-1.json
+++ b/packs/data/iconics.db/lini-level-1.json
@@ -4204,6 +4204,7 @@
             }
         },
         "crafting": {
+            "entries": {},
             "formulas": []
         },
         "customModifiers": {},
@@ -4236,7 +4237,7 @@
                 "value": ""
             },
             "gender": {
-                "value": ""
+                "value": "F/She/Her"
             },
             "height": {
                 "value": ""

--- a/packs/data/iconics.db/lini-level-5.json
+++ b/packs/data/iconics.db/lini-level-5.json
@@ -4073,7 +4073,7 @@
                 "level": {
                     "value": 4
                 },
-                "location": "class-2",
+                "location": "class-4",
                 "prerequisites": {
                     "value": [
                         {
@@ -4125,7 +4125,7 @@
                 "level": {
                     "value": 1
                 },
-                "location": "class-4",
+                "location": "class-2",
                 "prerequisites": {
                     "value": []
                 },
@@ -5611,6 +5611,7 @@
             }
         },
         "crafting": {
+            "entries": {},
             "formulas": []
         },
         "customModifiers": {},
@@ -5643,7 +5644,7 @@
                 "value": ""
             },
             "gender": {
-                "value": ""
+                "value": "F/She/Her"
             },
             "height": {
                 "value": ""

--- a/packs/data/iconics.db/quinn-level-1.json
+++ b/packs/data/iconics.db/quinn-level-1.json
@@ -2861,6 +2861,7 @@
             }
         },
         "crafting": {
+            "entries": {},
             "formulas": []
         },
         "details": {
@@ -2892,7 +2893,7 @@
                 "value": ""
             },
             "gender": {
-                "value": ""
+                "value": "M/He/Him"
             },
             "height": {
                 "value": ""

--- a/packs/data/iconics.db/quinn-level-5.json
+++ b/packs/data/iconics.db/quinn-level-5.json
@@ -3503,85 +3503,6 @@
             "type": "consumable"
         },
         {
-            "_id": "hEw3QvU2mRzC8C5w",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.equipment-srd.5GbC7RTgyAeaOcAI"
-                }
-            },
-            "img": "systems/pf2e/icons/equipment/adventuring-gear/magnifying-glass.webp",
-            "name": "Magnifying Glass",
-            "sort": 0,
-            "system": {
-                "baseItem": null,
-                "containerId": null,
-                "description": {
-                    "value": "<p>This quality handheld lens gives you a +1 item bonus to Perception checks to notice minute details of documents, fabric, and the like.</p>"
-                },
-                "equipped": {
-                    "carryType": "worn",
-                    "invested": null
-                },
-                "equippedBulk": {
-                    "value": ""
-                },
-                "hardness": 0,
-                "hp": {
-                    "brokenThreshold": 0,
-                    "max": 0,
-                    "value": 0
-                },
-                "level": {
-                    "value": 0
-                },
-                "negateBulk": {
-                    "value": "0"
-                },
-                "preciousMaterial": {
-                    "value": ""
-                },
-                "preciousMaterialGrade": {
-                    "value": ""
-                },
-                "price": {
-                    "value": {
-                        "gp": 40
-                    }
-                },
-                "quantity": 1,
-                "rules": [
-                    {
-                        "key": "FlatModifier",
-                        "label": "Magnifying Glass (minute details)",
-                        "predicate": [
-                            "minute-details"
-                        ],
-                        "selector": "perception",
-                        "type": "item",
-                        "value": 1
-                    }
-                ],
-                "size": "med",
-                "slug": "magnifying-glass",
-                "source": {
-                    "value": "Pathfinder Core Rulebook"
-                },
-                "stackGroup": null,
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                },
-                "usage": {
-                    "value": "held-in-one-hand"
-                },
-                "weight": {
-                    "value": "-"
-                }
-            },
-            "type": "equipment"
-        },
-        {
             "_id": "doTfHnTdmTHSc4gA",
             "flags": {
                 "core": {
@@ -4174,6 +4095,85 @@
                 }
             },
             "type": "treasure"
+        },
+        {
+            "_id": "LkghwEgxgiyGkZ09",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.equipment-srd.5GbC7RTgyAeaOcAI"
+                }
+            },
+            "img": "systems/pf2e/icons/equipment/adventuring-gear/magnifying-glass.webp",
+            "name": "Magnifying Glass",
+            "sort": 0,
+            "system": {
+                "baseItem": null,
+                "containerId": null,
+                "description": {
+                    "value": "<p>This quality handheld lens gives you a +1 item bonus to Perception checks to notice minute details of documents, fabric, and the like.</p>"
+                },
+                "equipped": {
+                    "carryType": "worn",
+                    "invested": null
+                },
+                "equippedBulk": {
+                    "value": ""
+                },
+                "hardness": 0,
+                "hp": {
+                    "brokenThreshold": 0,
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 3
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "preciousMaterial": {
+                    "value": ""
+                },
+                "preciousMaterialGrade": {
+                    "value": ""
+                },
+                "price": {
+                    "value": {
+                        "gp": 40
+                    }
+                },
+                "quantity": 1,
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "label": "Magnifying Glass (minute details)",
+                        "predicate": [
+                            "minute-details"
+                        ],
+                        "selector": "perception",
+                        "type": "item",
+                        "value": 1
+                    }
+                ],
+                "size": "med",
+                "slug": "magnifying-glass",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "stackGroup": null,
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "usage": {
+                    "value": "held-in-one-hand"
+                },
+                "weight": {
+                    "value": "-"
+                }
+            },
+            "type": "equipment"
         }
     ],
     "name": "Quinn (Level 5)",
@@ -4228,6 +4228,7 @@
             }
         },
         "crafting": {
+            "entries": {},
             "formulas": []
         },
         "customModifiers": {},
@@ -4260,7 +4261,7 @@
                 "value": ""
             },
             "gender": {
-                "value": ""
+                "value": "M/He/Him"
             },
             "height": {
                 "value": ""

--- a/packs/data/iconics.db/sajan-level-1.json
+++ b/packs/data/iconics.db/sajan-level-1.json
@@ -2856,6 +2856,7 @@
             }
         },
         "crafting": {
+            "entries": {},
             "formulas": []
         },
         "customModifiers": {},
@@ -2888,7 +2889,7 @@
                 "value": ""
             },
             "gender": {
-                "value": ""
+                "value": "M/He/Him"
             },
             "height": {
                 "value": ""

--- a/packs/data/iconics.db/sajan-level-5.json
+++ b/packs/data/iconics.db/sajan-level-5.json
@@ -2913,7 +2913,7 @@
                 "level": {
                     "value": 4
                 },
-                "location": "class-2",
+                "location": "class-4",
                 "prerequisites": {
                     "value": []
                 },
@@ -2961,7 +2961,7 @@
                 "level": {
                     "value": 2
                 },
-                "location": "class-4",
+                "location": "class-2",
                 "prerequisites": {
                     "value": [
                         {
@@ -3029,7 +3029,7 @@
                 "level": {
                     "value": 2
                 },
-                "location": "skill-2",
+                "location": "skill-4",
                 "prerequisites": {
                     "value": [
                         {
@@ -3082,7 +3082,7 @@
                 "level": {
                     "value": 1
                 },
-                "location": "skill-4",
+                "location": "skill-2",
                 "prerequisites": {
                     "value": [
                         {
@@ -3814,6 +3814,7 @@
             }
         },
         "crafting": {
+            "entries": {},
             "formulas": []
         },
         "customModifiers": {},
@@ -3846,7 +3847,7 @@
                 "value": ""
             },
             "gender": {
-                "value": ""
+                "value": "M/He/Him"
             },
             "height": {
                 "value": ""

--- a/packs/data/iconics.db/seoni-level-1.json
+++ b/packs/data/iconics.db/seoni-level-1.json
@@ -3826,6 +3826,7 @@
             }
         },
         "crafting": {
+            "entries": {},
             "formulas": []
         },
         "customModifiers": {},
@@ -3858,7 +3859,7 @@
                 "value": ""
             },
             "gender": {
-                "value": ""
+                "value": "F/She/Her"
             },
             "height": {
                 "value": ""

--- a/packs/data/iconics.db/seoni-level-5.json
+++ b/packs/data/iconics.db/seoni-level-5.json
@@ -3404,7 +3404,7 @@
                 "level": {
                     "value": 4
                 },
-                "location": "class-2",
+                "location": "class-4",
                 "prerequisites": {
                     "value": []
                 },
@@ -3454,7 +3454,7 @@
                 "level": {
                     "value": 1
                 },
-                "location": "class-4",
+                "location": "class-2",
                 "prerequisites": {
                     "value": []
                 },
@@ -5263,6 +5263,7 @@
             }
         },
         "crafting": {
+            "entries": {},
             "formulas": []
         },
         "customModifiers": {},
@@ -5295,7 +5296,7 @@
                 "value": ""
             },
             "gender": {
-                "value": ""
+                "value": "F/She/Her"
             },
             "height": {
                 "value": ""


### PR DESCRIPTION
- Feiya5 missing expert skills
- Harsk5 had lvl4 class feat in lvl2 slot
- Jirelle5 had lvl4 class feat in lvl2 slot
- Korakai pronouns s/b "M/He/Him"
- Lem5 missing expert skills
- Lini5 had lvl4 class feat in lvl2 slot
- Lini/Droogami pronouns s/b "F/She/Her"
- Sajan pronouns s/b "M/He/Him"
- Sajan5 had lvl4 class feat in lvl2 slot
- Sajan5 Powerful Leap cannot be taken until level 4. Swapped with Quick Jump
- Quinn pronouns s/b "M/He/Him"
- Quinn's Magnifying Glass replaced from compendia (previously showed as lvl 0)
- Seoni pronouns s/b "F/She/Her"
- Seoni had lvl4 class feat in lvl2 slot