### PR TITLE
Remove deprecated use of `content` parameter in item activation panel editor

### DIFF
--- a/static/templates/items/activation-panel.html
+++ b/static/templates/items/activation-panel.html
@@ -84,7 +84,7 @@
                 {{/each}}
             </div>
 
-            {{editor content=action.description.value target=(concat base ".description.value") button=true owner=@root.owner editable=@root.editable}}
+            {{editor description target=(concat base ".description.value") button=true owner=@root.owner editable=@root.editable}}
             <input type="hidden" name="{{base}}.description.value" value="{{action.description.value}}"/>
         </div>
     {{/each}}


### PR DESCRIPTION
The description editor is currently unsued but it was generated a deprecation warning.