### PR TITLE
Remove double borders from frames and round corners

### DIFF
--- a/src/styles/actor/_inventory.scss
+++ b/src/styles/actor/_inventory.scss
@@ -39,6 +39,10 @@
             padding: 12px;
             cursor: pointer;
             margin-right: 4px;
+
+            .item-icon {
+                border: none;
+            }
         }
 
         .size {

--- a/src/styles/actor/_spell-list.scss
+++ b/src/styles/actor/_spell-list.scss
@@ -159,11 +159,12 @@ ol.spell-list {
                 height: 1.5rem;
                 width: 1.5rem;
                 margin: 2px 0;
-                border-radius: 0;
+                border-radius: 2px;
                 cursor: pointer;
 
                 .item-icon {
-                    max-width: 23px;
+                    max-width: 24px;
+                    border: none;
                 }
 
                 &:hover {

--- a/src/styles/actor/character/_actions.scss
+++ b/src/styles/actor/character/_actions.scss
@@ -34,6 +34,7 @@
                     height: 32px;
                     width: 32px;
                     padding: 11px;
+                    border-radius: 2px;
                 }
 
                 .action-options {

--- a/src/styles/actor/character/_crafting.scss
+++ b/src/styles/actor/character/_crafting.scss
@@ -187,13 +187,14 @@
                         height: 24px;
                         width: 24px;
                         margin: 2px 0;
-                        border-radius: 0;
+                        border-radius: 2px;
                         margin-left: 4px;
                         cursor: pointer;
                         .item-icon {
-                            max-width: 23px;
+                            max-width: 24px;
+                            border: none;
                         }
-
+                        
                         &:hover {
                             background: url("../../../icons/svg/d20-black.svg") no-repeat center, #f1eee9;
                             background-size: contain;

--- a/src/styles/actor/character/_crafting.scss
+++ b/src/styles/actor/character/_crafting.scss
@@ -194,7 +194,7 @@
                             max-width: 24px;
                             border: none;
                         }
-                        
+
                         &:hover {
                             background: url("../../../icons/svg/d20-black.svg") no-repeat center, #f1eee9;
                             background-size: contain;

--- a/src/styles/actor/character/_effects.scss
+++ b/src/styles/actor/character/_effects.scss
@@ -15,6 +15,10 @@
             border-image: linear-gradient(90deg, #f1edea, $border-color) 1 repeat;
         }
 
+        .item-image {
+            border-radius: 2px;
+        }
+
         .item:last-child {
             border-bottom: none;
         }

--- a/src/styles/actor/character/_feats.scss
+++ b/src/styles/actor/character/_feats.scss
@@ -60,12 +60,16 @@
                 @include frame-icon;
                 height: 24px;
                 width: 24px;
-                border-radius: 0;
+                border-radius: 2px;
                 margin-left: 8px;
                 margin-right: 8px;
                 cursor: pointer;
                 background-color: var(--tertiary);
                 position: relative;
+
+                .item-icon {
+                    border: none;
+                }
 
                 &:hover {
                     background: #f1eee9;

--- a/src/styles/mixins/_frames.scss
+++ b/src/styles/mixins/_frames.scss
@@ -17,7 +17,7 @@
 }
 
 @mixin frame-icon {
-    border: 1px solid var(--body);
+    border: none;
     /* prettier-ignore */
     box-shadow:
         0 0 0 1px var(--tertiary),


### PR DESCRIPTION
Before: (Notice the black border touching the frame and the inner one containing the image)
![image](https://user-images.githubusercontent.com/77904738/196064202-99b41d8c-2fca-471e-b9b5-5ec6a91e257b.png)![image](https://user-images.githubusercontent.com/77904738/196064362-597e2b1e-8a93-4caf-b449-0641bb76e0fc.png)![image](https://user-images.githubusercontent.com/77904738/196064394-19bca488-2685-4a03-b3e9-fb4aa33ea030.png)


After:
![image](https://user-images.githubusercontent.com/77904738/196064204-75e40674-ab49-4a79-b324-4227daf1e5ed.png)![image](https://user-images.githubusercontent.com/77904738/196064382-13605e6e-1d15-4a8b-95aa-40397d616945.png)![image](https://user-images.githubusercontent.com/77904738/196064412-7d59cfdc-a6dc-4779-adf0-427ed2d7df96.png)


The rounding of the corners is just a minor aesthetic thing; I just thought it looked nicer but I'm not married to the idea