### PR TITLE
Make `RollDataPF2e#damaging` required

### DIFF
--- a/src/module/chat-message/data.ts
+++ b/src/module/chat-message/data.ts
@@ -38,7 +38,7 @@ type ChatMessageFlagsPF2e = foundry.data.ChatMessageFlags & {
 interface StrikeLookupData {
     actor: ActorUUID | TokenDocumentUUID;
     index: number;
-    damaging?: boolean;
+    damaging: boolean;
     name: string;
     altUsage?: "thrown" | "melee" | null;
 }

--- a/src/module/system/check/strike/attack-roll.ts
+++ b/src/module/system/check/strike/attack-roll.ts
@@ -7,11 +7,6 @@ export class StrikeAttackRoll extends CheckRoll {
         if (!this._evaluated) await this.evaluate({ async: true });
         const { isPrivate, flavor, template } = options;
 
-        // Temporarily fill missing property
-        if (this.options.strike) {
-            this.options.strike.damaging ??= true;
-        }
-
         const chatData: Record<string, unknown> = {
             formula: isPrivate ? "???" : this._formula,
             flavor: isPrivate ? null : flavor,


### PR DESCRIPTION
This was just a backward compatiblity attempt so that recent attack roll chat messages prior to updating would be considered damaging