### PR TITLE
Fix modifier adjustments for top level selectors

### DIFF
--- a/src/module/actor/modifiers.ts
+++ b/src/module/actor/modifiers.ts
@@ -557,7 +557,7 @@ class CheckModifier extends StatisticModifier {
         slug: string,
         statistic: { modifiers: readonly ModifierPF2e[] },
         modifiers: ModifierPF2e[] = [],
-        rollOptions: string[] = []
+        rollOptions: string[] | Set<string> = new Set()
     ) {
         super(slug, statistic.modifiers.map((modifier) => modifier.clone()).concat(modifiers), rollOptions);
     }


### PR DESCRIPTION
This fixes modifier adjustments for sub-domain adjustments on parent domains is still broken (such as spell-attack adjustment on an all modifier)