### PR TITLE
Accommodate macros ending with single-line comments

### DIFF
--- a/src/module/macro.ts
+++ b/src/module/macro.ts
@@ -14,7 +14,8 @@ export class MacroPF2e extends Macro {
 
         // Attempt script execution
         const AsyncFunction = async function () {}.constructor as { new (...args: string[]): Function };
-        const fn = new AsyncFunction("speaker", "actor", "token", "character", `{${this.command}}`);
+        const command = ["{", this.command, "}"].join("\n");
+        const fn = new AsyncFunction("speaker", "actor", "token", "character", command);
         try {
             return fn.call(this, speaker, actor, token, character);
         } catch {


### PR DESCRIPTION
Supersedes #4422, which for some reason can't be merged.