### PR TITLE
Fix Peryton Heart Ripper ability

### DIFF
--- a/packs/data/pathfinder-bestiary-2.db/peryton.json
+++ b/packs/data/pathfinder-bestiary-2.db/peryton.json
@@ -147,7 +147,7 @@
                     "value": 1
                 },
                 "description": {
-                    "value": "<p>The peryton rips out the heart of an adjacent corpse with their jaws. The creature must have died in the last minute. As the peryton rips the heart free and swallows it whole, they regain 2d6 HP, and any non-peryton that witnesses this event must succeed at a @Check[type:will|dc:21] save or become @Compendium[pf2e.conditionitems.Frightened]{Frightened 1} (or frightened 2 on a critical failure).</p>"
+                    "value": "<p>The peryton rips out the heart of an adjacent corpse with their jaws. The creature must have died in the last minute. As the peryton rips the heart free and swallows it whole, they regain [[/r {2d6} #hit points]]{2d6 HP}, and any non-peryton that witnesses this event must succeed at a @Check[type:will|dc:21] save or become @Compendium[pf2e.conditionitems.Frightened]{Frightened 1} (or @Compendium[pf2e.conditionitems.Frightened]{Frightened 2} on a critical failure).</p>"
                 },
                 "requirements": {
                     "value": ""


### PR DESCRIPTION
Closes [#4606](https://github.com/foundryvtt/pf2e/issues/4606)