### PR TITLE
Add the option to set effects as unidentified

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -13,12 +13,12 @@ exports[`too-much-lint`] = {
     "types/foundry/client/collections/compendium-collection.d.ts:3957627828": [
       [210, 23, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "types/foundry/client/documents/mixins/canvas-document-mixin.d.ts:4239377699": [
+    "types/foundry/client/documents/mixins/canvas-document-mixin.d.ts:3303075782": [
       [16, 22, 3, "Unexpected any. Specify a different type.", "193409811"],
       [21, 57, 3, "Unexpected any. Specify a different type.", "193409811"],
       [54, 57, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "types/foundry/client/documents/mixins/client-document-mixin.d.ts:3665440820": [
+    "types/foundry/client/documents/mixins/client-document-mixin.d.ts:2424756609": [
       [8, 18, 3, "Unexpected any. Specify a different type.", "193409811"],
       [65, 43, 3, "Unexpected any. Specify a different type.", "193409811"],
       [163, 17, 3, "Unexpected any. Specify a different type.", "193409811"],
@@ -54,8 +54,8 @@ exports[`too-much-lint`] = {
     "types/foundry/common/abstract/data.d.ts:1438318714": [
       [22, 34, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "types/foundry/common/abstract/document.d.ts:3086286863": [
-      [572, 29, 3, "Unexpected any. Specify a different type.", "193409811"]
+    "types/foundry/common/abstract/document.d.ts:2061890606": [
+      [571, 29, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
     "types/foundry/common/utils/collection.d.ts:3114157620": [
       [111, 31, 3, "Unexpected any. Specify a different type.", "193409811"],

--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -91,7 +91,7 @@ class ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
     override get itemTypes(): { [K in keyof ItemTypeMap]: Embedded<ItemTypeMap[K]>[] } {
         const items = (this._itemTypes ??= super.itemTypes);
         if (game.user.isGM) return items;
-        items.effect = items.effect.filter((effect) => !effect.system.gmOnly);
+        items.effect = items.effect.filter((effect) => !effect.system.unidentified);
         return items;
     }
 

--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -89,7 +89,10 @@ class ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
 
     /** Cache the return data before passing it to the caller */
     override get itemTypes(): { [K in keyof ItemTypeMap]: Embedded<ItemTypeMap[K]>[] } {
-        return (this._itemTypes ??= super.itemTypes);
+        const items = (this._itemTypes ??= super.itemTypes);
+        if (game.user.isGM) return items;
+        items.effect = items.effect.filter((effect) => !effect.system.gmOnly);
+        return items;
     }
 
     get allowedItemTypes(): (ItemType | "physical")[] {

--- a/src/module/actor/modifiers.ts
+++ b/src/module/actor/modifiers.ts
@@ -140,6 +140,9 @@ class ModifierPF2e implements RawModifier {
     notes: string;
     hideIfDisabled: boolean;
 
+    unidentified: boolean;
+    originalLabel: string;
+
     /**
      * Create a new modifier.
      * Legacy parameters:
@@ -194,6 +197,10 @@ class ModifierPF2e implements RawModifier {
         // Force splash damage into being critical-only or not doubling on critical hits
         this.critical = this.damageCategory === "splash" ? !!params.critical : params.critical ?? null;
 
+        this.originalLabel = this.label;
+        this.unidentified = params.unidentified ?? false;
+        if (this.unidentified && !game.user.isGM) this.label = "Unidentified";
+
         if (this.force && this.type === "untyped") {
             throw ErrorPF2e("A forced modifier must have a type");
         }
@@ -203,8 +210,8 @@ class ModifierPF2e implements RawModifier {
     clone(options: { test?: Set<string> | string[] } = {}): ModifierPF2e {
         const clone =
             this.modifier === this.#originalValue
-                ? new ModifierPF2e(this)
-                : new ModifierPF2e({ ...this, modifier: this.#originalValue });
+                ? new ModifierPF2e({ ...this, label: this.originalLabel })
+                : new ModifierPF2e({ ...this, modifier: this.#originalValue, label: this.originalLabel });
         if (options.test) clone.test(options.test);
 
         return clone;
@@ -244,6 +251,7 @@ class ModifierPF2e implements RawModifier {
 
 type ModifierObjectParams = RawModifier & {
     name?: string;
+    unidentified?: boolean;
 };
 
 type ModifierOrderedParams = [

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -757,6 +757,11 @@ export abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorShee
             return [item];
         }
 
+        if (game.user.isGM && itemSource.type === "effect") {
+            const ctrlHeld = game.keyboard.isModifierActive(KeyboardManager.MODIFIER_KEYS.CONTROL);
+            if (ctrlHeld) itemSource.system.gmOnly = true;
+        }
+
         if (isPhysicalData(itemSource)) {
             const containerId =
                 $(event.target).closest('[data-item-is-container="true"]').attr("data-item-id")?.trim() || null;

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -759,7 +759,7 @@ export abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorShee
 
         if (game.user.isGM && itemSource.type === "effect") {
             const ctrlHeld = game.keyboard.isModifierActive(KeyboardManager.MODIFIER_KEYS.CONTROL);
-            if (ctrlHeld) itemSource.system.gmOnly = true;
+            if (ctrlHeld) itemSource.system.unidentified = true;
         }
 
         if (isPhysicalData(itemSource)) {

--- a/src/module/canvas/token/object.ts
+++ b/src/module/canvas/token/object.ts
@@ -1,3 +1,4 @@
+import { EffectPF2e } from "@item";
 import { TokenDocumentPF2e } from "@module/scene";
 import { pick } from "@util";
 import { CanvasPF2e, measureDistanceRect, TokenLayerPF2e } from "..";
@@ -217,6 +218,12 @@ class TokenPF2e extends Token<TokenDocumentPF2e> {
     /** Emit floaty text from this tokens */
     async showFloatyText(params: number | ShowFloatyEffectParams): Promise<void> {
         if (!this.isVisible) return;
+        if (!game.user.isGM && typeof params !== "number") {
+            const [change, document] = Object.entries(params)[0];
+            if (document.type === "effect" && (change === "create" || change === "delete")) {
+                if ((document as EffectPF2e).system.gmOnly) return;
+            }
+        }
 
         const scrollingTextArgs = ((): Parameters<CanvasPF2e["interface"]["createScrollingText"]> | null => {
             if (typeof params === "number") {
@@ -430,7 +437,7 @@ interface TokenImage extends PIXI.Sprite {
     src?: VideoPath;
 }
 
-type NumericFloatyEffect = { name: string; value?: number | null };
+type NumericFloatyEffect = { name: string; value?: number | null; type?: string };
 type ShowFloatyEffectParams =
     | number
     | { create: NumericFloatyEffect }

--- a/src/module/canvas/token/object.ts
+++ b/src/module/canvas/token/object.ts
@@ -221,7 +221,7 @@ class TokenPF2e extends Token<TokenDocumentPF2e> {
         if (!game.user.isGM && typeof params !== "number") {
             const [change, document] = Object.entries(params)[0];
             if (document.type === "effect" && (change === "create" || change === "delete")) {
-                if ((document as EffectPF2e).system.gmOnly) return;
+                if ((document as EffectPF2e).system.unidentified) return;
             }
         }
 

--- a/src/module/item/effect/data.ts
+++ b/src/module/item/effect/data.ts
@@ -35,6 +35,7 @@ interface EffectSystemSource extends ItemSystemSource, ItemLevelData {
         sustained: boolean;
         expiry: EffectExpiryType | null;
     };
+    gmOnly: boolean;
     tokenIcon: {
         show: boolean;
     };

--- a/src/module/item/effect/data.ts
+++ b/src/module/item/effect/data.ts
@@ -35,7 +35,7 @@ interface EffectSystemSource extends ItemSystemSource, ItemLevelData {
         sustained: boolean;
         expiry: EffectExpiryType | null;
     };
-    gmOnly: boolean;
+    unidentified: boolean;
     tokenIcon: {
         show: boolean;
     };

--- a/src/module/rules/rule-element/flat-modifier.ts
+++ b/src/module/rules/rule-element/flat-modifier.ts
@@ -127,6 +127,7 @@ class FlatModifierRuleElement extends RuleElementPF2e {
                     critical: this.critical,
                     hideIfDisabled: this.hideIfDisabled,
                     source: this.item.uuid,
+                    unidentified: this.item.isOfType("effect") && this.item.system.unidentified,
                 });
                 if (options.test) modifier.test(options.test);
 

--- a/src/module/system/rolls.ts
+++ b/src/module/system/rolls.ts
@@ -403,12 +403,14 @@ class CheckPF2e {
             label: string;
             name?: string;
             description?: string;
+            unidentified?: string;
         }
 
         const toTagElement = (tag: TagObject, cssClass: string | null = null): HTMLElement => {
             const span = document.createElement("span");
             span.classList.add("tag");
             if (cssClass) span.classList.add(`tag_${cssClass}`);
+            if (tag.unidentified) span.dataset.unidentified = tag.unidentified;
 
             span.innerText = tag.label;
 
@@ -469,8 +471,12 @@ class CheckPF2e {
             .filter((m) => m.enabled)
             .map((modifier) => {
                 const sign = modifier.modifier < 0 ? "" : "+";
-                const label = `${modifier.label} ${sign}${modifier.modifier}`;
-                return toTagElement({ name: modifier.slug, label }, "transparent");
+                const signedValue = `${sign}${modifier.modifier}`;
+                const label = `${modifier.originalLabel} ${signedValue}`;
+                const unidentified = modifier.unidentified
+                    ? `${game.i18n.localize("PF2E.identification.Unidentified")} ${signedValue}`
+                    : undefined;
+                return toTagElement({ name: modifier.slug, label, unidentified }, "transparent");
             });
         const tagsFromOptions = extraTags.map((t) => toTagElement({ label: game.i18n.localize(t) }, "transparent"));
         const modifiersAndExtras = document.createElement("div");

--- a/src/scripts/ui/user-visibility.ts
+++ b/src/scripts/ui/user-visibility.ts
@@ -7,6 +7,13 @@ class UserVisibilityPF2e {
         const html = $html instanceof HTMLElement ? $html : $html[0]!;
         if ($html instanceof HTMLElement) $html = $($html);
 
+        if (!game.user.isGM) {
+            const unidentifiedElements = htmlQueryAll(html, "[data-unidentified]");
+            for (const element of unidentifiedElements) {
+                element.innerHTML = element.dataset.unidentified as string;
+            }
+        }
+
         const visibilityElements = htmlQueryAll(html, "[data-visibility]");
 
         // Remove all visibility=none elements

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1973,7 +1973,7 @@
                     "StartOfTurn": "Start of Turn",
                     "EndOfTurn": "End of Turn"
                 },
-                "GMOnly": "GM Only?",
+                "Unidentified": "Unidentified?",
                 "ShowTokenIcon": "Show token icon?",
                 "AddBadge": "Add Counter",
                 "BadgeType": {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1973,6 +1973,7 @@
                     "StartOfTurn": "Start of Turn",
                     "EndOfTurn": "End of Turn"
                 },
+                "GMOnly": "GM Only?",
                 "ShowTokenIcon": "Show token icon?",
                 "AddBadge": "Add Counter",
                 "BadgeType": {

--- a/static/templates/items/effect-sidebar.html
+++ b/static/templates/items/effect-sidebar.html
@@ -44,6 +44,14 @@
             <input type="checkbox" name="system.tokenIcon.show" {{checked data.tokenIcon.show}} />
         </div>
     </div>
+    {{#if user.isGM}}
+    <div class="form-group">
+        <label for="data.gmOnly">{{localize "PF2E.Item.Effect.GMOnly"}}</label>
+        <div class="form-fields">
+            <input type="checkbox" name="system.gmOnly" {{checked data.gmOnly}} />
+        </div>
+    </div>
+    {{/if}}
     <hr/>
     <div class="form-group">
         {{#if data.badge}}

--- a/static/templates/items/effect-sidebar.html
+++ b/static/templates/items/effect-sidebar.html
@@ -46,9 +46,9 @@
     </div>
     {{#if user.isGM}}
     <div class="form-group">
-        <label for="data.gmOnly">{{localize "PF2E.Item.Effect.GMOnly"}}</label>
+        <label for="data.unidentified">{{localize "PF2E.Item.Effect.Unidentified"}}</label>
         <div class="form-fields">
-            <input type="checkbox" name="system.gmOnly" {{checked data.gmOnly}} />
+            <input type="checkbox" name="system.unidentified" {{checked data.unidentified}} />
         </div>
     </div>
     {{/if}}


### PR DESCRIPTION
A new option to set an effect `unidentified` is available, this will result in the hiding of the effect from the actor sheet, effects panel, token, combat tracker, etc for the players.

If the effect generates flat modifiers, those will be displayed as "Unidentified" in the tooltips, check modifiers dialog window and in chat card tags for the players.

When an effect is `unidentified`, no floaty text will be displayed over the token at creation or deletion of the effect for the players.

A checkbox input is available in the effect sheet sidebar for the GM and if the GM holds the `ctrl` key when an effect is 'drag & drop' onto a token or an actor sheet, the effect will automatically receive the `unidentified` state. 

Notes: 
- for a reason i don't understand, the `ctrl` key must be held before starting to drag the effect.
- there is more than likely a few scenarios i have not thought about and therefore not have taken care of yet.