### PR TITLE
Add a getter for a damage instance's "formal description"

### DIFF
--- a/src/module/system/damage/roll.ts
+++ b/src/module/system/damage/roll.ts
@@ -290,6 +290,18 @@ class DamageInstance extends AbstractDamageRoll {
         return DamageInstance.expectedValueOf(this.head);
     }
 
+    /** An array of statements for use in predicate testing */
+    get formalDescription(): string[] {
+        const typeCategory = DamageCategorization.fromDamageType(this.type);
+        return [
+            "damage",
+            `damage:type:{this.type}`,
+            typeCategory ? `damage:category:${typeCategory}` : [],
+            this.persistent ? "damage:category:persistent" : [],
+            this.materials.map((m) => `damage:material:${m}`),
+        ].flat();
+    }
+
     get iconClass(): string | null {
         return DAMAGE_TYPE_ICONS[this.type];
     }


### PR DESCRIPTION
A damage instance's "domain" to compare against IWR predicates