### PR TITLE
Brushup EC Book 4 NPCs part 1

### DIFF
--- a/packs/data/bestiary-effects.db/effect-deceitful-feast-failure.json
+++ b/packs/data/bestiary-effects.db/effect-deceitful-feast-failure.json
@@ -1,0 +1,53 @@
+{
+    "_id": "vc3AOrJpacJ7T1hO",
+    "img": "systems/pf2e/icons/spells/heroes-feast.webp",
+    "name": "Effect: Deceitful Feast (Failure)",
+    "system": {
+        "badge": {
+            "type": "counter",
+            "value": 1
+        },
+        "description": {
+            "value": "<p>The creature takes a -1 circumstance penalty to Will saves against any of the brughadatch's spells or abilities. The penalty increases with each failed save, to a maximum of -5.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "unlimited",
+            "value": -1
+        },
+        "level": {
+            "value": 10
+        },
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "origin:trait:fey",
+                    "origin:trait:amphibious"
+                ],
+                "selector": "will",
+                "type": "circumstance",
+                "value": "-@item.badge.value"
+            }
+        ],
+        "source": {
+            "value": "Pathfinder #154: Siege of the Dinosaurs"
+        },
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "target": null,
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        },
+        "unidentified": false
+    },
+    "type": "effect"
+}

--- a/packs/data/bestiary-effects.db/effect-deceitful-feast-failure.json
+++ b/packs/data/bestiary-effects.db/effect-deceitful-feast-failure.json
@@ -23,8 +23,7 @@
             {
                 "key": "FlatModifier",
                 "predicate": [
-                    "origin:trait:fey",
-                    "origin:trait:amphibious"
+                    "origin:name:brughadatch"
                 ],
                 "selector": "will",
                 "type": "circumstance",

--- a/packs/data/extinction-curse-bestiary.db/brughadatch.json
+++ b/packs/data/extinction-curse-bestiary.db/brughadatch.json
@@ -1260,7 +1260,13 @@
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "domain": "all",
+                        "key": "RollOption",
+                        "option": "self:name:brughadatch"
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""

--- a/packs/data/extinction-curse-bestiary.db/brughadatch.json
+++ b/packs/data/extinction-curse-bestiary.db/brughadatch.json
@@ -110,7 +110,7 @@
             "type": "spellcastingEntry"
         },
         {
-            "_id": "6USlYA38sqGxcwG8",
+            "_id": "ynX8G4uYLHMHNihb",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.LiGbewa9pO0yjbsY"
@@ -224,14 +224,15 @@
                     "rarity": "common",
                     "value": [
                         "emotion",
-                        "mental"
+                        "mental",
+                        "primal"
                     ]
                 }
             },
             "type": "spell"
         },
         {
-            "_id": "NkGtJCRELnWwlnKw",
+            "_id": "8pRFsXM33LWB2RgP",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.IihxWhRfpsBgQ5jS"
@@ -246,7 +247,7 @@
                 },
                 "area": {
                     "areaType": "",
-                    "value": null
+                    "value": ""
                 },
                 "areasize": {
                     "value": ""
@@ -339,14 +340,15 @@
                     "rarity": "common",
                     "value": [
                         "auditory",
-                        "emotion"
+                        "emotion",
+                        "primal"
                     ]
                 }
             },
             "type": "spell"
         },
         {
-            "_id": "ZB9t6M119c34t3oC",
+            "_id": "ZixVF8IxkTYL68z1",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.HRb2doyaLtaoCfi3"
@@ -361,7 +363,7 @@
                 },
                 "area": {
                     "areaType": "burst",
-                    "value": 10
+                    "value": "10"
                 },
                 "areasize": {
                     "value": "10-foot burst"
@@ -450,14 +452,15 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "light"
+                        "light",
+                        "primal"
                     ]
                 }
             },
             "type": "spell"
         },
         {
-            "_id": "Y6tVshdW8l8FJEjE",
+            "_id": "ApFDFlsUVFDxLeaD",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.tlSE7Ly8vi1Dgddv"
@@ -472,7 +475,7 @@
                 },
                 "area": {
                     "areaType": "",
-                    "value": null
+                    "value": ""
                 },
                 "areasize": {
                     "value": ""
@@ -561,21 +564,22 @@
                     "rarity": "common",
                     "value": [
                         "emotion",
-                        "mental"
+                        "mental",
+                        "primal"
                     ]
                 }
             },
             "type": "spell"
         },
         {
-            "_id": "y8vGTIiAyi5xZLCi",
+            "_id": "q2hMXszV7WfZt7lw",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.vLA0q0WOK2YPuJs6"
                 }
             },
             "img": "systems/pf2e/icons/spells/charm.webp",
-            "name": "Charm (At Will)",
+            "name": "Charm (At-Will)",
             "sort": 600000,
             "system": {
                 "ability": {
@@ -617,9 +621,6 @@
                         "8": {
                             "target": {
                                 "value": "10 creatures"
-                            },
-                            "time": {
-                                "value": "2"
                             }
                         }
                     },
@@ -695,7 +696,7 @@
             "type": "spell"
         },
         {
-            "_id": "f0TCqvICfTf6hmnC",
+            "_id": "uecgewf3w1w4H4uK",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.gpzpAAAJ1Lza2JVl"
@@ -800,22 +801,23 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
+                        "cantrip",
                         "detection",
-                        "cantrip"
+                        "primal"
                     ]
                 }
             },
             "type": "spell"
         },
         {
-            "_id": "5nsrAn3nFM4LfcE6",
+            "_id": "5fE5X1TnaedkAQkG",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.4koZzrnMXhhosn0D"
                 }
             },
             "img": "systems/pf2e/icons/spells/fear.webp",
-            "name": "Fear (At Will)",
+            "name": "Fear (At-Will)",
             "sort": 800000,
             "system": {
                 "ability": {
@@ -857,9 +859,6 @@
                         "3": {
                             "target": {
                                 "value": "5 creatures"
-                            },
-                            "time": {
-                                "value": "2"
                             }
                         }
                     },
@@ -936,7 +935,7 @@
             "type": "spell"
         },
         {
-            "_id": "xQjaMzfT93e6EsGi",
+            "_id": "kmFLLYOKWX1PRRi4",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.O9w7r4BKgPogYDDe"
@@ -951,7 +950,7 @@
                 },
                 "area": {
                     "areaType": "",
-                    "value": null
+                    "value": ""
                 },
                 "areasize": {
                     "value": ""
@@ -974,6 +973,7 @@
                             "applyMod": true,
                             "type": {
                                 "categories": [],
+                                "subtype": "",
                                 "value": "fire"
                             },
                             "value": "1d4"
@@ -1056,8 +1056,9 @@
                     "rarity": "common",
                     "value": [
                         "attack",
+                        "cantrip",
                         "fire",
-                        "cantrip"
+                        "primal"
                     ]
                 }
             },
@@ -1073,6 +1074,7 @@
                     "value": ""
                 },
                 "attackEffects": {
+                    "custom": "",
                     "value": [
                         "grab"
                     ]
@@ -1137,7 +1139,9 @@
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "agile"
+                    ]
                 },
                 "weaponType": {
                     "value": "melee"
@@ -1146,7 +1150,52 @@
             "type": "melee"
         },
         {
-            "_id": "ErQkuHl7SaaIqYL9",
+            "_id": "DqZJwi3AmpInsFhs",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.qCCLZhnp2HhP3Ex6"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Darkvision",
+            "sort": 1200000,
+            "system": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Darkvision]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "darkvision",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "a0TSS06q0DBjSQ3n",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.2YRDYVnC1eljaXKK"
@@ -1154,7 +1203,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "At-Will Spells",
-            "sort": 1200000,
+            "sort": 1300000,
             "system": {
                 "actionCategory": {
                     "value": "interaction"
@@ -1194,7 +1243,7 @@
             "_id": "YHBBkkagd6BLfiQo",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Deceitful Feast",
-            "sort": 1300000,
+            "sort": 1400000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -1206,7 +1255,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>The brughadatch conjures a decadent, enticing feast void of nutritional substance. This conjuration takes 1 minute and lasts for 24 hours. For each item of illusory food a creature eats, it must attempt a @Check[type:will|dc:29] save.</p>\n<hr />\n<p><strong>Critical Success</strong> The creature sees through the illusion and becomes immune to the effects of Deceitful Feast for 24 hours.</p>\n<p><strong>Success</strong> The creature doesn't see through the illusion but is unaffected by the food.</p>\n<p><strong>Failure</strong> The creature takes a -1 circumstance penalty to Will saves against any of the brughadatch's spells or abilities. The penalty increases with each failed save, to a maximum of -5.</p>\n<p><strong>Critical Failure</strong> As failure, plus for 1 hour, the creature's attitude becomes helpful to the brughadatch, and the creature can't use hostile actions against them.</p>"
+                    "value": "<p>The brughadatch conjures a decadent, enticing feast void of nutritional substance. This conjuration takes 1 minute and lasts for 24 hours. For each item of illusory food a creature eats, it must attempt a @Check[type:will|dc:29] save.</p>\n<hr />\n<p><strong>Critical Success</strong> The creature sees through the illusion and becomes immune to the effects of Deceitful Feast for 24 hours.</p>\n<p><strong>Success</strong> The creature doesn't see through the illusion but is unaffected by the food.</p>\n<p><strong>Failure</strong> The creature takes a -1 circumstance penalty to Will saves against any of the brughadatch's spells or abilities. The penalty increases with each failed save, to a maximum of -5.</p>\n<p><strong>Critical Failure</strong> As failure, plus for 1 hour, the creature's attitude becomes helpful to the brughadatch, and the creature can't use hostile actions against them.</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Effect: Deceitful Feast (Failure)]{Effect: Deceitful Feast (Failure)}</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -1236,7 +1285,7 @@
             "_id": "oKMZi1P2n9vQ9SvK",
             "img": "systems/pf2e/icons/actions/OneAction.webp",
             "name": "Psychic Sip",
-            "sort": 1400000,
+            "sort": 1500000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -1248,7 +1297,7 @@
                     "value": 1
                 },
                 "description": {
-                    "value": "<p><strong>Requirements</strong> Targets must have critically failed a save against a brughadatch's Deceitful Feast or charm innate spell</p>\n<p><strong>Frequency</strong> once per round</p>\n<hr />\n<p><strong>Effect</strong> The brughadatch feasts on the souls of the creatures they've tricked. They target up to five creatures within 30 feet and feast on their ambient brainpower, dealing [[/r {4d10}[mental]]]{4d10 mental damage} (@Check[type:will|dc:26|basic:true] save) to each creature. Unless a target succeeds at the Will save, this damage does not end the charm effect or the effect of Deceitful Feast as a hostile action normally would.</p>"
+                    "value": "<p><strong>Requirements</strong> Targets must have critically failed a save against a brughadatch's Deceitful Feast or charm innate spell</p>\n<p><strong>Frequency</strong> once per round</p>\n<hr />\n<p><strong>Effect</strong> The brughadatch feasts on the souls of the creatures they've tricked. They target up to five creatures within 30 feet and feast on their ambient brainpower, dealing [[/r {4d10}[mental]]]{4d10 mental damage} (@Check[type:will|dc:26|basic:true] save) to each creature. Unless a target succeeds at the Will save, this damage does not end the <em>@UUID[Compendium.pf2e.spells-srd.Charm]{Charm}</em> effect or the effect of Deceitful Feast as a hostile action normally would.</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -1273,10 +1322,55 @@
             "type": "action"
         },
         {
+            "_id": "75B144VmeAAs88N3",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.Tkd8sH4pwFIPzqTr"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Grab",
+            "sort": 1600000,
+            "system": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Grab]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "grab",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
             "_id": "DIaU2wUNHLckNrwx",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Athletics",
-            "sort": 1500000,
+            "sort": 1700000,
             "system": {
                 "description": {
                     "value": ""
@@ -1304,7 +1398,7 @@
             "_id": "rVDixTgehUPgrN1A",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Deception",
-            "sort": 1600000,
+            "sort": 1800000,
             "system": {
                 "description": {
                     "value": ""
@@ -1332,7 +1426,7 @@
             "_id": "IPHFHuqjtseI01hk",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Intimidation",
-            "sort": 1700000,
+            "sort": 1900000,
             "system": {
                 "description": {
                     "value": ""
@@ -1360,7 +1454,7 @@
             "_id": "54Y6gzUCq4wQe1C8",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Nature",
-            "sort": 1800000,
+            "sort": 2000000,
             "system": {
                 "description": {
                     "value": ""
@@ -1388,7 +1482,7 @@
             "_id": "iVVUJz4LU8bTOBDk",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Survival",
-            "sort": 1900000,
+            "sort": 2100000,
             "system": {
                 "description": {
                     "value": ""
@@ -1475,7 +1569,7 @@
                 "value": 10
             },
             "privateNotes": "",
-            "publicNotes": "",
+            "publicNotes": "<p>The biggest difference between a gahlepod and a grown brughadatch isn't their humanoid appearance, but the powerful magic they gain as they mature.</p>\n<hr />\n<p>Brughadatches are malevolent fey tricksters with distinct stages of life: they spawn from the First World's primal energies as esurient tadpoles, grow into humanoids capable of creating enticing illusions, then finally evolve into huge, slothful toads that warp their environs with mere thoughts.</p>",
             "source": {
                 "value": "Pathfinder #154: Siege of the Dinosaurs"
             }

--- a/packs/data/extinction-curse-bestiary.db/gahlepod.json
+++ b/packs/data/extinction-curse-bestiary.db/gahlepod.json
@@ -43,10 +43,100 @@
             "type": "melee"
         },
         {
+            "_id": "9GD9cU7HYaHGStvx",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.qCCLZhnp2HhP3Ex6"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Darkvision",
+            "sort": 200000,
+            "system": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Darkvision]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "darkvision",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "1PpMA6kgFuFqrS88",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.rqfnQ5VHT5hxm25r"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Scent (Imprecise) 30 feet",
+            "sort": 300000,
+            "system": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Scent]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "scent",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
             "_id": "jMeQhmA9WidXyyaB",
             "img": "systems/pf2e/icons/actions/Reaction.webp",
             "name": "Churning Frenzy",
-            "sort": 200000,
+            "sort": 400000,
             "system": {
                 "actionCategory": {
                     "value": "defensive"
@@ -63,7 +153,41 @@
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "key": "Note",
+                        "outcome": [
+                            "criticalSuccess"
+                        ],
+                        "predicate": [
+                            "item:jaws",
+                            "churning-frenzy"
+                        ],
+                        "selector": "strike-damage",
+                        "text": "The gahlepod is spurred into a frenzy by the others. For the rest of the round, their jaws Strike deals @Localize[PF2E.PersistentDamage.Bleed1d6.criticalSuccess] in addition to the listed damage.",
+                        "title": "Churning Frenzy"
+                    },
+                    {
+                        "domain": "damage",
+                        "key": "RollOption",
+                        "option": "churning-frenzy",
+                        "toggleable": true,
+                        "value": false
+                    },
+                    {
+                        "key": "Note",
+                        "outcome": [
+                            "success"
+                        ],
+                        "predicate": [
+                            "item:jaws",
+                            "churning-frenzy"
+                        ],
+                        "selector": "strike-damage",
+                        "text": "The gahlepod is spurred into a frenzy by the others. For the rest of the round, their jaws Strike deals @Localize[PF2E.PersistentDamage.Bleed1d6.success] in addition to the listed damage.",
+                        "title": "Churning Frenzy"
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""
@@ -86,7 +210,7 @@
             "_id": "jfPpeD4tNHyNCw4q",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Acrobatics",
-            "sort": 300000,
+            "sort": 500000,
             "system": {
                 "description": {
                     "value": ""
@@ -114,7 +238,7 @@
             "_id": "BSwEGR2JSKpN9oBP",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Survival",
-            "sort": 400000,
+            "sort": 600000,
             "system": {
                 "description": {
                     "value": ""
@@ -201,7 +325,7 @@
                 "value": 7
             },
             "privateNotes": "",
-            "publicNotes": "",
+            "publicNotes": "<p>The youngest brughadatches resemble overlarge tadpoles about 2 feet long.</p>\n<hr />\n<p>Brughadatches are malevolent fey tricksters with distinct stages of life: they spawn from the First World's primal energies as esurient tadpoles, grow into humanoids capable of creating enticing illusions, then finally evolve into huge, slothful toads that warp their environs with mere thoughts.</p>",
             "source": {
                 "value": "Pathfinder #154: Siege of the Dinosaurs"
             }
@@ -230,13 +354,13 @@
             "dr": [],
             "dv": [
                 {
-                    "label": "Cold Iron",
+                    "exceptions": "",
                     "type": "coldiron",
-                    "value": "5"
+                    "value": 5
                 }
             ],
             "languages": {
-                "custom": "",
+                "custom": "Can't Speak Any Language",
                 "selected": [],
                 "value": [
                     "sylvan"

--- a/packs/data/extinction-curse-bestiary.db/gahlepod.json
+++ b/packs/data/extinction-curse-bestiary.db/gahlepod.json
@@ -164,7 +164,7 @@
                             "churning-frenzy"
                         ],
                         "selector": "strike-damage",
-                        "text": "@Localize[PF2E.PersistentDamage.Bleed1d6.criticalSuccess]",
+                        "text": "PF2E.PersistentDamage.Bleed1d6.criticalSuccess",
                         "title": "{item|name}"
                     },
                     {
@@ -184,7 +184,7 @@
                             "churning-frenzy"
                         ],
                         "selector": "strike-damage",
-                        "text": "@Localize[PF2E.PersistentDamage.Bleed1d6.success]",
+                        "text": "PF2E.PersistentDamage.Bleed1d6.success",
                         "title": "{item|name}"
                     }
                 ],

--- a/packs/data/extinction-curse-bestiary.db/gahlepod.json
+++ b/packs/data/extinction-curse-bestiary.db/gahlepod.json
@@ -160,12 +160,12 @@
                             "criticalSuccess"
                         ],
                         "predicate": [
-                            "item:jaws",
+                            "item:slug:jaws",
                             "churning-frenzy"
                         ],
                         "selector": "strike-damage",
-                        "text": "The gahlepod is spurred into a frenzy by the others. For the rest of the round, their jaws Strike deals @Localize[PF2E.PersistentDamage.Bleed1d6.criticalSuccess] in addition to the listed damage.",
-                        "title": "Churning Frenzy"
+                        "text": "@Localize[PF2E.PersistentDamage.Bleed1d6.criticalSuccess]",
+                        "title": "{item|name}"
                     },
                     {
                         "domain": "damage",
@@ -180,12 +180,12 @@
                             "success"
                         ],
                         "predicate": [
-                            "item:jaws",
+                            "item:slug:jaws",
                             "churning-frenzy"
                         ],
                         "selector": "strike-damage",
-                        "text": "The gahlepod is spurred into a frenzy by the others. For the rest of the round, their jaws Strike deals @Localize[PF2E.PersistentDamage.Bleed1d6.success] in addition to the listed damage.",
-                        "title": "Churning Frenzy"
+                        "text": "@Localize[PF2E.PersistentDamage.Bleed1d6.success]",
+                        "title": "{item|name}"
                     }
                 ],
                 "slug": null,

--- a/packs/data/extinction-curse-bestiary.db/starved-staff.json
+++ b/packs/data/extinction-curse-bestiary.db/starved-staff.json
@@ -12,6 +12,7 @@
                     "value": ""
                 },
                 "attackEffects": {
+                    "custom": "",
                     "value": [
                         "grab"
                     ]
@@ -26,7 +27,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>(reach 10 feet)</p>"
+                    "value": ""
                 },
                 "rules": [],
                 "slug": null,
@@ -68,7 +69,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>(agile, reach 15 feet)</p>"
+                    "value": ""
                 },
                 "rules": [],
                 "slug": null,
@@ -90,13 +91,18 @@
             "type": "melee"
         },
         {
-            "_id": "rNe7hr19TVEKyp1e",
+            "_id": "6x5ndW51ukQRdEkd",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.qCCLZhnp2HhP3Ex6"
+                }
+            },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Starvation Aura",
+            "name": "Darkvision",
             "sort": 300000,
             "system": {
                 "actionCategory": {
-                    "value": "defensive"
+                    "value": "interaction"
                 },
                 "actionType": {
                     "value": "passive"
@@ -105,15 +111,15 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>(aura, divine, mental, necromancy) 60 feet. Any creature that ends its turn in the aura feels the intense pain of starvation and must attempt a @Check[type:fortitude|dc:32|traits:damaging-effect] save. On a failure, the creature becomes fatigued and takes [[/r {7d6}]]{7d6 damage}. The damage and fatigue a creature takes from this aura can't be healed until the affected creature has eaten a full meal.</p>"
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Darkvision]</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "darkvision",
                 "source": {
-                    "value": ""
+                    "value": "Pathfinder Bestiary"
                 },
                 "traits": {
                     "custom": "",
@@ -130,10 +136,122 @@
             "type": "action"
         },
         {
+            "_id": "LqrQ3Kv7BGLa9Qyo",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.TTCw5NusiSSkJU1x"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Negative Healing",
+            "sort": 400000,
+            "system": {
+                "actionCategory": {
+                    "value": "defensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.NegativeHealing]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "system.attributes.hp.negativeHealing",
+                        "value": true
+                    }
+                ],
+                "slug": "negative-healing",
+                "source": {
+                    "value": "Pathfinder Bestiary 2"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "rNe7hr19TVEKyp1e",
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Starvation Aura",
+            "sort": 500000,
+            "system": {
+                "actionCategory": {
+                    "value": "defensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Template[type:emanation|distance:60]{60 feet} @UUID[Compendium.pf2e.bestiary-ability-glossary-srd.Aura]{Aura}</p>\n<p>Any creature that ends its turn in the aura feels the intense pain of starvation and must attempt a @Check[type:fortitude|dc:32] save. On a failure, the creature becomes @UUID[Compendium.pf2e.conditionitems.Fatigued]{Fatigued} and takes [[/r 7d6]]{7d6 damage}. Damage and fatigue a creature takes from this aura can't be healed until the affected creature has eaten a full meal.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [
+                    {
+                        "colors": {
+                            "border": "#00FF00",
+                            "fill": "#00FF00"
+                        },
+                        "key": "Aura",
+                        "radius": 30,
+                        "slug": "starvation-aura",
+                        "traits": [
+                            "divine",
+                            "mental",
+                            "necromancy"
+                        ]
+                    }
+                ],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "aura",
+                        "divine",
+                        "mental",
+                        "necromancy"
+                    ]
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
             "_id": "tk1qMQuv7snMkpnc",
             "img": "systems/pf2e/icons/actions/TwoActions.webp",
             "name": "Breath Weapon",
-            "sort": 400000,
+            "sort": 600000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -145,7 +263,7 @@
                     "value": 2
                 },
                 "description": {
-                    "value": "<p>The gashadokuro breathes a spray of bone shards in a @Template[type:cone|distance:30]. Each creature in the area takes [[/r {9d12}[piercing]]]{9d12 piercing damage} (@Check[type:reflex|dc:36|basic:true] save). It can't use again for [[/br 1d4 #rounds]]{1d4 rounds}.</p>"
+                    "value": "<p>The gashadokuro breathes a spray of bone shards in a @Template[type:cone|distance:30]. Each creature in the area takes [[/r {9d12}[piercing]]]{9d12 piercing damage} (@Check[type:reflex|dc:36|basic:true] save).</p>\n<p>It can't use Breath Weapon again for [[/br 1d4 #rounds]]{1d4 rounds}.</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -176,7 +294,7 @@
             "_id": "vhSzb4rXivmMx69j",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Corpse Consumption",
-            "sort": 500000,
+            "sort": 700000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -188,7 +306,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>(divine, necromancy) If the gashadokuro kills a creature with Swallow Whole, it immediately regains Hit Points equal to the swallowed creature's level. As long as the gashadokuro still exists, creatures consumed in this way can't be resurrected except by wish or a similarly powerful effect.</p>"
+                    "value": "<p>If the gashadokuro kills a creature with Swallow Whole, it immediately regains Hit Points equal to the swallowed creature's level. As long as the gashadokuro still exists, creatures consumed in this way can't be resurrected except by <em>@UUID[Compendium.pf2e.spells-srd.Wish]{Wish}</em> or a similarly powerful effect.</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -201,7 +319,10 @@
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "divine",
+                        "necromancy"
+                    ]
                 },
                 "trigger": {
                     "value": ""
@@ -213,10 +334,15 @@
             "type": "action"
         },
         {
-            "_id": "BvLfh5ffQBKPiHJF",
+            "_id": "3gJM7nNe6xASowZz",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.uJSseLa57HZYSMUu"
+                }
+            },
             "img": "systems/pf2e/icons/actions/OneAction.webp",
             "name": "Swallow Whole",
-            "sort": 600000,
+            "sort": 800000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -228,15 +354,15 @@
                     "value": 1
                 },
                 "description": {
-                    "value": "<p>Large, 3d10 bludgeoning, Rupture 26</p>"
+                    "value": "<p>Large, [[/r {3d10}[bludgeoning]]]{3d10 bludgeoning}, Rupture 26</p>\n<hr />\n<p>@Localize[PF2E.NPC.Abilities.Glossary.SwallowWhole]</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "swallow-whole",
                 "source": {
-                    "value": ""
+                    "value": "Pathfinder Bestiary"
                 },
                 "traits": {
                     "custom": "",
@@ -255,10 +381,55 @@
             "type": "action"
         },
         {
+            "_id": "uI0lVkJrLHDNJ0a3",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.Tkd8sH4pwFIPzqTr"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Grab",
+            "sort": 900000,
+            "system": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Grab]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "grab",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
             "_id": "oNhifza8xpfHaIo5",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Athletics",
-            "sort": 700000,
+            "sort": 1000000,
             "system": {
                 "description": {
                     "value": ""
@@ -286,7 +457,7 @@
             "_id": "5jRDZpBWMfM0nO8A",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Intimidation",
-            "sort": 800000,
+            "sort": 1100000,
             "system": {
                 "description": {
                     "value": ""
@@ -362,7 +533,7 @@
             "alignment": {
                 "value": "NE"
             },
-            "blurb": "",
+            "blurb": "Elite gashadokuro",
             "creatureType": "",
             "level": {
                 "value": 14
@@ -429,10 +600,10 @@
             ],
             "dv": [],
             "languages": {
-                "custom": "",
+                "custom": "Can't Speak Any Language",
                 "selected": [],
                 "value": [
-                    "common (can't speak any language)"
+                    "common"
                 ]
             },
             "rarity": "unique",

--- a/packs/data/extinction-curse-bestiary.db/xulgath-herd-tender.json
+++ b/packs/data/extinction-curse-bestiary.db/xulgath-herd-tender.json
@@ -3,7 +3,7 @@
     "img": "systems/pf2e/icons/default-icons/npc.svg",
     "items": [
         {
-            "_id": "bOzjPxBWac697tBc",
+            "_id": "W8SyDxIX2baPiKD7",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.equipment-srd.gWr4q4HiyGhETA8H"
@@ -70,16 +70,16 @@
                     }
                 },
                 "propertyRune1": {
-                    "value": ""
+                    "value": null
                 },
                 "propertyRune2": {
-                    "value": ""
+                    "value": null
                 },
                 "propertyRune3": {
-                    "value": ""
+                    "value": null
                 },
                 "propertyRune4": {
-                    "value": ""
+                    "value": null
                 },
                 "quantity": 4,
                 "range": 20,
@@ -117,7 +117,7 @@
                 },
                 "stackGroup": null,
                 "strikingRune": {
-                    "value": ""
+                    "value": null
                 },
                 "traits": {
                     "custom": "",
@@ -140,7 +140,7 @@
             "type": "weapon"
         },
         {
-            "_id": "Iey4TON79hg1gc5c",
+            "_id": "nYZMYEzR32X1P92B",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.equipment-srd.e4NwsnPnpQKbDZ9F"
@@ -172,8 +172,8 @@
                     "value": "<p>This shortbow is made from horn, wood, and sinew laminated together to increase the power of its pull and the force of its projectile. Its compact size and power make it a favorite of mounted archers. Any time an ability is specifically restricted to a shortbow, it also applies to composite shortbows unless otherwise stated.</p>"
                 },
                 "equipped": {
-                    "carryType": "held",
-                    "handsHeld": 2,
+                    "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "equippedBulk": {
@@ -259,7 +259,7 @@
             "type": "weapon"
         },
         {
-            "_id": "x1XE6q7ed9jB84iN",
+            "_id": "yjr96NTn2dmpnLe9",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.equipment-srd.f1gwoTkf3Nn0v3PN"
@@ -379,7 +379,7 @@
             "type": "weapon"
         },
         {
-            "_id": "HaBZjt7RqWV6zo72",
+            "_id": "2capJkB8aKjuDrD7",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.equipment-srd.AnwzlOs0njF9Jqnr"
@@ -406,8 +406,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
-                    "handsHeld": 0,
-                    "inSlot": true,
+                    "inSlot": false,
                     "invested": null
                 },
                 "equippedBulk": {
@@ -485,7 +484,7 @@
             "type": "armor"
         },
         {
-            "_id": "pX6pT8NyaFOGilHr",
+            "_id": "c8ksgcE5cpLKm4iF",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.equipment-srd.w2ENw2VMPcsbif8g"
@@ -774,31 +773,52 @@
             "type": "melee"
         },
         {
-            "_id": "2haiGlhcoRBqLB57",
+            "_id": "8vEzM2MigepekMyc",
+            "flags": {
+                "pf2e": {
+                    "linkedWeapon": "W8SyDxIX2baPiKD7"
+                }
+            },
             "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "Alchemist's Fire",
+            "name": "Alchemist's Fire (Moderate)",
             "sort": 1000000,
             "system": {
                 "attack": {
                     "value": ""
                 },
                 "attackEffects": {
-                    "custom": "",
                     "value": []
                 },
                 "bonus": {
                     "value": 20
                 },
                 "damageRolls": {
-                    "obl9iupo1k5yaf3lcf4z": {
+                    "Dp1kb7EkZXLsMoZp": {
                         "damage": "2d8",
                         "damageType": "fire"
                     }
                 },
                 "description": {
-                    "value": "<p>[[/r {2}[persistent,fire]]] @UUID[Compendium.pf2e.conditionitems.Persistent Damage]{Persistent Fire Damage}</p>\n<p>[[/r {2}[splash,fire]]]{2 fire splash damage}</p>"
+                    "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "key": "Note",
+                        "outcome": [
+                            "success"
+                        ],
+                        "selector": "{item|_id}-damage",
+                        "text": "PF2E.BombNotes.AlchemistsFire.Moderate.success"
+                    },
+                    {
+                        "key": "Note",
+                        "outcome": [
+                            "criticalSuccess"
+                        ],
+                        "selector": "{item|_id}-damage",
+                        "text": "PF2E.BombNotes.AlchemistsFire.Moderate.criticalSuccess"
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""
@@ -807,6 +827,7 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
+                        "bomb",
                         "range-increment-20",
                         "splash"
                     ]
@@ -818,10 +839,55 @@
             "type": "melee"
         },
         {
+            "_id": "Bqkj3XCvzqqQZur2",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.qCCLZhnp2HhP3Ex6"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Darkvision",
+            "sort": 1100000,
+            "system": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Darkvision]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "darkvision",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
             "_id": "OpULqY48Og5zS0iV",
             "img": "systems/pf2e/icons/actions/Reaction.webp",
             "name": "Mounted Defense",
-            "sort": 1100000,
+            "sort": 1200000,
             "system": {
                 "actionCategory": {
                     "value": "defensive"
@@ -838,7 +904,24 @@
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "domain": "ac",
+                        "key": "RollOption",
+                        "option": "mounted-defense",
+                        "toggleable": true,
+                        "value": false
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "predicate": [
+                            "mounted-defense"
+                        ],
+                        "selector": "ac",
+                        "type": "circumstance",
+                        "value": 2
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""
@@ -861,7 +944,7 @@
             "_id": "ax83ccfFLMazkzxs",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Powerful Stench",
-            "sort": 1200000,
+            "sort": 1300000,
             "system": {
                 "actionCategory": {
                     "value": "defensive"
@@ -873,12 +956,25 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>30 feet. A creature that enters the area must attempt a @Check[type:fortitude|dc:26] save. On a failure, the creature is @UUID[Compendium.pf2e.conditionitems.Sickened]{Sickened 2}, and on a critical failure, the creature is also @UUID[Compendium.pf2e.conditionitems.Slowed]{Slowed 1} for as long as it is @UUID[Compendium.pf2e.conditionitems.Sickened]{Sickened}. While within the aura, the creature takes a -2 circumstance penalty to saves to recover from the @UUID[Compendium.pf2e.conditionitems.Sickened]{Sickened} condition. A creature that succeeds at its save is temporarily immune to all xulgaths' stenches for 1 minute.</p>"
+                    "value": "<p>@Template[type:emanation|distance:30]{30 feet} @UUID[Compendium.pf2e.bestiary-ability-glossary-srd.Aura]{Aura}</p>\n<hr />\n<p>A creature that enters the area must attempt a @Check[type:fortitude|dc:26] save. On a failure, the creature is @UUID[Compendium.pf2e.conditionitems.Sickened]{Sickened 2}, and on a critical failure, the creature is also @UUID[Compendium.pf2e.conditionitems.Slowed]{Slowed 1} for as long as it is sickened. While within the aura, the creature takes a -2 circumstance penalty to saves to recover from the sickened condition. A creature that succeeds at its save is temporarily immune to all xulgaths' stenches for 1 minute.</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "colors": {
+                            "border": "#00FF00",
+                            "fill": "#00FF00"
+                        },
+                        "key": "Aura",
+                        "radius": 30,
+                        "slug": "powerful-stench",
+                        "traits": [
+                            "olfactory"
+                        ]
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""
@@ -904,7 +1000,7 @@
             "_id": "jaYwPmKt8kxpFg9N",
             "img": "systems/pf2e/icons/actions/TwoActions.webp",
             "name": "Feral Directive",
-            "sort": 1300000,
+            "sort": 1400000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -916,7 +1012,7 @@
                     "value": 2
                 },
                 "description": {
-                    "value": "<p>The xulgath attempts to Command an Animal on their mount, but instead of demanding a specific action such as Stride or Strike, the xulgath gives a general directive, such as to return to camp or to attack a small group the mount can see. The mount and the xulgath each retain 3 actions on their turns, but the mount doesn't change its general tactics until the xulgath uses Feral Directive or Command an Animal again.</p>"
+                    "value": "<p>The xulgath attempts to @UUID[Compendium.pf2e.actionspf2e.Command an Animal]{Command an Animal} on their mount, but instead of demanding a specific action such as Stride or Strike, the xulgath gives a general directive, such as to return to camp or to attack a small group the mount can see. The mount and the xulgath each retain 3 actions on their turns, but the mount doesn't change its general tactics until the xulgath uses Feral Directive or Command an Animal again.</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -944,7 +1040,7 @@
             "_id": "c1nV69h5eKoUvmDM",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Mounted Superiority",
-            "sort": 1400000,
+            "sort": 1500000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -961,7 +1057,24 @@
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "domain": "all",
+                        "key": "RollOption",
+                        "option": "mounted-superiority",
+                        "toggleable": true,
+                        "value": false
+                    },
+                    {
+                        "diceNumber": 1,
+                        "dieSize": "d8",
+                        "key": "DamageDice",
+                        "predicate": [
+                            "mounted-superiority"
+                        ],
+                        "selector": "damage"
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""
@@ -984,7 +1097,7 @@
             "_id": "aESx6vSWpBErsFJX",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Acrobatics",
-            "sort": 1500000,
+            "sort": 1600000,
             "system": {
                 "description": {
                     "value": ""
@@ -1012,7 +1125,7 @@
             "_id": "VDwYRZThNfOjUNuG",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Athletics",
-            "sort": 1600000,
+            "sort": 1700000,
             "system": {
                 "description": {
                     "value": ""
@@ -1037,37 +1150,9 @@
             "type": "lore"
         },
         {
-            "_id": "yb0kvbXjvkWZXjnZ",
-            "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Initmidation",
-            "sort": 1700000,
-            "system": {
-                "description": {
-                    "value": ""
-                },
-                "mod": {
-                    "value": 16
-                },
-                "proficient": {
-                    "value": 0
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                }
-            },
-            "type": "lore"
-        },
-        {
             "_id": "ycvmtIzMkmfLy5hY",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Lore: Dinosaur",
+            "name": "Dinosaur Lore",
             "sort": 1800000,
             "system": {
                 "description": {
@@ -1093,10 +1178,38 @@
             "type": "lore"
         },
         {
+            "_id": "juP0vKVgjsTaCHMq",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Intimidation",
+            "sort": 1900000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 16
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "lore"
+        },
+        {
             "_id": "aKeXjpU2OxlNzZyR",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Nature",
-            "sort": 1900000,
+            "sort": 2000000,
             "system": {
                 "description": {
                     "value": ""
@@ -1124,7 +1237,7 @@
             "_id": "uhlPJDJHQWn59jLy",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Stealth",
-            "sort": 2000000,
+            "sort": 2100000,
             "system": {
                 "description": {
                     "value": ""
@@ -1152,7 +1265,7 @@
             "_id": "4p2MGnGoUiVGQSAx",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Survival",
-            "sort": 2100000,
+            "sort": 2200000,
             "system": {
                 "description": {
                     "value": ""

--- a/packs/data/extinction-curse-bestiary.db/xulgath-herd-tender.json
+++ b/packs/data/extinction-curse-bestiary.db/xulgath-herd-tender.json
@@ -963,10 +963,6 @@
                 },
                 "rules": [
                     {
-                        "colors": {
-                            "border": "#00FF00",
-                            "fill": "#00FF00"
-                        },
                         "key": "Aura",
                         "radius": 30,
                         "slug": "powerful-stench",


### PR DESCRIPTION
Brushup for: Xulgath Herd-Tenders, Gahlepod, Starved Staff, Brughadatch

New effect: "Effect: Deceitful Feast (Failure)" for Brughadatch