### PR TITLE
Update "Perilous Flash Flood" hazard

### DIFF
--- a/packs/data/hazards.db/perilous-flash-flood.json
+++ b/packs/data/hazards.db/perilous-flash-flood.json
@@ -41,45 +41,6 @@
                 }
             },
             "type": "action"
-        },
-        {
-            "_id": "Pz2JfI4HEqH5iEwA",
-            "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Filth Fever",
-            "sort": 0,
-            "system": {
-                "actionCategory": {
-                    "value": "offensive"
-                },
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "description": {
-                    "value": "<p>The sickened and @Compendium[pf2e.conditionitems.Unconscious]{Unconscious} conditions from filth fever don't improve on their own until the disease is cured.</p>\n<p><strong>Saving Throw</strong> @Check[type:fortitude|dc:20]</p>\n<p><strong>Stage 1</strong> carrier with no ill effect (1d4 hours)</p>\n<p><strong>Stage 2</strong> @Compendium[pf2e.conditionitems.Sickened]{Sickened 1} (1 day)</p>\n<p><strong>Stage 3</strong> sickened 1 and @Compendium[pf2e.conditionitems.Slowed]{Slowed 1} as long as it remains sickened (1 day)</p>\n<p><strong>Stage 4</strong> unconscious (1 day)</p>\n<p><strong>Stage 5</strong> dead</p>"
-                },
-                "requirements": {
-                    "value": ""
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": [
-                        "disease"
-                    ]
-                },
-                "trigger": {
-                    "value": ""
-                }
-            },
-            "type": "action"
         }
     ],
     "name": "Perilous Flash Flood",


### PR DESCRIPTION
Remove inappropriate "Filth Fever" item that has nothing to do with that hazard.