### PR TITLE
Add support for non-valued showDC arguments in @Check

### DIFF
--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -210,6 +210,8 @@ class TextEditorPF2e extends TextEditor {
             if (param.startsWith("traits:")) {
                 // Special case for "traits" that may be roll options
                 params.traits = param.substring(7);
+            } else if (param === "showDC") {
+                params.showDC = "all";
             } else {
                 const paramParts = param.split(":");
                 if (paramParts.length !== 2) {


### PR DESCRIPTION
`showDC` is now equivalent to `showDC:all`.