### PR TITLE
Set Spell Name cursor type to pointer

### DIFF
--- a/src/styles/actor/_spell-list.scss
+++ b/src/styles/actor/_spell-list.scss
@@ -198,6 +198,7 @@ ol.spell-list {
                 letter-spacing: -0.075em;
                 line-height: 1;
                 margin-left: 8px;
+                cursor: pointer;
 
                 &:hover {
                     color: var(--secondary);


### PR DESCRIPTION
Bring it in line with the rest of the `<h4>`s on the different tabs of character sheet