### PR TITLE
Update claws.json to make it translation friendly

### DIFF
--- a/packs/data/ancestryfeatures.db/claws.json
+++ b/packs/data/ancestryfeatures.db/claws.json
@@ -35,6 +35,7 @@
                 "key": "Strike",
                 "label": "PF2E.Weapon.Base.claw",
                 "range": null,
+                "slug": "claw",
                 "traits": [
                     "finesse",
                     "agile",


### PR DESCRIPTION
Adding the slug in English will allow this added strike to be target by other feats. At the moment, as the label of the claw is localized, a feat like [Razor claws](https://github.com/foundryvtt/pf2e/blob/master/packs/data/feats.db/razor-claws.json) doesn't work if localized. Forcing the english slug fixes the problem.