### PR TITLE
Draft: add resource sheet

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -10,7 +10,7 @@ module.exports = {
             },
         },
         {
-            files: "*.html",
+            files: "*.hbs",
             options: {
                 requirePragma: false,
                 parser: "html",

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -204,6 +204,7 @@ type ConfiguredConfig = Config<
     CompendiumDirectoryPF2e,
     HotbarPF2e,
     ItemPF2e,
+    JournalEntryPagePF2e,
     MacroPF2e,
     MeasuredTemplateDocumentPF2e,
     TileDocumentPF2e,

--- a/src/module/journal-entry-page/base.ts
+++ b/src/module/journal-entry-page/base.ts
@@ -1,0 +1,36 @@
+import { JournalEntryPageSourcePF2e, JournalEntryPageDataPF2e } from "./data";
+import { JournalPageSheetPF2e } from "./sheet/base";
+
+interface JournalEntryPageConstructionContextPF2e extends DocumentConstructionContext<JournalEntryPagePF2e> {
+    pf2e?: {
+        ready?: boolean;
+    };
+}
+
+class JournalEntryPagePF2e extends JournalEntryPage {
+    static get theme(): string | null {
+        return null;
+    }
+
+    constructor(data: PreCreate<JournalEntryPageSourcePF2e>, context: JournalEntryPageConstructionContextPF2e = {}) {
+        if (context.pf2e?.ready) {
+            super(data, context);
+        } else {
+            context.pf2e = mergeObject(context.pf2e ?? {}, { ready: true });
+            const JournalEntryPageConstructor = CONFIG.PF2E.JournalEntryPage.documentClasses[data.type];
+            return JournalEntryPageConstructor
+                ? new JournalEntryPageConstructor(data, context)
+                : new JournalEntryPagePF2e(data, context);
+        }
+    }
+}
+
+interface JournalEntryPagePF2e {
+    readonly data: JournalEntryPageDataPF2e;
+
+    _sheet: JournalPageSheetPF2e<this> | null;
+
+    get sheet(): JournalPageSheetPF2e<this>;
+}
+
+export { JournalEntryPagePF2e };

--- a/src/module/journal-entry-page/data/base.ts
+++ b/src/module/journal-entry-page/data/base.ts
@@ -1,0 +1,34 @@
+import type { JournalEntryPagePF2e } from "../base";
+import { DocumentSchemaRecord } from "@module/data";
+import { JournalEntryPageType } from ".";
+
+type BaseJournalEntryPageSourcePF2e<
+    TType extends JournalEntryPageType = JournalEntryPageType,
+    TSystemSource extends JournalEntryPageSystemSource = JournalEntryPageSystemSource
+> = foundry.data.JournalEntryPageSource<TType, TSystemSource>;
+
+interface BaseJournalEntryPageDataPF2e<
+    TJournalEntryPage extends JournalEntryPagePF2e = JournalEntryPagePF2e,
+    TType extends JournalEntryPageType = JournalEntryPageType,
+    TSystemData extends JournalEntryPageSystemData = JournalEntryPageSystemData,
+    TSource extends BaseJournalEntryPageSourcePF2e<TType> = BaseJournalEntryPageSourcePF2e<TType>
+> extends Omit<BaseJournalEntryPageSourcePF2e<TType, JournalEntryPageSystemSource>, "system">,
+        foundry.data.JournalEntryPageData<TJournalEntryPage> {
+    readonly type: TType;
+    readonly system: TSystemData;
+
+    readonly _source: TSource;
+}
+
+interface JournalEntryPageSystemSource {
+    schema: DocumentSchemaRecord;
+}
+
+type JournalEntryPageSystemData = JournalEntryPageSystemSource;
+
+export {
+    JournalEntryPageSystemData,
+    JournalEntryPageSystemSource,
+    BaseJournalEntryPageDataPF2e,
+    BaseJournalEntryPageSourcePF2e,
+};

--- a/src/module/journal-entry-page/data/index.ts
+++ b/src/module/journal-entry-page/data/index.ts
@@ -1,0 +1,10 @@
+import { ResourcePageData, ResourcePageSource } from "../resource";
+
+export type JournalEntryPageDataPF2e = ResourcePageData;
+
+export type JournalEntryPageType = "resource";
+
+export type JournalEntryPageSourcePF2e = JournalEntryPageDataPF2e["_source"];
+export type { ResourcePageData };
+
+export { ResourcePageSource };

--- a/src/module/journal-entry-page/index.ts
+++ b/src/module/journal-entry-page/index.ts
@@ -1,0 +1,3 @@
+export { JournalPageSheetPF2e } from "./sheet/base";
+export { JournalEntryPagePF2e } from "./base";
+export * from "./resource";

--- a/src/module/journal-entry-page/resource/data.ts
+++ b/src/module/journal-entry-page/resource/data.ts
@@ -1,0 +1,31 @@
+import { ResourcePagePF2e } from ".";
+import {
+    BaseJournalEntryPageDataPF2e,
+    BaseJournalEntryPageSourcePF2e,
+    JournalEntryPageSystemSource,
+} from "../data/base";
+
+type ResourcePageSource = BaseJournalEntryPageSourcePF2e<"resource", ResourcePageSystemSource>;
+
+type ResourcePageData = Omit<ResourcePageSource, "system" | "flags"> &
+    BaseJournalEntryPageDataPF2e<ResourcePagePF2e, "resource", ResourcePageSystemData, ResourcePageSource>;
+
+export type ResourcePageSystemSource = JournalEntryPageSystemSource;
+
+interface ResourcePageSystemData extends ResourcePageSystemSource {
+    text: {
+        content: string | null;
+    };
+    img: string;
+    min: number;
+    max: number;
+    value: number;
+    thresholds: ThresholdData[];
+}
+
+interface ThresholdData {
+    value: number;
+    label: string;
+}
+
+export { ResourcePageData, ResourcePageSource, ResourcePageSystemData, ThresholdData };

--- a/src/module/journal-entry-page/resource/document.ts
+++ b/src/module/journal-entry-page/resource/document.ts
@@ -1,0 +1,10 @@
+import { JournalEntryPagePF2e } from "../base";
+import { ResourcePageData } from "./data";
+
+class ResourcePagePF2e extends JournalEntryPagePF2e {}
+interface ResourcePagePF2e {
+    readonly data: ResourcePageData;
+    readonly system: ResourcePageData["system"];
+}
+
+export { ResourcePagePF2e };

--- a/src/module/journal-entry-page/resource/index.ts
+++ b/src/module/journal-entry-page/resource/index.ts
@@ -1,0 +1,2 @@
+export { ResourcePagePF2e } from "./document";
+export { ResourcePageData, ResourcePageSource } from "./data";

--- a/src/module/journal-entry-page/resource/sheet.ts
+++ b/src/module/journal-entry-page/resource/sheet.ts
@@ -1,0 +1,116 @@
+import { ResourcePagePF2e } from ".";
+import { ResourcePageSheetData } from "../sheet/data-types";
+import { JournalPageSheetPF2e } from "../sheet/base";
+import { EnrichHTMLOptionsPF2e } from "@system/text-editor";
+
+export class ResourcePageSheetPF2e extends JournalPageSheetPF2e<ResourcePagePF2e> {
+    override get template(): string {
+        return `systems/pf2e/templates/journal/page-resource-${this.isEditable ? "edit" : "view"}.hbs`;
+    }
+
+    override async getData(options?: Partial<DocumentSheetOptions>): Promise<ResourcePageSheetData> {
+        const sheetData = (await super.getData(options)) as ResourcePageSheetData;
+
+        sheetData.editor = {
+            engine: "tinymce",
+            collaborate: true,
+            content: await TextEditor.enrichHTML(sheetData.data.text.content || "", {
+                relativeTo: this.object,
+                secrets: this.object.isOwner,
+                async: true,
+            } as EnrichHTMLOptionsPF2e),
+        };
+        const thresholds = [...this.document.system.thresholds];
+        sheetData.sortedThresholds = thresholds?.sort((a, b) => {
+            return b.value - a.value;
+        });
+        const currentThreshold = sheetData.sortedThresholds?.find((threshold) => {
+            return threshold.value <= this.document.system.value;
+        });
+        sheetData.currentThreshold = currentThreshold?.label || "";
+        sheetData.sortedThresholds?.reverse();
+        return sheetData;
+    }
+
+    override activateListeners($html: JQuery<HTMLElement>): void {
+        super.activateListeners($html);
+        const html = $html[0];
+
+        // add buttons for default thresholds, resources, and thresholds on a resource
+        html.querySelector("a.add-threshold")?.addEventListener("click", async () => {
+            await this.submit({ preventClose: true, preventRender: false });
+            const thresholds = this.document.system.thresholds || [];
+            thresholds.push({ value: 0, label: "New Threshold" });
+            await this.document.update({ system: { thresholds } });
+            this.render();
+        });
+
+        for (const thresholdDeleteButton of html.querySelectorAll<HTMLLinkElement>(".delete-threshold")) {
+            thresholdDeleteButton.addEventListener("click", async () => {
+                await this.submit({ preventClose: true, preventRender: false });
+                const thresholds = this.document.system.thresholds || [];
+                const thresholdIndex = thresholdDeleteButton
+                    .closest("[data-threshold-index]")
+                    ?.getAttribute("data-threshold-index");
+                thresholds.splice(Number(thresholdIndex), 1);
+                await this.document.update({ system: { thresholds } });
+                this.render();
+            });
+        }
+
+        // editing threshold values and names
+        for (const thresholdValueForm of html.querySelectorAll<HTMLFormElement>(".threshold-array-value")) {
+            thresholdValueForm?.addEventListener("change", () => {
+                const thresholds = this.document.system.thresholds || [];
+                const thresholdIndex = thresholdValueForm
+                    .closest("[data-threshold-index]")
+                    ?.getAttribute("data-threshold-index");
+                const value = Number(thresholdValueForm.valueAsNumber);
+                thresholds[Number(thresholdIndex)].value = value;
+                this.document.update({ system: { thresholds } });
+            });
+        }
+
+        for (const thresholdLabelForm of html.querySelectorAll<HTMLFormElement>(".threshold-array-label")) {
+            thresholdLabelForm?.addEventListener("change", () => {
+                const thresholds = this.document.system.thresholds || [];
+                const thresholdIndex = thresholdLabelForm
+                    .closest("[data-threshold-index]")
+                    ?.getAttribute("data-threshold-index");
+                const value = thresholdLabelForm.value || "";
+                thresholds[Number(thresholdIndex)].label = value;
+                this.document.update({ system: { thresholds } });
+            });
+        }
+
+        for (const resourceValueForm of html.querySelectorAll<HTMLFormElement>(".resource-value")) {
+            resourceValueForm?.addEventListener("change", async () => {
+                const change = Number(resourceValueForm.value);
+                await this.submit({ preventClose: true, preventRender: false });
+                const value = Math.clamped(change, this.document.system.min, this.document.system.max ?? 0);
+                await this.document.update({ system: { value } });
+                this.render();
+            });
+        }
+
+        for (const reduceResourceValue of html.querySelectorAll<HTMLFormElement>(".reduce-resource-value")) {
+            reduceResourceValue?.addEventListener("click", async () => {
+                const change = this.document.system.value - 1;
+                await this.submit({ preventClose: true, preventRender: false });
+                const value = Math.clamped(change, this.document.system.min, this.document.system.max ?? 0);
+                await this.document.update({ system: { value } });
+                this.render();
+            });
+        }
+
+        for (const increaseResourceValue of html.querySelectorAll<HTMLFormElement>(".increase-resource-value")) {
+            increaseResourceValue?.addEventListener("click", async () => {
+                const change = this.document.system.value + 1;
+                await this.submit({ preventClose: true, preventRender: false });
+                const value = Math.clamped(change, this.document.system.min, this.document.system.max ?? 0);
+                await this.document.update({ system: { value } });
+                this.render();
+            });
+        }
+    }
+}

--- a/src/module/journal-entry-page/sheet/base.ts
+++ b/src/module/journal-entry-page/sheet/base.ts
@@ -1,0 +1,27 @@
+import { JournalEntryPagePF2e } from "..";
+import type * as TinyMCE from "tinymce";
+
+class JournalTextTinyMCESheetPF2e extends JournalTextTinyMCESheet {
+    override async activateEditor(
+        name: string,
+        options: Partial<TinyMCE.EditorOptions> = {},
+        initialContent = ""
+    ): Promise<TinyMCE.Editor> {
+        const editor = await super.activateEditor(name, options, initialContent);
+
+        const parentSheet = this.object.parent?.sheet.constructor as { theme?: string } | undefined;
+        const theme = parentSheet?.theme;
+        editor.contentDocument.documentElement.classList.add("journal-entry-page", "text");
+        editor.contentDocument.body.classList.add("journal-page-content");
+        if (theme) {
+            editor.contentDocument.documentElement.classList.add(theme);
+        }
+
+        return editor;
+    }
+}
+
+export class JournalPageSheetPF2e<
+    TJournalEntryPage extends JournalEntryPagePF2e
+> extends JournalPageSheet<TJournalEntryPage> {}
+export { JournalTextTinyMCESheetPF2e };

--- a/src/module/journal-entry-page/sheet/data-types.ts
+++ b/src/module/journal-entry-page/sheet/data-types.ts
@@ -1,0 +1,23 @@
+import { ResourcePagePF2e, JournalEntryPagePF2e } from "..";
+import { ThresholdData } from "../resource/data";
+
+export interface JournalPageSheetDataPF2e<TJournalEntryPage extends JournalEntryPagePF2e>
+    extends JournalPageSheetData<TJournalEntryPage> {
+    journalEntryPage: TJournalEntryPage["data"];
+    data: TJournalEntryPage["data"]["system"];
+    enrichedContent: Record<string, string>;
+}
+
+export interface ResourcePageSheetData extends JournalPageSheetDataPF2e<ResourcePagePF2e> {
+    editor: {
+        engine: string;
+        collaborate: boolean;
+        content: string;
+    };
+    text: {
+        content: string | null;
+    };
+    progressPercent: number;
+    sortedThresholds: ThresholdData[];
+    currentThreshold: string;
+}

--- a/src/module/journal-entry-page/sheet/index.ts
+++ b/src/module/journal-entry-page/sheet/index.ts
@@ -1,0 +1,1 @@
+export { JournalPageSheetPF2e, JournalTextTinyMCESheetPF2e } from "./base";

--- a/src/module/journal-entry/sheet.ts
+++ b/src/module/journal-entry/sheet.ts
@@ -1,5 +1,3 @@
-import type * as TinyMCE from "tinymce";
-
 class JournalSheetPF2e<TJournalEntry extends JournalEntry = JournalEntry> extends JournalSheet<TJournalEntry> {
     static get theme(): string | null {
         return null;
@@ -16,24 +14,4 @@ class JournalSheetPF2e<TJournalEntry extends JournalEntry = JournalEntry> extend
     }
 }
 
-class JournalTextTinyMCESheetPF2e extends JournalTextTinyMCESheet {
-    override async activateEditor(
-        name: string,
-        options: Partial<TinyMCE.EditorOptions> = {},
-        initialContent = ""
-    ): Promise<TinyMCE.Editor> {
-        const editor = await super.activateEditor(name, options, initialContent);
-
-        const parentSheet = this.object.parent?.sheet.constructor as { theme?: string } | undefined;
-        const theme = parentSheet?.theme;
-        editor.contentDocument.documentElement.classList.add("journal-entry-page", "text");
-        editor.contentDocument.body.classList.add("journal-page-content");
-        if (theme) {
-            editor.contentDocument.documentElement.classList.add(theme);
-        }
-
-        return editor;
-    }
-}
-
-export { JournalSheetPF2e, JournalTextTinyMCESheetPF2e };
+export { JournalSheetPF2e };

--- a/src/scripts/config/index.ts
+++ b/src/scripts/config/index.ts
@@ -40,7 +40,6 @@ import {
     WeaponReloadTime,
 } from "@item/weapon/types";
 import { Size } from "@module/data";
-import { JournalSheetPF2e } from "@module/journal-entry/sheet";
 import { DAMAGE_TYPES } from "@system/damage";
 import { DamageCategoryUnique, DamageType } from "@system/damage/types";
 import { pick, sluggify } from "@util";
@@ -72,6 +71,7 @@ import {
     vehicleTraits,
     weaponTraits,
 } from "./traits";
+import { ResourcePagePF2e } from "@module/journal-entry-page";
 
 export type StatusEffectIconTheme = "default" | "blackWhite";
 
@@ -1723,9 +1723,11 @@ export const PF2ECONFIG = {
             weapon: weaponTraits,
         },
     },
-
-    JournalEntry: { sheetClass: JournalSheetPF2e },
-
+    JournalEntryPage: {
+        documentClasses: {
+            resource: ResourcePagePF2e,
+        },
+    },
     Canvas: {
         darkness: {
             default: CONFIG.Canvas.darknessColor,

--- a/src/scripts/handlebars.ts
+++ b/src/scripts/handlebars.ts
@@ -50,8 +50,8 @@ export function registerHandlebarsHelpers(): void {
         return a * b;
     });
 
-    Handlebars.registerHelper("percentage", (value, max) => {
-        return (value * 100) / max;
+    Handlebars.registerHelper("percentage", (value, max, min = 0) => {
+        return ((value - min) * 100) / (max - min);
     });
 
     Handlebars.registerHelper("strip_tags", (value) => {

--- a/src/scripts/hooks/load.ts
+++ b/src/scripts/hooks/load.ts
@@ -19,6 +19,7 @@ import { monkeyPatchFoundry } from "@scripts/🐵🩹";
 import { CheckRoll, StrikeAttackRoll } from "@system/check";
 import { DamageInstance, DamageRoll } from "@system/damage/roll";
 import { ArithmeticExpression, Grouping, InstancePool, IntermediateDie } from "@system/damage/terms";
+import { JournalEntryPagePF2e } from "@module/journal-entry-page";
 
 /** Not an actual hook listener but rather things to run on initial load */
 export const Load = {
@@ -32,6 +33,7 @@ export const Load = {
         CONFIG.Combat.documentClass = EncounterPF2e;
         CONFIG.Combatant.documentClass = CombatantPF2e;
         CONFIG.Item.documentClass = ItemPF2e;
+        CONFIG.JournalEntryPage.documentClass = JournalEntryPagePF2e;
         CONFIG.Macro.documentClass = MacroPF2e;
         CONFIG.MeasuredTemplate.documentClass = MeasuredTemplateDocumentPF2e;
         CONFIG.Scene.documentClass = ScenePF2e;

--- a/src/scripts/register-sheets.ts
+++ b/src/scripts/register-sheets.ts
@@ -28,7 +28,10 @@ import {
     WeaponSheetPF2e,
 } from "@item";
 import { AfflictionSheetPF2e } from "@item/affliction";
-import { JournalSheetPF2e, JournalTextTinyMCESheetPF2e } from "@module/journal-entry/sheet";
+import { JournalSheetPF2e } from "@module/journal-entry/sheet";
+import { JournalTextTinyMCESheetPF2e } from "@module/journal-entry-page/sheet";
+import { ResourcePageSheetPF2e } from "@module/journal-entry-page/resource/sheet";
+import { JournalEntryPagePF2e } from "@module/journal-entry-page";
 import { UserPF2e } from "@module/user";
 import { UserConfigPF2e } from "@module/user/sheet";
 import { TokenConfigPF2e, TokenDocumentPF2e } from "@scene";
@@ -60,7 +63,12 @@ export function registerSheets() {
     Actors.unregisterSheet("core", ActorSheet);
 
     const localizeType = (type: string) => {
-        const entityType = type in CONFIG.PF2E.Actor.documentClasses ? "ACTOR" : "ITEM";
+        const entityType =
+            type in CONFIG.PF2E.Actor.documentClasses
+                ? "ACTOR"
+                : type in CONFIG.PF2E.Item.documentClasses
+                ? "ITEM"
+                : "JOURNAL";
         const camelized = type[0].toUpperCase() + type.slice(1).toLowerCase();
         return game.i18n.localize(`${entityType}.Type${camelized}`);
     };
@@ -155,6 +163,13 @@ export function registerSheets() {
             makeDefault: true,
         });
     }
+
+    // Register Resource Sheet
+    DocumentSheetConfig.registerSheet(JournalEntryPagePF2e, "pf2e", ResourcePageSheetPF2e, {
+        types: ["resource"],
+        label: game.i18n.format(sheetLabel, { type: localizeType("resource") }),
+        makeDefault: true,
+    });
 
     // User
 

--- a/src/styles/journal/_index.scss
+++ b/src/styles/journal/_index.scss
@@ -1,0 +1,1 @@
+@import 'resource';

--- a/src/styles/journal/_resource.scss
+++ b/src/styles/journal/_resource.scss
@@ -1,0 +1,55 @@
+.resource-page {
+    .resource-block {
+        @include frame-elegant;
+        padding: 7px;
+    }
+
+    .meter {
+        height: auto;
+        width: 100%;
+        position: relative;
+        background: rgba(10, 0, 0, 0.7);
+        padding: 2px;
+        border-radius: 4px;
+        margin: 5px;
+        margin-bottom: 8px;
+        .meter-label {
+            position: absolute;
+            top: 3px;
+            right: 5px;
+            margin: 0px;
+            color: white;
+        }
+    }
+    .meter > span {
+        display: block;
+        height: 20px;
+        border-radius: 4px;
+        background-color: var(--color-underline-header);
+        box-shadow: inset 0 2px 9px rgba(255, 255, 255, 0.3), inset 0 -2px 6px rgba(0, 0, 0, 0.4);
+        overflow: hidden;
+    }
+    .resource-content {
+        background: rgba(0, 0, 0, 0.1);
+        border-radius: 4px;
+        padding: 8px;
+        padding-top: 1px;
+        padding-bottom: 1px;
+    }
+    .meter-edit {
+        display: flex;
+    }
+    .resource-change-button {
+        height: 20px;
+        width: 20px;
+        margin-top: 6px;
+        margin-bottom: 8px;
+        text-align: center;
+        vertical-align: middle;
+        padding: 2px;
+        border-radius: 4px;
+        box-shadow: 0px 0px 2px rgb(0, 0, 0);
+        flex-shrink: none;
+        flex-grow: none;
+    }
+}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -12,4 +12,5 @@
         "settings", // PF2E Settings Applications
         "system",   // PF2E System Applications
         "tags",     // Trait, trait-like, and tagify styles
-        "gm";       // GM tools
+        "gm",       // GM tools
+        "journal";  // styling for resource pages

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -33,6 +33,9 @@
         "TypeTreasure": "Treasure",
         "TypeWeapon": "Weapon"
     },
+    "JOURNAL": {
+        "TypeResource": "Resource"
+    },
     "COMBAT": {
         "Begin": "Begin Encounter",
         "CombatantNotInScene": "The participant {name} is not present in your currently viewed scene.",
@@ -2411,6 +2414,16 @@
         "ItemTitle": "Item",
         "ItemUUIDLabel": "UUID:",
         "ItemsLabel": "Items",
+        "JournalAddResource": "Add Resource",
+        "JournalAddThreshold": "Add Threshold",
+        "JournalImageCaptionLabel": "Caption",
+        "JournalResourceMin": "Minimum",
+        "JournalResourceMinPlaceholder": "Min #",
+        "JournalResourceMax": "Maximum",
+        "JournalResourceMaxPlaceholder": "Max #",
+        "JournalResourceThresholdValue": "Threshold",
+        "JournalResourceThresholdName": "Name",
+        "JournalResourceValue": "Current Value",
         "KeyAbility": "Key Ability Score",
         "KeyAbilityLabel": "Key Ability",
         "Keybinding": {

--- a/static/template.json
+++ b/static/template.json
@@ -1,13 +1,6 @@
 {
     "Actor": {
-        "types": [
-            "character",
-            "npc",
-            "hazard",
-            "loot",
-            "familiar",
-            "vehicle"
-        ],
+        "types": ["character", "npc", "hazard", "loot", "familiar", "vehicle"],
         "templates": {
             "common": {
                 "attributes": {
@@ -65,9 +58,7 @@
             "details.publicNotes"
         ],
         "character": {
-            "templates": [
-                "common"
-            ],
+            "templates": ["common"],
             "abilities": {},
             "saves": {},
             "attributes": {
@@ -203,9 +194,7 @@
             }
         },
         "npc": {
-            "templates": [
-                "common"
-            ],
+            "templates": ["common"],
             "abilities": {
                 "str": {
                     "mod": 0
@@ -539,7 +528,6 @@
                                 "value": ""
                             }
                         }
-
                     },
                     "misidentified": {}
                 },
@@ -582,15 +570,9 @@
                 "modifiers": []
             }
         },
-        "htmlFields": [
-            "description.value",
-            "identification.data.description.value"
-        ],
+        "htmlFields": ["description.value", "identification.data.description.value"],
         "affliction": {
-            "templates": [
-                "common",
-                "itemLevel"
-            ],
+            "templates": ["common", "itemLevel"],
             "duration": {
                 "value": -1,
                 "unit": "unlimited"
@@ -603,12 +585,7 @@
             "stages": {}
         },
         "backpack": {
-            "templates": [
-                "common",
-                "physical",
-                "itemLevel",
-                "investable"
-            ],
+            "templates": ["common", "physical", "itemLevel", "investable"],
             "bulkCapacity": {
                 "value": ""
             },
@@ -619,29 +596,16 @@
             }
         },
         "book": {
-            "templates": [
-                "common",
-                "physical",
-                "itemLevel"
-            ],
+            "templates": ["common", "physical", "itemLevel"],
             "subtype": "formula",
             "capacity": 1,
             "items": []
         },
         "treasure": {
-            "templates": [
-                "common",
-                "physical",
-                "itemLevel"
-            ]
+            "templates": ["common", "physical", "itemLevel"]
         },
         "weapon": {
-            "templates": [
-                "common",
-                "physical",
-                "itemLevel",
-                "investable"
-            ],
+            "templates": ["common", "physical", "itemLevel", "investable"],
             "category": "simple",
             "group": null,
             "bonus": {
@@ -705,12 +669,7 @@
             }
         },
         "armor": {
-            "templates": [
-                "common",
-                "physical",
-                "itemLevel",
-                "investable"
-            ],
+            "templates": ["common", "physical", "itemLevel", "investable"],
             "armor": {
                 "value": 0
             },
@@ -751,9 +710,7 @@
             }
         },
         "melee": {
-            "templates": [
-                "common"
-            ],
+            "templates": ["common"],
             "weaponType": {
                 "value": "melee"
             },
@@ -769,11 +726,7 @@
             }
         },
         "consumable": {
-            "templates": [
-                "common",
-                "physical",
-                "itemLevel"
-            ],
+            "templates": ["common", "physical", "itemLevel"],
             "consumableType": {
                 "value": "other"
             },
@@ -793,20 +746,13 @@
             "spell": null
         },
         "equipment": {
-            "templates": [
-                "common",
-                "physical",
-                "itemLevel",
-                "investable"
-            ],
+            "templates": ["common", "physical", "itemLevel", "investable"],
             "usage": {
                 "value": "held-in-one-hand"
             }
         },
         "ancestry": {
-            "templates": [
-                "common"
-            ],
+            "templates": ["common"],
             "hp": 6,
             "size": "med",
             "reach": 5,
@@ -832,9 +778,7 @@
             "vision": "normal"
         },
         "background": {
-            "templates": [
-                "common"
-            ],
+            "templates": ["common"],
             "boosts": {
                 "0": { "value": [] },
                 "1": { "value": [] }
@@ -846,9 +790,7 @@
             }
         },
         "class": {
-            "templates": [
-                "common"
-            ],
+            "templates": ["common"],
             "keyAbility": { "value": [] },
             "items": {},
             "hp": 0,
@@ -876,17 +818,14 @@
                 "heavy": 0
             },
             "classDC": 0,
-            "ancestryFeatLevels": { "value": [ 1, 5, 9, 13, 17 ] },
-            "classFeatLevels": { "value": [ 1, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20 ] },
-            "generalFeatLevels": { "value": [ 3, 7, 11, 15, 19 ] },
-            "skillFeatLevels": { "value": [ 2, 4, 6, 8, 10, 12, 14, 16, 18, 20 ] },
-            "skillIncreaseLevels": { "value": [ 3, 5, 7, 9, 11, 13, 15, 17, 19 ] }
+            "ancestryFeatLevels": { "value": [1, 5, 9, 13, 17] },
+            "classFeatLevels": { "value": [1, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20] },
+            "generalFeatLevels": { "value": [3, 7, 11, 15, 19] },
+            "skillFeatLevels": { "value": [2, 4, 6, 8, 10, 12, 14, 16, 18, 20] },
+            "skillIncreaseLevels": { "value": [3, 5, 7, 9, 11, 13, 15, 17, 19] }
         },
         "feat": {
-            "templates": [
-                "common",
-                "itemLevel"
-            ],
+            "templates": ["common", "itemLevel"],
             "featType": {
                 "value": "bonus"
             },
@@ -904,15 +843,11 @@
             "location": null
         },
         "heritage": {
-            "templates": [
-                "common"
-            ],
+            "templates": ["common"],
             "ancestry": null
         },
         "lore": {
-            "templates": [
-                "common"
-            ],
+            "templates": ["common"],
             "mod": {
                 "value": 0
             },
@@ -921,9 +856,7 @@
             }
         },
         "action": {
-            "templates": [
-                "common"
-            ],
+            "templates": ["common"],
             "actionType": {
                 "value": ""
             },
@@ -942,10 +875,7 @@
             "deathNote": false
         },
         "spell": {
-            "templates": [
-                "common",
-                "itemLevel"
-            ],
+            "templates": ["common", "itemLevel"],
             "spellType": {
                 "value": "attack"
             },
@@ -1004,9 +934,7 @@
             }
         },
         "spellcastingEntry": {
-            "templates": [
-                "common"
-            ],
+            "templates": ["common"],
             "ability": {
                 "value": "cha"
             },
@@ -1097,19 +1025,14 @@
             }
         },
         "kit": {
-            "templates": [
-                "common"
-            ],
+            "templates": ["common"],
             "items": {},
             "price": {
                 "value": {}
             }
         },
         "condition": {
-            "templates": [
-                "common",
-                "status"
-            ],
+            "templates": ["common", "status"],
             "base": "",
             "group": "",
             "value": {
@@ -1129,9 +1052,7 @@
             "overrides": []
         },
         "effect": {
-            "templates": [
-                "common"
-            ],
+            "templates": ["common"],
             "level": {
                 "value": 1
             },
@@ -1163,9 +1084,7 @@
             "category": "deity",
             "alignment": {
                 "own": "N",
-                "follower": [
-                    "N"
-                ]
+                "follower": ["N"]
             },
             "domains": {
                 "primary": [],
@@ -1182,6 +1101,19 @@
                 "version": null,
                 "lastMigration": null
             }
+        }
+    },
+    "JournalEntryPage": {
+        "types": ["resource"],
+        "templates": {
+            "common": {}
+        },
+        "resource": {
+            "img": "",
+            "min": 0,
+            "max": 4,
+            "value": 0,
+            "thresholds": []
         }
     }
 }

--- a/static/templates/journal/page-resource-edit.hbs
+++ b/static/templates/journal/page-resource-edit.hbs
@@ -1,0 +1,50 @@
+<form class="{{cssClass}} flexcol" autocomplete="off">
+    {{> journalEntryPageHeader}}
+    <ol class="form-list">
+        <div class="form-group">
+            <label>{{localize "PF2E.ImageLabel"}}</label>
+            <div class="form-fields">
+                {{filePicker target="system.img" type="imagevideo"}}
+                <input
+                    class="image"
+                    type="text"
+                    name="system.img"
+                    placeholder="path/image.png"
+                    value="{{data.system.img}}"
+                />
+            </div>
+        </div>
+        <hr />
+        <div class="form-group">
+            <label>{{localize "PF2E.JournalResourceMin"}}</label>
+            <input type="number" name="system.min" value="{{data.system.min}}" placeholder="{{localize
+            "PF2E.JournalResourceMinPlaceholder"}}" />
+            <label>{{localize "PF2E.JournalResourceMax"}}</label>
+            <input type="number" name="system.max" value="{{data.system.max}}" placeholder="{{localize
+            "PF2E.JournalResourceMaxPlaceholder"}}" />
+        </div>
+        <div class="form-group">
+            <label>{{localize "PF2E.JournalResourceValue"}}</label>
+            <input type="number" value="{{data.system.value}}" class="resource-value" />
+        </div>
+        <div class="form-group">
+            <label>{{localize "PF2E.JournalResourceThresholdValue"}}</label>
+            <label>{{localize "PF2E.JournalResourceThresholdName"}}</label>
+        </div>
+        {{#each data.system.thresholds as |threshold idx|}}
+        <div class="form-group" data-threshold-index="{{idx}}">
+            <input type="number" value="{{threshold.value}}" class="threshold-array-value" />
+            <input type="text" value="{{threshold.label}}" class="threshold-array-label" />
+            <a class="delete-threshold" style="flex-grow: unset"><i class="fas fa-trash"></i></a>
+        </div>
+        {{/each}}
+        <div>
+            <a class="add-threshold">
+                <i class="fas fa-plus add-threshold"></i>
+                {{localize "PF2E.JournalAddThreshold"}}
+            </a>
+        </div>
+    </ol>
+    {{editor editor.content target="text.content" class="journal-page-content" button=false editable=true button=true
+    owner=owner}}
+</form>

--- a/static/templates/journal/page-resource-view.hbs
+++ b/static/templates/journal/page-resource-view.hbs
@@ -1,0 +1,33 @@
+<section class="journal-page-content resource-page">
+    <section class="resource-block">
+        {{#if data.title.show}}
+        <header class="journal-page-header">
+            <h{{data.title.level}}>{{data.name}}</h{{data.title.level}}>
+        </header>
+        {{/if}} {{#if (ne data.system.img "")}}
+        <img src="{{data.system.img}}" class="resource-image" />
+        {{/if}} {{#if document.isOwner}}
+        <div class="meter-edit">
+            <a class="reduce-resource-value resource-change-button"><i class="fas fa-minus"></i></a>
+            <div class="meter">
+                <span style="width: {{percentage data.system.value data.system.max data.system.min}}%"></span>
+                <p class="meter-label">
+                    {{currentThreshold}}{{#if (eq data.system.min 0)}}
+                    <strong>{{data.system.value}}</strong>
+                    /
+                    <strong>{{data.system.max}}</strong>
+                    {{/if}}
+                </p>
+            </div>
+            <a class="increase-resource-value resource-change-button"><i class="fas fa-plus"></i></a>
+        </div>
+        {{else}}
+        <div class="meter">
+            <span style="width: {{percentage data.system.value data.system.max data.system.min}}%"></span>
+            <p class="meter-label">{{currentThreshold}}</p>
+        </div>
+        {{/if}} {{#if (ne editor.content "")}}
+        <div class="resource-content">{{{editor.content}}}</div>
+        {{/if}}
+    </section>
+</section>

--- a/types/foundry/client/application/form-application/document-sheet/journal-page-sheet.d.ts
+++ b/types/foundry/client/application/form-application/document-sheet/journal-page-sheet.d.ts
@@ -1,3 +1,7 @@
+declare interface JournalPageSheetData<J extends JournalEntryPage> extends DocumentSheetData<J> {
+    data: object;
+}
+
 /**
  * The Application responsible for displaying and editing a single JournalEntryPage document.
  * @param object    The JournalEntryPage instance which is being edited.

--- a/types/foundry/client/collections/world-collection/journal.d.ts
+++ b/types/foundry/client/collections/world-collection/journal.d.ts
@@ -20,5 +20,25 @@ declare global {
          * @param force   Display the entry to all players regardless of normal permissions
          */
         static _showEntry(entryId: string, mode?: string, force?: boolean): Promise<void>;
+
+        /* -------------------------------------------- */
+        /*  Methods                                     */
+        /* -------------------------------------------- */
+
+        /**
+         * Register a Journal sheet class as a candidate which can be used to display Journals of a given type
+         * See DocumentSheetConfig.registerSheet for details
+         */
+        static registerSheet(
+            scope: string,
+            sheetClass: ConstructorOf<JournalPageSheet>,
+            options?: RegisterSheetOptions
+        ): void;
+
+        /**
+         * Unregister a Journal sheet class, removing it from the list of avaliable sheet Applications to use
+         * See DocumentSheetConfig.unregisterSheet for details
+         */
+        static unregisterSheet(scope: string, sheetClass: ConstructorOf<JournalPageSheet>, types?: string[]): void;
     }
 }

--- a/types/foundry/client/config.d.ts
+++ b/types/foundry/client/config.d.ts
@@ -14,6 +14,7 @@ declare global {
         TCompendiumDirectory extends CompendiumDirectory = CompendiumDirectory,
         THotbar extends Hotbar = Hotbar,
         TItem extends Item = Item,
+        TJournalEntryPage extends JournalEntryPage = JournalEntryPage,
         TMacro extends Macro = Macro,
         TMeasuredTemplateDocument extends MeasuredTemplateDocument = MeasuredTemplateDocument,
         TTileDocument extends TileDocument = TileDocument,
@@ -107,6 +108,29 @@ declare global {
                     {
                         id: string;
                         cls: typeof ItemSheet;
+                        default: boolean;
+                    }
+                >
+            >;
+            typeLabels: Record<string, string | undefined>;
+        };
+
+        /** Configuration for the JournalEntryPage document */
+        JournalEntryPage: {
+            documentClass: {
+                new (
+                    data: PreCreate<TJournalEntryPage["_source"]>,
+                    context?: DocumentConstructionContext<TJournalEntryPage>
+                ): TJournalEntryPage;
+            };
+            collection: typeof JournalEntryPage;
+            sheetClasses: Record<
+                string,
+                Record<
+                    string,
+                    {
+                        id: string;
+                        cls: typeof JournalPageSheet;
                         default: boolean;
                     }
                 >

--- a/types/foundry/client/documents/journal-entry-page.d.ts
+++ b/types/foundry/client/documents/journal-entry-page.d.ts
@@ -4,9 +4,13 @@ declare global {
     class JournalEntryPage extends JournalEntryPageConstructor {
         static slugifyHeading(heading: HTMLHeadingElement | string): string;
         get type(): string;
+
+        protected override _getSheetClass(): ConstructorOf<NonNullable<this["_sheet"]>>;
     }
 
     interface JournalEntryPage {
         parent: JournalEntry | null;
+
+        _sheet: JournalPageSheet<this> | null;
     }
 }

--- a/types/foundry/common/data/data/journal-entry-page-data.d.ts
+++ b/types/foundry/common/data/data/journal-entry-page-data.d.ts
@@ -63,15 +63,16 @@ declare module foundry {
          * @property {object} [ownership]  An object which configures the ownership of this page.
          * @property {object} [flags]      An object of optional key/value flags.
          */
-        interface JournalEntryPageSource {
+        interface JournalEntryPageSource<TType extends string = string, TSystemSource extends object = object> {
             _id: string;
             name: string;
             title: JournalEntryPageTitleData;
+            type: TType;
             image: JournalEntryPageImageData;
             text: JournalEntryPageTextData;
             video: JournalEntryPageVideoData;
             src?: string | null;
-            system: object; // will be filled out later
+            system: TSystemSource;
             sort: number;
             ownership?: Record<string, DocumentOwnershipLevel>;
             flags: object; // will be filled out later
@@ -83,7 +84,8 @@ declare module foundry {
             protected override _initializeSource(data: this["_source"]): this["_source"];
         }
 
-        interface JournalEntryPageData<TDocument extends documents.BaseJournalEntryPage> {
+        interface JournalEntryPageData<TDocument extends documents.BaseJournalEntryPage>
+            extends JournalEntryPageSource {
             readonly _source: JournalEntryPageSource;
         }
     }

--- a/types/foundry/common/documents/base-journal-entry-page.d.ts
+++ b/types/foundry/common/documents/base-journal-entry-page.d.ts
@@ -8,11 +8,14 @@ declare module foundry {
         }
 
         interface BaseJournalEntryPage {
-            readonly data: data.JournalEntryPageData<this>;
+            readonly data: data.JournalEntryPageData<BaseJournalEntryPage>;
 
             readonly parent: BaseJournalEntry | null;
 
             get documentName(): typeof BaseJournalEntryPage["metadata"]["name"];
+
+            /** Shim for V10 preparation */
+            readonly system: this["data"]["system"];
         }
     }
 


### PR DESCRIPTION
Adds a sheet that can track simple numeric counters or progress to the system. This is mostly built with subsystems like Reputation, chase, research, or influence in mind and should be able to help GMs dealing with those subsystems

![image](https://user-images.githubusercontent.com/74384067/210009346-b498e087-7cae-4cec-a5fd-4a02bc6ebc77.png)
