### PR TITLE
Allow for injected selectors in RollTwice

### DIFF
--- a/src/module/rules/rule-element/roll-twice.ts
+++ b/src/module/rules/rule-element/roll-twice.ts
@@ -16,7 +16,7 @@ export class RollTwiceRuleElement extends RuleElementPF2e {
         super(data, item, options);
 
         if (this.#isValid(data)) {
-            this.selector = data.selector;
+            this.selector = this.resolveInjectedProperties(data.selector);
             this.keep = data.keep;
 
             const expireEffects = game.settings.get("pf2e", "automation.effectExpiration");


### PR DESCRIPTION
This allows for inline properties such as `{item|flags.pf2e.rulesSelections.skill}` to return as a valid selector and function properly with RollTwice