### PR TITLE
Reorganize grant-deletion processing

### DIFF
--- a/src/module/rules/rule-element/grant-item/helpers.ts
+++ b/src/module/rules/rule-element/grant-item/helpers.ts
@@ -4,63 +4,63 @@ import { ItemPF2e } from "@item";
 async function processGrantDeletions(item: Embedded<ItemPF2e>, pendingItems: Embedded<ItemPF2e>[]): Promise<void> {
     const { actor } = item;
 
-    // First, process the items granted by the to-be-deleted item:
-    for (const grant of Object.values(item.flags.pf2e.itemGrants)) {
+    const granter = actor.items.get(item.flags.pf2e.grantedBy?.id ?? "");
+    const parentGrant = Object.values(granter?.flags.pf2e.itemGrants ?? {}).find((g) => g.id === item.id);
+    const grants = Object.values(item.flags.pf2e.itemGrants);
+
+    // Handle deletion restrictions, aborting early if found in either this item's granter or any of its grants
+    if (granter && parentGrant?.onDelete === "restrict" && !pendingItems.includes(granter)) {
+        ui.notifications.warn(
+            game.i18n.format("PF2E.Item.RemovalPrevented", { item: item.name, preventer: granter.name })
+        );
+        pendingItems.splice(pendingItems.indexOf(item), 1);
+        return;
+    }
+
+    for (const grant of grants) {
         const grantee = actor.items.get(grant.id);
         if (grantee?.flags.pf2e.grantedBy?.id !== item.id) continue;
 
-        switch (grantee.flags.pf2e.grantedBy.onDelete) {
-            case "restrict": {
-                if (!pendingItems.includes(grantee)) {
-                    ui.notifications.warn(
-                        game.i18n.format("PF2E.Item.RemovalPrevented", { item: item.name, preventer: grantee.name })
-                    );
-                    pendingItems.splice(pendingItems.indexOf(item), 1);
-                }
-                break;
-            }
-            case "cascade": {
-                if (!pendingItems.includes(grantee)) {
-                    pendingItems.push(grantee);
-                    await processGrantDeletions(grantee, pendingItems);
-                }
-                break;
-            }
-            default: {
-                // Unset the grant flag and leave the granted item on the actor
-                await grantee.update({ "flags.pf2e.-=grantedBy": null }, { render: false });
-                break;
-            }
+        if (grantee.flags.pf2e.grantedBy.onDelete === "restrict" && !pendingItems.includes(grantee)) {
+            ui.notifications.warn(
+                game.i18n.format("PF2E.Item.RemovalPrevented", { item: item.name, preventer: grantee.name })
+            );
+            pendingItems.splice(pendingItems.indexOf(item), 1);
+            return;
         }
     }
 
-    // Second, process the item that granted the to-be-deleted item
-    const granter = actor.items.get(item.flags.pf2e.grantedBy?.id ?? "");
-    const grant = Object.values(granter?.flags.pf2e.itemGrants ?? {}).find((g) => g.id === item.id);
-    if (!(granter && grant)) return;
+    // Handle deletion cascades, pushing additional items onto the `pendingItems` array
+    if (granter && parentGrant?.onDelete === "cascade" && !pendingItems.includes(granter)) {
+        pendingItems.push(granter);
+        await processGrantDeletions(granter, pendingItems);
+    }
 
-    switch (grant.onDelete) {
-        case "restrict": {
-            if (!pendingItems.includes(granter)) {
-                ui.notifications.warn(
-                    game.i18n.format("PF2E.Item.RemovalPrevented", { item: item.name, preventer: granter.name })
-                );
-                pendingItems.splice(pendingItems.indexOf(item), 1);
-            }
-            break;
+    for (const grant of grants) {
+        const grantee = actor.items.get(grant.id);
+        if (grantee?.flags.pf2e.grantedBy?.id !== item.id) continue;
+
+        if (grantee.flags.pf2e.grantedBy.onDelete === "cascade" && !pendingItems.includes(grantee)) {
+            pendingItems.push(grantee);
+            await processGrantDeletions(grantee, pendingItems);
         }
-        case "cascade": {
-            if (!pendingItems.includes(granter)) {
-                pendingItems.push(granter);
-                await processGrantDeletions(granter, pendingItems);
-            }
-            break;
+    }
+
+    // Finally, handle detachments, removing the grant data from granters `itemGrants` object
+    const [key] = Object.entries(granter?.flags.pf2e.itemGrants ?? {}).find(([, g]) => g === parentGrant) ?? [null];
+    if (granter && key) {
+        await granter.update({ [`flags.pf2e.itemGrants.-=${key}`]: null }, { render: false });
+    }
+
+    for (const grant of grants) {
+        const grantee = actor.items.get(grant.id);
+        if (grantee?.flags.pf2e.grantedBy?.id !== item.id || pendingItems.includes(grantee)) {
+            continue;
         }
-        default: {
-            // Remove the grant from the granter's `itemGrants` array
-            const itemGrants = Object.values(granter.flags.pf2e.itemGrants).filter((g) => g.id !== item.id);
-            await granter.update({ "flags.pf2e.itemGrants": itemGrants }, { render: false });
-            break;
+
+        // Unset the grant flag and leave the granted item on the actor
+        if (grantee.flags.pf2e.grantedBy.onDelete === "detach") {
+            await grantee.update({ "flags.pf2e.-=grantedBy": null }, { render: false });
         }
     }
 }


### PR DESCRIPTION
Instead of processing the granter's grant data and then the grantee's own grant data, it now handles "restrict", "cascade", and finally "detach", with each looking at granter and then grantee.