### PR TITLE
Correct spelling of Woolly Rhinoceros

### DIFF
--- a/packs/data/monsters-of-myth-bestiary.db/ainamuuren.json
+++ b/packs/data/monsters-of-myth-bestiary.db/ainamuuren.json
@@ -243,7 +243,7 @@
                 }
             },
             "img": "systems/pf2e/icons/spells/summon-animal.webp",
-            "name": "Summon Animal (Cave Bear or Wooly Rhinoceros Only)",
+            "name": "Summon Animal (Cave Bear or Woolly Rhinoceros Only)",
             "sort": 300000,
             "system": {
                 "ability": {

--- a/packs/data/pathfinder-bestiary-2.db/woolly-rhinoceros.json
+++ b/packs/data/pathfinder-bestiary-2.db/woolly-rhinoceros.json
@@ -240,7 +240,7 @@
                     "value": 2
                 },
                 "description": {
-                    "value": "<p>The wooly rhinoceros Strides twice, then makes a horn Strike. As long as the wooly rhinoceros moved at least 20 feet, the Strike's damage increases to [[/r (3d12+6)[piercing]]] damage. A Medium or smaller creature struck by this attack must succeed at a @Check[type:reflex|dc:24] save or be automatically @UUID[Compendium.pf2e.actionspf2e.Shove]{Shoved} back 5 feet and knocked @UUID[Compendium.pf2e.conditionitems.Prone]{Prone} by the force of the blow.</p>"
+                    "value": "<p>The woolly rhinoceros Strides twice, then makes a horn Strike. As long as the woolly rhinoceros moved at least 20 feet, the Strike's damage increases to [[/r (3d12+6)[piercing]]] damage. A Medium or smaller creature struck by this attack must succeed at a @Check[type:reflex|dc:24] save or be automatically @UUID[Compendium.pf2e.actionspf2e.Shove]{Shoved} back 5 feet and knocked @UUID[Compendium.pf2e.conditionitems.Prone]{Prone} by the force of the blow.</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -373,7 +373,7 @@
             "type": "lore"
         }
     ],
-    "name": "Wooly Rhinoceros",
+    "name": "Woolly Rhinoceros",
     "system": {
         "abilities": {
             "cha": {


### PR DESCRIPTION
Small fix to the spelling of the Woolly Rhinocerous sheet and token. Also corrects the spelling in one NPCs spellcasting entry.