### PR TITLE
Enable condition retrieval/recovery via persistent-damage-x string

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -2,7 +2,7 @@ import { AttackItem, AttackRollContext, StrikeRollContext, StrikeRollContextPara
 import { ActorAlliance, ActorDimensions, AuraData, SaveType } from "@actor/types";
 import { ArmorPF2e, ContainerPF2e, ItemPF2e, PhysicalItemPF2e, type ConditionPF2e } from "@item";
 import { ActionTrait } from "@item/action/data";
-import { ConditionSlug } from "@item/condition/data";
+import { ConditionKey, ConditionSlug } from "@item/condition/data";
 import { isCycle } from "@item/container/helpers";
 import { ItemSourcePF2e, ItemType, PhysicalItemSource } from "@item/data";
 import { ActionCost, ActionType } from "@item/data/base";
@@ -1196,11 +1196,11 @@ class ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
      * @param [options.all=false] return all conditions of the requested type in the order described above
      */
     getCondition(
-        slug: ConditionSlug,
+        slug: ConditionKey,
         { all }: { all: boolean } = { all: false }
     ): Embedded<ConditionPF2e>[] | Embedded<ConditionPF2e> | null {
         const conditions = this.itemTypes.condition
-            .filter((condition) => condition.slug === slug)
+            .filter((condition) => condition.key === slug || condition.slug === slug)
             .sort((conditionA, conditionB) => {
                 const [valueA, valueB] = [conditionA.value ?? 0, conditionB.value ?? 0] as const;
                 const [durationA, durationB] = [conditionA.duration ?? 0, conditionB.duration ?? 0] as const;
@@ -1229,7 +1229,7 @@ class ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
 
     /** Decrease the value of condition or remove it entirely */
     async decreaseCondition(
-        conditionSlug: ConditionSlug | Embedded<ConditionPF2e>,
+        conditionSlug: ConditionKey | Embedded<ConditionPF2e>,
         { forceRemove }: { forceRemove: boolean } = { forceRemove: false }
     ): Promise<void> {
         // Find a valid matching condition if a slug was passed
@@ -1434,11 +1434,11 @@ interface ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
         options?: DocumentModificationContext
     ): Promise<ActiveEffectPF2e[] | ItemPF2e[]>;
 
-    getCondition(conditionType: ConditionSlug, { all }: { all: true }): Embedded<ConditionPF2e>[];
-    getCondition(conditionType: ConditionSlug, { all }: { all: false }): Embedded<ConditionPF2e> | null;
-    getCondition(conditionType: ConditionSlug): Embedded<ConditionPF2e> | null;
+    getCondition(conditionType: ConditionKey, { all }: { all: true }): Embedded<ConditionPF2e>[];
+    getCondition(conditionType: ConditionKey, { all }: { all: false }): Embedded<ConditionPF2e> | null;
+    getCondition(conditionType: ConditionKey): Embedded<ConditionPF2e> | null;
     getCondition(
-        conditionType: ConditionSlug,
+        conditionType: ConditionKey,
         { all }: { all: boolean }
     ): Embedded<ConditionPF2e>[] | Embedded<ConditionPF2e> | null;
 }

--- a/src/module/item/condition/data.ts
+++ b/src/module/item/condition/data.ts
@@ -96,6 +96,7 @@ type ConditionValueData =
       };
 
 type ConditionSlug = SetElement<typeof CONDITION_SLUGS>;
+type ConditionKey = ConditionSlug | `persistent-damage-${string}`;
 
 interface PersistentSourceData {
     formula: string;
@@ -103,4 +104,4 @@ interface PersistentSourceData {
     dc: number;
 }
 
-export { ConditionData, ConditionSource, ConditionSlug, ConditionSystemData, PersistentDamageData };
+export { ConditionData, ConditionKey, ConditionSource, ConditionSlug, ConditionSystemData, PersistentDamageData };

--- a/src/module/item/condition/document.ts
+++ b/src/module/item/condition/document.ts
@@ -3,7 +3,7 @@ import { ItemPF2e } from "@item";
 import { RuleElementOptions, RuleElementPF2e } from "@module/rules";
 import { UserPF2e } from "@module/user";
 import { ErrorPF2e } from "@util";
-import { ConditionData, ConditionSlug, ConditionSystemData, PersistentDamageData } from "./data";
+import { ConditionData, ConditionKey, ConditionSlug, ConditionSystemData, PersistentDamageData } from "./data";
 import { DamageRoll } from "@system/damage/roll";
 import { ChatMessagePF2e } from "@module/chat-message";
 import { TokenDocumentPF2e } from "@scene";
@@ -18,7 +18,7 @@ class ConditionPF2e extends AbstractEffectPF2e {
     }
 
     /** A key that can be used in place of slug for condition types that are split up (persistent damage) */
-    get key(): string {
+    get key(): ConditionKey {
         return this.system.persistent ? `persistent-damage-${this.system.persistent.damageType}` : this.slug;
     }
 


### PR DESCRIPTION
Now that its kinda done, in hindsight it might have been possible to make slug the adjusted one, and then introduce a "base slug" (or pull slug from source data). For example, persistent-damage-fire has a base/source slug of persistent-damage. But it might require tweaks and some startsWith() shenanigans, so I'd prefer to try that refactor post launch. It should have no effect for the api unless someone is fetching condition.key directly, and this update should prevent any modules (*cough cough mine*) from having to do that.