### PR TITLE
Remove unneeded resistance labels for EC

### DIFF
--- a/packs/data/extinction-curse-bestiary.db/ammut.json
+++ b/packs/data/extinction-curse-bestiary.db/ammut.json
@@ -1261,21 +1261,18 @@
             },
             "dr": [
                 {
-                    "label": "Fire",
                     "type": "fire",
-                    "value": "20"
+                    "value": 20
                 },
                 {
-                    "label": "Poison",
                     "type": "poison",
-                    "value": "20"
+                    "value": 20
                 }
             ],
             "dv": [
                 {
-                    "label": "Good",
                     "type": "good",
-                    "value": "20"
+                    "value": 20
                 }
             ],
             "languages": {

--- a/packs/data/extinction-curse-bestiary.db/ararda.json
+++ b/packs/data/extinction-curse-bestiary.db/ararda.json
@@ -1973,16 +1973,14 @@
             },
             "dr": [
                 {
-                    "label": "Electricity",
                     "type": "electricity",
-                    "value": "20"
+                    "value": 20
                 }
             ],
             "dv": [
                 {
-                    "label": "Sonic",
                     "type": "sonic",
-                    "value": "20"
+                    "value": 20
                 }
             ],
             "languages": {

--- a/packs/data/extinction-curse-bestiary.db/arskuva-the-gnasher.json
+++ b/packs/data/extinction-curse-bestiary.db/arskuva-the-gnasher.json
@@ -591,9 +591,8 @@
             "dr": [],
             "dv": [
                 {
-                    "label": "Positive",
                     "type": "positive",
-                    "value": "15"
+                    "value": 15
                 }
             ],
             "languages": {

--- a/packs/data/extinction-curse-bestiary.db/aukashungi-swarm.json
+++ b/packs/data/extinction-curse-bestiary.db/aukashungi-swarm.json
@@ -297,29 +297,24 @@
             },
             "dr": [
                 {
-                    "label": "Bludgeoning",
                     "type": "bludgeoning",
-                    "value": "5"
+                    "value": 5
                 },
                 {
-                    "label": "Piercing",
                     "type": "piercing",
-                    "value": "10"
+                    "value": 10
                 },
                 {
-                    "label": "Slashing",
                     "type": "slashing",
-                    "value": "10"
+                    "value": 10
                 }
             ],
             "dv": [
                 {
-                    "exceptions": "",
                     "type": "area-damage",
                     "value": 10
                 },
                 {
-                    "exceptions": "",
                     "type": "splash-damage",
                     "value": 10
                 }

--- a/packs/data/extinction-curse-bestiary.db/brughadatch.json
+++ b/packs/data/extinction-curse-bestiary.db/brughadatch.json
@@ -1609,9 +1609,8 @@
             "dr": [],
             "dv": [
                 {
-                    "label": "Cold Iron",
                     "type": "coldiron",
-                    "value": "10"
+                    "value": 10
                 }
             ],
             "languages": {

--- a/packs/data/extinction-curse-bestiary.db/cat-sith.json
+++ b/packs/data/extinction-curse-bestiary.db/cat-sith.json
@@ -777,9 +777,9 @@
         "traits": {
             "ci": [],
             "di": {
-                "custom": "misfortune effects",
+                "custom": "",
                 "value": [
-                    "custom"
+                    "misfortune-effects"
                 ]
             },
             "dr": [],

--- a/packs/data/extinction-curse-bestiary.db/cat-sith.json
+++ b/packs/data/extinction-curse-bestiary.db/cat-sith.json
@@ -785,9 +785,8 @@
             "dr": [],
             "dv": [
                 {
-                    "label": "Cold Iron",
                     "type": "coldiron",
-                    "value": "5"
+                    "value": 5
                 }
             ],
             "languages": {

--- a/packs/data/extinction-curse-bestiary.db/convergence-lattice.json
+++ b/packs/data/extinction-curse-bestiary.db/convergence-lattice.json
@@ -100,14 +100,12 @@
             "dr": [],
             "dv": [
                 {
-                    "label": "Chaotic",
                     "type": "chaotic",
-                    "value": "30"
+                    "value": 30
                 },
                 {
-                    "label": "Mental",
                     "type": "mental",
-                    "value": "30"
+                    "value": 30
                 }
             ],
             "rarity": "unique",

--- a/packs/data/extinction-curse-bestiary.db/convergent-giant-eagle.json
+++ b/packs/data/extinction-curse-bestiary.db/convergent-giant-eagle.json
@@ -562,9 +562,8 @@
             "dr": [],
             "dv": [
                 {
-                    "label": "Chaotic",
                     "type": "chaotic",
-                    "value": "10"
+                    "value": 10
                 }
             ],
             "languages": {

--- a/packs/data/extinction-curse-bestiary.db/convergent-soldier.json
+++ b/packs/data/extinction-curse-bestiary.db/convergent-soldier.json
@@ -933,9 +933,8 @@
             "dr": [],
             "dv": [
                 {
-                    "label": "Chaotic",
                     "type": "chaotic",
-                    "value": "10"
+                    "value": 10
                 }
             ],
             "languages": {

--- a/packs/data/extinction-curse-bestiary.db/counteflora.json
+++ b/packs/data/extinction-curse-bestiary.db/counteflora.json
@@ -513,14 +513,12 @@
             "dr": [],
             "dv": [
                 {
-                    "label": "Cold",
                     "type": "cold",
-                    "value": "10"
+                    "value": 10
                 },
                 {
-                    "label": "Fire",
                     "type": "fire",
-                    "value": "10"
+                    "value": 10
                 }
             ],
             "languages": {

--- a/packs/data/extinction-curse-bestiary.db/cu-sith.json
+++ b/packs/data/extinction-curse-bestiary.db/cu-sith.json
@@ -487,9 +487,8 @@
             "dr": [],
             "dv": [
                 {
-                    "label": "Cold Iron",
                     "type": "coldiron",
-                    "value": "5"
+                    "value": 5
                 }
             ],
             "languages": {

--- a/packs/data/extinction-curse-bestiary.db/deghuun-child-of-mhar.json
+++ b/packs/data/extinction-curse-bestiary.db/deghuun-child-of-mhar.json
@@ -1033,14 +1033,12 @@
             "dr": [],
             "dv": [
                 {
-                    "label": "Cold",
                     "type": "cold",
-                    "value": "10"
+                    "value": 10
                 },
                 {
-                    "label": "Good",
                     "type": "good",
-                    "value": "10"
+                    "value": 10
                 }
             ],
             "languages": {

--- a/packs/data/extinction-curse-bestiary.db/doblagub.json
+++ b/packs/data/extinction-curse-bestiary.db/doblagub.json
@@ -2587,9 +2587,8 @@
             "dr": [],
             "dv": [
                 {
-                    "label": "Cold Iron",
                     "type": "coldiron",
-                    "value": "15"
+                    "value": 15
                 }
             ],
             "languages": {

--- a/packs/data/extinction-curse-bestiary.db/dyzallin-shraen.json
+++ b/packs/data/extinction-curse-bestiary.db/dyzallin-shraen.json
@@ -8023,9 +8023,8 @@
             ],
             "dv": [
                 {
-                    "label": "Fire",
                     "type": "fire",
-                    "value": "15"
+                    "value": 15
                 }
             ],
             "languages": {

--- a/packs/data/extinction-curse-bestiary.db/elysian-sheep.json
+++ b/packs/data/extinction-curse-bestiary.db/elysian-sheep.json
@@ -425,9 +425,8 @@
             "dr": [],
             "dv": [
                 {
-                    "label": "Evil",
                     "type": "evil",
-                    "value": "5"
+                    "value": 5
                 }
             ],
             "languages": {

--- a/packs/data/extinction-curse-bestiary.db/faceless-butcher.json
+++ b/packs/data/extinction-curse-bestiary.db/faceless-butcher.json
@@ -834,9 +834,8 @@
             },
             "dr": [
                 {
-                    "label": "Bludgeoning",
                     "type": "bludgeoning",
-                    "value": "8"
+                    "value": 8
                 }
             ],
             "dv": [],

--- a/packs/data/extinction-curse-bestiary.db/herecite-of-zevgavizeb.json
+++ b/packs/data/extinction-curse-bestiary.db/herecite-of-zevgavizeb.json
@@ -2676,9 +2676,8 @@
             "dr": [],
             "dv": [
                 {
-                    "label": "Good",
                     "type": "good",
-                    "value": "10"
+                    "value": 10
                 }
             ],
             "languages": {

--- a/packs/data/extinction-curse-bestiary.db/hollow-hush.json
+++ b/packs/data/extinction-curse-bestiary.db/hollow-hush.json
@@ -1856,9 +1856,8 @@
             },
             "dr": [
                 {
-                    "label": "Mental",
                     "type": "mental",
-                    "value": "20"
+                    "value": 20
                 }
             ],
             "dv": [],

--- a/packs/data/extinction-curse-bestiary.db/kharostan.json
+++ b/packs/data/extinction-curse-bestiary.db/kharostan.json
@@ -2041,15 +2041,14 @@
                 "value": [
                     "death-effects",
                     "disease",
-                    "fear effects"
+                    "fear-effects"
                 ]
             },
             "dr": [],
             "dv": [
                 {
-                    "label": "Positive",
                     "type": "positive",
-                    "value": "15"
+                    "value": 15
                 }
             ],
             "languages": {

--- a/packs/data/extinction-curse-bestiary.db/kimilekki.json
+++ b/packs/data/extinction-curse-bestiary.db/kimilekki.json
@@ -2702,14 +2702,12 @@
             "dr": [],
             "dv": [
                 {
-                    "label": "Cold Iron",
                     "type": "coldiron",
-                    "value": "15"
+                    "value": 15
                 },
                 {
-                    "label": "Good",
                     "type": "good",
-                    "value": "15"
+                    "value": 15
                 }
             ],
             "languages": {

--- a/packs/data/extinction-curse-bestiary.db/mechanical-carny.json
+++ b/packs/data/extinction-curse-bestiary.db/mechanical-carny.json
@@ -362,9 +362,8 @@
             ],
             "dv": [
                 {
-                    "label": "Electricity",
                     "type": "electricity",
-                    "value": "6"
+                    "value": 6
                 }
             ],
             "languages": {

--- a/packs/data/extinction-curse-bestiary.db/muurfeli.json
+++ b/packs/data/extinction-curse-bestiary.db/muurfeli.json
@@ -1677,9 +1677,8 @@
             ],
             "dv": [
                 {
-                    "label": "Cold",
                     "type": "cold",
-                    "value": "10"
+                    "value": 10
                 }
             ],
             "languages": {

--- a/packs/data/extinction-curse-bestiary.db/qurashith.json
+++ b/packs/data/extinction-curse-bestiary.db/qurashith.json
@@ -1013,21 +1013,18 @@
             },
             "dr": [
                 {
-                    "label": "Acid",
                     "type": "acid",
-                    "value": "15"
+                    "value": 15
                 }
             ],
             "dv": [
                 {
-                    "label": "Good",
                     "type": "good",
-                    "value": "15"
+                    "value": 15
                 },
                 {
-                    "label": "Lawful",
                     "type": "lawful",
-                    "value": "15"
+                    "value": 15
                 }
             ],
             "languages": {

--- a/packs/data/extinction-curse-bestiary.db/sarvel-ever-hunger.json
+++ b/packs/data/extinction-curse-bestiary.db/sarvel-ever-hunger.json
@@ -4506,14 +4506,12 @@
             "dr": [],
             "dv": [
                 {
-                    "label": "Cold Iron",
                     "type": "coldiron",
-                    "value": "15"
+                    "value": 15
                 },
                 {
-                    "label": "Good",
                     "type": "good",
-                    "value": "15"
+                    "value": 15
                 }
             ],
             "languages": {

--- a/packs/data/extinction-curse-bestiary.db/shraen-graveknight.json
+++ b/packs/data/extinction-curse-bestiary.db/shraen-graveknight.json
@@ -1917,9 +1917,8 @@
             },
             "dr": [
                 {
-                    "label": "Positive",
                     "type": "positive",
-                    "value": "30"
+                    "value": 30
                 }
             ],
             "dv": [],

--- a/packs/data/extinction-curse-bestiary.db/starved-staff.json
+++ b/packs/data/extinction-curse-bestiary.db/starved-staff.json
@@ -569,29 +569,24 @@
             },
             "dr": [
                 {
-                    "label": "Cold",
                     "type": "cold",
-                    "value": "10"
+                    "value": 10
                 },
                 {
-                    "label": "Electricity",
                     "type": "electricity",
-                    "value": "10"
+                    "value": 10
                 },
                 {
-                    "label": "Fire",
                     "type": "fire",
-                    "value": "10"
+                    "value": 10
                 },
                 {
-                    "label": "Piercing",
                     "type": "piercing",
-                    "value": "10"
+                    "value": 10
                 },
                 {
-                    "label": "Slashing",
                     "type": "slashing",
-                    "value": "10"
+                    "value": 10
                 }
             ],
             "dv": [],

--- a/packs/data/extinction-curse-bestiary.db/tallow-ooze.json
+++ b/packs/data/extinction-curse-bestiary.db/tallow-ooze.json
@@ -381,16 +381,14 @@
             },
             "dr": [
                 {
-                    "label": "Cold",
                     "type": "cold",
-                    "value": "10"
+                    "value": 10
                 }
             ],
             "dv": [
                 {
-                    "label": "Fire",
                     "type": "fire",
-                    "value": "10"
+                    "value": 10
                 }
             ],
             "languages": {

--- a/packs/data/extinction-curse-bestiary.db/the-vanish-man.json
+++ b/packs/data/extinction-curse-bestiary.db/the-vanish-man.json
@@ -1341,9 +1341,8 @@
             },
             "dr": [
                 {
-                    "label": "Bludgeoning",
                     "type": "bludgeoning",
-                    "value": "10"
+                    "value": 10
                 }
             ],
             "dv": [],

--- a/packs/data/extinction-curse-bestiary.db/thessekka.json
+++ b/packs/data/extinction-curse-bestiary.db/thessekka.json
@@ -2579,9 +2579,8 @@
             },
             "dr": [
                 {
-                    "label": "Physical",
                     "type": "physical",
-                    "value": "14"
+                    "value": 14
                 }
             ],
             "dv": [],

--- a/packs/data/extinction-curse-bestiary.db/urdefhan-dominator.json
+++ b/packs/data/extinction-curse-bestiary.db/urdefhan-dominator.json
@@ -3582,10 +3582,11 @@
             },
             "ci": [],
             "di": {
-                "custom": "Death Effects (except Necrotic Decay)",
+                "custom": "",
                 "value": [
+                    "death-effects",
                     "disease",
-                    "fear effects"
+                    "fear-effects"
                 ]
             },
             "dr": [],

--- a/packs/data/extinction-curse-bestiary.db/urdefhan-dominator.json
+++ b/packs/data/extinction-curse-bestiary.db/urdefhan-dominator.json
@@ -3582,9 +3582,8 @@
             },
             "ci": [],
             "di": {
-                "custom": "",
+                "custom": "Death Effects (except necrotic decay)",
                 "value": [
-                    "death-effects",
                     "disease",
                     "fear-effects"
                 ]

--- a/packs/data/extinction-curse-bestiary.db/urdefhan-high-tormentor.json
+++ b/packs/data/extinction-curse-bestiary.db/urdefhan-high-tormentor.json
@@ -2768,15 +2768,14 @@
                 "value": [
                     "death-effects",
                     "disease",
-                    "fear effects"
+                    "fear-effects"
                 ]
             },
             "dr": [],
             "dv": [
                 {
-                    "label": "Positive",
                     "type": "positive",
-                    "value": "10"
+                    "value": 10
                 }
             ],
             "languages": {

--- a/packs/data/extinction-curse-bestiary.db/urdefhan-high-tormentor.json
+++ b/packs/data/extinction-curse-bestiary.db/urdefhan-high-tormentor.json
@@ -2764,9 +2764,8 @@
         "traits": {
             "ci": [],
             "di": {
-                "custom": "",
+                "custom": "Death Effects (except necrotic decay)",
                 "value": [
-                    "death-effects",
                     "disease",
                     "fear-effects"
                 ]

--- a/packs/data/extinction-curse-bestiary.db/urdefhan-hunter.json
+++ b/packs/data/extinction-curse-bestiary.db/urdefhan-hunter.json
@@ -1569,10 +1569,11 @@
             },
             "ci": [],
             "di": {
-                "custom": "Death Effects (except necrotic decay)",
+                "custom": "",
                 "value": [
+                    "death-effects",
                     "disease",
-                    "fear effects"
+                    "fear-effects"
                 ]
             },
             "dr": [],

--- a/packs/data/extinction-curse-bestiary.db/urdefhan-hunter.json
+++ b/packs/data/extinction-curse-bestiary.db/urdefhan-hunter.json
@@ -1569,9 +1569,8 @@
             },
             "ci": [],
             "di": {
-                "custom": "",
+                "custom": "Death Effects (except necrotic decay)",
                 "value": [
-                    "death-effects",
                     "disease",
                     "fear-effects"
                 ]

--- a/packs/data/extinction-curse-bestiary.db/vavakia.json
+++ b/packs/data/extinction-curse-bestiary.db/vavakia.json
@@ -2551,14 +2551,12 @@
             "dr": [],
             "dv": [
                 {
-                    "label": "Cold Iron",
                     "type": "coldiron",
-                    "value": "15"
+                    "value": 15
                 },
                 {
-                    "label": "Good",
                     "type": "good",
-                    "value": "15"
+                    "value": 15
                 }
             ],
             "languages": {

--- a/packs/data/extinction-curse-bestiary.db/viktor-volkano.json
+++ b/packs/data/extinction-curse-bestiary.db/viktor-volkano.json
@@ -477,9 +477,8 @@
             },
             "dr": [
                 {
-                    "label": "Fire",
                     "type": "fire",
-                    "value": "5"
+                    "value": 5
                 }
             ],
             "dv": [],

--- a/packs/data/extinction-curse-bestiary.db/xilvirek.json
+++ b/packs/data/extinction-curse-bestiary.db/xilvirek.json
@@ -1214,14 +1214,12 @@
             "dr": [],
             "dv": [
                 {
-                    "label": "Good",
                     "type": "good",
-                    "value": "10"
+                    "value": 10
                 },
                 {
-                    "label": "Lawful",
                     "type": "lawful",
-                    "value": "10"
+                    "value": 10
                 }
             ],
             "languages": {

--- a/packs/data/extinction-curse-bestiary.db/xulgath-bomber.json
+++ b/packs/data/extinction-curse-bestiary.db/xulgath-bomber.json
@@ -1367,9 +1367,8 @@
             },
             "dr": [
                 {
-                    "label": "Poison",
                     "type": "poison",
-                    "value": "5"
+                    "value": 5
                 }
             ],
             "dv": [],

--- a/src/module/actor/values.ts
+++ b/src/module/actor/values.ts
@@ -74,6 +74,7 @@ export const IMMUNITY_TYPES = new Set([
     "healing",
     "inhaled",
     "magic",
+    "misfortune-effects",
     "nonlethal-attacks",
     "nonmagical-attacks",
     "object-immunities",

--- a/src/scripts/config/index.ts
+++ b/src/scripts/config/index.ts
@@ -214,6 +214,7 @@ const immunityTypes: Record<ImmunityType, string> = {
     light: "PF2E.TraitLight",
     magic: "PF2E.TraitMagic",
     magical: "PF2E.TraitMagical",
+    "misfortune-effects": "PF2E.TraitMisfortuneEffects",
     "nonlethal-attacks": "PF2E.TraitNonlethalAttacks",
     "nonmagical-attacks": "PF2E.TraitNonmagicalAttacks",
     "object-immunities": "PF2E.TraitObjectImmunities",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -3900,6 +3900,7 @@
         "TraitMinion": "Minion",
         "TraitMindshift": "Mindshift",
         "TraitMisfortune": "Misfortune",
+        "TraitMisfortuneEffects": "Misfortune Effects",
         "TraitModification": "Modification",
         "TraitModular": "Modular B, P, or S",
         "TraitMonitor": "Monitor",


### PR DESCRIPTION
<strike>Note: I modified the custom di in Urdefhan Hunter and Urdefhan Dominator to match all other Urdefhan.</strike>

<strike>"custom": "Death Effects (except Necrotic Decay)" -> standard "death-effects"</strike>