### PR TITLE
Fix `Spell#createTemplate` default width

### DIFF
--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -362,7 +362,7 @@ class SpellPF2e extends ItemPF2e {
         };
 
         if (areaType === "ray") {
-            templateData.width = CONFIG.MeasuredTemplate.defaults.width;
+            templateData.width = CONFIG.MeasuredTemplate.defaults.width * (canvas.dimensions?.distance ?? 1);
         } else if (areaType === "cone") {
             templateData.angle = CONFIG.MeasuredTemplate.defaults.angle;
         }


### PR DESCRIPTION
This was probably a v10 change but I don't have v9 installed anymore so I can't verify. The fix duplicates line `36407` in `foundry.js`.

Closes #4554