### PR TITLE
Remove superfluous main category and fix negative spell modifiers

### DIFF
--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -255,8 +255,7 @@ class SpellPF2e extends ItemPF2e {
             if (!parts.length) parts.push("0");
 
             const baseFormula = Roll.replaceFormulaData(parts.join(" + "), rollData);
-            const baseFormulaFixed = baseFormula.replace(/[\s]*\+[\s]*-[\s]*/g, " - ");
-            const formula = combineTerms(baseFormulaFixed);
+            const formula = combineTerms(baseFormula);
 
             // Add damage. Merge if the type and category matches
             const tags = [damage.type.subtype ? damage.type.subtype : [], damage.type.categories ?? []].flat();
@@ -288,7 +287,7 @@ class SpellPF2e extends ItemPF2e {
                             type: "untyped",
                             modifier: actor.abilities[ability].mod,
                             damageType: d.type.value,
-                            damageCategory: d.type.subtype ?? DamageCategorization.fromDamageType(d.type.value),
+                            damageCategory: d.type.subtype ?? null,
                         })
                 );
             modifiers.push(...abilityModifiers);
@@ -363,7 +362,9 @@ class SpellPF2e extends ItemPF2e {
         try {
             if (combinedInstanceData.length) {
                 // Validate if the formulas are valid first
-                const invalid = combinedInstanceData.map((d) => d.formula).filter((formula) => !Roll.validate(formula));
+                const invalid = combinedInstanceData
+                    .map((d) => d.formula)
+                    .filter((formula) => !DamageRoll.validate(formula));
                 if (invalid.length) {
                     throw ErrorPF2e(`Invalid damage formulas on ${this.name}: ${invalid.join(", ")}`);
                 }

--- a/src/scripts/dice.ts
+++ b/src/scripts/dice.ts
@@ -186,11 +186,14 @@ class DicePF2e {
     }
 }
 
-/** Sum constant values and combine alike dice into single `NumericTerm` and `Die` terms, respectively */
+/**
+ * Combines dice and flat values together in a condensed expression. Also repairs any + - errors.
+ * For example, 3d4 + 2d4 + 3d6 + 5 + 2 is combined into 5d4 + 3d6 + 7.
+ */
 function combineTerms(formula: string): string {
     if (formula === "0") return formula;
 
-    const roll = new Roll(formula);
+    const roll = new Roll(formula.replace(/\s*\+\s*-\s*/g, " - "));
     if (!roll.terms.every((t) => t.expression === " + " || t instanceof Die || t instanceof NumericTerm)) {
         // This isn't a simple summing of dice: return the roll unaltered
         return roll.formula;


### PR DESCRIPTION
Fixes spell breakdowns and negative ability modifiers. Removes the "energy" from the below:
![image](https://user-images.githubusercontent.com/1286721/210163937-fac5c3f6-0876-40a7-bd31-286f14eea7ad.png)
