### PR TITLE
Allow the use of 'alt' key to add an unidentified effect

### DIFF
--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -692,6 +692,12 @@ export abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorShee
         const { actor } = this;
         const itemSource = item.toObject();
 
+        // Set effect to unidentified if ctrl key is held
+        if (game.user.isGM && itemSource.type === "effect") {
+            const ctrlHeld = event.ctrlKey || game.keyboard.isModifierActive(KeyboardManager.MODIFIER_KEYS.CONTROL);
+            if (ctrlHeld) itemSource.system.unidentified = true;
+        }
+
         // mystify the item if the alt key was pressed
         if (event.altKey && item.isOfType("physical") && isPhysicalData(itemSource)) {
             itemSource.system.identification.unidentified = item.getMystifiedData("unidentified");

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -692,7 +692,7 @@ export abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorShee
         const { actor } = this;
         const itemSource = item.toObject();
 
-        // Set effect to unidentified if ctrl key is held
+        // Set effect to unidentified if alt key is held
         if (game.user.isGM && itemSource.type === "effect") {
             const altHeld = event.altKey || game.keyboard.isModifierActive(KeyboardManager.MODIFIER_KEYS.ALT);
             if (altHeld) itemSource.system.unidentified = true;

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -695,7 +695,7 @@ export abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorShee
         // Set effect to unidentified if alt key is held
         if (game.user.isGM && itemSource.type === "effect") {
             const altHeld = event.altKey || game.keyboard.isModifierActive(KeyboardManager.MODIFIER_KEYS.ALT);
-            if (altHeld) itemSource.system.unidentified = true;
+            itemSource.system.unidentified ||= altHeld;
         }
 
         // mystify the item if the alt key was pressed

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -694,8 +694,8 @@ export abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorShee
 
         // Set effect to unidentified if ctrl key is held
         if (game.user.isGM && itemSource.type === "effect") {
-            const ctrlHeld = event.ctrlKey || game.keyboard.isModifierActive(KeyboardManager.MODIFIER_KEYS.CONTROL);
-            if (ctrlHeld) itemSource.system.unidentified = true;
+            const altHeld = event.altKey || game.keyboard.isModifierActive(KeyboardManager.MODIFIER_KEYS.ALT);
+            if (altHeld) itemSource.system.unidentified = true;
         }
 
         // mystify the item if the alt key was pressed


### PR DESCRIPTION
If the GM holds the `alt` key while dragging an effect onto a token or an actor sheet, the effect will be forcibly set to `unidentified`.