### PR TITLE
Fixes for ancestors oracle curse effects not applying correctly

### DIFF
--- a/packs/data/feat-effects.db/effect-ancestor-curse.json
+++ b/packs/data/feat-effects.db/effect-ancestor-curse.json
@@ -118,7 +118,7 @@
                         ]
                     }
                 ],
-                "selector": "mundane-attack",
+                "selector": "strike-attack-roll",
                 "text": "PF2E.OracleCurses.Ancestor.MinorFailure",
                 "title": "{item|name}"
             },
@@ -160,7 +160,7 @@
                         ]
                     }
                 ],
-                "selector": "mundane-attack",
+                "selector": "strike-attack-roll",
                 "text": "PF2E.OracleCurses.Ancestor.ModerateFailure",
                 "title": "{item|name}"
             },
@@ -204,7 +204,7 @@
                         ]
                     }
                 ],
-                "selector": "mundane-attack",
+                "selector": "strike-attack-roll",
                 "text": "PF2E.OracleCurses.Ancestor.MajorFailure",
                 "title": "{item|name}"
             },
@@ -280,7 +280,7 @@
                         ]
                     }
                 ],
-                "selector": "mundane-attack",
+                "selector": "strike-attack-roll",
                 "type": "status",
                 "value": 1
             },

--- a/packs/data/feat-effects.db/effect-ancestor-curse.json
+++ b/packs/data/feat-effects.db/effect-ancestor-curse.json
@@ -96,7 +96,7 @@
                         "value": "extreme:spell"
                     }
                 ],
-                "flag": "oracular-curse:stage",
+                "rollOption": "oracular-curse:stage",
                 "key": "ChoiceSet",
                 "predicate": [
                     {
@@ -118,7 +118,7 @@
                         ]
                     }
                 ],
-                "selector": "attack",
+                "selector": "mundane-attack",
                 "text": "PF2E.OracleCurses.Ancestor.MinorFailure",
                 "title": "{item|name}"
             },
@@ -141,12 +141,26 @@
                 "predicate": [
                     {
                         "or": [
+                            "oracular-curse:stage:minor:battle",
+                            "oracular-curse:stage:minor:spell"
+                        ]
+                    }
+                ],
+                "selector": "perception",
+                "text": "PF2E.OracleCurses.Ancestor.MinorFailure",
+                "title": "{item|name}"
+            },
+            {
+                "key": "Note",
+                "predicate": [
+                    {
+                        "or": [
                             "oracular-curse:stage:moderate:skill",
                             "oracular-curse:stage:moderate:spell"
                         ]
                     }
                 ],
-                "selector": "attack",
+                "selector": "mundane-attack",
                 "text": "PF2E.OracleCurses.Ancestor.ModerateFailure",
                 "title": "{item|name}"
             },
@@ -169,6 +183,20 @@
                 "predicate": [
                     {
                         "or": [
+                            "oracular-curse:stage:moderate:battle",
+                            "oracular-curse:stage:moderate:spell"
+                        ]
+                    }
+                ],
+                "selector": "perception",
+                "text": "PF2E.OracleCurses.Ancestor.ModerateFailure",
+                "title": "{item|name}"
+            },
+            {
+                "key": "Note",
+                "predicate": [
+                    {
+                        "or": [
                             "oracular-curse:stage:major:skill",
                             "oracular-curse:stage:major:spell",
                             "oracular-curse:stage:extreme:skill",
@@ -176,7 +204,7 @@
                         ]
                     }
                 ],
-                "selector": "attack",
+                "selector": "mundane-attack",
                 "text": "PF2E.OracleCurses.Ancestor.MajorFailure",
                 "title": "{item|name}"
             },
@@ -197,11 +225,26 @@
                 "title": "{item|name}"
             },
             {
+                "key": "Note",
+                "predicate": [
+                    {
+                        "or": [
+                            "oracular-curse:stage:major:battle",
+                            "oracular-curse:stage:major:spell",
+                            "oracular-curse:stage:extreme:battle",
+                            "oracular-curse:stage:extreme:spell"
+                        ]
+                    }
+                ],
+                "selector": "perception",
+                "text": "PF2E.OracleCurses.Ancestor.MajorFailure",
+                "title": "{item|name}"
+            },
+            {
                 "key": "FlatModifier",
                 "predicate": [
                     "item:spell-slot",
                     "item:duration:0",
-                    "damaging-effect",
                     "oracular-curse:stage:moderate:spell"
                 ],
                 "selector": "spell-damage",
@@ -214,7 +257,6 @@
                 "predicate": [
                     "item:spell-slot",
                     "item:duration:0",
-                    "damaging-effect",
                     {
                         "or": [
                             "oracular-curse:stage:major:spell",
@@ -238,7 +280,7 @@
                         ]
                     }
                 ],
-                "selector": "attack",
+                "selector": "mundane-attack",
                 "type": "status",
                 "value": 1
             },


### PR DESCRIPTION
I'm running an Ancestors oracle and ran into some challenges with the curse's effects not applying properly. Here's as many of the fixes as I could figure out how to implement.

* "flag" needed to be changed to "rollOption" in order for any of the other rule elements to actually apply.
* Added failure notes for Perception checks when not on the Skillful ancestor.
* Don't apply Battle ancestor's attack bonus to spell attacks (it should only be for Strikes)
* No longer limit the bonus from the Spellcasting ancestor to damaging effects (because it's also supposed to apply to healing).

The only elements of the curse that still aren't handled properly after these changes is that the damage bonus from the Spellcasting ancestor should apply to any non-cantrip spells, not just those cast from spell slots (that is, it should apply to focus spells, innate spells, etc.) I wasn't readily able to figure out on my own how to structure a predicate to that effect. Additionally (though lower priority), there isn't a note provided about the flat check being needed when Casting a Spell when not on the Spellcasting ancestor.