### PR TITLE
Allow effects to be hidden from players

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -239,7 +239,7 @@ class ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
 
         const effectTokenEffects = this.itemTypes.effect
             .filter((effect) => effect.system.tokenIcon?.show)
-            .filter((effect) => !effect.secret || game.user.isGM)
+            .filter((effect) => !effect.unidentified || game.user.isGM)
             .map((effect) => new TokenEffect(effect.img));
 
         return super.temporaryEffects

--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -239,6 +239,7 @@ class ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
 
         const effectTokenEffects = this.itemTypes.effect
             .filter((effect) => effect.system.tokenIcon?.show)
+            .filter((effect) => !effect.secret || game.user.isGM)
             .map((effect) => new TokenEffect(effect.img));
 
         return super.temporaryEffects

--- a/src/module/actor/creature/sheet.ts
+++ b/src/module/actor/creature/sheet.ts
@@ -477,22 +477,15 @@ export abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends Act
         });
 
         // Change whether an effect is secret to players or not
-        for (const effects_sections of htmlQueryAll(html, ".effects-list") ?? []) {
-            for (const element of htmlQueryAll(effects_sections, "[data-action=effect-toggle-secret]") ?? []) {
-                element.addEventListener("click", async (event) => {
-                    const effectId = htmlClosest(event.currentTarget, "[data-item-id]")?.dataset.itemId;
-                    const effect = this.actor.items.get(effectId, { strict: true });
-                    /*
-            const target = $(event.currentTarget);
-            const parent = target.parents(".item");
-            const effect = this.actor?.items.get(parent.attr("data-item-id") ?? "");
-            */
-                    if (effect instanceof AbstractEffectPF2e) {
-                        const isSecret = effect.secret;
-                        await effect.update({ "system.secret": !isSecret });
-                    }
-                });
-            }
+        for (const element of htmlQueryAll(html, ".effects-list [data-action=effect-toggle-secret]") ?? []) {
+            element.addEventListener("click", async (event) => {
+                const effectId = htmlClosest(event.currentTarget, "[data-item-id]")?.dataset.itemId;
+                const effect = this.actor.items.get(effectId, { strict: true });
+                if (effect instanceof AbstractEffectPF2e) {
+                    const isSecret = effect.secret;
+                    await effect.update({ "system.secret": !isSecret });
+                }
+            });
         }
     }
 

--- a/src/module/actor/creature/sheet.ts
+++ b/src/module/actor/creature/sheet.ts
@@ -477,15 +477,23 @@ export abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends Act
         });
 
         // Change whether an effect is secret to players or not
-        $html.find("a[data-action=effect-toggle-secret]").on("click", async (event) => {
+        for (const effects_sections of htmlQueryAll(html, ".effects-list") ?? []) {
+            for (const element of htmlQueryAll(effects_sections, "[data-action=effect-toggle-secret]") ?? []) {
+                element.addEventListener("click", async (event) => {
+                    const effectId = htmlClosest(event.currentTarget, "[data-item-id]")?.dataset.itemId;
+                    const effect = this.actor.items.get(effectId, { strict: true });
+                    /*
             const target = $(event.currentTarget);
             const parent = target.parents(".item");
             const effect = this.actor?.items.get(parent.attr("data-item-id") ?? "");
-            if (effect instanceof AbstractEffectPF2e) {
-                const isSecret = effect.secret;
-                await effect.update({ "system.secret": !isSecret });
+            */
+                    if (effect instanceof AbstractEffectPF2e) {
+                        const isSecret = effect.secret;
+                        await effect.update({ "system.secret": !isSecret });
+                    }
+                });
             }
-        });
+        }
     }
 
     /** Adds support for moving spells between spell levels, spell collections, and spell preparation */

--- a/src/module/actor/creature/sheet.ts
+++ b/src/module/actor/creature/sheet.ts
@@ -475,6 +475,17 @@ export abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends Act
                 await effect.increase();
             }
         });
+
+        // Change whether an effect is secret to players or not
+        $html.find("a[data-action=effect-toggle-secret]").on("click", async (event) => {
+            const target = $(event.currentTarget);
+            const parent = target.parents(".item");
+            const effect = this.actor?.items.get(parent.attr("data-item-id") ?? "");
+            if (effect instanceof AbstractEffectPF2e) {
+                const isSecret = effect.secret;
+                await effect.update({ "system.secret": !isSecret });
+            }
+        });
     }
 
     /** Adds support for moving spells between spell levels, spell collections, and spell preparation */

--- a/src/module/actor/creature/sheet.ts
+++ b/src/module/actor/creature/sheet.ts
@@ -477,13 +477,13 @@ export abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends Act
         });
 
         // Change whether an effect is secret to players or not
-        for (const element of htmlQueryAll(html, ".effects-list [data-action=effect-toggle-secret]") ?? []) {
+        for (const element of htmlQueryAll(html, ".effects-list [data-action=effect-toggle-unidentified]") ?? []) {
             element.addEventListener("click", async (event) => {
                 const effectId = htmlClosest(event.currentTarget, "[data-item-id]")?.dataset.itemId;
                 const effect = this.actor.items.get(effectId, { strict: true });
                 if (effect instanceof AbstractEffectPF2e) {
-                    const isSecret = effect.secret;
-                    await effect.update({ "system.secret": !isSecret });
+                    const isUnidentified = effect.unidentified;
+                    await effect.update({ "system.unidentified": !isUnidentified });
                 }
             });
         }

--- a/src/module/apps/effects-panel.ts
+++ b/src/module/apps/effects-panel.ts
@@ -25,7 +25,7 @@ export class EffectsPanel extends Application {
     override async getData(options?: ApplicationOptions): Promise<EffectsPanelData> {
         const { actor } = this;
         if (!actor || !game.user.settings.showEffectPanel) {
-            return { conditions: [], effects: [], actor: null };
+            return { conditions: [], effects: [], actor: null, isGM: false };
         }
 
         const effects =
@@ -62,6 +62,7 @@ export class EffectsPanel extends Application {
             actor,
             effects,
             conditions,
+            isGM: game.user.isGM,
         };
     }
 
@@ -162,4 +163,5 @@ interface EffectsPanelData {
     conditions: FlattenedCondition[];
     effects: EffectPF2e[];
     actor: ActorPF2e | null;
+    isGM: boolean;
 }

--- a/src/module/apps/effects-panel.ts
+++ b/src/module/apps/effects-panel.ts
@@ -25,7 +25,7 @@ export class EffectsPanel extends Application {
     override async getData(options?: ApplicationOptions): Promise<EffectsPanelData> {
         const { actor } = this;
         if (!actor || !game.user.settings.showEffectPanel) {
-            return { conditions: [], effects: [], actor: null, isGM: false };
+            return { conditions: [], effects: [], actor: null, user: { isGM: false } };
         }
 
         const effects =
@@ -62,7 +62,9 @@ export class EffectsPanel extends Application {
             actor,
             effects,
             conditions,
-            isGM: game.user.isGM,
+            user: {
+                isGM: game.user.isGM,
+            },
         };
     }
 
@@ -163,5 +165,7 @@ interface EffectsPanelData {
     conditions: FlattenedCondition[];
     effects: EffectPF2e[];
     actor: ActorPF2e | null;
-    isGM: boolean;
+    user: {
+        isGM: boolean;
+    };
 }

--- a/src/module/item/abstract-effect/document.ts
+++ b/src/module/item/abstract-effect/document.ts
@@ -12,6 +12,9 @@ export abstract class AbstractEffectPF2e extends ItemPF2e {
     abstract increase(): Promise<void>;
     abstract decrease(): Promise<void>;
 
+    /** If true, the AbstractEffect should be hidden from the user unless they are a GM */
+    abstract get secret(): boolean;
+
     override prepareBaseData(): void {
         super.prepareBaseData();
 

--- a/src/module/item/abstract-effect/document.ts
+++ b/src/module/item/abstract-effect/document.ts
@@ -13,7 +13,9 @@ export abstract class AbstractEffectPF2e extends ItemPF2e {
     abstract decrease(): Promise<void>;
 
     /** If true, the AbstractEffect should be hidden from the user unless they are a GM */
-    abstract get secret(): boolean;
+    get secret(): boolean {
+        return false;
+    }
 
     override prepareBaseData(): void {
         super.prepareBaseData();

--- a/src/module/item/abstract-effect/document.ts
+++ b/src/module/item/abstract-effect/document.ts
@@ -13,7 +13,7 @@ export abstract class AbstractEffectPF2e extends ItemPF2e {
     abstract decrease(): Promise<void>;
 
     /** If true, the AbstractEffect should be hidden from the user unless they are a GM */
-    get secret(): boolean {
+    get unidentified(): boolean {
         return false;
     }
 

--- a/src/module/item/condition/document.ts
+++ b/src/module/item/condition/document.ts
@@ -41,6 +41,10 @@ class ConditionPF2e extends AbstractEffectPF2e {
         return this.system.sources.hud;
     }
 
+    override get secret(): boolean {
+        return false;
+    }
+
     override async increase(): Promise<void> {
         if (this.actor && this.system.removable) {
             await this.actor.increaseCondition(this as Embedded<ConditionPF2e>);

--- a/src/module/item/condition/document.ts
+++ b/src/module/item/condition/document.ts
@@ -41,10 +41,6 @@ class ConditionPF2e extends AbstractEffectPF2e {
         return this.system.sources.hud;
     }
 
-    override get secret(): boolean {
-        return false;
-    }
-
     override async increase(): Promise<void> {
         if (this.actor && this.system.removable) {
             await this.actor.increaseCondition(this as Embedded<ConditionPF2e>);

--- a/src/module/item/effect/data.ts
+++ b/src/module/item/effect/data.ts
@@ -38,7 +38,7 @@ interface EffectSystemSource extends ItemSystemSource, ItemLevelData {
     tokenIcon: {
         show: boolean;
     };
-    secret: boolean;
+    unidentified: boolean;
     target: string | null;
     expired?: boolean;
     badge: EffectBadge | null;

--- a/src/module/item/effect/data.ts
+++ b/src/module/item/effect/data.ts
@@ -38,6 +38,7 @@ interface EffectSystemSource extends ItemSystemSource, ItemLevelData {
     tokenIcon: {
         show: boolean;
     };
+    secret: boolean;
     target: string | null;
     expired?: boolean;
     badge: EffectBadge | null;

--- a/src/module/item/effect/document.ts
+++ b/src/module/item/effect/document.ts
@@ -63,8 +63,8 @@ class EffectPF2e extends AbstractEffectPF2e {
         }
     }
 
-    override get secret(): boolean {
-        return this.system.secret ?? false;
+    override get unidentified(): boolean {
+        return this.system.unidentified ?? false;
     }
 
     /** Does this effect originate from an aura? */

--- a/src/module/item/effect/document.ts
+++ b/src/module/item/effect/document.ts
@@ -63,6 +63,10 @@ class EffectPF2e extends AbstractEffectPF2e {
         }
     }
 
+    override get secret(): boolean {
+        return this.system.secret ?? false;
+    }
+
     /** Does this effect originate from an aura? */
     get fromAura(): boolean {
         return !!this.flags.pf2e.aura;

--- a/src/module/system/conditions/manager.ts
+++ b/src/module/system/conditions/manager.ts
@@ -84,6 +84,7 @@ export class ConditionManager {
                 value: condition.value,
                 description: condition.description,
                 img: condition.img,
+                secret: condition.secret,
                 references: false,
                 locked: condition.isLocked,
                 parents: [],

--- a/src/module/system/conditions/manager.ts
+++ b/src/module/system/conditions/manager.ts
@@ -84,7 +84,7 @@ export class ConditionManager {
                 value: condition.value,
                 description: condition.description,
                 img: condition.img,
-                secret: condition.secret,
+                unidentified: condition.unidentified,
                 references: false,
                 locked: condition.isLocked,
                 parents: [],

--- a/src/module/system/conditions/types.ts
+++ b/src/module/system/conditions/types.ts
@@ -9,6 +9,7 @@ interface FlattenedCondition {
     description: string;
     enrichedDescription?: string;
     img: ImagePath;
+    secret: boolean;
     locked: boolean;
     references: boolean;
     breakdown?: string;

--- a/src/module/system/conditions/types.ts
+++ b/src/module/system/conditions/types.ts
@@ -9,7 +9,7 @@ interface FlattenedCondition {
     description: string;
     enrichedDescription?: string;
     img: ImagePath;
-    secret: boolean;
+    unidentified: boolean;
     locked: boolean;
     references: boolean;
     breakdown?: string;

--- a/src/styles/mixins/_effects-list.scss
+++ b/src/styles/mixins/_effects-list.scss
@@ -128,6 +128,12 @@ $-alt-color: #786452 !default;
             }
         }
 
+        &.secret {
+            border-radius: 1px;
+            outline: 1px dotted rgba(75, 74, 68, 0.5);
+            background: var(--visibility-gm-bg);
+        }
+
         .button-group {
             display: flex;
             justify-content: flex-end;

--- a/src/styles/mixins/_effects-list.scss
+++ b/src/styles/mixins/_effects-list.scss
@@ -128,7 +128,7 @@ $-alt-color: #786452 !default;
             }
         }
 
-        &.secret {
+        &.unidentified {
             border-radius: 1px;
             outline: 1px dotted rgba(75, 74, 68, 0.5);
             background: var(--visibility-gm-bg);

--- a/src/styles/system/_effects-panel.scss
+++ b/src/styles/system/_effects-panel.scss
@@ -96,6 +96,10 @@
                 color: white;
                 background-color: rgba(0, 0, 0, 0.75);
             }
+
+            &.secret {
+                filter: drop-shadow(0 0 8px var(--visibility-gm-bg));
+            }
         }
     }
 

--- a/src/styles/system/_effects-panel.scss
+++ b/src/styles/system/_effects-panel.scss
@@ -97,7 +97,7 @@
                 background-color: rgba(0, 0, 0, 0.75);
             }
 
-            &.secret {
+            &.unidentified {
                 filter: drop-shadow(0 0 8px var(--visibility-gm-bg));
             }
         }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1441,6 +1441,7 @@
                 "ZeroRoundsExpireTurnStart": "0 rounds remaining, expires start of initiative {initiative}"
             },
             "RemoveToolTip": "[Right Click] Remove effect",
+            "Secret": "Secret",
             "Sustained": "Sustained?",
             "UnlimitedDuration": "Unlimited duration",
             "UntilEncounterEnds": "Until encounter ends"
@@ -1974,6 +1975,7 @@
                     "EndOfTurn": "End of Turn"
                 },
                 "ShowTokenIcon": "Show token icon?",
+                "Secret": "Secret?",
                 "AddBadge": "Add Counter",
                 "BadgeType": {
                     "Counter": "Counter"
@@ -3287,6 +3289,7 @@
                 "UntilEncounterEnds": "Until encounter ends"
             }
         },
+        "ToggleEffectSecrecy": "Toggle Whether Effect Is Secret",
         "TogglesLabel": "Toggles",
         "ToggleSignatureSpellTitle": "Toggle Signature Spell",
         "ToggleSpellVisibilityTitle": "Spell Preparation",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1441,7 +1441,7 @@
                 "ZeroRoundsExpireTurnStart": "0 rounds remaining, expires start of initiative {initiative}"
             },
             "RemoveToolTip": "[Right Click] Remove effect",
-            "Secret": "Secret",
+            "Unidentified": "Unidentified",
             "Sustained": "Sustained?",
             "UnlimitedDuration": "Unlimited duration",
             "UntilEncounterEnds": "Until encounter ends"
@@ -1975,7 +1975,7 @@
                     "EndOfTurn": "End of Turn"
                 },
                 "ShowTokenIcon": "Show token icon?",
-                "Secret": "Secret?",
+                "Unidentified": "Unidentified?",
                 "AddBadge": "Add Counter",
                 "BadgeType": {
                     "Counter": "Counter"
@@ -3289,7 +3289,7 @@
                 "UntilEncounterEnds": "Until encounter ends"
             }
         },
-        "ToggleEffectSecrecy": "Toggle Whether Effect Is Secret",
+        "ToggleEffectUnidentified": "Toggle Whether Effect Is Unidentified",
         "TogglesLabel": "Toggles",
         "ToggleSignatureSpellTitle": "Toggle Signature Spell",
         "ToggleSpellVisibilityTitle": "Spell Preparation",

--- a/static/templates/actors/familiar-sheet.html
+++ b/static/templates/actors/familiar-sheet.html
@@ -213,7 +213,8 @@
                     <ol class="effects-list item-list">
                         {{#each items as |item idx|}}
                         {{#if (eq item.type "effect")}}
-                            <li class="item effects" data-item-id="{{item._id}}">
+                        {{#if (or (not item.system.secret) @root.user.isGM)}}
+                            <li class="item effects {{#if item.system.secret}}secret{{/if}}" data-item-id="{{item._id}}">
                                 <div class="item-name">
                                     <div class="item-image" style="background-image: url({{item.img}})">
                                         <i class="fas fa-comment-alt"></i>
@@ -222,6 +223,10 @@
                                 </div>
                                 {{#if ../owner}}
                                 <div class="item-controls">
+                                    {{#if @root.user.isGM}}
+                                    <a class="item-control" data-action="effect-toggle-secret" title="{{localize 'PF2E.ToggleEffectSecrecy'}}"><i
+                                        class="fas fa-fw fa-eye"></i></a>
+                                    {{/if}}
                                     <a class="item-control item-edit" title="{{localize 'PF2E.EditItemTitle'}}"><i
                                             class="fas fa-edit"></i></a>
                                     <a class="item-control item-delete" title="{{localize PF2E.DeleteItemTitle}}"><i
@@ -230,6 +235,7 @@
                                 {{/if}}
                                 <div class="item-summary"></div>
                             </li>
+                        {{/if}}
                         {{/if}}
                         {{/each}}
                     </ol>

--- a/static/templates/actors/familiar-sheet.html
+++ b/static/templates/actors/familiar-sheet.html
@@ -213,8 +213,8 @@
                     <ol class="effects-list item-list">
                         {{#each items as |item idx|}}
                         {{#if (eq item.type "effect")}}
-                        {{#if (or (not item.system.secret) @root.user.isGM)}}
-                            <li class="item effects {{#if item.system.secret}}secret{{/if}}" data-item-id="{{item._id}}">
+                        {{#if (or (not item.system.unidentified) @root.user.isGM)}}
+                            <li class="item effects {{#if item.system.unidentified}}unidentified{{/if}}" data-item-id="{{item._id}}">
                                 <div class="item-name">
                                     <div class="item-image" style="background-image: url({{item.img}})">
                                         <i class="fas fa-comment-alt"></i>
@@ -224,7 +224,7 @@
                                 {{#if ../owner}}
                                 <div class="item-controls">
                                     {{#if @root.user.isGM}}
-                                    <a class="item-control" data-action="effect-toggle-secret" title="{{localize 'PF2E.ToggleEffectSecrecy'}}"><i
+                                    <a class="item-control" data-action="effect-toggle-unidentified" title="{{localize 'PF2E.ToggleEffectUnidentified'}}"><i
                                         class="fas fa-fw fa-eye"></i></a>
                                     {{/if}}
                                     <a class="item-control item-edit" title="{{localize 'PF2E.EditItemTitle'}}"><i

--- a/static/templates/actors/partials/conditions.html
+++ b/static/templates/actors/partials/conditions.html
@@ -1,5 +1,7 @@
 {{#each conditions as |item ii|}}
-<li class="item effects expandable" data-item-id="{{item.id}}" data-action-index="{{ii}}">
+{{#if (or (not item.secret) @root.user.isGM)}}
+<li class="item effects expandable {{#if item.secret}}secret{{/if}}" data-item-id="{{item.id}}"
+    data-action-index="{{ii}}">
     <div class="item-name rollable">
         <div class="item-image" style="background-image: url({{item.img}})">
             <i class="fas fa-comment-alt"></i>
@@ -16,6 +18,10 @@
                 class="fas fa-plus"></i></a>
             <a class="item-control decrement" title="{{localize 'PF2E.DecrementEffectTitle'}}"><i
                 class="fas fa-minus"></i></a>
+        {{/if}}
+        {{#if (and (eq item.type "effect") @root.user.isGM)}}
+            <a class="item-control" data-action="effect-toggle-secret" title="{{localize 'PF2E.ToggleEffectSecrecy'}}"><i
+                class="fas fa-fw fa-eye"></i></a>
         {{/if}}
         {{#if (eq item.type "effect")}}
             <a class="item-control item-edit" title="{{localize 'PF2E.EditItemTitle'}}"><i
@@ -57,4 +63,5 @@
         </div>
     {{/if}}
 </li>
+{{/if}}
 {{/each}}

--- a/static/templates/actors/partials/conditions.html
+++ b/static/templates/actors/partials/conditions.html
@@ -1,6 +1,6 @@
 {{#each conditions as |item ii|}}
-{{#if (or (not item.secret) @root.user.isGM)}}
-<li class="item effects expandable {{#if item.secret}}secret{{/if}}" data-item-id="{{item.id}}"
+{{#if (or (not item.unidentified) @root.user.isGM)}}
+<li class="item effects expandable {{#if item.unidentified}}unidentified{{/if}}" data-item-id="{{item.id}}"
     data-action-index="{{ii}}">
     <div class="item-name rollable">
         <div class="item-image" style="background-image: url({{item.img}})">
@@ -20,7 +20,7 @@
                 class="fas fa-minus"></i></a>
         {{/if}}
         {{#if (and (eq item.type "effect") @root.user.isGM)}}
-            <a class="item-control" data-action="effect-toggle-secret" title="{{localize 'PF2E.ToggleEffectSecrecy'}}"><i
+            <a class="item-control" data-action="effect-toggle-unidentified" title="{{localize 'PF2E.ToggleEffectUnidentified'}}"><i
                 class="fas fa-fw fa-eye"></i></a>
         {{/if}}
         {{#if (eq item.type "effect")}}

--- a/static/templates/items/effect-sidebar.html
+++ b/static/templates/items/effect-sidebar.html
@@ -44,6 +44,12 @@
             <input type="checkbox" name="system.tokenIcon.show" {{checked data.tokenIcon.show}} />
         </div>
     </div>
+    <div class="form-group">
+        <label for="data.secret">{{localize "PF2E.Item.Effect.Secret"}}</label>
+        <div class="form-fields">
+            <input type="checkbox" name="system.secret" {{checked data.secret}} />
+        </div>
+    </div>
     <hr/>
     <div class="form-group">
         {{#if data.badge}}

--- a/static/templates/items/effect-sidebar.html
+++ b/static/templates/items/effect-sidebar.html
@@ -46,9 +46,9 @@
     </div>
     {{#if user.isGM}}
     <div class="form-group">
-        <label for="data.secret">{{localize "PF2E.Item.Effect.Secret"}}</label>
+        <label for="data.unidentified">{{localize "PF2E.Item.Effect.Unidentified"}}</label>
         <div class="form-fields">
-            <input type="checkbox" name="system.secret" {{checked data.secret}} />
+            <input type="checkbox" name="system.unidentified" {{checked data.unidentified}} />
         </div>
     </div>
     {{/if}}

--- a/static/templates/items/effect-sidebar.html
+++ b/static/templates/items/effect-sidebar.html
@@ -44,12 +44,14 @@
             <input type="checkbox" name="system.tokenIcon.show" {{checked data.tokenIcon.show}} />
         </div>
     </div>
+    {{#if user.isGM}}
     <div class="form-group">
         <label for="data.secret">{{localize "PF2E.Item.Effect.Secret"}}</label>
         <div class="form-fields">
             <input type="checkbox" name="system.secret" {{checked data.secret}} />
         </div>
     </div>
+    {{/if}}
     <hr/>
     <div class="form-group">
         {{#if data.badge}}

--- a/static/templates/system/effects-panel.html
+++ b/static/templates/system/effects-panel.html
@@ -11,7 +11,7 @@
 </section>
 
 {{#*inline "effect"}}
-{{#if (or (not effect.secret) @root.isGM)}}
+{{#if (or (not effect.secret) @root.user.isGM)}}
 <div class="effect-item">
     <div class="effect-info">
         <h1>{{effect.name}}</h1>

--- a/static/templates/system/effects-panel.html
+++ b/static/templates/system/effects-panel.html
@@ -11,7 +11,7 @@
 </section>
 
 {{#*inline "effect"}}
-{{#if (or (not effect.secret) @root.user.isGM)}}
+{{#if (or (not effect.unidentified) @root.user.isGM)}}
 <div class="effect-item">
     <div class="effect-info">
         <h1>{{effect.name}}</h1>
@@ -20,8 +20,8 @@
                 {{#if (and effect.system.duration.sustained (not effect.system.expired))}}
                     <div class="tag tag_secondary">{{localize "PF2E.EffectPanel.Sustained"}}</div>
                 {{/if}}
-                {{#if effect.secret}}
-                    <div class="tag tag_secondary">{{localize "PF2E.EffectPanel.Secret"}}</div>
+                {{#if effect.unidentified}}
+                    <div class="tag tag_secondary">{{localize "PF2E.EffectPanel.Unidentified"}}</div>
                 {{/if}}
                 {{#if effect.breakdown}}
                     <div class="tag tag_secondary">{{effect.breakdown}}</div>
@@ -42,7 +42,7 @@
             {{/if}}
         </div>
     </div>
-    <div class="icon {{#if effect.secret}}secret{{/if}}" data-item-id="{{effect.id}}" data-locked="{{#if effect.locked}}true{{/if}}" style="background-image: url({{effect.img}})">
+    <div class="icon {{#if effect.unidentified}}unidentified{{/if}}" data-item-id="{{effect.id}}" data-locked="{{#if effect.locked}}true{{/if}}" style="background-image: url({{effect.img}})">
         {{#if effect.locked}}
             <div class="linked"><i class="fas fa-link"></i></div>
         {{/if}}

--- a/static/templates/system/effects-panel.html
+++ b/static/templates/system/effects-panel.html
@@ -11,6 +11,7 @@
 </section>
 
 {{#*inline "effect"}}
+{{#if (or (not effect.secret) @root.isGM)}}
 <div class="effect-item">
     <div class="effect-info">
         <h1>{{effect.name}}</h1>
@@ -18,6 +19,9 @@
             <div class="tags">
                 {{#if (and effect.system.duration.sustained (not effect.system.expired))}}
                     <div class="tag tag_secondary">{{localize "PF2E.EffectPanel.Sustained"}}</div>
+                {{/if}}
+                {{#if effect.secret}}
+                    <div class="tag tag_secondary">{{localize "PF2E.EffectPanel.Secret"}}</div>
                 {{/if}}
                 {{#if effect.breakdown}}
                     <div class="tag tag_secondary">{{effect.breakdown}}</div>
@@ -38,7 +42,7 @@
             {{/if}}
         </div>
     </div>
-    <div class="icon" data-item-id="{{effect.id}}" data-locked="{{#if effect.locked}}true{{/if}}" style="background-image: url({{effect.img}})">
+    <div class="icon {{#if effect.secret}}secret{{/if}}" data-item-id="{{effect.id}}" data-locked="{{#if effect.locked}}true{{/if}}" style="background-image: url({{effect.img}})">
         {{#if effect.locked}}
             <div class="linked"><i class="fas fa-link"></i></div>
         {{/if}}
@@ -49,4 +53,5 @@
         {{/if}}
     </div>
 </div>
+{{/if}}
 {{/inline}}


### PR DESCRIPTION
https://user-images.githubusercontent.com/43446478/198745341-3c8c56de-92c4-4171-bce3-ff8ef09f15a7.mp4


This PR adds a feature that allows GM to apply effects to player characters, NPCs, and familiars, without revealing them to them.

- This is only for effects, but a way was paved for conditions if hiding conditions is ever desired.
- Effects are hidden from players on their characters' effects tabs, the effects panel on the top right, and the tokens on the scene.
- For the GM, effects that are hidden from players show up
  - with a dotted outline and `--visibility-gm-bg` colour in the PC effects tab,
  - with a `--visibility-gm-bg` drop shadow and a "SECRET" secondary tag on the effects panel,
  - plainly on tokens on the scene.
- Effects can quickly be toggled on and off on the effects tabs of characters.
- This does not hide any, well, effects of effects -- for example, a FlatModifier applied by a secret effect will still show up in modifier calculations, without being obfuscated in any way.