### PR TITLE
Use proper flat-footed condition for TotM option

### DIFF
--- a/src/module/actor/creature/index.ts
+++ b/src/module/actor/creature/index.ts
@@ -385,7 +385,9 @@ export abstract class CreaturePF2e extends ActorPF2e {
         rollOptions.all[`self:size:${sizeSlug}`] = true;
 
         // make sure "origin:target:condition:flat-footed" works ...
-        rollOptions.all["self:target:condition:flat-footed"] ??= rollOptions.all["target:condition:flat-footed"];
+        if (rollOptions.all["target:condition:flat-footed"]) {
+            rollOptions.all["self:target:condition:flat-footed"] = true;
+        }
 
         // Add modifiers from being flat-footed
         const { isFlatFooted, dueToText } = this.checkFlatFooted();

--- a/src/module/actor/creature/types.ts
+++ b/src/module/actor/creature/types.ts
@@ -67,9 +67,13 @@ interface GetReachParameters {
     weapon?: WeaponPF2e | MeleePF2e | null;
 }
 
-interface IsFlatFootedParams {
+interface FlatFootedResult {
+    isFlatFooted: boolean;
+
     /** The circumstance potentially imposing the flat-footed condition */
-    dueTo: "flanking" | "surprise" | "hidden" | "undetected";
+    dueTo?: "flanking" | "surprise" | "hidden" | "undetected" | "other" | undefined;
+
+    dueToText?: string;
 }
 
 interface CreatureUpdateContext<T extends CreaturePF2e> extends ActorUpdateContext<T> {
@@ -115,7 +119,7 @@ export {
     CreatureSheetData,
     CreatureUpdateContext,
     GetReachParameters,
-    IsFlatFootedParams,
+    FlatFootedResult,
     ModeOfBeing,
     SpellcastingSheetData,
     StrikeRollContext,

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1636,7 +1636,7 @@
             },
             "CannotAddType": "{type} items cannot be added to this actor.",
             "Condition": {
-                "FlatFooted": "Flat-Footed",
+                "FlatFooted": "Flat-Footed (Other)",
                 "Flanked": "Flat-Footed (Flanked)"
             },
             "CreationDialog": {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1636,6 +1636,7 @@
             },
             "CannotAddType": "{type} items cannot be added to this actor.",
             "Condition": {
+                "FlatFooted": "Flat-Footed",
                 "Flanked": "Flat-Footed (Flanked)"
             },
             "CreationDialog": {


### PR DESCRIPTION
My proposal for a simple solution to use the correct Flat-Footed attack calculation (AC -2) when the TotM option "Enable abilities that require a flat-footed target" is set.

For this I also changed the isFlatFooted method to checkFlatFooted and return the dueTo with text, which should make things simpler in the end, when the other reasons get added.