### PR TITLE
Refrain from highlighting measured templates invisible to players

### DIFF
--- a/src/module/canvas/measured-template.ts
+++ b/src/module/canvas/measured-template.ts
@@ -7,14 +7,15 @@ class MeasuredTemplatePF2e extends MeasuredTemplate<MeasuredTemplateDocumentPF2e
         return this.document.t;
     }
 
-    /** The highlight layer for this template */
-    get highlightId(): string {
-        return `Template.${this.id}`;
-    }
-
     override highlightGrid(): void {
         if (!["circle", "cone"].includes(this.type) || canvas.grid.type !== CONST.GRID_TYPES.SQUARE) {
             return super.highlightGrid();
+        }
+
+        // Refrain from highlighting if not visible
+        if (!this.isVisible) {
+            canvas.grid.getHighlightLayer(this.highlightId)?.clear();
+            return;
         }
 
         highlightGrid({

--- a/types/foundry/client/pixi/placeable-object/measured-template.d.ts
+++ b/types/foundry/client/pixi/placeable-object/measured-template.d.ts
@@ -51,6 +51,12 @@ declare class MeasuredTemplate<
     /** A flag for whether the current User has full ownership over the MeasuredTemplate document. */
     get owner(): boolean;
 
+    /** Is this MeasuredTemplate currently visible on the Canvas? */
+    get isVisible(): boolean;
+
+    /** A unique identifier which is used to uniquely identify related objects like a template effect or grid highlight. */
+    get highlightId(): string;
+
     /* -------------------------------------------- */
     /*  Rendering                                   */
     /* -------------------------------------------- */


### PR DESCRIPTION
Closes #4443

Since we completely replace the parent method for circles and cones, this check needs to be pulled over.