### PR TITLE
Add safeguards to `GrantItemRuleElement#reevaluateOnUpdate`

### DIFF
--- a/src/module/item/sheet/rule-elements/index.ts
+++ b/src/module/item/sheet/rule-elements/index.ts
@@ -1,4 +1,4 @@
-import { GrantItemSource } from "@module/rules/rule-element/grant-item/base";
+import { GrantItemSource } from "@module/rules/rule-element/grant-item/rule-element";
 import { DEGREE_OF_SUCCESS_STRINGS } from "@system/degree-of-success";
 import { tagify } from "@util";
 import { RuleElementForm } from "./base";

--- a/src/module/rules/rule-element/grant-item/index.ts
+++ b/src/module/rules/rule-element/grant-item/index.ts
@@ -1,1 +1,1 @@
-export { GrantItemRuleElement } from "./base";
+export { GrantItemRuleElement } from "./rule-element";


### PR DESCRIPTION
- Force `replaceSelf` and `allowDuplicate` to be false
- Fail validation if no predicate is included