### PR TITLE
Set secret trait roll mode before dialog and remove secret parameter

### DIFF
--- a/src/module/system/check-modifiers-dialog.ts
+++ b/src/module/system/check-modifiers-dialog.ts
@@ -32,12 +32,6 @@ export class CheckModifiersDialog extends Application {
         this.resolve = resolve;
         this.substitutions = context?.substitutions ?? [];
         this.context = context;
-
-        if (this.context.secret) {
-            this.context.rollMode = "blindroll";
-        } else {
-            this.context.rollMode ??= game.settings.get("core", "rollMode");
-        }
     }
 
     static override get defaultOptions(): ApplicationOptions {

--- a/src/module/system/check/check.ts
+++ b/src/module/system/check/check.ts
@@ -51,6 +51,10 @@ class CheckPF2e {
         if (Array.isArray(context.options)) context.options = new Set(context.options);
         const rollOptions = context.options ?? new Set();
 
+        // Figure out the default roll mode (if not already set by the event)
+        if (rollOptions.has("secret")) context.rollMode ??= "blindroll";
+        context.rollMode ??= game.settings.get("core", "rollMode");
+
         if (rollOptions.size > 0 && !context.isReroll) {
             check.calculateTotal(rollOptions);
         }
@@ -209,8 +213,6 @@ class CheckPF2e {
                 .join("");
         })();
 
-        const secret = context.secret ?? rollOptions.has("secret");
-
         const contextFlag: CheckRollContextFlag = {
             ...context,
             item: undefined,
@@ -220,8 +222,7 @@ class CheckPF2e {
             target: context.target ? { actor: context.target.actor.uuid, token: context.target.token.uuid } : null,
             options: Array.from(rollOptions).sort(),
             notes: notes.filter((n) => n.predicate.test(rollOptions)).map((n) => n.toObject()),
-            secret,
-            rollMode: secret ? "blindroll" : context.rollMode ?? game.settings.get("core", "rollMode"),
+            rollMode: context.rollMode ?? game.settings.get("core", "rollMode"),
             rollTwice: context.rollTwice ?? false,
             title: context.title ?? "PF2E.Check.Label",
             type: context.type ?? "check",

--- a/src/module/system/rolls.ts
+++ b/src/module/system/rolls.ts
@@ -43,8 +43,6 @@ interface BaseRollContext {
     options?: Set<string>;
     /** Any notes which should be shown for the roll. */
     notes?: (RollNotePF2e | RollNoteSource)[];
-    /** If true, this is a secret roll which should only be seen by the GM. */
-    secret?: boolean;
     /** The roll mode (i.e., 'roll', 'blindroll', etc) to use when rendering this roll. */
     rollMode?: RollMode;
     /** If this is an attack, the target of that attack */


### PR DESCRIPTION
This should lead to actual secret trait feeling less buggy. Clicking a secret roll button will set the roll mode to blind in the dropdown of the dialog, rather than doing it as a surprise last minute.