### PR TITLE
Create new base weapon type for injection spear

### DIFF
--- a/packs/data/equipment.db/injection-spear.json
+++ b/packs/data/equipment.db/injection-spear.json
@@ -6,7 +6,7 @@
         "MAP": {
             "value": ""
         },
-        "baseItem": "spear",
+        "baseItem": "injection-spear",
         "bonus": {
             "value": 0
         },

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -4412,6 +4412,7 @@
                 "heavy-crossbow": "Heavy Crossbow",
                 "hongali-hornbow": "Hongali Hornbow",
                 "horsechopper": "Horsechopper",
+                "injection-spear": "Injection Spear",
                 "javelin": "Javelin",
                 "jaws": "Jaws",
                 "jezail": "Jezail",


### PR DESCRIPTION
I see no reason for the injection spear not to have its own base weapon type; it's a distinct weapon, rather than a modification of a spear.