### PR TITLE
Move strike-roll context methods from `CreaturePF2e` to `ActorPF2e`

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -1,6 +1,7 @@
-import { ModeOfBeing } from "@actor/creature/types";
+import { AttackItem, AttackRollContext, StrikeRollContext, StrikeRollContextParams } from "@actor/types";
 import { ActorAlliance, ActorDimensions, AuraData, SaveType } from "@actor/types";
 import { ArmorPF2e, ContainerPF2e, ItemPF2e, PhysicalItemPF2e, type ConditionPF2e } from "@item";
+import { ActionTrait } from "@item/action/data";
 import { ConditionSlug } from "@item/condition/data";
 import { isCycle } from "@item/container/helpers";
 import { ItemSourcePF2e, ItemType, PhysicalItemSource } from "@item/data";
@@ -20,12 +21,14 @@ import { TokenDocumentPF2e } from "@scene";
 import { DicePF2e } from "@scripts/dice";
 import { eventToRollParams } from "@scripts/sheet-util";
 import { Statistic } from "@system/statistic";
-import { ErrorPF2e, isObject, objectHasKey, tupleHasValue } from "@util";
+import { ErrorPF2e, isObject, objectHasKey, traitSlugToObject, tupleHasValue } from "@util";
 import type { CreaturePF2e } from "./creature";
 import { VisionLevel, VisionLevels } from "./creature/data";
+import { GetReachParameters, ModeOfBeing } from "./creature/types";
 import { ActorDataPF2e, ActorSourcePF2e, ActorType } from "./data";
-import { ActorFlagsPF2e, BaseTraitsData, PrototypeTokenPF2e, RollOptionFlags } from "./data/base";
+import { ActorFlagsPF2e, BaseTraitsData, PrototypeTokenPF2e, RollOptionFlags, StrikeData } from "./data/base";
 import { ActorSizePF2e } from "./data/size";
+import { calculateRangePenalty, getRangeIncrement } from "./helpers";
 import { ActorInventory } from "./inventory";
 import { ItemTransfer } from "./item-transfer";
 import { ActorSheetPF2e } from "./sheet/base";
@@ -253,6 +256,9 @@ class ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
     isOfType<T extends ActorType>(
         ...types: T[]
     ): this is InstanceType<ConfigPF2e["PF2E"]["Actor"]["documentClasses"][T]>;
+    isOfType<T extends "creature" | ActorType>(
+        ...types: T[]
+    ): this is CreaturePF2e | InstanceType<ConfigPF2e["PF2E"]["Actor"]["documentClasses"][Exclude<T, "creature">]>;
     isOfType<T extends ActorType | "creature">(...types: T[]): boolean {
         return types.some((t) => (t === "creature" ? tupleHasValue(CREATURE_ACTOR_TYPES, this.type) : this.type === t));
     }
@@ -271,7 +277,7 @@ class ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
     }
 
     /** The actor's reach: a meaningful implementation is found in `CreaturePF2e` and `HazardPF2e`. */
-    getReach(_options: { action?: "interact" | "attack" }): number {
+    getReach(_options: GetReachParameters): number {
         return 0;
     }
 
@@ -597,6 +603,135 @@ class ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
     /* -------------------------------------------- */
     /*  Rolls                                       */
     /* -------------------------------------------- */
+
+    protected getStrikeRollContext<I extends AttackItem>(
+        params: StrikeRollContextParams<I>
+    ): StrikeRollContext<this, I> {
+        const targetToken = Array.from(game.user.targets).find((t) => t.actor?.isOfType("creature", "hazard")) ?? null;
+
+        const selfToken =
+            canvas.tokens.controlled.find((t) => t.actor === this) ?? this.getActiveTokens().shift() ?? null;
+        const reach = params.item.isOfType("melee")
+            ? params.item.reach
+            : params.item.isOfType("weapon")
+            ? this.getReach({ action: "attack", weapon: params.item })
+            : null;
+
+        const selfOptions = this.getRollOptions(params.domains ?? []);
+        if (targetToken && typeof reach === "number" && selfToken?.isFlanking(targetToken, { reach })) {
+            selfOptions.push("self:flanking");
+        }
+
+        const selfActor = params.viewOnly ? this : this.getContextualClone(selfOptions);
+        const actions: StrikeData[] = selfActor.system.actions?.flatMap((a) => [a, a.altUsages ?? []].flat()) ?? [];
+
+        const selfItem: AttackItem =
+            params.viewOnly || params.item.isOfType("spell")
+                ? params.item
+                : actions
+                      .map((a): AttackItem => a.item)
+                      .find((weapon) => {
+                          // Find the matching weapon or melee item
+                          if (!(params.item.id === weapon.id && weapon.name === params.item.name)) return false;
+                          if (params.item.isOfType("melee") && weapon.isOfType("melee")) return true;
+
+                          // Discriminate between melee/thrown usages by checking that both are either melee or ranged
+                          return (
+                              params.item.isOfType("weapon") &&
+                              weapon.isOfType("weapon") &&
+                              params.item.isMelee === weapon.isMelee
+                          );
+                      }) ?? params.item;
+
+        const traitSlugs: ActionTrait[] = [
+            "attack" as const,
+            // CRB p. 544: "Due to the complexity involved in preparing bombs, Strikes to throw alchemical bombs gain
+            // the manipulate trait."
+            selfItem.isOfType("weapon") && selfItem.baseType === "alchemical-bomb" ? ("manipulate" as const) : [],
+        ].flat();
+        for (const adjustment of this.synthetics.strikeAdjustments) {
+            if (selfItem.isOfType("weapon", "melee")) {
+                adjustment.adjustTraits?.(selfItem, traitSlugs);
+            }
+        }
+        const traits = traitSlugs.map((t) => traitSlugToObject(t, CONFIG.PF2E.actionTraits));
+
+        // Clone the actor to recalculate its AC with contextual roll options
+        const targetActor = params.viewOnly
+            ? null
+            : targetToken?.actor?.getContextualClone([...selfActor.getSelfRollOptions("origin")]) ?? null;
+
+        // Target roll options
+        const targetOptions = targetActor?.getSelfRollOptions("target") ?? [];
+        if (targetToken && targetOptions.length > 0) {
+            const mark = this.synthetics.targetMarks.get(targetToken.document.uuid);
+            if (mark) targetOptions.push(`target:mark:${mark}`);
+        }
+
+        const rollOptions = new Set([
+            ...params.options,
+            ...selfOptions,
+            ...targetOptions,
+            ...selfItem.getRollOptions("item"),
+            // Backward compatibility for predication looking for an "attack" trait by its lonesome
+            "attack",
+        ]);
+
+        // Calculate distance and range increment, set as a roll option
+        const distance = selfToken && targetToken && !!canvas.grid ? selfToken.distanceTo(targetToken) : null;
+        if (typeof distance === "number") rollOptions.add(`target:distance:${distance}`);
+
+        const rangeIncrement = getRangeIncrement(selfItem, distance);
+        if (rangeIncrement) rollOptions.add(`target:range-increment:${rangeIncrement}`);
+
+        const self = {
+            actor: selfActor,
+            token: selfToken?.document ?? null,
+            item: selfItem as I,
+            modifiers: [],
+        };
+
+        const target =
+            targetActor && targetToken && distance !== null
+                ? { actor: targetActor, token: targetToken.document, distance, rangeIncrement }
+                : null;
+
+        return {
+            options: rollOptions,
+            self,
+            target,
+            traits,
+        };
+    }
+
+    /**
+     * Calculates attack roll target data including the target's DC.
+     * All attack rolls have the "all" and "attack-roll" domains and the "attack" trait,
+     * but more can be added via the options.
+     */
+    getAttackRollContext<I extends AttackItem>(params: StrikeRollContextParams<I>): AttackRollContext<this, I> {
+        const context = this.getStrikeRollContext(params);
+        const targetActor = context.target?.actor;
+        const rangeIncrement = context.target?.rangeIncrement ?? null;
+
+        const rangePenalty = calculateRangePenalty(this, rangeIncrement, params.domains, context.options);
+        if (rangePenalty) context.self.modifiers.push(rangePenalty);
+
+        return {
+            ...context,
+            dc: targetActor?.attributes.ac
+                ? {
+                      scope: "attack",
+                      slug: "ac",
+                      value: targetActor.attributes.ac.value,
+                  }
+                : null,
+        };
+    }
+
+    getDamageRollContext<I extends AttackItem>(params: StrikeRollContextParams<I>): StrikeRollContext<this, I> {
+        return this.getStrikeRollContext(params);
+    }
 
     /**
      * Roll a Save Check

--- a/src/module/actor/character/index.ts
+++ b/src/module/actor/character/index.ts
@@ -1,12 +1,6 @@
 import { CreaturePF2e, FamiliarPF2e } from "@actor";
 import { Abilities, CreatureSpeeds, LabeledSpeed, MovementType, SkillAbbreviation } from "@actor/creature/data";
-import {
-    AttackItem,
-    AttackRollContext,
-    CreatureUpdateContext,
-    StrikeRollContext,
-    StrikeRollContextParams,
-} from "@actor/creature/types";
+import { CreatureUpdateContext } from "@actor/creature/types";
 import { ALLIANCES } from "@actor/creature/values";
 import { CharacterSource } from "@actor/data";
 import { ActorSizePF2e } from "@actor/data/size";
@@ -20,7 +14,14 @@ import {
     ProficiencyModifier,
     StatisticModifier,
 } from "@actor/modifiers";
-import { AbilityString, SaveType } from "@actor/types";
+import {
+    AbilityString,
+    AttackItem,
+    AttackRollContext,
+    SaveType,
+    StrikeRollContext,
+    StrikeRollContextParams,
+} from "@actor/types";
 import {
     ABILITY_ABBREVIATIONS,
     SAVE_TYPES,
@@ -105,10 +106,10 @@ import {
     WeaponGroupProficiencyKey,
 } from "./data";
 import { CharacterSheetTabVisibility } from "./data/sheet";
-import { CHARACTER_SHEET_TABS } from "./values";
 import { CharacterFeats } from "./feats";
 import { createForceOpenPenalty, createShoddyPenalty, StrikeWeaponTraits } from "./helpers";
 import { CharacterHitPointsSummary, CharacterSkills, CreateAuxiliaryParams, DexterityModifierCapData } from "./types";
+import { CHARACTER_SHEET_TABS } from "./values";
 
 class CharacterPF2e extends CreaturePF2e {
     /** Core singular embeds for PCs */

--- a/src/module/actor/creature/types.ts
+++ b/src/module/actor/creature/types.ts
@@ -1,15 +1,10 @@
-import { ActorPF2e } from "@actor";
 import { ActorSheetDataPF2e } from "@actor/sheet/data-types";
-import { MeleePF2e, SpellPF2e, WeaponPF2e } from "@item";
+import { MeleePF2e, WeaponPF2e } from "@item";
 import { SpellcastingEntryData } from "@item/data";
 import { SpellcastingAbilityData } from "@item/spellcasting-entry/data";
-import { ModifierPF2e } from "@actor/modifiers";
-import { TokenDocumentPF2e } from "@scene";
-import { CheckDC } from "@system/degree-of-success";
 import { CreaturePF2e } from ".";
 import { SheetOptions } from "@module/sheet/helpers";
 import { ALIGNMENTS, ALIGNMENT_TRAITS } from "./values";
-import { TraitViewData } from "@actor/data/base";
 import { FlattenedCondition } from "@system/conditions";
 import { ActorUpdateContext } from "@actor/base";
 import { AbilityData, CreatureSystemData, SaveData, SkillData } from "./data";
@@ -19,48 +14,7 @@ import { AbilityString, SaveType } from "@actor/types";
 type Alignment = SetElement<typeof ALIGNMENTS>;
 type AlignmentTrait = SetElement<typeof ALIGNMENT_TRAITS>;
 
-type AttackItem = WeaponPF2e | MeleePF2e | SpellPF2e;
-
 type ModeOfBeing = "living" | "undead" | "construct" | "object";
-
-interface StrikeSelf<A extends ActorPF2e = ActorPF2e, I extends AttackItem = AttackItem> {
-    actor: A;
-    token: TokenDocumentPF2e | null;
-    /** The item used for the strike */
-    item: I;
-    /** Bonuses and penalties added at the time of a strike */
-    modifiers: ModifierPF2e[];
-}
-
-interface AttackTarget {
-    actor: ActorPF2e;
-    token: TokenDocumentPF2e;
-    distance: number;
-    rangeIncrement: number | null;
-}
-
-/** Context for the attack or damage roll of a strike */
-interface StrikeRollContext<A extends ActorPF2e, I extends AttackItem> {
-    /** Roll options */
-    options: Set<string>;
-    self: StrikeSelf<A, I>;
-    target: AttackTarget | null;
-    traits: TraitViewData[];
-}
-
-interface StrikeRollContextParams<T extends AttackItem> {
-    item: T;
-    /** Domains from which to draw roll options */
-    domains: string[];
-    /** Initial roll options for the strike */
-    options: Set<string>;
-    /** Whether the request is for display in a sheet view. If so, targets are not considered */
-    viewOnly?: boolean;
-}
-
-interface AttackRollContext<A extends ActorPF2e, I extends AttackItem> extends StrikeRollContext<A, I> {
-    dc: CheckDC | null;
-}
 
 interface GetReachParameters {
     action?: "interact" | "attack";
@@ -109,16 +63,10 @@ type SpellcastingSheetData = RawObject<SpellcastingEntryData> & SpellcastingAbil
 export {
     Alignment,
     AlignmentTrait,
-    AttackItem,
-    AttackRollContext,
-    AttackTarget,
     CreatureSheetData,
     CreatureUpdateContext,
     GetReachParameters,
     IsFlatFootedParams,
     ModeOfBeing,
     SpellcastingSheetData,
-    StrikeRollContext,
-    StrikeRollContextParams,
-    StrikeSelf,
 };

--- a/src/module/actor/data/base.ts
+++ b/src/module/actor/data/base.ts
@@ -54,6 +54,7 @@ interface ActorSystemData extends ActorSystemSource {
         level: { value: number };
         alliance: ActorAlliance;
     };
+    actions?: StrikeData[];
     attributes: BaseActorAttributes;
     traits: BaseTraitsData<string>;
     /** Icons appearing in the Effects Tracker application */
@@ -230,7 +231,8 @@ interface StrikeData extends StatisticModifier {
     damage?: RollFunction<StrikeRollParams>;
     /** Roll critical damage for this weapon. */
     critical?: RollFunction<StrikeRollParams>;
-
+    /** Alternative usages of a strike weapon: thrown, combination-melee, etc. */
+    altUsages?: StrikeData[];
     /** A list of attack variants which apply the Multiple Attack Penalty. */
     variants: { label: string; roll: RollFunction<StrikeRollParams> }[];
 

--- a/src/module/actor/helpers.ts
+++ b/src/module/actor/helpers.ts
@@ -1,8 +1,22 @@
 import { ActorPF2e } from "@actor";
-import { ItemPF2e } from "@item";
-import { extractModifierAdjustments } from "@module/rules/util";
-import { AttackItem } from "./creature/types";
-import { ModifierPF2e, MODIFIER_TYPE } from "./modifiers";
+import { ItemPF2e, MeleePF2e } from "@item";
+import {
+    extractDegreeOfSuccessAdjustments,
+    extractModifierAdjustments,
+    extractModifiers,
+    extractNotes,
+    extractRollSubstitutions,
+    extractRollTwice,
+} from "@module/rules/util";
+import { CheckPF2e, CheckRoll } from "@system/check";
+import { DamageType, WeaponDamagePF2e } from "@system/damage";
+import { DamageRollPF2e, RollParameters } from "@system/rolls";
+import { ErrorPF2e, sluggify } from "@util";
+import { RollFunction, TraitViewData } from "./data/base";
+import { CheckModifier, ModifierPF2e, MODIFIER_TYPE, StatisticModifier } from "./modifiers";
+import { NPCStrike } from "./npc/data";
+import { StrikeAttackTraits } from "./npc/strike-attack-traits";
+import { AttackItem } from "./types";
 
 /** Reset and rerender a provided list of actors. Omit argument to reset all world and synthetic actors */
 async function resetAndRerenderActors(actors?: Iterable<ActorPF2e>): Promise<void> {
@@ -52,6 +66,235 @@ function calculateMAPs(
 
     // Find lowest multiple attack penalty: penalties are negative, so actually looking for the highest value
     return [baseMap, ...fromSynthetics].reduce((lowest, p) => (p.map1 > lowest.map1 ? p : lowest));
+}
+
+/** Create a strike statistic from a melee item: for use by NPCs and Hazards */
+function createStrikeStatistic(item: Embedded<MeleePF2e>): NPCStrike {
+    const { ability, traits, isMelee, isThrown } = item;
+    const { actor } = item;
+    if (!actor.isOfType("npc", "hazard")) {
+        throw ErrorPF2e("Attempted to create melee-item strike statistic for non-NPC/hazard");
+    }
+
+    // Conditions and Custom modifiers to attack rolls
+    const slug = item.slug ?? sluggify(item.name);
+    const unarmedOrWeapon = traits.has("unarmed") ? "unarmed" : "weapon";
+    const meleeOrRanged = isMelee ? "melee" : "ranged";
+
+    const domains = [
+        "attack",
+        "mundane-attack",
+        `${slug}-attack`,
+        `${item.id}-attack`,
+        `${unarmedOrWeapon}-attack-roll`,
+        `${meleeOrRanged}-attack-roll`,
+        "strike-attack-roll",
+        "attack-roll",
+        "all",
+    ];
+
+    if (actor.isOfType("npc")) {
+        domains.push(`${ability}-attack`, `${ability}-based`);
+    }
+
+    const { synthetics } = actor;
+    const modifiers: ModifierPF2e[] = [
+        new ModifierPF2e({
+            slug: "base",
+            label: "PF2E.ModifierTitle",
+            modifier: item.attackModifier,
+            adjustments: extractModifierAdjustments(synthetics.modifierAdjustments, domains, "base"),
+        }),
+    ];
+
+    modifiers.push(...extractModifiers(synthetics, domains));
+    modifiers.push(...StrikeAttackTraits.createAttackModifiers(item));
+    const notes = extractNotes(synthetics.rollNotes, domains);
+
+    // action image
+    const { imageUrl, actionGlyph } = ActorPF2e.getActionGraphics("action", 1);
+
+    const attackEffects: Record<string, string | undefined> = CONFIG.PF2E.attackEffects;
+    const additionalEffects = item.attackEffects.map((tag) => {
+        const label = attackEffects[tag] ?? actor.items.find((i) => (i.slug ?? sluggify(i.name)) === tag)?.name ?? tag;
+        return { tag, label };
+    });
+
+    const baseOptions = [...actor.getRollOptions(domains), ...item.traits];
+    // Legacy support for "melee", "ranged", and "thrown" roll options
+    if (isMelee) {
+        baseOptions.push("melee");
+    } else if (isThrown) {
+        baseOptions.push("ranged", "thrown");
+    } else {
+        baseOptions.push("ranged");
+    }
+
+    const statistic = new StatisticModifier(`${slug}-strike`, modifiers, baseOptions);
+    statistic.adjustments = extractDegreeOfSuccessAdjustments(synthetics, domains);
+    const traitObjects = Array.from(traits).map(
+        (t): TraitViewData => ({
+            name: t,
+            label: CONFIG.PF2E.npcAttackTraits[t] ?? t,
+            description: CONFIG.PF2E.traitsDescriptions[t],
+        })
+    );
+
+    const strike: NPCStrike = mergeObject(statistic, {
+        label: item.name,
+        type: "strike" as const,
+        glyph: actionGlyph,
+        description: item.description,
+        imageUrl,
+        sourceId: item.id,
+        attackRollType: item.isRanged ? "PF2E.NPCAttackRanged" : "PF2E.NPCAttackMelee",
+        additionalEffects,
+        item,
+        weapon: item,
+        traits: traitObjects,
+        options: [],
+        variants: [],
+        success: "",
+        ready: true,
+        criticalSuccess: "",
+    });
+
+    strike.breakdown = strike.modifiers
+        .filter((m) => m.enabled)
+        .map((m) => `${m.label} ${m.modifier < 0 ? "" : "+"}${m.modifier}`)
+        .join(", ");
+
+    // Add a damage roll breakdown
+    strike.damageBreakdown = Object.values(item.system.damageRolls).flatMap((roll) => {
+        const damageType = game.i18n.localize(CONFIG.PF2E.damageTypes[roll.damageType as DamageType]);
+        return [`${roll.damage} ${damageType}`];
+    });
+
+    const strikeLabel = game.i18n.localize("PF2E.WeaponStrikeLabel");
+    const multipleAttackPenalty = calculateMAPs(item, { domains, options: baseOptions });
+    const sign = strike.totalModifier < 0 ? "" : "+";
+    const attackTrait = {
+        name: "attack",
+        label: CONFIG.PF2E.featTraits.attack,
+        description: CONFIG.PF2E.traitsDescriptions.attack,
+    };
+
+    strike.variants = [
+        null,
+        new ModifierPF2e("PF2E.MultipleAttackPenalty", multipleAttackPenalty.map1, MODIFIER_TYPE.UNTYPED),
+        new ModifierPF2e("PF2E.MultipleAttackPenalty", multipleAttackPenalty.map2, MODIFIER_TYPE.UNTYPED),
+    ].map((map) => {
+        const label = map
+            ? game.i18n.format("PF2E.MAPAbbreviationLabel", { penalty: map.modifier })
+            : `${strikeLabel} ${sign}${strike.totalModifier}`;
+        return {
+            label,
+            roll: async (params: RollParameters = {}): Promise<Rolled<CheckRoll> | null> => {
+                const attackEffects = actor.isOfType("npc") ? await actor.getAttackEffects(item) : [];
+                const rollNotes = notes.concat(attackEffects);
+
+                params.options ??= [];
+                // Always add all weapon traits as options
+                const context = actor.getAttackRollContext({
+                    item,
+                    viewOnly: false,
+                    domains,
+                    options: new Set([...baseOptions, ...params.options, ...traits]),
+                });
+
+                // Check whether target is out of maximum range; abort early if so
+                if (context.self.item.isRanged && typeof context.target?.distance === "number") {
+                    const maxRange = item.maxRange ?? 10;
+                    if (context.target.distance > maxRange) {
+                        ui.notifications.warn("PF2E.Action.Strike.OutOfRange", { localize: true });
+                        return null;
+                    }
+                }
+
+                const otherModifiers = [map ?? [], context.self.modifiers].flat();
+                const checkName = game.i18n.format(
+                    item.isMelee ? "PF2E.Action.Strike.MeleeLabel" : "PF2E.Action.Strike.RangedLabel",
+                    { weapon: item.name }
+                );
+
+                const roll = await CheckPF2e.roll(
+                    new CheckModifier(checkName, strike, otherModifiers),
+                    {
+                        type: "attack-roll",
+                        actor: context.self.actor,
+                        item: context.self.item,
+                        target: context.target,
+                        domains,
+                        options: context.options,
+                        notes: rollNotes,
+                        dc: params.dc ?? context.dc,
+                        rollTwice: extractRollTwice(synthetics.rollTwice, domains, context.options),
+                        substitutions: extractRollSubstitutions(synthetics.rollSubstitutions, domains, context.options),
+
+                        traits: [attackTrait],
+                    },
+                    params.event
+                );
+
+                for (const rule of actor.rules.filter((r) => !r.ignored)) {
+                    await rule.afterRoll?.({
+                        roll,
+                        selectors: domains,
+                        domains,
+                        rollOptions: context.options,
+                    });
+                }
+
+                return roll;
+            },
+        };
+    });
+    strike.roll = strike.attack = strike.variants[0].roll;
+
+    const damageRoll =
+        (outcome: "success" | "criticalSuccess"): RollFunction =>
+        async (params: RollParameters = {}) => {
+            const domains = ["all", "strike-damage", "damage-roll"];
+            const context = actor.getDamageRollContext({
+                item,
+                viewOnly: false,
+                domains,
+                options: new Set(params.options ?? []),
+            });
+            // always add all weapon traits as options
+            const options = new Set([...context.options, ...traits, ...context.self.item.getRollOptions("item")]);
+
+            if (!context.self.item.dealsDamage) {
+                return ui.notifications.warn("PF2E.ErrorMessage.WeaponNoDamage", { localize: true });
+            }
+
+            const damage = WeaponDamagePF2e.calculateStrikeNPC(
+                context.self.item,
+                context.self.actor,
+                [attackTrait],
+                deepClone(synthetics.statisticsModifiers),
+                deepClone(synthetics.modifierAdjustments),
+                deepClone(synthetics.damageDice),
+                1,
+                options,
+                synthetics.rollNotes,
+                synthetics.strikeAdjustments
+            );
+            if (!damage) throw ErrorPF2e("This weapon deals no damage");
+
+            const { self, target } = context;
+
+            await DamageRollPF2e.roll(
+                damage,
+                { type: "damage-roll", self, target, outcome, options, domains },
+                params.callback
+            );
+        };
+
+    strike.damage = damageRoll("success");
+    strike.critical = damageRoll("criticalSuccess");
+
+    return strike;
 }
 
 function calculateBaseMAP(item: ItemPF2e): MAPData {
@@ -115,4 +358,4 @@ interface MAPData {
     map2: number;
 }
 
-export { calculateMAPs, calculateRangePenalty, getRangeIncrement, resetAndRerenderActors };
+export { calculateMAPs, calculateRangePenalty, createStrikeStatistic, getRangeIncrement, resetAndRerenderActors };

--- a/src/module/actor/types.ts
+++ b/src/module/actor/types.ts
@@ -1,4 +1,10 @@
+import { ActorPF2e } from "@actor";
+import { MeleePF2e, SpellPF2e, WeaponPF2e } from "@item";
 import { ItemTrait } from "@item/data/base";
+import { TokenDocumentPF2e } from "@scene";
+import { CheckDC } from "@system/degree-of-success";
+import { TraitViewData } from "./data/base";
+import { ModifierPF2e } from "./modifiers";
 import { ABILITY_ABBREVIATIONS, DC_SLUGS, SAVE_TYPES, SKILL_ABBREVIATIONS, SKILL_LONG_FORMS } from "./values";
 
 type AbilityString = SetElement<typeof ABILITY_ABBREVIATIONS>;
@@ -43,10 +49,58 @@ interface AuraColors {
     fill: `#${string}`;
 }
 
+/* -------------------------------------------- */
+/*  Attack Rolls                                */
+/* -------------------------------------------- */
+
+type AttackItem = WeaponPF2e | MeleePF2e | SpellPF2e;
+
+interface StrikeSelf<A extends ActorPF2e = ActorPF2e, I extends AttackItem = AttackItem> {
+    actor: A;
+    token: TokenDocumentPF2e | null;
+    /** The item used for the strike */
+    item: I;
+    /** Bonuses and penalties added at the time of a strike */
+    modifiers: ModifierPF2e[];
+}
+
+interface AttackTarget {
+    actor: ActorPF2e;
+    token: TokenDocumentPF2e;
+    distance: number;
+    rangeIncrement: number | null;
+}
+
+/** Context for the attack or damage roll of a strike */
+interface StrikeRollContext<A extends ActorPF2e, I extends AttackItem> {
+    /** Roll options */
+    options: Set<string>;
+    self: StrikeSelf<A, I>;
+    target: AttackTarget | null;
+    traits: TraitViewData[];
+}
+
+interface StrikeRollContextParams<T extends AttackItem> {
+    item: T;
+    /** Domains from which to draw roll options */
+    domains: string[];
+    /** Initial roll options for the strike */
+    options: Set<string>;
+    /** Whether the request is for display in a sheet view. If so, targets are not considered */
+    viewOnly?: boolean;
+}
+
+interface AttackRollContext<A extends ActorPF2e, I extends AttackItem> extends StrikeRollContext<A, I> {
+    dc: CheckDC | null;
+}
+
 export {
     AbilityString,
     ActorAlliance,
     ActorDimensions,
+    AttackItem,
+    AttackRollContext,
+    AttackTarget,
     AuraColors,
     AuraData,
     AuraEffectData,
@@ -54,4 +108,7 @@ export {
     SaveType,
     SkillAbbreviation,
     SkillLongForm,
+    StrikeRollContext,
+    StrikeRollContextParams,
+    StrikeSelf,
 };

--- a/src/module/system/check/check.ts
+++ b/src/module/system/check/check.ts
@@ -1,5 +1,5 @@
 import { ActorPF2e, CharacterPF2e } from "@actor";
-import { AttackTarget } from "@actor/creature/types";
+import { AttackTarget } from "@actor/types";
 import { StrikeData, TraitViewData } from "@actor/data/base";
 import { ItemPF2e, WeaponPF2e } from "@item";
 import { ChatMessagePF2e } from "@module/chat-message";

--- a/src/module/system/check/types.ts
+++ b/src/module/system/check/types.ts
@@ -1,5 +1,5 @@
 import { ActorPF2e } from "@actor";
-import { AttackTarget } from "@actor/creature/types";
+import { AttackTarget } from "@actor/types";
 import { ItemPF2e } from "@item";
 import { RollSubstitution } from "@module/rules/synthetics";
 import { TokenDocumentPF2e } from "@scene/token-document";

--- a/src/module/system/damage/helpers.ts
+++ b/src/module/system/damage/helpers.ts
@@ -1,4 +1,4 @@
-import { StrikeSelf, AttackTarget } from "@actor/creature/types";
+import { StrikeSelf, AttackTarget } from "@actor/types";
 import { DegreeOfSuccessString } from "@system/degree-of-success";
 import { BaseRollContext } from "@system/rolls";
 import { DamageDieSize } from "./types";

--- a/src/module/system/damage/weapon.ts
+++ b/src/module/system/damage/weapon.ts
@@ -1,4 +1,4 @@
-import { ActorPF2e, CharacterPF2e, NPCPF2e } from "@actor";
+import { ActorPF2e, CharacterPF2e, HazardPF2e, NPCPF2e } from "@actor";
 import { TraitViewData } from "@actor/data/base";
 import {
     DamageDiceOverride,
@@ -12,8 +12,10 @@ import {
 import { AbilityString } from "@actor/types";
 import { MeleePF2e, WeaponPF2e } from "@item";
 import { MeleeDamageRoll } from "@item/melee/data";
-import { getPropertyRuneModifiers } from "@item/physical";
-import { WeaponDamage, WeaponMaterialEffect, WEAPON_MATERIAL_EFFECTS } from "@item/weapon";
+import { getPropertyRuneModifiers } from "@item/physical/runes";
+import { WeaponDamage } from "@item/weapon/data";
+import { WeaponMaterialEffect } from "@item/weapon/types";
+import { WEAPON_MATERIAL_EFFECTS } from "@item/weapon/values";
 import { RollNotePF2e } from "@module/notes";
 import {
     DamageDiceSynthetics,
@@ -31,7 +33,7 @@ import { DamageCategorization, DamageDieSize, DamageType, nextDamageDieSize } fr
 class WeaponDamagePF2e {
     static calculateStrikeNPC(
         attack: MeleePF2e,
-        actor: NPCPF2e,
+        actor: NPCPF2e | HazardPF2e,
         traits: TraitViewData[] = [],
         statisticsModifiers: ModifierSynthetics,
         modifierAdjustments: ModifierAdjustmentSynthetics,
@@ -86,7 +88,7 @@ class WeaponDamagePF2e {
 
     static calculate(
         weapon: WeaponPF2e | MeleePF2e,
-        actor: CharacterPF2e | NPCPF2e,
+        actor: CharacterPF2e | NPCPF2e | HazardPF2e,
         traits: TraitViewData[] = [],
         statisticsModifiers: ModifierSynthetics,
         modifierAdjustments: ModifierAdjustmentSynthetics,
@@ -117,10 +119,11 @@ class WeaponDamagePF2e {
             options.add(PROFICIENCY_RANK_OPTION[proficiencyRank]);
         }
 
+        const isMelee = !!weapon.isMelee;
+        options.add(isMelee ? "melee" : "ranged");
+
         // Determine ability modifier
-        {
-            const isMelee = !!weapon.isMelee;
-            options.add(isMelee ? "melee" : "ranged");
+        if (actor.isOfType("character", "npc")) {
             const strengthModValue = actor.abilities.str.mod;
             const modifierValue = WeaponDamagePF2e.strengthModToDamage(weapon)
                 ? strengthModValue

--- a/src/module/system/rolls.ts
+++ b/src/module/system/rolls.ts
@@ -1,4 +1,4 @@
-import { AttackTarget } from "@actor/creature/types";
+import { AttackTarget } from "@actor/types";
 import { TraitViewData } from "@actor/data/base";
 import { StrikeLookupData } from "@module/chat-message/data";
 import { ZeroToThree } from "@module/data";


### PR DESCRIPTION
preparation for giving hazards proper strikes