### PR TITLE
Refine the attack note of Battle Cry 

### DIFF
--- a/packs/data/feats.db/battle-cry.json
+++ b/packs/data/feats.db/battle-cry.json
@@ -42,7 +42,7 @@
                 ],
                 "predicate": [
                     "skill:itm:rank:4"
-                ]
+                ],
                 "selector": "attack",
                 "text": "You can use a reaction to <span data-pf2-action=\"demoralize\" data-pf2-glyph=\"R\">Demoralize</span> your foe when you critically succeed at an attack roll.",
                 "title": "{item|name}"

--- a/packs/data/feats.db/battle-cry.json
+++ b/packs/data/feats.db/battle-cry.json
@@ -37,6 +37,17 @@
             },
             {
                 "key": "Note",
+                "outcome": [
+                    "criticalSuccess"
+                ],
+                "predicate": [
+                    {
+                        "eq": [
+                            "skill:itm:rank",
+                            4
+                        ]
+                    }
+                ],
                 "selector": "attack",
                 "text": "You can use a reaction to <span data-pf2-action=\"demoralize\" data-pf2-glyph=\"R\">Demoralize</span> your foe when you critically succeed at an attack roll.",
                 "title": "{item|name}"

--- a/packs/data/feats.db/battle-cry.json
+++ b/packs/data/feats.db/battle-cry.json
@@ -41,13 +41,8 @@
                     "criticalSuccess"
                 ],
                 "predicate": [
-                    {
-                        "eq": [
-                            "skill:itm:rank",
-                            4
-                        ]
-                    }
-                ],
+                    "skill:itm:rank:4"
+                ]
                 "selector": "attack",
                 "text": "You can use a reaction to <span data-pf2-action=\"demoralize\" data-pf2-glyph=\"R\">Demoralize</span> your foe when you critically succeed at an attack roll.",
                 "title": "{item|name}"


### PR DESCRIPTION
Refine the attack note of Battle Cry to display only when all criteria are met instead of on all attacks.

I'm using this tiny change to dip my toe into the Contribution waters.