### PR TITLE
Remove disabling of ABP in BattleForm RE

### DIFF
--- a/src/module/actor/character/automatic-bonus-progression.ts
+++ b/src/module/actor/character/automatic-bonus-progression.ts
@@ -66,14 +66,14 @@ export class AutomaticBonusProgression {
             const attack = values.attack;
             const damage = values.damage;
             if (attack > 0) {
-                const modifiers = (synthetics.statisticsModifiers["mundane-attack"] ??= []);
+                const modifiers = (synthetics.statisticsModifiers["strike-attack-roll"] ??= []);
                 modifiers.push(
                     () =>
                         new ModifierPF2e({
                             slug: "attack-potency",
                             label: "PF2E.AutomaticBonusProgression.attackPotency",
                             modifier: attack,
-                            type: MODIFIER_TYPE.POTENCY,
+                            type: "potency",
                         })
                 );
             }
@@ -107,13 +107,12 @@ export class AutomaticBonusProgression {
             if (attack > 0) {
                 const potency: PotencySynthetic = {
                     label: game.i18n.localize("PF2E.AutomaticBonusProgression.attackPotency"),
-                    type: MODIFIER_TYPE.POTENCY,
+                    type: "potency",
                     bonus: attack,
                     predicate: new PredicatePF2e(),
                 };
-                synthetics.weaponPotency["mundane-attack"] = (synthetics.weaponPotency["mundane-attack"] || []).concat(
-                    potency
-                );
+                const potencySynthetics = (synthetics.weaponPotency["strike-attack-roll"] ??= []);
+                potencySynthetics.push(potency);
             }
         }
     }

--- a/src/module/rules/rule-element/battle-form/rule-element.ts
+++ b/src/module/rules/rule-element/battle-form/rule-element.ts
@@ -121,9 +121,6 @@ export class BattleFormRuleElement extends RuleElementPF2e {
         overrides.immunities ??= [];
         overrides.weaknesses ??= [];
         overrides.resistances ??= [];
-
-        // Disable Automatic Bonus Progression
-        this.actor.flags.pf2e.disableABP = true;
     }
 
     override async preCreate({ itemSource, ruleSource }: RuleElementPF2e.PreCreateParams): Promise<void> {
@@ -414,7 +411,8 @@ export class BattleFormRuleElement extends RuleElementPF2e {
                 const sign = action.totalModifier < 0 ? "" : "+";
                 action.variants[0].label = `${title} ${sign}${action.totalModifier}`;
             } else {
-                this.actor.rollOptions.all["battle-form:own-attack-modifier"] = true;
+                const options = (this.actor.rollOptions["strike-attack-roll"] ??= {});
+                options["battle-form:own-attack-modifier"] = true;
             }
         }
     }


### PR DESCRIPTION
Relic of original implementation when suppressing potency bonuses was a game of whack-a-mole. Also does some unification of relevant domains.