### PR TITLE
Have `DamageRoll#total` return a minimum of 1

### DIFF
--- a/src/module/system/damage/roll.ts
+++ b/src/module/system/damage/roll.ts
@@ -121,6 +121,14 @@ class DamageRoll extends AbstractDamageRoll {
         return instances.map((i) => i.formula).join(" + ");
     }
 
+    override get total(): number | undefined {
+        // CRB pg.450 If the combined penalties on an attack would reduce the damage to 0 or below, you still deal 1 damage.
+        if (this._total && this._total < 1) {
+            return 1;
+        }
+        return this._total;
+    }
+
     get instances(): DamageInstance[] {
         const pool = this.terms[0];
         return pool instanceof PoolTerm


### PR DESCRIPTION
Should the minimum damage override be noted somewhere?

![image](https://user-images.githubusercontent.com/41452412/210185763-40566b6c-a8b7-4099-9343-28b0077a9306.png)
