### PR TITLE
Set Skill Training AE-like to upgrade

### DIFF
--- a/packs/data/feats.db/skill-training.json
+++ b/packs/data/feats.db/skill-training.json
@@ -151,7 +151,7 @@
             },
             {
                 "key": "ActiveEffectLike",
-                "mode": "add",
+                "mode": "upgrade",
                 "path": "system.skills.{item|flags.pf2e.rulesSelections.skill}.rank",
                 "value": 1
             }


### PR DESCRIPTION
While the predicate of rank `0` will likely stop anything weird happening, this feels "more correct"