### PR TITLE
Add roll mode param to cast() function

### DIFF
--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -40,12 +40,6 @@ interface SpellConstructionContext extends ItemConstructionContextPF2e {
     fromConsumable?: boolean;
 }
 
-interface SpellToMessageOptions extends ToMessageOptions {
-    data?: {
-        castLevel?: number;
-    };
-}
-
 class SpellPF2e extends ItemPF2e {
     readonly isFromConsumable: boolean;
 
@@ -427,9 +421,9 @@ class SpellPF2e extends ItemPF2e {
 
     override async toMessage(
         event?: JQuery.TriggeredEvent,
-        { create = true, data = {} }: SpellToMessageOptions = {}
+        { create = true, data = {}, rollMode }: SpellToMessageOptions = {}
     ): Promise<ChatMessagePF2e | undefined> {
-        const message = await super.toMessage(event, { create: false, data });
+        const message = await super.toMessage(event, { create: false, data, rollMode });
         if (!message) return undefined;
 
         const messageSource = message.toObject();
@@ -786,9 +780,10 @@ interface SpellVariantChatData {
     sort: number;
 }
 
-interface ToMessageOptions {
+interface SpellToMessageOptions {
     create?: boolean;
-    data?: Record<string, unknown> & { slotLevel?: number; castLevel?: number };
+    rollMode?: RollMode;
+    data?: { castLevel?: number };
 }
 
-export { SpellPF2e };
+export { SpellPF2e, SpellToMessageOptions };

--- a/src/module/item/spellcasting-entry/data/types.ts
+++ b/src/module/item/spellcasting-entry/data/types.ts
@@ -14,7 +14,7 @@ interface BaseSpellcastingEntry {
     ability: AbilityString;
     tradition: MagicTradition | null;
     statistic: Statistic;
-    cast(spell: SpellPF2e, options: {}): Promise<void>;
+    cast(spell: SpellPF2e, options: CastOptions): Promise<void>;
 }
 
 interface SpellcastingEntry extends BaseSpellcastingEntry {
@@ -22,6 +22,18 @@ interface SpellcastingEntry extends BaseSpellcastingEntry {
     isSpontaneous: boolean;
     isInnate: boolean;
     isFocusPool: boolean;
+}
+
+interface CastOptions {
+    message?: boolean;
+    rollMode?: RollMode;
+}
+
+interface SpellcastingEntryPF2eCastOptions extends CastOptions {
+    consume?: boolean;
+    /** The slot level to consume to cast the spell at */
+    level?: number;
+    slot?: number;
 }
 
 // temporary type until the spellcasting entry is migrated to no longer use slotX keys
@@ -91,12 +103,14 @@ interface SpellcastingEntrySystemData extends ItemSystemData {
 
 export {
     BaseSpellcastingEntry,
+    CastOptions,
     PreparationType,
     SlotKey,
     SpellAttackRollModifier,
     SpellDifficultyClass,
     SpellcastingEntry,
     SpellcastingEntryData,
+    SpellcastingEntryPF2eCastOptions,
     SpellcastingEntrySource,
     SpellcastingEntrySystemData,
 };

--- a/src/module/item/spellcasting-entry/index.ts
+++ b/src/module/item/spellcasting-entry/index.ts
@@ -8,7 +8,13 @@ import { UserPF2e } from "@module/user";
 import { Statistic } from "@system/statistic";
 import { ErrorPF2e, setHasElement, sluggify } from "@util";
 import { SpellCollection } from "./collection";
-import { SpellcastingAbilityData, SpellcastingEntry, SpellcastingEntryData, SpellcastingEntryListData } from "./data";
+import {
+    SpellcastingAbilityData,
+    SpellcastingEntry,
+    SpellcastingEntryData,
+    SpellcastingEntryListData,
+    SpellcastingEntryPF2eCastOptions,
+} from "./data";
 
 class SpellcastingEntryPF2e extends ItemPF2e implements SpellcastingEntry {
     spells!: SpellCollection | null;
@@ -134,17 +140,14 @@ class SpellcastingEntryPF2e extends ItemPF2e implements SpellcastingEntry {
     }
 
     /** Casts the given spell as if it was part of this spellcasting entry */
-    async cast(
-        spell: Embedded<SpellPF2e>,
-        options: { slot?: number; level?: number; consume?: boolean; message?: boolean } = {}
-    ): Promise<void> {
+    async cast(spell: Embedded<SpellPF2e>, options: SpellcastingEntryPF2eCastOptions = {}): Promise<void> {
         const consume = options.consume ?? true;
         const message = options.message ?? true;
         const slotLevel = options.level ?? spell.level;
         const valid = !consume || spell.isCantrip || (await this.consume(spell, slotLevel, options.slot));
         if (message && valid) {
             const castLevel = spell.computeCastLevel(slotLevel);
-            await spell.toMessage(undefined, { data: { castLevel } });
+            await spell.toMessage(undefined, { rollMode: options.rollMode, data: { castLevel } });
         }
     }
 

--- a/src/module/item/spellcasting-entry/trick.ts
+++ b/src/module/item/spellcasting-entry/trick.ts
@@ -3,7 +3,7 @@ import { AbilityString } from "@actor/types";
 import { SpellPF2e } from "@item";
 import { extractModifiers } from "@module/rules/util";
 import { Statistic } from "@system/statistic";
-import { BaseSpellcastingEntry } from "./data";
+import { BaseSpellcastingEntry, CastOptions } from "./data";
 
 export const TRICK_MAGIC_SKILLS = ["arcana", "nature", "occultism", "religion"] as const;
 export type TrickMagicItemSkill = typeof TRICK_MAGIC_SKILLS[number];
@@ -81,12 +81,14 @@ export class TrickMagicItemEntry implements BaseSpellcastingEntry {
         });
     }
 
-    async cast(spell: SpellPF2e, options: { level?: number } = {}): Promise<void> {
-        const slotLevel = options.level ?? spell.level;
-        const castLevel = spell.computeCastLevel(slotLevel);
+    async cast(spell: SpellPF2e, options: CastOptions = {}): Promise<void> {
+        const { rollMode, message } = options;
+        const castLevel = spell.computeCastLevel(spell.level);
+        if (message === false) return;
+
         try {
             spell.trickMagicEntry = this;
-            await spell.toMessage(undefined, { data: { castLevel } });
+            await spell.toMessage(undefined, { rollMode, data: { castLevel } });
         } finally {
             spell.trickMagicEntry = null;
         }


### PR DESCRIPTION
Since I couldn't figure out a clean way to get private casting going (why would you blind roll a spell instead of private roll? Blind roll is the global ctrl roll mode) this can wait till next release. Trick Magic Item heightening still works.