### PR TITLE
Implement "shoddy" tag for physical items

### DIFF
--- a/src/module/actor/character/helpers.ts
+++ b/src/module/actor/character/helpers.ts
@@ -1,4 +1,4 @@
-import { WeaponPF2e } from "@item";
+import { ArmorPF2e, WeaponPF2e } from "@item";
 import { ModifierPF2e, MODIFIER_TYPE } from "@actor/modifiers";
 import { PredicatePF2e } from "@system/predication";
 import { ErrorPF2e, objectHasKey, setHasElement } from "@util";
@@ -121,7 +121,7 @@ class StrikeWeaponTraits {
 /** Create a penalty for attempting to Force Open without a crowbar or equivalent tool */
 function createForceOpenPenalty(actor: CharacterPF2e, domains: string[]): ModifierPF2e {
     const slug = "no-crowbar";
-    const synthetics = actor.synthetics.modifierAdjustments;
+    const { modifierAdjustments } = actor.synthetics;
     return new ModifierPF2e({
         slug,
         label: "PF2E.Actions.ForceOpen.NoCrowbarPenalty",
@@ -129,8 +129,26 @@ function createForceOpenPenalty(actor: CharacterPF2e, domains: string[]): Modifi
         modifier: -2,
         predicate: ["action:force-open", "action:force-open:prying"],
         hideIfDisabled: true,
-        adjustments: extractModifierAdjustments(synthetics, domains, slug),
+        adjustments: extractModifierAdjustments(modifierAdjustments, domains, slug),
     });
 }
 
-export { createForceOpenPenalty, StrikeWeaponTraits };
+function createShoddyPenalty(
+    actor: CharacterPF2e,
+    item: WeaponPF2e | ArmorPF2e,
+    domains: string[]
+): ModifierPF2e | null {
+    if (!item.isShoddy) return null;
+
+    const slug = "shoddy";
+    const { modifierAdjustments } = actor.synthetics;
+    return new ModifierPF2e({
+        label: "PF2E.Item.Physical.OtherTag.Shoddy",
+        type: "item",
+        slug,
+        modifier: -2,
+        adjustments: extractModifierAdjustments(modifierAdjustments, domains, slug),
+    });
+}
+
+export { createForceOpenPenalty, createShoddyPenalty, StrikeWeaponTraits };

--- a/src/module/actor/character/index.ts
+++ b/src/module/actor/character/index.ts
@@ -108,7 +108,7 @@ import {
 import { CharacterSheetTabVisibility } from "./data/sheet";
 import { CHARACTER_SHEET_TABS } from "./values";
 import { CharacterFeats } from "./feats";
-import { createForceOpenPenalty, StrikeWeaponTraits } from "./helpers";
+import { createForceOpenPenalty, createShoddyPenalty, StrikeWeaponTraits } from "./helpers";
 import { CharacterHitPointsSummary, CharacterSkills, CreateAuxiliaryParams, DexterityModifierCapData } from "./types";
 
 class CharacterPF2e extends CreaturePF2e {
@@ -679,12 +679,15 @@ class CharacterPF2e extends CreaturePF2e {
                 modifiers.unshift(
                     new ModifierPF2e({
                         label: wornArmor.name,
-                        type: MODIFIER_TYPE.ITEM,
+                        type: "item",
                         slug,
                         modifier: wornArmor.acBonus,
                         adjustments: extractModifierAdjustments(synthetics.modifierAdjustments, ["all", "ac"], slug),
                     })
                 );
+
+                const shoddyPenalty = createShoddyPenalty(this, wornArmor, ["all", "ac"]);
+                if (shoddyPenalty) modifiers.push(shoddyPenalty);
             }
 
             // Proficiency bonus
@@ -1581,6 +1584,9 @@ class CharacterPF2e extends CreaturePF2e {
             modifiers.push(new ModifierPF2e(weaponPotency.label, weaponPotency.bonus, weaponPotency.type));
             weaponTraits.add("magical");
         }
+
+        const shoddyPenalty = createShoddyPenalty(this, weapon, selectors);
+        if (shoddyPenalty) modifiers.push(shoddyPenalty);
 
         // Everything from relevant synthetics
         modifiers.push(

--- a/src/module/item/armor/document.ts
+++ b/src/module/item/armor/document.ts
@@ -41,7 +41,7 @@ class ArmorPF2e extends PhysicalItemPF2e {
     }
 
     get checkPenalty(): number | null {
-        return this.isShield ? null : this.system.check.value;
+        return this.isShield ? null : this.system.check.value || null;
     }
 
     get speedPenalty(): number {
@@ -114,7 +114,6 @@ class ArmorPF2e extends PhysicalItemPF2e {
 
         const { traits } = this.system;
         traits.value = Array.from(new Set([...baseTraits, ...fromRunes, ...magicTraits]));
-        traits.otherTags ??= [];
     }
 
     override prepareDerivedData(): void {
@@ -129,6 +128,12 @@ class ArmorPF2e extends PhysicalItemPF2e {
                 (rune): rune is string => !!rune
             ),
         };
+
+        // Work around upstream double data-preparation bug
+        // https://github.com/foundryvtt/foundryvtt/issues/7987
+        if (this.isShoddy && this._source.system.check.value) {
+            this.system.check.value = this._source.system.check.value - 2;
+        }
     }
 
     override prepareActorData(): void {

--- a/src/module/item/armor/sheet.ts
+++ b/src/module/item/armor/sheet.ts
@@ -1,5 +1,6 @@
 import {
     ARMOR_MATERIAL_VALUATION_DATA,
+    CoinsPF2e,
     getPropertySlots,
     PhysicalItemSheetData,
     PhysicalItemSheetPF2e,
@@ -36,6 +37,7 @@ class ArmorSheetPF2e extends PhysicalItemSheetPF2e<ArmorPF2e> {
             preciousMaterials: this.prepareMaterials(ARMOR_MATERIAL_VALUATION_DATA),
             ...propertyRuneSlots,
             otherTags: createSheetTags(CONFIG.PF2E.otherArmorTags, sheetData.data.traits.otherTags),
+            basePrice: new CoinsPF2e(this.item._source.system.price.value),
         };
     }
 
@@ -60,6 +62,7 @@ interface ArmorSheetData extends PhysicalItemSheetData<ArmorPF2e> {
     bulkTypes: ConfigPF2e["PF2E"]["bulkTypes"];
     preciousMaterials: PreparedMaterials;
     otherTags: SheetOptions;
+    basePrice: CoinsPF2e;
 }
 
 export { ArmorSheetPF2e };

--- a/src/module/item/armor/types.ts
+++ b/src/module/item/armor/types.ts
@@ -5,6 +5,6 @@ type ArmorCategory = keyof ConfigPF2e["PF2E"]["armorTypes"];
 type ArmorGroup = keyof ConfigPF2e["PF2E"]["armorGroups"];
 type BaseArmorType = keyof typeof LocalizePF2e.translations.PF2E.Item.Armor.Base;
 type ResilientRuneType = "" | "resilient" | "greaterResilient" | "majorResilient";
-type OtherArmorTag = "innovation";
+type OtherArmorTag = "shoddy";
 
 export { ArmorTrait, ArmorCategory, ArmorGroup, BaseArmorType, ResilientRuneType, OtherArmorTag };

--- a/src/module/item/physical/document.ts
+++ b/src/module/item/physical/document.ts
@@ -94,6 +94,10 @@ abstract class PhysicalItemPF2e extends ItemPF2e {
         return this.system.temporary;
     }
 
+    get isShoddy(): boolean {
+        return this.system.traits.otherTags.includes("shoddy");
+    }
+
     get isDamaged(): boolean {
         return this.system.hp.value > 0 && this.system.hp.value < this.system.hp.max;
     }
@@ -250,6 +254,11 @@ abstract class PhysicalItemPF2e extends ItemPF2e {
             const modifiedIsHigher = adjustedPrice.copperValue > basePrice.copperValue;
             const highestPrice = modifiedIsHigher ? adjustedPrice : basePrice;
             systemData.price.value = highestPrice;
+        }
+        if (this.isShoddy) {
+            systemData.price.value = systemData.price.value.scale(0.5);
+            systemData.hp.max = Math.floor(systemData.hp.max / 2);
+            systemData.hp.brokenThreshold = Math.floor(systemData.hp.brokenThreshold / 2);
         }
 
         // Update properties according to identification status

--- a/src/module/item/weapon/document.ts
+++ b/src/module/item/weapon/document.ts
@@ -206,7 +206,6 @@ class WeaponPF2e extends PhysicalItemPF2e {
         systemData.propertyRune3.value ||= null;
         systemData.propertyRune4.value ||= null;
         systemData.reload.value ||= null;
-        systemData.traits.otherTags ??= [];
         systemData.selectedAmmoId ||= null;
         systemData.damage.die ||= null;
         systemData.damage.modifier ??= 0;

--- a/src/module/item/weapon/types.ts
+++ b/src/module/item/weapon/types.ts
@@ -17,7 +17,7 @@ type WeaponGroup = SetElement<typeof WEAPON_GROUPS>;
 type BaseWeaponType = keyof typeof LocalizePF2e.translations.PF2E.Weapon.Base;
 
 type WeaponTrait = keyof ConfigPF2e["PF2E"]["weaponTraits"];
-type OtherWeaponTag = "crossbow" | "improvised";
+type OtherWeaponTag = "crossbow" | "improvised" | "shoddy";
 
 type WeaponRangeIncrement = SetElement<typeof WEAPON_RANGES>;
 type WeaponReloadTime = "-" | "0" | "1" | "2" | "3" | "10";

--- a/src/module/system/tag-selector/index.ts
+++ b/src/module/system/tag-selector/index.ts
@@ -57,7 +57,6 @@ const SELECTABLE_TAG_FIELDS = [
     "npcAttackTraits",
     "otherArmorTags",
     "otherConsumableTags",
-    "otherEquipmentTags",
     "otherWeaponTags",
     "preciousMaterialGrades",
     "preciousMaterials",

--- a/src/scripts/config/index.ts
+++ b/src/scripts/config/index.ts
@@ -52,7 +52,6 @@ import {
     npcAttackTraits,
     otherArmorTags,
     otherConsumableTags,
-    otherEquipmentTags,
     otherWeaponTags,
     preciousMaterials,
     spellOtherTraits,
@@ -1110,13 +1109,11 @@ export const PF2ECONFIG = {
     otherArmorTags,
 
     equipmentTraits,
-    otherEquipmentTags,
-
-    actionTraits,
 
     consumableTraits,
     otherConsumableTags,
 
+    actionTraits,
     spellTraits,
     featTraits,
     creatureTraits,

--- a/src/scripts/config/traits.ts
+++ b/src/scripts/config/traits.ts
@@ -3,7 +3,6 @@ import { OtherArmorTag } from "@item/armor/types";
 import { ClassTrait } from "@item/class/data";
 import { OtherConsumableTag } from "@item/consumable/types";
 import { RANGE_TRAITS } from "@item/data/values";
-import { OtherEquipmentTag } from "@item/equipment/types";
 import { PreciousMaterialType } from "@item/physical/types";
 import { MagicSchool, MagicTradition } from "@item/spell/types";
 import { OtherWeaponTag } from "@item/weapon/types";
@@ -507,20 +506,17 @@ const preciousMaterials: Record<PreciousMaterialType, string> = {
 };
 
 const otherArmorTags: Record<OtherArmorTag, string> = {
-    innovation: "PF2E.Item.Physical.OtherTag.Innovation",
+    shoddy: "PF2E.Item.Physical.OtherTag.Shoddy",
 };
 
 const otherConsumableTags: Record<OtherConsumableTag, string> = {
     herbal: "PF2E.Item.Physical.OtherTag.Herbal",
 };
 
-const otherEquipmentTags: Record<OtherEquipmentTag, string> = {
-    implement: "PF2E.Item.Physical.OtherTag.Implement",
-};
-
 const otherWeaponTags: Record<OtherWeaponTag, string> = {
     crossbow: "PF2E.Weapon.Base.crossbow",
-    improvised: "PF2E.Item.Weapon.Improvised",
+    improvised: "PF2E.Item.Physical.OtherTag.Improvised",
+    shoddy: "PF2E.Item.Physical.OtherTag.Shoddy",
 };
 
 const rangeTraits = RANGE_TRAITS.reduce(
@@ -811,7 +807,6 @@ export {
     npcAttackTraits,
     otherArmorTags,
     otherConsumableTags,
-    otherEquipmentTags,
     otherWeaponTags,
     preciousMaterials,
     spellOtherTraits,

--- a/src/styles/item/_index.scss
+++ b/src/styles/item/_index.scss
@@ -306,6 +306,11 @@
                     font-weight: 400;
                 }
             }
+
+            input.adjusted-lower:not(:focus) {
+                font-weight: 700;
+                color: $adjusted-lower;
+            }
         }
 
         .tags {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2013,8 +2013,8 @@
                 "PriceLabel": "Price: {price}",
                 "OtherTag": {
                     "Herbal": "Herbal",
-                    "Implement": "Implement",
-                    "Innovation": "Innovation"
+                    "Improvised": "Improvised",
+                    "Shoddy": "Shoddy"
                 },
                 "OtherTags": {
                     "Label": "Other Tags",
@@ -2128,7 +2128,6 @@
                     "StrikingMaterial": "{striking} {material} {base}"
                 },
                 "HandsLabel": "Hands",
-                "Improvised": "Improvised",
                 "MandatoryMelee": "This weapon has a trait that can only be used with melee weapons.",
                 "MaterialAndRunes": {
                     "MaterialOption": "{type} ({grade})",

--- a/static/templates/items/armor-details.html
+++ b/static/templates/items/armor-details.html
@@ -143,7 +143,7 @@
 
 <div class="form-group">
     <label>{{localize "PF2E.ArmorCheckLabel"}}</label>
-    <input type="number" name="system.check.value" value="{{data.check.value}}" />
+    <input type="number"{{#if (and document.isArmor document.isShoddy)}} class="adjusted-lower"{{/if}} data-property="system.check.value" data-value-base="{{document._source.system.check.value}}" value="{{data.check.value}}" />
 </div>
 
 <div class="form-group">
@@ -158,7 +158,7 @@
 
 <div class="form-group">
     <label>{{localize "PF2E.MaxHitPointsHeader"}}</label>
-    <input type="number" name="system.hp.max" value="{{data.hp.max}}" />
+    <input type="number"{{#if document.isShoddy}} class="adjusted-lower"{{/if}} data-property="system.hp.max" data-value-base="{{document._source.system.hp.max}}" value="{{data.hp.max}}" />
 </div>
 
 <div class="form-group">
@@ -168,9 +168,24 @@
 
 <div class="form-group">
     <label>{{localize "PF2E.ShieldBrokenThresholdLabel"}}</label>
-    <input type="number" name="system.hp.brokenThreshold" value="{{data.hp.brokenThreshold}}" />
+    <input type="number"{{#if document.isShoddy}} class="adjusted-lower"{{/if}} data-property="system.hp.brokenThreshold" data-value-base="{{document._source.system.hp.brokenThreshold}}" value="{{data.hp.brokenThreshold}}" />
 </div>
 <div class="form-group">
     <label>{{localize "PF2E.ShieldHardnessLabel"}}</label>
     <input type="number" name="system.hardness" value="{{data.hardness}}" />
+</div>
+
+<div class="form-group-stacked">
+    <label>
+        {{localize "PF2E.Item.Physical.OtherTags.Label"}}
+        <i class="fas fa-info-circle other-tags-hint" title="PF2E.Item.Physical.OtherTags.Hint"></i>
+        {{#if editable}}
+            <a class="tag-selector" data-tag-selector="basic" data-config-types="otherArmorTags" data-title="PF2E.Item.Physical.OtherTags.Label" data-property="system.traits.otherTags"><i class="fas fa-edit"></i></a>
+        {{/if}}
+    </label>
+    <ul class="traits-list tags">
+        {{#each otherTags as |tag|}}
+            <li class="tag tag_alt">{{tag.label}}</li>
+        {{/each}}
+    </ul>
 </div>

--- a/static/templates/items/armor-sidebar.html
+++ b/static/templates/items/armor-sidebar.html
@@ -41,7 +41,7 @@
 
     <div class="form-group">
         <label>{{localize "PF2E.PriceLabel"}}</label>
-        <input type="text" name="system.price.value" value="{{priceString}}" />
+        <input type="text"{{#if document.isShoddy}} class="adjusted-lower"{{/if}} data-property="system.price.value" data-value-base="{{basePrice}}" value="{{priceString}}" spellcheck="false" />
     </div>
 
     <ol class="item-tags tags">

--- a/static/templates/items/weapon-sidebar.html
+++ b/static/templates/items/weapon-sidebar.html
@@ -52,7 +52,7 @@
             {{localize "PF2E.PriceLabel"}}
             {{#if adjustedPriceHint}}<i class="fas fa-info-circle small" title="{{adjustedPriceHint}}"></i>{{/if}}
         </label>
-        <input type="text" {{#if adjustedPriceHint}}class="adjusted"{{/if}} data-property="system.price.value" data-value-base="{{basePriceString}}" value="{{priceString}}" spellcheck="false" />
+        <input type="text"{{#if adjustedPriceHint}} class="adjusted"{{/if}} data-property="system.price.value" data-value-base="{{basePriceString}}" value="{{priceString}}" spellcheck="false" />
     </div>
     <ol class="item-tags tags">
         {{#if otherTags}}


### PR DESCRIPTION
Closes #3793.

Penalties are currently only applied to armor and weapons: we'll need to figure out what besides those qualify for "checks involving a shoddy item take a –2 item penalty."