### PR TITLE
Update style of inlines with repost buttons

### DIFF
--- a/src/styles/_globals.scss
+++ b/src/styles/_globals.scss
@@ -127,11 +127,6 @@ a.foundry-href {
     padding: 1px 0.2em 0;
     white-space: nowrap;
     word-break: break-all;
-
-    &.with-repost {
-        border-right: none;
-        padding-right: 0;
-    }
 }
 
 /* ----------------------------------------- */
@@ -264,22 +259,19 @@ span[data-pf2-effect-area] {
 /* ----------------------------------------- */
 
 i[data-pf2-repost] {
+    @include quick-transition;
     background: var(--inline-repost-bg);
-    border: 2px outset var(--color-text-light-7);
     color: var(--color-text-dark-inactive);
-    font-size: 0.833em;
-    margin-left: 0.25em;
-    padding: 0.167em;
-    position: relative;
-    top: -0.125em; // Cover top border
+    border-left: 1px solid var(--color-border-dark-tertiary);
+    background: #FFF9;
+    padding: 2px;
+    margin-right: -3px;
+    margin-left: 2px;
+    text-shadow: none;
 
     &:hover {
-        color: var(--color-text-light-7);
-        text-shadow: none;
-    }
-
-    &:active {
-        border-style: inset;
+        color: white;
+        text-shadow: 0px 0px 2px black;
     }
 }
 

--- a/src/styles/_globals.scss
+++ b/src/styles/_globals.scss
@@ -281,7 +281,7 @@ i[data-pf2-repost] {
     display: inline-block;
     line-height: 1em;
     outline: 1px dotted rgba(75, 74, 68, 0.5);
-    padding: 2px 1px 1px;
+    padding: 2px 1px 0px;
 
     /* ----------------------------------------- */
     /* GM Visibility Elements                    */

--- a/src/styles/mixins/_animations.scss
+++ b/src/styles/mixins/_animations.scss
@@ -30,3 +30,8 @@
         opacity: 1;
     }
 }
+
+@mixin quick-transition {
+    $transitionTime: 0.15s;
+    transition: text-shadow $transitionTime ease-in-out, background-color $transitionTime ease-in-out, border $transitionTime ease-in-out, color $transitionTime ease-in-out, box-shadow $transitionTime ease-in-out;
+}


### PR DESCRIPTION
Current (top button is hovered):
<img width="207" alt="CleanShot 2022-12-10 at 14 45 17@2x" src="https://user-images.githubusercontent.com/1561190/206858359-019ec9f6-df0e-47ce-be9c-57059607f2cc.png">
In AV premium module:
<img width="175" alt="CleanShot 2022-12-10 at 14 47 40@2x" src="https://user-images.githubusercontent.com/1561190/206858500-02770f41-914f-44b3-a6e6-71a60e79bc4e.png">


New:
<img width="208" alt="CleanShot 2022-12-10 at 14 34 55@2x" src="https://user-images.githubusercontent.com/1561190/206857867-c2bf051e-42ca-4d9b-8927-77a886991818.png">
on hovering the top icon:
<img width="206" alt="CleanShot 2022-12-10 at 14 35 19@2x" src="https://user-images.githubusercontent.com/1561190/206857971-b0e950bb-ffa3-4e2d-9f8d-145f31e5f8bd.png">
In AV premium module:
<img width="171" alt="CleanShot 2022-12-10 at 14 49 08@2x" src="https://user-images.githubusercontent.com/1561190/206858579-1a406ba5-7cd6-4ca7-bb12-03694961db7c.png">

