### PR TITLE
Apply ancestors oracle spell damage bonus to correct spells

### DIFF
--- a/packs/data/feat-effects.db/effect-ancestor-curse.json
+++ b/packs/data/feat-effects.db/effect-ancestor-curse.json
@@ -243,7 +243,11 @@
             {
                 "key": "FlatModifier",
                 "predicate": [
-                    "item:spell-slot",
+                    {
+                        "nor":[
+                            "cantrip"
+                        ]
+                    },
                     "item:duration:0",
                     "oracular-curse:stage:moderate:spell"
                 ],
@@ -255,7 +259,11 @@
             {
                 "key": "FlatModifier",
                 "predicate": [
-                    "item:spell-slot",
+                    {
+                        "nor":[
+                            "cantrip"
+                        ]
+                    },
                     "item:duration:0",
                     {
                         "or": [

--- a/packs/data/feat-effects.db/effect-ancestor-curse.json
+++ b/packs/data/feat-effects.db/effect-ancestor-curse.json
@@ -244,7 +244,7 @@
                 "key": "FlatModifier",
                 "predicate": [
                     {
-                        "nor":[
+                        "nor": [
                             "cantrip"
                         ]
                     },
@@ -260,7 +260,7 @@
                 "key": "FlatModifier",
                 "predicate": [
                     {
-                        "nor":[
+                        "nor": [
                             "cantrip"
                         ]
                     },


### PR DESCRIPTION
Fixes the major remaining issue with the Ancestors oracle curse; the Spellcasting ancestor's damage increase should apply to all non-cantrip spells, not just those cast from spell slots. Previously, things like focus spells and innate spells were being excluded; this PR should fix that.