### PR TITLE
Remove use of deprecated `roll` property in `ChatMessage` create data

### DIFF
--- a/src/module/rules/rule-element/fast-healing.ts
+++ b/src/module/rules/rule-element/fast-healing.ts
@@ -64,7 +64,7 @@ class FastHealingRuleElement extends RuleElementPF2e {
         const flavor = `${preFlavor}${postFlavor}`;
         const rollMode = this.actor.hasPlayerOwner ? "publicroll" : "gmroll";
         const speaker = ChatMessagePF2e.getSpeaker({ actor: this.actor, token: this.token });
-        ChatMessagePF2e.create({ flavor, speaker, type: CONST.CHAT_MESSAGE_TYPES.ROLL, roll }, { rollMode });
+        ChatMessagePF2e.create({ flavor, speaker, type: CONST.CHAT_MESSAGE_TYPES.ROLL, rolls: [roll] }, { rollMode });
     }
 }
 

--- a/src/module/system/damage/damage.ts
+++ b/src/module/system/damage/damage.ts
@@ -216,7 +216,7 @@ export class DamagePF2e {
                 speaker: ChatMessagePF2e.getSpeaker({ actor: self?.actor, token: self?.token }),
                 flavor,
                 content: await roll.render(),
-                roll: roll.toJSON(),
+                rolls: [roll.toJSON()],
                 sound: "sounds/dice.wav",
                 flags: {
                     core: { canPopout: true },

--- a/src/scripts/macros/encouraging-words.ts
+++ b/src/scripts/macros/encouraging-words.ts
@@ -20,12 +20,8 @@ export function encouragingWords(options: ActionDefaultOptions): void {
         options.push(translations.Title);
         options.push("action:encourage-words");
 
-        const dc = {
-            value: DC,
-        };
-
         dip.roll({
-            dc: dc,
+            dc: { value: DC },
             options: options,
             callback: async (roll: Rolled<Roll>) => {
                 let healFormula: string | undefined, successLabel: string | undefined;
@@ -53,7 +49,7 @@ export function encouragingWords(options: ActionDefaultOptions): void {
                         speaker: ChatMessagePF2e.getSpeaker({ actor, token }),
                         type: CONST.CHAT_MESSAGE_TYPES.ROLL,
                         flavor: `<strong>${rollType} ${translations.Title}</strong> (${successLabel})`,
-                        roll: healRoll.toJSON(),
+                        rolls: [healRoll.toJSON()],
                     });
                 }
             },

--- a/src/scripts/macros/treat-wounds.ts
+++ b/src/scripts/macros/treat-wounds.ts
@@ -150,7 +150,7 @@ async function applyChanges(actor: CreaturePF2e, $html: JQuery, event: JQuery.Tr
                 ChatMessagePF2e.create({
                     type: CONST.CHAT_MESSAGE_TYPES.ROLL,
                     flavor: `<strong>${game.i18n.localize("PF2E.Actions.TreatWounds.Rolls.RiskySurgery")}</strong>`,
-                    roll: (await new Roll("{1d8}[slashing]").roll({ async: true })).toJSON(),
+                    rolls: [(await new Roll("{1d8}[slashing]").roll({ async: true })).toJSON()],
                     speaker,
                 });
             }
@@ -164,7 +164,7 @@ async function applyChanges(actor: CreaturePF2e, $html: JQuery, event: JQuery.Tr
                 ChatMessagePF2e.create({
                     type: CONST.CHAT_MESSAGE_TYPES.ROLL,
                     flavor: `<strong>${rollType}</strong> (${successLabel})`,
-                    roll: healRoll.toJSON(),
+                    rolls: [healRoll.toJSON()],
                     speaker,
                 });
             }

--- a/types/foundry/client/documents/chat-message.d.ts
+++ b/types/foundry/client/documents/chat-message.d.ts
@@ -137,7 +137,7 @@ declare global {
          * Obtain an Actor instance which represents the speaker of this message (if any)
          * @param speaker The speaker data object
          */
-        static getSpeakerActor(speaker: foundry.data.ChatSpeakerSource | foundry.data.ChatSpeakerData): Actor | null;
+        static getSpeakerActor(speaker: DeepPartial<foundry.data.ChatSpeakerSource>): Actor | null;
 
         /** Obtain a data object used to evaluate any dice rolls associated with this particular chat message */
         getRollData(): object;

--- a/types/foundry/common/data/data/chat-message-data.d.ts
+++ b/types/foundry/common/data/data/chat-message-data.d.ts
@@ -12,7 +12,7 @@ declare module foundry {
             speaker: ChatSpeakerSource;
             whisper: string[];
             blind: boolean;
-            roll: string | RollJSON;
+            rolls: (string | RollJSON)[];
             sound: AudioPath;
             emote?: boolean;
             flags: ChatMessageFlags;


### PR DESCRIPTION
Foundry documents it as deprecated and shims it but for some reason doesn't throw a deprecation warning.