### PR TITLE
Fix style of damage cards with triple-damage buttons

### DIFF
--- a/src/styles/ui/sidebar/chat/_damage.scss
+++ b/src/styles/ui/sidebar/chat/_damage.scss
@@ -152,9 +152,14 @@
         margin-top: 3px;
 
         button {
-            flex: 1 1 0;
+            align-items: center;
+            display: flex;
+            flex-direction: column;
             font-size: var(--font-size-18);
-            line-height: 0.5em;
+            height: 2em;
+            justify-content: space-around;
+            line-height: unset;
+            padding: 0;
 
             &.half-damage {
                 position: relative;

--- a/static/templates/chat/damage/buttons.html
+++ b/static/templates/chat/damage/buttons.html
@@ -1,4 +1,4 @@
-<div class="chat-damage-buttons{{#if showTripleDamage}} includes-fumble{{/if}}">
+<div class="chat-damage-buttons">
     <button type="button" class="full-damage" title="{{localize "PF2E.DamageButton.Full"}}">
         <i class="fa-solid fa-heart-broken fa-fw"></i>
         <span class="label">{{localize "PF2E.DamageButton.FullShort"}}</span>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/106829671/194765703-6ac0946e-39d0-40e7-a46e-1f7b7f0c3ebe.png)

After:
![image](https://user-images.githubusercontent.com/106829671/194765676-7f59d85b-aa4e-480c-aa2c-116770461eb5.png)
