### PR TITLE
Add quantity of alchemical bombs to actions tab

### DIFF
--- a/static/templates/actors/character/tabs/actions.html
+++ b/static/templates/actors/character/tabs/actions.html
@@ -251,6 +251,9 @@
                 {{/select}}
             </select>
         {{/if}}
+        {{#if item.isAlchemical}}
+            <span class="ammo-remaining"><i class="ammo-icon"></i> ({{quantity}})</span>
+        {{/if}}
     </div>
 {{/inline}}
 


### PR DESCRIPTION
Previously you could not see the quantity of remaining bombs without going to the equipment tab. Someone good at css can make it prettier if they want.

![image](https://user-images.githubusercontent.com/85046656/198904520-ff807467-8db3-4d15-b61c-543cf9224fe0.png)
