### PR TITLE
Add `IntermediateDie` term class to handle non-numeric numbers/faces

### DIFF
--- a/roll-grammar.peggy
+++ b/roll-grammar.peggy
@@ -1,5 +1,5 @@
 {{
-  function createNumericTerm(number, flavor = null) {
+  function createNumericTerm(number, { flavor = null } = {}) {
     const formula = flavor ? `${number}[${flavor}]` : number.toString();
     const obj = {
       class: "NumericTerm",
@@ -51,25 +51,38 @@ Term = head:TermOperand tail:(_ ("*" / "/") _ TermOperand)* {
 TermOperand = DiceTerm / MathTerm / Grouping / FlavoredNumber / Number;
 
 MathTerm = fn:Identifier "(" _ head:FunctionArg? _ tail:(_ "," _ @FunctionArg)* _ ")" {
+  const terms = head
+    ? [head, ...tail].map((t) => typeof t === "number" ? t.toString() : t.formula)
+    : [];
   return {
     class: "MathTerm",
     formula: text(),
     fn,
-    terms: head ? [head, ...tail].map((t) => t.formula) : [],
+    terms,
     evaluated: false,
   };
 };
 
-FunctionArg = DiceTerm / Grouping / Number / MathTerm;
+FunctionArg = Term / DiceTerm / Grouping / Number / MathTerm;
 
-DiceTerm = number:(Grouping / Number) [dD] faces:(Grouping / Number / Identifier) flavor:Flavor? {
-  const obj = {
-    class: "DiceTerm",
-    formula: text(),
-    number,
-    faces,
-    evaluated: false,
-  };
+DiceTerm = number:(Grouping / MathTerm / Number) [dD] faces:(Grouping / MathTerm / Number / Identifier) flavor:Flavor? {
+  const obj =
+    number instanceof Object || faces instanceof Object
+      ? {
+            class: "IntermediateDie",
+            formula: text(),
+            number: typeof number === "number" ? createNumericTerm(number) : number,
+            faces: typeof faces === "number" ? createNumericTerm(faces) : faces,
+            evaluated: false,
+        }
+      : {
+            class: "DiceTerm",
+            formula: text(),
+            number,
+            faces,
+            evaluated: false,
+        };
+
   if (flavor) obj.options = { flavor };
 
   return obj;
@@ -119,7 +132,7 @@ Pool = "{" _ head:Expression tail:("," _ @Expression)* "}" modifiers:ModifiersSt
   ];
 
   const obj = {
-    class: "PoolTerm",
+    class: "InstancePool",
     formula: text(),
     terms,
     rolls,
@@ -142,7 +155,7 @@ Number = _ [-+]? [0-9]+ ("." [0-9]+)? {
 };
 
 FlavoredNumber = number:Number flavor:Flavor {
-  return createNumericTerm(number, flavor);
+  return createNumericTerm(number, { flavor });
 };
 
 Identifier = $([a-z$_]i [a-z$_0-9]i*);

--- a/src/scripts/hooks/load.ts
+++ b/src/scripts/hooks/load.ts
@@ -18,7 +18,7 @@ import {
 import { monkeyPatchFoundry } from "@scripts/🐵🩹";
 import { CheckRoll, StrikeAttackRoll } from "@system/check";
 import { DamageInstance, DamageRoll } from "@system/damage/roll";
-import { ArithmeticExpression, Grouping, InstancePool } from "@system/damage/terms";
+import { ArithmeticExpression, Grouping, InstancePool, IntermediateDie } from "@system/damage/terms";
 
 /** Not an actual hook listener but rather things to run on initial load */
 export const Load = {
@@ -41,7 +41,7 @@ export const Load = {
         CONFIG.User.documentClass = UserPF2e;
 
         CONFIG.Dice.rolls.push(CheckRoll, StrikeAttackRoll, DamageRoll, DamageInstance);
-        for (const TermCls of [ArithmeticExpression, Grouping, InstancePool]) {
+        for (const TermCls of [ArithmeticExpression, Grouping, InstancePool, IntermediateDie]) {
             CONFIG.Dice.termTypes[TermCls.name] = TermCls;
         }
 

--- a/types/foundry/client/roll-term/dice-term/die.d.ts
+++ b/types/foundry/client/roll-term/dice-term/die.d.ts
@@ -191,6 +191,7 @@ declare global {
     }
 
     interface DieData extends DiceTermData {
+        number: number;
         faces: number;
         marginSuccess?: boolean;
         marginFailure?: boolean;

--- a/types/foundry/client/roll-term/math-term.d.ts
+++ b/types/foundry/client/roll-term/math-term.d.ts
@@ -4,7 +4,7 @@ declare global {
     class MathTerm<TFunctionName extends MathFunctionName = MathFunctionName> extends RollTerm<
         MathTermData<TFunctionName>
     > {
-        constructor({ fn, terms, options }: { fn: TFunctionName; terms: string[]; options?: MathTermData });
+        constructor({ fn, terms, options }: MathTermData<TFunctionName>);
 
         /** The named function in the Math environment which should be applied to the term */
         fn: TFunctionName;
@@ -18,11 +18,9 @@ declare global {
         /** The cached result of evaluating the method arguments */
         result: number | undefined;
 
-        /** @override */
-        isIntermediate: true;
+        override isIntermediate: true;
 
-        /** @override */
-        static SERIALIZE_ATTRIBUTES: ["fn", "terms"];
+        static override SERIALIZE_ATTRIBUTES: ["fn", "terms"];
 
         /* -------------------------------------------- */
         /*  Math Term Attributes                        */
@@ -31,21 +29,23 @@ declare global {
         /** An array of evaluated DiceTerm instances that should be bubbled up to the parent Roll */
         get dice(): DiceTerm[];
 
-        /** @override */
-        get total(): number | undefined;
+        override get total(): number | undefined;
 
-        /** @inheritdoc */
-        get expression(): `${MathFunctionName}(${string})`;
+        override get expression(): `${MathFunctionName}(${string})`;
 
         /* -------------------------------------------- */
         /*  Math Term Methods                           */
         /* -------------------------------------------- */
 
-        /** @override */
-        protected _evaluateSync({ minimize, maximize }?: { minimize?: boolean; maximize?: boolean }): Evaluated<this>;
+        protected override _evaluateSync({
+            minimize,
+            maximize,
+        }?: {
+            minimize?: boolean;
+            maximize?: boolean;
+        }): Evaluated<this>;
 
-        /** @override */
-        protected _evaluate({
+        protected override _evaluate({
             minimize,
             maximize,
         }?: {
@@ -65,6 +65,7 @@ declare global {
         | "safeEval";
 
     interface MathTermData<TFunctionName extends MathFunctionName = MathFunctionName> extends RollTermData {
+        class?: "MathTerm";
         fn?: TFunctionName;
         terms?: RollTerm[];
     }

--- a/types/foundry/client/roll-term/numeric-term.d.ts
+++ b/types/foundry/client/roll-term/numeric-term.d.ts
@@ -38,6 +38,7 @@ declare global {
     }
 
     interface NumericTermData extends RollTermData {
+        class?: "NumericTerm";
         number?: number;
     }
 }


### PR DESCRIPTION
This will take care of inline rolls with math terms.

Before:
![Screenshot from 2023-01-02 20-46-07](https://user-images.githubusercontent.com/106829671/210294152-d1e5c34c-1d78-4909-a418-da5dfbd972f4.png)

After:
![image](https://user-images.githubusercontent.com/106829671/210294139-3fb2fc73-1f51-47c5-af1f-5eddfa43cfd4.png)
