### PR TITLE
Fix actor sidebar showing the actor level to users that lack permission

### DIFF
--- a/src/module/apps/ui/actor-directory.ts
+++ b/src/module/apps/ui/actor-directory.ts
@@ -1,4 +1,5 @@
 import { ActorPF2e } from "@actor/base";
+import { htmlQueryAll } from "@util";
 
 /** Extend ActorDirectory to show more information */
 export class ActorDirectoryPF2e<TDocument extends ActorPF2e> extends ActorDirectory<TDocument> {
@@ -13,6 +14,18 @@ export class ActorDirectoryPF2e<TDocument extends ActorPF2e> extends ActorDirect
             ...(await super.getData()),
             documentPartial: "systems/pf2e/templates/sidebar/actor-document-partial.html",
         };
+    }
+
+    override activateListeners($html: JQuery<HTMLElement>): void {
+        super.activateListeners($html);
+        const html = $html[0];
+
+        for (const element of htmlQueryAll(html, "li.directory-item")) {
+            const actor = game.actors.get(element.dataset.documentId ?? "");
+            if (!actor?.testUserPermission(game.user, "OBSERVER")) {
+                element.querySelector("span.actor-level")?.remove();
+            }
+        }
     }
 
     /** Include flattened update data so parent method can read nested update keys */


### PR DESCRIPTION
I'm not really happy with creating a new handlebars helper that is only used for this but it I believe it is the best solution.
As the actor rendering is done inside `templates/sidebar/document-directory.html` with an array of full `Document` instances the alternative would have been to subclass `SidebarDirectory` and override `SidebarDirectory#getData` to generate new render data for each actor, including the user permission, and passing that to a modfied template.

Closes #4482 