### PR TITLE
Fix Clawsong versatile spell effect

### DIFF
--- a/packs/data/spell-effects.db/spell-effect-clawsong-versatile-piercing.json
+++ b/packs/data/spell-effects.db/spell-effect-clawsong-versatile-piercing.json
@@ -18,12 +18,11 @@
         },
         "rules": [
             {
-                "damageType": "slashing",
-                "key": "DamageDice",
-                "selector": "claw-damage",
-                "traits": [
-                    "versatile-p"
-                ]
+                "definition":["item:slug:claw"],
+                "key":"AdjustStrike",
+                "mode":"add",
+                "property":"weapon-traits",
+                "value":"versatile-p"
             }
         ],
         "source": {


### PR DESCRIPTION
Fix Clawsong versatile-piercing rule element.
Before:
![image](https://user-images.githubusercontent.com/63196064/210784731-56c777ca-09ed-4ddb-a44a-bd302a7a9067.png)
After:
![image](https://user-images.githubusercontent.com/63196064/210784830-70476cfc-c6e4-4860-b10c-637038d4bb0f.png)