### PR TITLE
Move calling of RE `preUpdateActor` to `ActorPF2e.updateDocuments`

### DIFF
--- a/src/module/rules/helpers.ts
+++ b/src/module/rules/helpers.ts
@@ -1,8 +1,11 @@
+import { ActorPF2e } from "@actor";
 import { DamageDicePF2e, DeferredValueParams, ModifierAdjustment, ModifierPF2e } from "@actor/modifiers";
+import { ItemSourcePF2e } from "@item/data";
 import { RollNotePF2e } from "@module/notes";
 import { DegreeOfSuccessAdjustment } from "@system/degree-of-success";
 import { RollTwiceOption } from "@system/rolls";
 import { isObject, pick } from "@util";
+import { RuleElementPF2e } from "./rule-element";
 import { BracketedValue } from "./rule-element/data";
 import { DamageDiceSynthetics, RollSubstitution, RollTwiceSynthetic, RuleElementSynthetics } from "./synthetics";
 
@@ -80,6 +83,42 @@ function isBracketedValue(value: unknown): value is BracketedValue {
     return isObject<{ brackets?: unknown }>(value) && Array.isArray(value.brackets);
 }
 
+async function processPreUpdateActorHooks(
+    changed: DocumentUpdateData<ActorPF2e>,
+    { pack }: { pack: string | null }
+): Promise<void> {
+    const actorId = String(changed._id);
+    const actor = pack ? await game.packs.get(pack)?.getDocument(actorId) : game.actors.get(actorId);
+    if (!(actor instanceof ActorPF2e)) return;
+
+    // Run preUpdateActor rule element callbacks
+    type WithPreUpdateActor = RuleElementPF2e & {
+        preUpdateActor: NonNullable<RuleElementPF2e["preUpdateActor"]>;
+    };
+    const rules = actor.rules.filter((r): r is WithPreUpdateActor => !!r.preUpdateActor);
+    if (rules.length === 0) return;
+
+    actor.flags.pf2e.rollOptions = actor.clone(changed, { keepId: true }).flags.pf2e.rollOptions;
+    const createDeletes = (
+        await Promise.all(
+            rules.map(
+                (r): Promise<{ create: ItemSourcePF2e[]; delete: string[] }> =>
+                    actor.items.has(r.item.id) ? r.preUpdateActor() : new Promise(() => ({ create: [], delete: [] }))
+            )
+        )
+    ).reduce(
+        (combined, cd) => ({
+            create: [...combined.create, ...cd.create],
+            delete: Array.from(new Set([...combined.delete, ...cd.delete])),
+        }),
+        { create: [], delete: [] }
+    );
+    createDeletes.delete = createDeletes.delete.filter((id) => actor.items.has(id));
+
+    await actor.createEmbeddedDocuments("Item", createDeletes.create, { keepId: true, render: false });
+    await actor.deleteEmbeddedDocuments("Item", createDeletes.delete, { render: false });
+}
+
 export {
     extractDamageDice,
     extractDegreeOfSuccessAdjustments,
@@ -89,4 +128,5 @@ export {
     extractRollSubstitutions,
     extractRollTwice,
     isBracketedValue,
+    processPreUpdateActorHooks,
 };

--- a/src/module/rules/rule-element/base.ts
+++ b/src/module/rules/rule-element/base.ts
@@ -373,7 +373,7 @@ interface RuleElementPF2e {
     afterRoll?(params: RuleElementPF2e.AfterRollParams): Promise<void>;
 
     /** Runs before the rule's parent item's owning actor is updated */
-    preUpdateActor?(): Promise<void>;
+    preUpdateActor?(): Promise<{ create: ItemSourcePF2e[]; delete: string[] }>;
 
     /**
      * Runs before this rules element's parent item is created. The item is temporarilly constructed. A rule element can

--- a/types/foundry/common/abstract/document.d.ts
+++ b/types/foundry/common/abstract/document.d.ts
@@ -220,10 +220,11 @@ declare global {
                  * const updated = await Actor.updateDocuments([{_id: actor.id, name: "New Name"}], {pack: "mymodule.mypack"});
                  */
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                static updateDocuments<T extends ConstructorOf<any>>(
-                    updates?: DocumentUpdateData<InstanceType<T>>[],
+                static updateDocuments<T extends Document>(
+                    this: ConstructorOf<T>,
+                    updates?: DocumentUpdateData<T>[],
                     context?: DocumentModificationContext
-                ): Promise<InstanceType<T>[]>;
+                ): Promise<T[]>;
 
                 /**
                  * Delete one or multiple existing Documents using an array of provided ids.


### PR DESCRIPTION
Also creates/deletes all at once instead of for each reevaluated grant