### PR TITLE
Tweak colors/icons of some damage types

### DIFF
--- a/src/module/system/damage/values.ts
+++ b/src/module/system/damage/values.ts
@@ -78,7 +78,7 @@ const DAMAGE_TYPE_ICONS: Record<DamageType, string | null> = {
     electricity: "bolt",
     evil: "face-angry-horns",
     fire: "fire",
-    force: "hand-sparkles",
+    force: "sparkles",
     good: "face-smile-halo",
     lawful: "scale-balanced",
     mental: "brain",
@@ -87,7 +87,7 @@ const DAMAGE_TYPE_ICONS: Record<DamageType, string | null> = {
     poison: "spider",
     positive: "sun",
     slashing: "axe",
-    sonic: "volume-up",
+    sonic: "waveform-lines",
     untyped: null,
 };
 

--- a/src/styles/ui/sidebar/chat/_damage.scss
+++ b/src/styles/ui/sidebar/chat/_damage.scss
@@ -184,7 +184,7 @@
             }
 
             &.force {
-                $color: #4078a6;
+                $color: #6300aa;
                 border-color: $color;
                 color: color.adjust($color, $lightness: $darker);
 
@@ -241,7 +241,7 @@
             }
 
             &.negative {
-                $color: black;
+                $color: #00001f;
                 border-color: $color;
                 color: $color;
 
@@ -269,7 +269,7 @@
             }
 
             &.poison {
-                $color: darkolivegreen;
+                $color: #5b7332;
                 border-color: $color;
                 color: color.adjust($color, $lightness: $darker);
 
@@ -283,13 +283,13 @@
             }
 
             &.positive {
-                $color: white;
+                $color: #ffffe0;
                 border-color: $color;
                 color: color.adjust($color, $lightness: $darker);
 
                 &:not(.tooltip-part), &.tooltip-part > header {
                     background: rgba($color, $transparent);
-                    text-shadow: 1px 1px rgba(black, 0.35);
+                    text-shadow: 1px 1px rgba(black, 0.60);
                 }
 
                 .icon {


### PR DESCRIPTION
Before/After
![image](https://user-images.githubusercontent.com/106829671/208387171-4e58994e-7e77-41e1-8993-e1e3d7031a30.png) ![image](https://user-images.githubusercontent.com/106829671/208387053-9a15530a-030d-45fe-a96d-3d110a2dbd54.png)
