### PR TITLE
Refactor damage roll chat message content rendering

### DIFF
--- a/src/module/system/damage/types.ts
+++ b/src/module/system/damage/types.ts
@@ -4,4 +4,26 @@ type DamageCategory = SetElement<typeof DAMAGE_CATEGORIES>;
 type DamageDieSize = SetElement<typeof DAMAGE_DIE_FACES>;
 type DamageType = SetElement<typeof DAMAGE_TYPES>;
 
-export { DamageCategory, DamageDieSize, DamageType };
+interface DamageCategoryRenderData {
+    dice: {
+        faces: number;
+        result: number;
+    }[];
+    formula: string;
+    label: string;
+    total: number;
+}
+
+interface DamageTypeRenderData {
+    icon: string;
+    categories: Record<string, DamageCategoryRenderData>;
+    label: string;
+}
+
+interface DamageRollRenderData {
+    formula: string;
+    damageTypes: Record<string, DamageTypeRenderData>;
+    total: number;
+}
+
+export { DamageCategory, DamageDieSize, DamageRollRenderData, DamageType };

--- a/static/templates/chat/damage/damage-card-content.html
+++ b/static/templates/chat/damage/damage-card-content.html
@@ -1,34 +1,29 @@
 <div class="dice-roll">
     <div class="dice-result">
-        <div class="dice-formula">{{damage.formula}}</div>
-        <div class="dice-tooltip">
-            {{#each damage.types}}
-            <div class="damage-type {{@key}}">
-                <h3 class="flexrow">{{@key}}</h3>
-                {{#each this as |categories|}}
+        <div class="dice-formula">{{formula}}</div>
+        <div class="dice-tooltip" style="display: none;">
+            {{#each damageTypes as |data type|}}
+            <div class="damage-type {{type}}">
+                <h3 class="flexrow"><span>{{localize data.label}}</span><i class="fa fa-{{data.icon}}"></i></h3>
+                {{#each data.categories as |category|}}
                 <section class="tooltip-part">
                     <div class="dice">
                         <header class="part-header flexrow">
-                            <span class="part-formula">{{this.formula}}</span>
-                            <span class="part-flavor">{{this.label}}</span>
-                            <span class="part-total">{{this.total}}</span>
+                            <span class="part-formula">{{category.formula}}</span>
+                            <span class="part-flavor">{{localize category.label}}</span>
+                            <span class="part-total">{{category.total}}</span>
                         </header>
                     </div>
                     <ol class="dice-rolls">
-                        {{#each this.results as |rolls damageDie|}}
-                            {{#each rolls}}
-                            <li class="roll die {{damageDie}} {{#if (eq this 1)}}min{{/if}} {{#if (eq (add 'd' this) damageDie)}}max{{/if}}">{{this}}</li>
-                            {{/each}}
+                        {{#each category.dice as |die|}}
+                            <li class="roll die d{{die.faces}}">{{die.result}}</li>
                         {{/each}}
-                        {{#if this.modifier}}
-                        <li class="roll" style="background: none;">{{numberFormat this.modifier sign=true decimals=0}}</li>
-                        {{/if}}
                     </ol>
                 </section>
                 {{/each}}
             </div>
             {{/each}}
         </div>
-        <h4 class="dice-total">{{damage.total}}</h4>
+        <h4 class="dice-total">{{total}}</h4>
     </div>
 </div>


### PR DESCRIPTION
This utilizes the previously unused `damage-card-content.html` template to render the damage roll conent instead of building it with string concatenations.
As a bonus `damageType` and `damageCategory` are now localized strings instead of a capitalized slug,

Before:
![before](https://user-images.githubusercontent.com/41452412/194754940-d4c7b950-b5cd-4fea-af08-bb045f6d0984.png)

After:
![after](https://user-images.githubusercontent.com/41452412/194754946-ce267b48-b105-4f02-930b-92c87b65c82a.png)
