### PR TITLE
Fix cha modifier of tallow guardian

### DIFF
--- a/packs/data/crown-of-the-kobold-king-bestiary.db/tallow-guardian.json
+++ b/packs/data/crown-of-the-kobold-king-bestiary.db/tallow-guardian.json
@@ -221,7 +221,7 @@
     "system": {
         "abilities": {
             "cha": {
-                "mod": null
+                "mod": -5
             },
             "con": {
                 "mod": 2


### PR DESCRIPTION
`null` seemed wrong to me, and I checked [pf2e tools](https://pf2easy.com/index.php?id=22710) to confirm (this compendium isn’t on aonprd yet).