### PR TITLE
Remove accidentally included custom trait on some NPCs

### DIFF
--- a/packs/data/bestiary-ability-glossary-srd.db/change-shape.json
+++ b/packs/data/bestiary-ability-glossary-srd.db/change-shape.json
@@ -23,7 +23,7 @@
             "value": "Pathfinder Bestiary"
         },
         "traits": {
-            "custom": "[magical tradition]",
+            "custom": "",
             "rarity": "common",
             "value": [
                 "concentrate",

--- a/packs/data/blood-lords-bestiary.db/yshula.json
+++ b/packs/data/blood-lords-bestiary.db/yshula.json
@@ -1423,7 +1423,7 @@
                     "value": "Pathfinder Bestiary"
                 },
                 "traits": {
-                    "custom": "[magical tradition]",
+                    "custom": "",
                     "rarity": "common",
                     "value": [
                         "concentrate",

--- a/packs/data/kingmaker-bestiary.db/gaetane.json
+++ b/packs/data/kingmaker-bestiary.db/gaetane.json
@@ -707,7 +707,7 @@
                     "value": "Pathfinder Bestiary"
                 },
                 "traits": {
-                    "custom": "[magical tradition]",
+                    "custom": "",
                     "rarity": "common",
                     "value": [
                         "concentrate",

--- a/packs/data/kingmaker-bestiary.db/kundal.json
+++ b/packs/data/kingmaker-bestiary.db/kundal.json
@@ -414,7 +414,7 @@
                     "value": "Pathfinder Bestiary"
                 },
                 "traits": {
-                    "custom": "[magical tradition]",
+                    "custom": "",
                     "rarity": "common",
                     "value": [
                         "concentrate",

--- a/packs/data/kingmaker-bestiary.db/vilderavn-herald.json
+++ b/packs/data/kingmaker-bestiary.db/vilderavn-herald.json
@@ -1484,7 +1484,7 @@
                     "value": "Pathfinder Bestiary"
                 },
                 "traits": {
-                    "custom": "[magical tradition]",
+                    "custom": "",
                     "rarity": "common",
                     "value": [
                         "concentrate",

--- a/packs/data/kingmaker-bestiary.db/virthad.json
+++ b/packs/data/kingmaker-bestiary.db/virthad.json
@@ -2848,7 +2848,7 @@
                     "value": "Pathfinder Bestiary"
                 },
                 "traits": {
-                    "custom": "[magical tradition]",
+                    "custom": "",
                     "rarity": "common",
                     "value": [
                         "arcane",


### PR DESCRIPTION
Also gets rid of it on the change shape action, since we can't edit or see custom traits on actions now anyways.