### PR TITLE
Remove `getDamageRollContext` and `rollSaves` methods from `ActorPF2e`

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -19,7 +19,6 @@ import { LocalizePF2e } from "@module/system/localize";
 import { UserPF2e } from "@module/user";
 import { TokenDocumentPF2e } from "@scene";
 import { DicePF2e } from "@scripts/dice";
-import { eventToRollParams } from "@scripts/sheet-util";
 import { Statistic } from "@system/statistic";
 import { ErrorPF2e, isObject, objectHasKey, traitSlugToObject, tupleHasValue } from "@util";
 import type { CreaturePF2e } from "./creature";
@@ -604,9 +603,7 @@ class ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
     /*  Rolls                                       */
     /* -------------------------------------------- */
 
-    protected getStrikeRollContext<I extends AttackItem>(
-        params: StrikeRollContextParams<I>
-    ): StrikeRollContext<this, I> {
+    getStrikeRollContext<I extends AttackItem>(params: StrikeRollContextParams<I>): StrikeRollContext<this, I> {
         const targetToken = Array.from(game.user.targets).find((t) => t.actor?.isOfType("creature", "hazard")) ?? null;
 
         const selfToken =
@@ -727,20 +724,6 @@ class ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
                   }
                 : null,
         };
-    }
-
-    getDamageRollContext<I extends AttackItem>(params: StrikeRollContextParams<I>): StrikeRollContext<this, I> {
-        return this.getStrikeRollContext(params);
-    }
-
-    /**
-     * Roll a Save Check
-     * Prompt the user for input regarding Advantage/Disadvantage and any Situational Bonus.
-     * @deprecated
-     */
-    rollSave(event: JQuery.TriggeredEvent, saveType: SaveType): void {
-        console.warn("ActorPF2e#rollSaves is deprecated: use actor.saves[saveType].check.roll()");
-        this.saves?.[saveType]?.check.roll(eventToRollParams(event));
     }
 
     /**

--- a/src/module/actor/character/index.ts
+++ b/src/module/actor/character/index.ts
@@ -1804,7 +1804,7 @@ class CharacterPF2e extends CreaturePF2e {
             action[method] = async (params: StrikeRollParams = {}): Promise<string | void> => {
                 const domains = ["all", "strike-damage", "damage-roll"];
                 params.options ??= [];
-                const context = this.getDamageRollContext({
+                const context = this.getStrikeRollContext({
                     item: weapon,
                     viewOnly: params.getFormula ?? false,
                     domains,
@@ -1895,7 +1895,7 @@ class CharacterPF2e extends CreaturePF2e {
     }
 
     /** Possibly modify this weapon depending on its */
-    protected override getStrikeRollContext<I extends AttackItem>(
+    override getStrikeRollContext<I extends AttackItem>(
         params: StrikeRollContextParams<I>
     ): StrikeRollContext<this, I> {
         const context = super.getStrikeRollContext(params);

--- a/src/module/actor/helpers.ts
+++ b/src/module/actor/helpers.ts
@@ -254,7 +254,7 @@ function strikeFromMeleeItem(item: Embedded<MeleePF2e>): NPCStrike {
         (outcome: "success" | "criticalSuccess"): RollFunction =>
         async (params: RollParameters = {}) => {
             const domains = ["all", "strike-damage", "damage-roll"];
-            const context = actor.getDamageRollContext({
+            const context = actor.getStrikeRollContext({
                 item,
                 viewOnly: false,
                 domains,


### PR DESCRIPTION
One is protected and unused, and the other has been deprecated with a promise of impending removal.