### PR TITLE
Fix dragging persistent inline rolls from actor item summaries

### DIFF
--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -572,7 +572,9 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
     /** Add support for dropping actions and toggles */
     protected override _onDragStart(event: ElementDragEvent): void {
         // Avoid intercepting content-link drag targets
-        if (event.target !== event.currentTarget && event.target.classList.contains("content-link")) {
+        const isContentLink = event.target.classList.contains("content-link");
+        const isPersistent = "persistent" in event.target.dataset;
+        if (event.target !== event.currentTarget && (isContentLink || isPersistent)) {
             return;
         }
 


### PR DESCRIPTION
This doesn't fix what happens when you click on them, but I didn't break that :P