### PR TITLE
Make sure only TextEditor.enrichHTML calls are being made

### DIFF
--- a/src/module/actor/character/crafting/helpers.ts
+++ b/src/module/actor/character/crafting/helpers.ts
@@ -35,7 +35,7 @@ async function prepStrings(costs: Costs, item: PhysicalItemPF2e) {
         lostMaterials: game.i18n.format("PF2E.Actions.Craft.Details.LostMaterials", {
             cost: costs.lostMaterials.toString(),
         }),
-        itemLink: await game.pf2e.TextEditor.enrichHTML(item.link, { rollData, async: true }),
+        itemLink: await TextEditor.enrichHTML(item.link, { rollData, async: true }),
     };
 }
 

--- a/src/module/actor/sheet/item-summary-renderer.ts
+++ b/src/module/actor/sheet/item-summary-renderer.ts
@@ -155,7 +155,7 @@ export class ItemSummaryRenderer<TActor extends ActorPF2e> {
 
         const description = isItemSystemData(chatData)
             ? chatData.description.value
-            : await game.pf2e.TextEditor.enrichHTML(item.description, { rollData: item.getRollData(), async: true });
+            : await TextEditor.enrichHTML(item.description, { rollData: item.getRollData(), async: true });
 
         $div.append(propertiesElem, levelPriceLabel, `<div class="item-description">${description}</div>`);
         UserVisibilityPF2e.process($div);

--- a/src/module/item/base.ts
+++ b/src/module/item/base.ts
@@ -281,7 +281,7 @@ class ItemPF2e extends Item<ActorPF2e> {
         if (isItemSystemData(data)) {
             const chatData = duplicate(data);
             htmlOptions.rollData = mergeObject(this.getRollData(), htmlOptions.rollData ?? {});
-            chatData.description.value = await game.pf2e.TextEditor.enrichHTML(chatData.description.value, {
+            chatData.description.value = await TextEditor.enrichHTML(chatData.description.value, {
                 ...htmlOptions,
                 async: true,
             });

--- a/src/module/item/sheet/base.ts
+++ b/src/module/item/sheet/base.ts
@@ -81,7 +81,7 @@ export class ItemSheetPF2e<TItem extends ItemPF2e> extends ItemSheet<TItem> {
         // Enrich content
         const enrichedContent: Record<string, string> = {};
         const rollData = { ...this.item.getRollData(), ...this.actor?.getRollData() };
-        enrichedContent.description = await game.pf2e.TextEditor.enrichHTML(itemData.system.description.value, {
+        enrichedContent.description = await TextEditor.enrichHTML(itemData.system.description.value, {
             rollData,
             async: true,
         });

--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -503,7 +503,7 @@ class SpellPF2e extends ItemPF2e {
         const systemData: SpellSystemData = this.system;
 
         const options = { ...htmlOptions, rollData };
-        const description = await game.pf2e.TextEditor.enrichHTML(this.description, { ...options, async: true });
+        const description = await TextEditor.enrichHTML(this.description, { ...options, async: true });
 
         const trickData = this.trickMagicEntry;
         const spellcasting = this.spellcasting;

--- a/src/module/system/damage/roll-dialog.ts
+++ b/src/module/system/damage/roll-dialog.ts
@@ -139,10 +139,7 @@ export class DamageRollModifiersDialog extends Application {
         const damageNotes = await Promise.all(
             damage.notes
                 .filter((note) => note.outcome.length === 0 || note.outcome.includes(outcome))
-                .map(
-                    async (note) =>
-                        await game.pf2e.TextEditor.enrichHTML(note.text, { rollData: noteRollData, async: true })
-                )
+                .map(async (note) => await TextEditor.enrichHTML(note.text, { rollData: noteRollData, async: true }))
         );
         const notes = damageNotes.join("<br />");
         flavor += `${notes}`;

--- a/src/scripts/macros/hotbar.ts
+++ b/src/scripts/macros/hotbar.ts
@@ -84,7 +84,7 @@ export async function rollActionMacro(actorId: string, _actionIndex: number, act
         actor,
         strike,
         strikeIndex: strikes.indexOf(strike),
-        strikeDescription: await game.pf2e.TextEditor.enrichHTML(game.i18n.localize(strike.description), {
+        strikeDescription: await TextEditor.enrichHTML(game.i18n.localize(strike.description), {
             async: true,
         }),
     };


### PR DESCRIPTION
While working on a module, i realized that there were some inconsistent calls to the `TextEditor.enrichHTML`, in 7 occurences, the call was made using `game.pf2e.TextEditor.enrichHTML` instead, making wrapping around `TextEditor.enrichHTML` not working in all those cases.

I took the liberty to just change those hopping it is fine.