### PR TITLE
Add automation to chronoskimmer

### DIFF
--- a/packs/data/feats.db/chronoskimmer-dedication.json
+++ b/packs/data/feats.db/chronoskimmer-dedication.json
@@ -24,7 +24,32 @@
         "prerequisites": {
             "value": []
         },
-        "rules": [],
+        "rules": [
+            {
+                "effectType": "fortune",
+                "key": "SubstituteRoll",
+                "label": "PF2E.SpecificRule.Chronoskimmer.StabilizeLabel",
+                "required": false,
+                "selector": "initiative",
+                "value": 10
+            },
+            {
+                "effectType": "fortune",
+                "key": "SubstituteRoll",
+                "label": "PF2E.SpecificRule.Chronoskimmer.DestabilizeSuccessLabel",
+                "required": false,
+                "selector": "initiative",
+                "value": 19
+            },
+            {
+                "effectType": "fortune",
+                "key": "SubstituteRoll",
+                "label": "PF2E.SpecificRule.Chronoskimmer.DestabilizeFailureLabel",
+                "required": false,
+                "selector": "initiative",
+                "value": 1
+            }
+        ],
         "source": {
             "value": "Pathfinder Dark Archive"
         },

--- a/src/module/actor/creature/index.ts
+++ b/src/module/actor/creature/index.ts
@@ -25,7 +25,12 @@ import { Rarity, SIZES, SIZE_SLUGS } from "@module/data";
 import { CombatantPF2e } from "@module/encounter";
 import { RollNotePF2e } from "@module/notes";
 import { RuleElementSynthetics } from "@module/rules";
-import { extractModifierAdjustments, extractModifiers, extractRollTwice } from "@module/rules/util";
+import {
+    extractModifierAdjustments,
+    extractModifiers,
+    extractRollTwice,
+    extractRollSubstitutions,
+} from "@module/rules/util";
 import { LightLevels } from "@module/scene/data";
 import { UserPF2e } from "@module/user";
 import { CheckPF2e, CheckRoll, CheckRollContext } from "@system/check";
@@ -461,6 +466,7 @@ export abstract class CreaturePF2e extends ActorPF2e {
                 if (!combatant) return null;
 
                 const rollTwice = extractRollTwice(this.synthetics.rollTwice, domains, rollOptions);
+                const substitutions = extractRollSubstitutions(this.synthetics.rollSubstitutions, domains, rollOptions);
                 const context: CheckRollContext = {
                     actor: this,
                     type: "initiative",
@@ -470,6 +476,7 @@ export abstract class CreaturePF2e extends ActorPF2e {
                     rollTwice,
                     skipDialog: args.skipDialog,
                     rollMode: args.rollMode,
+                    substitutions,
                 };
                 if (combatant.hidden) {
                     context.rollMode = CONST.DICE_ROLL_MODES.PRIVATE;

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -1055,6 +1055,11 @@
             "CelestialResistance": {
                 "Prompt": "Select a type of energy associated with your bloodline."
             },
+            "Chronoskimmer": {
+                "DestabilizeFailureLabel": "Destabilize timestream (Failure)",
+                "DestabilizeSuccessLabel": "Destabilize timestream (Success)",
+                "StabilizeLabel": "Stabilize timestream"
+            },
             "ClanWeapon": {
                 "Label": "Clan Weapon",
                 "Prompt": "Select a clan weapon.",


### PR DESCRIPTION
Resolves #4107

I'm not entirely sure whether I need to follow in the steps of the example for assurance where other modifiers need to be suppressed.
Adds roll options to improve automation. Does not automate the flat check.