### PR TITLE
Allow parameters to be shadowed in script macros' eval scopes

### DIFF
--- a/src/module/macro.ts
+++ b/src/module/macro.ts
@@ -3,4 +3,22 @@ export class MacroPF2e extends Macro {
     override get visible(): boolean {
         return this.permission >= CONST.DOCUMENT_PERMISSION_LEVELS.OBSERVER;
     }
+
+    /** Allow unbound variables to be shadowed in script's evaluation scope */
+    protected override _executeScript({ actor, token }: { actor?: Actor; token?: Token | null } = {}): void {
+        // Add variables to the evaluation scope
+        const speaker = ChatMessage.implementation.getSpeaker();
+        const character = game.user.character;
+        actor ??= game.actors.get(speaker.actor ?? "");
+        token ??= canvas.ready ? canvas.tokens.get(speaker.token ?? "") : null;
+
+        // Attempt script execution
+        const AsyncFunction = async function () {}.constructor as { new (...args: string[]): Function };
+        const fn = new AsyncFunction("speaker", "actor", "token", "character", `{${this.command}}`);
+        try {
+            return fn.call(this, speaker, actor, token, character);
+        } catch {
+            ui.notifications.error("There was an error in your macro syntax. See the console (F12) for details");
+        }
+    }
 }


### PR DESCRIPTION
Workaround for https://github.com/foundryvtt/foundryvtt-premium-content/issues/120 until upstream issue is addressed