### PR TITLE
Brushup EC Book 3 NPCs: Yaganty, Xulgath Stoneliege, Runkrunk, and Cat Sith

### DIFF
--- a/packs/data/bestiary-effects.db/effect-cat-siths-mark.json
+++ b/packs/data/bestiary-effects.db/effect-cat-siths-mark.json
@@ -1,0 +1,56 @@
+{
+    "_id": "zTrZozbWDd1A5L5S",
+    "img": "systems/pf2e/icons/spells/fey-disapperance.webp",
+    "name": "Effect: Cat Sith's Mark",
+    "system": {
+        "badge": null,
+        "description": {
+            "value": "<p>Whenever the cursed creature rolls a critical success on a skill check or saving throw, it gets a success instead. Each day, a cursed creature can attempt a @Check[type:flat|dc:10|trait:curse,misfortune|name:Break Cat Sith's Mark] check to break the curse.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "unlimited",
+            "value": -1
+        },
+        "level": {
+            "value": 1
+        },
+        "rules": [
+            {
+                "adjustment": {
+                    "all": "one-degree-worse"
+                },
+                "key": "AdjustDegreeOfSuccess",
+                "selector": "saving-throw",
+                "type": "save"
+            },
+            {
+                "adjustment": {
+                    "all": "one-degree-worse"
+                },
+                "key": "AdjustDegreeOfSuccess",
+                "selector": "skill-check",
+                "type": "skill"
+            }
+        ],
+        "source": {
+            "value": ""
+        },
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "target": null,
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        },
+        "unidentified": false
+    },
+    "type": "effect"
+}

--- a/packs/data/bestiary-effects.db/effect-cat-siths-mark.json
+++ b/packs/data/bestiary-effects.db/effect-cat-siths-mark.json
@@ -19,7 +19,7 @@
         "rules": [
             {
                 "adjustment": {
-                    "all": "one-degree-worse"
+                    "criticalSuccess": "one-degree-worse"
                 },
                 "key": "AdjustDegreeOfSuccess",
                 "selector": "saving-throw",
@@ -27,7 +27,7 @@
             },
             {
                 "adjustment": {
-                    "all": "one-degree-worse"
+                    "criticalSuccess": "one-degree-worse"
                 },
                 "key": "AdjustDegreeOfSuccess",
                 "selector": "skill-check",
@@ -35,7 +35,7 @@
             }
         ],
         "source": {
-            "value": ""
+            "value": "Pathfinder #153: Life's Long Shadows"
         },
         "start": {
             "initiative": null,

--- a/packs/data/bestiary-effects.db/effect-ill-omen.json
+++ b/packs/data/bestiary-effects.db/effect-ill-omen.json
@@ -28,7 +28,7 @@
             }
         ],
         "source": {
-            "value": ""
+            "value": "Pathfinder #153: Life's Long Shadows"
         },
         "start": {
             "initiative": null,

--- a/packs/data/bestiary-effects.db/effect-ill-omen.json
+++ b/packs/data/bestiary-effects.db/effect-ill-omen.json
@@ -1,0 +1,49 @@
+{
+    "_id": "zXzXDlh0HkyPJu8f",
+    "img": "systems/pf2e/icons/spells/moon-frenzy.webp",
+    "name": "Effect: Ill Omen",
+    "system": {
+        "badge": null,
+        "description": {
+            "value": "<p>The creature takes a -1 penalty to attack rolls, skill checks, and saving throws while within the ill omen aura and becomes immune to fortune effects for 1 day.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "unlimited",
+            "value": -1
+        },
+        "level": {
+            "value": 1
+        },
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "selector": [
+                    "saving-throw",
+                    "attack",
+                    "skill-check"
+                ],
+                "value": -1
+            }
+        ],
+        "source": {
+            "value": ""
+        },
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "target": null,
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        },
+        "unidentified": false
+    },
+    "type": "effect"
+}

--- a/packs/data/extinction-curse-bestiary.db/cat-sith.json
+++ b/packs/data/extinction-curse-bestiary.db/cat-sith.json
@@ -112,7 +112,7 @@
             "type": "spellcastingEntry"
         },
         {
-            "_id": "v6Wf5KWz3b3ruI2y",
+            "_id": "n86sZNE8O0jn1kkF",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.2qGqa33E4GPUCbMV"
@@ -160,6 +160,7 @@
                     "value": 2
                 },
                 "location": {
+                    "heightenedLevel": 2,
                     "value": "zP8eq2K9H89vQwFw"
                 },
                 "materials": {
@@ -223,7 +224,7 @@
             "type": "spell"
         },
         {
-            "_id": "8Y87HOsudvHkIQNY",
+            "_id": "NPXKE4YvXOrMaRte",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.Mkbq9xlAUxHUHyR2"
@@ -281,6 +282,11 @@
                     "value": 2
                 },
                 "location": {
+                    "heightenedLevel": 2,
+                    "uses": {
+                        "max": 2,
+                        "value": 2
+                    },
                     "value": "zP8eq2K9H89vQwFw"
                 },
                 "materials": {
@@ -334,8 +340,7 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "mental",
-                        "occult"
+                        "mental"
                     ]
                 }
             },
@@ -427,7 +432,7 @@
             "type": "melee"
         },
         {
-            "_id": "6EcvoVX14Nrhhbna",
+            "_id": "NAIEy57GDQ8NKq2y",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.fFu2sZz4KB01fVRc"
@@ -487,7 +492,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>@Template[type:emanation|distance:60]{60 feet} @UUID[Compendium.pf2e.bestiary-ability-glossary-srd.Aura]{Aura}</p>\n<p>Any creature within the area that can see the cat sith must succeed at a @Check[type:will|dc:21] save or become struck by an ill omen. On a failure, the creature becomes immune to fortune effects as long as it remains in the aura and for 1 minute thereafter. On a critical failure, the creature takes a -1 penalty to attack rolls, skill checks, and saving throws while within the ill omen aura and becomes immune to fortune effects for 1 day.</p>"
+                    "value": "<p>@Template[type:emanation|distance:60]{60 feet} @UUID[Compendium.pf2e.bestiary-ability-glossary-srd.Aura]{Aura}</p>\n<p>Any creature within the area that can see the cat sith must succeed at a @Check[type:will|dc:21] save or become struck by an ill omen. On a failure, the creature becomes immune to fortune effects as long as it remains in the aura and for 1 minute thereafter. On a critical failure, the creature takes a -1 penalty to attack rolls, skill checks, and saving throws while within the ill omen aura and becomes immune to fortune effects for 1 day.</p>\n<hr />\n<p>@UUID[Compendium.pf2e.bestiary-effects.Effect: Ill Omen]{Effect: Ill Omen}</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -532,7 +537,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>A creature hit by a cat sith's claw must succeed at a @Check[type:will|dc:23] save or be cursed with misfortune. Whenever the cursed creature rolls a critical success on a skill check or saving throw, it gets a success instead. Each day, a cursed creature can attempt a @Check[type:flat|dc:10|name:Break Cat Sith's Mark] check to break the curse.</p>"
+                    "value": "<p>A creature hit by a cat sith's claw must succeed at a @Check[type:will|dc:23] save or be cursed with misfortune. Whenever the cursed creature rolls a critical success on a skill check or saving throw, it gets a success instead. Each day, a cursed creature can attempt a @Check[type:flat|dc:10|name:Break Cat Sith's Mark] check to break the curse.</p>\n<hr />\n<p>@UUID[Compendium.pf2e.bestiary-effects.Effect: Cat Sith's Mark]{Effect: Cat Sith's Mark}</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -575,7 +580,7 @@
                     "value": 2
                 },
                 "description": {
-                    "value": "<p>The cat sith touches a dying creature or a creature that died within the past 3 days. If the target is a dying creature, it must attempt a @Check[type:fortitude|dc:25] save; on a failure, its dying value increases by 1 (or 2 on a critical failure). If the target is dead, it receives no save and its soul is imprisoned in the cat sith's body, becoming freed only if the cat sith is slain. While the soul is imprisoned, the creature can't be brought back to life by any means short of a wish or miracle. The cat sith can hold only one soul at a time and can release a soul as a free action.</p>"
+                    "value": "<p>The cat sith touches a dying creature or a creature that died within the past 3 days. If the target is a dying creature, it must attempt a @Check[type:fortitude|dc:25] save; on a failure, its dying value increases by 1 (or 2 on a critical failure). If the target is dead, it receives no save and its soul is imprisoned in the cat sith's body, becoming freed only if the cat sith is slain. While the soul is imprisoned, the creature can't be brought back to life by any means short of a <em>@UUID[Compendium.pf2e.spells-srd.Wish]{Wish}</em> or <em>@UUID[Compendium.pf2e.spells-srd.Miracle]{Miracle}</em>. The cat sith can hold only one soul at a time and can release a soul as a free action.</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -744,7 +749,7 @@
                 "value": 6
             },
             "privateNotes": "",
-            "publicNotes": "",
+            "publicNotes": "<p>Cat siths can easily pass for common black house cats, noteworthy only for the white spots on their chests and their unusually bristly personalities. In actuality, they are cunning fey, fully capable of speech, trickery, and even walking upright on their hind legs and using their forepaws almost as skillfully as hands. Cat siths live around highland towns and cities, regularly venturing unnoticed into nearby communities by posing as domesticated felines or using magic to take humanoid form. While some cat siths gather information and undertake tasks for more powerful fey creatures, others serve only their own mysterious agendas.</p>\n<p>Cat siths are harbingers of misfortune and find amusement in the unluckiness that follows in their wake. Though they are rarely malicious, they are fascinated by death in all its forms, and may go so far as to steal the souls of the dying for some inscrutable purpose.</p>",
             "source": {
                 "value": "Pathfinder #153: Life's Long Shadows"
             }

--- a/packs/data/extinction-curse-bestiary.db/cat-sith.json
+++ b/packs/data/extinction-curse-bestiary.db/cat-sith.json
@@ -492,7 +492,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>@Template[type:emanation|distance:60]{60 feet} @UUID[Compendium.pf2e.bestiary-ability-glossary-srd.Aura]{Aura}</p>\n<p>Any creature within the area that can see the cat sith must succeed at a @Check[type:will|dc:21] save or become struck by an ill omen. On a failure, the creature becomes immune to fortune effects as long as it remains in the aura and for 1 minute thereafter. On a critical failure, the creature takes a -1 penalty to attack rolls, skill checks, and saving throws while within the ill omen aura and becomes immune to fortune effects for 1 day.</p>\n<hr />\n<p>@UUID[Compendium.pf2e.bestiary-effects.Effect: Ill Omen]{Effect: Ill Omen}</p>"
+                    "value": "<p>@Template[type:emanation|distance:60]{60 feet} @UUID[Compendium.pf2e.bestiary-ability-glossary-srd.Aura]{Aura}</p>\n<p>Any creature within the area that can see the cat sith must succeed at a @Check[type:will|dc:21] save or become struck by an ill omen. On a failure, the creature becomes immune to fortune effects as long as it remains in the aura and for 1 minute thereafter. On a critical failure, the creature takes a -1 penalty to attack rolls, skill checks, and saving throws while within the ill omen aura and becomes immune to fortune effects for 1 day.</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Effect: Ill Omen]{Effect: Ill Omen}</p>"
                 },
                 "requirements": {
                     "value": ""

--- a/packs/data/extinction-curse-bestiary.db/runkrunk.json
+++ b/packs/data/extinction-curse-bestiary.db/runkrunk.json
@@ -48,7 +48,7 @@
             "type": "melee"
         },
         {
-            "_id": "5TPY6WPs2yKNZ1jM",
+            "_id": "RHWWGr2v6M4d2qBz",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.qCCLZhnp2HhP3Ex6"
@@ -317,7 +317,7 @@
                     "value": 1
                 },
                 "description": {
-                    "value": "<p><strong>Requirements</strong> The golem is berserk.</p>\n<hr />\n<p><strong>Effect</strong> The clay golem @UUID[Compendium.pf2e.actionspf2e.Strike]{Strikes} with its fist at a -1 circumstance penalty. If it hits, it deals an additional [[/r {1d8}[bludgeoning]]]{1d8 bludgeoning damage} and knocks the target @UUID[Compendium.pf2e.conditionitems.Prone]{Prone}.</p>"
+                    "value": "<p><strong>Requirements</strong> The golem is berserk.</p>\n<hr />\n<p><strong>Effect</strong> The clay golem Strikes with its fist at a -1 circumstance penalty. If it hits, it deals an additional [[/r {1d8}[bludgeoning]]]{1d8 bludgeoning damage} and knocks the target @UUID[Compendium.pf2e.conditionitems.Prone]{Prone}.</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -558,7 +558,7 @@
         "traits": {
             "ci": [],
             "di": {
-                "custom": "",
+                "custom": "Magic (see Golem Antimagic)",
                 "value": [
                     "acid",
                     "bleed",
@@ -568,7 +568,6 @@
                     "drained",
                     "fatigued",
                     "healing",
-                    "magic",
                     "mental",
                     "necromancy",
                     "nonlethal-attacks",

--- a/packs/data/extinction-curse-bestiary.db/xulgath-stoneliege.json
+++ b/packs/data/extinction-curse-bestiary.db/xulgath-stoneliege.json
@@ -112,7 +112,7 @@
             "type": "spellcastingEntry"
         },
         {
-            "_id": "YwHD4QeXnVB1tD8C",
+            "_id": "4a9CzHBlA6bF9xkK",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.McnPlLFvKtQVXNcG"
@@ -319,6 +319,7 @@
                     "value": ""
                 },
                 "attackEffects": {
+                    "custom": "",
                     "value": [
                         "grab"
                     ]
@@ -354,7 +355,7 @@
             "type": "melee"
         },
         {
-            "_id": "BOeEBr5RTcqfpH0m",
+            "_id": "VsbGRflYaQb24YM7",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.qCCLZhnp2HhP3Ex6"
@@ -399,14 +400,14 @@
             "type": "action"
         },
         {
-            "_id": "iUtdet5TqBqTZ7LU",
+            "_id": "3QVgbicaKeJdgy6l",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.j2wsK6IsW5yMW1jW"
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense (Imprecise) 30 feet",
+            "name": "Tremorsense (imprecise) 30 feet",
             "sort": 700000,
             "system": {
                 "actionCategory": {
@@ -459,7 +460,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>30 feet. A creature that enters the area must attempt a @Check[type:fortitude|dc:24] save. On a failure, the creature is @UUID[Compendium.pf2e.conditionitems.Sickened]{Sickened 1}, and on a critical failure, the creature also takes a -5-foot status penalty to its Speeds for 1 round. While within the aura, the creature takes a -2 circumstance penalty to saves to recover from the @UUID[Compendium.pf2e.conditionitems.Sickened]{Sickened} condition. A creature that succeeds at its save is temporarily immune to all xulgaths' stenches for 1 minute.</p>"
+                    "value": "<p>@Template[type:emanation|distance:30]{30 feet} @UUID[Compendium.pf2e.bestiary-ability-glossary-srd.Aura]{Aura}</p>\n<hr />\n<p>A creature entering the aura must attempt a @Check[type:fortitude|dc:24] save. On a failure, the creature is @UUID[Compendium.pf2e.conditionitems.Sickened]{Sickened 1}, and on a critical failure, the creature also takes a -5-foot status penalty to its Speeds for 1 round. While within the aura, the creature takes a -2 circumstance penalty to saves to recover from the sickened condition. A creature that succeeds at its save is temporarily immune to all xulgaths' stench for 1 minute.</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Effect: Xulgath Stench]{Effect: Xulgath Stench}</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -616,7 +617,7 @@
             "type": "action"
         },
         {
-            "_id": "higNsDz9ZW1P7b5G",
+            "_id": "lGlw9snRuf39t1H3",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.Tkd8sH4pwFIPzqTr"
@@ -863,7 +864,7 @@
                 "value": 8
             },
             "privateNotes": "",
-            "publicNotes": "",
+            "publicNotes": "<p>Stonelieges are xulgaths magically infused with living earth—the very bones of the world. They are created through a process xulgaths call stone-binding, which can be performed with complex alchemy, powerful psychic magic, or Abyssal rituals. Their scales are like stone slabs, and their bones are as dense as bedrock, so they are among the hardiest and longest-lived xulgaths. To stonelieges, earth is as mutable as water, and their innate power to shape the soil and stone beneath their feet makes them integral members of xulgath society (as well as formidable combatants).</p>",
             "source": {
                 "value": "Pathfinder #153: Life's Long Shadows"
             }
@@ -896,9 +897,9 @@
             },
             "dr": [
                 {
-                    "label": "Physical",
+                    "exceptions": "",
                     "type": "physical",
-                    "value": "8"
+                    "value": 8
                 }
             ],
             "dv": [],

--- a/packs/data/extinction-curse-bestiary.db/yaganty.json
+++ b/packs/data/extinction-curse-bestiary.db/yaganty.json
@@ -112,7 +112,7 @@
             "type": "spellcastingEntry"
         },
         {
-            "_id": "eBVhev9U4WDKwCFr",
+            "_id": "jMXjNvH84Jg5Sk7O",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.VlNcjmYyu95vOUe8"
@@ -225,7 +225,6 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "occult",
                         "teleportation"
                     ]
                 }
@@ -233,7 +232,7 @@
             "type": "spell"
         },
         {
-            "_id": "Srsu0u0N7KKqEw9y",
+            "_id": "A5FCx8lIbcsUVO8d",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.4GE2ZdODgIQtg51c"
@@ -248,7 +247,7 @@
                 },
                 "area": {
                     "areaType": "burst",
-                    "value": "20"
+                    "value": 20
                 },
                 "areasize": {
                     "value": "20-foot burst"
@@ -338,15 +337,14 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "darkness",
-                        "occult"
+                        "darkness"
                     ]
                 }
             },
             "type": "spell"
         },
         {
-            "_id": "rLexOEMW50mQrvPT",
+            "_id": "RvMf41zpryADGZ5v",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.y6rAdMK6EFlV6U0t"
@@ -361,7 +359,7 @@
                 },
                 "area": {
                     "areaType": "cone",
-                    "value": "15"
+                    "value": 15
                 },
                 "areasize": {
                     "value": ""
@@ -381,10 +379,8 @@
                 "damage": {
                     "value": {
                         "0": {
-                            "applyMod": false,
                             "type": {
                                 "categories": [],
-                                "subtype": "",
                                 "value": "fire"
                             },
                             "value": "2d6"
@@ -470,15 +466,14 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "fire",
-                        "occult"
+                        "fire"
                     ]
                 }
             },
             "type": "spell"
         },
         {
-            "_id": "dDnGl1jyUzVNQckn",
+            "_id": "FuI6URovialGRq8P",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.O9w7r4BKgPogYDDe"
@@ -493,7 +488,7 @@
                 },
                 "area": {
                     "areaType": "",
-                    "value": ""
+                    "value": null
                 },
                 "areasize": {
                     "value": ""
@@ -516,7 +511,6 @@
                             "applyMod": true,
                             "type": {
                                 "categories": [],
-                                "subtype": "",
                                 "value": "fire"
                             },
                             "value": "1d4"
@@ -599,9 +593,8 @@
                     "rarity": "common",
                     "value": [
                         "attack",
-                        "cantrip",
                         "fire",
-                        "occult"
+                        "cantrip"
                     ]
                 }
             },
@@ -661,6 +654,7 @@
                     "value": ""
                 },
                 "attackEffects": {
+                    "custom": "",
                     "value": [
                         "grab"
                     ]
@@ -698,7 +692,7 @@
             "type": "melee"
         },
         {
-            "_id": "wiJYkffuGVmDIgZQ",
+            "_id": "ztjUvBPpUPyRPb5P",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.4Ho2xMPEC05aSxzr"
@@ -743,7 +737,7 @@
             "type": "action"
         },
         {
-            "_id": "Sd1XeR2dY94yR6eY",
+            "_id": "n178y9YC0VdwlUrF",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.hFtNbo1LKYCoDy2O"
@@ -849,7 +843,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>A yaganty who is doused with water or otherwise has their candle fingers extinguished takes @Localize[PF2E.PersistentDamage.Mental3d6.success], becomes @UUID[Compendium.pf2e.conditionitems.Quickened]{Quickened 1}, and screams in agony until they reignite their candles (typically by casting produce flame and lighting their fingers with an Interact action).</p>"
+                    "value": "<p>A yaganty who is doused with water or otherwise has their candle fingers extinguished takes @Localize[PF2E.PersistentDamage.Mental3d6.success], becomes @UUID[Compendium.pf2e.conditionitems.Quickened]{Quickened 1}, and screams in agony until they reignite their candles (typically by casting <em>@UUID[Compendium.pf2e.spells-srd.Produce Flame]{Produce Flame}</em> and lighting their fingers with an Interact action).</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -889,7 +883,7 @@
                     "value": 2
                 },
                 "description": {
-                    "value": "<p>The yaganty whips a stream of scalding wax in a @Template[type:line|distance:30]. Each glob deals [[/r {1d6}[persistent,fire]]] @UUID[Compendium.pf2e.conditionitems.Persistent Damage]{Persistent Fire Damage}. An affected creature or adjacent ally can remove one glob of wax by spending an Interact action to scrape it off. The yaganty can't use Fling Wax again for [[/br 1d4 #rounds]]{1d4 rounds}. Creatures in the area must attempt a @Check[type:reflex|dc:27|traits:damaging-effect] save.</p>\n<hr />\n<p><strong>Critical Success</strong> The creature is unaffected.</p>\n<p><strong>Success</strong> The creature is splattered with 1d2+1 globs of wax.</p>\n<p><strong>Failure</strong> The creature is splattered with 1d4+2 globs of wax.</p>\n<p><strong>Critical Failure</strong> As failure, and the creature is @UUID[Compendium.pf2e.conditionitems.Blinded]{Blinded} until it removes the globs of wax.</p>"
+                    "value": "<p>The yaganty whips a stream of scalding wax in a @Template[type:line|distance:30]. Each glob deals [[/r {1d6}[persistent,fire]]] @UUID[Compendium.pf2e.conditionitems.Persistent Damage]{Persistent Fire Damage}. An affected creature or adjacent ally can remove one glob of wax by spending an Interact action to scrape it off. The yaganty can't use Fling Wax again for [[/br 1d4 #rounds]]{1d4 rounds}. Creatures in the area must attempt a @Check[type:reflex|dc:27|traits:damaging-effect] save.</p>\n<hr />\n<p><strong>Critical Success</strong> The creature is unaffected.</p>\n<p><strong>Success</strong> The creature is splattered with [[/r 1d2+1]]{1d2+1 globs of wax}.</p>\n<p><strong>Failure</strong> The creature is splattered with [[/r 1d4+2]]{1d4+2 globs of wax}.</p>\n<p><strong>Critical Failure</strong> As failure, and the creature is @UUID[Compendium.pf2e.conditionitems.Blinded]{Blinded} until it removes the globs of wax.</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -916,7 +910,7 @@
             "type": "action"
         },
         {
-            "_id": "Q9t0tU1IUEQaozBF",
+            "_id": "7I2FYqAcQ3SORicy",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.Tkd8sH4pwFIPzqTr"
@@ -1130,7 +1124,7 @@
                 "value": 10
             },
             "privateNotes": "",
-            "publicNotes": "",
+            "publicNotes": "<p>Yaganties are lean, hairy humanoids with lanky torsos, horned heads, and bulbous black eyes. The elongated fingers of one their hands are made of candlestick wax, and their fingertips, which have wicks instead of nails, burn endlessly. In the dead of night, the flickering light of a yaganty's fingertips casts dramatic shadows across their face and highlights their trollish visage.</p>\n<p>Yaganty fables follow a common formula. A wayward pedestrian, traveling at night and usually in a forest, follows distant lights with the hope that the lights belong to a fellow wayfarer, only to come face-to-face with a gangly monster. The story ends in one of three ways: the traveler appeals to the yaganty with a gift of gold (the exact sum necessary varies wildly by the telling), the yaganty slays the traveler over some incomprehensible transgression, or, even more inexplicably, the yaganty offers the lost traveler five candles in simple charity so that the light might guide them home.</p>",
             "source": {
                 "value": "Pathfinder #153: Life's Long Shadows"
             }
@@ -1163,16 +1157,16 @@
             },
             "dr": [
                 {
-                    "label": "Fire",
+                    "exceptions": "",
                     "type": "fire",
-                    "value": "10"
+                    "value": 10
                 }
             ],
             "dv": [
                 {
-                    "label": "Cold Iron",
+                    "exceptions": "",
                     "type": "coldiron",
-                    "value": "10"
+                    "value": 10
                 }
             ],
             "languages": {


### PR DESCRIPTION
Brushup EC Book 3 NPCs: Yaganty, Xulgath Stoneliege, Runkrunk, and Cat Sith. Adds two effects for Cat Sith abilities.