### PR TITLE
Add `htmlFields` arrays to template.json

### DIFF
--- a/static/template.json
+++ b/static/template.json
@@ -53,6 +53,24 @@
                 }
             }
         },
+        "htmlFields": [
+            "details.biography.appearance",
+            "details.biography.backstory",
+            "details.biography.birthPlace",
+            "details.biography.attitude",
+            "details.biography.beliefs",
+            "details.biography.likes",
+            "details.biography.dislikes",
+            "details.biography.catchphrases",
+            "details.biography.campaignNotes",
+            "details.biography.allies",
+            "details.biography.enemies",
+            "details.biography.organaizations",
+            "details.description",
+            "details.description.value",
+            "details.privateNotes",
+            "details.publicNotes"
+        ],
         "character": {
             "templates": [
                 "common"
@@ -620,6 +638,10 @@
                 "modifiers": []
             }
         },
+        "htmlFields": [
+            "description.value",
+            "identification.data.description.value"
+        ],
         "backpack": {
             "templates": [
                 "common",


### PR DESCRIPTION
These inform the server which fields have HTML in them and should be sanitized against security vulnerabilities. Coverage won't be perfect (we can't include arrays or objects with randomly-generated keys), but it's better than nothing. 