### PR TITLE
Allow effect badge counters to be set on drag

### DIFF
--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -754,6 +754,11 @@ export abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorShee
             if (typeof level === "number" && level >= 0) {
                 itemSource.system.level.value = level;
             }
+        } else if (itemSource.type === "effect" && data && itemSource.system.badge) {
+            const value = data.value;
+            if (typeof value === "number" && itemSource.system.badge.type === "counter") {
+                itemSource.system.badge.value = value;
+            }
         } else if (item.isOfType("physical") && actor.isOfType("character") && craftingTab) {
             const actorFormulas = deepClone(actor.system.crafting.formulas);
             if (!actorFormulas.some((f) => f.uuid === item.uuid)) {


### PR DESCRIPTION
This will allow us to condense some effects as we can just use the badge number in the label similar to how conditions are handled.