### PR TITLE
Brushup EC Book 4 NPCs part 4

### DIFF
--- a/packs/data/bestiary-effects.db/effect-bloodline-magic-stirvyn-banyan.json
+++ b/packs/data/bestiary-effects.db/effect-bloodline-magic-stirvyn-banyan.json
@@ -1,0 +1,46 @@
+{
+    "_id": "EqdXFH2l0TyeOTQz",
+    "img": "systems/pf2e/icons/spells/boil-blood.webp",
+    "name": "Effect: Bloodline Magic (Stirvyn Banyan)",
+    "system": {
+        "badge": null,
+        "description": {
+            "value": "<p>When Stirvyn casts a bloodline spell, a surge of ancestral memories grants either him or a target of the spell a +1 status bonus to skill checks for 1 round.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "selector": "skill-check",
+                "type": "status",
+                "value": 1
+            }
+        ],
+        "source": {
+            "value": ""
+        },
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "target": null,
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        },
+        "unidentified": false
+    },
+    "type": "effect"
+}

--- a/packs/data/bestiary-effects.db/effect-bloodline-magic-stirvyn-banyan.json
+++ b/packs/data/bestiary-effects.db/effect-bloodline-magic-stirvyn-banyan.json
@@ -25,7 +25,7 @@
             }
         ],
         "source": {
-            "value": ""
+            "value": "Pathfinder #154: Siege of the Dinosaurs"
         },
         "start": {
             "initiative": null,

--- a/packs/data/extinction-curse-bestiary.db/ledorick-banyan-possessed.json
+++ b/packs/data/extinction-curse-bestiary.db/ledorick-banyan-possessed.json
@@ -1,5 +1,5 @@
 {
-    "_id": "lh3pcyJlUUtNpWcI",
+    "_id": "xGTl3DVCD0etE6MU",
     "img": "systems/pf2e/icons/default-icons/npc.svg",
     "items": [
         {
@@ -123,20 +123,20 @@
             "type": "weapon"
         },
         {
-            "_id": "ix9mbv1z3onh9Lsi",
+            "_id": "xNeFCRc6vVzyQDT0",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.equipment-srd.LJdbVTOZog39EEbi"
+                    "sourceId": "Compendium.pf2e.equipment-srd.UfurZQK6H6SgOjqe"
                 }
             },
-            "img": "systems/pf2e/icons/equipment/weapons/longsword.webp",
-            "name": "Longsword",
+            "img": "systems/pf2e/icons/equipment/weapons/ranseur.webp",
+            "name": "Bokrug's Lashing Tail",
             "sort": 200000,
             "system": {
                 "MAP": {
                     "value": ""
                 },
-                "baseItem": "longsword",
+                "baseItem": "ranseur",
                 "bonus": {
                     "value": 0
                 },
@@ -146,13 +146,13 @@
                 "category": "martial",
                 "containerId": null,
                 "damage": {
-                    "damageType": "slashing",
+                    "damageType": "piercing",
                     "dice": 1,
-                    "die": "d8",
+                    "die": "d10",
                     "value": ""
                 },
                 "description": {
-                    "value": "<p>Longswords can be one‑edged or two‑edged swords. Their blades are heavy and they're between 3 and 4 feet in length.</p>"
+                    "value": "<p>This polearm is a long trident with a central prong that's longer than the other two.</p>"
                 },
                 "equipped": {
                     "carryType": "worn",
@@ -162,7 +162,7 @@
                 "equippedBulk": {
                     "value": ""
                 },
-                "group": "sword",
+                "group": "polearm",
                 "hardness": 0,
                 "hp": {
                     "brokenThreshold": 0,
@@ -186,11 +186,11 @@
                 },
                 "price": {
                     "value": {
-                        "gp": 1
+                        "gp": 2
                     }
                 },
                 "propertyRune1": {
-                    "value": null
+                    "value": "keen"
                 },
                 "propertyRune2": {
                     "value": null
@@ -208,7 +208,7 @@
                 },
                 "rules": [],
                 "size": "med",
-                "slug": "longsword",
+                "slug": "ranseur",
                 "source": {
                     "value": "Pathfinder Core Rulebook"
                 },
@@ -226,16 +226,17 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
+                        "disarm",
                         "evocation",
                         "magical",
-                        "versatile-p"
+                        "reach"
                     ]
                 },
                 "usage": {
-                    "value": "held-in-one-hand"
+                    "value": "held-in-two-hands"
                 },
                 "weight": {
-                    "value": "1"
+                    "value": "2"
                 }
             },
             "type": "weapon"
@@ -545,7 +546,7 @@
             "type": "consumable"
         },
         {
-            "_id": "WpzASnS15q1C9Bin",
+            "_id": "aHA48ciYUyFpLXja",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.equipment-srd.w2ENw2VMPcsbif8g"
@@ -660,53 +661,10 @@
             "type": "consumable"
         },
         {
-            "_id": "bQB1uLPL0KXt6C4L",
-            "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "Longsword",
-            "sort": 700000,
-            "system": {
-                "attack": {
-                    "value": ""
-                },
-                "attackEffects": {
-                    "value": []
-                },
-                "bonus": {
-                    "value": 29
-                },
-                "damageRolls": {
-                    "zqzaz3ga4kg07pprjvp0": {
-                        "damage": "3d8+13",
-                        "damageType": "slashing"
-                    }
-                },
-                "description": {
-                    "value": ""
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": [
-                        "magical",
-                        "versatile-p"
-                    ]
-                },
-                "weaponType": {
-                    "value": "melee"
-                }
-            },
-            "type": "melee"
-        },
-        {
             "_id": "jQn2KwqwhEwFFaZA",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Fist",
-            "sort": 800000,
+            "sort": 700000,
             "system": {
                 "attack": {
                     "value": ""
@@ -739,6 +697,50 @@
                         "finesse",
                         "nonlethal",
                         "unarmed"
+                    ]
+                },
+                "weaponType": {
+                    "value": "melee"
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "9P7DE9pnYbvjzjog",
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Ranseur",
+            "sort": 800000,
+            "system": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "value": []
+                },
+                "bonus": {
+                    "value": 29
+                },
+                "damageRolls": {
+                    "3fELwjSqaYfKClh4": {
+                        "damage": "3d10+13",
+                        "damageType": "piercing"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "disarm",
+                        "magical",
+                        "reach"
                     ]
                 },
                 "weaponType": {
@@ -981,10 +983,47 @@
             "type": "action"
         },
         {
+            "_id": "pxM83ECTkuL1t1yb",
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Possessed",
+            "sort": 1400000,
+            "system": {
+                "actionCategory": {
+                    "value": "defensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>Ledorick is possessed by the dybbuk @UUID[Compendium.pf2e.extinction-curse-bestiary.Lyrt Cozurn]{Lyrt Cozurn}, and he is controlled by the dybbuk. However, Ledorick's personality is strong; each time Ledorick takes Hit Point damage, Lyrt takes half of this damage as well (reduced by his Resistances, if applicable).</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
             "_id": "ZwZxW282cbsJVc4E",
             "img": "systems/pf2e/icons/actions/OneAction.webp",
             "name": "Dueling Parry",
-            "sort": 1400000,
+            "sort": 1500000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -1041,7 +1080,7 @@
             "_id": "mQ8k4znou6fvkiXP",
             "img": "systems/pf2e/icons/actions/OneAction.webp",
             "name": "Guiding Finish",
-            "sort": 1500000,
+            "sort": 1600000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -1081,7 +1120,7 @@
             "_id": "qAcFJ6ENZ6hIxnoG",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Show-Off",
-            "sort": 1600000,
+            "sort": 1700000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -1136,7 +1175,7 @@
             "_id": "VMTjcCiLutAHY3LX",
             "img": "systems/pf2e/icons/actions/TwoActions.webp",
             "name": "Sudden Charge",
-            "sort": 1700000,
+            "sort": 1800000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -1176,7 +1215,7 @@
             "_id": "sFPjANNBVh0L52D9",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Acrobatics",
-            "sort": 1800000,
+            "sort": 1900000,
             "system": {
                 "description": {
                     "value": ""
@@ -1204,7 +1243,7 @@
             "_id": "1FdVVIvFCyUYO42c",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Athletics",
-            "sort": 1900000,
+            "sort": 2000000,
             "system": {
                 "description": {
                     "value": ""
@@ -1248,7 +1287,7 @@
             "_id": "BoQdzt794f7orrzY",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Deception",
-            "sort": 2000000,
+            "sort": 2100000,
             "system": {
                 "description": {
                     "value": ""
@@ -1276,7 +1315,7 @@
             "_id": "nytoSDZtlhW0h0Vo",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Diplomacy",
-            "sort": 2100000,
+            "sort": 2200000,
             "system": {
                 "description": {
                     "value": ""
@@ -1304,7 +1343,7 @@
             "_id": "8SWPC29pX3Jcob5T",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Intimidation",
-            "sort": 2200000,
+            "sort": 2300000,
             "system": {
                 "description": {
                     "value": ""
@@ -1332,7 +1371,7 @@
             "_id": "VYR8pSk4oT2cjGv4",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Society",
-            "sort": 2300000,
+            "sort": 2400000,
             "system": {
                 "description": {
                     "value": ""
@@ -1360,7 +1399,7 @@
             "_id": "hCTilN2T9gjd8N5c",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Willowside Lore",
-            "sort": 2400000,
+            "sort": 2500000,
             "system": {
                 "description": {
                     "value": ""
@@ -1385,7 +1424,10 @@
             "type": "lore"
         }
     ],
-    "name": "Ledorick Banyan",
+    "name": "Ledorick Banyan (Possessed)",
+    "prototypeToken": {
+        "name": "Ledorick Banyan"
+    },
     "system": {
         "abilities": {
             "cha": {

--- a/packs/data/extinction-curse-bestiary.db/mukradi-summoning-runes.json
+++ b/packs/data/extinction-curse-bestiary.db/mukradi-summoning-runes.json
@@ -53,6 +53,7 @@
             "ac": {
                 "value": 0
             },
+            "emitsSound": "encounter",
             "hardness": 0,
             "hasHealth": true,
             "hp": {
@@ -93,6 +94,7 @@
             }
         },
         "source": {
+            "author": "",
             "value": "Pathfinder #154: Siege of the Dinosaurs"
         },
         "statusEffects": [],

--- a/packs/data/extinction-curse-bestiary.db/poisoned-secret-door-trap.json
+++ b/packs/data/extinction-curse-bestiary.db/poisoned-secret-door-trap.json
@@ -136,6 +136,7 @@
             "ac": {
                 "value": 36
             },
+            "emitsSound": "encounter",
             "hardness": 23,
             "hasHealth": true,
             "hp": {
@@ -147,7 +148,7 @@
             },
             "stealth": {
                 "details": "<p>(master)</p>",
-                "value": 34
+                "value": 24
             }
         },
         "creatureType": "",
@@ -176,6 +177,7 @@
             }
         },
         "source": {
+            "author": "",
             "value": "Pathfinder #154: Siege of the Dinosaurs"
         },
         "statusEffects": [],
@@ -198,7 +200,8 @@
             },
             "value": [
                 "magical",
-                "mechanical"
+                "mechanical",
+                "trap"
             ]
         }
     },

--- a/packs/data/extinction-curse-bestiary.db/stirvyn-banyan.json
+++ b/packs/data/extinction-curse-bestiary.db/stirvyn-banyan.json
@@ -249,9 +249,9 @@
                         "value": 0
                     },
                     "slot1": {
-                        "max": 0,
+                        "max": 6,
                         "prepared": [],
-                        "value": 0
+                        "value": 6
                     },
                     "slot10": {
                         "max": 0,
@@ -324,7 +324,7 @@
             "type": "spellcastingEntry"
         },
         {
-            "_id": "kS4qWbPWJoVZYKuz",
+            "_id": "4A2FqefBMjdwEAkG",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.r7ihOgKv19eJQnik"
@@ -443,6 +443,7 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
+                        "arcane",
                         "attack"
                     ]
                 }
@@ -450,7 +451,7 @@
             "type": "spell"
         },
         {
-            "_id": "3GIiXDyBGRzhiDUX",
+            "_id": "DuCX5DPMCZF925HT",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.WPXzPl7YbMEIGWfi"
@@ -465,7 +466,7 @@
                 },
                 "area": {
                     "areaType": "",
-                    "value": null
+                    "value": ""
                 },
                 "areasize": {
                     "value": ""
@@ -552,13 +553,15 @@
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "arcane"
+                    ]
                 }
             },
             "type": "spell"
         },
         {
-            "_id": "PdYAb5KcU4Ze50vw",
+            "_id": "JVXTeZ7dphgXzBaT",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.h47yv6j6x1pUtzlr"
@@ -657,6 +660,7 @@
                     "custom": "",
                     "rarity": "uncommon",
                     "value": [
+                        "arcane",
                         "sorcerer"
                     ]
                 }
@@ -664,7 +668,7 @@
             "type": "spell"
         },
         {
-            "_id": "YhfRXHRmpWwoopah",
+            "_id": "NxhJvnLDRlISP1tW",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.TCk2MDwf5L5OYjFC"
@@ -679,7 +683,7 @@
                 },
                 "area": {
                     "areaType": "",
-                    "value": null
+                    "value": ""
                 },
                 "areasize": {
                     "value": ""
@@ -767,6 +771,7 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
+                        "arcane",
                         "visual"
                     ]
                 }
@@ -774,7 +779,7 @@
             "type": "spell"
         },
         {
-            "_id": "Oo32H43uHR0zglzu",
+            "_id": "Nfl5jjpPpfNoWq1r",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.Ek5XI0aEdZhBgm21"
@@ -789,7 +794,7 @@
                 },
                 "area": {
                     "areaType": "",
-                    "value": null
+                    "value": ""
                 },
                 "areasize": {
                     "value": ""
@@ -878,6 +883,7 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
+                        "arcane",
                         "scrying"
                     ]
                 }
@@ -885,7 +891,7 @@
             "type": "spell"
         },
         {
-            "_id": "xYXqFTyzM9blA2Ks",
+            "_id": "NQkDvWNUbGrwNTQq",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.BilnTGuXrof9Dt9D"
@@ -995,7 +1001,7 @@
             "type": "spell"
         },
         {
-            "_id": "Wp9NKCRstmcPgEJg",
+            "_id": "jMcfM3ReE7036kGy",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.OAt2ZEns1gIOCgrn"
@@ -1114,7 +1120,7 @@
             "type": "spell"
         },
         {
-            "_id": "BKcnHaiWzpGCXRBc",
+            "_id": "ccNZcs7m46yCzrI1",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.VlNcjmYyu95vOUe8"
@@ -1227,6 +1233,7 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
+                        "arcane",
                         "teleportation"
                     ]
                 }
@@ -1234,7 +1241,7 @@
             "type": "spell"
         },
         {
-            "_id": "L0DJsRKzmmHCRoW9",
+            "_id": "F2Q7HHDK3xVM9LfL",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.aqRYNoSvxsVfqglH"
@@ -1249,7 +1256,7 @@
                 },
                 "area": {
                     "areaType": "",
-                    "value": null
+                    "value": ""
                 },
                 "areasize": {
                     "value": ""
@@ -1337,13 +1344,15 @@
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "arcane"
+                    ]
                 }
             },
             "type": "spell"
         },
         {
-            "_id": "hid4OaS0S7RIxjc7",
+            "_id": "XkxbarGOthWJFrUD",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.FhOaQDTSnsY7tiam"
@@ -1458,7 +1467,7 @@
             "type": "spell"
         },
         {
-            "_id": "BLbvosyOQAh2KzzD",
+            "_id": "NOSr7e7rID0dDwdG",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.KSAEhNfZyXMO7Z7V"
@@ -1562,6 +1571,7 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
+                        "arcane",
                         "curse",
                         "mental",
                         "misfortune"
@@ -1571,7 +1581,7 @@
             "type": "spell"
         },
         {
-            "_id": "NjZYrlJbR15uYbz6",
+            "_id": "tXud0ybfok8cnIAD",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.qwlh6aDgi86U3Q7H"
@@ -1684,6 +1694,7 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
+                        "arcane",
                         "incapacitation",
                         "linguistic",
                         "mental"
@@ -1693,7 +1704,7 @@
             "type": "spell"
         },
         {
-            "_id": "x1RLWiD5a4GrkMAA",
+            "_id": "u4aFlrl4VTrOrc8c",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.HqTI6wRrck1YXp3F"
@@ -1804,7 +1815,7 @@
             "type": "spell"
         },
         {
-            "_id": "ilbCpPV13gSJokKC",
+            "_id": "4tKJ7Y5UdxpNAPkp",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.IihxWhRfpsBgQ5jS"
@@ -1819,7 +1830,7 @@
                 },
                 "area": {
                     "areaType": "",
-                    "value": null
+                    "value": ""
                 },
                 "areasize": {
                     "value": ""
@@ -1907,6 +1918,7 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
+                        "arcane",
                         "auditory",
                         "emotion"
                     ]
@@ -1915,7 +1927,7 @@
             "type": "spell"
         },
         {
-            "_id": "n9VDD1pTptort78Y",
+            "_id": "6lS2yPkbDDZoF1UQ",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.GxxnhRIaoGKtu1iO"
@@ -1930,7 +1942,7 @@
                 },
                 "area": {
                     "areaType": "",
-                    "value": null
+                    "value": ""
                 },
                 "areasize": {
                     "value": ""
@@ -2014,6 +2026,7 @@
                     "custom": "",
                     "rarity": "uncommon",
                     "value": [
+                        "arcane",
                         "metamagic",
                         "sorcerer"
                     ]
@@ -2022,7 +2035,7 @@
             "type": "spell"
         },
         {
-            "_id": "iuaHYcXTPdLFY0vy",
+            "_id": "K6WQMq6h1LiudgTH",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.o6YCGx4lycsYpww4"
@@ -2135,13 +2148,15 @@
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "arcane"
+                    ]
                 }
             },
             "type": "spell"
         },
         {
-            "_id": "W6iaXcw45UQLMWgd",
+            "_id": "iT8ctFUpSwpJ4VOC",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.ZYoC630tNGutgbE0"
@@ -2248,7 +2263,7 @@
             "type": "spell"
         },
         {
-            "_id": "eojKsHIePuE2tFM6",
+            "_id": "rACR0zcq5oP8MYX7",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.9AAkVUCwF6WVNNY2"
@@ -2368,6 +2383,7 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
+                        "arcane",
                         "electricity"
                     ]
                 }
@@ -2375,7 +2391,7 @@
             "type": "spell"
         },
         {
-            "_id": "ekJmugEv6ENZkIJ6",
+            "_id": "FKF31av68Tqns20x",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.vh1RpbWfqdNC4L3P"
@@ -2390,7 +2406,7 @@
                 },
                 "area": {
                     "areaType": "",
-                    "value": null
+                    "value": ""
                 },
                 "areasize": {
                     "value": ""
@@ -2478,6 +2494,7 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
+                        "arcane",
                         "earth"
                     ]
                 }
@@ -2485,7 +2502,7 @@
             "type": "spell"
         },
         {
-            "_id": "PoCUSUc2S8ASP1ke",
+            "_id": "TlbIeluWEmoJLLbd",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.KHnhPHL4x1AQHfbC"
@@ -2500,7 +2517,7 @@
                 },
                 "area": {
                     "areaType": "",
-                    "value": null
+                    "value": ""
                 },
                 "areasize": {
                     "value": ""
@@ -2588,6 +2605,7 @@
                     "custom": "",
                     "rarity": "uncommon",
                     "value": [
+                        "arcane",
                         "detection",
                         "mental"
                     ]
@@ -2596,7 +2614,7 @@
             "type": "spell"
         },
         {
-            "_id": "NUSR1HWx5B2R2STV",
+            "_id": "i7FfrdsAETg6Ip3m",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.WsUwpfmhKrKwoIe3"
@@ -2709,13 +2727,15 @@
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "arcane"
+                    ]
                 }
             },
             "type": "spell"
         },
         {
-            "_id": "JU3j7pQW8u8nuzm8",
+            "_id": "95Jawlj2yaHPMvSi",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.N1Z1oLPdBxaSgrEE"
@@ -2730,7 +2750,7 @@
                 },
                 "area": {
                     "areaType": "",
-                    "value": null
+                    "value": ""
                 },
                 "areasize": {
                     "value": ""
@@ -2750,8 +2770,10 @@
                 "damage": {
                     "value": {
                         "0": {
+                            "applyMod": false,
                             "type": {
                                 "categories": [],
+                                "subtype": "",
                                 "value": "negative"
                             },
                             "value": "6d6"
@@ -2834,6 +2856,7 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
+                        "arcane",
                         "death",
                         "negative"
                     ]
@@ -2842,7 +2865,7 @@
             "type": "spell"
         },
         {
-            "_id": "lI4ltrXQ51Mv7nhM",
+            "_id": "r1apebeGjs2g7HG7",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.3JG1t3T4mWn6vTke"
@@ -2857,7 +2880,7 @@
                 },
                 "area": {
                     "areaType": "",
-                    "value": null
+                    "value": ""
                 },
                 "areasize": {
                     "value": ""
@@ -2945,6 +2968,7 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
+                        "arcane",
                         "visual"
                     ]
                 }
@@ -2952,7 +2976,7 @@
             "type": "spell"
         },
         {
-            "_id": "5A3ClvMYGRkTr9oJ",
+            "_id": "cOTgdTnzlLzzJ4sL",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.9HpwDN4MYQJnW0LG"
@@ -2967,7 +2991,7 @@
                 },
                 "area": {
                     "areaType": "",
-                    "value": null
+                    "value": ""
                 },
                 "areasize": {
                     "value": ""
@@ -3056,13 +3080,15 @@
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "arcane"
+                    ]
                 }
             },
             "type": "spell"
         },
         {
-            "_id": "jAowWwvsLnUzfJ3P",
+            "_id": "U9pndnhmg5lU8y93",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.9HpwDN4MYQJnW0LG"
@@ -3077,7 +3103,7 @@
                 },
                 "area": {
                     "areaType": "",
-                    "value": null
+                    "value": ""
                 },
                 "areasize": {
                     "value": ""
@@ -3166,13 +3192,15 @@
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "arcane"
+                    ]
                 }
             },
             "type": "spell"
         },
         {
-            "_id": "wdMwZiHCAQq9XI2q",
+            "_id": "yMlt9pYILaKGGetL",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.tlSE7Ly8vi1Dgddv"
@@ -3187,7 +3215,7 @@
                 },
                 "area": {
                     "areaType": "",
-                    "value": null
+                    "value": ""
                 },
                 "areasize": {
                     "value": ""
@@ -3275,6 +3303,7 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
+                        "arcane",
                         "emotion",
                         "mental"
                     ]
@@ -3283,7 +3312,7 @@
             "type": "spell"
         },
         {
-            "_id": "Rfy2mZCaEZgLtzrD",
+            "_id": "10l3PmlHHs1HcPBQ",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.Mkbq9xlAUxHUHyR2"
@@ -3402,7 +3431,7 @@
             "type": "spell"
         },
         {
-            "_id": "P1vLgsTGKZxBnoWk",
+            "_id": "Uyn2jvzP6p8gd7mZ",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.CQb8HtQ1BPeZmu9h"
@@ -3417,7 +3446,7 @@
                 },
                 "area": {
                     "areaType": "",
-                    "value": null
+                    "value": ""
                 },
                 "areasize": {
                     "value": ""
@@ -3505,6 +3534,7 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
+                        "arcane",
                         "mental"
                     ]
                 }
@@ -3512,7 +3542,7 @@
             "type": "spell"
         },
         {
-            "_id": "lBURg5skVbn73drI",
+            "_id": "BR05jrvdZX5nliny",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.dtOUkMC57izf93z5"
@@ -3527,7 +3557,7 @@
                 },
                 "area": {
                     "areaType": "",
-                    "value": null
+                    "value": ""
                 },
                 "areasize": {
                     "value": ""
@@ -3611,6 +3641,7 @@
                     "custom": "",
                     "rarity": "uncommon",
                     "value": [
+                        "arcane",
                         "sorcerer"
                     ]
                 }
@@ -3618,7 +3649,7 @@
             "type": "spell"
         },
         {
-            "_id": "xYqr2Q7ilmzEYSS3",
+            "_id": "6prUX6z5BpYdzAjL",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.mAMEt4FFbdqoRnkN"
@@ -3656,6 +3687,7 @@
                             "applyMod": true,
                             "type": {
                                 "categories": [],
+                                "subtype": "",
                                 "value": "negative"
                             },
                             "value": "1d4"
@@ -3737,6 +3769,7 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
+                        "arcane",
                         "cantrip",
                         "negative"
                     ]
@@ -3745,7 +3778,7 @@
             "type": "spell"
         },
         {
-            "_id": "gsmBdnIO8qsFAUGR",
+            "_id": "o4E0CK2uJwWLPPN3",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.4gBIw4IDrSfFHik4"
@@ -3754,6 +3787,136 @@
             "img": "systems/pf2e/icons/spells/daze.webp",
             "name": "Daze",
             "sort": 3400000,
+            "system": {
+                "ability": {
+                    "value": ""
+                },
+                "area": {
+                    "areaType": "",
+                    "value": ""
+                },
+                "areasize": {
+                    "value": ""
+                },
+                "category": {
+                    "value": "spell"
+                },
+                "components": {
+                    "focus": false,
+                    "material": false,
+                    "somatic": true,
+                    "verbal": true
+                },
+                "cost": {
+                    "value": ""
+                },
+                "damage": {
+                    "value": {
+                        "0": {
+                            "applyMod": true,
+                            "type": {
+                                "categories": [],
+                                "subtype": "",
+                                "value": "mental"
+                            },
+                            "value": "0"
+                        }
+                    }
+                },
+                "description": {
+                    "value": "<p>You cloud the target's mind and daze it with a mental jolt. The jolt deals mental damage equal to your spellcasting ability modifier; the target must attempt a basic Will save. If the target critically fails the save, it is also @UUID[Compendium.pf2e.conditionitems.Stunned]{Stunned 1}.</p>\n<hr />\n<p><strong>Heightened (+2)</strong> The damage increases by 1d6.</p>"
+                },
+                "duration": {
+                    "value": "1 round"
+                },
+                "hasCounteractCheck": {
+                    "value": false
+                },
+                "heightening": {
+                    "damage": {
+                        "0": "1d6"
+                    },
+                    "interval": 2,
+                    "type": "interval"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": {
+                    "value": "cXwerHf1acuccvb8"
+                },
+                "materials": {
+                    "value": ""
+                },
+                "prepared": {
+                    "value": ""
+                },
+                "primarycheck": {
+                    "value": ""
+                },
+                "range": {
+                    "value": "60 feet"
+                },
+                "rules": [],
+                "save": {
+                    "basic": "basic",
+                    "value": "will"
+                },
+                "school": {
+                    "value": "enchantment"
+                },
+                "secondarycasters": {
+                    "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "daze",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "spellType": {
+                    "value": "save"
+                },
+                "sustained": {
+                    "value": false
+                },
+                "target": {
+                    "value": "1 creature"
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traditions": {
+                    "value": [
+                        "arcane",
+                        "divine",
+                        "occult"
+                    ]
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "arcane",
+                        "cantrip",
+                        "mental",
+                        "nonlethal"
+                    ]
+                }
+            },
+            "type": "spell"
+        },
+        {
+            "_id": "EPhRO1QmC5jt7Be1",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.4gBIw4IDrSfFHik4"
+                }
+            },
+            "img": "systems/pf2e/icons/spells/daze.webp",
+            "name": "Daze",
+            "sort": 3500000,
             "system": {
                 "ability": {
                     "value": ""
@@ -3873,135 +4036,7 @@
             "type": "spell"
         },
         {
-            "_id": "jpzcporpB0klbI6q",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.4gBIw4IDrSfFHik4"
-                }
-            },
-            "img": "systems/pf2e/icons/spells/daze.webp",
-            "name": "Daze",
-            "sort": 3500000,
-            "system": {
-                "ability": {
-                    "value": ""
-                },
-                "area": {
-                    "areaType": "",
-                    "value": null
-                },
-                "areasize": {
-                    "value": ""
-                },
-                "category": {
-                    "value": "spell"
-                },
-                "components": {
-                    "focus": false,
-                    "material": false,
-                    "somatic": true,
-                    "verbal": true
-                },
-                "cost": {
-                    "value": ""
-                },
-                "damage": {
-                    "value": {
-                        "0": {
-                            "applyMod": true,
-                            "type": {
-                                "categories": [],
-                                "value": "mental"
-                            },
-                            "value": "0"
-                        }
-                    }
-                },
-                "description": {
-                    "value": "<p>You cloud the target's mind and daze it with a mental jolt. The jolt deals mental damage equal to your spellcasting ability modifier; the target must attempt a basic Will save. If the target critically fails the save, it is also @UUID[Compendium.pf2e.conditionitems.Stunned]{Stunned 1}.</p>\n<hr />\n<p><strong>Heightened (+2)</strong> The damage increases by 1d6.</p>"
-                },
-                "duration": {
-                    "value": "1 round"
-                },
-                "hasCounteractCheck": {
-                    "value": false
-                },
-                "heightening": {
-                    "damage": {
-                        "0": "1d6"
-                    },
-                    "interval": 2,
-                    "type": "interval"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": {
-                    "value": "cXwerHf1acuccvb8"
-                },
-                "materials": {
-                    "value": ""
-                },
-                "prepared": {
-                    "value": ""
-                },
-                "primarycheck": {
-                    "value": ""
-                },
-                "range": {
-                    "value": "60 feet"
-                },
-                "rules": [],
-                "save": {
-                    "basic": "basic",
-                    "value": "will"
-                },
-                "school": {
-                    "value": "enchantment"
-                },
-                "secondarycasters": {
-                    "value": ""
-                },
-                "secondarycheck": {
-                    "value": ""
-                },
-                "slug": "daze",
-                "source": {
-                    "value": "Pathfinder Core Rulebook"
-                },
-                "spellType": {
-                    "value": "save"
-                },
-                "sustained": {
-                    "value": false
-                },
-                "target": {
-                    "value": "1 creature"
-                },
-                "time": {
-                    "value": "2"
-                },
-                "traditions": {
-                    "value": [
-                        "arcane",
-                        "divine",
-                        "occult"
-                    ]
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": [
-                        "cantrip",
-                        "mental",
-                        "nonlethal"
-                    ]
-                }
-            },
-            "type": "spell"
-        },
-        {
-            "_id": "FrIX2qvDE8FAqy2b",
+            "_id": "cs9D6zSPlntBJcWq",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.gpzpAAAJ1Lza2JVl"
@@ -4044,11 +4079,6 @@
                 },
                 "hasCounteractCheck": {
                     "value": false
-                },
-                "heightening": {
-                    "damage": {},
-                    "interval": 1,
-                    "type": "interval"
                 },
                 "level": {
                     "value": 1
@@ -4120,7 +4150,7 @@
             "type": "spell"
         },
         {
-            "_id": "4fkkLTi2ZrSX5cqM",
+            "_id": "nBGvcCY1H0bpugkW",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.i35dpZFI7jZcRoBo"
@@ -4223,6 +4253,7 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
+                        "arcane",
                         "visual"
                     ]
                 }
@@ -4230,7 +4261,7 @@
             "type": "spell"
         },
         {
-            "_id": "hFLL85HWApKVUCdh",
+            "_id": "bWupnt4FSvWXMoVi",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.Azoh0BSoCASrA1lr"
@@ -4333,13 +4364,15 @@
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "arcane"
+                    ]
                 }
             },
             "type": "spell"
         },
         {
-            "_id": "kvQVDuY77P2a9Kvy",
+            "_id": "ZF8GZNR56cdWEUE9",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.gKKqvLohtrSJj3BM"
@@ -4453,6 +4486,7 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
+                        "arcane",
                         "force"
                     ]
                 }
@@ -4460,7 +4494,7 @@
             "type": "spell"
         },
         {
-            "_id": "mdi0oLmMdrb0BrqJ",
+            "_id": "Tg2R7Arhv20rRTDy",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.D442XMADp01qJ7Cs"
@@ -4569,7 +4603,7 @@
             "type": "spell"
         },
         {
-            "_id": "W9MilCbCDltPa7aG",
+            "_id": "9Xao9HoRAqsHGrb4",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.R8bqnYiThB6MYTxD"
@@ -4706,7 +4740,7 @@
             "type": "spell"
         },
         {
-            "_id": "L74m4qihMKG17jpp",
+            "_id": "l5gSHh2Oxy6JZTKb",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.R8bqnYiThB6MYTxD"
@@ -4843,7 +4877,7 @@
             "type": "spell"
         },
         {
-            "_id": "o84jOFZx062EBnGP",
+            "_id": "Cf5pF6HFycDJ8FaV",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.R8bqnYiThB6MYTxD"
@@ -4980,7 +5014,7 @@
             "type": "spell"
         },
         {
-            "_id": "wd4dt6btWJVqmqm1",
+            "_id": "H5E2gc9b27mPc3Xc",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.Qw3fnUlaUbnn7ipC"
@@ -4995,7 +5029,7 @@
                 },
                 "area": {
                     "areaType": "",
-                    "value": null
+                    "value": ""
                 },
                 "areasize": {
                     "value": ""
@@ -5085,6 +5119,7 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
+                        "arcane",
                         "cantrip"
                     ]
                 }
@@ -5092,7 +5127,7 @@
             "type": "spell"
         },
         {
-            "_id": "lmvkS5VGbapMke58",
+            "_id": "C8rUSpXcMmPspBc5",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.gYjPm7YwGtEa1oxh"
@@ -5107,7 +5142,7 @@
                 },
                 "area": {
                     "areaType": "",
-                    "value": null
+                    "value": ""
                 },
                 "areasize": {
                     "value": ""
@@ -5130,6 +5165,7 @@
                             "applyMod": true,
                             "type": {
                                 "categories": [],
+                                "subtype": "",
                                 "value": "cold"
                             },
                             "value": "1d4"
@@ -5211,16 +5247,17 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
+                        "arcane",
                         "attack",
-                        "cold",
-                        "cantrip"
+                        "cantrip",
+                        "cold"
                     ]
                 }
             },
             "type": "spell"
         },
         {
-            "_id": "WW1ndNE3dAeG0IOj",
+            "_id": "KYlpTBSEKHRQdhQb",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.TVKNbcgTee19PXZR"
@@ -5235,7 +5272,7 @@
                 },
                 "area": {
                     "areaType": "",
-                    "value": null
+                    "value": ""
                 },
                 "areasize": {
                     "value": ""
@@ -5323,6 +5360,7 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
+                        "arcane",
                         "cantrip",
                         "force"
                     ]
@@ -5331,7 +5369,7 @@
             "type": "spell"
         },
         {
-            "_id": "iqmjbeCYw7NUxLOc",
+            "_id": "m6uUs9H4WGpa7aEH",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.Gb7SeieEvd0pL2Eh"
@@ -5346,7 +5384,7 @@
                 },
                 "area": {
                     "areaType": "",
-                    "value": null
+                    "value": ""
                 },
                 "areasize": {
                     "value": ""
@@ -5434,6 +5472,7 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
+                        "arcane",
                         "fortune"
                     ]
                 }
@@ -5441,7 +5480,7 @@
             "type": "spell"
         },
         {
-            "_id": "HOLJZrbRuLLDmwOx",
+            "_id": "iK01xznghuNo1ggg",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.equipment-srd.DTIBj6Yhy73G5P6j"
@@ -5473,8 +5512,8 @@
                     "value": "<p>This polished wooden staff bears a swirling motif reminiscent of the folds of a brain. While wielding the staff, you gain a +2 circumstance bonus to checks to identify mental magic.</p>\n<p><strong>Activate</strong> Cast a Spell</p>\n<hr />\n<p><strong>Effect</strong> You expend a number of charges from the staff to cast a spell from its list.</p>\n<ul>\n<li><strong>Cantrip</strong> <em>@UUID[Compendium.pf2e.spells-srd.Daze]{Daze}</em></li>\n<li><strong>1st</strong> <em>@UUID[Compendium.pf2e.spells-srd.Mindlink]{Mindlink}</em> <em>@UUID[Compendium.pf2e.spells-srd.Phantom Pain]{Phantom Pain}</em></li>\n<li><strong>2nd</strong> <em>@UUID[Compendium.pf2e.spells-srd.Paranoia]{Paranoia}</em></li>\n<li><strong>3rd</strong> <em>@UUID[Compendium.pf2e.spells-srd.Hypercognition]{Hypercognition}</em> <em>@UUID[Compendium.pf2e.spells-srd.Phantom Pain]{Phantom Pain}</em></li>\n<li><strong>4th</strong> <em>@UUID[Compendium.pf2e.spells-srd.Modify Memory]{Modify Memory}</em> <em>@UUID[Compendium.pf2e.spells-srd.Telepathy]{Telepathy}</em></li>\n<li><strong>5th</strong> <em>@UUID[Compendium.pf2e.spells-srd.Phantom Pain]{Phantom Pain}</em> <em>@UUID[Compendium.pf2e.spells-srd.Synaptic Pulse]{Synaptic Pulse}</em> <em>@UUID[Compendium.pf2e.spells-srd.Synesthesia]{Synesthesia}</em></li>\n</ul>\n<p><strong>Craft Requirements</strong> Supply one casting of all listed levels of all listed spells.</p>"
                 },
                 "equipped": {
-                    "carryType": "held",
-                    "handsHeld": 2,
+                    "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "equippedBulk": {
@@ -5663,7 +5702,7 @@
             "type": "equipment"
         },
         {
-            "_id": "kP4GruF3Ipr01owe",
+            "_id": "9siPff9BhSHUe2TK",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.equipment-srd.Y7UD64foDbDMV9sx"
@@ -5911,9 +5950,29 @@
                     }
                 },
                 "description": {
-                    "value": "<p>(magical, two-hand d8)</p>"
+                    "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "domain": "damage-roll",
+                        "key": "RollOption",
+                        "label": "PF2E.SpecificRule.TwoHanded.Staff",
+                        "option": "two-handed",
+                        "toggleable": true,
+                        "value": false
+                    },
+                    {
+                        "key": "DamageDice",
+                        "label": "PF2E.TraitTwoHandD8",
+                        "override": {
+                            "dieSize": "d8"
+                        },
+                        "predicate": [
+                            "two-handed"
+                        ],
+                        "selector": "{item|_id}-damage"
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""
@@ -5923,7 +5982,7 @@
                     "rarity": "common",
                     "value": [
                         "magical",
-                        "two-hand d8"
+                        "two-hand-d8"
                     ]
                 },
                 "weaponType": {
@@ -5933,7 +5992,7 @@
             "type": "melee"
         },
         {
-            "_id": "hHxtu0wbS1th2eWk",
+            "_id": "3eMwI2ZGla9CVsIz",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.kakyXBG5WA8c6Zfd"
@@ -5993,7 +6052,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>(concentrate, move)</p>\n<p><strong>Trigger</strong> Stirvyn is targeted with an attack and is adjacent to an ally</p>\n<hr />\n<p><strong>Effect</strong> Stirvyn and the ally swap places, and the ally becomes the target of the attack.</p>"
+                    "value": "<p><strong>Trigger</strong> Stirvyn is targeted with an attack and is adjacent to an ally</p>\n<hr />\n<p><strong>Effect</strong> Stirvyn and the ally swap places, and the ally becomes the target of the attack.</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -6006,7 +6065,10 @@
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "concentrate",
+                        "move"
+                    ]
                 },
                 "trigger": {
                     "value": ""
@@ -6033,7 +6095,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>When Stirvyn casts a bloodline spell, a surge of ancestral memories grants either him or a target of the spell a +1 status bonus to skill checks for 1 round.</p>"
+                    "value": "<p>When Stirvyn casts a bloodline spell, a surge of ancestral memories grants either him or a target of the spell a +1 status bonus to skill checks for 1 round.</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Effect: Bloodline Magic (Stirvyn Banyan)]{Effect: Bloodline Magic (Stirvyn Banyan)}</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -6078,7 +6140,20 @@
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "phase": "afterDerived",
+                        "predicate": [
+                            "item:spell-slot",
+                            "item:duration:0",
+                            "damaging-effect"
+                        ],
+                        "selector": "spell-damage",
+                        "type": "status",
+                        "value": "@spell.level"
+                    }
+                ],
                 "slug": "dangerous-sorcery",
                 "source": {
                     "value": ""
@@ -6329,7 +6404,7 @@
             "alignment": {
                 "value": "N"
             },
-            "blurb": "",
+            "blurb": "Male human town protector",
             "creatureType": "",
             "level": {
                 "value": 12

--- a/packs/data/extinction-curse-bestiary.db/tashlock-banyan.json
+++ b/packs/data/extinction-curse-bestiary.db/tashlock-banyan.json
@@ -3,7 +3,7 @@
     "img": "systems/pf2e/icons/default-icons/npc.svg",
     "items": [
         {
-            "_id": "XySUrnlbfEHbuF90",
+            "_id": "ZCYqySTC44S2U1ig",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.equipment-srd.e4NwsnPnpQKbDZ9F"
@@ -35,8 +35,8 @@
                     "value": "<p>This shortbow is made from horn, wood, and sinew laminated together to increase the power of its pull and the force of its projectile. Its compact size and power make it a favorite of mounted archers. Any time an ability is specifically restricted to a shortbow, it also applies to composite shortbows unless otherwise stated.</p>"
                 },
                 "equipped": {
-                    "carryType": "held",
-                    "handsHeld": 2,
+                    "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "equippedBulk": {
@@ -122,7 +122,7 @@
             "type": "weapon"
         },
         {
-            "_id": "r42pMUEWL15chb4R",
+            "_id": "9ysQBDvKbsfYCZAe",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.equipment-srd.tH5GirEy7YB3ZgCk"
@@ -242,7 +242,7 @@
             "type": "weapon"
         },
         {
-            "_id": "sCHs6qaie96PgmD9",
+            "_id": "orAEjgUO2zLIc2Di",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.equipment-srd.4tIVTg9wj56RrveA"
@@ -270,7 +270,7 @@
                 "equipped": {
                     "carryType": "worn",
                     "handsHeld": 0,
-                    "inSlot": true,
+                    "inSlot": false,
                     "invested": null
                 },
                 "equippedBulk": {
@@ -352,7 +352,7 @@
             "type": "armor"
         },
         {
-            "_id": "0aUmdrq0FB9IEULH",
+            "_id": "iQwKv9vX7MOI9n3I",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.equipment-srd.xShIDyydOMkGvGNb"
@@ -466,7 +466,122 @@
             "type": "consumable"
         },
         {
-            "_id": "29mligYBjlDHVrjY",
+            "_id": "nhJVPi5ooGHYKN4i",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.equipment-srd.w2ENw2VMPcsbif8g"
+                }
+            },
+            "img": "systems/pf2e/icons/equipment/weapons/arrows.webp",
+            "name": "Arrows",
+            "sort": 500000,
+            "system": {
+                "activation": {
+                    "condition": "",
+                    "cost": 0,
+                    "type": ""
+                },
+                "autoDestroy": {
+                    "_deprecated": true,
+                    "value": true
+                },
+                "autoUse": {
+                    "_deprecated": true,
+                    "value": true
+                },
+                "baseItem": null,
+                "charges": {
+                    "_deprecated": true,
+                    "max": 0,
+                    "value": 0
+                },
+                "consumableType": {
+                    "value": "ammo"
+                },
+                "consume": {
+                    "_deprecated": true,
+                    "value": ""
+                },
+                "containerId": null,
+                "description": {
+                    "value": "<p>These projectiles are the ammunition for bows. The shaft of an arrow is made of wood. It is stabilized in flight by fletching at one end and bears a metal head on the other.</p>"
+                },
+                "duration": {
+                    "units": "",
+                    "value": null
+                },
+                "equipped": {
+                    "carryType": "worn",
+                    "handsHeld": 0
+                },
+                "equippedBulk": {
+                    "value": ""
+                },
+                "hardness": 0,
+                "hp": {
+                    "brokenThreshold": 0,
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "preciousMaterial": {
+                    "value": ""
+                },
+                "preciousMaterialGrade": {
+                    "value": ""
+                },
+                "price": {
+                    "per": 10,
+                    "value": {
+                        "sp": 1
+                    }
+                },
+                "quantity": 20,
+                "range": {
+                    "long": null,
+                    "units": "",
+                    "value": null
+                },
+                "rules": [],
+                "size": "med",
+                "slug": "arrows",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "stackGroup": "arrows",
+                "target": {
+                    "type": "",
+                    "units": "",
+                    "value": null
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "usage": {
+                    "value": "held-in-one-hand"
+                },
+                "uses": {
+                    "autoDestroy": true,
+                    "autoUse": true,
+                    "max": 0,
+                    "per": null,
+                    "value": 0
+                },
+                "weight": {
+                    "value": "L"
+                }
+            },
+            "type": "consumable"
+        },
+        {
+            "_id": "v6zCYm9g5DqHI81j",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.equipment-srd.88pGCHV0uKMskTVO"
@@ -474,7 +589,7 @@
             },
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/darkvision-elixir.webp",
             "name": "Darkvision Elixir (Lesser)",
-            "sort": 500000,
+            "sort": 600000,
             "system": {
                 "activation": {
                     "condition": "",
@@ -583,7 +698,7 @@
             "type": "consumable"
         },
         {
-            "_id": "Q4FwQDmZIum3ct3p",
+            "_id": "GeB1CiKcc6g90OtZ",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.equipment-srd.bikFUFRLwfdvX2x2"
@@ -591,7 +706,7 @@
             },
             "img": "systems/pf2e/icons/equipment/consumables/potions/invisibility-potion.webp",
             "name": "Invisibility Potion",
-            "sort": 600000,
+            "sort": 700000,
             "system": {
                 "activation": {
                     "condition": "",
@@ -701,121 +816,6 @@
             "type": "consumable"
         },
         {
-            "_id": "UbyLHIEdmifGsrSp",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.equipment-srd.w2ENw2VMPcsbif8g"
-                }
-            },
-            "img": "systems/pf2e/icons/equipment/weapons/arrows.webp",
-            "name": "Arrows",
-            "sort": 700000,
-            "system": {
-                "activation": {
-                    "condition": "",
-                    "cost": 0,
-                    "type": ""
-                },
-                "autoDestroy": {
-                    "_deprecated": true,
-                    "value": true
-                },
-                "autoUse": {
-                    "_deprecated": true,
-                    "value": true
-                },
-                "baseItem": null,
-                "charges": {
-                    "_deprecated": true,
-                    "max": 0,
-                    "value": 0
-                },
-                "consumableType": {
-                    "value": "ammo"
-                },
-                "consume": {
-                    "_deprecated": true,
-                    "value": ""
-                },
-                "containerId": null,
-                "description": {
-                    "value": "<p>These projectiles are the ammunition for bows. The shaft of an arrow is made of wood. It is stabilized in flight by fletching at one end and bears a metal head on the other.</p>"
-                },
-                "duration": {
-                    "units": "",
-                    "value": null
-                },
-                "equipped": {
-                    "carryType": "worn",
-                    "handsHeld": 0
-                },
-                "equippedBulk": {
-                    "value": ""
-                },
-                "hardness": 0,
-                "hp": {
-                    "brokenThreshold": 0,
-                    "max": 0,
-                    "value": 0
-                },
-                "level": {
-                    "value": 0
-                },
-                "negateBulk": {
-                    "value": "0"
-                },
-                "preciousMaterial": {
-                    "value": ""
-                },
-                "preciousMaterialGrade": {
-                    "value": ""
-                },
-                "price": {
-                    "per": 10,
-                    "value": {
-                        "sp": 1
-                    }
-                },
-                "quantity": 20,
-                "range": {
-                    "long": null,
-                    "units": "",
-                    "value": null
-                },
-                "rules": [],
-                "size": "med",
-                "slug": "arrows",
-                "source": {
-                    "value": "Pathfinder Core Rulebook"
-                },
-                "stackGroup": "arrows",
-                "target": {
-                    "type": "",
-                    "units": "",
-                    "value": null
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                },
-                "usage": {
-                    "value": "held-in-one-hand"
-                },
-                "uses": {
-                    "autoDestroy": true,
-                    "autoUse": true,
-                    "max": 0,
-                    "per": null,
-                    "value": 0
-                },
-                "weight": {
-                    "value": "L"
-                }
-            },
-            "type": "consumable"
-        },
-        {
             "_id": "OtJ0BMN8Z5o0eMdr",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Rapier",
@@ -837,7 +837,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>(deadly 1d8, disarm, finesse, magical)</p>"
+                    "value": ""
                 },
                 "rules": [],
                 "slug": null,
@@ -882,7 +882,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>(deadly 2d10, magical, propulsive, range increment 60 feet, reload 0)</p>"
+                    "value": ""
                 },
                 "rules": [],
                 "slug": null,
@@ -1014,7 +1014,24 @@
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "domain": "ac",
+                        "key": "RollOption",
+                        "option": "nimble-dodge",
+                        "toggleable": true,
+                        "value": false
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "predicate": [
+                            "nimble-dodge"
+                        ],
+                        "selector": "ac",
+                        "type": "circumstance",
+                        "value": 2
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""
@@ -1049,12 +1066,22 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>When Tashlock deals damage to a target on a critical hit, the target is slowed 2 until the end of Tashlock's next turn.</p>"
+                    "value": "<p>When Tashlock deals damage to a target on a critical hit, the target is @UUID[Compendium.pf2e.conditionitems.Slowed]{Slowed 2} until the end of Tashlock's next turn.</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "key": "Note",
+                        "outcome": [
+                            "criticalSuccess"
+                        ],
+                        "selector": "strike-damage",
+                        "text": "{item|system.description.value}",
+                        "title": "{item|name}"
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""
@@ -1114,7 +1141,12 @@
             "type": "action"
         },
         {
-            "_id": "NXL0yA5ESy8Xz4NT",
+            "_id": "0ADnKFiKMszSKZaF",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.AWvNPE4U0kEJSL1T"
+                }
+            },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Sneak Attack",
             "sort": 1500000,
@@ -1134,10 +1166,42 @@
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
-                "slug": null,
+                "rules": [
+                    {
+                        "category": "precision",
+                        "diceNumber": 3,
+                        "dieSize": "d6",
+                        "key": "DamageDice",
+                        "predicate": [
+                            "target:condition:flat-footed",
+                            {
+                                "or": [
+                                    "item:trait:agile",
+                                    "item:trait:finesse",
+                                    {
+                                        "and": [
+                                            "item:ranged",
+                                            {
+                                                "not": "item:thrown-melee"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ],
+                        "selector": "strike-damage"
+                    },
+                    {
+                        "domain": "all",
+                        "key": "RollOption",
+                        "label": "PF2E.SpecificRule.TOTMToggle.FlatFooted",
+                        "option": "target:condition:flat-footed",
+                        "toggleable": "totm"
+                    }
+                ],
+                "slug": "sneak-attack",
                 "source": {
-                    "value": ""
+                    "value": "Pathfinder Bestiary"
                 },
                 "traits": {
                     "custom": "",
@@ -1174,7 +1238,29 @@
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "adjustment": {
+                            "failure": "one-degree-better"
+                        },
+                        "key": "AdjustDegreeOfSuccess",
+                        "predicate": [
+                            "action:sneak"
+                        ],
+                        "selector": "stealth",
+                        "type": "skill"
+                    },
+                    {
+                        "key": "Note",
+                        "outcome": [
+                            "failure"
+                        ],
+                        "predicate": "action:sneak",
+                        "selector": "stealth",
+                        "text": "{item|system.description.value}",
+                        "title": "{item|name}"
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""
@@ -1209,7 +1295,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>On the first round of combat, creatures that haven't acted yet are flat-footed to Tashlock.</p>"
+                    "value": "<p>On the first round of combat, creatures that haven't acted yet are @UUID[Compendium.pf2e.conditionitems.Flat-Footed]{Flat-Footed} to Tashlock.</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -1537,7 +1623,7 @@
             "alignment": {
                 "value": "N"
             },
-            "blurb": "",
+            "blurb": "Male human town protector",
             "creatureType": "",
             "level": {
                 "value": 12


### PR DESCRIPTION
Brushed up NPCs-- Poisoned Secret Door Trap, Ledorick Banyan, Stirvyn Banyan, Tashlock Banyan
Added variant-- Ledorick Banyan (Possessed)
Added effect-- Effect: Bloodline Magic (Stirvyn Banyan)
