### PR TITLE
Add splash category to DamageDiceRuleElement

### DIFF
--- a/src/module/actor/modifiers.ts
+++ b/src/module/actor/modifiers.ts
@@ -605,6 +605,7 @@ class DiceModifierPF2e implements BaseRawModifier {
     diceNumber: number;
     /** The size of the dice to add. */
     dieSize: DamageDieSize | null;
+    modifier: number;
     /**
      * True means the dice are added to critical without doubling; false means the dice are never added to critical
      * damage; omitted means add to normal damage and double on critical damage.
@@ -629,6 +630,7 @@ class DiceModifierPF2e implements BaseRawModifier {
 
         this.diceNumber = params.diceNumber ?? 0;
         this.dieSize = params.dieSize ?? null;
+        this.modifier = params.modifier ?? 0;
         this.critical = params.critical ?? null;
         this.damageType = params.damageType ?? null;
         this.category = params.category ?? null;

--- a/src/module/rules/rule-element/damage-dice.ts
+++ b/src/module/rules/rule-element/damage-dice.ts
@@ -16,11 +16,13 @@ class DamageDiceRuleElement extends RuleElementPF2e {
 
     dieSize: DamageDieSize | null = null;
 
+    modifier: number | string = 0;
+
     damageType: string | null = null;
 
     critical: boolean | null;
 
-    category: "precision" | "persistent" | null;
+    category: "precision" | "persistent" | "splash" | null;
 
     brackets: BracketedValue | null;
 
@@ -52,6 +54,13 @@ class DamageDiceRuleElement extends RuleElementPF2e {
             this.failValidation("dieSize must be a string or omitted");
         }
 
+        // Modifier
+        if (typeof data.modifier === "string" || typeof data.modifier === "number") {
+            this.modifier = data.modifier;
+        } else if ("modifier" in data) {
+            this.failValidation("modifier must be a string, number, or omitted");
+        }
+
         // Damage type
         if (typeof data.damageType === "string") {
             this.damageType = data.damageType;
@@ -64,10 +73,10 @@ class DamageDiceRuleElement extends RuleElementPF2e {
 
         // Add precision damage
         const category = data.category ?? data.damageCategory ?? null;
-        if (tupleHasValue(["persistent", "precision", null] as const, category)) {
+        if (tupleHasValue(["persistent", "precision", "splash", null] as const, category)) {
             this.category = category;
         } else {
-            this.failValidation('category must be "precision", "persistent", or omitted');
+            this.failValidation('category must be "precision", "persistent", "splash", or omitted');
             this.category = null;
         }
 
@@ -101,6 +110,9 @@ class DamageDiceRuleElement extends RuleElementPF2e {
             const diceNumber =
                 typeof this.diceNumber === "string" ? Number(this.resolveValue(this.diceNumber)) || 0 : this.diceNumber;
 
+            const modifier =
+                typeof this.modifier === "string" ? Number(this.resolveValue(this.modifier) || 0) : this.modifier;
+
             const resolvedBrackets = this.resolveValue(this.brackets, {});
             if (!this.#resolvedBracketsIsValid(resolvedBrackets)) {
                 this.failValidation("Brackets failed to validate");
@@ -132,6 +144,7 @@ class DamageDiceRuleElement extends RuleElementPF2e {
                 selector,
                 slug: this.slug,
                 label,
+                modifier,
                 dieSize: this.dieSize,
                 diceNumber,
                 critical: this.critical,
@@ -197,6 +210,7 @@ interface DamageDiceSource extends RuleElementSource {
     name?: unknown;
     diceNumber?: unknown;
     dieSize?: unknown;
+    modifier?: unknown;
     override?: unknown;
     damageType?: unknown;
     critical?: unknown;

--- a/src/module/system/damage/formula.ts
+++ b/src/module/system/damage/formula.ts
@@ -51,12 +51,15 @@ function createDamageFormula(
     // Dice always stack
     for (const dice of damage.dice.filter((d) => d.enabled)) {
         const dieSize = dice.dieSize || base.dieSize || null;
-        if (dice.diceNumber > 0 && dieSize) {
+        if ((dice.diceNumber > 0 && dieSize) || dice.modifier) {
             const damageType = dice.damageType ?? base.damageType;
             const list = typeMap.get(damageType) ?? [];
             list.push({
-                dice: { number: dice.diceNumber, faces: Number(dieSize.replace("d", "")) },
-                modifier: 0,
+                dice:
+                    dice.diceNumber > 0 && dieSize
+                        ? { number: dice.diceNumber, faces: Number(dieSize.replace("d", "")) }
+                        : null,
+                modifier: dice.modifier ?? 0,
                 persistent: dice.category === "persistent",
                 precision: dice.category === "precision",
                 splash: dice.category === "splash",


### PR DESCRIPTION
```json
{
  "key": "DamageDice",
  "category": "splash",
  "diceNumber": 1,
  "dieSize": "d4",
  "selector": "strike-damage",
  "damageType": "bludgeoning"
}
```
![image](https://user-images.githubusercontent.com/41452412/210641131-3cbbbb14-beec-4c80-8782-6d2dec09f41c.png)

```json
{
  "key": "DamageDice",
  "category": "splash",
  "modifier":"2",
  "selector": "strike-damage",
  "damageType": "acid"
}
```
![image](https://user-images.githubusercontent.com/41452412/210643049-2498cf46-dfb5-49dc-9f1c-c6edb6fba77d.png)

```json
{
  "key": "DamageDice",
  "category": "splash",
  "diceNumber": 1,
  "dieSize": "d4",
  "modifier":"2",
  "selector": "strike-damage",
  "damageType": "acid"
}
```
Mixing `modifier` and `dieSize/dieNumber` like the last example will work but produce a damage instance like this:
![image](https://user-images.githubusercontent.com/41452412/210642879-c29a4bb1-5216-4d77-9888-0993c81054e9.png)

