### PR TITLE
Add temporary mapping for persistent damage icons for each type

### DIFF
--- a/src/module/item/condition/document.ts
+++ b/src/module/item/condition/document.ts
@@ -7,6 +7,7 @@ import { ConditionData, ConditionKey, ConditionSlug, ConditionSystemData, Persis
 import { DamageRoll } from "@system/damage/roll";
 import { ChatMessagePF2e } from "@module/chat-message";
 import { TokenDocumentPF2e } from "@scene";
+import { PERSISTENT_DAMAGE_IMAGES } from "@system/damage";
 
 class ConditionPF2e extends AbstractEffectPF2e {
     override get badge(): EffectBadge | null {
@@ -98,10 +99,11 @@ class ConditionPF2e extends AbstractEffectPF2e {
             this.name = game.i18n.format(localizationKey, { formula: roll.formula, dc });
             systemData.persistent.damage = roll;
             systemData.persistent.expectedValue = roll.expectedValue;
+            this.img = PERSISTENT_DAMAGE_IMAGES[damageType] ?? this._source.img;
+        } else {
+            const folder = CONFIG.PF2E.statusEffects.iconDir;
+            this.img = `${folder}${this.slug}.webp`;
         }
-
-        const folder = CONFIG.PF2E.statusEffects.iconDir;
-        this.img = `${folder}${this.slug}.webp`;
     }
 
     override prepareSiblingData(): void {

--- a/src/module/system/damage/values.ts
+++ b/src/module/system/damage/values.ts
@@ -96,6 +96,27 @@ const DAMAGE_TYPE_ICONS: Record<DamageType, string | null> = {
     untyped: null,
 };
 
+/** Image map for conditions, currently placed here until we get a new set */
+const PERSISTENT_DAMAGE_IMAGES: Partial<Record<DamageType, ImagePath>> = {
+    piercing: "systems/pf2e/icons/equipment/weapons/throwing-knife.webp",
+    bludgeoning: "systems/pf2e/icons/equipment/weapons/bola.webp",
+    slashing: "systems/pf2e/icons/equipment/weapons/scimitar.webp",
+    fire: "systems/pf2e/icons/spells/flaming-sphere.webp",
+    acid: "systems/pf2e/icons/spells/blister.webp",
+    cold: "systems/pf2e/icons/spells/chilling-spray.webp",
+    electricity: "systems/pf2e/icons/spells/chain-lightning.webp",
+    sonic: "systems/pf2e/icons/spells/cry-of-destruction.webp",
+    force: "systems/pf2e/icons/spells/magic-missile.webp",
+    mental: "systems/pf2e/icons/spells/modify-memory.webp",
+    poison: "systems/pf2e/icons/spells/acidic-burst.webp",
+    lawful: "systems/pf2e/icons/equipment/adventuring-gear/merchant-scale.webp",
+    chaotic: "systems/pf2e/icons/spells/dinosaur-form.webp",
+    good: "systems/pf2e/icons/spells/angelic-wings.webp",
+    evil: "systems/pf2e/icons/spells/daemonic-pact.webp",
+    positive: "systems/pf2e/icons/spells/moment-of-renewal.webp",
+    negative: "systems/pf2e/icons/spells/grim-tendrils.webp",
+};
+
 export {
     ALIGNMENT_DAMAGE_TYPES,
     BASE_DAMAGE_TYPES_TO_CATEGORIES,
@@ -108,4 +129,5 @@ export {
     DAMAGE_TYPES,
     ENERGY_DAMAGE_TYPES,
     PHYSICAL_DAMAGE_TYPES,
+    PERSISTENT_DAMAGE_IMAGES,
 };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1286721/210161287-2f14f93b-865b-4d5d-97e7-83ddc46dbfe6.png)
