### PR TITLE
Use item type unions for world and embedded collections

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -2,7 +2,7 @@ import { ActorPF2e } from "@actor/base";
 import { AutomaticBonusProgression } from "@actor/character/automatic-bonus-progression";
 import { FeatCategoryOptions } from "@actor/character/feats";
 import { CheckModifier, ModifierPF2e, MODIFIER_TYPE, StatisticModifier } from "@actor/modifiers";
-import { ItemPF2e } from "@item/base";
+import { ItemPF2e, ItemSubclassPF2e } from "@item";
 import { CoinsPF2e } from "@item/physical/helpers";
 import { ActiveEffectPF2e } from "@module/active-effect";
 import { CompendiumBrowser, CompendiumBrowserSettings } from "@module/apps/compendium-browser";
@@ -100,10 +100,25 @@ declare global {
 
     namespace globalThis {
         // eslint-disable-next-line no-var
-        var game: Game<ActorPF2e, ActorsPF2e, ChatMessagePF2e, EncounterPF2e, ItemPF2e, MacroPF2e, ScenePF2e, UserPF2e>;
+        var game: Game<
+            ActorPF2e,
+            ActorsPF2e,
+            ChatMessagePF2e,
+            EncounterPF2e,
+            ItemSubclassPF2e,
+            MacroPF2e,
+            ScenePF2e,
+            UserPF2e
+        >;
 
         // eslint-disable-next-line no-var
-        var ui: FoundryUI<ActorPF2e, ActorDirectoryPF2e, ItemPF2e, ChatLogPF2e, CompendiumDirectoryPF2e>;
+        var ui: FoundryUI<
+            ActorPF2e,
+            ActorDirectoryPF2e<ActorPF2e>,
+            ItemSubclassPF2e,
+            ChatLogPF2e,
+            CompendiumDirectoryPF2e
+        >;
     }
 
     interface Window {
@@ -188,7 +203,7 @@ type ConfiguredConfig = Config<
     AmbientLightDocumentPF2e,
     ActiveEffectPF2e,
     ActorPF2e,
-    ActorDirectoryPF2e,
+    ActorDirectoryPF2e<ActorPF2e>,
     ChatLogPF2e,
     ChatMessagePF2e,
     EncounterPF2e,

--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -1,6 +1,14 @@
 import { ModeOfBeing } from "@actor/creature/types";
 import { ActorAlliance, ActorDimensions, AuraData, SaveType } from "@actor/types";
-import { ArmorPF2e, ContainerPF2e, ItemPF2e, PhysicalItemPF2e, type ConditionPF2e } from "@item";
+import {
+    ArmorPF2e,
+    ContainerPF2e,
+    ItemPF2e,
+    ItemSubclassPF2e,
+    PhysicalItemPF2e,
+    PhysicalItemSubclass,
+    type ConditionPF2e,
+} from "@item";
 import { ConditionSlug } from "@item/condition/data";
 import { isCycle } from "@item/container/helpers";
 import { ItemSourcePF2e, ItemType, PhysicalItemSource } from "@item/data";
@@ -509,9 +517,7 @@ class ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
     /** Prepare the physical-item collection on this actor, item-sibling data, and rule elements */
     override prepareEmbeddedDocuments(): void {
         super.prepareEmbeddedDocuments();
-        const physicalItems: Embedded<PhysicalItemPF2e>[] = this.items.filter(
-            (item) => item instanceof PhysicalItemPF2e
-        );
+        const physicalItems = this.items.filter((i): i is Embedded<PhysicalItemSubclass> => i.isOfType("physical"));
         this.inventory = new ActorInventory(this, physicalItems);
 
         const spellcastingEntries = this.itemTypes.spellcastingEntry;
@@ -1240,7 +1246,7 @@ class ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
 interface ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
     readonly data: ActorDataPF2e;
 
-    readonly items: foundry.abstract.EmbeddedCollection<ItemPF2e>;
+    readonly items: foundry.abstract.EmbeddedCollection<ItemSubclassPF2e>;
 
     readonly effects: foundry.abstract.EmbeddedCollection<ActiveEffectPF2e>;
 

--- a/src/module/actor/character/index.ts
+++ b/src/module/actor/character/index.ts
@@ -914,7 +914,7 @@ class CharacterPF2e extends CreaturePF2e {
 
         // Set number of hands free
         const heldItems = this.inventory.filter((i) => i.isHeld);
-        const handsFree = heldItems.reduce((count, item) => {
+        const handsFree = heldItems.reduce((count, item: PhysicalItemPF2e) => {
             const handsOccupied = item.traits.has("free-hand") ? 0 : item.handsHeld;
             return Math.max(count - handsOccupied, 0);
         }, 2);

--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -484,7 +484,9 @@ class CharacterSheetPF2e extends CreatureSheetPF2e<CharacterPF2e> {
             const weapon = this.actor.items.get(action.item?.id ?? "");
             const ammo = this.actor.items.get($(event.currentTarget).val() as string);
 
-            if (weapon) weapon.update({ system: { selectedAmmoId: ammo?.id ?? null } });
+            if (weapon?.type === "weapon") {
+                weapon.update({ system: { selectedAmmoId: ammo?.id ?? null } });
+            }
         });
 
         $html.find(".add-modifier .fas.fa-plus-circle").on("click", (event) => this.#onIncrementModifierValue(event));

--- a/src/module/actor/inventory/index.ts
+++ b/src/module/actor/inventory/index.ts
@@ -1,13 +1,13 @@
 import { ActorPF2e } from "@actor";
-import { PhysicalItemPF2e, TreasurePF2e } from "@item";
+import { PhysicalItemSubclass, TreasurePF2e } from "@item";
 import { Coins } from "@item/physical/data";
 import { DENOMINATIONS } from "@item/physical/values";
 import { coinCompendiumIds, CoinsPF2e } from "@item/physical/helpers";
 import { ErrorPF2e, groupBy } from "@util";
 import { InventoryBulk } from "./bulk";
 
-class ActorInventory extends Collection<Embedded<PhysicalItemPF2e>> {
-    constructor(public readonly actor: ActorPF2e, entries?: Embedded<PhysicalItemPF2e>[]) {
+class ActorInventory extends Collection<Embedded<PhysicalItemSubclass>> {
+    constructor(public readonly actor: ActorPF2e, entries?: Embedded<PhysicalItemSubclass>[]) {
         super(entries?.map((entry) => [entry.id, entry]));
     }
 
@@ -50,13 +50,13 @@ class ActorInventory extends Collection<Embedded<PhysicalItemPF2e>> {
                     await item.update({ "system.quantity": item.quantity + quantity });
                 } else {
                     const compendiumId = coinCompendiumIds[denomination];
-                    const pack = game.packs.find<CompendiumCollection<PhysicalItemPF2e>>(
+                    const pack = game.packs.find<CompendiumCollection<PhysicalItemSubclass>>(
                         (p) => p.collection === "pf2e.equipment-srd"
                     );
                     if (!pack) throw ErrorPF2e("Unexpected error retrieving equipment compendium");
 
                     const item = (await pack.getDocument(compendiumId))?.clone();
-                    if (item?.isOfType("treasure")) {
+                    if (item?.type === "treasure") {
                         item.updateSource({ "system.quantity": quantity });
                         await this.actor.createEmbeddedDocuments("Item", [item.toObject()]);
                     }

--- a/src/module/actor/sheet/item-summary-renderer.ts
+++ b/src/module/actor/sheet/item-summary-renderer.ts
@@ -24,7 +24,7 @@ export class ItemSummaryRendererPF2e<TActor extends ActorPF2e> {
      * Returns true if it the item is valid and it was toggled.
      */
     async toggleSummary($element: JQuery, options: { instant?: boolean } = {}) {
-        const actor = this.sheet.actor;
+        const { actor } = this.sheet;
 
         const itemId = $element.attr("data-item-id");
         const itemType = $element.attr("data-item-type");

--- a/src/module/chat-message/document.ts
+++ b/src/module/chat-message/document.ts
@@ -1,6 +1,6 @@
 import { ActorPF2e } from "@actor";
 import { CriticalHitAndFumbleCards } from "./crit-fumble-cards";
-import { ItemPF2e } from "@item";
+import { ItemPF2e, ItemSubclassPF2e } from "@item";
 import { ChatMessageDataPF2e, ChatMessageFlagsPF2e, ChatMessageSourcePF2e } from "./data";
 import { TokenDocumentPF2e } from "@scene";
 import { traditionSkills, TrickMagicItemEntry } from "@item/spellcasting-entry/trick";
@@ -89,10 +89,10 @@ class ChatMessagePF2e extends ChatMessage<ActorPF2e> {
     }
 
     /** Get the owned item associated with this chat message */
-    get item(): Embedded<ItemPF2e> | null {
+    get item(): Embedded<ItemSubclassPF2e> | null {
         // If this is a strike, we usually want the strike's item
         const strike = this._strike;
-        if (strike?.item) return strike.item as Embedded<ItemPF2e>;
+        if (strike?.item) return strike.item as Embedded<ItemSubclassPF2e>;
 
         const item = (() => {
             const domItem = this.getItemFromDOM();
@@ -148,7 +148,7 @@ class ChatMessagePF2e extends ChatMessage<ActorPF2e> {
     }
 
     /** Get stringified item source from the DOM-rendering of this chat message */
-    getItemFromDOM(): Embedded<ItemPF2e> | null {
+    getItemFromDOM(): Embedded<ItemSubclassPF2e> | null {
         const $domMessage = $("ol#chat-log").children(`li[data-message-id="${this.id}"]`);
         const sourceString = $domMessage.find("div.pf2e.item-card").attr("data-embedded-item") ?? "null";
         try {
@@ -159,7 +159,7 @@ class ChatMessagePF2e extends ChatMessage<ActorPF2e> {
                       fromConsumable: this.flags?.pf2e?.isFromConsumable,
                   })
                 : null;
-            return item as Embedded<ItemPF2e> | null;
+            return item as Embedded<ItemSubclassPF2e> | null;
         } catch (_error) {
             return null;
         }

--- a/src/module/chat-message/listeners/cards.ts
+++ b/src/module/chat-message/listeners/cards.ts
@@ -1,6 +1,6 @@
 import { craftItem, craftSpellConsumable } from "@actor/character/crafting/helpers";
 import { SAVE_TYPES } from "@actor/values";
-import { ItemPF2e, PhysicalItemPF2e } from "@item";
+import { ItemSubclassPF2e, PhysicalItemPF2e } from "@item";
 import { isSpellConsumable } from "@item/consumable/spell-consumables";
 import { CoinsPF2e } from "@item/physical/helpers";
 import { eventToRollParams } from "@scripts/sheet-util";
@@ -211,7 +211,7 @@ export const ChatCards = {
      */
     rollActorSaves: async (
         event: JQuery.ClickEvent<HTMLElement, undefined, HTMLElement>,
-        item: Embedded<ItemPF2e>
+        item: Embedded<ItemSubclassPF2e>
     ): Promise<void> => {
         if (canvas.tokens.controlled.length > 0) {
             const saveType = event.currentTarget.dataset.save;

--- a/src/module/item/abc/index.ts
+++ b/src/module/item/abc/index.ts
@@ -12,8 +12,8 @@ abstract class ABCItemPF2e extends ItemPF2e {
         return this.actor.itemTypes.feat.filter((f) => existingABCIds.includes(f.system.location ?? ""));
     }
 
-    protected logAutoChange(this: Embedded<ABCItemPF2e>, path: string, value: string | number): void {
-        if (value === 0) return;
+    protected logAutoChange(path: string, value: string | number): void {
+        if (!this.actor || value === 0) return;
         this.actor.system.autoChanges[path] = [
             {
                 mode: "upgrade",

--- a/src/module/item/abc/manager.ts
+++ b/src/module/item/abc/manager.ts
@@ -1,4 +1,4 @@
-import { FeatPF2e, ClassPF2e, ItemPF2e, ABCItemPF2e } from "@item/index";
+import { FeatPF2e, ClassPF2e, ItemPF2e, ABCItemSubclass } from "@item/index";
 import { AncestrySource, BackgroundSource, ClassSource, ItemSourcePF2e } from "@item/data";
 import { ABCFeatureEntryData } from "@item/abc/data";
 import { CharacterPF2e } from "@actor/index";
@@ -90,7 +90,7 @@ export class AncestryBackgroundClassManager {
         name: string
     ): Promise<AncestrySource | BackgroundSource | ClassSource | FeatSource> {
         const slug = sluggify(name);
-        const pack = game.packs.get<CompendiumCollection<ABCItemPF2e>>(packName, { strict: true });
+        const pack = game.packs.get<CompendiumCollection<ABCItemSubclass>>(packName, { strict: true });
         const docs = await pack.getDocuments({ "system.slug": { $in: [slug] } });
         if (docs.length === 1) {
             return docs[0].toObject();

--- a/src/module/item/abstract-effect/document.ts
+++ b/src/module/item/abstract-effect/document.ts
@@ -1,4 +1,4 @@
-import { ItemPF2e } from "@item";
+import { EffectSubclass, ItemPF2e } from "@item";
 import { ErrorPF2e, sluggify } from "@util";
 import { EffectBadge } from "./data";
 
@@ -30,7 +30,7 @@ export abstract class AbstractEffectPF2e extends ItemPF2e {
         const badge = this.badge;
         if (typeof badge?.value === "number") {
             const otherEffects = actor.items.filter(
-                (i): i is Embedded<AbstractEffectPF2e> =>
+                (i): i is Embedded<EffectSubclass> =>
                     i instanceof AbstractEffectPF2e && i.rollOptionSlug === this.rollOptionSlug
             );
             const values = otherEffects

--- a/src/module/item/action/index.ts
+++ b/src/module/item/action/index.ts
@@ -3,7 +3,7 @@ import { ActionItemData, ActionItemSource } from "./data";
 import { OneToThree } from "@module/data";
 import { UserPF2e } from "@module/user";
 import { ActionCost, Frequency } from "@item/data/base";
-import { ItemSummaryData } from "@item/data";
+import { ItemSummaryData, TraitChatData } from "@item/data";
 
 class ActionItemPF2e extends ItemPF2e {
     get actionCost(): ActionCost | null {
@@ -29,10 +29,7 @@ class ActionItemPF2e extends ItemPF2e {
         }
     }
 
-    override async getChatData(
-        this: Embedded<ActionItemPF2e>,
-        htmlOptions: EnrichHTMLOptions = {}
-    ): Promise<ItemSummaryData> {
+    override async getChatData(htmlOptions: EnrichHTMLOptions = {}): Promise<ActionSummaryData> {
         const systemData = this.system;
 
         // Feat properties
@@ -70,7 +67,13 @@ class ActionItemPF2e extends ItemPF2e {
 }
 
 interface ActionItemPF2e {
+    readonly type: "action";
+
     readonly data: ActionItemData;
+}
+
+interface ActionSummaryData extends ItemSummaryData {
+    traits: TraitChatData[];
 }
 
 export { ActionItemPF2e };

--- a/src/module/item/ancestry/index.ts
+++ b/src/module/item/ancestry/index.ts
@@ -1,5 +1,4 @@
 import { CreatureTrait } from "@actor/creature/data";
-import { CharacterPF2e } from "@actor";
 import { Size } from "@module/data";
 import { ABCItemPF2e, FeatPF2e } from "@item";
 import { AncestryData } from "./data";
@@ -70,14 +69,14 @@ class AncestryPF2e extends ABCItemPF2e {
     }
 
     /** Prepare a character's data derived from their ancestry */
-    override prepareActorData(this: Embedded<AncestryPF2e>): void {
+    override prepareActorData(): void {
         const { actor } = this;
-        if (!(actor instanceof CharacterPF2e)) {
+        if (!actor?.isOfType("character")) {
             console.error("PF2e System | Only a character can have an ancestry");
             return;
         }
 
-        actor.ancestry = this;
+        actor.ancestry = this as Embedded<AncestryPF2e>;
 
         actor.system.attributes.ancestryhp = this.hitPoints;
         this.logAutoChange("system.attributes.ancestryhp", this.hitPoints);
@@ -139,6 +138,8 @@ class AncestryPF2e extends ABCItemPF2e {
 }
 
 interface AncestryPF2e {
+    readonly type: "ancestry";
+
     readonly data: AncestryData;
 }
 

--- a/src/module/item/armor/document.ts
+++ b/src/module/item/armor/document.ts
@@ -1,6 +1,5 @@
 import { AutomaticBonusProgression } from "@actor/character/automatic-bonus-progression";
-import { ItemSummaryData } from "@item/data";
-import { getResiliencyBonus, PhysicalItemHitPoints, PhysicalItemPF2e } from "@item/physical";
+import { getResiliencyBonus, PhysicalItemHitPoints, PhysicalItemPF2e, PhysicalItemSummaryData } from "@item/physical";
 import { MAGIC_TRADITIONS } from "@item/spell/values";
 import { LocalizePF2e } from "@module/system/localize";
 import { addSign, ErrorPF2e, setHasElement } from "@util";
@@ -175,10 +174,7 @@ class ArmorPF2e extends PhysicalItemPF2e {
         }
     }
 
-    override async getChatData(
-        this: Embedded<ArmorPF2e>,
-        htmlOptions: EnrichHTMLOptions = {}
-    ): Promise<ItemSummaryData> {
+    override async getChatData(htmlOptions: EnrichHTMLOptions = {}): Promise<PhysicalItemSummaryData> {
         const systemData = this.system;
         const translations = LocalizePF2e.translations.PF2E;
         const properties = [
@@ -212,6 +208,8 @@ class ArmorPF2e extends PhysicalItemPF2e {
 }
 
 interface ArmorPF2e {
+    readonly type: "armor";
+
     readonly data: ArmorData;
 }
 

--- a/src/module/item/background/index.ts
+++ b/src/module/item/background/index.ts
@@ -1,14 +1,18 @@
-import { ABCItemPF2e, FeatPF2e, ItemPF2e } from "@item";
+import { ABCItemPF2e, FeatPF2e } from "@item";
 import { OneToFour } from "@module/data";
+import { ErrorPF2e } from "@util";
 import { BackgroundData } from "./data";
 
 class BackgroundPF2e extends ABCItemPF2e {
     /** Set a skill feat granted by a GrantItem RE as one of this background's configured items */
-    override prepareSiblingData(this: Embedded<BackgroundPF2e>): void {
+    override prepareSiblingData(): void {
+        if (!this.actor) throw ErrorPF2e("prepareSiblingData may only be called from an embedded item");
+
         if (Object.keys(this.system.items).length > 0) return;
+        const { actor } = this;
         const grantedSkillFeat = this.flags.pf2e.itemGrants
-            .flatMap((g) => this.actor.items.get(g.id) ?? [])
-            .find((i: Embedded<ItemPF2e> & { featType?: unknown }): i is Embedded<FeatPF2e> => i.featType === "skill");
+            .flatMap((g) => actor.items.get(g.id) ?? [])
+            .find((i): i is Embedded<FeatPF2e> => i.type === "feat" && i.featType === "skill");
 
         if (grantedSkillFeat) {
             this.system.items["GRANT"] = {
@@ -21,13 +25,13 @@ class BackgroundPF2e extends ABCItemPF2e {
         }
     }
 
-    override prepareActorData(this: Embedded<BackgroundPF2e>): void {
-        if (!this.actor.isOfType("character")) {
+    override prepareActorData(): void {
+        if (!this.actor?.isOfType("character")) {
             console.error("Only a character can have a background");
             return;
         }
 
-        this.actor.background = this;
+        this.actor.background = this as Embedded<BackgroundPF2e>;
         const { build } = this.actor.system;
 
         // Add ability boosts
@@ -48,6 +52,8 @@ class BackgroundPF2e extends ABCItemPF2e {
 }
 
 interface BackgroundPF2e {
+    readonly type: "background";
+
     readonly data: BackgroundData;
 }
 

--- a/src/module/item/book/document.ts
+++ b/src/module/item/book/document.ts
@@ -4,6 +4,8 @@ import { BookData } from "./data";
 class BookPF2e extends PhysicalItemPF2e {}
 
 interface BookPF2e extends PhysicalItemPF2e {
+    readonly type: "book";
+
     readonly data: BookData;
 }
 

--- a/src/module/item/class/index.ts
+++ b/src/module/item/class/index.ts
@@ -75,13 +75,13 @@ class ClassPF2e extends ABCItemPF2e {
     }
 
     /** Prepare a character's data derived from their class */
-    override prepareActorData(this: Embedded<ClassPF2e>): void {
-        if (!this.actor.isOfType("character")) {
+    override prepareActorData(): void {
+        if (!this.actor?.isOfType("character")) {
             console.error("Only a character can have a class");
             return;
         }
 
-        this.actor.class = this;
+        this.actor.class = this as Embedded<ClassPF2e>;
         const { attributes, build, details, martial, proficiencies, saves, skills } = this.actor.system;
         const slug = this.slug ?? sluggify(this.name);
 
@@ -137,6 +137,8 @@ class ClassPF2e extends ABCItemPF2e {
 }
 
 interface ClassPF2e {
+    readonly type: "class";
+
     readonly data: ClassData;
 
     get slug(): ClassTrait | null;

--- a/src/module/item/condition/document.ts
+++ b/src/module/item/condition/document.ts
@@ -183,6 +183,8 @@ class ConditionPF2e extends AbstractEffectPF2e {
 }
 
 interface ConditionPF2e {
+    readonly type: "condition";
+
     readonly data: ConditionData;
 
     get slug(): ConditionSlug;

--- a/src/module/item/consumable/index.ts
+++ b/src/module/item/consumable/index.ts
@@ -38,10 +38,7 @@ class ConsumablePF2e extends PhysicalItemPF2e {
         }) as Embedded<SpellPF2e>;
     }
 
-    override async getChatData(
-        this: Embedded<ConsumablePF2e>,
-        htmlOptions: EnrichHTMLOptions = {}
-    ): Promise<ItemSummaryData> {
+    override async getChatData(htmlOptions: EnrichHTMLOptions = {}): Promise<ItemSummaryData> {
         const systemData = this.system;
         const translations = LocalizePF2e.translations.PF2E;
         const traits = this.traitChatData(CONFIG.PF2E.consumableTraits);
@@ -183,6 +180,8 @@ class ConsumablePF2e extends PhysicalItemPF2e {
 }
 
 interface ConsumablePF2e {
+    readonly type: "consumable";
+
     readonly data: ConsumableData;
 }
 

--- a/src/module/item/container/index.ts
+++ b/src/module/item/container/index.ts
@@ -3,6 +3,7 @@ import { ItemSummaryData } from "@item/data";
 import { EquipmentTrait } from "@item/equipment/data";
 import { PhysicalItemPF2e } from "@item/physical";
 import { Bulk, weightToBulk } from "@item/physical/bulk";
+import { ErrorPF2e } from "@util";
 import { ContainerData } from "./data";
 import { hasExtraDimensionalParent } from "./helpers";
 
@@ -38,7 +39,9 @@ class ContainerPF2e extends PhysicalItemPF2e {
     }
 
     /** Reload this container's contents following Actor embedded-document preparation */
-    override prepareSiblingData(this: Embedded<ContainerPF2e>): void {
+    override prepareSiblingData(): void {
+        if (!this.actor) throw ErrorPF2e("prepareSiblingData may only be called from an embedded item");
+
         this.contents = new Collection(
             this.actor.inventory.filter((item) => item.container?.id === this.id).map((item) => [item.id, item])
         );
@@ -52,10 +55,7 @@ class ContainerPF2e extends PhysicalItemPF2e {
         await this.actor.updateEmbeddedDocuments("Item", updates, { render: false });
     }
 
-    override async getChatData(
-        this: Embedded<ContainerPF2e>,
-        htmlOptions: EnrichHTMLOptions = {}
-    ): Promise<ItemSummaryData> {
+    override async getChatData(htmlOptions: EnrichHTMLOptions = {}): Promise<ItemSummaryData> {
         const systemData = this.system;
         const traits = this.traitChatData(CONFIG.PF2E.equipmentTraits);
 
@@ -64,6 +64,8 @@ class ContainerPF2e extends PhysicalItemPF2e {
 }
 
 interface ContainerPF2e {
+    readonly type: "backpack";
+
     readonly data: ContainerData;
 
     get traits(): Set<EquipmentTrait>;

--- a/src/module/item/data/index.ts
+++ b/src/module/item/data/index.ts
@@ -20,8 +20,9 @@ import type { SpellData, SpellSource } from "@item/spell/data";
 import type { SpellcastingEntryData, SpellcastingEntrySource } from "@item/spellcasting-entry/data";
 import type { TreasureData, TreasureSource } from "@item/treasure/data";
 import type { WeaponData, WeaponSource } from "@item/weapon/data";
-import { PROFICIENCY_RANKS } from "@module/data";
+import { PROFICIENCY_RANKS, TraitsWithRarity } from "@module/data";
 import { PhysicalItemTraits } from "../physical/data";
+import { ItemTrait } from "./base";
 
 export type ProficiencyRank = typeof PROFICIENCY_RANKS[number];
 
@@ -76,16 +77,15 @@ export type ItemDataPF2e =
 export type PhysicalItemSource = PhysicalItemData["_source"];
 export type ItemSourcePF2e = ItemDataPF2e["_source"];
 
-export interface ItemSummaryData {
-    [key: string]: unknown;
+interface ItemSummaryData {
     description?: {
         value: string;
     };
-    traits?: TraitChatData[];
+    traits?: TraitChatData[] | TraitsWithRarity<ItemTrait>;
     properties?: (string | number | null)[];
 }
 
-export interface TraitChatData {
+interface TraitChatData {
     value: string;
     label: string;
     description?: string;
@@ -129,11 +129,13 @@ export {
     EffectSource,
     EquipmentSource,
     FeatSource,
+    ItemSummaryData,
     KitSource,
     LoreSource,
     MeleeSource,
-    SpellcastingEntrySource,
     SpellSource,
+    SpellcastingEntrySource,
+    TraitChatData,
     TreasureSource,
     WeaponSource,
 };

--- a/src/module/item/deity/document.ts
+++ b/src/module/item/deity/document.ts
@@ -30,14 +30,14 @@ class DeityPF2e extends ItemPF2e {
         }
     }
 
-    override prepareActorData(this: Embedded<DeityPF2e>): void {
-        if (!this.actor.isOfType("character")) {
+    override prepareActorData(): void {
+        if (!this.actor?.isOfType("character")) {
             // This should never happen, but ...
             this.delete({ render: false });
             return;
         }
 
-        this.actor.deity = this;
+        this.actor.deity = this as Embedded<DeityPF2e>;
 
         const { deities } = this.actor.system.details;
         const systemData = this.system;
@@ -97,7 +97,7 @@ class DeityPF2e extends ItemPF2e {
         }
     }
 
-    override getRollOptions(prefix = this.type): string[] {
+    override getRollOptions(prefix: string = this.type): string[] {
         const baseOptions = super.getRollOptions(prefix);
         const delimitedPrefix = prefix ? `${prefix}:` : "";
         return [...baseOptions, `${delimitedPrefix}category:${this.category}`].sort();
@@ -105,6 +105,8 @@ class DeityPF2e extends ItemPF2e {
 }
 
 interface DeityPF2e extends ItemPF2e {
+    readonly type: "deity";
+
     readonly data: DeityData;
 }
 

--- a/src/module/item/effect/document.ts
+++ b/src/module/item/effect/document.ts
@@ -110,7 +110,7 @@ class EffectPF2e extends AbstractEffectPF2e {
     }
 
     /** Include a trimmed version of the "slug" roll option (e.g., effect:rage instead of effect:effect-rage) */
-    override getRollOptions(prefix = this.type): string[] {
+    override getRollOptions(prefix: string = this.type): string[] {
         const slug = this.slug ?? sluggify(this.name);
         const delimitedPrefix = prefix ? `${prefix}:` : "";
         const trimmedSlug = slug.replace(/^(?:spell-)?(?:effect|stance)-/, "");
@@ -196,6 +196,8 @@ class EffectPF2e extends AbstractEffectPF2e {
 }
 
 interface EffectPF2e {
+    readonly type: "effect";
+
     readonly data: EffectData;
 }
 

--- a/src/module/item/equipment/index.ts
+++ b/src/module/item/equipment/index.ts
@@ -26,10 +26,7 @@ class EquipmentPF2e extends PhysicalItemPF2e {
         }
     }
 
-    override async getChatData(
-        this: Embedded<EquipmentPF2e>,
-        htmlOptions: EnrichHTMLOptions = {}
-    ): Promise<ItemSummaryData> {
+    override async getChatData(htmlOptions: EnrichHTMLOptions = {}): Promise<ItemSummaryData> {
         const data = this.system;
         const traits = this.traitChatData(CONFIG.PF2E.equipmentTraits);
         const properties = [this.isEquipped ? game.i18n.localize("PF2E.EquipmentEquippedLabel") : null].filter(
@@ -58,6 +55,8 @@ class EquipmentPF2e extends PhysicalItemPF2e {
 }
 
 interface EquipmentPF2e {
+    readonly type: "equipment";
+
     readonly data: EquipmentData;
 
     get traits(): Set<EquipmentTrait>;

--- a/src/module/item/feat/index.ts
+++ b/src/module/item/feat/index.ts
@@ -2,7 +2,7 @@ import { ItemPF2e } from "..";
 import { FeatData, FeatSource, FeatTrait, FeatType } from "./data";
 import { OneToThree } from "@module/data";
 import { UserPF2e } from "@module/user";
-import { sluggify } from "@util";
+import { ErrorPF2e, sluggify } from "@util";
 import { FeatCategory } from "@actor/character/feats";
 import { Frequency } from "@item/data/base";
 import { ItemSummaryData } from "@item/data";
@@ -105,16 +105,15 @@ class FeatPF2e extends ItemPF2e {
     }
 
     /** Set a self roll option for this feat(ure) */
-    override prepareActorData(this: Embedded<FeatPF2e>): void {
+    override prepareActorData(): void {
+        if (!this.actor) throw ErrorPF2e("prepareSiblingData may only be called from an embedded item");
+
         const prefix = this.isFeature ? "feature" : "feat";
         const slug = this.slug ?? sluggify(this.name);
         this.actor.rollOptions.all[`${prefix}:${slug}`] = true;
     }
 
-    override async getChatData(
-        this: Embedded<FeatPF2e>,
-        htmlOptions: EnrichHTMLOptions = {}
-    ): Promise<ItemSummaryData> {
+    override async getChatData(htmlOptions: EnrichHTMLOptions = {}): Promise<ItemSummaryData> {
         const systemData = this.system;
         const properties = [
             `Level ${systemData.level.value || 0}`,
@@ -218,6 +217,8 @@ class FeatPF2e extends ItemPF2e {
 }
 
 interface FeatPF2e {
+    readonly type: "feat";
+
     readonly data: FeatData;
 }
 

--- a/src/module/item/heritage/document.ts
+++ b/src/module/item/heritage/document.ts
@@ -15,8 +15,13 @@ class HeritagePF2e extends ItemPF2e {
     }
 
     /** Prepare a character's data derived from their heritage */
-    override prepareActorData(this: Embedded<HeritagePF2e>): void {
-        this.actor.heritage = this;
+    override prepareActorData(): void {
+        if (!this.actor?.isOfType("character")) {
+            console.error("PF2e System | Only a character can have an ancestry");
+            return;
+        }
+
+        this.actor.heritage = this as Embedded<HeritagePF2e>;
 
         // Add and remove traits as specified
         this.actor.system.traits.value.push(...this.traits);
@@ -34,6 +39,8 @@ class HeritagePF2e extends ItemPF2e {
 
 interface HeritagePF2e extends ItemPF2e {
     readonly parent: CharacterPF2e | null;
+
+    readonly type: "heritage";
 
     readonly data: HeritageData;
 }

--- a/src/module/item/index.ts
+++ b/src/module/item/index.ts
@@ -1,25 +1,83 @@
-export { ItemPF2e, ItemConstructionContextPF2e } from "./base";
-export { PhysicalItemPF2e } from "./physical";
-export { ABCItemPF2e } from "./abc";
-export { AbstractEffectPF2e } from "./abstract-effect";
-export { ActionItemPF2e } from "./action";
-export { AncestryPF2e } from "./ancestry";
-export { ArmorPF2e } from "./armor";
-export { BackgroundPF2e } from "./background";
-export { BookPF2e } from "./book/document";
-export { ClassPF2e } from "./class";
-export { ConditionPF2e } from "./condition";
-export { ConsumablePF2e } from "./consumable";
-export { ContainerPF2e } from "./container";
-export { DeityPF2e } from "./deity";
-export { EffectPF2e } from "./effect";
-export { EquipmentPF2e } from "./equipment";
-export { FeatPF2e } from "./feat";
-export { HeritagePF2e } from "./heritage";
-export { KitPF2e } from "./kit";
-export { LorePF2e } from "./lore";
-export { MeleePF2e } from "./melee";
-export { SpellPF2e } from "./spell";
-export { SpellcastingEntryPF2e } from "./spellcasting-entry";
-export { TreasurePF2e } from "./treasure";
-export { WeaponPF2e } from "./weapon";
+import { ItemPF2e, ItemConstructionContextPF2e } from "./base";
+import { PhysicalItemPF2e } from "./physical";
+import { ABCItemPF2e } from "./abc";
+import { AbstractEffectPF2e } from "./abstract-effect";
+import { ActionItemPF2e } from "./action";
+import { AncestryPF2e } from "./ancestry";
+import { ArmorPF2e } from "./armor";
+import { BackgroundPF2e } from "./background";
+import { BookPF2e } from "./book/document";
+import { ClassPF2e } from "./class";
+import { ConditionPF2e } from "./condition";
+import { ConsumablePF2e } from "./consumable";
+import { ContainerPF2e } from "./container";
+import { DeityPF2e } from "./deity";
+import { EffectPF2e } from "./effect";
+import { EquipmentPF2e } from "./equipment";
+import { FeatPF2e } from "./feat";
+import { HeritagePF2e } from "./heritage";
+import { KitPF2e } from "./kit";
+import { LorePF2e } from "./lore";
+import { MeleePF2e } from "./melee";
+import { SpellPF2e } from "./spell";
+import { SpellcastingEntryPF2e } from "./spellcasting-entry";
+import { TreasurePF2e } from "./treasure";
+import { WeaponPF2e } from "./weapon";
+
+type EffectSubclass = ConditionPF2e | EffectPF2e;
+type ABCItemSubclass = AncestryPF2e | BackgroundPF2e | ClassPF2e;
+type PhysicalItemSubclass =
+    | ArmorPF2e
+    | BookPF2e
+    | ConsumablePF2e
+    | ContainerPF2e
+    | EquipmentPF2e
+    | TreasurePF2e
+    | WeaponPF2e;
+
+type ItemSubclassPF2e =
+    | ABCItemSubclass
+    | EffectSubclass
+    | PhysicalItemSubclass
+    | ActionItemPF2e
+    | DeityPF2e
+    | FeatPF2e
+    | HeritagePF2e
+    | KitPF2e
+    | LorePF2e
+    | MeleePF2e
+    | SpellPF2e
+    | SpellcastingEntryPF2e;
+
+export {
+    ABCItemPF2e,
+    ABCItemSubclass,
+    AbstractEffectPF2e,
+    ActionItemPF2e,
+    AncestryPF2e,
+    ArmorPF2e,
+    BackgroundPF2e,
+    BookPF2e,
+    ClassPF2e,
+    ConditionPF2e,
+    ConsumablePF2e,
+    ContainerPF2e,
+    DeityPF2e,
+    EffectPF2e,
+    EffectSubclass,
+    EquipmentPF2e,
+    FeatPF2e,
+    HeritagePF2e,
+    ItemConstructionContextPF2e,
+    ItemPF2e,
+    ItemSubclassPF2e,
+    KitPF2e,
+    LorePF2e,
+    MeleePF2e,
+    PhysicalItemPF2e,
+    PhysicalItemSubclass,
+    SpellPF2e,
+    SpellcastingEntryPF2e,
+    TreasurePF2e,
+    WeaponPF2e,
+};

--- a/src/module/item/kit/index.ts
+++ b/src/module/item/kit/index.ts
@@ -92,6 +92,8 @@ class KitPF2e extends ItemPF2e {
 }
 
 interface KitPF2e {
+    readonly type: "kit";
+
     readonly data: KitData;
 }
 

--- a/src/module/item/lore/index.ts
+++ b/src/module/item/lore/index.ts
@@ -4,5 +4,7 @@ import { LoreData } from "./data";
 export class LorePF2e extends ItemPF2e {}
 
 export interface LorePF2e {
+    readonly type: "lore";
+
     readonly data: LoreData;
 }

--- a/src/module/item/melee/data.ts
+++ b/src/module/item/melee/data.ts
@@ -60,4 +60,4 @@ interface MeleeDamageRoll {
 export type NPCAttackTrait = keyof ConfigPF2e["PF2E"]["npcAttackTraits"];
 export type NPCAttackTraits = ItemTraits<NPCAttackTrait>;
 
-export { MeleeDamageRoll, MeleeData, MeleeSource, MeleeSystemData, MeleeSystemSource };
+export { MeleeDamageRoll, MeleeData, MeleeSource, MeleeSystemSource };

--- a/src/module/item/melee/index.ts
+++ b/src/module/item/melee/index.ts
@@ -1,12 +1,12 @@
 import { ItemPF2e } from "@item/base";
-import { ItemSummaryData } from "@item/data";
+import { ItemSummaryData, TraitChatData } from "@item/data";
 import { WeaponDamage } from "@item/weapon/data";
 import { WeaponRangeIncrement } from "@item/weapon/types";
 import { combineTerms } from "@scripts/dice";
 import { WeaponDamagePF2e } from "@system/damage";
-import { MeleeData, MeleeSystemData, NPCAttackTrait } from "./data";
+import { MeleeData, NPCAttackTrait } from "./data";
 
-export class MeleePF2e extends ItemPF2e {
+class MeleePF2e extends ItemPF2e {
     get traits(): Set<NPCAttackTrait> {
         return new Set(this.system.traits.value);
     }
@@ -137,7 +137,7 @@ export class MeleePF2e extends ItemPF2e {
     }
 
     /** Generate a list of strings for use in predication */
-    override getRollOptions(prefix = this.type): string[] {
+    override getRollOptions(prefix: string = this.type): string[] {
         const baseOptions = super.getRollOptions(prefix);
         const delimitedPrefix = prefix ? `${prefix}:` : "";
         const otherOptions = Object.entries({
@@ -153,21 +153,27 @@ export class MeleePF2e extends ItemPF2e {
         return [baseOptions, otherOptions].flat().sort();
     }
 
-    override async getChatData(
-        this: Embedded<MeleePF2e>,
-        htmlOptions: EnrichHTMLOptions = {}
-    ): Promise<ItemSummaryData & { map2: string; map3: string } & Omit<MeleeSystemData, "traits">> {
-        const systemData = this.system;
+    override async getChatData(htmlOptions: EnrichHTMLOptions = {}): Promise<MeleeSummaryData> {
         const traits = this.traitChatData(CONFIG.PF2E.weaponTraits);
-
         const isAgile = this.traits.has("agile");
         const map2 = isAgile ? "-4" : "-5";
         const map3 = isAgile ? "-8" : "-10";
 
-        return this.processChatData(htmlOptions, { ...systemData, traits, map2, map3 });
+        return this.processChatData(htmlOptions, { ...this.system, traits, map2, map3 });
     }
 }
 
-export interface MeleePF2e {
+interface MeleePF2e {
+    readonly type: "melee";
+
     readonly data: MeleeData;
 }
+
+interface MeleeSummaryData extends ItemSummaryData {
+    traits: TraitChatData[];
+    map2: string;
+    map3: string;
+    bonus: { value: number };
+}
+
+export { MeleePF2e };

--- a/src/module/item/physical/index.ts
+++ b/src/module/item/physical/index.ts
@@ -1,6 +1,6 @@
 export * from "./bulk";
 export * from "./data";
-export { PhysicalItemPF2e } from "./document";
+export { PhysicalItemPF2e, PhysicalItemSummaryData } from "./document";
 export * from "./helpers";
 export * from "./materials";
 export * from "./runes";

--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -23,15 +23,7 @@ import { CheckPF2e } from "@system/rolls";
 import { StatisticRollParameters } from "@system/statistic";
 import { EnrichHTMLOptionsPF2e } from "@system/text-editor";
 import { ErrorPF2e, getActionIcon, objectHasKey, ordinal, traitSlugToObject } from "@util";
-import {
-    SpellData,
-    SpellHeightenLayer,
-    SpellOverlay,
-    SpellOverlayType,
-    SpellSource,
-    SpellSystemData,
-    SpellSystemSource,
-} from "./data";
+import { SpellData, SpellHeightenLayer, SpellOverlay, SpellOverlayType, SpellSource, SpellSystemSource } from "./data";
 import { applyDamageDice } from "./helpers";
 import { SpellOverlayCollection } from "./overlay";
 import { MagicSchool, MagicTradition, SpellComponent, SpellTrait } from "./types";
@@ -389,14 +381,16 @@ class SpellPF2e extends ItemPF2e {
         this.overlays = new SpellOverlayCollection(this, this.system.overlays);
     }
 
-    override prepareSiblingData(this: Embedded<SpellPF2e>): void {
+    override prepareSiblingData(): void {
+        if (!this.actor) throw ErrorPF2e("prepareSiblingData may only be called from an embedded item");
+
         this.system.traits.value.push(this.school, ...this.traditions);
         if (this.spellcasting?.isInnate) {
             mergeObject(this.system.location, { uses: { value: 1, max: 1 } }, { overwrite: false });
         }
     }
 
-    override getRollOptions(prefix = this.type): string[] {
+    override getRollOptions(prefix: string = this.type): string[] {
         const options = new Set<string>();
 
         const entryHasSlots = this.spellcasting?.isPrepared || this.spellcasting?.isSpontaneous;
@@ -463,7 +457,7 @@ class SpellPF2e extends ItemPF2e {
     override async getChatData(
         htmlOptions: EnrichHTMLOptionsPF2e = {},
         rollOptions: { castLevel?: number | string } = {}
-    ): Promise<Omit<ItemSummaryData, "traits">> {
+    ): Promise<ItemSummaryData> {
         if (!this.actor) throw ErrorPF2e(`Cannot retrieve chat data for unowned spell ${this.name}`);
         const slotLevel = Number(rollOptions.castLevel) || this.level;
         const castLevel = this.computeCastLevel(slotLevel);
@@ -495,7 +489,7 @@ class SpellPF2e extends ItemPF2e {
         rollData.item ??= this;
 
         const localize: Localization["localize"] = game.i18n.localize.bind(game.i18n);
-        const systemData: SpellSystemData = this.system;
+        const systemData = this.system;
 
         const options = { ...htmlOptions, rollData };
         const description = await game.pf2e.TextEditor.enrichHTML(this.description, { ...options, async: true });
@@ -506,7 +500,7 @@ class SpellPF2e extends ItemPF2e {
             console.warn(
                 `PF2e System | Orphaned spell ${this.name} (${this.id}) on actor ${this.actor.name} (${this.actor.id})`
             );
-            return { ...systemData };
+            return { ...systemData, traits: [] };
         }
 
         const statistic = trickData?.statistic || spellcasting?.statistic;
@@ -514,7 +508,7 @@ class SpellPF2e extends ItemPF2e {
             console.warn(
                 `PF2e System | Spell ${this.name} is missing a statistic to cast with (${this.id}) on actor ${this.actor.name} (${this.actor.id})`
             );
-            return { ...systemData };
+            return { ...systemData, traits: [] };
         }
 
         const statisticChatData = statistic.getChatData({ item: this });
@@ -774,6 +768,8 @@ class SpellPF2e extends ItemPF2e {
 }
 
 interface SpellPF2e {
+    readonly type: "spell";
+
     readonly data: SpellData;
 
     overlays: SpellOverlayCollection;

--- a/src/module/item/spellcasting-entry/data/sheet.ts
+++ b/src/module/item/spellcasting-entry/data/sheet.ts
@@ -1,4 +1,5 @@
 import { SpellPF2e } from "@item";
+import { ItemSummaryData } from "@item/data";
 import { MagicTradition } from "@item/spell/types";
 import { ZeroToTen } from "@module/data";
 import { StatisticChatData } from "@system/statistic";
@@ -52,7 +53,7 @@ export interface SpellPrepEntry {
 
 export interface ActiveSpell {
     spell: Embedded<SpellPF2e>;
-    chatData: Record<string, unknown>;
+    chatData: ItemSummaryData;
     expended?: boolean;
     /** Is this spell marked as signature/collection */
     signature?: boolean;

--- a/src/module/item/spellcasting-entry/index.ts
+++ b/src/module/item/spellcasting-entry/index.ts
@@ -93,14 +93,13 @@ class SpellcastingEntryPF2e extends ItemPF2e implements SpellcastingEntry {
         }
     }
 
-    override prepareActorData(this: Embedded<SpellcastingEntryPF2e>): void {
-        const actor = this.actor;
+    override prepareActorData(): void {
+        const { actor, tradition } = this;
 
         // Upgrade the actor proficiency using the internal ones
         // Innate spellcasting will always be elevated by other spellcasting proficiencies but never do
         // the elevating itself
-        const tradition = this.tradition;
-        if (actor.isOfType("character") && !this.isInnate && tradition) {
+        if (actor?.isOfType("character") && !this.isInnate && tradition) {
             const proficiency = actor.system.proficiencies.traditions[tradition];
             const rank = this.system.proficiency.value;
             proficiency.rank = Math.max(rank, proficiency.rank) as OneToFour;
@@ -273,7 +272,7 @@ class SpellcastingEntryPF2e extends ItemPF2e implements SpellcastingEntry {
         };
     }
 
-    override getRollOptions(prefix = this.type): string[] {
+    override getRollOptions(prefix: string = this.type): string[] {
         return [`${prefix}:${this.ability}`, `${prefix}:${this.tradition}`, `${prefix}:${this.system.prepared.value}`];
     }
 
@@ -308,6 +307,8 @@ class SpellcastingEntryPF2e extends ItemPF2e implements SpellcastingEntry {
 }
 
 interface SpellcastingEntryPF2e {
+    readonly type: "spellcastingEntry";
+
     readonly data: SpellcastingEntryData;
 }
 

--- a/src/module/item/treasure/index.ts
+++ b/src/module/item/treasure/index.ts
@@ -22,10 +22,7 @@ class TreasurePF2e extends PhysicalItemPF2e {
         }
     }
 
-    override async getChatData(
-        this: Embedded<TreasurePF2e>,
-        htmlOptions: EnrichHTMLOptions = {}
-    ): Promise<ItemSummaryData> {
+    override async getChatData(htmlOptions: EnrichHTMLOptions = {}): Promise<ItemSummaryData> {
         const systemData = this.system;
         const traits = this.traitChatData({});
 
@@ -34,6 +31,8 @@ class TreasurePF2e extends PhysicalItemPF2e {
 }
 
 interface TreasurePF2e {
+    readonly type: "treasure";
+
     readonly data: TreasureData;
 }
 

--- a/src/module/item/weapon/document.ts
+++ b/src/module/item/weapon/document.ts
@@ -1,7 +1,7 @@
 import { AutomaticBonusProgression } from "@actor/character/automatic-bonus-progression";
 import { ActorSizePF2e } from "@actor/data/size";
 import { ConsumablePF2e, MeleePF2e, PhysicalItemPF2e } from "@item";
-import { ItemSummaryData, MeleeSource } from "@item/data";
+import { MeleeSource } from "@item/data";
 import { MeleeDamageRoll, NPCAttackTrait } from "@item/melee/data";
 import {
     Bulk,
@@ -10,6 +10,7 @@ import {
     IdentificationStatus,
     MaterialGradeData,
     MystifiedData,
+    PhysicalItemSummaryData,
     RuneValuationData,
     WeaponPropertyRuneData,
     WEAPON_MATERIAL_VALUATION_DATA,
@@ -363,10 +364,7 @@ class WeaponPF2e extends PhysicalItemPF2e {
         return materialData?.[material.precious?.grade ?? "low"] ?? null;
     }
 
-    override async getChatData(
-        this: Embedded<WeaponPF2e>,
-        htmlOptions: EnrichHTMLOptions = {}
-    ): Promise<ItemSummaryData> {
+    override async getChatData(htmlOptions: EnrichHTMLOptions = {}): Promise<PhysicalItemSummaryData> {
         const traits = this.traitChatData(CONFIG.PF2E.weaponTraits);
         const chatData = await super.getChatData();
         return this.processChatData(htmlOptions, {
@@ -468,15 +466,15 @@ class WeaponPF2e extends PhysicalItemPF2e {
         ].flat();
     }
 
-    override clone<T extends this>(
+    override clone(
         data: DocumentUpdateData<this> | undefined,
         options: Omit<WeaponCloneOptions, "save"> & { save: true }
-    ): Promise<T>;
-    override clone<T extends this>(
+    ): Promise<this>;
+    override clone(
         data?: DocumentUpdateData<this>,
         options?: Omit<WeaponCloneOptions, "save"> & { save?: false }
-    ): T;
-    override clone<T extends this>(data?: DocumentUpdateData<this>, options?: WeaponCloneOptions): T | Promise<T>;
+    ): this;
+    override clone(data?: DocumentUpdateData<this>, options?: WeaponCloneOptions): this | Promise<this>;
     override clone(data?: DocumentUpdateData<this>, options?: WeaponCloneOptions): this | Promise<this> {
         const clone = super.clone(data, options);
         if (options?.altUsage && clone instanceof WeaponPF2e) {
@@ -651,6 +649,8 @@ class WeaponPF2e extends PhysicalItemPF2e {
 }
 
 interface WeaponPF2e {
+    readonly type: "weapon";
+
     readonly data: WeaponData;
 
     get traits(): Set<WeaponTrait>;

--- a/src/module/rules/rule-element/choice-set/rule-element.ts
+++ b/src/module/rules/rule-element/choice-set/rule-element.ts
@@ -1,5 +1,5 @@
 import { RuleElementPF2e, RuleElementOptions } from "../";
-import { FeatPF2e, ItemPF2e } from "@item";
+import { FeatPF2e, ItemPF2e, ItemSubclassPF2e } from "@item";
 import { PickableThing } from "@module/apps/pick-a-thing-prompt";
 import { PredicatePF2e } from "@system/predication";
 import { ErrorPF2e, isObject, objectHasKey, sluggify } from "@util";
@@ -305,7 +305,7 @@ class ChoiceSetRuleElement extends RuleElementPF2e {
                 type: itemType,
             };
             const items = (await pack?.getDocuments(query)) ?? [];
-            if (!items.every((i): i is ItemPF2e => i instanceof ItemPF2e)) {
+            if (!items.every((i): i is ItemSubclassPF2e => i instanceof ItemPF2e)) {
                 return [];
             }
 

--- a/src/module/rules/rule-element/grant-item/helpers.ts
+++ b/src/module/rules/rule-element/grant-item/helpers.ts
@@ -6,7 +6,7 @@ async function processGrantDeletions(item: Embedded<ItemPF2e>, pendingItems: Emb
 
     // First, process the items granted by the to-be-deleted item:
     for (const grant of item.flags.pf2e.itemGrants) {
-        const grantee = actor.items.get(grant.id);
+        const grantee: Embedded<ItemPF2e> | undefined = actor.items.get(grant.id);
         if (grantee?.flags.pf2e.grantedBy?.id !== item.id) continue;
 
         switch (grantee.flags.pf2e.grantedBy.onDelete) {
@@ -35,7 +35,7 @@ async function processGrantDeletions(item: Embedded<ItemPF2e>, pendingItems: Emb
     }
 
     // Second, process the item that granted the to-be-deleted item
-    const granter = actor.items.get(item.flags.pf2e.grantedBy?.id ?? "");
+    const granter: Embedded<ItemPF2e> | undefined = actor.items.get(item.flags.pf2e.grantedBy?.id ?? "");
     const grant = granter?.flags.pf2e.itemGrants.find((g) => g.id === item.id);
     if (!(granter && grant)) return;
 

--- a/src/module/system/conditions/manager.ts
+++ b/src/module/system/conditions/manager.ts
@@ -54,7 +54,7 @@ export class ConditionManager {
         const actor = actorOrToken instanceof ActorPF2e ? actorOrToken : actorOrToken.actor;
         const condition = actor?.items.get(itemId);
 
-        if (condition?.isOfType("condition")) {
+        if (condition?.type === "condition") {
             if (value === 0) {
                 // Value is zero, remove the condition
                 await condition.delete();

--- a/src/module/system/damage/roll-dialog.ts
+++ b/src/module/system/damage/roll-dialog.ts
@@ -90,7 +90,7 @@ export class DamageRollModifiersDialog extends Application {
                 : "";
 
             const properties = ((): string => {
-                if (item?.isOfType("weapon") && item.isRanged) {
+                if (item?.type === "weapon" && item.isRanged) {
                     // Show the range increment for ranged weapons
                     const { rangeIncrement } = item;
                     const slug = `range-increment-${rangeIncrement}`;

--- a/src/module/system/damage/weapon.ts
+++ b/src/module/system/damage/weapon.ts
@@ -130,7 +130,7 @@ class WeaponDamagePF2e {
                     : Math.floor(strengthModValue / 2)
                 : null;
 
-            if (weapon.isOfType("weapon") && typeof modifierValue === "number") {
+            if (weapon.type === "weapon" && typeof modifierValue === "number") {
                 const strModifier = new ModifierPF2e({
                     label: CONFIG.PF2E.abilities.str,
                     ability: "str",
@@ -166,7 +166,7 @@ class WeaponDamagePF2e {
             rule.beforeRoll?.(selectors, options);
         }
 
-        if (weapon.isOfType("weapon")) {
+        if (weapon.type === "weapon") {
             // Kickback trait
             if (weaponTraits.includes("kickback")) {
                 // For NPCs, subtract from the base damage and add back as an untype bonus
@@ -246,7 +246,7 @@ class WeaponDamagePF2e {
             });
 
             // find best striking source
-            const strikingRune = weapon.isOfType("weapon") ? weapon.system.runes.striking : null;
+            const strikingRune = weapon.type === "weapon" ? weapon.system.runes.striking : null;
             if (strikingRune) {
                 strikingList.push({
                     label: "PF2E.StrikingRuneLabel",
@@ -427,7 +427,7 @@ class WeaponDamagePF2e {
             dice.ignored = !dice.enabled;
         }
 
-        const excludeFrom = weapon.isOfType("weapon") ? weapon : null;
+        const excludeFrom = weapon.type === "weapon" ? weapon : null;
         this.excludeDamage({ actor, weapon: excludeFrom, modifiers: [...numericModifiers, ...diceModifiers], options });
 
         return {
@@ -687,7 +687,7 @@ class WeaponDamagePF2e {
             "damage",
         ];
 
-        if (weapon.isOfType("melee")) {
+        if (weapon.type === "melee") {
             if (this.strengthBasedDamage(weapon)) {
                 selectors.push("str-damage");
             }
@@ -757,7 +757,7 @@ class WeaponDamagePF2e {
 
     /** Determine whether a strike's damage includes the actor's strength modifier */
     static strengthModToDamage(weapon: WeaponPF2e | MeleePF2e): boolean {
-        return weapon.isOfType("weapon") && this.strengthBasedDamage(weapon);
+        return weapon.type === "weapon" && this.strengthBasedDamage(weapon);
     }
 }
 

--- a/src/module/system/rolls.ts
+++ b/src/module/system/rolls.ts
@@ -1,7 +1,7 @@
 import { ActorPF2e, CharacterPF2e } from "@actor";
 import { AttackTarget } from "@actor/creature/types";
 import { StrikeData, TraitViewData } from "@actor/data/base";
-import { ItemPF2e, WeaponPF2e } from "@item";
+import { ItemPF2e, ItemSubclassPF2e, WeaponPF2e } from "@item";
 import { ChatMessagePF2e } from "@module/chat-message";
 import { ChatMessageSourcePF2e } from "@module/chat-message/data";
 import { ZeroToThree } from "@module/data";
@@ -110,7 +110,7 @@ interface CheckRollContext extends BaseRollContext {
     /** The token which initiated this roll. */
     token?: TokenDocumentPF2e;
     /** The originating item of this attack, if any */
-    item?: Embedded<ItemPF2e> | null;
+    item?: Embedded<ItemSubclassPF2e> | null;
     /** Optional title of the roll options dialog; defaults to the check name */
     title?: string;
     /** Optional DC data for the check */
@@ -314,7 +314,7 @@ class CheckPF2e {
                 return parseHTML(note.text);
             };
             const incapacitation =
-                item?.isOfType("spell") && item.traits.has("incapacitation") ? incapacitationNote() : "";
+                item?.type === "spell" && item.traits.has("incapacitation") ? incapacitationNote() : "";
 
             const header = document.createElement("h4");
             header.classList.add("action");
@@ -432,7 +432,7 @@ class CheckPF2e {
             : [];
 
         const properties = ((): HTMLElement[] => {
-            if (item?.isOfType("weapon") && item.isRanged) {
+            if (item?.type === "weapon" && item.isRanged) {
                 // Show the range increment for ranged weapons
                 const range = item.rangeIncrement ?? 10;
                 const label = game.i18n.format("PF2E.Item.Weapon.RangeIncrementN.Label", { range });

--- a/src/module/system/statistic/index.ts
+++ b/src/module/system/statistic/index.ts
@@ -9,7 +9,7 @@ import {
     StatisticModifier,
 } from "@actor/modifiers";
 import { AbilityString } from "@actor/types";
-import { ItemPF2e } from "@item";
+import { ItemSubclassPF2e } from "@item";
 import { ZeroToFour } from "@module/data";
 import {
     extractDegreeOfSuccessAdjustments,
@@ -39,7 +39,7 @@ export interface StatisticRollParameters {
     /** Additional modifiers */
     modifiers?: ModifierPF2e[];
     /** The originating item of this attack, if any */
-    item?: Embedded<ItemPF2e> | null;
+    item?: Embedded<ItemSubclassPF2e> | null;
     /** Is this a secret roll? */
     secret?: boolean;
     /** Should the dialog be skipped */
@@ -52,7 +52,7 @@ export interface StatisticRollParameters {
 
 interface RollOptionParameters {
     extraRollOptions?: string[];
-    item?: ItemPF2e | null;
+    item?: ItemSubclassPF2e | null;
     target?: ActorPF2e | null;
 }
 

--- a/types/foundry/client/documents/item.d.ts
+++ b/types/foundry/client/documents/item.d.ts
@@ -14,6 +14,8 @@ declare global {
 
         img: ImagePath;
 
+        readonly type: string;
+
         /** A convenience alias of Item#isEmbedded which is preserves legacy support */
         get isOwned(): boolean;
 
@@ -22,9 +24,6 @@ declare global {
          * The returned instances are the ActiveEffect instances which exist on the Item itself.
          */
         get transferredEffects(): CollectionValue<this["data"]["effects"]>[];
-
-        /** A convenience reference to the item type (data.type) of this Item */
-        get type(): string;
 
         /** Prepare a data object which defines the data schema used by dice roll commands against this Item */
         getRollData(): object;

--- a/types/foundry/common/abstract/document.d.ts
+++ b/types/foundry/common/abstract/document.d.ts
@@ -119,15 +119,15 @@ declare global {
                  * @param [options.keepId=false]  Keep the original Document ID? Otherwise the ID will become undefined
                  * @returns The cloned Document instance
                  */
-                clone<T extends this>(
+                clone(
                     data: DocumentUpdateData<this> | undefined,
                     options: { save: true; keepId?: boolean }
-                ): Promise<T>;
-                clone<T extends this>(data?: DocumentUpdateData<this>, options?: { save?: false; keepId?: boolean }): T;
-                clone<T extends this>(
+                ): Promise<this>;
+                clone(data?: DocumentUpdateData<this>, options?: { save?: false; keepId?: boolean }): this;
+                clone(
                     data?: DocumentUpdateData<this>,
                     options?: { save?: boolean; keepId?: boolean }
-                ): T | Promise<T>;
+                ): this | Promise<this>;
 
                 /**
                  * Get the permission level that a specific User has over this Document, a value in CONST.ENTITY_PERMISSIONS.


### PR DESCRIPTION
Runtime changes are minimal: mostly replacing a few `ItemPF2e#isOfType` method calls with `item.type === "..."`.