### PR TITLE
Add `evaluatePersistent` option to `DamageRoll`

### DIFF
--- a/src/module/item/condition/document.ts
+++ b/src/module/item/condition/document.ts
@@ -92,7 +92,7 @@ class ConditionPF2e extends AbstractEffectPF2e {
 
         if (systemData.persistent) {
             const { formula, damageType } = systemData.persistent;
-            const roll = new DamageRoll(`(${formula})[${damageType}]`, {}, { fromPersistent: { damageType } });
+            const roll = new DamageRoll(`(${formula})[persistent,${damageType}]`, {}, { evaluatePersistent: true });
             const dc = game.user.isGM && systemData.persistent.dc !== 15 ? systemData.persistent.dc : null;
             const localizationKey = `PF2E.Item.Condition.PersistentDamage.${dc !== null ? "NameWithDC" : "Name"}`;
             this.name = game.i18n.format(localizationKey, { formula: roll.formula, dc });


### PR DESCRIPTION
This will instruct persistent-damage instances to evaluate themselves