### PR TITLE
Fix dropping melee items on other sheets

### DIFF
--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -21,7 +21,7 @@ import {
     TagSelectorType,
     TAG_SELECTOR_TYPES,
 } from "@system/tag-selector";
-import { ErrorPF2e, htmlQuery, objectHasKey, tupleHasValue } from "@util";
+import { ErrorPF2e, htmlClosest, htmlQuery, objectHasKey, tupleHasValue } from "@util";
 import { ActorSizePF2e } from "../data/size";
 import { ActorSheetDataPF2e, CoinageSummary, InventoryItem, SheetInventory } from "./data-types";
 import { ItemSummaryRenderer } from "./item-summary-renderer";
@@ -578,19 +578,17 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
             return;
         }
 
-        const $target = $(event.currentTarget);
-        const $itemRef = $target.closest(".item");
+        const targetElement = event.currentTarget;
+        const previewElement = htmlClosest(targetElement, ".item");
 
         // Show a different drag/drop preview element and copy some data if this is a handle
         // This will make the preview nicer and also trick foundry into thinking the actual item started drag/drop
-        const targetElement = $target.get(0);
-        const previewElement = $itemRef.get(0);
         if (previewElement && targetElement && targetElement !== previewElement) {
             const { x, y } = previewElement.getBoundingClientRect();
             event.dataTransfer.setDragImage(previewElement, event.pageX - x, event.pageY - y);
         }
 
-        const itemId = $itemRef.attr("data-item-id");
+        const itemId = previewElement?.dataset.itemId;
         const item = this.actor.items.get(itemId ?? "");
 
         const baseDragData: { [key: string]: unknown } = {
@@ -599,26 +597,27 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
             tokenId: this.actor.token?.id ?? null,
             ...item?.toDragData(),
         };
+        if (previewElement?.dataset.isFormula) {
+            baseDragData.isFormula = true;
+        }
 
         // Dragging ...
         const supplementalData = (() => {
-            const actionIndex = $itemRef.attr("data-action-index");
+            const actionIndex = previewElement?.dataset.actionIndex;
             const rollOptionData = {
-                ...($itemRef.find("input[type=checkbox][data-action=toggle-roll-option]").get(0)?.dataset ?? {}),
+                ...(htmlQuery(previewElement, "input[type=checkbox][data-action=toggle-roll-option]")?.dataset ?? {}),
             };
-            const itemType = $itemRef.attr("data-item-type");
 
-            // ... an action?
+            // ... an action (or melee item possibly to be treated as an action)?
             if (actionIndex) {
-                return {
-                    type: "Action",
-                    index: Number(actionIndex),
-                };
+                return "itemType" in baseDragData && baseDragData.itemType === "melee"
+                    ? { index: Number(actionIndex) }
+                    : { type: "Action", index: Number(actionIndex) };
             }
 
             // ... a roll-option toggle?
-            if (item && Object.keys(rollOptionData).length > 0) {
-                const label = $itemRef.text().trim();
+            const label = previewElement?.innerText.trim();
+            if (item && label && Object.keys(rollOptionData).length > 0) {
                 delete rollOptionData.action;
                 return {
                     type: "RollOption",
@@ -629,7 +628,7 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
             }
 
             // ... a crafting formula?
-            if (itemType === "formula") {
+            if (baseDragData.isFormula) {
                 return {
                     pf2e: {
                         type: "CraftingFormula",
@@ -825,7 +824,9 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
                 actor.isOfType("creature");
             if (resizeItem) itemSource.system.size = actor.size;
         }
-        return this._onDropItemCreate(itemSource);
+
+        // Creating a new item: clear the _id via cloning it
+        return this._onDropItemCreate(new ItemPF2e(itemSource).clone().toObject());
     }
 
     protected override async _onDropFolder(

--- a/src/module/actor/sheet/item-summary-renderer.ts
+++ b/src/module/actor/sheet/item-summary-renderer.ts
@@ -29,8 +29,10 @@ export class ItemSummaryRenderer<TActor extends ActorPF2e> {
 
         const itemId = $element.attr("data-item-id");
         const itemType = $element.attr("data-item-type");
+        const isFormula = !!$element.attr("data-is-formula");
+
         if (itemType === "spellSlot") return;
-        const item = itemType === "formula" ? await fromUuid(itemId ?? "") : actor.items.get(itemId ?? "");
+        const item = isFormula ? await fromUuid(itemId ?? "") : actor.items.get(itemId ?? "");
 
         // If there is no item id (such as PC strikes) or it is a condition, this is just a visibility toggle
         // We need a better way to detect pre-rendered item-summaries

--- a/src/module/apps/hotbar.ts
+++ b/src/module/apps/hotbar.ts
@@ -17,6 +17,11 @@ class HotbarPF2e extends Hotbar<MacroPF2e> {
         }
         if (Hooks.call("hotbarDrop", this, data, slot) === false) return;
 
+        // A melee item dropped on the hotbar is to instead generate an action macro
+        if (data.type === "Item" && data.itemType === "melee" && typeof data.index === "number") {
+            data.type = "Action";
+        }
+
         switch (data.type) {
             case "Item": {
                 const itemId = data.id ?? (isObject<{ _id?: unknown }>(data.data) ? data.data._id : null);
@@ -96,6 +101,7 @@ type HotbarDropData = Partial<DropCanvasData> & {
     skill?: string;
     skillName?: string;
     index?: number;
+    itemType?: string;
     pf2e?: {
         type: string;
         property: string;

--- a/src/module/item/base.ts
+++ b/src/module/item/base.ts
@@ -369,6 +369,11 @@ class ItemPF2e extends Item<ActorPF2e> {
         return processed ? super.importFromJSON(processed) : this;
     }
 
+    /** Include the item type along with data from upstream */
+    override toDragData(): { type: string; itemType: string; [key: string]: unknown } {
+        return { ...super.toDragData(), itemType: this.type };
+    }
+
     static override async createDocuments<T extends foundry.abstract.Document>(
         this: ConstructorOf<T>,
         data?: PreCreate<T["_source"]>[],

--- a/static/templates/actors/character/tabs/crafting.hbs
+++ b/static/templates/actors/character/tabs/crafting.hbs
@@ -44,7 +44,7 @@
                     </li>
                     <!-- Add formula items for each formula level -->
                     {{#each section as |craftedItem i|}}
-                        <li class="item formula-item" data-formula-lvl="{{lvl}}" data-item-id="{{craftedItem.uuid}}" data-item-type="formula">
+                        <li class="item formula-item" data-formula-lvl="{{lvl}}" data-item-id="{{craftedItem.uuid}}" data-is-formula="true">
                             <div class="item-name rollable">
                                 <div class="item-image">
                                     <img class="item-icon" src="{{craftedItem.img}}" alt="{{craftedItem.name}}">

--- a/static/templates/actors/npc/partials/attack.hbs
+++ b/static/templates/actors/npc/partials/attack.hbs
@@ -1,4 +1,4 @@
-<li class="item attack flexrow" data-action-index="{{index}}" data-item-name="{{action.item.name}}" data-item-id="{{action.sourceId}}">
+<li class="item attack flexrow" data-action-index="{{index}}" data-item-type="melee" data-item-id="{{action.sourceId}}">
     <div class="attack-header">
         <h4 class="attack-name tags">
             <span>

--- a/types/foundry/client/documents/mixins/client-document-mixin.d.ts
+++ b/types/foundry/client/documents/mixins/client-document-mixin.d.ts
@@ -309,5 +309,5 @@ declare class ClientDocument<TDocument extends foundry.abstract.Document = found
      * Serialize salient information about this Document when dragging it.
      * @return An object of drag data.
      */
-    toDragData(): object;
+    toDragData(): { type: string; [key: string]: unknown };
 }


### PR DESCRIPTION
I had to untangle some deep-running mess, so this should wait until 4.7 work starts.

A melee item's drag data needs all necessary properties for creating an strike macro if dropped the hotbar and an item clone if dropped onto another sheet.