### PR TITLE
fix hidden thorn weapon group

### DIFF
--- a/packs/data/feats.db/hidden-thorn.json
+++ b/packs/data/feats.db/hidden-thorn.json
@@ -34,7 +34,7 @@
                         "die": "d6"
                     }
                 },
-                "group": "brawling",
+                "group": "knife",
                 "img": "systems/pf2e/icons/unarmed-attacks/spine.webp",
                 "key": "Strike",
                 "label": "PF2E.BattleForm.Attack.Thorn",


### PR DESCRIPTION
Some flowers can hide their thorns, and yours happen to be hidden along your arms. You gain a thorns unarmed attack that deals 1d6 piercing damage. Your thorns are in the **knife** weapon group and have the finesse and unarmed traits.