### PR TITLE
Fix deadly variant of Clawsong spell effect

### DIFF
--- a/packs/data/spell-effects.db/spell-effect-clawsong-deadly-d8.json
+++ b/packs/data/spell-effects.db/spell-effect-clawsong-deadly-d8.json
@@ -18,15 +18,11 @@
         },
         "rules": [
             {
-                "critical": "true",
-                "damageType": "slashing",
-                "diceNumber": 1,
-                "dieSize": "d8",
-                "key": "DamageDice",
-                "selector": "strike-damage",
-                "traits": [
-                    "deadly-d8"
-                ]
+                "definition": ["item:slug:claw"],
+                "key": "AdjustStrike",
+                "mode": "add",
+                "property": "weapon-traits",
+                "value": "deadly-d8"
             }
         ],
         "source": {


### PR DESCRIPTION
At the moment the rule element for the Deadly part adds a D8 dice all the time to the damage roll, instead of just adjusting the strike to give it Deadly (D8). This will fix it.
Before: 
![image](https://user-images.githubusercontent.com/63196064/210782317-db5be9af-b929-4889-a694-66b732dccef3.png)
After:
![image](https://user-images.githubusercontent.com/63196064/210782533-49c6a26e-a746-4c82-88a5-80bb1dc15dbe.png)
