### PR TITLE
Expose self and target's ID as rollOptions

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -503,6 +503,9 @@ class ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
             },
         });
 
+        // Always add the actor's ID to the rolloptions.
+        this.rollOptions.all[`self:id:${this.id}`] = true;
+
         this.setEncounterRollOptions();
     }
 

--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -504,7 +504,9 @@ class ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
         });
 
         // Always add the actor's ID to the rolloptions.
-        this.rollOptions.all[`self:id:${this.id}`] = true;
+        if (this.id) {
+            this.rollOptions.all[`self:id:${this.id}`] = true;
+        }
 
         this.setEncounterRollOptions();
     }

--- a/src/module/actor/creature/index.ts
+++ b/src/module/actor/creature/index.ts
@@ -303,9 +303,6 @@ export abstract class CreaturePF2e extends ActorPF2e {
             };
         }
 
-        // Always add the actor's ID to the rolloptions.
-        this.rollOptions.all[`self:id:${this.id}`] = true;
-
         // Toggles
         this.system.toggles = [];
 

--- a/src/module/actor/creature/index.ts
+++ b/src/module/actor/creature/index.ts
@@ -303,6 +303,9 @@ export abstract class CreaturePF2e extends ActorPF2e {
             };
         }
 
+        // Always add the actor's ID to the rolloptions.
+        this.rollOptions.all[`self:id:${this.id}`] = true;
+
         // Toggles
         this.system.toggles = [];
 


### PR DESCRIPTION
Assuming a single target for a roll, this PR will make it so that `self:id:XYZ` and `target:id:ABC` are now available rollOptions to use.

`self:id` is available for targetless rolls as well.