### PR TITLE
Deprecate ActorPF2e#getActionGraphics()

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -5,11 +5,12 @@ import { ActionTrait } from "@item/action/data";
 import { ConditionSlug } from "@item/condition/data";
 import { isCycle } from "@item/container/helpers";
 import { ItemSourcePF2e, ItemType, PhysicalItemSource } from "@item/data";
+import { ActionCost, ActionType } from "@item/data/base";
 import { hasInvestedProperty } from "@item/data/helpers";
 import { EffectFlags, EffectSource } from "@item/effect/data";
 import type { ActiveEffectPF2e } from "@module/active-effect";
 import { ChatMessagePF2e } from "@module/chat-message";
-import { Size } from "@module/data";
+import { OneToThree, Size } from "@module/data";
 import { preImportJSON } from "@module/doc-helpers";
 import { RuleElementSynthetics } from "@module/rules";
 import { RuleElementPF2e } from "@module/rules/rule-element/base";
@@ -19,7 +20,15 @@ import { UserPF2e } from "@module/user";
 import { TokenDocumentPF2e } from "@scene";
 import { DicePF2e } from "@scripts/dice";
 import { Statistic } from "@system/statistic";
-import { ErrorPF2e, isObject, objectHasKey, traitSlugToObject, tupleHasValue } from "@util";
+import {
+    ErrorPF2e,
+    getActionGlyph,
+    getActionIcon,
+    isObject,
+    objectHasKey,
+    traitSlugToObject,
+    tupleHasValue,
+} from "@util";
 import type { CreaturePF2e } from "./creature";
 import { VisionLevel, VisionLevels } from "./creature/data";
 import { GetReachParameters, ModeOfBeing } from "./creature/types";
@@ -1101,31 +1110,17 @@ class ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
         return { updates, totalApplied };
     }
 
-    static getActionGraphics(actionType: string, actionCount?: number): { imageUrl: ImagePath; actionGlyph: string } {
-        let actionImg: number | string = 0;
-        if (actionType === "action") actionImg = actionCount ?? 1;
-        else if (actionType === "reaction") actionImg = "reaction";
-        else if (actionType === "free") actionImg = "free";
-        else if (actionType === "passive") actionImg = "passive";
-        const graphics: Record<string, { imageUrl: ImagePath; actionGlyph: string }> = {
-            1: { imageUrl: "systems/pf2e/icons/actions/OneAction.webp", actionGlyph: "A" },
-            2: { imageUrl: "systems/pf2e/icons/actions/TwoActions.webp", actionGlyph: "D" },
-            3: { imageUrl: "systems/pf2e/icons/actions/ThreeActions.webp", actionGlyph: "T" },
-            free: { imageUrl: "systems/pf2e/icons/actions/FreeAction.webp", actionGlyph: "F" },
-            reaction: { imageUrl: "systems/pf2e/icons/actions/Reaction.webp", actionGlyph: "R" },
-            passive: { imageUrl: "systems/pf2e/icons/actions/Passive.webp", actionGlyph: "" },
+    static getActionGraphics(type: ActionType, actionCount?: OneToThree): { imageUrl: ImagePath; actionGlyph: string } {
+        console.warn(
+            "PF2E System | ActorPF2e#getActionGraphics() is deprecated. If you rely on this function, please inform the Pathfinder2e dev team"
+        );
+
+        const actionCost: ActionCost | null = type === "passive" ? null : { type, value: actionCount ?? 1 };
+
+        return {
+            imageUrl: getActionIcon(actionCost),
+            actionGlyph: getActionGlyph(actionCost),
         };
-        if (objectHasKey(graphics, actionImg)) {
-            return {
-                imageUrl: graphics[actionImg].imageUrl,
-                actionGlyph: graphics[actionImg].actionGlyph,
-            };
-        } else {
-            return {
-                imageUrl: "systems/pf2e/icons/actions/Empty.webp",
-                actionGlyph: "",
-            };
-        }
     }
 
     /**

--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -10,7 +10,16 @@ import { restForTheNight } from "@scripts/macros/rest-for-the-night";
 import { craft } from "@system/action-macros/crafting/craft";
 import { CheckDC } from "@system/degree-of-success";
 import { LocalizePF2e } from "@system/localize";
-import { ErrorPF2e, groupBy, htmlQueryAll, isObject, objectHasKey, setHasElement, tupleHasValue } from "@util";
+import {
+    ErrorPF2e,
+    getActionIcon,
+    groupBy,
+    htmlQueryAll,
+    isObject,
+    objectHasKey,
+    setHasElement,
+    tupleHasValue,
+} from "@util";
 import { CharacterPF2e } from ".";
 import { CreatureSheetPF2e } from "../creature/sheet";
 import { AbilityBuilderPopup } from "../sheet/popups/ability-builder";
@@ -262,15 +271,12 @@ class CharacterSheetPF2e extends CreatureSheetPF2e<CharacterPF2e> {
         for (const itemData of sheetData.items) {
             const item = this.actor.items.get(itemData._id, { strict: true });
 
-            // Feats
-            if (itemData.type === "feat") {
-                const actionType = itemData.system.actionType.value || "passive";
-                if (Object.keys(actions).includes(actionType)) {
+            // Feats (non-passive feats may show action icons)
+            if (item.isOfType("feat")) {
+                const actionType = item.actionCost?.type;
+                if (actionType) {
                     itemData.feat = true;
-                    itemData.img = CharacterPF2e.getActionGraphics(
-                        actionType,
-                        parseInt((itemData.system.actions || {}).value, 10) || 1
-                    ).imageUrl;
+                    itemData.img = getActionIcon(item.actionCost);
                     actions[actionType].actions.push(itemData);
                 }
             }
@@ -293,15 +299,9 @@ class CharacterSheetPF2e extends CreatureSheetPF2e<CharacterPF2e> {
 
             // Actions
             else if (item.isOfType("action")) {
-                const actionType = ["free", "reaction", "passive"].includes(item.system.actionType.value)
-                    ? item.system.actionType.value
-                    : "action";
-                itemData.img = CharacterPF2e.getActionGraphics(
-                    actionType,
-                    Number(item.system.actions.value) || 1
-                ).imageUrl;
-                if (actionType === "passive") actions.free.actions.push(itemData);
-                else actions[actionType].actions.push(itemData);
+                itemData.img = getActionIcon(item.actionCost);
+                const actionType = item.actionCost?.type ?? "free";
+                actions[actionType].actions.push(itemData);
             }
         }
 

--- a/src/module/actor/helpers.ts
+++ b/src/module/actor/helpers.ts
@@ -13,7 +13,7 @@ import {
 import { CheckPF2e, CheckRoll } from "@system/check";
 import { DamageType, WeaponDamagePF2e } from "@system/damage";
 import { DamageRollPF2e, RollParameters } from "@system/rolls";
-import { ErrorPF2e, sluggify } from "@util";
+import { ErrorPF2e, getActionGlyph, getActionIcon, sluggify } from "@util";
 import { ActorSourcePF2e } from "./data";
 import { RollFunction, TraitViewData } from "./data/base";
 import { CheckModifier, ModifierPF2e, MODIFIER_TYPE, StatisticModifier } from "./modifiers";
@@ -130,9 +130,6 @@ function strikeFromMeleeItem(item: Embedded<MeleePF2e>): NPCStrike {
     modifiers.push(...StrikeAttackTraits.createAttackModifiers(item));
     const notes = extractNotes(synthetics.rollNotes, domains);
 
-    // action image
-    const { imageUrl, actionGlyph } = ActorPF2e.getActionGraphics("action", 1);
-
     const attackEffects: Record<string, string | undefined> = CONFIG.PF2E.attackEffects;
     const additionalEffects = item.attackEffects.map((tag) => {
         const label = attackEffects[tag] ?? actor.items.find((i) => (i.slug ?? sluggify(i.name)) === tag)?.name ?? tag;
@@ -161,9 +158,9 @@ function strikeFromMeleeItem(item: Embedded<MeleePF2e>): NPCStrike {
     const strike: NPCStrike = mergeObject(statistic, {
         label: item.name,
         type: "strike" as const,
-        glyph: actionGlyph,
+        glyph: getActionGlyph({ type: "action", value: 1 }),
         description: item.description,
-        imageUrl,
+        imageUrl: getActionIcon({ type: "action", value: 1 }),
         sourceId: item.id,
         attackRollType: item.isRanged ? "PF2E.NPCAttackRanged" : "PF2E.NPCAttackMelee",
         additionalEffects,

--- a/src/module/actor/vehicle/sheet.ts
+++ b/src/module/actor/vehicle/sheet.ts
@@ -1,7 +1,7 @@
 import { ActorSheetPF2e } from "../sheet/base";
 import { VehiclePF2e } from "@actor/vehicle";
 import { ItemDataPF2e } from "@item/data";
-import { tupleHasValue } from "@util";
+import { getActionIcon } from "@util";
 import { VehicleSheetData } from "./data";
 
 export class VehicleSheetPF2e extends ActorSheetPF2e<VehiclePF2e> {
@@ -54,19 +54,10 @@ export class VehicleSheetPF2e extends ActorSheetPF2e<VehiclePF2e> {
             }
 
             // Actions
-            if (itemData.type === "action") {
-                const actionTypes = ["free", "reaction", "passive"] as const;
-                const fromItem: string = itemData.system.actionType.value;
-                const actionType = tupleHasValue(actionTypes, fromItem) ? fromItem : "action";
-                itemData.img = VehiclePF2e.getActionGraphics(
-                    actionType,
-                    parseInt((itemData.system.actions || {}).value, 10) || 1
-                ).imageUrl;
-                if (actionType === "passive") {
-                    actions.free.actions.push(itemData);
-                } else {
-                    actions[actionType].actions.push(itemData);
-                }
+            if (item.isOfType("action")) {
+                itemData.img = getActionIcon(item.actionCost);
+                const actionType = item.actionCost?.type ?? "free";
+                actions[actionType].actions.push(itemData);
             }
         }
 

--- a/src/module/item/data/base.ts
+++ b/src/module/item/data/base.ts
@@ -34,7 +34,7 @@ type ItemTrait = ActionTrait | CreatureTrait | PhysicalItemTrait | NPCAttackTrai
 type ActionType = keyof ConfigPF2e["PF2E"]["actionTypes"];
 
 interface ActionCost {
-    type: ActionType;
+    type: Exclude<ActionType, "passive">;
     value: OneToThree | null;
 }
 

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -206,7 +206,7 @@ function getActionIcon(actionType: string | ActionCost | null, fallback: ImagePa
 function getActionIcon(actionType: string | ActionCost | null): ImagePath;
 function getActionIcon(
     action: string | ActionCost | null,
-    fallback: ImagePath | null = "systems/pf2e/icons/default-icons/mystery-man.svg"
+    fallback: ImagePath | null = "systems/pf2e/icons/actions/Empty.webp"
 ): ImagePath | null {
     if (action === null) return actionImgMap["passive"];
     const value = typeof action !== "object" ? action : action.type === "action" ? action.value : action.type;


### PR DESCRIPTION
The helpers are not exposed, so if someone wants to be able to get icons from action costs, they should probably let us know before is too late.