### PR TITLE
Fix uses of “collapsed” to be boolean

### DIFF
--- a/packs/data/paizo-pregens.db/grimmnir.json
+++ b/packs/data/paizo-pregens.db/grimmnir.json
@@ -635,7 +635,7 @@
                 "bulkCapacity": {
                     "value": "4"
                 },
-                "collapsed": true,
+                "collapsed": false,
                 "containerId": null,
                 "description": {
                     "value": "<p>A backpack holds up to 4 Bulk of items and the first 2 Bulk of these items don't count against your Bulk limits. If you're carrying or stowing the pack rather than wearing it on your back, its Bulk is light instead of negligible</p>"

--- a/packs/data/paizo-pregens.db/izni.json
+++ b/packs/data/paizo-pregens.db/izni.json
@@ -2031,7 +2031,7 @@
                 "bulkCapacity": {
                     "value": "4"
                 },
-                "collapsed": true,
+                "collapsed": false,
                 "containerId": null,
                 "description": {
                     "value": "<p>A backpack holds up to 4 Bulk of items and the first 2 Bulk of these items don't count against your Bulk limits. If you're carrying or stowing the pack rather than wearing it on your back, its Bulk is light instead of negligible</p>"

--- a/packs/data/paizo-pregens.db/rhin.json
+++ b/packs/data/paizo-pregens.db/rhin.json
@@ -2272,7 +2272,7 @@
                 "bulkCapacity": {
                     "value": "4"
                 },
-                "collapsed": true,
+                "collapsed": false,
                 "containerId": null,
                 "description": {
                     "value": "<p>A backpack holds up to 4 Bulk of items and the first 2 Bulk of these items don't count against your Bulk limits. If you're carrying or stowing the pack rather than wearing it on your back, its Bulk is light instead of negligible</p>"

--- a/packs/data/pathfinder-bestiary-2.db/planetar.json
+++ b/packs/data/pathfinder-bestiary-2.db/planetar.json
@@ -3051,9 +3051,7 @@
                 "category": {
                     "value": "ritual"
                 },
-                "collapsed": {
-                    "value": false
-                },
+                "collapsed": false,
                 "components": {
                     "focus": false,
                     "material": false,

--- a/static/template.json
+++ b/static/template.json
@@ -626,9 +626,7 @@
             "bulkCapacity": {
                 "value": ""
             },
-            "collapsed": {
-                "value": false
-            },
+            "collapsed": false,
             "stowing": false,
             "usage": {
                 "value": "worn"


### PR DESCRIPTION
Closes [#4691](https://github.com/foundryvtt/pf2e/issues/4691)

Migration728FlattenPhysicalProperties indicates that flattened is correct.