### PR TITLE
Fix measured template rotation triggering the browser zoom in Firefox and Edge

### DIFF
--- a/src/module/canvas/ghost-measured-template.ts
+++ b/src/module/canvas/ghost-measured-template.ts
@@ -3,7 +3,7 @@ import { MeasuredTemplatePF2e } from "./measured-template";
 export class GhostTemplate extends MeasuredTemplatePF2e {
     moveTime = 0;
     // Workaround for https://github.com/microsoft/TypeScript/issues/32912
-    #wheelListenerOptions: AddEventListenerOptions & EventListenerOptions = { passive: true };
+    #wheelListenerOptions: AddEventListenerOptions & EventListenerOptions = { passive: false };
 
     private _onMouseMove = (event: PIXI.InteractionEvent) => {
         event.stopPropagation();
@@ -30,6 +30,7 @@ export class GhostTemplate extends MeasuredTemplatePF2e {
 
     override _onMouseWheel = (event: WheelEvent) => {
         if (event.ctrlKey) {
+            event.preventDefault();
             event.stopPropagation();
             const delta = canvas.grid.type > CONST.GRID_TYPES.SQUARE ? 30 : 15;
             const snap = event.shiftKey ? delta : 5;


### PR DESCRIPTION
Passive listeners can't call `preventDefault` so that has to be reverted. Explicitly setting `passive: false` still prevents the console warning. 
Note to self: Test listener changes in different browsers. 🙃 

Closes #4591 