### PR TITLE
Heighten spells retrieved from chat messages

### DIFF
--- a/src/module/chat-message/document.ts
+++ b/src/module/chat-message/document.ts
@@ -118,11 +118,11 @@ class ChatMessagePF2e extends ChatMessage<ActorPF2e> {
             item.trickMagicEntry = trick;
         }
 
-        const spellVariant = this.flags.pf2e.spellVariant;
-        if (spellVariant && item?.isOfType("spell")) {
-            return item.loadVariant({
-                overlayIds: spellVariant.overlayIds,
-            });
+        if (item?.isOfType("spell")) {
+            const spellVariant = this.flags.pf2e.spellVariant;
+            const castLevel = this.flags.pf2e.casting?.level ?? item.level;
+            const modifiedSpell = item.loadVariant({ overlayIds: spellVariant?.overlayIds, castLevel });
+            return modifiedSpell ?? item.clone({ "system.location.heightenedLevel": castLevel }, { keepId: true });
         }
 
         return item;

--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -310,6 +310,12 @@ class SpellPF2e extends ItemPF2e {
                 mergeObject(source.system, overlay.system);
             }
 
+            // Set the spell as heightened if necessary
+            const currentLevel = source.system.location.heightenedLevel ?? source.system.level.value;
+            if (castLevel && castLevel > currentLevel) {
+                source.system.location.heightenedLevel = castLevel;
+            }
+
             return source;
         })();
         if (!override) return null;


### PR DESCRIPTION
Mostly applicable for modules but also followup work. Should probably be in the patch notes so that module authors know they can remove their weird workarounds now.