### PR TITLE
Fix double-granting world items from ABC items

### DIFF
--- a/src/module/item/abc/manager.ts
+++ b/src/module/item/abc/manager.ts
@@ -135,20 +135,6 @@ export class AncestryBackgroundClassManager {
                     })
                 );
             }
-            // Get feats from the game.items collection
-            const worldEntries = entries.filter((e) => e.uuid.startsWith("Item."));
-            feats.push(
-                ...worldEntries.map((entry) => {
-                    const item = fromUuidSync(entry.uuid);
-                    if (item instanceof FeatPF2e) {
-                        const source = item.toObject();
-                        source._id = randomID(16);
-                        return source;
-                    } else {
-                        throw ErrorPF2e("Invalid item type referenced in ABCFeatureEntryData");
-                    }
-                })
-            );
         }
         return feats;
     }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2132,7 +2132,8 @@
             "Rules": {
                 "Apply": "Apply",
                 "Close": "Close"
-            }
+            },
+            "WorldItemWarning": "This is a World Item and will not work if saved in a compendium"
         },
         "ItemBonus0": "0",
         "ItemBonus1": "+1 Weapon Potency",

--- a/static/templates/items/class-details.html
+++ b/static/templates/items/class-details.html
@@ -271,7 +271,7 @@
     <li data-pack-id="{{item.pack}}" data-index="{{i}}" data-item-uuid="{{item.uuid}}">
         <img src="{{item.img}}">
         <div class="name">
-            {{item.name}}{{#if item.isWorldItem}}<i class="fa fa-globe" title="{{localize "PF2E.AncestryFeatures"}}"></i>{{/if}}
+            {{item.name}}{{#if item.fromWorld}}<i class="fa fa-globe" title="{{localize "PF2E.Item.WorldItemWarning"}}"></i>{{/if}}
         </div>
         <input type="number" class="level" value="{{item.level}}" name="system.items.{{i}}.level" />
         <input value="{{item.uuid}}" name="system.items.{{i}}.uuid" type="hidden" data-dtype="String" />


### PR DESCRIPTION
Conversion to uuid has made the split between compendium/non-compendium no longer necessary. I guess we can see later if the extra migration becomes a problem for world items.

Fixes #4361