### PR TITLE
Allow GrantItem REs to assign a badge value to granted items

### DIFF
--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -862,7 +862,8 @@
             "GrantItem": {
                 "AllowDuplicate": "Allow Duplicates",
                 "ReplaceSelf": "Replace Self",
-                "ReevaluateOnUpdate": "Reevaluate on Update"
+                "ReevaluateOnUpdate": "Reevaluate on Update",
+                "BadgeValue": "Badge Value"
             },
             "Note": {
                 "Hidden": "Hidden",
@@ -1036,7 +1037,7 @@
             "Conrasu": {
                 "CeremonyEvenedHand": {
                     "Prompt": "Select an unarmed attack."
-                 },
+                },
                 "RiteOfPassage": {
                     "Note": "When you use the Acrobatics skill to Balance on narrow surfaces or uneven ground within forests, and you roll a success, you get a critical success instead."
                 }
@@ -1064,7 +1065,7 @@
             "Dhampir": {
                 "Adhyabhau": {
                     "SaveNote": "When you roll a success on a Will save against an emotion effect, you get a critical success instead."
-                 },
+                },
                 "BloodlettingFangs": {
                     "AttackNote": "Your fangs Strike deals an additional [[/r {1d4}[persistent,bleed]]] @Compendium[pf2e.conditionitems.lDVqvLKA6eF3Df60]{Persistent Bleed Damage} on a critical hit."
                 }

--- a/static/templates/items/rules/grant-item.html
+++ b/static/templates/items/rules/grant-item.html
@@ -17,10 +17,10 @@
     <div class="details-container-flex-row">
         <input type="text" name="system.rules.{{index}}.uuid" value="{{rule.uuid}}" />
         {{#if granted}}
-            <a class="granted content-link" data-uuid="{{granted.uuid}}">
-                <img src="{{granted.img}}"/>
-                {{granted.name}}
-            </a>
+        <a class="granted content-link" data-uuid="{{granted.uuid}}">
+            <img src="{{granted.img}}"/>
+            {{granted.name}}
+        </a>
         {{/if}}
     </div>
 
@@ -28,4 +28,8 @@
 <div class="form-group">
     <label class="short">{{localize "PF2E.RuleEditor.General.Predicate"}}</label>
     <input type="text" name="system.rules.{{index}}.predicate" value="{{json rule.predicate}}" />
+</div>
+<div class="form-group">
+    <label class="short">{{localize "PF2E.RuleEditor.GrantItem.BadgeValue"}}</label>
+    <input type="text" name="system.rules.{{index}}.badgeValue" value="{{rule.badgeValue}}"/>
 </div>


### PR DESCRIPTION

https://user-images.githubusercontent.com/43446478/198371192-b2a6fc47-c853-4220-9acb-64334920bda2.mp4

This PR changes the behaviour of GrantItem REs so that they can now set the granted item's badge value if applicable (right now, only Effects and Conditions).

If "Reevaluate on Update" is ticked on, the granted item's badge value will update if something changes on the actor / item.