### PR TITLE
Make unidentifiable the modifiers of an unidentified effect

### DIFF
--- a/src/module/actor/modifiers.ts
+++ b/src/module/actor/modifiers.ts
@@ -140,6 +140,9 @@ class ModifierPF2e implements RawModifier {
     notes: string;
     hideIfDisabled: boolean;
 
+    unidentified: boolean;
+    originalLabel: string;
+
     /**
      * Create a new modifier.
      * Legacy parameters:
@@ -194,6 +197,10 @@ class ModifierPF2e implements RawModifier {
         // Force splash damage into being critical-only or not doubling on critical hits
         this.critical = this.damageCategory === "splash" ? !!params.critical : params.critical ?? null;
 
+        this.originalLabel = this.label;
+        this.unidentified = params.unidentified ?? false;
+        if (this.unidentified && !game.user.isGM) this.label = "Unidentified";
+
         if (this.force && this.type === "untyped") {
             throw ErrorPF2e("A forced modifier must have a type");
         }
@@ -203,8 +210,8 @@ class ModifierPF2e implements RawModifier {
     clone(options: { test?: Set<string> | string[] } = {}): ModifierPF2e {
         const clone =
             this.modifier === this.#originalValue
-                ? new ModifierPF2e(this)
-                : new ModifierPF2e({ ...this, modifier: this.#originalValue });
+                ? new ModifierPF2e({ ...this, label: this.originalLabel })
+                : new ModifierPF2e({ ...this, modifier: this.#originalValue, label: this.originalLabel });
         if (options.test) clone.test(options.test);
 
         return clone;
@@ -244,6 +251,7 @@ class ModifierPF2e implements RawModifier {
 
 type ModifierObjectParams = RawModifier & {
     name?: string;
+    unidentified?: boolean;
 };
 
 type ModifierOrderedParams = [

--- a/src/module/actor/modifiers.ts
+++ b/src/module/actor/modifiers.ts
@@ -143,6 +143,10 @@ class ModifierPF2e implements RawModifier {
     unidentified: boolean;
     originalLabel: string;
 
+    static get UNIDENTIFIED() {
+        return game.i18n.localize("PF2E.identification.Unidentified");
+    }
+
     /**
      * Create a new modifier.
      * Legacy parameters:
@@ -199,7 +203,7 @@ class ModifierPF2e implements RawModifier {
 
         this.originalLabel = this.label;
         this.unidentified = params.unidentified ?? false;
-        if (this.unidentified && !game.user.isGM) this.label = "Unidentified";
+        if (this.unidentified && !game.user.isGM) this.label = ModifierPF2e.UNIDENTIFIED;
 
         if (this.force && this.type === "untyped") {
             throw ErrorPF2e("A forced modifier must have a type");

--- a/src/module/rules/rule-element/flat-modifier.ts
+++ b/src/module/rules/rule-element/flat-modifier.ts
@@ -127,6 +127,7 @@ class FlatModifierRuleElement extends RuleElementPF2e {
                     critical: this.critical,
                     hideIfDisabled: this.hideIfDisabled,
                     source: this.item.uuid,
+                    unidentified: this.item.isOfType("effect") && this.item.system.unidentified,
                 });
                 if (options.test) modifier.test(options.test);
 

--- a/src/module/rules/rule-element/flat-modifier.ts
+++ b/src/module/rules/rule-element/flat-modifier.ts
@@ -2,7 +2,7 @@ import { ActorType } from "@actor/data";
 import { DeferredValueParams, ModifierPF2e, ModifierType, MODIFIER_TYPE, MODIFIER_TYPES } from "@actor/modifiers";
 import { AbilityString } from "@actor/types";
 import { ABILITY_ABBREVIATIONS } from "@actor/values";
-import { ItemPF2e, PhysicalItemPF2e } from "@item";
+import { AbstractEffectPF2e, ItemPF2e, PhysicalItemPF2e } from "@item";
 import { setHasElement, sluggify } from "@util";
 import { RuleElementData, RuleElementOptions, RuleElementPF2e, RuleElementSource } from "./";
 
@@ -127,7 +127,7 @@ class FlatModifierRuleElement extends RuleElementPF2e {
                     critical: this.critical,
                     hideIfDisabled: this.hideIfDisabled,
                     source: this.item.uuid,
-                    unidentified: this.item.isOfType("effect") && this.item.system.unidentified,
+                    unidentified: this.item instanceof AbstractEffectPF2e && this.item.unidentified,
                 });
                 if (options.test) modifier.test(options.test);
 

--- a/src/module/system/damage/roll-dialog.ts
+++ b/src/module/system/damage/roll-dialog.ts
@@ -134,7 +134,7 @@ export class DamageRollModifiersDialog extends Application {
                 const label = m instanceof ModifierPF2e ? m.originalLabel : m.label;
                 const unidentified = m instanceof ModifierPF2e ? m.unidentified : false;
                 const unidentifiedDataset = unidentified
-                    ? ` data-unidentified="${game.i18n.localize("PF2E.identification.Unidentified")} ${signedModifier}"`
+                    ? ` data-unidentified="${ModifierPF2e.UNIDENTIFIED} ${signedModifier}"`
                     : "";
 
                 return `<span class="tag tag_transparent"${unidentifiedDataset}>${label} ${signedModifier}</span>`;

--- a/src/module/system/damage/roll-dialog.ts
+++ b/src/module/system/damage/roll-dialog.ts
@@ -130,8 +130,14 @@ export class DamageRollModifiersDialog extends Application {
                         ? game.i18n.localize(damageTypes[m.damageType as DamageType] ?? m.damageType)
                         : null;
                 const typeLabel = damageType ? ` ${damageType}` : "";
+                const signedModifier = modifier + typeLabel;
+                const label = m instanceof ModifierPF2e ? m.originalLabel : m.label;
+                const unidentified = m instanceof ModifierPF2e ? m.unidentified : false;
+                const unidentifiedDataset = unidentified
+                    ? ` data-unidentified="${game.i18n.localize("PF2E.identification.Unidentified")} ${signedModifier}"`
+                    : "";
 
-                return `<span class="tag tag_transparent">${m.label} ${modifier}${typeLabel}</span>`;
+                return `<span class="tag tag_transparent"${unidentifiedDataset}>${label} ${signedModifier}</span>`;
             })
             .join("");
         flavor += `<div class="tags">${baseBreakdown}${modifierBreakdown}</div>`;

--- a/src/module/system/rolls.ts
+++ b/src/module/system/rolls.ts
@@ -473,9 +473,7 @@ class CheckPF2e {
                 const sign = modifier.modifier < 0 ? "" : "+";
                 const signedValue = `${sign}${modifier.modifier}`;
                 const label = `${modifier.originalLabel} ${signedValue}`;
-                const unidentified = modifier.unidentified
-                    ? `${game.i18n.localize("PF2E.identification.Unidentified")} ${signedValue}`
-                    : undefined;
+                const unidentified = modifier.unidentified ? `${ModifierPF2e.UNIDENTIFIED} ${signedValue}` : undefined;
                 return toTagElement({ name: modifier.slug, label, unidentified }, "transparent");
             });
         const tagsFromOptions = extraTags.map((t) => toTagElement({ label: game.i18n.localize(t) }, "transparent"));

--- a/src/module/system/rolls.ts
+++ b/src/module/system/rolls.ts
@@ -403,12 +403,14 @@ class CheckPF2e {
             label: string;
             name?: string;
             description?: string;
+            unidentified?: string;
         }
 
         const toTagElement = (tag: TagObject, cssClass: string | null = null): HTMLElement => {
             const span = document.createElement("span");
             span.classList.add("tag");
             if (cssClass) span.classList.add(`tag_${cssClass}`);
+            if (tag.unidentified) span.dataset.unidentified = tag.unidentified;
 
             span.innerText = tag.label;
 
@@ -469,8 +471,12 @@ class CheckPF2e {
             .filter((m) => m.enabled)
             .map((modifier) => {
                 const sign = modifier.modifier < 0 ? "" : "+";
-                const label = `${modifier.label} ${sign}${modifier.modifier}`;
-                return toTagElement({ name: modifier.slug, label }, "transparent");
+                const signedValue = `${sign}${modifier.modifier}`;
+                const label = `${modifier.originalLabel} ${signedValue}`;
+                const unidentified = modifier.unidentified
+                    ? `${game.i18n.localize("PF2E.identification.Unidentified")} ${signedValue}`
+                    : undefined;
+                return toTagElement({ name: modifier.slug, label, unidentified }, "transparent");
             });
         const tagsFromOptions = extraTags.map((t) => toTagElement({ label: game.i18n.localize(t) }, "transparent"));
         const modifiersAndExtras = document.createElement("div");

--- a/src/scripts/ui/user-visibility.ts
+++ b/src/scripts/ui/user-visibility.ts
@@ -7,6 +7,13 @@ class UserVisibilityPF2e {
         const html = $html instanceof HTMLElement ? $html : $html[0]!;
         if ($html instanceof HTMLElement) $html = $($html);
 
+        if (!game.user.isGM) {
+            const unidentifiedElements = htmlQueryAll(html, "[data-unidentified]");
+            for (const element of unidentifiedElements) {
+                element.innerHTML = element.dataset.unidentified as string;
+            }
+        }
+
         const visibilityElements = htmlQueryAll(html, "[data-visibility]");
 
         // Remove all visibility=none elements

--- a/src/scripts/ui/user-visibility.ts
+++ b/src/scripts/ui/user-visibility.ts
@@ -11,6 +11,7 @@ class UserVisibilityPF2e {
             const unidentifiedElements = htmlQueryAll(html, "[data-unidentified]");
             for (const element of unidentifiedElements) {
                 element.innerHTML = element.dataset.unidentified as string;
+                delete element.dataset.unidentified;
             }
         }
 

--- a/src/styles/_tags.scss
+++ b/src/styles/_tags.scss
@@ -101,6 +101,10 @@ li.chat-message .tags .tag {
     &_transparent {
         line-height: 1.25em;
         padding: 0.1em 0.25em;
+
+        &[data-unidentified] {
+            background-color: var(--visibility-gm-bg);
+        }
     }
 }
 


### PR DESCRIPTION
This is an attempt of making the modifiers generated by an `unidentified` effect as `unidentified` themselves for the players while displaying the regular information for the GM.

I am not familiar enough with the PF2e system source code to be able to find all the places i should work on for this matter, but i started nonetheless, for now, here is what i changed and could test:
- Modifiers tooltipster tooltips
- Breakdown html titles
- CheckModifiersDialog window
- CheckPF2e chat message tags
- DamageRollModifiersDialog chat message tags

I am willing to bet there are many other places i have missed and would be willing to go look there.