### PR TITLE
Adjust ghost-measured-template rotation logic

### DIFF
--- a/src/module/canvas/ghost-measured-template.ts
+++ b/src/module/canvas/ghost-measured-template.ts
@@ -11,24 +11,18 @@ export class GhostTemplate extends MeasuredTemplatePF2e {
         if (now - this.moveTime <= 20) return;
         const center = event.data.getLocalPosition(this.layer);
         const snapped = canvas.grid.getSnappedPosition(center.x, center.y, 2);
-        this.document.x = snapped.x;
-        this.document.y = snapped.y;
         if (
             this.moveTime === 0 &&
             (canvas.grid.type === CONST.GRID_TYPES.HEXODDR || canvas.grid.type === CONST.GRID_TYPES.HEXEVENR)
         ) {
-            this.document._source.direction += 30;
-            this.document.direction = this.document._source.direction;
+            this.document.updateSource({ direction: this.document.direction + 30 });
         }
+        this.document.updateSource({ direction: this.document.direction, x: snapped.x, y: snapped.y });
         this.refresh();
         this.moveTime = now;
     };
 
     private _onLeftClick = () => {
-        const destination = canvas.grid.getSnappedPosition(this.x, this.y, 2);
-        this.document._source.x = destination.x;
-        this.document._source.y = destination.y;
-
         if (canvas.scene) {
             canvas.scene.createEmbeddedDocuments("MeasuredTemplate", [this.document.toObject()]);
         }
@@ -40,15 +34,21 @@ export class GhostTemplate extends MeasuredTemplatePF2e {
             event.preventDefault();
             event.stopPropagation();
             const snap = event.shiftKey ? 15 : 5;
-            this.document._source.direction += snap * Math.sign(event.deltaY);
-            this.document.direction = this.document._source.direction;
+            this.document.updateSource({
+                direction: this.document.direction + snap * Math.sign(event.deltaY),
+                x: this.document.x,
+                y: this.document.y,
+            });
             this.refresh();
         } else if (event.shiftKey) {
             event.stopPropagation();
             const snap =
                 canvas.grid.type >= CONST.GRID_TYPES.HEXODDR && canvas.grid.type <= CONST.GRID_TYPES.HEXEVENQ ? 60 : 45;
-            this.document._source.direction += snap * Math.sign(event.deltaY);
-            this.document.direction = this.document._source.direction;
+            this.document.updateSource({
+                direction: this.document.direction + snap * Math.sign(event.deltaY),
+                x: this.document.x,
+                y: this.document.y,
+            });
             this.refresh();
         }
     };

--- a/src/module/canvas/ghost-measured-template.ts
+++ b/src/module/canvas/ghost-measured-template.ts
@@ -17,7 +17,7 @@ export class GhostTemplate extends MeasuredTemplatePF2e {
         ) {
             this.document.updateSource({ direction: this.document.direction + 30 });
         }
-        this.document.updateSource({ direction: this.document.direction, x: snapped.x, y: snapped.y });
+        this.document.updateSource({ x: snapped.x, y: snapped.y });
         this.refresh();
         this.moveTime = now;
     };
@@ -34,21 +34,13 @@ export class GhostTemplate extends MeasuredTemplatePF2e {
             event.preventDefault();
             event.stopPropagation();
             const snap = event.shiftKey ? 15 : 5;
-            this.document.updateSource({
-                direction: this.document.direction + snap * Math.sign(event.deltaY),
-                x: this.document.x,
-                y: this.document.y,
-            });
+            this.document.updateSource({ direction: this.document.direction + snap * Math.sign(event.deltaY) });
             this.refresh();
         } else if (event.shiftKey) {
             event.stopPropagation();
             const snap =
                 canvas.grid.type >= CONST.GRID_TYPES.HEXODDR && canvas.grid.type <= CONST.GRID_TYPES.HEXEVENQ ? 60 : 45;
-            this.document.updateSource({
-                direction: this.document.direction + snap * Math.sign(event.deltaY),
-                x: this.document.x,
-                y: this.document.y,
-            });
+            this.document.updateSource({ direction: this.document.direction + snap * Math.sign(event.deltaY) });
             this.refresh();
         }
     };

--- a/src/module/canvas/ghost-measured-template.ts
+++ b/src/module/canvas/ghost-measured-template.ts
@@ -16,7 +16,7 @@ export class GhostTemplate extends MeasuredTemplatePF2e {
             this.moveTime === 0 && hexTypes.includes(canvas.grid.type)
                 ? this.document.direction + 30
                 : this.document.direction;
-        this.document.updateSource({ x: snapped.x, y: snapped.y, direction });
+        this.document.updateSource({ ...snapped, direction });
 
         this.refresh();
         this.moveTime = now;

--- a/src/module/canvas/ghost-measured-template.ts
+++ b/src/module/canvas/ghost-measured-template.ts
@@ -11,13 +11,13 @@ export class GhostTemplate extends MeasuredTemplatePF2e {
         if (now - this.moveTime <= 20) return;
         const center = event.data.getLocalPosition(this.layer);
         const snapped = canvas.grid.getSnappedPosition(center.x, center.y, 2);
-        if (
-            this.moveTime === 0 &&
-            (canvas.grid.type === CONST.GRID_TYPES.HEXODDR || canvas.grid.type === CONST.GRID_TYPES.HEXEVENR)
-        ) {
-            this.document.updateSource({ direction: this.document.direction + 30 });
-        }
-        this.document.updateSource({ x: snapped.x, y: snapped.y });
+        const hexTypes: number[] = [CONST.GRID_TYPES.HEXODDR, CONST.GRID_TYPES.HEXEVENR];
+        const direction =
+            this.moveTime === 0 && hexTypes.includes(canvas.grid.type)
+                ? this.document.direction + 30
+                : this.document.direction;
+        this.document.updateSource({ x: snapped.x, y: snapped.y, direction });
+
         this.refresh();
         this.moveTime = now;
     };

--- a/src/module/canvas/ghost-measured-template.ts
+++ b/src/module/canvas/ghost-measured-template.ts
@@ -13,7 +13,10 @@ export class GhostTemplate extends MeasuredTemplatePF2e {
         const snapped = canvas.grid.getSnappedPosition(center.x, center.y, 2);
         this.document.x = snapped.x;
         this.document.y = snapped.y;
-        if ((this.moveTime == 0) && (canvas.grid.type == CONST.GRID_TYPES.HEXODDR || canvas.grid.type == CONST.GRID_TYPES.HEXEVENR)) {
+        if (
+            this.moveTime === 0 &&
+            (canvas.grid.type === CONST.GRID_TYPES.HEXODDR || canvas.grid.type === CONST.GRID_TYPES.HEXEVENR)
+        ) {
             this.document._source.direction += 30;
             this.document.direction = this.document._source.direction;
         }
@@ -42,7 +45,8 @@ export class GhostTemplate extends MeasuredTemplatePF2e {
             this.refresh();
         } else if (event.shiftKey) {
             event.stopPropagation();
-            const snap = (canvas.grid.type >= CONST.GRID_TYPES.HEXODDR && canvas.grid.type <= CONST.GRID_TYPES.HEXEVENQ) ? 60 : 45;
+            const snap =
+                canvas.grid.type >= CONST.GRID_TYPES.HEXODDR && canvas.grid.type <= CONST.GRID_TYPES.HEXEVENQ ? 60 : 45;
             this.document._source.direction += snap * Math.sign(event.deltaY);
             this.document.direction = this.document._source.direction;
             this.refresh();

--- a/src/module/canvas/ghost-measured-template.ts
+++ b/src/module/canvas/ghost-measured-template.ts
@@ -13,6 +13,10 @@ export class GhostTemplate extends MeasuredTemplatePF2e {
         const snapped = canvas.grid.getSnappedPosition(center.x, center.y, 2);
         this.document.x = snapped.x;
         this.document.y = snapped.y;
+        if ((this.moveTime == 0) && (canvas.grid.type == CONST.GRID_TYPES.HEXODDR || canvas.grid.type == CONST.GRID_TYPES.HEXEVENR)) {
+            this.document._source.direction += 30;
+            this.document.direction = this.document._source.direction;
+        }
         this.refresh();
         this.moveTime = now;
     };
@@ -32,16 +36,15 @@ export class GhostTemplate extends MeasuredTemplatePF2e {
         if (event.ctrlKey) {
             event.preventDefault();
             event.stopPropagation();
-            const delta = canvas.grid.type > CONST.GRID_TYPES.SQUARE ? 30 : 15;
-            const snap = event.shiftKey ? delta : 5;
+            const snap = event.shiftKey ? 15 : 5;
             this.document._source.direction += snap * Math.sign(event.deltaY);
-            this.document.direction += snap * Math.sign(event.deltaY);
+            this.document.direction = this.document._source.direction;
             this.refresh();
         } else if (event.shiftKey) {
             event.stopPropagation();
-            const snap = 45;
+            const snap = (canvas.grid.type >= CONST.GRID_TYPES.HEXODDR && canvas.grid.type <= CONST.GRID_TYPES.HEXEVENQ) ? 60 : 45;
             this.document._source.direction += snap * Math.sign(event.deltaY);
-            this.document.direction += snap * Math.sign(event.deltaY);
+            this.document.direction = this.document._source.direction;
             this.refresh();
         }
     };


### PR DESCRIPTION
Adjust ghost-measured-template placed from chat to behave more like placed templates with regards to rotation. Added additional logic for hex grids. This should complement pr #4143 and pr #4173 which addressed issue #4126 .

- Set ctrl to rotate by 5deg (this did not change)
- Set ctrl+shift to rotate by 15deg (this used to be 15deg for square or grid-less and 30deg otherwise)
- Set shift to rotate by 60deg on hex and 45deg on anything else (this used to just be 45deg which was quite useless on hex)
- Compensate for hex row format by offsetting the original angle by 30deg so 60deg aligns properly. (this could be omitted if the hex angle is set to 30deg but makes hex much more usable)
- Reduce recalculations. (set this.document.direction to value just calculated in this.document._source.direction instead of recalculating how much the template should be rotated)