### PR TITLE
Fix handling of splash damage in sumExpression function

### DIFF
--- a/src/module/system/damage/formula.ts
+++ b/src/module/system/damage/formula.ts
@@ -180,7 +180,8 @@ function sumExpression(terms: (string | null)[], { double = false } = {}): strin
     if (terms.every((t) => !t)) return null;
 
     const summed = terms.filter((p): p is string => !!p).join(" + ") || null;
-    const enclosed = double && hasOperators(summed) ? `(${summed})` : summed;
+    const hasSplash = !!summed?.includes("[splash]");
+    const enclosed = (double && hasOperators(summed)) || hasSplash ? `(${summed})` : summed;
 
     return double ? `2 * ${enclosed}` : enclosed;
 }


### PR DESCRIPTION
Feel free to alter the PR title to be more appropriate. I couldn't come up with a more descriptive one.