### PR TITLE
Remove `value` property from loot actor description

### DIFF
--- a/src/module/actor/loot/data.ts
+++ b/src/module/actor/loot/data.ts
@@ -48,9 +48,7 @@ interface LootAttributesData extends LootAttributesSource {
 }
 
 interface LootDetailsSource {
-    description: {
-        value: string;
-    };
+    description: string;
     level: {
         value: number;
     };

--- a/src/module/actor/loot/sheet.ts
+++ b/src/module/actor/loot/sheet.ts
@@ -34,7 +34,7 @@ export class LootSheetPF2e extends ActorSheetPF2e<LootPF2e> {
 
         // Enrich content
         const rollData = this.actor.getRollData();
-        sheetData.enrichedContent.description = await TextEditor.enrichHTML(sheetData.data.details.description.value, {
+        sheetData.enrichedContent.description = await TextEditor.enrichHTML(sheetData.data.details.description, {
             rollData,
             async: true,
         });

--- a/src/module/migration/migrations/810-loot-description-value.ts
+++ b/src/module/migration/migrations/810-loot-description-value.ts
@@ -1,0 +1,20 @@
+import { ActorSourcePF2e } from "@actor/data";
+import { MigrationBase } from "../base";
+
+/** Remove value property from loot actor description */
+export class Migration810LootDescriptionValue extends MigrationBase {
+    static override version = 0.81;
+
+    override async updateActor(source: ActorSourcePF2e): Promise<void> {
+        if (source.type === "loot") {
+            const details: MaybeWithValue = source.system.details;
+            if (details.description instanceof Object) {
+                details.description = String(details.description.value ?? "");
+            }
+        }
+    }
+}
+
+interface MaybeWithValue {
+    description: { value: string } | string;
+}

--- a/src/module/migration/migrations/index.ts
+++ b/src/module/migration/migrations/index.ts
@@ -207,3 +207,4 @@ export { Migration806TorchImprovisedOtherTags } from "./806-torch-improvised-oth
 export { Migration807RMActivatedEffectFields } from "./807-rm-activated-effect-fields";
 export { Migration808CountDamageDice } from "./808-count-damage-dice";
 export { Migration809AutomatonEnhancements } from "./809-automaton-enhancements";
+export { Migration810LootDescriptionValue } from "./810-loot-description-value";

--- a/src/module/migration/runner/base.ts
+++ b/src/module/migration/runner/base.ts
@@ -14,7 +14,7 @@ interface CollectionDiff<T extends foundry.data.ActiveEffectSource | ItemSourceP
 export class MigrationRunnerBase {
     migrations: MigrationBase[];
 
-    static LATEST_SCHEMA_VERSION = 0.809;
+    static LATEST_SCHEMA_VERSION = 0.81;
 
     static MINIMUM_SAFE_VERSION = 0.618;
 

--- a/static/template.json
+++ b/static/template.json
@@ -67,7 +67,6 @@
             "details.biography.enemies",
             "details.biography.organaizations",
             "details.description",
-            "details.description.value",
             "details.privateNotes",
             "details.publicNotes"
         ],
@@ -355,9 +354,7 @@
             "templates": [],
             "attributes": {},
             "details": {
-                "description": {
-                    "value": ""
-                },
+                "description": "",
                 "level": {
                     "value": 0
                 }

--- a/static/templates/actors/loot/sidebar.html
+++ b/static/templates/actors/loot/sidebar.html
@@ -15,7 +15,7 @@
     {{/if}}
 
     {{#if owner}}
-        {{editor enrichedContent.description target="system.details.description.value" button=true user=user editable=editable}}
+        {{editor enrichedContent.description target="system.details.description" button=true user=user editable=editable}}
     {{else}}
         <div class="description">{{{enrichedContent.description}}}</div>
     {{/if}}


### PR DESCRIPTION
This fixes the HTML sanitation error and allows loot actors to be created again.