### PR TITLE
Add roll inspector support for casted spells

### DIFF
--- a/src/module/chat-message/data.ts
+++ b/src/module/chat-message/data.ts
@@ -19,7 +19,7 @@ interface ChatMessageSourcePF2e extends foundry.data.ChatMessageSource {
 type ChatMessageFlagsPF2e = foundry.data.ChatMessageFlags & {
     pf2e: {
         damageRoll?: DamageRollFlag;
-        context?: CheckRollContextFlag | DamageRollContextFlag;
+        context?: ChatContextFlag;
         origin?: { type: ItemType; uuid: string } | null;
         casting?: { id: string; level: number; tradition: MagicTradition } | null;
         modifierName?: string;
@@ -33,6 +33,8 @@ type ChatMessageFlagsPF2e = foundry.data.ChatMessageFlags & {
     };
     core: NonNullable<foundry.data.ChatMessageFlags["core"]>;
 };
+
+type ChatContextFlag = CheckRollContextFlag | DamageRollContextFlag | SpellCastContextFlag;
 
 /** Data used to lookup a strike on an actor */
 interface StrikeLookupData {
@@ -93,7 +95,16 @@ interface DamageRollContextFlag extends Required<Omit<DamageRollContext, Context
     options: string[];
 }
 
+interface SpellCastContextFlag {
+    type: "spell-cast";
+    domains: string[];
+    options: string[];
+    /** The roll mode (i.e., 'roll', 'blindroll', etc) to use when rendering this roll. */
+    rollMode?: RollMode;
+}
+
 export {
+    ChatContextFlag,
     ChatMessageDataPF2e,
     ChatMessageSourcePF2e,
     ChatMessageFlagsPF2e,

--- a/src/module/chat-message/document.ts
+++ b/src/module/chat-message/document.ts
@@ -52,7 +52,9 @@ class ChatMessagePF2e extends ChatMessage<ActorPF2e> {
 
     /** If this is a check or damage roll, it will have target information */
     get target(): { actor: ActorPF2e; token: Embedded<TokenDocumentPF2e> } | null {
-        const targetUUID = this.flags.pf2e.context?.target?.token;
+        const context = this.flags.pf2e.context;
+        if (!context) return null;
+        const targetUUID = "target" in context ? context.target?.token : null;
         if (!targetUUID) return null;
 
         const match = /^Scene\.(\w+)\.Token\.(\w+)$/.exec(targetUUID ?? "") ?? [];
@@ -80,7 +82,7 @@ class ChatMessagePF2e extends ChatMessage<ActorPF2e> {
     /** Does the message include a rerolled check? */
     get isReroll(): boolean {
         const context = this.flags.pf2e.context;
-        return !!context && context.type !== "damage-roll" && !!context.isReroll;
+        return !!context && "isReroll" in context && !!context.isReroll;
     }
 
     /** Does the message include a check that hasn't been rerolled? */

--- a/src/module/chat-message/helpers.ts
+++ b/src/module/chat-message/helpers.ts
@@ -1,0 +1,8 @@
+import { tupleHasValue } from "@util";
+import { ChatContextFlag, CheckRollContextFlag } from "./data";
+
+function isCheckContextFlag(flag?: ChatContextFlag): flag is CheckRollContextFlag {
+    return !!flag && !tupleHasValue(["damage-roll", "spell-cast"], flag.type);
+}
+
+export { isCheckContextFlag };

--- a/src/module/chat-message/listeners/cards.ts
+++ b/src/module/chat-message/listeners/cards.ts
@@ -35,7 +35,7 @@ export const ChatCards = {
             const strikeAction = message._strike;
             if (strikeAction && action?.startsWith("strike-")) {
                 const context = message.flags.pf2e.context;
-                const altUsage = context && context.type !== "damage-roll" ? context?.altUsage : null;
+                const altUsage = context && "altUsage" in context ? context.altUsage : null;
                 const options = actor.getRollOptions(["all", "attack-roll"]);
                 switch (sluggify(action ?? "")) {
                     case "strike-attack":

--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -446,21 +446,33 @@ class SpellPF2e extends ItemPF2e {
         const contextualData = Object.keys(data).length > 0 ? data : nearestItem.dataset || {};
 
         const messageSource = message.toObject();
+        const flags = messageSource.flags.pf2e;
         const entry = this.trickMagicEntry ?? this.spellcasting;
         if (entry) {
             // Eventually we need to figure out a way to request a tradition if the ability doesn't provide one
             const tradition = Array.from(this.traditions).at(0);
-            messageSource.flags.pf2e.casting = {
+            flags.casting = {
                 id: entry.id,
                 level: data.castLevel ?? (Number(contextualData.castLevel) || this.level),
                 tradition: entry.tradition ?? tradition ?? "arcane",
             };
+
+            // The only data that can possibly exist in a casted spell is the dc, so we pull that data.
+            if (this.system.spellType.value === "save" || this.system.save.value !== "") {
+                const dc = entry.statistic.withRollOptions({ item: this }).dc;
+                flags.context = {
+                    type: "spell-cast",
+                    domains: dc.domains,
+                    options: [...dc.options],
+                    rollMode,
+                };
+            }
         }
 
-        messageSource.flags.pf2e.isFromConsumable = this.isFromConsumable;
+        flags.isFromConsumable = this.isFromConsumable;
 
         if (this.isVariant) {
-            messageSource.flags.pf2e.spellVariant = {
+            flags.spellVariant = {
                 overlayIds: [...this.appliedOverlays!.values()],
             };
         }

--- a/src/module/system/check/check.ts
+++ b/src/module/system/check/check.ts
@@ -21,6 +21,7 @@ import { LocalizePF2e } from "../localize";
 import { TextEditorPF2e } from "../text-editor";
 import { CheckRollContext } from "./types";
 import { StrikeAttackRoll } from "./strike/attack-roll";
+import { isCheckContextFlag } from "@module/chat-message/helpers";
 
 interface RerollOptions {
     heroPoint?: boolean;
@@ -374,7 +375,7 @@ class CheckPF2e {
 
         const systemFlags = deepClone(message.flags.pf2e);
         const context = systemFlags.context;
-        if (!context || context.type === "damage-roll") return;
+        if (!isCheckContextFlag(context)) return;
 
         context.skipDialog = true;
         context.isReroll = true;

--- a/src/module/system/statistic/index.ts
+++ b/src/module/system/statistic/index.ts
@@ -440,10 +440,11 @@ class StatisticDifficultyClass {
     domains: string[];
     value: number;
     modifiers: ModifierPF2e[];
+    options: Set<string>;
 
-    constructor(private parent: Statistic, data: StatisticData, options: RollOptionParameters = {}) {
+    constructor(parent: Statistic, data: StatisticData, options: RollOptionParameters = {}) {
         this.domains = (data.domains ?? []).concat(data.dc?.domains ?? []);
-        const rollOptions = parent.createRollOptions(this.domains, options);
+        this.options = parent.createRollOptions(this.domains, options);
 
         // Add all modifiers from all sources together, then test them
         const allDCModifiers = [
@@ -451,13 +452,9 @@ class StatisticDifficultyClass {
             data.dc?.modifiers ?? [],
             extractModifiers(parent.actor.synthetics, this.domains),
         ].flat();
-        this.modifiers = allDCModifiers.map((modifier) => modifier.clone({ test: rollOptions }));
+        this.modifiers = allDCModifiers.map((modifier) => modifier.clone({ test: this.options }));
 
-        this.value = (data.dc?.base ?? 10) + new StatisticModifier("", this.modifiers, rollOptions).totalModifier;
-    }
-
-    createRollOptions(args: RollOptionParameters = {}): Set<string> {
-        return this.parent.createRollOptions(this.domains, args);
+        this.value = (data.dc?.base ?? 10) + new StatisticModifier("", this.modifiers, this.options).totalModifier;
     }
 
     get breakdown() {


### PR DESCRIPTION
The sooner we can get off of SpellPF2e#toMessage() the better.