### PR TITLE
Include damage modifiers and dice in roll inspector

### DIFF
--- a/src/module/chat-message/chat-roll-details.ts
+++ b/src/module/chat-message/chat-roll-details.ts
@@ -1,3 +1,5 @@
+import { BaseRawModifier, DamageDicePF2e } from "@actor/modifiers";
+import { addSign } from "@util";
 import { ChatMessagePF2e } from ".";
 
 class ChatRollDetails extends Application {
@@ -23,7 +25,23 @@ class ChatRollDetails extends Application {
         const remainingOptions = allOptions.filter((option) => option.includes(":"));
         const rollOptions = [...topLevelOptions.sort(), ...remainingOptions.sort()];
         const domains = context?.domains.sort();
-        return { context, domains, modifiers, rollOptions, hasModifiers: !!modifiers };
+        const preparedModifiers = modifiers ? this.prepareModifiers(modifiers) : [];
+        return { context, domains, modifiers: preparedModifiers, rollOptions, hasModifiers: !!modifiers };
+    }
+
+    protected prepareModifiers(modifiers: (BaseRawModifier | DamageDicePF2e)[]) {
+        return modifiers.map((mod) => {
+            const value = "dieSize" in mod ? `+${mod.diceNumber}${mod.dieSize}` : addSign(mod.modifier ?? 0);
+
+            return {
+                ...mod,
+                value,
+                critical:
+                    mod.critical !== null
+                        ? game.i18n.localize(`PF2E.RuleEditor.General.CriticalBehavior.${mod.critical}`)
+                        : null,
+            };
+        });
     }
 }
 

--- a/src/module/chat-message/data.ts
+++ b/src/module/chat-message/data.ts
@@ -1,6 +1,6 @@
 import { ItemType } from "@item/data";
 import { MagicTradition } from "@item/spell/types";
-import { RawModifier } from "@actor/modifiers";
+import { BaseRawModifier } from "@actor/modifiers";
 import { DegreeOfSuccessString } from "@system/degree-of-success";
 import { ChatMessagePF2e } from ".";
 import { RollNoteSource } from "@module/notes";
@@ -23,7 +23,7 @@ type ChatMessageFlagsPF2e = foundry.data.ChatMessageFlags & {
         origin?: { type: ItemType; uuid: string } | null;
         casting?: { id: string; level: number; tradition: MagicTradition } | null;
         modifierName?: string;
-        modifiers?: RawModifier[];
+        modifiers?: BaseRawModifier[];
         preformatted?: "flavor" | "content" | "both";
         isFromConsumable?: boolean;
         journalEntry?: DocumentUUID;

--- a/src/module/system/damage/damage.ts
+++ b/src/module/system/damage/damage.ts
@@ -198,6 +198,7 @@ export class DamagePF2e {
                     context: contextFlag,
                     damageRoll: rollData,
                     target: targetFlag,
+                    modifiers: data.modifiers,
                     origin,
                     strike,
                     preformatted: "both",

--- a/src/module/system/damage/types.ts
+++ b/src/module/system/damage/types.ts
@@ -71,6 +71,7 @@ interface BaseDamageTemplate {
     notes: RollNotePF2e[];
     traits: string[];
     materials: WeaponMaterialEffect[];
+    modifiers?: (ModifierPF2e | DamageDicePF2e)[];
 }
 
 interface WeaponDamageTemplate extends BaseDamageTemplate {

--- a/src/module/system/damage/weapon.ts
+++ b/src/module/system/damage/weapon.ts
@@ -417,6 +417,7 @@ class WeaponDamagePF2e {
             notes,
             traits: (traits ?? []).map((t) => t.name),
             materials: Array.from(materials),
+            modifiers: [...modifiers, ...damageDice],
             damage: {
                 ...damage,
                 formula: {

--- a/src/styles/ui/sidebar/chat/_chat-roll-details.scss
+++ b/src/styles/ui/sidebar/chat/_chat-roll-details.scss
@@ -63,6 +63,7 @@
 
     .modifier-list {
         @include scrollbar;
+        flex: 1 0 0;
         display: flex;
         flex-direction: column;
         gap: 4px;

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -55,17 +55,13 @@ function isBlank(text: Optional<string>): text is null | undefined | "" {
     return text === null || text === undefined || text.trim() === "";
 }
 
-/**
- * Adds a + if positive, nothing if 0 or - if negative
- */
+/** Returns a formatted number string with a preceding + if non-negative */
 function addSign(number: number): string {
     if (number < 0) {
         return `${number}`;
     }
-    if (number > 0) {
-        return `+${number}`;
-    }
-    return "0";
+
+    return `+${number}`;
 }
 
 /**

--- a/static/templates/chat/chat-roll-details.hbs
+++ b/static/templates/chat/chat-roll-details.hbs
@@ -30,8 +30,8 @@
                     <div class="modifier {{disabled (not m.enabled)}}">
                         <h4>{{m.label}} <span class="slug">({{m.slug}})</span></h4>
                         <div>
-                            <span>{{m.type}} {{numberFormat m.modifier sign=true}}</span>
-                            <span>{{m.ability}}</span>
+                            <span>{{m.type}} {{m.value}} {{m.damageType}} {{#if m.category}}({{m.category}}){{/if}}</span>
+                            <span>{{m.critical}} {{m.ability}}</span>
                         </div>
                     </div>
                 {{/each}}

--- a/tests/module/utils.test.ts
+++ b/tests/module/utils.test.ts
@@ -2,7 +2,7 @@ import { addSign, applyNTimes, padArray, zip } from "@util";
 
 describe("format sign for numbers", () => {
     test("0", () => {
-        expect(addSign(0)).toEqual("0");
+        expect(addSign(0)).toEqual("+0");
     });
 
     test("negative", () => {


### PR DESCRIPTION
Note that currently we don't have a way to tell which modifiers were used in which outcomes, since damage templates do every category at once. That said, with the critical property being shown, I think people can still deduce it anyways.

![image](https://user-images.githubusercontent.com/1286721/209936994-a6c228cf-3881-426d-a322-c5a1d8ea3435.png)
