### PR TITLE
Fix CheckPF2e rerolls being constructed from wrong data

### DIFF
--- a/src/module/system/rolls.ts
+++ b/src/module/system/rolls.ts
@@ -518,8 +518,9 @@ class CheckPF2e {
         if (!(oldRoll instanceof CheckRoll)) throw ErrorPF2e("Unexpected error retrieving prior roll");
 
         const RollCls = oldRoll.constructor as typeof Check.Roll;
-        const newData = { ...oldRoll.data, isReroll: true };
-        const newRoll = await new RollCls(oldRoll.formula, newData).evaluate({ async: true });
+        const newData = deepClone(oldRoll.data);
+        const newOptions = { ...oldRoll.options, isReroll: true };
+        const newRoll = await new RollCls(oldRoll.formula, newData, newOptions).evaluate({ async: true });
 
         // Keep the new roll by default; Old roll is discarded
         let keptRoll = newRoll;


### PR DESCRIPTION
`CheckRoll` expects the `data` object as the second constructor parameter and `option`s  as the third.
What previously was passed in as `data` corresponds to the current `options`. I'm not sure when that was changed.

Closes #4751 