### PR TITLE
Create persistent damage conditions from drag drop inline rolls

### DIFF
--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -67,6 +67,12 @@ class TextEditorPF2e extends TextEditor {
             anchor.innerHTML = `${icon.outerHTML}${label}`;
             anchor.dataset.tooltip = roll.formula;
             anchor.dataset.damageRoll = "";
+
+            const isPersistent = !roll.instances.some((i) => !i.persistent);
+            if (isPersistent) {
+                anchor.draggable = true;
+                anchor.dataset.persistent = "";
+            }
         }
 
         return anchor;

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -68,7 +68,7 @@ class TextEditorPF2e extends TextEditor {
             anchor.dataset.tooltip = roll.formula;
             anchor.dataset.damageRoll = "";
 
-            const isPersistent = !roll.instances.some((i) => !i.persistent);
+            const isPersistent = roll.instances.length > 0 && roll.instances.every((i) => i.persistent);
             if (isPersistent) {
                 anchor.draggable = true;
                 anchor.dataset.persistent = "";

--- a/src/scripts/hooks/drop-canvas-data.ts
+++ b/src/scripts/hooks/drop-canvas-data.ts
@@ -1,4 +1,5 @@
 import { DropCanvasItemDataPF2e } from "@module/canvas/drop-canvas-data";
+import { DamageRoll } from "@system/damage/roll";
 
 export const DropCanvasData = {
     listen: (): void => {
@@ -11,10 +12,27 @@ export const DropCanvasData = {
                     return data.x >= token.x && data.y >= token.y && data.x <= maximumX && data.y <= maximumY;
                 });
 
-            if (dropTarget?.actor && data.type === "Item") {
-                dropTarget.actor.sheet.emulateItemDrop(data as DropCanvasItemDataPF2e);
+            const actor = dropTarget?.actor;
+            if (actor && data.type === "Item") {
+                actor.sheet.emulateItemDrop(data as DropCanvasItemDataPF2e);
                 return false; // Prevent modules from doing anything further
             }
+
+            if (actor && data.type === "PersistentDamage" && "formula" in data) {
+                const roll = new DamageRoll(String(data.formula));
+                const instances = roll.instances.filter((i) => i.persistent);
+                const baseConditionSource = game.pf2e.ConditionManager.getCondition("persistent-damage").toObject();
+                const conditions = instances.map((i) =>
+                    mergeObject(baseConditionSource, {
+                        system: {
+                            persistent: { formula: i.head.expression, damageType: i.type, dc: 15 },
+                        },
+                    })
+                );
+                actor.createEmbeddedDocuments("Item", conditions);
+                return false; // Prevent modules from doing anything further
+            }
+
             return true;
         });
     },

--- a/src/scripts/system/dragstart-handler.ts
+++ b/src/scripts/system/dragstart-handler.ts
@@ -9,44 +9,49 @@ import { htmlClosest } from "@util";
 export function extendDragData(): void {
     document.body.addEventListener("dragstart", (event): void => {
         const { dataTransfer, target } = event;
-        if (!(dataTransfer && target instanceof HTMLAnchorElement && target.classList.contains("content-link"))) {
-            return;
+        if (!(dataTransfer && target instanceof HTMLAnchorElement)) return;
+
+        if (target.classList.contains("content-link")) {
+            // If this is a content link for an item, we need to extend existing data
+            const data: DropCanvasItemDataPF2e = JSON.parse(dataTransfer.getData("text/plain"));
+            if (data.type !== "Item") return;
+
+            // Add value field to TextEditor#_onDragEntityLink data. This is mainly used for conditions.
+            const name = target.innerText.trim();
+            const match = name.match(/[0-9]+/);
+            if (match) data.value = Number(match[0]);
+
+            // Detect spell level of containing element, if available
+            const containerElement = htmlClosest(target, "[data-cast-level]");
+            const castLevel = Number(containerElement?.dataset.castLevel);
+            if (castLevel > 0) data.level = castLevel;
+
+            const messageId = htmlClosest(target, "li.chat-message")?.dataset.messageId;
+            const message = game.messages.get(messageId ?? "");
+            if (message?.actor) {
+                const { actor, token, target } = message;
+                const roll = message.rolls.at(-1);
+
+                data.context = {
+                    origin: {
+                        actor: actor.uuid,
+                        token: token?.uuid ?? null,
+                    },
+                    target: target ? { actor: target.actor.uuid, token: target.token.uuid } : null,
+                    roll: roll
+                        ? {
+                              total: roll.total,
+                              degreeOfSuccess: roll instanceof CheckRoll ? roll.degreeOfSuccess ?? null : null,
+                          }
+                        : null,
+                };
+            }
+
+            dataTransfer.setData("text/plain", JSON.stringify(data));
+        } else if ("persistent" in target.dataset && target.dataset.formula) {
+            // Pass along the persistent damage formula so the drop-canvas-data hook can handle it
+            const data = { type: "PersistentDamage", formula: target.dataset.formula };
+            dataTransfer.setData("text/plain", JSON.stringify(data));
         }
-
-        const data: DropCanvasItemDataPF2e = JSON.parse(dataTransfer.getData("text/plain"));
-        if (data.type !== "Item") return;
-
-        // Add value field to TextEditor#_onDragEntityLink data. This is mainly used for conditions.
-        const name = target.innerText.trim();
-        const match = name.match(/[0-9]+/);
-        if (match) data.value = Number(match[0]);
-
-        // Detect spell level of containing element, if available
-        const containerElement = htmlClosest(target, "[data-cast-level]");
-        const castLevel = Number(containerElement?.dataset.castLevel);
-        if (castLevel > 0) data.level = castLevel;
-
-        const messageId = htmlClosest(target, "li.chat-message")?.dataset.messageId;
-        const message = game.messages.get(messageId ?? "");
-        if (message?.actor) {
-            const { actor, token, target } = message;
-            const roll = message.rolls.at(-1);
-
-            data.context = {
-                origin: {
-                    actor: actor.uuid,
-                    token: token?.uuid ?? null,
-                },
-                target: target ? { actor: target.actor.uuid, token: target.token.uuid } : null,
-                roll: roll
-                    ? {
-                          total: roll.total,
-                          degreeOfSuccess: roll instanceof CheckRoll ? roll.degreeOfSuccess ?? null : null,
-                      }
-                    : null,
-            };
-        }
-
-        dataTransfer.setData("text/plain", JSON.stringify(data));
     });
 }


### PR DESCRIPTION
I am blanking on visual changes to make it obvious its drag/droppable though. 

We will also need a migration for persistent damage inline rolls (the previous migration kinda skipped it, some still have the {1}[persistent,acid] syntax). The migration will also need to remove all embedded persistent damage conditions following an inline roll (which was never necessary in the module do not put that evil on me!)