### PR TITLE
Skip migration of synthetic actors lacking migratable actor data

### DIFF
--- a/packs/scripts/extract.ts
+++ b/packs/scripts/extract.ts
@@ -1,6 +1,6 @@
 import type { ActorPF2e } from "@actor/base";
 import { ActorSourcePF2e } from "@actor/data";
-import { NPCSystemData } from "@actor/npc/data";
+import { NPCAttributesSource, NPCSystemSource } from "@actor/npc/data";
 import type { ItemPF2e } from "@item/base";
 import { ActionItemSource, ItemSourcePF2e, MeleeSource, SpellSource } from "@item/data";
 import { isPhysicalData } from "@item/data/helpers";
@@ -175,15 +175,15 @@ function pruneTree(docSource: PackEntry, topLevel: PackEntry): void {
                     }
 
                     if (docSource.type === "npc") {
-                        const { source } = docSource.system.details;
-                        source.author = source.author?.trim() || undefined;
+                        const source: Partial<NPCSystemSource["details"]["source"]> = docSource.system.details.source;
+                        if (!source.author?.trim) delete source.author;
 
-                        const { speed } = docSource.system.attributes;
-                        speed.details = speed.details?.trim() || undefined;
+                        const speed: Partial<NPCAttributesSource["speed"]> = docSource.system.attributes.speed;
+                        if (!speed.details?.trim()) delete speed.details;
 
                         for (const key of Object.keys(docSource.system)) {
                             if (!npcSystemKeys.has(key)) {
-                                delete (docSource.system as NPCSystemData & { extraneous?: unknown })[
+                                delete (docSource.system as NPCSystemSource & { extraneous?: unknown })[
                                     key as "extraneous"
                                 ];
                             }

--- a/src/module/actor/creature/index.ts
+++ b/src/module/actor/creature/index.ts
@@ -696,7 +696,7 @@ abstract class CreaturePF2e extends ActorPF2e {
         return preparedSenses;
     }
 
-    prepareSpeed(movementType: "land"): CreatureSpeeds;
+    prepareSpeed(movementType: "land"): this["system"]["attributes"]["speed"];
     prepareSpeed(movementType: Exclude<MovementType, "land">): (LabeledSpeed & StatisticModifier) | null;
     prepareSpeed(movementType: MovementType): CreatureSpeeds | (LabeledSpeed & StatisticModifier) | null;
     prepareSpeed(movementType: MovementType): CreatureSpeeds | (LabeledSpeed & StatisticModifier) | null {

--- a/src/module/actor/npc/data.ts
+++ b/src/module/actor/npc/data.ts
@@ -6,6 +6,7 @@ import {
     CreatureDetails,
     CreatureHitPoints,
     CreatureInitiative,
+    CreatureSpeeds,
     CreatureSystemData,
     CreatureSystemSource,
     CreatureTraitsData,
@@ -80,7 +81,7 @@ interface NPCAttributesSource {
     speed: {
         value: number;
         otherSpeeds: LabeledSpeed[];
-        details?: string;
+        details: string;
     };
     allSaves: {
         value: string;
@@ -138,8 +139,9 @@ interface NPCDetailsSource extends Omit<CreatureDetails, "creature"> {
     /** Which sourcebook this creature comes from. */
     source: {
         value: string;
-        author?: string;
+        author: string;
     };
+
     /** The type of this creature (such as 'undead') */
     creatureType: string;
     /** A very brief description */
@@ -225,6 +227,7 @@ interface NPCAttributes extends CreatureAttributes {
 
     initiative: CreatureInitiative;
 
+    speed: NPCSpeeds;
     /**
      * Data related to the currently equipped shield. This is copied from the shield data itself, and exists to
      * allow for the shield health to be shown in a token.
@@ -233,6 +236,10 @@ interface NPCAttributes extends CreatureAttributes {
     /** Textual information about any special benefits that apply to all saves. */
     allSaves: { value: string };
     familiarAbilities: StatisticModifier;
+}
+
+interface NPCSpeeds extends CreatureSpeeds {
+    details: string;
 }
 
 export {

--- a/static/template.json
+++ b/static/template.json
@@ -230,6 +230,9 @@
                 },
                 "allSaves": {
                     "value": ""
+                },
+                "speed": {
+                    "details": ""
                 }
             },
             "saves": {
@@ -254,7 +257,8 @@
             },
             "details": {
                 "source": {
-                    "value": ""
+                    "value": "",
+                    "author": ""
                 },
                 "creatureType": "",
                 "blurb": "",


### PR DESCRIPTION
This will speed up migrations on newer worlds, at least.