### PR TITLE
remove unnecessary labels from equipment effects REs A-E

### DIFF
--- a/packs/data/equipment-effects.db/effect-aeon-stone-black-pearl.json
+++ b/packs/data/equipment-effects.db/effect-aeon-stone-black-pearl.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/aeon-stone-black-pearl.webp",
     "name": "Effect: Aeon Stone (Black Pearl)",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by activating @Compendium[pf2e.equipment-srd.Aeon Stone (Black Pearl)]{Aeon Stone (Black Pearl)}</p>"
         },
@@ -18,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Black Pearl Aeon Stone (vs. a mental effect)",
                 "predicate": [
                     "mental"
                 ],

--- a/packs/data/equipment-effects.db/effect-aeon-stone-orange-prism-arcana.json
+++ b/packs/data/equipment-effects.db/effect-aeon-stone-orange-prism-arcana.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/aeon-stone-orange-prism.webp",
     "name": "Effect: Aeon Stone (Orange Prism) (Arcana)",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by activating @Compendium[pf2e.equipment-srd.Aeon Stone (Orange Prism)]{Aeon Stone (Orange Prism)} when the last spell you cast was an Arcane spell.</p>"
         },
@@ -18,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Aeon Stone (Orange Prism)",
                 "selector": "arcana",
                 "type": "item",
                 "value": 2

--- a/packs/data/equipment-effects.db/effect-aeon-stone-orange-prism-nature.json
+++ b/packs/data/equipment-effects.db/effect-aeon-stone-orange-prism-nature.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/aeon-stone-orange-prism.webp",
     "name": "Effect: Aeon Stone (Orange Prism) (Nature)",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by activating @Compendium[pf2e.equipment-srd.Aeon Stone (Orange Prism)]{Aeon Stone (Orange Prism)} when the last spell you cast was a Primal spell.</p>"
         },
@@ -18,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Aeon Stone (Orange Prism)",
                 "selector": "nature",
                 "type": "item",
                 "value": 2

--- a/packs/data/equipment-effects.db/effect-aeon-stone-orange-prism-occultism.json
+++ b/packs/data/equipment-effects.db/effect-aeon-stone-orange-prism-occultism.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/aeon-stone-orange-prism.webp",
     "name": "Effect: Aeon Stone (Orange Prism) (Occultism)",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by @Compendium[pf2e.equipment-srd.Aeon Stone (Orange Prism)]{Aeon Stone (Orange Prism)} when the last spell you cast was an Occult spell.</p>"
         },
@@ -18,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Aeon Stone (Orange Prism)",
                 "selector": "occultism",
                 "type": "item",
                 "value": 2

--- a/packs/data/equipment-effects.db/effect-aeon-stone-orange-prism-religion.json
+++ b/packs/data/equipment-effects.db/effect-aeon-stone-orange-prism-religion.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/aeon-stone-orange-prism.webp",
     "name": "Effect: Aeon Stone (Orange Prism) (Religion)",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by activating @Compendium[pf2e.equipment-srd.Aeon Stone (Orange Prism)]{Aeon Stone (Orange Prism)} when the last spell you cast was a Divine spell.</p>"
         },
@@ -18,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Aeon Stone (Orange Prism)",
                 "selector": "religion",
                 "type": "item",
                 "value": 2

--- a/packs/data/equipment-effects.db/effect-antidote-greater.json
+++ b/packs/data/equipment-effects.db/effect-antidote-greater.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/antidote.webp",
     "name": "Effect: Antidote (Greater)",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by @Compendium[pf2e.equipment-srd.Antidote (Greater)]{Antidote (Greater)}</p>\n<p>Implemented effects:</p>\n<ul>\n<li>+4 item bonus to Fortitude saves against poisons</li>\n</ul>"
         },
@@ -18,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Antidote Greater (vs. poison)",
                 "predicate": [
                     "poison"
                 ],

--- a/packs/data/equipment-effects.db/effect-antidote-lesser.json
+++ b/packs/data/equipment-effects.db/effect-antidote-lesser.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/antidote.webp",
     "name": "Effect: Antidote (Lesser)",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by @Compendium[pf2e.equipment-srd.Antidote (Lesser)]{Antidote (Lesser)}</p>\n<p>Implemented effects:</p>\n<ul>\n<li>+2 item bonus to Fortitude saves against poisons</li>\n</ul>"
         },
@@ -18,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Antidote Lesser (vs. poison)",
                 "predicate": [
                     "poison"
                 ],

--- a/packs/data/equipment-effects.db/effect-antidote-major.json
+++ b/packs/data/equipment-effects.db/effect-antidote-major.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/antidote.webp",
     "name": "Effect: Antidote (Major)",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by @Compendium[pf2e.equipment-srd.Antidote (Major)]{Antidote (Major)}</p>\n<p>Implemented effects:</p>\n<ul>\n<li>+4 item bonus to Fortitude saves against poisons</li>\n</ul>\n<p>Unimplemented effects:</p>\n<ul>\n<li>Immediately attempt a saving throw against one poison of 14th level or lower affecting you. If you succeed, the poison is neutralised. </li>\n</ul>"
         },
@@ -18,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Antidote Major (vs. poison)",
                 "predicate": [
                     "poison"
                 ],

--- a/packs/data/equipment-effects.db/effect-antidote-moderate.json
+++ b/packs/data/equipment-effects.db/effect-antidote-moderate.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/antidote.webp",
     "name": "Effect: Antidote (Moderate)",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by @Compendium[pf2e.equipment-srd.Antidote (Moderate)]{Antidote (Moderate)}</p>\n<p>Implemented effects:</p>\n<ul>\n<li>+3 item bonus to Fortitude saves against poisons</li>\n</ul>"
         },
@@ -18,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Antidote Moderate (vs. poison)",
                 "predicate": [
                     "poison"
                 ],

--- a/packs/data/equipment-effects.db/effect-antiplague-greater.json
+++ b/packs/data/equipment-effects.db/effect-antiplague-greater.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/antiplague.webp",
     "name": "Effect: Antiplague (Greater)",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by @Compendium[pf2e.equipment-srd.Antiplague (Greater)]{Antiplague (Greater)}</p>\n<p>Implemented effects:</p>\n<ul>\n<li>+4 item bonus to Fortitude saves against diseases</li>\n</ul>"
         },
@@ -18,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Antiplague Greater(vs. disease)",
                 "predicate": [
                     "disease"
                 ],

--- a/packs/data/equipment-effects.db/effect-antiplague-lesser.json
+++ b/packs/data/equipment-effects.db/effect-antiplague-lesser.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/antiplague.webp",
     "name": "Effect: Antiplague (Lesser)",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by @Compendium[pf2e.equipment-srd.Antiplague (Lesser)]{Antiplague (Lesser)}</p>\n<p>Implemented effects:</p>\n<ul>\n<li>+2 item bonus to Fortitude saves against diseases</li>\n</ul>"
         },
@@ -18,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Antiplague Lesser (vs. disease)",
                 "predicate": [
                     "disease"
                 ],

--- a/packs/data/equipment-effects.db/effect-antiplague-major.json
+++ b/packs/data/equipment-effects.db/effect-antiplague-major.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/antiplague.webp",
     "name": "Effect: Antiplague (Major)",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by @Compendium[pf2e.equipment-srd.Antiplague (Major)]{Antiplague (Major)}</p>\n<p>Implemented effects:</p>\n<ul>\n<li>+4 item bonus to Fortitude saves against diseases</li>\n</ul>\n<p>Unimplemented effects:</p>\n<ul>\n<li>Immediately attempt a saving throw against one disease of 14th level or lower affecting you. If you succeed, you are cured of the disease.</li>\n</ul>"
         },
@@ -18,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Antiplague Major(vs. disease)",
                 "predicate": [
                     "disease"
                 ],

--- a/packs/data/equipment-effects.db/effect-antiplague-moderate.json
+++ b/packs/data/equipment-effects.db/effect-antiplague-moderate.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/antiplague.webp",
     "name": "Effect: Antiplague (Moderate)",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by @Compendium[pf2e.equipment-srd.Antiplague (Moderate)]{Antiplague (Moderate)}</p>\n<p>Implemented effects:</p>\n<ul>\n<li>+3 item bonus to Fortitude saves against diseases</li>\n</ul>"
         },
@@ -18,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Antiplague Moderate(vs. disease)",
                 "predicate": [
                     "disease"
                 ],

--- a/packs/data/equipment-effects.db/effect-applereed-mutagen-greater.json
+++ b/packs/data/equipment-effects.db/effect-applereed-mutagen-greater.json
@@ -19,23 +19,18 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Applereed Mutagen (Greater)",
                 "selector": "athletics",
                 "type": "item",
                 "value": 4
             },
             {
                 "key": "FlatModifier",
-                "label": "Applereed Mutagen (Greater)",
                 "selector": "ac",
-                "type": "untyped",
                 "value": -1
             },
             {
                 "key": "FlatModifier",
-                "label": "Applereed Mutagen (Greater)",
                 "selector": "reflex",
-                "type": "untyped",
                 "value": -2
             },
             {

--- a/packs/data/equipment-effects.db/effect-bloodhound-mask-greater.json
+++ b/packs/data/equipment-effects.db/effect-bloodhound-mask-greater.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-tools/bloodhound-mask.webp",
     "name": "Effect: Bloodhound Mask (Greater)",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by @Compendium[pf2e.equipment-srd.Bloodhound Mask (Greater)]{Bloodhound Mask (Greater)}</p>"
         },
@@ -25,7 +26,6 @@
             },
             {
                 "key": "FlatModifier",
-                "label": "Bloodhound Mask (Track by scent)",
                 "predicate": [
                     "action:track",
                     "scent"

--- a/packs/data/equipment-effects.db/effect-bloodhound-mask-lesser.json
+++ b/packs/data/equipment-effects.db/effect-bloodhound-mask-lesser.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-tools/bloodhound-mask.webp",
     "name": "Effect: Bloodhound Mask (Lesser)",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by @Compendium[pf2e.equipment-srd.Bloodhound Mask (Lesser)]{Bloodhound Mask (Lesser)}</p>"
         },
@@ -25,7 +26,6 @@
             },
             {
                 "key": "FlatModifier",
-                "label": "Bloodhound Mask (Track by scent)",
                 "predicate": [
                     "action:track",
                     "scent"

--- a/packs/data/equipment-effects.db/effect-bloodhound-mask-moderate.json
+++ b/packs/data/equipment-effects.db/effect-bloodhound-mask-moderate.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-tools/bloodhound-mask.webp",
     "name": "Effect: Bloodhound Mask (Moderate)",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by @Compendium[pf2e.equipment-srd.Bloodhound Mask (Moderate)]{Bloodhound Mask (Moderate)}</p>"
         },
@@ -25,7 +26,6 @@
             },
             {
                 "key": "FlatModifier",
-                "label": "Bloodhound Mask (Track by scent)",
                 "predicate": [
                     "action:track",
                     "scent"

--- a/packs/data/equipment-effects.db/effect-boulderhead-bock.json
+++ b/packs/data/equipment-effects.db/effect-boulderhead-bock.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/boulderhead-bock.webp",
     "name": "Effect: Boulderhead Bock",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by @Compendium[pf2e.equipment-srd.Boulderhead Bock]{Boulderhead Bock}.</p>"
         },
@@ -18,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Boulderhead Bock (vs. stunned/stupefied)",
                 "predicate": [
                     {
                         "or": [

--- a/packs/data/equipment-effects.db/effect-bravos-brew-greater.json
+++ b/packs/data/equipment-effects.db/effect-bravos-brew-greater.json
@@ -19,6 +19,7 @@
         "rules": [
             {
                 "key": "FlatModifier",
+                "slug": "bravos-brew-greater",
                 "selector": "will",
                 "type": "item",
                 "value": 3

--- a/packs/data/equipment-effects.db/effect-bravos-brew-greater.json
+++ b/packs/data/equipment-effects.db/effect-bravos-brew-greater.json
@@ -25,6 +25,8 @@
             },
             {
                 "key": "FlatModifier",
+                "label": "PF2E.SpecificRule.Equipment.BravosBrew.Greater.FearLabel",
+                "slug": "bravos-brew-greater-fear",
                 "predicate": [
                     "fear"
                 ],

--- a/packs/data/equipment-effects.db/effect-bravos-brew-greater.json
+++ b/packs/data/equipment-effects.db/effect-bravos-brew-greater.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/bravos-brew.webp",
     "name": "Effect: Bravo's Brew (Greater)",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by @Compendium[pf2e.equipment-srd.Bravo's Brew (Greater)]{Bravo's Brew (Greater)}</p>\n<p>Implemented effects:</p>\n<ul>\n<li>+3 item bonus to Will saves</li>\n<li>+4 item bonus to Will saves against fear</li>\n</ul>\n<p>Unimplemented effects:</p>\n<ul>\n<li>If you roll a success on a save against fear, you get a critical success instead.</li>\n</ul>"
         },
@@ -18,14 +19,12 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Bravo's Brew (Greater)",
                 "selector": "will",
                 "type": "item",
                 "value": 3
             },
             {
                 "key": "FlatModifier",
-                "label": "Bravo's Brew Greater (vs. fear)",
                 "predicate": [
                     "fear"
                 ],

--- a/packs/data/equipment-effects.db/effect-bravos-brew-lesser.json
+++ b/packs/data/equipment-effects.db/effect-bravos-brew-lesser.json
@@ -19,6 +19,7 @@
         "rules": [
             {
                 "key": "FlatModifier",
+                "slug": "bravos-brew-lesser",
                 "selector": "will",
                 "type": "item",
                 "value": 1

--- a/packs/data/equipment-effects.db/effect-bravos-brew-lesser.json
+++ b/packs/data/equipment-effects.db/effect-bravos-brew-lesser.json
@@ -26,6 +26,8 @@
             },
             {
                 "key": "FlatModifier",
+                "label": "PF2E.SpecificRule.Equipment.BravosBrew.Lesser.FearLabel",
+                "slug": "bravos-brew-lesser-fear",
                 "predicate": [
                     "fear"
                 ],

--- a/packs/data/equipment-effects.db/effect-bravos-brew-lesser.json
+++ b/packs/data/equipment-effects.db/effect-bravos-brew-lesser.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/bravos-brew.webp",
     "name": "Effect: Bravo's Brew (Lesser)",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by @Compendium[pf2e.equipment-srd.Bravo's Brew (Lesser)]{Bravo's Brew (Lesser)}</p>\n<p>Implemented effects:</p>\n<ul>\n<li>+1 item bonus to Will saves</li>\n<li>+2 item bonus to Will saves against fear</li>\n</ul>"
         },
@@ -18,14 +19,12 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Bravo's Brew (Lesser)",
                 "selector": "will",
                 "type": "item",
                 "value": 1
             },
             {
                 "key": "FlatModifier",
-                "label": "Bravo's Brew Lesser (vs. fear)",
                 "predicate": [
                     "fear"
                 ],

--- a/packs/data/equipment-effects.db/effect-bravos-brew-moderate.json
+++ b/packs/data/equipment-effects.db/effect-bravos-brew-moderate.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/bravos-brew.webp",
     "name": "Effect: Bravo's Brew (Moderate)",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by @Compendium[pf2e.equipment-srd.Bravo's Brew (Moderate)]{Bravo's Brew (Moderate)}</p>\n<p>Implemented effects:</p>\n<ul>\n<li>+2 item bonus to Will saves</li>\n<li>+3 item bonus to Will saves against fear</li>\n</ul>"
         },
@@ -18,14 +19,12 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Bravo's Brew (Moderate)",
                 "selector": "will",
                 "type": "item",
                 "value": 2
             },
             {
                 "key": "FlatModifier",
-                "label": "Bravo's Brew Moderate (vs. fear)",
                 "predicate": [
                     "fear"
                 ],

--- a/packs/data/equipment-effects.db/effect-bravos-brew-moderate.json
+++ b/packs/data/equipment-effects.db/effect-bravos-brew-moderate.json
@@ -19,6 +19,7 @@
         "rules": [
             {
                 "key": "FlatModifier",
+                "slug": "bravos-brew-moderate",
                 "selector": "will",
                 "type": "item",
                 "value": 2

--- a/packs/data/equipment-effects.db/effect-bravos-brew-moderate.json
+++ b/packs/data/equipment-effects.db/effect-bravos-brew-moderate.json
@@ -26,6 +26,8 @@
             },
             {
                 "key": "FlatModifier",
+                "label": "PF2E.SpecificRule.Equipment.BravosBrew.Moderate.FearLabel",
+                "slug": "bravos-brew-moderate-fear",
                 "predicate": [
                     "fear"
                 ],

--- a/packs/data/equipment-effects.db/effect-breastplate-of-command.json
+++ b/packs/data/equipment-effects.db/effect-breastplate-of-command.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/armor/specific-magic-armor/breastplate-of-command.webp",
     "name": "Effect: Breastplate of Command",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by @Compendium[pf2e.equipment-srd.Breastplate of Command]{Breastplate of Command}</p>"
         },
@@ -18,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Breastplate of Command (vs. fear)",
                 "predicate": [
                     "fear"
                 ],

--- a/packs/data/equipment-effects.db/effect-brewers-regret-greater.json
+++ b/packs/data/equipment-effects.db/effect-brewers-regret-greater.json
@@ -19,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Greater Brewer's Regret",
                 "predicate": [
                     {
                         "or": [

--- a/packs/data/equipment-effects.db/effect-brewers-regret.json
+++ b/packs/data/equipment-effects.db/effect-brewers-regret.json
@@ -19,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Brewer's Regret",
                 "predicate": [
                     {
                         "or": [

--- a/packs/data/equipment-effects.db/effect-bronze-bull-pendant.json
+++ b/packs/data/equipment-effects.db/effect-bronze-bull-pendant.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/consumables/talismans/bronze-bull-pendant.webp",
     "name": "Effect: Bronze Bull Pendant",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by @Compendium[pf2e.equipment-srd.Bronze Bull Pendant]{Bronze Bull Pendant}</p>"
         },
@@ -18,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Bronze Bull Pendant (Shove)",
                 "predicate": [
                     "action:shove"
                 ],

--- a/packs/data/equipment-effects.db/effect-clandestine-cloak-greater.json
+++ b/packs/data/equipment-effects.db/effect-clandestine-cloak-greater.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/clandestine-cloak.webp",
     "name": "Effect: Clandestine Cloak (Greater)",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by @Compendium[pf2e.equipment-srd.Clandestine Cloak (Greater)]{Clandestine Cloak (Greater)}</p>"
         },
@@ -24,7 +25,6 @@
             },
             {
                 "key": "FlatModifier",
-                "label": "Clandestine Cloak, Greater (Impersonate forgettable person)",
                 "predicate": [
                     "impersonate"
                 ],

--- a/packs/data/equipment-effects.db/effect-clandestine-cloak.json
+++ b/packs/data/equipment-effects.db/effect-clandestine-cloak.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/clandestine-cloak.webp",
     "name": "Effect: Clandestine Cloak",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by @Compendium[pf2e.equipment-srd.Clandestine Cloak]{Clandestine Cloak}</p>"
         },
@@ -24,7 +25,6 @@
             },
             {
                 "key": "FlatModifier",
-                "label": "Clandestine Cloak (Impersonate forgettable person)",
                 "predicate": [
                     "impersonate"
                 ],

--- a/packs/data/equipment-effects.db/effect-cognitive-mutagen-greater.json
+++ b/packs/data/equipment-effects.db/effect-cognitive-mutagen-greater.json
@@ -19,28 +19,24 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Cognitive Mutagen (Greater)",
                 "selector": "arcana",
                 "type": "item",
                 "value": 3
             },
             {
                 "key": "FlatModifier",
-                "label": "Cognitive Mutagen (Greater)",
                 "selector": "crafting",
                 "type": "item",
                 "value": 3
             },
             {
                 "key": "FlatModifier",
-                "label": "Cognitive Mutagen (Greater)",
                 "selector": "occultism",
                 "type": "item",
                 "value": 3
             },
             {
                 "key": "FlatModifier",
-                "label": "Cognitive Mutagen (Greater)",
                 "selector": "society",
                 "type": "item",
                 "value": 3
@@ -62,7 +58,6 @@
             },
             {
                 "key": "FlatModifier",
-                "label": "Cognitive Mutagen (Recall knowledge)",
                 "predicate": [
                     "action:recall-knowledge"
                 ],

--- a/packs/data/equipment-effects.db/effect-cognitive-mutagen-lesser.json
+++ b/packs/data/equipment-effects.db/effect-cognitive-mutagen-lesser.json
@@ -19,28 +19,24 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Cognitive Mutagen (Lesser)",
                 "selector": "arcana",
                 "type": "item",
                 "value": 1
             },
             {
                 "key": "FlatModifier",
-                "label": "Cognitive Mutagen (Lesser)",
                 "selector": "crafting",
                 "type": "item",
                 "value": 1
             },
             {
                 "key": "FlatModifier",
-                "label": "Cognitive Mutagen (Lesser)",
                 "selector": "occultism",
                 "type": "item",
                 "value": 1
             },
             {
                 "key": "FlatModifier",
-                "label": "Cognitive Mutagen (Lesser)",
                 "selector": "society",
                 "type": "item",
                 "value": 1
@@ -62,7 +58,6 @@
             },
             {
                 "key": "FlatModifier",
-                "label": "Cognitive Mutagen (Recall knowledge)",
                 "predicate": [
                     "action:recall-knowledge"
                 ],

--- a/packs/data/equipment-effects.db/effect-cognitive-mutagen-major.json
+++ b/packs/data/equipment-effects.db/effect-cognitive-mutagen-major.json
@@ -19,28 +19,24 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Cognitive Mutagen (Major)",
                 "selector": "arcana",
                 "type": "item",
                 "value": 4
             },
             {
                 "key": "FlatModifier",
-                "label": "Cognitive Mutagen (Major)",
                 "selector": "crafting",
                 "type": "item",
                 "value": 4
             },
             {
                 "key": "FlatModifier",
-                "label": "Cognitive Mutagen (Major)",
                 "selector": "occultism",
                 "type": "item",
                 "value": 4
             },
             {
                 "key": "FlatModifier",
-                "label": "Cognitive Mutagen (Major)",
                 "selector": "society",
                 "type": "item",
                 "value": 4
@@ -62,7 +58,6 @@
             },
             {
                 "key": "FlatModifier",
-                "label": "Cognitive Mutagen (Recall knowledge)",
                 "predicate": [
                     "action:recall-knowledge"
                 ],

--- a/packs/data/equipment-effects.db/effect-cognitive-mutagen-moderate.json
+++ b/packs/data/equipment-effects.db/effect-cognitive-mutagen-moderate.json
@@ -19,28 +19,24 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Cognitive Mutagen (Moderate)",
                 "selector": "arcana",
                 "type": "item",
                 "value": 2
             },
             {
                 "key": "FlatModifier",
-                "label": "Cognitive Mutagen (Moderate)",
                 "selector": "crafting",
                 "type": "item",
                 "value": 2
             },
             {
                 "key": "FlatModifier",
-                "label": "Cognitive Mutagen (Moderate)",
                 "selector": "occultism",
                 "type": "item",
                 "value": 2
             },
             {
                 "key": "FlatModifier",
-                "label": "Cognitive Mutagen (Moderate)",
                 "selector": "society",
                 "type": "item",
                 "value": 2
@@ -62,7 +58,6 @@
             },
             {
                 "key": "FlatModifier",
-                "label": "Cognitive Mutagen (Recall knowledge)",
                 "predicate": [
                     "action:recall-knowledge"
                 ],

--- a/packs/data/equipment-effects.db/effect-crimson-fulcrum-lens.json
+++ b/packs/data/equipment-effects.db/effect-crimson-fulcrum-lens.json
@@ -19,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Crimson Fulcrum Lens (vs fear)",
                 "predicate": [
                     "fear"
                 ],
@@ -29,7 +28,6 @@
             },
             {
                 "key": "FlatModifier",
-                "label": "Crimson Fulcrum Lens",
                 "predicate": [
                     "melee"
                 ],
@@ -39,7 +37,6 @@
             },
             {
                 "key": "FlatModifier",
-                "label": "Crimson Fulcrum Lens - Jaws",
                 "predicate": [
                     "melee"
                 ],

--- a/packs/data/equipment-effects.db/effect-curse-of-potent-poison.json
+++ b/packs/data/equipment-effects.db/effect-curse-of-potent-poison.json
@@ -19,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Curse of Potent Poison",
                 "selector": "fortitude",
                 "type": "status",
                 "value": -1

--- a/packs/data/equipment-effects.db/effect-deadweight-snare-failure-critical-failure.json
+++ b/packs/data/equipment-effects.db/effect-deadweight-snare-failure-critical-failure.json
@@ -19,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Deadweight Snare (Failure or Critical Failure)",
                 "selector": "attack",
                 "type": "status",
                 "value": -2

--- a/packs/data/equipment-effects.db/effect-deadweight-snare-success.json
+++ b/packs/data/equipment-effects.db/effect-deadweight-snare-success.json
@@ -19,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Deadweight Snare (Success)",
                 "selector": "attack",
                 "type": "status",
                 "value": -1

--- a/packs/data/equipment-effects.db/effect-diplomats-badge.json
+++ b/packs/data/equipment-effects.db/effect-diplomats-badge.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/diplomats-badge.webp",
     "name": "Effect: Diplomat's Badge",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by activating @Compendium[pf2e.equipment-srd.Diplomat's Badge]{Diplomat's Badge}.</p>"
         },
@@ -18,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Diplomat's Badge (specific group)",
                 "predicate": [
                     "group"
                 ],

--- a/packs/data/equipment-effects.db/effect-dragonfly-potion.json
+++ b/packs/data/equipment-effects.db/effect-dragonfly-potion.json
@@ -19,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Dragonfly Potion",
                 "predicate": [
                     "visual"
                 ],

--- a/packs/data/equipment-effects.db/effect-dragons-blood-pudding-greater.json
+++ b/packs/data/equipment-effects.db/effect-dragons-blood-pudding-greater.json
@@ -19,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Greater Dragon's Blood Pudding Intmidation",
                 "predicate": [
                     "action:demoralize"
                 ],

--- a/packs/data/equipment-effects.db/effect-dragons-blood-pudding-major.json
+++ b/packs/data/equipment-effects.db/effect-dragons-blood-pudding-major.json
@@ -19,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Greater Dragon's Blood Pudding Intmidation",
                 "predicate": [
                     "action:demoralize"
                 ],

--- a/packs/data/equipment-effects.db/effect-dragons-blood-pudding-moderate.json
+++ b/packs/data/equipment-effects.db/effect-dragons-blood-pudding-moderate.json
@@ -19,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Greater Dragon's Blood Pudding Intmidation",
                 "predicate": [
                     "action:demoralize"
                 ],

--- a/packs/data/equipment-effects.db/effect-drakeheart-mutagen-greater.json
+++ b/packs/data/equipment-effects.db/effect-drakeheart-mutagen-greater.json
@@ -24,35 +24,28 @@
             },
             {
                 "key": "FlatModifier",
-                "label": "Drakeheart Mutagen (Greater)",
                 "selector": "ac",
                 "type": "item",
                 "value": 6
             },
             {
                 "key": "FlatModifier",
-                "label": "Drakeheart Mutagen (Greater)",
                 "selector": "perception",
                 "type": "item",
                 "value": 3
             },
             {
                 "key": "FlatModifier",
-                "label": "Drakeheart Mutagen (Greater)",
                 "selector": "will",
-                "type": "untyped",
                 "value": -1
             },
             {
                 "key": "FlatModifier",
-                "label": "Drakeheart Mutagen (Greater)",
                 "selector": "reflex",
-                "type": "untyped",
                 "value": -1
             },
             {
                 "key": "FlatModifier",
-                "label": "Drakeheart Mutagen (Recall Knowledge)",
                 "predicate": [
                     "action:recall-knowledge"
                 ],

--- a/packs/data/equipment-effects.db/effect-drakeheart-mutagen-lesser.json
+++ b/packs/data/equipment-effects.db/effect-drakeheart-mutagen-lesser.json
@@ -24,35 +24,28 @@
             },
             {
                 "key": "FlatModifier",
-                "label": "Drakeheart Mutagen (Lesser)",
                 "selector": "ac",
                 "type": "item",
                 "value": 4
             },
             {
                 "key": "FlatModifier",
-                "label": "Drakeheart Mutagen (Lesser)",
                 "selector": "perception",
                 "type": "item",
                 "value": 1
             },
             {
                 "key": "FlatModifier",
-                "label": "Drakeheart Mutagen (Lesser)",
                 "selector": "will",
-                "type": "untyped",
                 "value": -1
             },
             {
                 "key": "FlatModifier",
-                "label": "Drakeheart Mutagen (Lesser)",
                 "selector": "reflex",
-                "type": "untyped",
                 "value": -1
             },
             {
                 "key": "FlatModifier",
-                "label": "Drakeheart Mutagen (Recall Knowledge)",
                 "predicate": [
                     "action:recall-knowledge"
                 ],

--- a/packs/data/equipment-effects.db/effect-drakeheart-mutagen-major.json
+++ b/packs/data/equipment-effects.db/effect-drakeheart-mutagen-major.json
@@ -24,35 +24,28 @@
             },
             {
                 "key": "FlatModifier",
-                "label": "Drakeheart Mutagen (Major)",
                 "selector": "ac",
                 "type": "item",
                 "value": 7
             },
             {
                 "key": "FlatModifier",
-                "label": "Drakeheart Mutagen (Major)",
                 "selector": "perception",
                 "type": "item",
                 "value": 4
             },
             {
                 "key": "FlatModifier",
-                "label": "Drakeheart Mutagen (Major)",
                 "selector": "will",
-                "type": "untyped",
                 "value": -1
             },
             {
                 "key": "FlatModifier",
-                "label": "Drakeheart Mutagen (Major)",
                 "selector": "reflex",
-                "type": "untyped",
                 "value": -1
             },
             {
                 "key": "FlatModifier",
-                "label": "Drakeheart Mutagen (Recall Knowledge)",
                 "predicate": [
                     "action:recall-knowledge"
                 ],

--- a/packs/data/equipment-effects.db/effect-drakeheart-mutagen-moderate.json
+++ b/packs/data/equipment-effects.db/effect-drakeheart-mutagen-moderate.json
@@ -24,35 +24,28 @@
             },
             {
                 "key": "FlatModifier",
-                "label": "Drakeheart Mutagen (Moderate)",
                 "selector": "ac",
                 "type": "item",
                 "value": 5
             },
             {
                 "key": "FlatModifier",
-                "label": "Drakeheart Mutagen (Moderate)",
                 "selector": "perception",
                 "type": "item",
                 "value": 2
             },
             {
                 "key": "FlatModifier",
-                "label": "Drakeheart Mutagen (Moderate)",
                 "selector": "will",
-                "type": "untyped",
                 "value": -1
             },
             {
                 "key": "FlatModifier",
-                "label": "Drakeheart Mutagen (Moderate)",
                 "selector": "reflex",
-                "type": "untyped",
                 "value": -1
             },
             {
                 "key": "FlatModifier",
-                "label": "Drakeheart Mutagen (Recall Knowledge)",
                 "predicate": [
                     "action:recall-knowledge"
                 ],

--- a/packs/data/equipment-effects.db/effect-dueling-cape.json
+++ b/packs/data/equipment-effects.db/effect-dueling-cape.json
@@ -19,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Dueling Cape (Feint)",
                 "predicate": [
                     "action:feint"
                 ],

--- a/packs/data/equipment-effects.db/effect-eagle-eye-elixir-greater.json
+++ b/packs/data/equipment-effects.db/effect-eagle-eye-elixir-greater.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/eagle-eyes-elixir.webp",
     "name": "Effect: Eagle Eye Elixir (Greater)",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by @Compendium[pf2e.equipment-srd.Eagle Eye Elixir (Greater)]{Eagle Eye Elixir (Greater)}</p>\n<p>Implemented effects:</p>\n<ul>\n<li>+3 item bonus to Perception checks</li>\n<li>+4 item bonus to Perception checks to find secret doors and traps</li>\n</ul>"
         },
@@ -18,14 +19,12 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Eagle Eye Elixir (Greater)",
                 "selector": "perception",
                 "type": "item",
                 "value": 3
             },
             {
                 "key": "FlatModifier",
-                "label": "Eagle Eye Elixir Greater (secret doors & traps)",
                 "predicate": [
                     "secret doors and traps"
                 ],

--- a/packs/data/equipment-effects.db/effect-eagle-eye-elixir-greater.json
+++ b/packs/data/equipment-effects.db/effect-eagle-eye-elixir-greater.json
@@ -25,8 +25,12 @@
             },
             {
                 "key": "FlatModifier",
+                "label": "PF2E.SpecificRule.Equipment.EagleEyeElixir.Greater.SecretLabel",
+                "slug": "eagle-eye-elixir-greater-secrets",
                 "predicate": [
-                    "secret doors and traps"
+                    {
+                        "or": ["secret-door", "trap"]
+                    }
                 ],
                 "selector": "perception",
                 "type": "item",

--- a/packs/data/equipment-effects.db/effect-eagle-eye-elixir-lesser.json
+++ b/packs/data/equipment-effects.db/effect-eagle-eye-elixir-lesser.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/eagle-eyes-elixir.webp",
     "name": "Effect: Eagle Eye Elixir (Lesser)",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by @Compendium[pf2e.equipment-srd.Eagle Eye Elixir (Lesser)]{Eagle Eye Elixir (Lesser)}</p>\n<p>Implemented effects:</p>\n<ul>\n<li>+1 item bonus to Perception checks</li>\n<li>+2 item bonus to Perception checks to find secret doors and traps</li>\n</ul>"
         },
@@ -18,14 +19,12 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Eagle Eye Elixir (Lesser)",
                 "selector": "perception",
                 "type": "item",
                 "value": 1
             },
             {
                 "key": "FlatModifier",
-                "label": "Eagle Eye Elixir Lesser (secret doors & traps)",
                 "predicate": [
                     "secret doors and traps"
                 ],

--- a/packs/data/equipment-effects.db/effect-eagle-eye-elixir-lesser.json
+++ b/packs/data/equipment-effects.db/effect-eagle-eye-elixir-lesser.json
@@ -19,6 +19,7 @@
         "rules": [
             {
                 "key": "FlatModifier",
+                "slug": "eagle-eye-elixir-lesser",
                 "selector": "perception",
                 "type": "item",
                 "value": 1

--- a/packs/data/equipment-effects.db/effect-eagle-eye-elixir-lesser.json
+++ b/packs/data/equipment-effects.db/effect-eagle-eye-elixir-lesser.json
@@ -26,6 +26,8 @@
             },
             {
                 "key": "FlatModifier",
+                "label": "PF2E.SpecificRule.Equipment.EagleEyeElixir.Lesser.SecretLabel",
+                "slug": "eagle-eye-elixir-lesser-secrets",
                 "predicate": [
                     "secret doors and traps"
                 ],

--- a/packs/data/equipment-effects.db/effect-eagle-eye-elixir-major.json
+++ b/packs/data/equipment-effects.db/effect-eagle-eye-elixir-major.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/eagle-eyes-elixir.webp",
     "name": "Effect: Eagle Eye Elixir (Major)",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by @Compendium[pf2e.equipment-srd.Eagle Eye Elixir (Major)]{Eagle Eye Elixir (Major)}</p>\n<p>Implemented effects:</p>\n<ul>\n<li>+3 item bonus to Perception checks</li>\n<li>+4 item bonus to Perception checks to find secret doors and traps</li>\n</ul>\n<p>Unimplemented effects:</p>\n<ul>\n<li>Each time you pass within 10 feet of a secret door or trap, the GM automatically rolls a secret check for you to find it.</li>\n</ul>"
         },
@@ -18,14 +19,12 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Eagle Eye Elixir (Major)",
                 "selector": "perception",
                 "type": "item",
                 "value": 3
             },
             {
                 "key": "FlatModifier",
-                "label": "Eagle Eye Elixir Major (secret doors & traps)",
                 "predicate": [
                     "secret doors and traps"
                 ],

--- a/packs/data/equipment-effects.db/effect-eagle-eye-elixir-major.json
+++ b/packs/data/equipment-effects.db/effect-eagle-eye-elixir-major.json
@@ -25,6 +25,8 @@
             },
             {
                 "key": "FlatModifier",
+                "label": "PF2E.SpecificRule.Equipment.EagleEyeElixir.Major.SecretLabel",
+                "slug": "eagle-eye-elixir-major-secrets",
                 "predicate": [
                     "secret doors and traps"
                 ],

--- a/packs/data/equipment-effects.db/effect-eagle-eye-elixir-major.json
+++ b/packs/data/equipment-effects.db/effect-eagle-eye-elixir-major.json
@@ -19,6 +19,7 @@
         "rules": [
             {
                 "key": "FlatModifier",
+                "slug": "eagle-eye-elixir-major",
                 "selector": "perception",
                 "type": "item",
                 "value": 3

--- a/packs/data/equipment-effects.db/effect-eagle-eye-elixir-moderate.json
+++ b/packs/data/equipment-effects.db/effect-eagle-eye-elixir-moderate.json
@@ -19,6 +19,7 @@
         "rules": [
             {
                 "key": "FlatModifier",
+                "slug": "eagle-eye-elixir-moderate",
                 "selector": "perception",
                 "type": "item",
                 "value": 2

--- a/packs/data/equipment-effects.db/effect-eagle-eye-elixir-moderate.json
+++ b/packs/data/equipment-effects.db/effect-eagle-eye-elixir-moderate.json
@@ -26,6 +26,8 @@
             },
             {
                 "key": "FlatModifier",
+                "label": "PF2E.SpecificRule.Equipment.EagleEyeElixir.Moderate.SecretLabel",
+                "slug": "eagle-eye-elixir-moderate-secrets",
                 "predicate": [
                     "secret doors and traps"
                 ],

--- a/packs/data/equipment-effects.db/effect-eagle-eye-elixir-moderate.json
+++ b/packs/data/equipment-effects.db/effect-eagle-eye-elixir-moderate.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/eagle-eyes-elixir.webp",
     "name": "Effect: Eagle Eye Elixir (Moderate)",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by @Compendium[pf2e.equipment-srd.Eagle Eye Elixir (Moderate)]{Eagle Eye Elixir (Moderate)}</p>\n<p>Implemented effects:</p>\n<ul>\n<li>+2 item bonus to Perception checks</li>\n<li>+3 item bonus to Perception checks to find secret doors and traps</li>\n</ul>"
         },
@@ -18,14 +19,12 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Eagle Eye Elixir (Moderate)",
                 "selector": "perception",
                 "type": "item",
                 "value": 2
             },
             {
                 "key": "FlatModifier",
-                "label": "Eagle Eye Elixir Moderate (secret doors & traps)",
                 "predicate": [
                     "secret doors and traps"
                 ],

--- a/packs/data/equipment-effects.db/effect-earplugs-pfs-guide.json
+++ b/packs/data/equipment-effects.db/effect-earplugs-pfs-guide.json
@@ -5,7 +5,7 @@
     "system": {
         "badge": null,
         "description": {
-            "value": "<p>Grants a +1 item bonus to saves vs. auditory effects and a -2 penalty to perception checks that rely on hearing.</p><p>Granted by @UUID[Compendium.pf2e.equipment-srd.iYiA6CMR1N2E2Ny2]{Earplugs (PFS Guide)}</p>"
+            "value": "<p>Grants a +1 item bonus to saves vs. auditory effects and a -2 penalty to perception checks that rely on hearing.</p>\n<p>Granted by @UUID[Compendium.pf2e.equipment-srd.iYiA6CMR1N2E2Ny2]{Earplugs (PFS Guide)}</p>"
         },
         "duration": {
             "expiry": "turn-start",

--- a/packs/data/equipment-effects.db/effect-earplugs.json
+++ b/packs/data/equipment-effects.db/effect-earplugs.json
@@ -19,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Earplugs (vs. auditory)",
                 "predicate": [
                     "auditory"
                 ],
@@ -29,7 +28,6 @@
             },
             {
                 "key": "FlatModifier",
-                "label": "Earplugs (hearing)",
                 "predicate": [
                     "hearing"
                 ],

--- a/packs/data/equipment-effects.db/effect-ebon-fulcrum-lens-2-action.json
+++ b/packs/data/equipment-effects.db/effect-ebon-fulcrum-lens-2-action.json
@@ -19,42 +19,36 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Ebon Fulcrum Lens Reaction",
                 "selector": "attack",
                 "type": "item",
                 "value": 1
             },
             {
                 "key": "FlatModifier",
-                "label": "Ebon Fulcrum Lens Reaction",
                 "selector": "saving-throw",
                 "type": "item",
                 "value": 1
             },
             {
                 "key": "FlatModifier",
-                "label": "Ebon Fulcrum Lens Reaction",
                 "selector": "skill-check",
                 "type": "item",
                 "value": 1
             },
             {
                 "key": "FlatModifier",
-                "label": "Ebon Fulcrum Lens Reaction",
                 "selector": "ac",
                 "type": "item",
                 "value": 1
             },
             {
                 "key": "FlatModifier",
-                "label": "Ebon Fulcrum Lens Reaction",
                 "selector": "perception",
                 "type": "item",
                 "value": 1
             },
             {
                 "key": "FlatModifier",
-                "label": "Ebon Fulcrum Lens Reaction",
                 "selector": "class",
                 "type": "item",
                 "value": 1

--- a/packs/data/equipment-effects.db/effect-ebon-fulcrum-lens-reaction.json
+++ b/packs/data/equipment-effects.db/effect-ebon-fulcrum-lens-reaction.json
@@ -19,42 +19,36 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Ebon Fulcrum Lens Reaction",
                 "selector": "attack",
                 "type": "item",
                 "value": 1
             },
             {
                 "key": "FlatModifier",
-                "label": "Ebon Fulcrum Lens Reaction",
                 "selector": "saving-throw",
                 "type": "item",
                 "value": 1
             },
             {
                 "key": "FlatModifier",
-                "label": "Ebon Fulcrum Lens Reaction",
                 "selector": "skill-check",
                 "type": "item",
                 "value": 1
             },
             {
                 "key": "FlatModifier",
-                "label": "Ebon Fulcrum Lens Reaction",
                 "selector": "ac",
                 "type": "item",
                 "value": 1
             },
             {
                 "key": "FlatModifier",
-                "label": "Ebon Fulcrum Lens Reaction",
                 "selector": "perception",
                 "type": "item",
                 "value": 1
             },
             {
                 "key": "FlatModifier",
-                "label": "Ebon Fulcrum Lens Reaction",
                 "selector": "class",
                 "type": "item",
                 "value": 1

--- a/packs/data/equipment-effects.db/effect-elixir-of-life-greater.json
+++ b/packs/data/equipment-effects.db/effect-elixir-of-life-greater.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/elixir-of-life.webp",
     "name": "Effect: Elixir of Life (Greater)",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by @Compendium[pf2e.equipment-srd.Elixir of Life (Greater)]{Elixir of Life (Greater)}</p>\n<p>Implemented effects:</p>\n<ul>\n<li>+2 item bonus to saving throws against diseases and poisons</li>\n</ul>\n<p>Unimplemented effects:</p>\n<ul>\n<li>Heal [[/r {7d6+18}[healing]]]{7d6+18 Hit Points}</li>\n</ul>"
         },
@@ -18,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Elixir of Life, Greater (vs. disease & poison)",
                 "predicate": [
                     {
                         "or": [

--- a/packs/data/equipment-effects.db/effect-elixir-of-life-lesser.json
+++ b/packs/data/equipment-effects.db/effect-elixir-of-life-lesser.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/elixir-of-life.webp",
     "name": "Effect: Elixir of Life (Lesser)",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by @Compendium[pf2e.equipment-srd.Elixir of Life (Lesser)]{Elixir of Life (Lesser)}</p>\n<p>Implemented effects:</p>\n<ul>\n<li>+1 item bonus to saving throws against diseases and poisons</li>\n</ul>\n<p>Unimplemented effects:</p>\n<ul>\n<li>Heal [[/r {3d6+6}[healing]]]{3d6+6 Hit Points}</li>\n</ul>"
         },
@@ -18,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Elixir of Life, Lesser (vs. disease & poison)",
                 "predicate": [
                     {
                         "or": [

--- a/packs/data/equipment-effects.db/effect-elixir-of-life-major.json
+++ b/packs/data/equipment-effects.db/effect-elixir-of-life-major.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/elixir-of-life.webp",
     "name": "Effect: Elixir of Life (Major)",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by @Compendium[pf2e.equipment-srd.Elixir of Life (Major)]{Elixir of Life (Major)}</p>\n<p>Implemented effects:</p>\n<ul>\n<li>+3 item bonus to saving throws against diseases and poisons</li>\n</ul>\n<p>Unimplemented effects:</p>\n<ul>\n<li>Heal [[/r {8d6+21}[healing]]]{8d6+21 Hit Points}</li>\n</ul>"
         },
@@ -18,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Elixir of Life, Major (vs. disease & poison)",
                 "predicate": [
                     {
                         "or": [

--- a/packs/data/equipment-effects.db/effect-elixir-of-life-minor.json
+++ b/packs/data/equipment-effects.db/effect-elixir-of-life-minor.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/elixir-of-life.webp",
     "name": "Effect: Elixir of Life (Minor)",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by @Compendium[pf2e.equipment-srd.Elixir of Life (Minor)]{Elixir of Life (Minor)}</p>\n<p>Implemented effects:</p>\n<ul>\n<li>+1 item bonus to saving throws against diseases and poisons</li>\n</ul>\n<p>Unimplemented effects:</p>\n<ul>\n<li>Heal [[/r {1d6}[healing]]]{1d6 Hit Points}</li>\n</ul>"
         },
@@ -18,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Elixir of Life, Minor (vs. disease & poison)",
                 "predicate": [
                     {
                         "or": [

--- a/packs/data/equipment-effects.db/effect-elixir-of-life-moderate.json
+++ b/packs/data/equipment-effects.db/effect-elixir-of-life-moderate.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/elixir-of-life.webp",
     "name": "Effect: Elixir of Life (Moderate)",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by @Compendium[pf2e.equipment-srd.Elixir of Life (Moderate)]{Elixir of Life (Moderate)}</p>\n<p>Implemented effects:</p>\n<ul>\n<li>+2 item bonus to saving throws against diseases and poisons</li>\n</ul>\n<p>Unimplemented effects:</p>\n<ul>\n<li>Heal [[/r {5d6+12}[healing]]]{5d6+12 Hit Points}</li>\n</ul>"
         },
@@ -18,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Elixir of Life, Moderate (vs. disease & poison)",
                 "predicate": [
                     {
                         "or": [

--- a/packs/data/equipment-effects.db/effect-elixir-of-life-true.json
+++ b/packs/data/equipment-effects.db/effect-elixir-of-life-true.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/elixir-of-life.webp",
     "name": "Effect: Elixir of Life (True)",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by @Compendium[pf2e.equipment-srd.Elixir of Life (True)]{Elixir of Life (True)}</p>\n<p>Implemented effects:</p>\n<ul>\n<li>+4 item bonus to saving throws against diseases and poisons</li>\n</ul>\n<p>Unimplemented effects:</p>\n<ul>\n<li>Heal [[/r {10d6+27}[healing]]]{10d6+27 Hit Points}</li>\n</ul>"
         },
@@ -18,7 +19,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Elixir of Life, True (vs. disease & poison)",
                 "predicate": [
                     {
                         "or": [

--- a/packs/data/equipment-effects.db/effect-euryale-curse-card.json
+++ b/packs/data/equipment-effects.db/effect-euryale-curse-card.json
@@ -3,6 +3,7 @@
     "img": "systems/pf2e/icons/equipment/cursed-items/euryale-curse-card.webp",
     "name": "Effect: Euryale (Curse) Card",
     "system": {
+        "badge": null,
         "description": {
             "value": "<p>Granted by @Compendium[pf2e.gmg-srd.Euryale (curse)]{Euryale (curse)} from the @Compendium[pf2e.equipment-srd.Deck of Many Things]{Deck of Many Things}</p>"
         },
@@ -20,7 +21,6 @@
                 "key": "FlatModifier",
                 "label": "Euryale Curse",
                 "selector": "saving-throw",
-                "type": "untyped",
                 "value": -1
             }
         ],


### PR DESCRIPTION
Removed unnecessary labels from the following equipment effects REs (each variant):
-aeon stone black
-aeon stone orange
-antidote
-antiplague
-applereed mutagen
-bloodhound mask
-boulderhead bock
-bravo's brew
-breastplate of command
-Brewer's Regret
-Bronze Bull Pendant
-clandestine cloak
-cognitive mutagen
-Curse of Potent Poison
-Crimson Fulcrum Lens
-Deadweight Snare
-Diplomat's Badge
-Dragon's Blood Pudding
-Dragonfly Potion
-Drakeheart mutagen
-Dueling Cape
-Eagle Eye Elixir
-Earplugs
-Ebon Fulcrum Lens
-Elixir Of Life