### PR TITLE
Do not include splash in main damage instance flavor for spells

### DIFF
--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -258,10 +258,9 @@ class SpellPF2e extends ItemPF2e {
             const formula = combineTerms(baseFormula);
 
             // Add damage. Merge if the type and category matches
-            const tags = [damage.type.subtype ? damage.type.subtype : [], damage.type.categories ?? []].flat();
             const damageType = damage.type.value;
             const instance = getInstance({ formula, damageType, damageCategory: damage.type.subtype });
-            for (const tag of tags) {
+            for (const tag of damage.type.categories ?? []) {
                 instance.tags.add(tag);
             }
         }


### PR DESCRIPTION
Spells with materials continue to work. The nested instance has splash, but not the top-level one.