### PR TITLE
Fix first level daze with negative modifier

### DIFF
--- a/src/scripts/dice.ts
+++ b/src/scripts/dice.ts
@@ -187,17 +187,19 @@ class DicePF2e {
 }
 
 /**
- * Combines dice and flat values together in a condensed expression. Also repairs any + - errors.
- * For example, 3d4 + 2d4 + 3d6 + 5 + 2 is combined into 5d4 + 3d6 + 7.
+ * Combines dice and flat values together in a condensed expression. Also repairs any + - and "- 3" errors.
+ * For example, 3d4 + 2d4 + 3d6 + 5 + 2 is combined into 5d4 + 3d6 + 7. - 4 is corrected to -4.
  */
 function combineTerms(formula: string): string {
     if (formula === "0") return formula;
 
-    const roll = new Roll(formula.replace(/\s*\+\s*-\s*/g, " - "));
+    const fixedFormula = formula.replace(/^\s*-\s+/, "-").replace(/\s*\+\s*-\s*/g, " - ");
+    const roll = new Roll(fixedFormula);
     if (!roll.terms.every((t) => t.expression === " + " || t instanceof Die || t instanceof NumericTerm)) {
-        // This isn't a simple summing of dice: return the roll unaltered
-        return roll.formula;
+        // This isn't a simple summing of dice: return the roll without further changes
+        return fixedFormula;
     }
+
     const dice = roll.terms.filter((term): term is Die => term instanceof Die);
     const diceByFaces = dice.reduce((counts: Record<number, number>, die) => {
         counts[die.faces] = (counts[die.faces] ?? 0) + die.number;


### PR DESCRIPTION
Foundry parser does interesting things with negative formulas.

![image](https://user-images.githubusercontent.com/1286721/210186238-eec919d2-a128-452e-90c5-1ae53c865656.png)

That said, why would you ever cast this daze?