### PR TITLE
Fix level not showing on first actor(s) in folders

### DIFF
--- a/src/module/apps/ui/actor-directory.ts
+++ b/src/module/apps/ui/actor-directory.ts
@@ -20,7 +20,7 @@ export class ActorDirectoryPF2e<TDocument extends ActorPF2e> extends ActorDirect
         super.activateListeners($html);
         const html = $html[0];
 
-        for (const element of htmlQueryAll(html, "li.directory-item")) {
+        for (const element of htmlQueryAll(html, "li.directory-item.actor")) {
             const actor = game.actors.get(element.dataset.documentId ?? "");
             if (!actor?.testUserPermission(game.user, "OBSERVER")) {
                 element.querySelector("span.actor-level")?.remove();


### PR DESCRIPTION
Folders were being selected in the query selection that checks for permissions to see the level. In such cases, the first valid descendant would have its level removed, leading to the first, or multiple in case of nesting, actors to have their level always hidden if they were in a folder. By only checking for actors, folders are excluded and levels should show correctly.

Before:
![2022-12-10 - 18 26 15 - Foundry_Virtual_Tabletop](https://user-images.githubusercontent.com/25198736/206867533-cbd273ac-2d1f-41ef-9ec9-d67b6aab2585.png)

After:
![2022-12-10 - 18 27 10 - Foundry_Virtual_Tabletop](https://user-images.githubusercontent.com/25198736/206867575-b89669dc-0155-4a62-bf7d-aa2a3e44e959.png)

Players still only see their owned actors' levels:
![image](https://user-images.githubusercontent.com/25198736/206867735-25fb7428-15f3-41da-836e-d39282fae4ff.png)

