### PR TITLE
Brushup Agents of Edgewatch Book 1

### DIFF
--- a/packs/data/agents-of-edgewatch-bestiary.db/almiraj.json
+++ b/packs/data/agents-of-edgewatch-bestiary.db/almiraj.json
@@ -202,7 +202,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>Any living creature slain by the almiraj's horn Strike immediately becomes @Compendium[pf2e.conditionitems.Petrified]{Petrified} with no saving throw, in addition to dying.</p>\n<p>A severed almiraj horn retains a wisp of its former magic; in combat, the horn can be wielded as a <em>@Compendium[pf2e.equipment-srd.Dagger]{+1 dagger}</em> or, if affixed to a shaft, a +1 <em>@Compendium[pf2e.equipment-srd.Spear]{spear}</em></p>"
+                    "value": "<p>Any living creature slain by the almiraj's horn Strike immediately becomes @Compendium[pf2e.conditionitems.Petrified]{Petrified} with no saving throw, in addition to dying.</p>\n<p>A severed almiraj horn retains a wisp of its former magic; in combat, the horn can be wielded as a <em>@Compendium[pf2e.equipment-srd.Dagger]{+1 dagger}</em> or, if affixed to a shaft, a <em>@Compendium[pf2e.equipment-srd.Spear]{+1 spear}</em></p>"
                 },
                 "requirements": {
                     "value": ""

--- a/packs/data/agents-of-edgewatch-bestiary.db/almiraj.json
+++ b/packs/data/agents-of-edgewatch-bestiary.db/almiraj.json
@@ -202,7 +202,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>Any living creature slain by the almiraj's horn Strike immediately becomes @Compendium[pf2e.conditionitems.Petrified]{Petrified} with no saving throw, in addition to dying.</p>\n<p>A severed almiraj horn retains a wisp of its former magic; in combat, the horn can be wielded as a <em>@Compendium[pf2e.equipment-srd.Dagger]{+1 dagger}</em> or, if affixed to a shaft, a <em>@Compendium[pf2e.equipment-srd.Spear]{+1 spear}</em></p>"
+                    "value": "<p>Any living creature slain by the almiraj's horn Strike immediately becomes @Compendium[pf2e.conditionitems.Petrified]{Petrified} with no saving throw, in addition to dying.</p>\n<p>A severed almiraj horn retains a wisp of its former magic; in combat, the horn can be wielded as a <em>+1 @Compendium[pf2e.equipment-srd.Dagger]{dagger}</em> or, if affixed to a shaft, a <em>+1 @Compendium[pf2e.equipment-srd.Spear]{spear}</em></p>"
                 },
                 "requirements": {
                     "value": ""

--- a/packs/data/agents-of-edgewatch-bestiary.db/binumir.json
+++ b/packs/data/agents-of-edgewatch-bestiary.db/binumir.json
@@ -214,7 +214,10 @@
                     "custom": "",
                     "rarity": "common",
                     "selected": {},
-                    "value": []
+                    "value": [
+                        "auditory",
+                        "concentrate"
+                    ]
                 },
                 "trigger": {
                     "value": ""

--- a/packs/data/agents-of-edgewatch-bestiary.db/boiling-fountains.json
+++ b/packs/data/agents-of-edgewatch-bestiary.db/boiling-fountains.json
@@ -52,7 +52,8 @@
             "ac": {
                 "value": 15
             },
-            "hardness": 0,
+            "emitsSound": "encounter",
+            "hardness": 8,
             "hasHealth": true,
             "hp": {
                 "details": "",
@@ -92,6 +93,7 @@
             }
         },
         "source": {
+            "author": "",
             "value": "Pathfinder #157: Devil at the Dreaming Palace"
         },
         "statusEffects": [],

--- a/packs/data/agents-of-edgewatch-bestiary.db/gref.json
+++ b/packs/data/agents-of-edgewatch-bestiary.db/gref.json
@@ -911,7 +911,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>A ratfolk grenadier has stretchy cheek pouches that can store up to 1 cubic foot of objects. The ratfolk can remove or store an item using the Interact action. As long as the ratfolk has at least one object in its cheek pouches, its speech is noticeably difficult to understand.</p>"
+                    "value": "<p>A ratfolk has stretchy cheek pouches that can store up to 1 cubic foot of objects. The ratfolk can remove or store an item using the Interact action. As long as the ratfolk has at least one object in its cheek pouches, its speech is noticeably difficult to understand.</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -952,7 +952,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>Kekker has trained extensively with the katar blade. Any katar he wields gains the finesse trait.</p>"
+                    "value": "<p>Gref has trained extensively with the katar blade. Any katar he wields gains the finesse trait.</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -992,7 +992,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p><strong>Frequency</strong> once per round.</p>\n<hr />\n<p><strong>Effect</strong> Kekker stores one held item of light or negligible Bulk in his cheek pouches.</p>"
+                    "value": "<p><strong>Frequency</strong> once per round.</p>\n<hr />\n<p><strong>Effect</strong> Gref stores one held item of light or negligible Bulk in his cheek pouches.</p>"
                 },
                 "requirements": {
                     "value": ""

--- a/packs/data/agents-of-edgewatch-bestiary.db/kekker.json
+++ b/packs/data/agents-of-edgewatch-bestiary.db/kekker.json
@@ -911,7 +911,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>A ratfolk grenadier has stretchy cheek pouches that can store up to 1 cubic foot of objects. The ratfolk can remove or store an item using the Interact action. As long as the ratfolk has at least one object in its cheek pouches, its speech is noticeably difficult to understand.</p>"
+                    "value": "<p>A ratfolk has stretchy cheek pouches that can store up to 1 cubic foot of objects. The ratfolk can remove or store an item using the Interact action. As long as the ratfolk has at least one object in its cheek pouches, its speech is noticeably difficult to understand.</p>"
                 },
                 "requirements": {
                     "value": ""

--- a/packs/data/agents-of-edgewatch-bestiary.db/kemeneles.json
+++ b/packs/data/agents-of-edgewatch-bestiary.db/kemeneles.json
@@ -1440,6 +1440,7 @@
             "name": "Spell Effect: Mage Armor",
             "sort": 1300000,
             "system": {
+                "badge": null,
                 "description": {
                     "value": "<p>Granted by <em>@Compendium[pf2e.spells-srd.Mage Armor]{Mage Armor}</em></p>\n<p>You ward yourself with shimmering magical energy, gaining a +1 item bonus to AC and a maximum Dexterity modifier of +5. While wearing mage armor, you use your unarmored proficiency to calculate your AC.</p>"
                 },
@@ -1727,7 +1728,7 @@
         "attributes": {
             "ac": {
                 "details": "(14 without mage armor)",
-                "value": 15
+                "value": 14
             },
             "allSaves": {
                 "value": ""

--- a/packs/data/agents-of-edgewatch-bestiary.db/shredskin.json
+++ b/packs/data/agents-of-edgewatch-bestiary.db/shredskin.json
@@ -188,7 +188,7 @@
                     "value": "action"
                 },
                 "actions": {
-                    "value": null
+                    "value": 1
                 },
                 "description": {
                     "value": "<p><strong>Requirements</strong> The shredskin is adjacent to a Medium or Small humanoid-shaped corpse</p>\n<hr />\n<p><strong>Effect</strong> The shredskin wraps itself around the corpse and takes control of the host body. While controlling a host, the shredskin uses the host's Speed but its own attacks, and it loses its Grab and Enshroud abilities.</p>\n<p>Attacks that target the shredskin while it controls a body deal half of the damage to the shredskin and half of the damage to the host body. Attacks that target an area deal damage to both the shredskin and host body normally.</p>\n<p>The shredskin can release the host body as a free action at the start of its turn. If the host is destroyed, the shredskin automatically releases the body and is @Compendium[pf2e.conditionitems.Flat-Footed]{Flat-Footed} for 1 round. A Medium corpse typically has 15 hit points, while a Small corpse typically has 10 Hit Points.</p>\n<p>Creatures can notice that a corpse is controlled by a shredskin by succeeding a Perception check against the shredskin's Deception DC.</p>"
@@ -232,7 +232,7 @@
                     "value": 1
                 },
                 "description": {
-                    "value": "<p><strong>Requirements</strong> The shredskin is grabbing a creature</p>\n<hr />\n<p><strong>Effect</strong> The shredskin attempts to pin the creature and wrap itself around the creature like a shirt. The shredskin rolls an Athletics check against the creature's Fortitude DC.</p>\n<p>On a success, the creature becomes @Compendium[pf2e.conditionitems.Restrained]{Restrained} and the shredskin can take control of the creature as if using Control Body.</p>\n<p>At the start of its turn, the shredskin can automatically Constrict the enshrouded creature as a free action.</p>\n<p>An enshrouded creature can attempt a DC 16 Escape check to break free (DC 18 if the shredskin critically succeeded its Athletics check to Enshroud).</p>"
+                    "value": "<p><strong>Requirements</strong> The shredskin is grabbing a creature</p>\n<hr />\n<p><strong>Effect</strong> The shredskin attempts to pin the creature and wrap itself around the creature like a shirt. The shredskin rolls an Athletics check against the creature's Fortitude DC.</p>\n<p>On a success, the creature becomes @Compendium[pf2e.conditionitems.Restrained]{Restrained} and the shredskin can take control of the creature as if using Control Body.</p>\n<p>At the start of its turn, the shredskin can automatically Constrict the enshrouded creature as a free action.</p>\n<p>An enshrouded creature can attempt a DC 16 @UUID[Compendium.pf2e.actionspf2e.SkZAQRkLLkmBQNB9]{Escape} check to break free (DC 18 if the shredskin critically succeeded its Athletics check to Enshroud).</p>"
                 },
                 "requirements": {
                     "value": ""

--- a/packs/data/agents-of-edgewatch-bestiary.db/siege-shard.json
+++ b/packs/data/agents-of-edgewatch-bestiary.db/siege-shard.json
@@ -215,7 +215,8 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "earth"
+                        "earth",
+                        "occult"
                     ]
                 }
             },
@@ -668,7 +669,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>Mental damage ignores a siege shard's hardness.</p>\n<p>Additionally, proving the siege shard's generative conflict is over with the Prove Peace activity reverts the creature to ordinary stone.</p>"
+                    "value": "<p>Mental damage ignores a siege shard's hardness.</p>\n<p>Additionally, proving the siege shard's generative conflict is over with the @UUID[Compendium.pf2e.actionspf2e.Ma93dpT4K7JbP9gu]{Prove Peace} activity reverts the creature to ordinary stone.</p>"
                 },
                 "requirements": {
                     "value": ""


### PR DESCRIPTION
corrected formatting on Almiraj horn
added hardness to Boiling Fountains
Fixed reference to different creature in Kekker and Gref
Corrected Kemeneles AC with Mage Armor spell effect in consideration
Added number of actions for Control Body to Shredskin, added link to Escape in Enshroud ability
Added missing traits on Agonizing Wail for Binumir
added link to Prove Peace activity in Siege Shard's Exorcism ability