### PR TITLE
Fix close button for rules editing

### DIFF
--- a/src/module/item/sheet/base.ts
+++ b/src/module/item/sheet/base.ts
@@ -274,14 +274,13 @@ export class ItemSheetPF2e<TItem extends ItemPF2e> extends ItemSheet<TItem> {
 
             html.querySelector<HTMLDivElement>(".rule-editing .editor-placeholder")?.replaceWith(view.dom);
 
-            html.querySelector<HTMLButtonElement>(".rule-editing button[data-action=close]")?.addEventListener(
-                "click",
-                (event) => {
-                    event.preventDefault();
-                    this.editingRuleElementIndex = null;
-                    this.render();
-                }
-            );
+            const closeBtn = html.querySelector<HTMLButtonElement>(".rule-editing button[data-action=close]");
+            closeBtn?.addEventListener("click", (event) => {
+                event.preventDefault();
+                this.editingRuleElementIndex = null;
+                this.render();
+            });
+            closeBtn?.removeAttribute("disabled");
 
             html.querySelector<HTMLButtonElement>(".rule-editing button[data-action=apply]")?.addEventListener(
                 "click",


### PR DESCRIPTION
The close button is disabled for the rules editing element when looking at something from compendium, creating a scenario in which the user cannot navigate backwards.
This is done on foundry's side, so this PR attempts to remedy that by explicitly removing the disabled attribute from the close button.