### PR TITLE
Add support for alternate ancestry boosts

### DIFF
--- a/src/module/actor/character/data/types.ts
+++ b/src/module/actor/character/data/types.ts
@@ -81,37 +81,7 @@ interface CharacterSystemData extends CreatureSystemData {
 
     /** Character build data, currently containing ability boosts and flaws */
     build: {
-        abilities: {
-            /**
-               Whether this PC's ability scores are being manually entered rather than drawn from ancestry, background,
-               and class
-            */
-            manual: boolean;
-            /** Key ability score options drawn from class and class features */
-            keyOptions: AbilityString[];
-            boosts: {
-                ancestry: AbilityString[];
-                background: AbilityString[];
-                class: AbilityString | null;
-                1: AbilityString[];
-                5: AbilityString[];
-                10: AbilityString[];
-                15: AbilityString[];
-                20: AbilityString[];
-            };
-
-            allowedBoosts: {
-                1: number;
-                5: number;
-                10: number;
-                15: number;
-                20: number;
-            };
-
-            flaws: {
-                ancestry: AbilityString[];
-            };
-        };
+        abilities: CharacterBuildingAbilitySystemData;
     };
 
     /** The three save types. */
@@ -158,6 +128,46 @@ interface CharacterSystemData extends CreatureSystemData {
 interface CharacterAbilityData extends AbilityData {
     /** An ability score prior to modification by items */
     base: number;
+}
+
+interface CharacterBuildingAbilitySourceData {
+    /** Whether this PC's ability scores are being manually entered (aka custom) */
+    manual: boolean;
+
+    boosts: {
+        1: AbilityString[];
+        5: AbilityString[];
+        10: AbilityString[];
+        15: AbilityString[];
+        20: AbilityString[];
+    };
+}
+
+/**
+ * Prepared system data for character ability scores. This is injected by ABC classes to complete it.
+ */
+interface CharacterBuildingAbilitySystemData extends CharacterBuildingAbilitySourceData {
+    /** Key ability score options drawn from class and class features */
+    keyOptions: AbilityString[];
+
+    boosts: CharacterBuildingAbilitySourceData["boosts"] & {
+        ancestry: AbilityString[];
+        background: AbilityString[];
+        class: AbilityString | null;
+    };
+
+    /** Number of remaining allowed boosts (UI and gradual ability boosts only) */
+    allowedBoosts: {
+        1: number;
+        5: number;
+        10: number;
+        15: number;
+        20: number;
+    };
+
+    flaws: {
+        ancestry: AbilityString[];
+    };
 }
 
 type CharacterAbilities = Record<AbilityString, CharacterAbilityData>;

--- a/src/module/item/ancestry/data.ts
+++ b/src/module/item/ancestry/data.ts
@@ -19,6 +19,8 @@ interface AncestrySystemSource extends ABCSystemSource {
         value: string[];
         custom: string;
     };
+    /** If present, use the alternate ancestry boosts, which are two free */
+    alternateAncestryBoosts?: AbilityString[];
     boosts: Record<string, { value: AbilityString[]; selected: AbilityString | null }>;
     flaws: Record<string, { value: AbilityString[]; selected: AbilityString | null }>;
     voluntary?: {

--- a/src/module/item/ancestry/document.ts
+++ b/src/module/item/ancestry/document.ts
@@ -25,6 +25,7 @@ class AncestryPF2e extends ABCItemPF2e {
         return this.system.size;
     }
 
+    /** Returns all boosts enforced by this ancestry normally */
     get lockedBoosts(): AbilityString[] {
         return Object.values(this.system.boosts)
             .filter((boost) => boost.value.length === 1)
@@ -90,12 +91,16 @@ class AncestryPF2e extends ABCItemPF2e {
 
         actor.system.attributes.speed.value = this.speed;
 
-        // Add ability boosts and flaws
         const { build } = actor.system;
-        for (const target of ["boosts", "flaws"] as const) {
-            for (const ability of Object.values(this.system[target])) {
-                if (ability.selected) {
-                    build.abilities[target].ancestry.push(ability.selected);
+        if (this.system.alternateAncestryBoosts) {
+            build.abilities.boosts.ancestry.push(...this.system.alternateAncestryBoosts);
+        } else {
+            // Add ability boosts and flaws
+            for (const target of ["boosts", "flaws"] as const) {
+                for (const ability of Object.values(this.system[target])) {
+                    if (ability.selected) {
+                        build.abilities[target].ancestry.push(ability.selected);
+                    }
                 }
             }
         }

--- a/src/styles/actor/character/_ability-builder.scss
+++ b/src/styles/actor/character/_ability-builder.scss
@@ -405,14 +405,26 @@
         text-transform: uppercase;
     }
 
-    div[data-tooltip-content] .description {
-        text-decoration: underline dotted;
-        text-underline-offset: 2px;
+    div[data-tooltip-content] {
+        &.description, .description {
+            text-decoration: underline dotted;
+            text-underline-offset: 2px;
+        }
     }
-
 
     .description {
         font: 600 var(--font-size-16) var(--serif);
+    }
+
+    .extra {
+        display: flex;
+        align-items: center;
+        font-size: var(--font-size-12);
+        margin-top: -0.25rem;
+        input[type=checkbox] {
+            height: var(--font-size-12);
+            margin: 0;
+        }
     }
 
     h3 {

--- a/static/templates/actors/character/ability-builder.hbs
+++ b/static/templates/actors/character/ability-builder.hbs
@@ -14,20 +14,23 @@
         <!-- ancestry boosts -->
         <div class="row{{#if manual}} not-eligible{{/if}}">
             {{#if ancestry}}
-                <div class="row-heading" data-tooltip-content="#{{actor.id}}-ancestry-tooltip">
+                <div class="row-heading">
                     {{#unless (eq ancestryBoosts.remaining 0)}}<div class="remaining extra">{{ancestryBoosts.remaining}}</div>{{/unless}}
                     <img class="" src="{{ancestry.img}}" title="{{ancestry.name}}" width="32" height="32" loading="lazy"/>
                     <div class="label">
                         <div class="title">{{localize "ITEM.TypeAncestry"}}</div>
-                        <div class="description">{{ancestry.name}}</div>
+                        <div class="description" data-tooltip-content="#{{actor.id}}-ancestry-tooltip">{{ancestry.name}}</div>
+                        <label class="extra">Alternate Boosts <input type="checkbox" {{checked alternateAncestryBoosts}} data-action="toggle-alternate-ancestry-boosts"></label>
                     </div>
                 </div>
                 {{#each ancestryBoosts.boosts as |boost ability|}}
                     <div class="row-column">
-                        <button type="button" data-action="voluntary-flaw" data-ability="{{ability}}" class="flaw locked selected{{#unless boost.lockedFlaw}} hidden{{/unless}}">
-                            {{#if boost.lockedFlaw}}<i class="fas fa-fw fa-lock"></i>{{/if}}
-                            {{localize "PF2E.Actor.Character.AbilityBuilder.Flaw"}}
-                        </button>
+                        {{#if @root.ancestryBoosts.hasLockedFlaws}}
+                            <button type="button" data-action="voluntary-flaw" data-ability="{{ability}}" class="flaw locked selected{{#unless boost.lockedFlaw}} hidden{{/unless}}">
+                                {{#if boost.lockedFlaw}}<i class="fas fa-fw fa-lock"></i>{{/if}}
+                                {{localize "PF2E.Actor.Character.AbilityBuilder.Flaw"}}
+                            </button>
+                        {{/if}}
 
                         <button type="button" data-action="ancestry-boost" data-ability="{{ability}}"
                             class="boost {{#if boost.boosted}} selected{{/if}}{{#if boost.lockedBoost}} locked{{/if}}"


### PR DESCRIPTION
BONUS: Ancestries without locked flaws have better alignment too.

Getting new flaw structure in eventually might be needed, though we'll need to reconcile it with the existing one somehow. In my opinion, its a separate thing to handle entirely from this PR.

https://user-images.githubusercontent.com/1286721/210765134-46ac6539-0c3b-4ed2-b465-c19454bdee39.mp4

