### PR TITLE
Fix tokens with animated art disappearing on reload/scene switch

### DIFF
--- a/src/scripts/hooks/canvas-ready.ts
+++ b/src/scripts/hooks/canvas-ready.ts
@@ -25,16 +25,14 @@ export const CanvasReady = {
 
             // Redraw tokens
             for (const token of canvas.tokens.placeables) {
-                let redrawTrigger = Promise.resolve();
+                const redrawTrigger = token.isVideo
+                    ? new Promise((resolve) => {
+                          // Wait until 50ms after the video starts playing to be safe - sometimes they'll still be
+                          // invisible if drawn immediately after they begin playing
+                          token.sourceElement.addEventListener("play", () => setTimeout(resolve, 50), { once: true });
+                      })
+                    : Promise.resolve();
 
-                // Animated tokens sometimes disappear if the underlying video isn't given a moment to begin playing
-                if (token.isVideo) {
-                    redrawTrigger = new Promise((resolve) => {
-                        // Wait until 50ms after the video starts playing to be safe - sometimes they'll still be
-                        // invisible if drawn immediately after they begin playing
-                        token.sourceElement.addEventListener("play", () => setTimeout(resolve, 50), { once: true });
-                    });
-                }
                 redrawTrigger.then(async () => {
                     const { visible } = token;
                     await token.draw();

--- a/src/scripts/hooks/canvas-ready.ts
+++ b/src/scripts/hooks/canvas-ready.ts
@@ -32,7 +32,7 @@ export const CanvasReady = {
                     redrawTrigger = new Promise((resolve) => {
                         // Wait until 50ms after the video starts playing to be safe - sometimes they'll still be
                         // invisible if drawn immediately after they begin playing
-                        token.sourceElement.addEventListener("play", () => setTimeout(resolve, 50));
+                        token.sourceElement.addEventListener("play", () => setTimeout(resolve, 50), { once: true });
                     });
                 }
                 redrawTrigger.then(async () => {

--- a/src/scripts/hooks/canvas-ready.ts
+++ b/src/scripts/hooks/canvas-ready.ts
@@ -23,14 +23,24 @@ export const CanvasReady = {
                 CONFIG.MeasuredTemplate.defaults.angle = canvas.scene.hasHexGrid ? 60 : 90;
             }
 
-            Promise.resolve().then(async () => {
-                // Redraw tokens
-                for (const token of canvas.tokens.placeables) {
+            // Redraw tokens
+            for (const token of canvas.tokens.placeables) {
+                let redrawTrigger = Promise.resolve();
+
+                // Animated tokens sometimes disappear if the underlying video isn't given a moment to begin playing
+                if (token.isVideo) {
+                    redrawTrigger = new Promise((resolve) => {
+                        // Wait until 50ms after the video starts playing to be safe - sometimes they'll still be
+                        // invisible if drawn immediately after they begin playing
+                        token.sourceElement.addEventListener("play", () => setTimeout(resolve, 50));
+                    });
+                }
+                redrawTrigger.then(async () => {
                     const { visible } = token;
                     await token.draw();
                     token.visible = visible;
-                }
-            });
+                });
+            }
         });
     },
 };


### PR DESCRIPTION
When redrawing tokens during a scene, animated tokens (and perhaps other tokens with art that loads slowly?) would sometimes have `visible` set to `false` incorrectly. The `isVisible` getter seems to always behave correctly though, so this simple one-line change fixes this issue.

Tokens that have been hidden by the GM or are out of sight due to walls/darkness still seem to work properly with this PR, but this may have other implications I'm not aware of, and I'm happy to change this PR if necessary.

Closes #5283 