### PR TITLE
Add support for setting border and fill alphas to the Auras RE

### DIFF
--- a/packs/scripts/run-migration.ts
+++ b/packs/scripts/run-migration.ts
@@ -32,6 +32,7 @@ import { Migration812RestructureIWR } from "@module/migration/migrations/812-res
 import { Migration813NormalizeColdIron } from "@module/migration/migrations/813-normalize-cold-iron";
 import { Migration814CalculatedExpandedSplash } from "@module/migration/migrations/814-calculated-expanded-splash";
 import { Migration815ConsumableDataCleanup } from "@module/migration/migrations/815-consumable-data-cleanup";
+import { Migration818AddAlphasToAuraColors } from "@module/migration/migrations/818-add-alphas-to-aura-colors";
 
 // ^^^ don't let your IDE use the index in these imports. you need to specify the full path ^^^
 
@@ -67,6 +68,7 @@ const migrations: MigrationBase[] = [
     new Migration813NormalizeColdIron(),
     new Migration814CalculatedExpandedSplash(),
     new Migration815ConsumableDataCleanup(),
+    new Migration818AddAlphasToAuraColors(),
 ];
 
 global.deepClone = <T>(original: T): T => {

--- a/src/module/actor/types.ts
+++ b/src/module/actor/types.ts
@@ -30,7 +30,8 @@ interface AuraData {
     slug: string;
     radius: number;
     effects: AuraEffectData[];
-    colors: AuraColors | null;
+    border: AuraPart | null;
+    fill: AuraPart | null;
     traits: ItemTrait[];
 }
 
@@ -46,9 +47,9 @@ interface AuraEffectData {
     removeOnExit: boolean;
 }
 
-interface AuraColors {
-    border: `#${string}`;
-    fill: `#${string}`;
+interface AuraPart {
+    color: HexColorString;
+    alpha: number;
 }
 
 /* -------------------------------------------- */
@@ -118,7 +119,7 @@ export {
     AttackItem,
     AttackRollContext,
     AttackTarget,
-    AuraColors,
+    AuraPart,
     AuraData,
     AuraEffectData,
     DCSlug,

--- a/src/module/canvas/effect-area-square.ts
+++ b/src/module/canvas/effect-area-square.ts
@@ -1,4 +1,4 @@
-import { TokenAuraColors } from "./token/aura";
+import { TokenAuraPart } from "@module/canvas/token/aura/renderer";
 
 /** A square (`PIXI.Rectangle`) with additional information about an effect area it's part of */
 export class EffectAreaSquare extends PIXI.Rectangle {
@@ -17,7 +17,7 @@ export class EffectAreaSquare extends PIXI.Rectangle {
         };
     }
 
-    highlight(layer: GridHighlight, colors: TokenAuraColors): void {
+    highlight(layer: GridHighlight, border: TokenAuraPart, fill: TokenAuraPart): void {
         // Don't bother highlighting if outside the map boundaries
         if (this.x < 0 || this.y < 0) return;
 
@@ -25,8 +25,9 @@ export class EffectAreaSquare extends PIXI.Rectangle {
             canvas.grid.grid.highlightGridPosition(layer, {
                 x: this.x,
                 y: this.y,
-                border: colors.border,
-                color: colors.fill,
+                border: border.color,
+                color: fill.color,
+                alpha: border.alpha,
             });
         } else {
             canvas.grid.grid.highlightGridPosition(layer, {

--- a/src/module/canvas/token/aura/index.ts
+++ b/src/module/canvas/token/aura/index.ts
@@ -1,2 +1,2 @@
 export { AuraRenderers } from "./map";
-export { AuraRenderer, TokenAuraColors } from "./renderer";
+export { AuraRenderer, TokenAuraPart } from "./renderer";

--- a/src/module/migration/base.ts
+++ b/src/module/migration/base.ts
@@ -5,18 +5,18 @@ import { ScenePF2e } from "@module/scene";
 
 /**
  * This is the base class for a migration.
- * If you make a change to the database schema (i.e. anything in template.json or data-definitions.ts),
+ * If you make a change to the database schema (i.e. anything in template.json or `src/module/.../types.ts`),
  * you should create a migration. To do so, there are several steps:
- * - Bump the schema number in system.json
+ * - Bump the schema number in MigrationRunnerBase.LATEST_SCHEMA_VERSION
  * - Make a class that inherits this base class and implements `updateActor` or `updateItem` using the
  *   new value of the schema number as the version
- * - Add this class to getAllMigrations() in src/module/migrations/index.ts
- * - Test that your changes work. We have unit tests in tests/module/migration.test.ts as well as you
- *   should add your migration to packs/run-migration
+ * - Add to the index in `src/module/migration/migrations/index.ts`
+ * - Add to the migrations array in `packs/scripts/run-migration.ts`
+ * - Test your changes work in a world, and make sure the unit tests in `tests/module/migration.test.ts` run.
  */
 abstract class MigrationBase {
     /**
-     * This is the schema version. Make sure it matches the new version in system.json
+     * This is the schema version, not the system version.
      */
     static readonly version: number;
 

--- a/src/module/migration/migrations/818-add-alphas-to-aura-colors.ts
+++ b/src/module/migration/migrations/818-add-alphas-to-aura-colors.ts
@@ -1,0 +1,46 @@
+import { ItemSourcePF2e } from "@item/data";
+import { MigrationBase } from "../base";
+import { isObject } from "@util";
+import { AuraEffectData, AuraPart } from "@actor/types";
+import { ItemTrait } from "@item/data/base";
+import { RuleElementSource } from "@module/rules";
+
+/** Add alphas to aura colors */
+export class Migration818AddAlphasToAuraColors extends MigrationBase {
+    static override version = 0.818;
+
+    override async updateItem(source: ItemSourcePF2e): Promise<void> {
+        const filter = source.system.rules
+            .filter((rule) => isObject<{ key: unknown }>(rule))
+            .filter((rule) => rule.key === "Aura");
+        for (const rule of filter) {
+            const aura: MaybeWithColorsAuraData = <MaybeWithColorsAuraData>rule;
+            if (aura.colors) {
+                aura.border = {
+                    color: aura.colors.border,
+                    alpha: 0.75,
+                };
+
+                aura.fill = {
+                    color: aura.colors.fill,
+                    alpha: 0,
+                };
+
+                delete aura["colors"];
+            }
+        }
+    }
+}
+
+interface MaybeWithColorsAuraData extends RuleElementSource {
+    slug: string;
+    radius: number;
+    effects: AuraEffectData[];
+    colors?: {
+        border: `#${string}`;
+        fill: `#${string}`;
+    } | null;
+    traits: ItemTrait[];
+    border: AuraPart | null;
+    fill: AuraPart | null;
+}

--- a/src/module/migration/migrations/index.ts
+++ b/src/module/migration/migrations/index.ts
@@ -213,3 +213,4 @@ export { Migration812RestructureIWR } from "./812-restructure-iwr";
 export { Migration813NormalizeColdIron } from "./813-normalize-cold-iron";
 export { Migration814CalculatedExpandedSplash } from "./814-calculated-expanded-splash";
 export { Migration815ConsumableDataCleanup } from "./815-consumable-data-cleanup";
+export { Migration818AddAlphasToAuraColors } from "./818-add-alphas-to-aura-colors";

--- a/src/module/migration/runner/base.ts
+++ b/src/module/migration/runner/base.ts
@@ -14,7 +14,7 @@ interface CollectionDiff<T extends foundry.data.ActiveEffectSource | ItemSourceP
 export class MigrationRunnerBase {
     migrations: MigrationBase[];
 
-    static LATEST_SCHEMA_VERSION = 0.815;
+    static LATEST_SCHEMA_VERSION = 0.818;
 
     static MINIMUM_SAFE_VERSION = 0.618;
 

--- a/src/module/scene/token-document/aura/index.ts
+++ b/src/module/scene/token-document/aura/index.ts
@@ -6,7 +6,7 @@ import { TokenAuraData } from "./types";
 import { TokenDocumentPF2e } from "../document";
 import { measureDistanceRect } from "@module/canvas";
 import { ActorPF2e } from "@actor";
-import { AuraColors, AuraData } from "@actor/types";
+import { AuraPart, AuraData } from "@actor/types";
 
 class TokenAura implements TokenAuraData {
     slug: string;
@@ -18,7 +18,9 @@ class TokenAura implements TokenAuraData {
 
     traits: Set<ItemTrait>;
 
-    colors: AuraColors | null;
+    border: AuraPart | null;
+
+    fill: AuraPart | null;
 
     /** Does this aura affect its emanating token? */
     private includesSelf: boolean;
@@ -30,7 +32,8 @@ class TokenAura implements TokenAuraData {
         this.radius = args.radius;
 
         this.traits = args.traits;
-        this.colors = args.colors ?? null;
+        this.border = args.border ?? null;
+        this.fill = args.fill ?? null;
         this.includesSelf = args.includesSelf;
     }
 

--- a/src/module/scene/token-document/document.ts
+++ b/src/module/scene/token-document/document.ts
@@ -157,7 +157,8 @@ class TokenDocumentPF2e<TActor extends ActorPF2e = ActorPF2e> extends TokenDocum
                     radius: data.radius,
                     token: this as Embedded<TokenDocumentPF2e>,
                     traits: new Set(data.traits),
-                    colors: data.colors,
+                    border: data.border,
+                    fill: data.fill,
                     includesSelf: true,
                 })
             );


### PR DESCRIPTION
E.g.
```{"key":"Aura","radius":10,"slug":"test-aura","alphas":{"border":0.23,"fill":0.42}}```
or
```{"key":"Aura","radius":10,"slug":"test-aura","colors": {"border":"#ff00ff", "fill": "#00ff00"}, "alphas":{"border":0.23,"fill":0.42}}```

The previous defaults of border 0.75 and fill 0 are used if the alphas property is not set.

I chose to keep alphas as a separate property from colors so as to avoid the need for any migration, and to keep them simpler.
