### PR TITLE
Release token when setting actorLink to false

### DIFF
--- a/src/module/scene/token-document/document.ts
+++ b/src/module/scene/token-document/document.ts
@@ -371,6 +371,11 @@ class TokenDocumentPF2e<TActor extends ActorPF2e = ActorPF2e> extends TokenDocum
             ui.combat.render();
         }
 
+        // Workaround for actor-data preparation issue: release token if this is made unlinked while controlled
+        if (changed.actorLink === false && this.rendered && this.object.controlled) {
+            this.object.release();
+        }
+
         // Handle ephemeral changes from synthetic actor
         if (!this.actorLink && this.parent && changed.actorData) {
             const preUpdateIcon = this.texture.src;


### PR DESCRIPTION
This is a workaround for an actor-data preparation issue in which retrieving a synthetic actor before it's made will cause a stack overflow