### PR TITLE
Allow duration coercion to be optional

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -313,8 +313,10 @@ class ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
 
                 const source = mergeObject(effect.toObject(), { flags });
                 source.system.level.value = data.level ?? source.system.level.value;
-                source.system.duration.unit = "unlimited";
-                source.system.duration.expiry = null;
+                if (!data.noDurationCoercion) {
+                    source.system.duration.unit = "unlimited";
+                    source.system.duration.expiry = null;
+                }
                 toCreate.push(source);
             }
         }

--- a/src/module/actor/types.ts
+++ b/src/module/actor/types.ts
@@ -36,6 +36,7 @@ interface AuraEffectData {
         dc: number;
     } | null;
     removeOnExit: boolean;
+    noDurationCoercion: boolean;
 }
 
 interface AuraColors {

--- a/src/module/rules/rule-element/aura.ts
+++ b/src/module/rules/rule-element/aura.ts
@@ -94,6 +94,7 @@ export class AuraRuleElement extends RuleElementPF2e {
         effect.affects ??= "all";
         effect.removeOnExit ??= Array.isArray(effect.events) ? effect.events.includes("enter") : false;
         effect.save ??= null;
+        effect.noDurationCoercion ??= false;
 
         return (
             typeof effect.uuid === "string" &&


### PR DESCRIPTION
### Problem
Right now auras force the applied effect duration to be unlimited and have no expiry style set. This means that even if you explicitly link to an effect that has a duration of N rounds, it will not be respected.
I suppose that the change was made because it was assumed auras should strictly be for aura-like effects. However, this strictness denies the possibility of using the aura system to apply effects to other tokens in a radius.
### Changes
Add a `noDurationCoercion` boolean field to the aura effect data type such that if it primitively evaluates to true, the coercion code is disabled and the original duration data from the effect (specified by uuid) is left alone.
e.g.
```
{
    "key": "Aura",
    "radius": 30,
    "effects": [{
        "affects": "allies",
        "events": ["enter"],
        "uuid": "Item.9Q68yHv607Y1EmSy",
        "removeOnExit": false,
        "noDurationCoercion": true
    }]
}
```
### Benefits
- Existing rules are not changed. Default when unspecified is still the original behaviour before this change
- Allows a Bard to cast `Inspire Courage` at different round counters easily by flickering the aura on and off (in combination with `"removeOnExit": false`)
