### PR TITLE
Update items on some of the unique AV NPCs

### DIFF
--- a/packs/data/abomination-vaults-bestiary.db/azvalvigander.json
+++ b/packs/data/abomination-vaults-bestiary.db/azvalvigander.json
@@ -836,15 +836,15 @@
             "type": "spell"
         },
         {
-            "_id": "x1k0ByrnVRL8cPMH",
-            "img": "systems/pf2e/icons/equipment/held-items/key-purple.webp",
-            "name": "Key",
+            "_id": "rdUiajy3hLLrKXt4",
+            "img": "systems/pf2e/icons/equipment/held-items/key-short-gold.webp",
+            "name": "Azvalvigander's Key",
             "sort": 900000,
             "system": {
                 "baseItem": null,
                 "containerId": null,
                 "description": {
-                    "value": "<p>key to area D4a</p>"
+                    "value": ""
                 },
                 "equipped": {
                     "carryType": "worn",
@@ -1603,6 +1603,7 @@
             "privateNotes": "",
             "publicNotes": "<p>Zebubs serve as Hell's messengers and spies. Their ability to share what they've seen with other creatures makes them especially useful-not only to other devils, but also to mortal conjurers. Some infernal lords unleash them in enormous, horrid swarms upon unsuspecting lands to debase flesh and land alike while collecting secrets the infernal host might later put to use. Zebubs use any opportunity to manipulate weak-willed or easily tempted mortals into serving the zebubs' whims. While arrogant and deceitful, zebubs lack the cunning and confidence of most devils, and thus their schemes often focus on satisfying self-serving or self-destructive ambitions. Zebubs form from the souls of childish and craven mortals, reshaped by the archdevil Baalzebul in the frozen, filthy wastes of Hell's seventh layer, Cocytus.</p>\n<hr />\n<p>Each type of devil plays a particular role in Hell's bureaucracies and hierarchies, though some have far more specialized functions than others.</p>",
             "source": {
+                "author": "",
                 "value": "Pathfinder #164: Hands of the Devil"
             }
         },

--- a/packs/data/abomination-vaults-bestiary.db/beluthus.json
+++ b/packs/data/abomination-vaults-bestiary.db/beluthus.json
@@ -1,11 +1,11 @@
 {
-    "_id": "To0MLA0arpkiE6Cz",
+    "_id": "3ry9WSvMMXHUe3kE",
     "img": "systems/pf2e/icons/default-icons/npc.svg",
     "items": [
         {
-            "_id": "xxK8rXRDWK5Rwj9i",
+            "_id": "yI8fil9Hp8Ob0BcY",
             "img": "systems/pf2e/icons/default-icons/spellcastingEntry.svg",
-            "name": "Divine Innate Spells",
+            "name": "Occult Innate Spells",
             "sort": 100000,
             "system": {
                 "autoHeightenLevel": {
@@ -24,10 +24,10 @@
                 },
                 "rules": [],
                 "showSlotlessLevels": {
-                    "value": false
+                    "value": true
                 },
                 "showUnpreparedSpells": {
-                    "value": true
+                    "value": false
                 },
                 "slots": {
                     "slot0": {
@@ -96,12 +96,12 @@
                     "value": ""
                 },
                 "spelldc": {
-                    "dc": 23,
+                    "dc": 31,
                     "mod": 0,
-                    "value": 18
+                    "value": 21
                 },
                 "tradition": {
-                    "value": "divine"
+                    "value": "occult"
                 },
                 "traits": {
                     "custom": "",
@@ -112,7 +112,7 @@
             "type": "spellcastingEntry"
         },
         {
-            "_id": "ioqicnfviMKvXg9T",
+            "_id": "vDdGrFDKu7JIcuaR",
             "img": "systems/pf2e/icons/default-icons/spellcastingEntry.svg",
             "name": "Rituals",
             "sort": 200000,
@@ -136,7 +136,7 @@
                     "value": true
                 },
                 "showUnpreparedSpells": {
-                    "value": true
+                    "value": false
                 },
                 "slots": {
                     "slot0": {
@@ -205,9 +205,9 @@
                     "value": ""
                 },
                 "spelldc": {
-                    "dc": 23,
+                    "dc": 31,
                     "mod": 0,
-                    "value": 18
+                    "value": 21
                 },
                 "tradition": {
                     "value": ""
@@ -221,14 +221,14 @@
             "type": "spellcastingEntry"
         },
         {
-            "_id": "ofhb2Xpvv2O62InP",
+            "_id": "zreCqcITRrrLbItP",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.zfn5RqAdF63neqpP"
+                    "sourceId": "Compendium.pf2e.spells-srd.5BbU1V6wGSGbrmRD"
                 }
             },
-            "img": "systems/pf2e/icons/spells/control-water.webp",
-            "name": "Control Water",
+            "img": "systems/pf2e/icons/spells/feeblemind.webp",
+            "name": "Feeblemind",
             "sort": 300000,
             "system": {
                 "ability": {
@@ -251,20 +251,19 @@
                     "value": {}
                 },
                 "description": {
-                    "value": "<p>By imposing your will upon the water, you can raise or lower the level of water in the chosen area by 10 feet. Water creatures in the area are subjected to the effects of <em>@UUID[Compendium.pf2e.spells-srd.Slow]{Slow}</em>.</p>\n<hr />\n<p><strong>Area</strong> 50 ft long by 50 ft wide</p>"
+                    "value": "<p>You drastically reduce the target's mental faculties. The target must attempt a Will save.</p>\n<hr />\n<p><strong>Critical Success</strong> The target is unaffected. The effects of this curse can be removed only through remove curse or another effect that targets curses.</p>\n<p><strong>Success</strong> The target is @UUID[Compendium.pf2e.conditionitems.Stupefied]{Stupefied 2} for 1 round.</p>\n<p><strong>Failure</strong> The target is @UUID[Compendium.pf2e.conditionitems.Stupefied]{Stupefied 4} with an unlimited duration.</p>\n<p><strong>Critical Failure</strong> The target's intellect is permanently reduced below that of an animal, and it treats its Charisma, Intelligence, and Wisdom modifiers as -5. It loses all class abilities that require mental faculties, including all spellcasting. If the target is a PC, they become an NPC under the GM's control.</p>"
                 },
                 "duration": {
-                    "value": ""
+                    "value": "varies"
                 },
                 "hasCounteractCheck": {
                     "value": false
                 },
                 "level": {
-                    "value": 5
+                    "value": 6
                 },
                 "location": {
-                    "heightenedLevel": 5,
-                    "value": "xxK8rXRDWK5Rwj9i"
+                    "value": "yI8fil9Hp8Ob0BcY"
                 },
                 "materials": {
                     "value": ""
@@ -276,15 +275,15 @@
                     "value": ""
                 },
                 "range": {
-                    "value": "500 feet"
+                    "value": "30 feet"
                 },
                 "rules": [],
                 "save": {
                     "basic": "",
-                    "value": ""
+                    "value": "will"
                 },
                 "school": {
-                    "value": "evocation"
+                    "value": "enchantment"
                 },
                 "secondarycasters": {
                     "value": ""
@@ -292,18 +291,18 @@
                 "secondarycheck": {
                     "value": ""
                 },
-                "slug": "control-water",
+                "slug": "feeblemind",
                 "source": {
-                    "value": "Pathfinder Core Rulebook"
+                    "value": ""
                 },
                 "spellType": {
-                    "value": "utility"
+                    "value": "save"
                 },
                 "sustained": {
                     "value": false
                 },
                 "target": {
-                    "value": ""
+                    "value": "1 creature"
                 },
                 "time": {
                     "value": "2"
@@ -311,28 +310,30 @@
                 "traditions": {
                     "value": [
                         "arcane",
-                        "primal"
+                        "occult"
                     ]
                 },
                 "traits": {
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "water"
+                        "curse",
+                        "incapacitation",
+                        "mental"
                     ]
                 }
             },
             "type": "spell"
         },
         {
-            "_id": "D0vga6qR9JJs237o",
+            "_id": "BjEU1XQw2QuAZp2t",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.VlNcjmYyu95vOUe8"
+                    "sourceId": "Compendium.pf2e.spells-srd.uqlxMQQeSGWEVjki"
                 }
             },
-            "img": "systems/pf2e/icons/spells/dimension-door.webp",
-            "name": "Dimension Door",
+            "img": "systems/pf2e/icons/spells/true-seeing.webp",
+            "name": "True Seeing",
             "sort": 400000,
             "system": {
                 "ability": {
@@ -355,452 +356,19 @@
                     "value": {}
                 },
                 "description": {
-                    "value": "<p>Opening a door that bypasses normal space, you instantly transport yourself and any items you're wearing and holding from your current space to a clear space within range you can see. If this would bring another creature with you-even if you're carrying it in an extradimensional container-the spell is lost.</p>\n<hr />\n<p><strong>Heightened (5th)</strong> The range increases to 1 mile. You don't need to be able to see your destination, as long as you have been there in the past and know its relative location and distance from you. You are temporarily immune for 1 hour.</p>"
-                },
-                "duration": {
-                    "value": ""
-                },
-                "hasCounteractCheck": {
-                    "value": false
-                },
-                "level": {
-                    "value": 4
-                },
-                "location": {
-                    "heightenedLevel": 5,
-                    "value": "xxK8rXRDWK5Rwj9i"
-                },
-                "materials": {
-                    "value": ""
-                },
-                "prepared": {
-                    "value": ""
-                },
-                "primarycheck": {
-                    "value": ""
-                },
-                "range": {
-                    "value": "120 feet"
-                },
-                "rules": [],
-                "save": {
-                    "basic": "",
-                    "value": ""
-                },
-                "school": {
-                    "value": "conjuration"
-                },
-                "secondarycasters": {
-                    "value": ""
-                },
-                "secondarycheck": {
-                    "value": ""
-                },
-                "slug": "dimension-door",
-                "source": {
-                    "value": "Pathfinder Core Rulebook"
-                },
-                "spellType": {
-                    "value": "utility"
-                },
-                "sustained": {
-                    "value": false
-                },
-                "target": {
-                    "value": ""
-                },
-                "time": {
-                    "value": "2"
-                },
-                "traditions": {
-                    "value": [
-                        "arcane",
-                        "occult"
-                    ]
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": [
-                        "teleportation"
-                    ]
-                }
-            },
-            "type": "spell"
-        },
-        {
-            "_id": "mxpkzQTw0tzSwaUL",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.VlNcjmYyu95vOUe8"
-                }
-            },
-            "img": "systems/pf2e/icons/spells/dimension-door.webp",
-            "name": "Dimension Door (At Will)",
-            "sort": 500000,
-            "system": {
-                "ability": {
-                    "value": ""
-                },
-                "area": null,
-                "category": {
-                    "value": "spell"
-                },
-                "components": {
-                    "focus": false,
-                    "material": false,
-                    "somatic": true,
-                    "verbal": true
-                },
-                "cost": {
-                    "value": ""
-                },
-                "damage": {
-                    "value": {}
-                },
-                "description": {
-                    "value": "<p>Opening a door that bypasses normal space, you instantly transport yourself and any items you're wearing and holding from your current space to a clear space within range you can see. If this would bring another creature with you-even if you're carrying it in an extradimensional container-the spell is lost.</p>\n<hr />\n<p><strong>Heightened (5th)</strong> The range increases to 1 mile. You don't need to be able to see your destination, as long as you have been there in the past and know its relative location and distance from you. You are temporarily immune for 1 hour.</p>"
-                },
-                "duration": {
-                    "value": ""
-                },
-                "hasCounteractCheck": {
-                    "value": false
-                },
-                "level": {
-                    "value": 4
-                },
-                "location": {
-                    "heightenedLevel": 4,
-                    "value": "xxK8rXRDWK5Rwj9i"
-                },
-                "materials": {
-                    "value": ""
-                },
-                "prepared": {
-                    "value": ""
-                },
-                "primarycheck": {
-                    "value": ""
-                },
-                "range": {
-                    "value": "120 feet"
-                },
-                "rules": [],
-                "save": {
-                    "basic": "",
-                    "value": ""
-                },
-                "school": {
-                    "value": "conjuration"
-                },
-                "secondarycasters": {
-                    "value": ""
-                },
-                "secondarycheck": {
-                    "value": ""
-                },
-                "slug": "dimension-door",
-                "source": {
-                    "value": "Pathfinder Core Rulebook"
-                },
-                "spellType": {
-                    "value": "utility"
-                },
-                "sustained": {
-                    "value": false
-                },
-                "target": {
-                    "value": ""
-                },
-                "time": {
-                    "value": "2"
-                },
-                "traditions": {
-                    "value": [
-                        "arcane",
-                        "occult"
-                    ]
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": [
-                        "teleportation"
-                    ]
-                }
-            },
-            "type": "spell"
-        },
-        {
-            "_id": "f6wcd2reTGcarw33",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.aqRYNoSvxsVfqglH"
-                }
-            },
-            "img": "systems/pf2e/icons/spells/freedom-of-movement.webp",
-            "name": "Freedom of Movement",
-            "sort": 600000,
-            "system": {
-                "ability": {
-                    "value": ""
-                },
-                "area": null,
-                "category": {
-                    "value": "spell"
-                },
-                "components": {
-                    "focus": false,
-                    "material": false,
-                    "somatic": true,
-                    "verbal": true
-                },
-                "cost": {
-                    "value": ""
-                },
-                "damage": {
-                    "value": {}
-                },
-                "description": {
-                    "value": "<p>You repel effects that would hinder a creature or slow its movement. While under this spell's effect, the target ignores effects that would give them a circumstance penalty to Speed. When they attempt to @UUID[Compendium.pf2e.actionspf2e.Escape]{Escape} an effect that has them @UUID[Compendium.pf2e.conditionitems.Immobilized]{Immobilized}, @UUID[Compendium.pf2e.conditionitems.Grabbed]{Grabbed}, or @UUID[Compendium.pf2e.conditionitems.Restrained]{Restrained}, they automatically succeed unless the effect is magical and of a higher level than the freedom of movement spell.</p>"
+                    "value": "<p>You see things within 60 feet as they actually are. The GM rolls a secret counteract check against any illusion or transmutation in the area, but only for the purpose of determining whether you see through it (for instance, if the check succeeds against a polymorph spell, you can see the creature's true form, but you don't end the polymorph spell).</p>"
                 },
                 "duration": {
                     "value": "10 minutes"
                 },
                 "hasCounteractCheck": {
-                    "value": false
+                    "value": true
                 },
                 "level": {
-                    "value": 4
+                    "value": 6
                 },
                 "location": {
-                    "heightenedLevel": 4,
-                    "value": "xxK8rXRDWK5Rwj9i"
-                },
-                "materials": {
-                    "value": ""
-                },
-                "prepared": {
-                    "value": ""
-                },
-                "primarycheck": {
-                    "value": ""
-                },
-                "range": {
-                    "value": "touch"
-                },
-                "rules": [],
-                "save": {
-                    "basic": "",
-                    "value": ""
-                },
-                "school": {
-                    "value": "abjuration"
-                },
-                "secondarycasters": {
-                    "value": ""
-                },
-                "secondarycheck": {
-                    "value": ""
-                },
-                "slug": "freedom-of-movement",
-                "source": {
-                    "value": "Pathfinder Core Rulebook"
-                },
-                "spellType": {
-                    "value": "utility"
-                },
-                "sustained": {
-                    "value": false
-                },
-                "target": {
-                    "value": "1 creature touched"
-                },
-                "time": {
-                    "value": "2"
-                },
-                "traditions": {
-                    "value": [
-                        "arcane",
-                        "divine",
-                        "primal"
-                    ]
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                }
-            },
-            "type": "spell"
-        },
-        {
-            "_id": "Vah9RFP70HLmi2n5",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.Y3G6Y6EDgCY0s3fq"
-                }
-            },
-            "img": "systems/pf2e/icons/spells/hydraulic-torrent.webp",
-            "name": "Hydraulic Torrent",
-            "sort": 700000,
-            "system": {
-                "ability": {
-                    "value": ""
-                },
-                "area": {
-                    "type": "line",
-                    "value": 60
-                },
-                "category": {
-                    "value": "spell"
-                },
-                "components": {
-                    "focus": false,
-                    "material": false,
-                    "somatic": true,
-                    "verbal": true
-                },
-                "cost": {
-                    "value": ""
-                },
-                "damage": {
-                    "value": {
-                        "0": {
-                            "type": {
-                                "categories": [],
-                                "value": "bludgeoning"
-                            },
-                            "value": "8d6"
-                        }
-                    }
-                },
-                "description": {
-                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures that fail the save are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
-                },
-                "duration": {
-                    "value": ""
-                },
-                "hasCounteractCheck": {
-                    "value": false
-                },
-                "heightening": {
-                    "damage": {
-                        "0": "2d6"
-                    },
-                    "interval": 1,
-                    "type": "interval"
-                },
-                "level": {
-                    "value": 4
-                },
-                "location": {
-                    "heightenedLevel": 4,
-                    "value": "xxK8rXRDWK5Rwj9i"
-                },
-                "materials": {
-                    "value": ""
-                },
-                "prepared": {
-                    "value": ""
-                },
-                "primarycheck": {
-                    "value": ""
-                },
-                "range": {
-                    "value": ""
-                },
-                "rules": [],
-                "save": {
-                    "basic": "",
-                    "value": "fortitude"
-                },
-                "school": {
-                    "value": "evocation"
-                },
-                "secondarycasters": {
-                    "value": ""
-                },
-                "secondarycheck": {
-                    "value": ""
-                },
-                "slug": "hydraulic-torrent",
-                "source": {
-                    "value": "Pathfinder Core Rulebook"
-                },
-                "spellType": {
-                    "value": "save"
-                },
-                "sustained": {
-                    "value": false
-                },
-                "target": {
-                    "value": ""
-                },
-                "time": {
-                    "value": "2"
-                },
-                "traditions": {
-                    "value": [
-                        "primal"
-                    ]
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": [
-                        "water"
-                    ]
-                }
-            },
-            "type": "spell"
-        },
-        {
-            "_id": "oIJY4ycXpaF4IjIM",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.jwK43yKsHTkJQvQ9"
-                }
-            },
-            "img": "systems/pf2e/icons/spells/see-invisibility.webp",
-            "name": "See Invisibility (Constant)",
-            "sort": 800000,
-            "system": {
-                "ability": {
-                    "value": ""
-                },
-                "area": null,
-                "category": {
-                    "value": "spell"
-                },
-                "components": {
-                    "focus": false,
-                    "material": false,
-                    "somatic": true,
-                    "verbal": true
-                },
-                "cost": {
-                    "value": ""
-                },
-                "damage": {
-                    "value": {}
-                },
-                "description": {
-                    "value": "<p>You can see @UUID[Compendium.pf2e.conditionitems.Invisible]{Invisible} creatures and objects. They appear to you as translucent shapes, and they are @UUID[Compendium.pf2e.conditionitems.Concealed]{Concealed} to you.</p>\n<hr />\n<p><strong>Heightened (5th)</strong> The spell has a duration of 8 hours.</p>"
-                },
-                "duration": {
-                    "value": "10 minutes"
-                },
-                "hasCounteractCheck": {
-                    "value": false
-                },
-                "level": {
-                    "value": 2
-                },
-                "location": {
-                    "heightenedLevel": 2,
-                    "value": "xxK8rXRDWK5Rwj9i"
+                    "value": "yI8fil9Hp8Ob0BcY"
                 },
                 "materials": {
                     "value": ""
@@ -828,9 +396,9 @@
                 "secondarycheck": {
                     "value": ""
                 },
-                "slug": "see-invisibility",
+                "slug": "true-seeing",
                 "source": {
-                    "value": "Pathfinder Core Rulebook"
+                    "value": ""
                 },
                 "spellType": {
                     "value": "utility"
@@ -848,7 +416,8 @@
                     "value": [
                         "arcane",
                         "divine",
-                        "occult"
+                        "occult",
+                        "primal"
                     ]
                 },
                 "traits": {
@@ -862,14 +431,430 @@
             "type": "spell"
         },
         {
-            "_id": "H2wGlqKKN7W5qqTm",
+            "_id": "QiSv1MMURWMhocma",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.30BBep9U4BDV0EgQ"
+                    "sourceId": "Compendium.pf2e.spells-srd.LiGbewa9pO0yjbsY"
                 }
             },
-            "img": "systems/pf2e/icons/spells/infernal-pact.webp",
-            "name": "Infernal Pact",
+            "img": "systems/pf2e/icons/spells/confusion.webp",
+            "name": "Confusion",
+            "sort": 500000,
+            "system": {
+                "ability": {
+                    "value": ""
+                },
+                "area": null,
+                "category": {
+                    "value": "spell"
+                },
+                "components": {
+                    "focus": false,
+                    "material": false,
+                    "somatic": true,
+                    "verbal": true
+                },
+                "cost": {
+                    "value": ""
+                },
+                "damage": {
+                    "value": {}
+                },
+                "description": {
+                    "value": "<p>You befuddle your target with strange impulses, causing it to act randomly. The effects are determined by the target's Will save. You can Dismiss the spell.</p>\n<hr />\n<p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target babbles incoherently and is @UUID[Compendium.pf2e.conditionitems.Stunned]{Stunned 1}.</p>\n<p><strong>Failure</strong> The target is @UUID[Compendium.pf2e.conditionitems.Confused]{Confused} for 1 minute. It can attempt a new save at the end of each of its turns to end the confusion.</p>\n<p><strong>Critical Failure</strong> The target is Confused for 1 minute, with no save to end early.</p>\n<hr />\n<p><strong>Heightened (8th)</strong> You can target up to 10 creatures.</p>"
+                },
+                "duration": {
+                    "value": "1 minute"
+                },
+                "hasCounteractCheck": {
+                    "value": false
+                },
+                "level": {
+                    "value": 4
+                },
+                "location": {
+                    "value": "yI8fil9Hp8Ob0BcY"
+                },
+                "materials": {
+                    "value": ""
+                },
+                "prepared": {
+                    "value": ""
+                },
+                "primarycheck": {
+                    "value": ""
+                },
+                "range": {
+                    "value": "30 feet"
+                },
+                "rules": [],
+                "save": {
+                    "basic": "",
+                    "value": "will"
+                },
+                "school": {
+                    "value": "enchantment"
+                },
+                "secondarycasters": {
+                    "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "confusion",
+                "source": {
+                    "value": ""
+                },
+                "spellType": {
+                    "value": "save"
+                },
+                "sustained": {
+                    "value": false
+                },
+                "target": {
+                    "value": "1 creature"
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traditions": {
+                    "value": [
+                        "arcane",
+                        "occult"
+                    ]
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "emotion",
+                        "mental"
+                    ]
+                }
+            },
+            "type": "spell"
+        },
+        {
+            "_id": "3doForP0E1THISrz",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.qwlh6aDgi86U3Q7H"
+                }
+            },
+            "img": "systems/pf2e/icons/spells/suggestion.webp",
+            "name": "Suggestion",
+            "sort": 600000,
+            "system": {
+                "ability": {
+                    "value": ""
+                },
+                "area": null,
+                "category": {
+                    "value": "spell"
+                },
+                "components": {
+                    "focus": false,
+                    "material": false,
+                    "somatic": true,
+                    "verbal": true
+                },
+                "cost": {
+                    "value": ""
+                },
+                "damage": {
+                    "value": {}
+                },
+                "description": {
+                    "value": "<p>Your honeyed words are difficult for creatures to resist. You suggest a course of action to the target, which must be phrased in such a way as to seem like a logical course of action to the target and can't be self-destructive or obviously against the target's self-interest. The target must attempt a Will save.</p>\n<hr /><strong>Critical Success</strong> The target is unaffected and knows you tried to control it.\n<p><strong>Success</strong> The target is unaffected and thinks you were talking to them normally, not casting a spell on them.</p>\n<p><strong>Failure</strong> The target immediately follows your suggestion. The spell has a duration of 1 minute, or until the target has completed a finite suggestion or the suggestion becomes self-destructive or has other obvious negative effects.</p>\n<p><strong>Critical Failure</strong> As failure, but the base duration is 1 hour.</p>\n<hr /><strong>Heightened (8th)</strong> You can target up to 10 creatures."
+                },
+                "duration": {
+                    "value": "varies"
+                },
+                "hasCounteractCheck": {
+                    "value": false
+                },
+                "level": {
+                    "value": 4
+                },
+                "location": {
+                    "value": "yI8fil9Hp8Ob0BcY"
+                },
+                "materials": {
+                    "value": ""
+                },
+                "prepared": {
+                    "value": ""
+                },
+                "primarycheck": {
+                    "value": ""
+                },
+                "range": {
+                    "value": "30 feet"
+                },
+                "rules": [],
+                "save": {
+                    "basic": "",
+                    "value": "will"
+                },
+                "school": {
+                    "value": "enchantment"
+                },
+                "secondarycasters": {
+                    "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "suggestion",
+                "source": {
+                    "value": ""
+                },
+                "spellType": {
+                    "value": "save"
+                },
+                "sustained": {
+                    "value": false
+                },
+                "target": {
+                    "value": "1 creature"
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traditions": {
+                    "value": [
+                        "arcane",
+                        "occult"
+                    ]
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "incapacitation",
+                        "linguistic",
+                        "mental"
+                    ]
+                }
+            },
+            "type": "spell"
+        },
+        {
+            "_id": "A4uTm2iKIjlq0c0S",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.GUeRTriJkMlMlVrk"
+                }
+            },
+            "img": "systems/pf2e/icons/spells/bind-undead.webp",
+            "name": "Bind Undead",
+            "sort": 700000,
+            "system": {
+                "ability": {
+                    "value": ""
+                },
+                "area": null,
+                "category": {
+                    "value": "spell"
+                },
+                "components": {
+                    "focus": false,
+                    "material": false,
+                    "somatic": true,
+                    "verbal": true
+                },
+                "cost": {
+                    "value": ""
+                },
+                "damage": {
+                    "value": {}
+                },
+                "description": {
+                    "value": "<p>With a word of necromantic power, you seize control of the target. It gains the minion trait. If you or an ally uses any hostile actions against the target, the spell ends.</p>"
+                },
+                "duration": {
+                    "value": "1 day"
+                },
+                "hasCounteractCheck": {
+                    "value": false
+                },
+                "level": {
+                    "value": 3
+                },
+                "location": {
+                    "value": "yI8fil9Hp8Ob0BcY"
+                },
+                "materials": {
+                    "value": ""
+                },
+                "prepared": {
+                    "value": ""
+                },
+                "primarycheck": {
+                    "value": ""
+                },
+                "range": {
+                    "value": "30 feet"
+                },
+                "rules": [],
+                "save": {
+                    "basic": "",
+                    "value": ""
+                },
+                "school": {
+                    "value": "necromancy"
+                },
+                "secondarycasters": {
+                    "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "bind-undead",
+                "source": {
+                    "value": ""
+                },
+                "spellType": {
+                    "value": "utility"
+                },
+                "sustained": {
+                    "value": false
+                },
+                "target": {
+                    "value": "1 mindless undead creature with a level no greater than bind undead's spell level"
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traditions": {
+                    "value": [
+                        "arcane",
+                        "divine",
+                        "occult"
+                    ]
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "spell"
+        },
+        {
+            "_id": "WRN1Hv86e4EgDc7w",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.DCQHaLrYXMI37dvW"
+                }
+            },
+            "img": "systems/pf2e/icons/spells/paralyze.webp",
+            "name": "Paralyze",
+            "sort": 800000,
+            "system": {
+                "ability": {
+                    "value": ""
+                },
+                "area": null,
+                "category": {
+                    "value": "spell"
+                },
+                "components": {
+                    "focus": false,
+                    "material": false,
+                    "somatic": true,
+                    "verbal": true
+                },
+                "cost": {
+                    "value": ""
+                },
+                "damage": {
+                    "value": {}
+                },
+                "description": {
+                    "value": "<p>You block the target's motor impulses before they can leave its mind, threatening to freeze the target in place. The target must attempt a Will save.</p>\n<hr />\n<p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target is @UUID[Compendium.pf2e.conditionitems.Stunned]{Stunned 1}.</p>\n<p><strong>Failure</strong> The target is @UUID[Compendium.pf2e.conditionitems.Paralyzed]{Paralyzed} for 1 round.</p>\n<p><strong>Critical Failure</strong> The target is Paralyzed for 4 rounds. At the end of each of its turns, it can attempt a new Will save to reduce the remaining duration by 1 round, or end it entirely on a critical success.</p>\n<hr />\n<p><strong>Heightened (7th)</strong> You can target up to 10 creatures.</p>"
+                },
+                "duration": {
+                    "value": "varies"
+                },
+                "hasCounteractCheck": {
+                    "value": false
+                },
+                "level": {
+                    "value": 3
+                },
+                "location": {
+                    "value": "yI8fil9Hp8Ob0BcY"
+                },
+                "materials": {
+                    "value": ""
+                },
+                "prepared": {
+                    "value": ""
+                },
+                "primarycheck": {
+                    "value": ""
+                },
+                "range": {
+                    "value": "30 feet"
+                },
+                "rules": [],
+                "save": {
+                    "basic": "",
+                    "value": "will"
+                },
+                "school": {
+                    "value": "enchantment"
+                },
+                "secondarycasters": {
+                    "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "paralyze",
+                "source": {
+                    "value": ""
+                },
+                "spellType": {
+                    "value": "save"
+                },
+                "sustained": {
+                    "value": false
+                },
+                "target": {
+                    "value": "1 creature"
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traditions": {
+                    "custom": "",
+                    "value": [
+                        "arcane",
+                        "occult"
+                    ]
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "incapacitation",
+                        "mental"
+                    ]
+                }
+            },
+            "type": "spell"
+        },
+        {
+            "_id": "80Cc6iuTrINoZxal",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.c3b6LdLlQDPngNIb"
+                }
+            },
+            "img": "systems/pf2e/icons/spells/create-undead.webp",
+            "name": "Create Undead",
             "sort": 900000,
             "system": {
                 "ability": {
@@ -886,13 +871,13 @@
                     "verbal": false
                 },
                 "cost": {
-                    "value": ""
+                    "value": "black onyx, see Table 7-1"
                 },
                 "damage": {
                     "value": {}
                 },
                 "description": {
-                    "value": "<p>You make an appeal to a powerful devil, asking it to bind some of its subordinates to your service. If you succeed, the devil sends you its choice of one devil whose level is no more than double <em>infernal pact's</em> level, two devils whose levels are each at least 2 less than double the spell level, or three devils whose levels are each at least 3 less than double the spell level.</p>\n<hr />\n<p><strong>Critical Success</strong> The devils are sent to you and serve you for [[/r 1d4 #weeks]]{1d4 weeks}.</p>\n<p><strong>Success</strong> The devils are sent to you and serve you for [[/r 1d4 #days]]{1d4 days}.</p>\n<p><strong>Failure</strong> Your request is denied.</p>\n<p><strong>Critical Failure</strong> Not only is your request denied, but the powerful devil sends word of its displeasure to your master.</p>"
+                    "value": "<p>You transform the target into an undead creature with a level up to that allowed in Table 7-1. There are many versions of this ritual, each specific to a particular type of undead (one ritual for all zombies, one for skeletons, one for ghouls, and so on), and the rituals that create rare undead are also rare. Some forms of undead, such as liches, form using their own unique methods and can't be created with a version of <em>create undead</em>.</p>\n<h2>Table 7-1: Creatures Creation Rituals</h2>\n<table class=\"pf2-table\">\n<thead>\n<tr>\n<th>Creature Level</th>\n<th>Spell Level Required</th>\n<th>Cost</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>-1 or 0</td>\n<td>2</td>\n<td>15 gp</td>\n</tr>\n<tr>\n<td>1</td>\n<td>2</td>\n<td>60 gp</td>\n</tr>\n<tr>\n<td>2</td>\n<td>3</td>\n<td>105 gp</td>\n</tr>\n<tr>\n<td>3</td>\n<td>3</td>\n<td>180 gp</td>\n</tr>\n<tr>\n<td>4</td>\n<td>4</td>\n<td>300 gp</td>\n</tr>\n<tr>\n<td>5</td>\n<td>4</td>\n<td>480 gp</td>\n</tr>\n<tr>\n<td>6</td>\n<td>5</td>\n<td>750 gp</td>\n</tr>\n<tr>\n<td>7</td>\n<td>5</td>\n<td>1,080 gp</td>\n</tr>\n<tr>\n<td>8</td>\n<td>6</td>\n<td>1,500 gp</td>\n</tr>\n<tr>\n<td>9</td>\n<td>6</td>\n<td>2,100 gp</td>\n</tr>\n<tr>\n<td>10</td>\n<td>7</td>\n<td>3,000 gp</td>\n</tr>\n<tr>\n<td>11</td>\n<td>7</td>\n<td>4,200 gp</td>\n</tr>\n<tr>\n<td>12</td>\n<td>8</td>\n<td>6,000 gp</td>\n</tr>\n<tr>\n<td>13</td>\n<td>8</td>\n<td>9,000 gp</td>\n</tr>\n<tr>\n<td>14</td>\n<td>9</td>\n<td>13,500 gp</td>\n</tr>\n<tr>\n<td>15</td>\n<td>9</td>\n<td>19,500 gp</td>\n</tr>\n<tr>\n<td>16</td>\n<td>10</td>\n<td>30,000 gp</td>\n</tr>\n<tr>\n<td>17</td>\n<td>10</td>\n<td>45,000 gp</td>\n</tr>\n</tbody>\n</table>\n<p><strong>Critical Success</strong> The target becomes an undead creature of the appropriate type. If it's at least 4 levels lower than you, you can make it a minion. This gives it the minion trait, meaning it can use 2 actions when you command it, and commanding it is a single action that has the auditory and concentrate traits. You can have a maximum of four minions under your control. If it's intelligent and doesn't become a minion, the undead is helpful to you for awakening it, though it's still a horrid and evil creature. If it's unintelligent and doesn't become a minion, you can give it one simple command. It pursues that goal single-mindedly, ignoring any of your subsequent commands.</p>\n<p><strong>Success</strong> As critical success, except an intelligent undead that doesn't become your minion is only friendly to you, and an unintelligent undead that doesn't become your minion leaves you alone unless you attack it. It marauds the local area rather than following your command.</p>\n<p><strong>Failure</strong> You fail to create the undead.</p>\n<p><strong>Critical Failure</strong> You create the undead, but its soul, tortured by your foul necromancy, is full of nothing but hatred for you. It attempts to destroy you.</p>"
                 },
                 "duration": {
                     "value": ""
@@ -901,10 +886,10 @@
                     "value": false
                 },
                 "level": {
-                    "value": 1
+                    "value": 2
                 },
                 "location": {
-                    "value": "ioqicnfviMKvXg9T"
+                    "value": "vDdGrFDKu7JIcuaR"
                 },
                 "materials": {
                     "value": ""
@@ -913,10 +898,10 @@
                     "value": ""
                 },
                 "primarycheck": {
-                    "value": "Religion (expert; you must be a devil)"
+                    "value": "Arcana (expert), Occultism (expert), or Religion (expert)"
                 },
                 "range": {
-                    "value": ""
+                    "value": "10 feet"
                 },
                 "rules": [],
                 "save": {
@@ -924,17 +909,17 @@
                     "value": ""
                 },
                 "school": {
-                    "value": "conjuration"
+                    "value": "necromancy"
                 },
                 "secondarycasters": {
-                    "value": ""
+                    "value": "1"
                 },
                 "secondarycheck": {
-                    "value": ""
+                    "value": "Religion"
                 },
-                "slug": "infernal-pact",
+                "slug": "create-undead",
                 "source": {
-                    "value": "Pathfinder Bestiary"
+                    "value": ""
                 },
                 "spellType": {
                     "value": "utility"
@@ -943,136 +928,253 @@
                     "value": false
                 },
                 "target": {
-                    "value": ""
+                    "value": "1 dead creature"
                 },
                 "time": {
                     "value": "1 day"
                 },
                 "traditions": {
+                    "custom": "",
                     "value": []
                 },
                 "traits": {
                     "custom": "",
                     "rarity": "uncommon",
-                    "value": []
+                    "value": [
+                        "evil"
+                    ]
                 }
             },
             "type": "spell"
         },
         {
-            "_id": "JCCJdKRetmUpfNFn",
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/aluum-charm.webp",
-            "name": "Fragment of Urevian's Pendant",
-            "sort": 1000000,
-            "system": {
-                "baseItem": null,
-                "containerId": "null",
-                "description": {
-                    "value": ""
-                },
-                "equipped": {
-                    "carryType": "worn",
-                    "handsHeld": 0,
-                    "invested": null
-                },
-                "equippedBulk": {
-                    "value": ""
-                },
-                "hardness": 0,
-                "hp": {
-                    "brokenThreshold": 0,
-                    "max": 0,
-                    "value": 0
-                },
-                "level": {
-                    "value": 0
-                },
-                "negateBulk": {
-                    "value": "0"
-                },
-                "preciousMaterial": {
-                    "value": null
-                },
-                "preciousMaterialGrade": {
-                    "value": null
-                },
-                "price": {
-                    "value": {}
-                },
-                "quantity": 1,
-                "rules": [],
-                "size": "med",
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "stackGroup": null,
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                },
-                "usage": {
-                    "value": "held-in-one-hand"
-                },
-                "weight": {
-                    "value": "-"
+            "_id": "e2XBaG3jb5ZCerH3",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.dLdRqT6UxTKlsPgp"
                 }
             },
-            "type": "equipment"
-        },
-        {
-            "_id": "LbkW4zjvlyreuGX1",
-            "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "Fangs",
-            "sort": 1100000,
+            "img": "systems/pf2e/icons/spells/death-knell.webp",
+            "name": "Death Knell",
+            "sort": 1000000,
             "system": {
-                "attack": {
+                "ability": {
                     "value": ""
                 },
-                "attackEffects": {
-                    "custom": "",
-                    "value": []
+                "area": null,
+                "category": {
+                    "value": "spell"
                 },
-                "bonus": {
-                    "value": 20
+                "components": {
+                    "focus": false,
+                    "material": false,
+                    "somatic": true,
+                    "verbal": true
                 },
-                "damageRolls": {
-                    "589ofmp1gxuypvnb4x7i": {
-                        "damage": "2d12+9",
-                        "damageType": "piercing"
-                    },
-                    "unhztp8iu335uhghi4gr": {
-                        "damage": "1d6",
-                        "damageType": "evil"
-                    }
+                "cost": {
+                    "value": ""
+                },
+                "damage": {
+                    "value": {}
                 },
                 "description": {
+                    "value": "<p>You snuff the life out of a creature on the brink of death. The target must attempt a Will save. If this kills it, you gain 10 temporary HP and a +1 status bonus to attack and damage rolls for 10 minutes.</p>\n<hr /><strong>Critical Success</strong> The target is unaffected.\n<p><strong>Success</strong> The target's @UUID[Compendium.pf2e.conditionitems.Dying]{Dying} value increases by 1.</p>\n<p><strong>Failure</strong> The target dies.</p>"
+                },
+                "duration": {
                     "value": ""
                 },
+                "hasCounteractCheck": {
+                    "value": false
+                },
+                "level": {
+                    "value": 2
+                },
+                "location": {
+                    "value": "yI8fil9Hp8Ob0BcY"
+                },
+                "materials": {
+                    "value": ""
+                },
+                "prepared": {
+                    "value": ""
+                },
+                "primarycheck": {
+                    "value": ""
+                },
+                "range": {
+                    "value": "touch"
+                },
                 "rules": [],
-                "slug": null,
+                "save": {
+                    "basic": "",
+                    "value": "will"
+                },
+                "school": {
+                    "value": "necromancy"
+                },
+                "secondarycasters": {
+                    "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "death-knell",
                 "source": {
                     "value": ""
+                },
+                "spellType": {
+                    "value": "save"
+                },
+                "sustained": {
+                    "value": false
+                },
+                "target": {
+                    "value": "1 living creature that has 0 HP"
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traditions": {
+                    "value": [
+                        "divine",
+                        "occult"
+                    ]
                 },
                 "traits": {
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "evil",
-                        "magical"
+                        "death"
                     ]
-                },
-                "weaponType": {
-                    "value": "melee"
                 }
             },
-            "type": "melee"
+            "type": "spell"
         },
         {
-            "_id": "TfHuj8LvtfwsXfXQ",
+            "_id": "1OH8BtvGWIO8Vtl9",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.wdA52JJnsuQWeyqz"
+                }
+            },
+            "img": "systems/pf2e/icons/spells/harm.webp",
+            "name": "Harm",
+            "sort": 1100000,
+            "system": {
+                "ability": {
+                    "value": ""
+                },
+                "area": {
+                    "details": "varies",
+                    "type": "emanation",
+                    "value": 30
+                },
+                "category": {
+                    "value": "spell"
+                },
+                "components": {
+                    "focus": false,
+                    "material": false,
+                    "somatic": false,
+                    "verbal": false
+                },
+                "cost": {
+                    "value": ""
+                },
+                "damage": {
+                    "value": {
+                        "0": {
+                            "type": {
+                                "categories": [],
+                                "value": "negative"
+                            },
+                            "value": "1d8"
+                        }
+                    }
+                },
+                "description": {
+                    "value": "<p>You channel negative energy to harm the living or heal the undead. If the target is a living creature, you deal 1d8 negative damage to it, and it gets a basic Fortitude save. If the target is a willing undead creature, you restore that amount of Hit Points. The number of actions you spend when Casting this Spell determines its targets, range, area, and other parameters.</p>\n<hr />\n<p><strong>1 Action</strong> (somatic) The spell has a range of touch.</p>\n<p><strong>2 Actions</strong> (verbal, somatic) The spell has a range of 30 feet. If you're healing an undead creature, increase the Hit Points restored by 8.</p>\n<p><strong>3 Actions</strong> (material, verbal, somatic) You disperse negative energy in a 30-foot emanation. This targets all living and undead creatures in the area.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The amount of healing or damage increases by 1d8, and the extra healing for the 2-action version increases by 8.</p>"
+                },
+                "duration": {
+                    "value": ""
+                },
+                "hasCounteractCheck": {
+                    "value": false
+                },
+                "heightening": {
+                    "damage": {
+                        "0": "1d8"
+                    },
+                    "interval": 1,
+                    "type": "interval"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": {
+                    "value": "yI8fil9Hp8Ob0BcY"
+                },
+                "materials": {
+                    "value": ""
+                },
+                "prepared": {
+                    "value": ""
+                },
+                "primarycheck": {
+                    "value": ""
+                },
+                "range": {
+                    "value": "varies"
+                },
+                "rules": [],
+                "save": {
+                    "basic": "basic",
+                    "value": "fortitude"
+                },
+                "school": {
+                    "value": "necromancy"
+                },
+                "secondarycasters": {
+                    "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "harm",
+                "source": {
+                    "value": ""
+                },
+                "spellType": {
+                    "value": "save"
+                },
+                "sustained": {
+                    "value": false
+                },
+                "target": {
+                    "value": "1 living creature or 1 willing undead creature"
+                },
+                "time": {
+                    "value": "1 to 3"
+                },
+                "traditions": {
+                    "value": [
+                        "divine"
+                    ]
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "negative"
+                    ]
+                }
+            },
+            "type": "spell"
+        },
+        {
+            "_id": "L8z6SDNKm57PB639",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "Tentacle Arm",
+            "name": "Claw",
             "sort": 1200000,
             "system": {
                 "attack": {
@@ -1081,20 +1183,16 @@
                 "attackEffects": {
                     "custom": "",
                     "value": [
-                        "sarglagon-venom"
+                        "drain-life"
                     ]
                 },
                 "bonus": {
-                    "value": 20
+                    "value": 24
                 },
                 "damageRolls": {
-                    "pjlrdhtwociy4agitatv": {
-                        "damage": "2d8+9",
-                        "damageType": "bludgeoning"
-                    },
-                    "pjr2qdzqzhjjivvrtu2e": {
-                        "damage": "1d6",
-                        "damageType": "evil"
+                    "0": {
+                        "damage": "2d10+13",
+                        "damageType": "slashing"
                     }
                 },
                 "description": {
@@ -1110,8 +1208,7 @@
                     "rarity": "common",
                     "value": [
                         "agile",
-                        "evil",
-                        "magical"
+                        "reach-10"
                     ]
                 },
                 "weaponType": {
@@ -1121,14 +1218,14 @@
             "type": "melee"
         },
         {
-            "_id": "BMv1jkvT4dSbEL8X",
+            "_id": "q0kSVZllWCY1CwD2",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.4Ho2xMPEC05aSxzr"
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.qCCLZhnp2HhP3Ex6"
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Greater Darkvision",
+            "name": "Darkvision",
             "sort": 1300000,
             "system": {
                 "actionCategory": {
@@ -1141,13 +1238,13 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.GreaterDarkvision]</p>"
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Darkvision]</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
                 "rules": [],
-                "slug": "greater-darkvision",
+                "slug": "darkvision",
                 "source": {
                     "value": "Pathfinder Bestiary"
                 },
@@ -1166,154 +1263,10 @@
             "type": "action"
         },
         {
-            "_id": "7NjsgQKMg0FvxDmJ",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.kdhbPaBMK1d1fpbA"
-                }
-            },
-            "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy 100 feet",
-            "sort": 1400000,
-            "system": {
-                "actionCategory": {
-                    "value": "interaction"
-                },
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "description": {
-                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Telepathy]</p>"
-                },
-                "requirements": {
-                    "value": ""
-                },
-                "rules": [],
-                "slug": "telepathy",
-                "source": {
-                    "value": "Pathfinder Bestiary"
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": [
-                        "aura",
-                        "divination",
-                        "magical"
-                    ]
-                },
-                "trigger": {
-                    "value": ""
-                },
-                "weapon": {
-                    "value": ""
-                }
-            },
-            "type": "action"
-        },
-        {
-            "_id": "kUtQvCE4ePTqjluS",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.2YRDYVnC1eljaXKK"
-                }
-            },
-            "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "At-Will Spells",
-            "sort": 1500000,
-            "system": {
-                "actionCategory": {
-                    "value": "interaction"
-                },
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "description": {
-                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.AtWillSpells]</p>"
-                },
-                "requirements": {
-                    "value": ""
-                },
-                "rules": [],
-                "slug": "at-will-spells",
-                "source": {
-                    "value": "Pathfinder Bestiary"
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                },
-                "trigger": {
-                    "value": ""
-                },
-                "weapon": {
-                    "value": ""
-                }
-            },
-            "type": "action"
-        },
-        {
-            "_id": "tIvtO7TbZgSNlr3F",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.kakyXBG5WA8c6Zfd"
-                }
-            },
-            "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Constant Spells",
-            "sort": 1600000,
-            "system": {
-                "actionCategory": {
-                    "value": "interaction"
-                },
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "description": {
-                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.ConstantSpells]</p>"
-                },
-                "requirements": {
-                    "value": ""
-                },
-                "rules": [],
-                "slug": "constant-spells",
-                "source": {
-                    "value": "Pathfinder Bestiary"
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                },
-                "trigger": {
-                    "value": ""
-                },
-                "weapon": {
-                    "value": ""
-                }
-            },
-            "type": "action"
-        },
-        {
-            "_id": "GoYV1mj4XKxDiBOM",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.kquBnQ0kObZztnBc"
-                }
-            },
+            "_id": "MeT5lDeI05fBDoW3",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "+1 Status to All Saves vs. Magic",
-            "sort": 1700000,
+            "sort": 1400000,
             "system": {
                 "actionCategory": {
                     "value": "defensive"
@@ -1338,9 +1291,9 @@
                                 "or": [
                                     "magical",
                                     "arcane",
-                                    "divine",
                                     "primal",
-                                    "occult"
+                                    "occult",
+                                    "divine"
                                 ]
                             }
                         ],
@@ -1349,7 +1302,7 @@
                         "value": 1
                     }
                 ],
-                "slug": "1-status-to-all-saves-vs-magic",
+                "slug": null,
                 "source": {
                     "value": ""
                 },
@@ -1368,10 +1321,15 @@
             "type": "action"
         },
         {
-            "_id": "tqSmdxFVDmY2CLns",
+            "_id": "XJ7A5MPGGNFZpxXP",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.TTCw5NusiSSkJU1x"
+                }
+            },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Heavy Aura",
-            "sort": 1800000,
+            "name": "Negative Healing",
+            "sort": 1500000,
             "system": {
                 "actionCategory": {
                     "value": "defensive"
@@ -1383,7 +1341,54 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>@Template[type:emanation|distance:10]{10 feet} @UUID[Compendium.pf2e.bestiary-ability-glossary-srd.Aura]{Aura}</p>\n<hr />\n<p>A creature that enters the heavy aura must attempt a @Check[type:will|dc:23] save. It is then temporarily immune for 10 minutes.</p>\n<hr />\n<p><strong>Success</strong> The creature is unaffected.</p>\n<p><strong>Failure</strong> The creature is @UUID[Compendium.pf2e.conditionitems.Encumbered]{Encumbered} while it remains in the area. If the creature is already encumbered, it is @UUID[Compendium.pf2e.conditionitems.Immobilized]{Immobilized} while it remains within the aura.</p>\n<p><strong>Critical Failure</strong> As failure, but the effect persists for 3 rounds after leaving the aura.</p>"
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.NegativeHealing]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "system.attributes.hp.negativeHealing",
+                        "value": true
+                    }
+                ],
+                "slug": "negative-healing",
+                "source": {
+                    "value": "Pathfinder Bestiary 2"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "N9qNd1NMgEeyNwcF",
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Spell Deflection",
+            "sort": 1600000,
+            "system": {
+                "actionCategory": {
+                    "value": "defensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>A spellcaster who targets a devourer with a mental spell, <em>@UUID[Compendium.pf2e.spells-srd.Banishment]{Banishment}</em>, <em>@UUID[Compendium.pf2e.spells-srd.Bind Soul]{Bind Soul}</em>, <em>@UUID[Compendium.pf2e.spells-srd.Divine Decree]{Divine Decree}</em>, <em>@UUID[Compendium.pf2e.spells-srd.Divine Wrath]{Divine Wrath}</em>, <em>@UUID[Compendium.pf2e.spells-srd.Possession]{Possession}</em>, <em>@UUID[Compendium.pf2e.spells-srd.Spirit Blast]{Spirit Blast}</em>, or <em>@UUID[Compendium.pf2e.spells-srd.Spirit Song]{Spirit Song}</em> can attempt a counteract check to free a soul the devourer has trapped with Devour Soul. If this counteract attempt succeeds, the trapped soul is released (though the creature remains dead), and the devourer can't use any soul charges from that creature.</p>\n<p>Devourers are otherwise immune to these spells.</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -1397,10 +1402,9 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "aura",
+                        "abjuration",
                         "divine",
-                        "incapacitation",
-                        "transmutation"
+                        "mental"
                     ]
                 },
                 "trigger": {
@@ -1413,50 +1417,10 @@
             "type": "action"
         },
         {
-            "_id": "myXt3SwrT2L8VMW4",
-            "img": "systems/pf2e/icons/actions/Reaction.webp",
-            "name": "Stygian Guardian",
-            "sort": 1900000,
-            "system": {
-                "actionCategory": {
-                    "value": "defensive"
-                },
-                "actionType": {
-                    "value": "reaction"
-                },
-                "actions": {
-                    "value": null
-                },
-                "description": {
-                    "value": "<p><strong>Trigger</strong> A creature or object within the sarglagon's reach is targeted by an attack</p>\n<hr />\n<p><strong>Effect</strong> The sarglagon interposes themself, giving the creature or object @UUID[Compendium.pf2e.other-effects.Effect: Cover]{Standard Cover} against the attack (+2 circumstance bonus to AC), or @UUID[Compendium.pf2e.other-effects.Effect: Cover]{Greater Cover} (+4 circumstance bonus to AC) if the sarglagon was already granting it lesser cover.</p>"
-                },
-                "requirements": {
-                    "value": ""
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                },
-                "trigger": {
-                    "value": ""
-                },
-                "weapon": {
-                    "value": ""
-                }
-            },
-            "type": "action"
-        },
-        {
-            "_id": "nBbFutvNlcdf1cgZ",
+            "_id": "bMX8ZvBxeu0Ty5cl",
             "img": "systems/pf2e/icons/actions/TwoActions.webp",
-            "name": "Drown",
-            "sort": 2000000,
+            "name": "Devour Soul",
+            "sort": 1700000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -1468,7 +1432,7 @@
                     "value": 2
                 },
                 "description": {
-                    "value": "<p>The sarglagon conjures murky water to fill the lungs of a creature that can't breathe water within 30 feet. The target must attempt a @Check[type:fortitude|dc:26] save.</p>\n<hr />\n<p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target coughs up water and is @UUID[Compendium.pf2e.conditionitems.Sickened]{Sickened 1}.</p>\n<p><strong>Failure</strong> The target is holding its breath. The only action it can take is to attempt a Fortitude save against Drown to expel the water, which is a single action.</p>\n<p><strong>Critical Failure</strong> The target falls @UUID[Compendium.pf2e.conditionitems.Unconscious]{Unconscious} and begins suffocating. If the target succeeds at its Fortitude save while suffocating, it coughs up the water and can breathe again.</p>"
+                    "value": "<p>The devourer touches a creature within reach, dealing [[/r 8d6[negative]]] damage (@Check[type:fortitude|dc:26|basic:true] save). If a creature is slain by this attack, its soul becomes trapped within the devourer. While its soul is trapped, a creature can't be resurrected except by powerful magic such as a <em>@UUID[Compendium.pf2e.spells-srd.Wish]{Wish}</em> spell. Destroying the devourer or successfully counteracting Devour Soul (see spell deflection) releases the soul. The devourer can hold only one soul at a time.</p>\n<p>A soul has 5 soul charges per level of the originating creature (see the soul spells ability below). The devourer can expend these charges to cast spells. If the soul is freed and the creature returns to life, the creature is @UUID[Compendium.pf2e.conditionitems.Drained]{Drained 1} for every 5 soul charges expended. If reduced to 0 soul charges, the soul is consumed and can be restored to life only by powerful magic such as <em>wish</em>.</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -1482,9 +1446,9 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "conjuration",
+                        "death",
                         "divine",
-                        "incapacitation"
+                        "necromancy"
                     ]
                 },
                 "trigger": {
@@ -1497,10 +1461,10 @@
             "type": "action"
         },
         {
-            "_id": "5Vw9VTB3I1sie1g1",
+            "_id": "2a2eONlkTBanM6W0",
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Sarglagon Venom",
-            "sort": 2100000,
+            "name": "Drain Life",
+            "sort": 1800000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -1512,7 +1476,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p><strong>Saving Throw</strong> @Check[type:fortitude|dc:26]</p>\n<hr />\n<p><strong>Maximum Duration</strong> 6 rounds</p>\n<p><strong>Stage 1</strong>[[/r 2d6[poison]]] damage and @UUID[Compendium.pf2e.conditionitems.Clumsy]{Clumsy 1} (1 round)</p>\n<p><strong>Stage 2</strong>[[/r 3d6[poison]]] damage and @UUID[Compendium.pf2e.conditionitems.Clumsy]{Clumsy 2} (1 round)</p>"
+                    "value": "<p>When the devourer damages a living creature with its claw Strike, the devourer gains 10 temporary Hit Points and the creature must succeed at a @Check[type:fortitude|dc:24] save or become @UUID[Compendium.pf2e.conditionitems.Drained]{Drained 1}. Further damage dealt by the devourer increases the condition value by 1 on a failed save, to a maximum of drained 4.</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -1526,7 +1490,8 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "poison"
+                        "divine",
+                        "necromancy"
                     ]
                 },
                 "trigger": {
@@ -1539,16 +1504,112 @@
             "type": "action"
         },
         {
-            "_id": "cziWyGkXTKOzxWfA",
+            "_id": "Hu1SdyNVG4WJmNcx",
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Soul Spells",
+            "sort": 1900000,
+            "system": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>A devourer casts occult innate spells, but to do so it must expend a number of soul charges equal to the spell's level (similar to casting a spell using charges from a staff). It can heighten any spell to a maximum of 6th level by expending more charges as it Casts the Spell. When encountered, a devourer typically has one trapped soul with 10 soul charges.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "9RblIhgpAIkvXhF8",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Arcana",
+            "sort": 2000000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 21
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "lore"
+        },
+        {
+            "_id": "yG9FIYj2H4oaIcl4",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Deception",
+            "sort": 2100000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 21
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "lore"
+        },
+        {
+            "_id": "vGVQJxXoMxXarr3E",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Intimidation",
             "sort": 2200000,
             "system": {
                 "description": {
                     "value": ""
                 },
                 "mod": {
-                    "value": 14
+                    "value": 23
                 },
                 "proficient": {
                     "value": 0
@@ -1567,16 +1628,16 @@
             "type": "lore"
         },
         {
-            "_id": "FrvH9Qjm4Ddo8J4J",
+            "_id": "oCZVrbX6Rp7CzDyW",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Athletics",
+            "name": "Occultism",
             "sort": 2300000,
             "system": {
                 "description": {
                     "value": ""
                 },
                 "mod": {
-                    "value": 18
+                    "value": 23
                 },
                 "proficient": {
                     "value": 0
@@ -1595,100 +1656,16 @@
             "type": "lore"
         },
         {
-            "_id": "dmFxBvhl0Mwqt8u5",
+            "_id": "NqUSk1Xz2L7yQckG",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Deception",
+            "name": "Stealth",
             "sort": 2400000,
             "system": {
                 "description": {
                     "value": ""
                 },
                 "mod": {
-                    "value": 15
-                },
-                "proficient": {
-                    "value": 0
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                }
-            },
-            "type": "lore"
-        },
-        {
-            "_id": "x75GI6dZABMCrzl8",
-            "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Diplomacy",
-            "sort": 2500000,
-            "system": {
-                "description": {
-                    "value": ""
-                },
-                "mod": {
-                    "value": 15
-                },
-                "proficient": {
-                    "value": 0
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                }
-            },
-            "type": "lore"
-        },
-        {
-            "_id": "O2Iy6hHlVcoWCJFF",
-            "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Intimidation",
-            "sort": 2600000,
-            "system": {
-                "description": {
-                    "value": ""
-                },
-                "mod": {
-                    "value": 17
-                },
-                "proficient": {
-                    "value": 0
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                }
-            },
-            "type": "lore"
-        },
-        {
-            "_id": "AqkCZNXs44e7j33l",
-            "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Stealth",
-            "sort": 2700000,
-            "system": {
-                "description": {
-                    "value": ""
-                },
-                "mod": {
-                    "value": 15
+                    "value": 19
                 },
                 "proficient": {
                     "value": 0
@@ -1707,23 +1684,23 @@
             "type": "lore"
         }
     ],
-    "name": "Sarglagon (AV)",
+    "name": "Beluthus",
     "system": {
         "abilities": {
             "cha": {
-                "mod": 3
+                "mod": 5
             },
             "con": {
-                "mod": 4
+                "mod": 5
             },
             "dex": {
                 "mod": 3
             },
             "int": {
-                "mod": 2
+                "mod": 5
             },
             "str": {
-                "mod": 6
+                "mod": 7
             },
             "wis": {
                 "mod": 4
@@ -1732,74 +1709,67 @@
         "attributes": {
             "ac": {
                 "details": "",
-                "value": 27
+                "value": 31
             },
             "allSaves": {
                 "value": "+1 status to all saves vs. magic"
             },
             "hp": {
-                "details": "",
-                "max": 120,
+                "details": "(negative healing)",
+                "max": 175,
                 "temp": 0,
-                "value": 120
+                "value": 175
             },
             "immunities": [
                 {
-                    "type": "fire"
+                    "type": "death-effects"
+                },
+                {
+                    "type": "disease"
+                },
+                {
+                    "type": "paralyzed"
+                },
+                {
+                    "type": "poison"
+                },
+                {
+                    "type": "spell-deflection"
+                },
+                {
+                    "type": "unconscious"
                 }
             ],
             "initiative": {
                 "ability": "perception"
             },
             "perception": {
-                "value": 18
+                "value": 22
             },
-            "resistances": [
-                {
-                    "exceptions": [
-                        "silver"
-                    ],
-                    "type": "physical",
-                    "value": 5
-                },
-                {
-                    "type": "poison",
-                    "value": 10
-                }
-            ],
             "speed": {
                 "otherSpeeds": [
                     {
                         "type": "fly",
-                        "value": 25
-                    },
-                    {
-                        "type": "swim",
                         "value": 30
                     }
                 ],
-                "value": 25
-            },
-            "weaknesses": [
-                {
-                    "type": "good",
-                    "value": 5
-                }
-            ]
+                "value": 30
+            }
         },
         "details": {
             "alignment": {
-                "value": "LE"
+                "value": "NE"
             },
-            "blurb": "",
-            "creatureType": "Fiend",
+            "blurb": "Male devourer (Pathfinder Bestiary 2 78)",
+            "creatureType": "Undead",
             "level": {
-                "value": 8
+                "value": 11
             },
             "privateNotes": "",
-            "publicNotes": "<p>Sarglagons dwell in Hell's myriad waterways, lakes, and oceans. They serve as guardians of the Academy of Lies-the repository of secrets in Stygia, the fifth layer of Hell. Sarglagons breathe water and air with equal ease, and can move through water, land, and even air with uncanny swiftness. Few fiends travel the waterways of the multiverse, but where a river crosses the planes, odds are sarglagons have traveled it to further their infernal machinations. The only body of water they avoid is the River Styx, as the fiends have yet to develop any defense against that waterway's memory-sapping qualities. Mortal spellcasters sometimes bind sarglagons as guardians of precious secrets or treasures, particularly in aquatic areas. Most strangely, sarglagons sometimes act as unnerving caretakers to mortals who have no idea what they did to earn their unwanted protectors' attention. The constant uninvited vigilance of these devils is often disturbing and stifling to their wards.</p>\n<hr />\n<p>Each type of devil plays a particular role in Hell's bureaucracies and hierarchies, though some have far more specialized functions than others.</p>",
+            "publicNotes": "<p>When fiends and powerful evil spellcasters are lost beyond the farthest reaches of the multiverse, they sometimes return as horrific undead called devourers that consume the souls of the living to fuel their arcane machinations. Their bodies are ruined and rebuilt, hollow and twisted, even as their minds undergo a spiritual transformation. They gain the ability to bind other souls to their own and drain their essence for magical power, yet can never be sated in their pursuit of it. Seething masses of distorted ghostly shapes surge within their hollow rib cages-manifestations of the devourers' most recently consumed souls.</p>",
             "source": {
-                "value": "Pathfinder #164: Hands of the Devil"
+                "author": "",
+                "value": "Pathfinder Abomination Vaults Hardcover Compilation"
             }
         },
         "resources": {
@@ -1811,15 +1781,15 @@
         "saves": {
             "fortitude": {
                 "saveDetail": "",
-                "value": 18
+                "value": 20
             },
             "reflex": {
                 "saveDetail": "",
-                "value": 13
+                "value": 18
             },
             "will": {
                 "saveDetail": "",
-                "value": 16
+                "value": 24
             }
         },
         "traits": {
@@ -1827,24 +1797,25 @@
                 "value": "hostile"
             },
             "languages": {
-                "custom": "Telepathy 100 feet",
+                "custom": "",
                 "selected": [],
                 "value": [
+                    "abyssal",
                     "celestial",
-                    "infernal"
+                    "common",
+                    "infernal",
+                    "necril"
                 ]
             },
-            "rarity": "common",
+            "rarity": "unique",
             "senses": {
-                "value": "greater darkvision; see invisibility"
+                "value": "darkvision"
             },
             "size": {
-                "value": "lg"
+                "value": "sm"
             },
             "value": [
-                "amphibious",
-                "devil",
-                "fiend"
+                "undead"
             ]
         }
     },

--- a/packs/data/abomination-vaults-bestiary.db/blood-of-belcorra.json
+++ b/packs/data/abomination-vaults-bestiary.db/blood-of-belcorra.json
@@ -52,6 +52,7 @@
             "ac": {
                 "value": 19
             },
+            "emitsSound": "encounter",
             "hardness": 0,
             "hasHealth": true,
             "hp": {
@@ -118,6 +119,7 @@
             }
         },
         "source": {
+            "author": "",
             "value": "Pathfinder #163: Ruins of Gauntlight"
         },
         "statusEffects": [],

--- a/packs/data/abomination-vaults-bestiary.db/bone-gladiator.json
+++ b/packs/data/abomination-vaults-bestiary.db/bone-gladiator.json
@@ -328,6 +328,7 @@
             "privateNotes": "",
             "publicNotes": "",
             "source": {
+                "author": "",
                 "value": "Pathfinder Abomination Vaults Hardcover Compilation"
             }
         },

--- a/packs/data/abomination-vaults-bestiary.db/caliddo-haruvex.json
+++ b/packs/data/abomination-vaults-bestiary.db/caliddo-haruvex.json
@@ -1,0 +1,1342 @@
+{
+    "_id": "oXnpdJVN6NIE58W3",
+    "img": "systems/pf2e/icons/default-icons/npc.svg",
+    "items": [
+        {
+            "_id": "Usuq1lTFnGGNGmOW",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.equipment-srd.dUC8Fsa6FZtVikS3"
+                }
+            },
+            "img": "systems/pf2e/icons/equipment/weapons/composite-longbow.webp",
+            "name": "Composite Longbow",
+            "sort": 100000,
+            "system": {
+                "MAP": {
+                    "value": ""
+                },
+                "baseItem": "composite-longbow",
+                "bonus": {
+                    "value": 0
+                },
+                "bonusDamage": {
+                    "value": 0
+                },
+                "category": "martial",
+                "containerId": null,
+                "damage": {
+                    "damageType": "piercing",
+                    "dice": 1,
+                    "die": "d8",
+                    "value": ""
+                },
+                "description": {
+                    "value": "<p>This projectile weapon is made from horn, wood, and sinew laminated together to increase the power of its pull and the force of its projectile. Like all longbows, its great size also increases the bow's range and power. You must use two hands to fire it, and it cannot be used while mounted. Any time an ability is specifically restricted to a longbow, such as Erastil's favored weapon, it also applies to composite longbows unless otherwise stated.</p>"
+                },
+                "equipped": {
+                    "carryType": "held",
+                    "handsHeld": 1,
+                    "invested": null
+                },
+                "equippedBulk": {
+                    "value": ""
+                },
+                "group": "bow",
+                "hardness": 0,
+                "hp": {
+                    "brokenThreshold": 0,
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "potencyRune": {
+                    "value": null
+                },
+                "preciousMaterial": {
+                    "value": null
+                },
+                "preciousMaterialGrade": {
+                    "value": null
+                },
+                "price": {
+                    "value": {
+                        "gp": 20
+                    }
+                },
+                "propertyRune1": {
+                    "value": ""
+                },
+                "propertyRune2": {
+                    "value": ""
+                },
+                "propertyRune3": {
+                    "value": ""
+                },
+                "propertyRune4": {
+                    "value": ""
+                },
+                "quantity": 1,
+                "range": 100,
+                "reload": {
+                    "value": "0"
+                },
+                "rules": [],
+                "size": "med",
+                "slug": "composite-longbow",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "specific": {
+                    "value": false
+                },
+                "splashDamage": {
+                    "value": 0
+                },
+                "stackGroup": null,
+                "strikingRune": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "deadly-d10",
+                        "propulsive",
+                        "volley-30"
+                    ]
+                },
+                "usage": {
+                    "value": "held-in-one-plus-hands"
+                },
+                "weight": {
+                    "value": "2"
+                }
+            },
+            "type": "weapon"
+        },
+        {
+            "_id": "yfLr23zjUHGPyekK",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.equipment-srd.UX71GkWBL9g41VwM"
+                }
+            },
+            "img": "systems/pf2e/icons/equipment/weapons/greatsword.webp",
+            "name": "Greatsword",
+            "sort": 200000,
+            "system": {
+                "MAP": {
+                    "value": ""
+                },
+                "baseItem": "greatsword",
+                "bonus": {
+                    "value": 0
+                },
+                "bonusDamage": {
+                    "value": 0
+                },
+                "category": "martial",
+                "containerId": null,
+                "damage": {
+                    "damageType": "slashing",
+                    "dice": 1,
+                    "die": "d12",
+                    "value": ""
+                },
+                "description": {
+                    "value": "<p>This immense two‑handed sword is nearly as tall as its wielder. Its lower blade is often somewhat dulled to allow it to be gripped for extra leverage in close‑quarter fights.</p>"
+                },
+                "equipped": {
+                    "carryType": "held",
+                    "handsHeld": 2,
+                    "invested": null
+                },
+                "equippedBulk": {
+                    "value": ""
+                },
+                "group": "sword",
+                "hardness": 0,
+                "hp": {
+                    "brokenThreshold": 0,
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "potencyRune": {
+                    "value": null
+                },
+                "preciousMaterial": {
+                    "value": null
+                },
+                "preciousMaterialGrade": {
+                    "value": null
+                },
+                "price": {
+                    "value": {
+                        "gp": 2
+                    }
+                },
+                "propertyRune1": {
+                    "value": ""
+                },
+                "propertyRune2": {
+                    "value": ""
+                },
+                "propertyRune3": {
+                    "value": ""
+                },
+                "propertyRune4": {
+                    "value": ""
+                },
+                "quantity": 1,
+                "range": null,
+                "reload": {
+                    "value": ""
+                },
+                "rules": [],
+                "size": "med",
+                "slug": "greatsword",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "specific": {
+                    "value": false
+                },
+                "splashDamage": {
+                    "value": 0
+                },
+                "stackGroup": null,
+                "strikingRune": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "versatile-p"
+                    ]
+                },
+                "usage": {
+                    "value": "held-in-two-hands"
+                },
+                "weight": {
+                    "value": "2"
+                }
+            },
+            "type": "weapon"
+        },
+        {
+            "_id": "vYamsmUJUWGVxqsL",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.equipment-srd.Gq1cZWSKOtJhKd2p"
+                }
+            },
+            "img": "systems/pf2e/icons/equipment//armor/fullplate.webp",
+            "name": "+1 Resilient Full Plate",
+            "sort": 300000,
+            "system": {
+                "armor": {
+                    "value": 6
+                },
+                "baseItem": "full-plate",
+                "category": "heavy",
+                "check": {
+                    "value": -3
+                },
+                "containerId": null,
+                "description": {
+                    "value": "<p>Plate mail consists of interlocking plates that encase nearly the entire body in a carapace of steel. It is costly and heavy, and the wearer often requires help to don it correctly, but it provides some of the best defense armor can supply. A suit of this armor comes with an undercoat of padded armor and a pair of gauntlets.</p>"
+                },
+                "dex": {
+                    "value": 0
+                },
+                "equipped": {
+                    "carryType": "worn",
+                    "inSlot": true,
+                    "invested": false
+                },
+                "equippedBulk": {
+                    "value": "4"
+                },
+                "group": "plate",
+                "hardness": 0,
+                "hp": {
+                    "brokenThreshold": 0,
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 2
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "potency": {},
+                "potencyRune": {
+                    "value": 1
+                },
+                "preciousMaterial": {
+                    "value": null
+                },
+                "preciousMaterialGrade": {
+                    "value": null
+                },
+                "price": {
+                    "value": {
+                        "gp": 30
+                    }
+                },
+                "propertyRune1": {
+                    "value": ""
+                },
+                "propertyRune2": {
+                    "value": ""
+                },
+                "propertyRune3": {
+                    "value": ""
+                },
+                "propertyRune4": {
+                    "value": ""
+                },
+                "quantity": 1,
+                "resiliencyRune": {
+                    "value": "resilient"
+                },
+                "rules": [],
+                "size": "med",
+                "slug": "full-plate",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "speed": {
+                    "value": -10
+                },
+                "stackGroup": null,
+                "strength": {
+                    "value": 18
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "bulwark"
+                    ]
+                },
+                "usage": {
+                    "value": "wornarmor"
+                },
+                "weight": {
+                    "value": "5"
+                }
+            },
+            "type": "armor"
+        },
+        {
+            "_id": "DSpF3QNsGXCQO5Re",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.equipment-srd.w2ENw2VMPcsbif8g"
+                }
+            },
+            "img": "systems/pf2e/icons/equipment/weapons/arrows.webp",
+            "name": "Arrows",
+            "sort": 400000,
+            "system": {
+                "autoDestroy": {
+                    "_deprecated": true,
+                    "value": true
+                },
+                "baseItem": null,
+                "charges": {
+                    "max": 0,
+                    "value": 0
+                },
+                "consumableType": {
+                    "value": "ammo"
+                },
+                "consume": {
+                    "value": ""
+                },
+                "containerId": null,
+                "description": {
+                    "value": "<p>These projectiles are the ammunition for bows. The shaft of an arrow is made of wood. It is stabilized in flight by fletching at one end and bears a metal head on the other.</p>"
+                },
+                "equipped": {
+                    "carryType": "held",
+                    "handsHeld": 1
+                },
+                "equippedBulk": {
+                    "value": ""
+                },
+                "hardness": 0,
+                "hp": {
+                    "brokenThreshold": 0,
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "preciousMaterial": {
+                    "value": ""
+                },
+                "preciousMaterialGrade": {
+                    "value": ""
+                },
+                "price": {
+                    "per": 10,
+                    "value": {
+                        "sp": 1
+                    }
+                },
+                "quantity": 20,
+                "rules": [],
+                "size": "med",
+                "slug": "arrows",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "stackGroup": "arrows",
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "usage": {
+                    "value": "held-in-one-hand"
+                },
+                "weight": {
+                    "value": "L"
+                }
+            },
+            "type": "consumable"
+        },
+        {
+            "_id": "ocPEHKgADYZ7WIYS",
+            "flags": {
+                "core": {
+                    "sourceId": "Item.chQYFKHvGRETJmhJ"
+                }
+            },
+            "img": "systems/pf2e/icons/equipment/held-items/key-ring-gold.webp",
+            "name": "Caliddo's Keys",
+            "sort": 500000,
+            "system": {
+                "baseItem": null,
+                "containerId": null,
+                "description": {
+                    "value": ""
+                },
+                "equipped": {
+                    "-=inSlot": null,
+                    "carryType": "worn",
+                    "handsHeld": 0
+                },
+                "equippedBulk": {
+                    "value": ""
+                },
+                "hardness": 0,
+                "hp": {
+                    "brokenThreshold": 0,
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "preciousMaterial": {
+                    "value": null
+                },
+                "preciousMaterialGrade": {
+                    "value": null
+                },
+                "price": {
+                    "value": {}
+                },
+                "quantity": 1,
+                "rules": [],
+                "size": "med",
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "stackGroup": null,
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "usage": {
+                    "value": ""
+                },
+                "weight": {
+                    "value": "-"
+                }
+            },
+            "type": "treasure"
+        },
+        {
+            "_id": "12LD6QHUzml95C9n",
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Frost Greatsword",
+            "sort": 600000,
+            "system": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "custom": "",
+                    "value": []
+                },
+                "bonus": {
+                    "value": 24
+                },
+                "damageRolls": {
+                    "eohgyhvhtgrdtl2k7kua": {
+                        "damage": "2d12+10",
+                        "damageType": "slashing"
+                    },
+                    "c9q7yk08hwk9j37lggiq": {
+                        "damage": "1d6",
+                        "damageType": "cold"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "cold",
+                        "magical",
+                        "versatile-p"
+                    ]
+                },
+                "weaponType": {
+                    "value": "melee"
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "4adEu2Sh2OYsvkLV",
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Fist",
+            "sort": 700000,
+            "system": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "custom": "",
+                    "value": []
+                },
+                "bonus": {
+                    "value": 23
+                },
+                "damageRolls": {
+                    "mgs4izgeqgvoi3r4d3r2": {
+                        "damage": "2d6+10",
+                        "damageType": "bludgeoning"
+                    },
+                    "eu9brchkzus9k057651g": {
+                        "damage": "1d6",
+                        "damageType": "cold"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "agile",
+                        "cold"
+                    ]
+                },
+                "weaponType": {
+                    "value": "melee"
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "XCfMmPXvB7LJznlU",
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Frost Composite Longbow",
+            "sort": 800000,
+            "system": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "custom": "",
+                    "value": []
+                },
+                "bonus": {
+                    "value": 21
+                },
+                "damageRolls": {
+                    "ykeryqhp11mn21lxueou": {
+                        "damage": "2d8+6",
+                        "damageType": "piercing"
+                    },
+                    "xrpg5ubgqwg6hoeo84gu": {
+                        "damage": "1d6",
+                        "damageType": "cold"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "cold",
+                        "deadly-d10",
+                        "magical",
+                        "range-increment-100",
+                        "reload-0",
+                        "volley-30"
+                    ]
+                },
+                "weaponType": {
+                    "value": "ranged"
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "yp7FDjO7715BHNPw",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.qCCLZhnp2HhP3Ex6"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Darkvision",
+            "sort": 900000,
+            "system": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Darkvision]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "darkvision",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "8R3jmOcyIfgNNdKr",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.TTCw5NusiSSkJU1x"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Negative Healing",
+            "sort": 1000000,
+            "system": {
+                "actionCategory": {
+                    "value": "defensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.NegativeHealing]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "system.attributes.hp.negativeHealing",
+                        "value": true
+                    }
+                ],
+                "slug": "negative-healing",
+                "source": {
+                    "value": "Pathfinder Bestiary 2"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "0Pe1uBGVehRLhBim",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.hFtNbo1LKYCoDy2O"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Reaction.webp",
+            "name": "Attack of Opportunity",
+            "sort": 1100000,
+            "system": {
+                "actionCategory": {
+                    "value": "defensive"
+                },
+                "actionType": {
+                    "value": "reaction"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.AttackOfOpportunity]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "attack-of-opportunity",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "oKuYToU9Nv9ALIIv",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-family-ability-glossary.ZIFaA4jDQjM0vq8q"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Rejuvenation",
+            "sort": 1200000,
+            "system": {
+                "actionCategory": {
+                    "value": "defensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "deathNote": true,
+                "description": {
+                    "value": "<p>When a graveknight is destroyed, its armor rebuilds its body over the course of [[/br 1d10 #days]]{1d10 days}-or more quickly if the armor is worn by a living host. If the body is destroyed before then, the process restarts.</p>\n<p>A graveknight can only be permanently destroyed by obliterating its armor (such as with <em>@UUID[Compendium.pf2e.spells-srd.Disintegrate]{Disintegrate}</em>), transporting it to the Positive Energy Plane, or throwing it into the heart of a volcano.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "graveknight-rejuvenation",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "divine",
+                        "necromancy"
+                    ]
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "xH6NrBw4bYEHU7e3",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-family-ability-glossary.bTJnxBQjr7G8yr30"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Sacrilegious Aura",
+            "sort": 1300000,
+            "system": {
+                "actionCategory": {
+                    "value": "defensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Template[type:emanation|distance:30]{30 feet} @UUID[Compendium.pf2e.bestiary-ability-glossary-srd.Aura]{Aura}</p>\n<hr />\n<p>When a creature in the aura uses a positive spell or ability, the graveknight automatically attempts to counteract it, with a counteract modifier of [[/r 1d20+17 #Counteract]]{+17}.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "graveknight-sacrilegious-aura",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "abjuration",
+                        "aura",
+                        "divine",
+                        "evil"
+                    ]
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "1UmNfowZ4HWxS9rx",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-family-ability-glossary.IxJbFJ8dG5RbZWBD"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Devastating Blast",
+            "sort": 1400000,
+            "system": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "description": {
+                    "value": "<p>The graveknight unleashes a @Template[type:cone|distance:30] of energy. Creatures in the area take [[/r 6d12[cold]]] damage (@Check[type:reflex|dc:29|basic:true] save).</p>\n<p>The graveknight can use this ability once every [[/br 1d4 #Recharge Devastating Blast]]{1d4 rounds}.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "graveknight-devastating-blast",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "arcane",
+                        "cold",
+                        "evocation"
+                    ]
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "snOrUVs5f8v8gtuP",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-family-ability-glossary.5dbzWZbiTyPKgwKS"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Graveknight's Curse",
+            "sort": 1500000,
+            "system": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>This curse affects anyone who wears a graveknight's armor for at least 1 hour.</p>\n<p><strong>Saving Throw</strong> @Check[type:will|dc:33] save</p>\n<hr />\n<p><strong>Onset</strong> 1 hour</p>\n<p><strong>Stage 1</strong> @UUID[Compendium.pf2e.conditionitems.Doomed]{Doomed 1} and cannot remove the armor (1 day)</p>\n<p><strong>Stage 2</strong> @UUID[Compendium.pf2e.conditionitems.Doomed]{Doomed 2}, the creature's Speed is reduced by 10, and cannot remove the armor (1 day)</p>\n<p><strong>Stage 3</strong> dies and transforms into the armor's graveknight.</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Effect: Graveknight's Curse]{Effect: Graveknight's Curse}</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "graveknight-graveknights-curse",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "arcane",
+                        "curse",
+                        "necromancy"
+                    ]
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "cYzNZC3Tju4useHD",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-family-ability-glossary.BgbSHRdkGH7raOgA"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/ThreeActions.webp",
+            "name": "Phantom Mount",
+            "sort": 1600000,
+            "system": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 3
+                },
+                "description": {
+                    "value": "<p>HP 58; AC 27, Fort +17, Ref +15, Will +14</p>\n<hr />\n<p>The graveknight summons a supernatural mount as per <em>@UUID[Compendium.pf2e.spells-srd.Phantom Steed]{Phantom Steed}</em>, heightened to a level equal to half the graveknight's level.</p>\n<p>Unlike <em>phantom steed</em>, the steed's AC and saving throw bonuses are all 4 lower than the graveknight's, and the steed has one-third the graveknight's Hit Points (rounded down).</p>\n<p>If the steed is destroyed, the graveknight must wait 1 hour before using this ability again.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "graveknight-phantom-mount",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "arcane",
+                        "conjuration",
+                        "summon"
+                    ]
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "t6KHJCiZXdNJnqxB",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-family-ability-glossary.6isn9nqnvfRrC1wW"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Weapon Master",
+            "sort": 1700000,
+            "system": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>The graveknight has access to the critical specialization effects of any weapons it wields.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [
+                    {
+                        "key": "Note",
+                        "outcome": [
+                            "criticalSuccess"
+                        ],
+                        "selector": "frost-greatsword-attack",
+                        "text": "PF2E.Item.Weapon.CriticalSpecialization.sword",
+                        "title": "{item|name}",
+                        "visibility": "gm"
+                    },
+                    {
+                        "key": "Note",
+                        "outcome": [
+                            "criticalSuccess"
+                        ],
+                        "selector": "fist-attack",
+                        "text": "PF2E.Item.Weapon.CriticalSpecialization.brawling",
+                        "title": "{item|name}",
+                        "visibility": "gm"
+                    },
+                    {
+                        "key": "Note",
+                        "outcome": [
+                            "criticalSuccess"
+                        ],
+                        "selector": "frost-composite-longbow-attack",
+                        "text": "PF2E.Item.Weapon.CriticalSpecialization.bow",
+                        "title": "{item|name}",
+                        "visibility": "gm"
+                    }
+                ],
+                "slug": "graveknight-weapon-master",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "1GsU8eXwhUC9xXyu",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Athletics",
+            "sort": 1800000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 23
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "lore"
+        },
+        {
+            "_id": "S7d8F6RUMUv74Lj9",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Intimidation",
+            "sort": 1900000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 22
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "lore"
+        },
+        {
+            "_id": "AstJsV2ZTVKdnMUq",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Religion",
+            "sort": 2000000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 19
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "lore"
+        },
+        {
+            "_id": "8CznKBBokxBMcUVf",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Warfare Lore",
+            "sort": 2100000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 20
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "lore"
+        }
+    ],
+    "name": "Caliddo Haruvex",
+    "system": {
+        "abilities": {
+            "cha": {
+                "mod": 5
+            },
+            "con": {
+                "mod": 4
+            },
+            "dex": {
+                "mod": 4
+            },
+            "int": {
+                "mod": 2
+            },
+            "str": {
+                "mod": 7
+            },
+            "wis": {
+                "mod": 3
+            }
+        },
+        "attributes": {
+            "ac": {
+                "details": "",
+                "value": 31
+            },
+            "allSaves": {
+                "value": ""
+            },
+            "hp": {
+                "details": "negative healing, rejuvenation",
+                "max": 175,
+                "temp": 0,
+                "value": 175
+            },
+            "immunities": [
+                {
+                    "type": "cold"
+                },
+                {
+                    "type": "death-effects"
+                },
+                {
+                    "type": "disease"
+                },
+                {
+                    "type": "paralyzed"
+                },
+                {
+                    "type": "poison"
+                },
+                {
+                    "type": "unconscious"
+                }
+            ],
+            "initiative": {
+                "ability": "perception"
+            },
+            "perception": {
+                "value": 19
+            },
+            "speed": {
+                "otherSpeeds": [],
+                "value": 25
+            }
+        },
+        "details": {
+            "alignment": {
+                "value": "LE"
+            },
+            "blurb": "Male graveknight (Pathfinder Bestiary 191)",
+            "creatureType": "Undead",
+            "level": {
+                "value": 10
+            },
+            "privateNotes": "",
+            "publicNotes": "<p>Graveknights are undead warriors granted unlife by a cursed suit of armor.</p>",
+            "source": {
+                "author": "",
+                "value": "Pathfinder Abomination Vaults Hardcover Compilation"
+            }
+        },
+        "resources": {},
+        "saves": {
+            "fortitude": {
+                "saveDetail": "",
+                "value": 21
+            },
+            "reflex": {
+                "saveDetail": "",
+                "value": 19
+            },
+            "will": {
+                "saveDetail": "",
+                "value": 18
+            }
+        },
+        "traits": {
+            "languages": {
+                "custom": "",
+                "selected": [],
+                "value": [
+                    "common",
+                    "necril"
+                ]
+            },
+            "rarity": "common",
+            "senses": {
+                "value": "darkvision"
+            },
+            "size": {
+                "value": "med"
+            },
+            "value": [
+                "undead"
+            ]
+        }
+    },
+    "type": "npc"
+}

--- a/packs/data/abomination-vaults-bestiary.db/child-of-belcorra.json
+++ b/packs/data/abomination-vaults-bestiary.db/child-of-belcorra.json
@@ -1,11 +1,11 @@
 {
-    "_id": "BOaM3pAuWl06Q6IZ",
+    "_id": "vHei0y2PKlXfxQ8Z",
     "img": "systems/pf2e/icons/default-icons/npc.svg",
     "items": [
         {
-            "_id": "zjVbARImBBAx6EKv",
+            "_id": "8SCH000Zv6X9BFPf",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "Vile Touch",
+            "name": "Fist",
             "sort": 100000,
             "system": {
                 "attack": {
@@ -13,15 +13,17 @@
                 },
                 "attackEffects": {
                     "custom": "",
-                    "value": []
+                    "value": [
+                        "bog-rot"
+                    ]
                 },
                 "bonus": {
-                    "value": 16
+                    "value": 14
                 },
                 "damageRolls": {
                     "0": {
-                        "damage": "2d8+8",
-                        "damageType": "negative"
+                        "damage": "2d6+5",
+                        "damageType": "bludgeoning"
                     }
                 },
                 "description": {
@@ -35,9 +37,7 @@
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": [
-                        "finesse"
-                    ]
+                    "value": []
                 },
                 "weaponType": {
                     "value": "melee"
@@ -46,54 +46,7 @@
             "type": "melee"
         },
         {
-            "_id": "C46qe4d4dQ5DqKp4",
-            "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "Vile Blowgun",
-            "sort": 200000,
-            "system": {
-                "attack": {
-                    "value": ""
-                },
-                "attackEffects": {
-                    "custom": "Range Increment 20ft",
-                    "value": [
-                        "spectral-corruption"
-                    ]
-                },
-                "bonus": {
-                    "value": 18
-                },
-                "damageRolls": {
-                    "nq95y207zrc43huqu4a9": {
-                        "damage": "3d6",
-                        "damageType": "negative"
-                    },
-                    "7pdb71okxfbcs5j9jn50": {
-                        "damage": "3d6",
-                        "damageType": "poison"
-                    }
-                },
-                "description": {
-                    "value": ""
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": "Pathfinder #165: Eyes of Empty Death"
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                },
-                "weaponType": {
-                    "value": "ranged"
-                }
-            },
-            "type": "melee"
-        },
-        {
-            "_id": "VzobMtkoa82xICPm",
+            "_id": "IFp4VK6X80nXiTJu",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.qCCLZhnp2HhP3Ex6"
@@ -101,7 +54,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Darkvision",
-            "sort": 300000,
+            "sort": 200000,
             "system": {
                 "actionCategory": {
                     "value": "interaction"
@@ -138,15 +91,15 @@
             "type": "action"
         },
         {
-            "_id": "9yk5MBYML8Z0OmtD",
+            "_id": "khwh43CDMROkIfgf",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.kdhbPaBMK1d1fpbA"
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.j2wsK6IsW5yMW1jW"
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy (with spectral thralls only)",
-            "sort": 400000,
+            "name": "Tremorsense (Imprecise) 30 feet",
+            "sort": 300000,
             "system": {
                 "actionCategory": {
                     "value": "interaction"
@@ -158,24 +111,20 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Telepathy]</p>"
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Tremorsense]</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
                 "rules": [],
-                "slug": "telepathy",
+                "slug": "tremorsense",
                 "source": {
                     "value": "Pathfinder Bestiary"
                 },
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": [
-                        "aura",
-                        "divination",
-                        "magical"
-                    ]
+                    "value": []
                 },
                 "trigger": {
                     "value": ""
@@ -187,7 +136,7 @@
             "type": "action"
         },
         {
-            "_id": "ZqBQutg0Cvs5YcxR",
+            "_id": "QaqXp54jr3aKQjWN",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.TTCw5NusiSSkJU1x"
@@ -195,7 +144,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Negative Healing",
-            "sort": 500000,
+            "sort": 400000,
             "system": {
                 "actionCategory": {
                     "value": "defensive"
@@ -239,15 +188,10 @@
             "type": "action"
         },
         {
-            "_id": "BPJS4QzIXUC3Zmwf",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.etMnv73EIdEZrYYu"
-                }
-            },
+            "_id": "HLcMADTgT1nixxce",
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Frightful Presence",
-            "sort": 600000,
+            "name": "Breath of the Bog",
+            "sort": 500000,
             "system": {
                 "actionCategory": {
                     "value": "defensive"
@@ -259,52 +203,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>@Template[type:emanation|distance:30]{30 feet} @UUID[Compendium.pf2e.bestiary-ability-glossary-srd.Aura]{Aura} @Check[type:will|dc:22]</p>\n<hr />\n<p>@Localize[PF2E.NPC.Abilities.Glossary.FrightfulPresence]</p>"
-                },
-                "requirements": {
-                    "value": ""
-                },
-                "rules": [],
-                "slug": "frightful-presence",
-                "source": {
-                    "value": "Pathfinder Bestiary"
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": [
-                        "aura",
-                        "emotion",
-                        "fear",
-                        "mental"
-                    ]
-                },
-                "trigger": {
-                    "value": ""
-                },
-                "weapon": {
-                    "value": ""
-                }
-            },
-            "type": "action"
-        },
-        {
-            "_id": "RGaUdIjwMpgnNYGg",
-            "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Pain Starvation",
-            "sort": 700000,
-            "system": {
-                "actionCategory": {
-                    "value": "defensive"
-                },
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "description": {
-                    "value": "<p>A specter that goes for more than a month without dealing negative damage to a living humanoid becomes desperate and almost feral. It changes alignment from lawful evil to chaotic evil, loses control of any corrupted thralls it might have, and becomes @UUID[Compendium.pf2e.conditionitems.Quickened]{Quickened}. It can use its additional action only to make vile touch Strikes against humanoid targets. At the end of any turn in which it deals any amount of negative damage to a living humanoid, it reverts to lawful evil and is no longer quickened, but any thralls it lost control of remain free.</p>"
+                    "value": "<p>@Template[type:emanation|distance:30]{30 feet} @UUID[Compendium.pf2e.bestiary-ability-glossary-srd.Aura]{Aura}</p>\n<hr />\n<p>A creature that begins its turn within the area feels as if its lungs were filling with water and must succeed at a @Check[type:fortitude|dc:19] save or be unable to speak or breathe. The creature can still hold its breath and can attempt a new saving throw at the end of its turn.</p>\n<p>A creature that succeeds is temporarily immune to breath of the bog for 24 hours.</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -318,7 +217,10 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "humanoid"
+                        "aura",
+                        "divine",
+                        "enchantment",
+                        "mental"
                     ]
                 },
                 "trigger": {
@@ -331,22 +233,22 @@
             "type": "action"
         },
         {
-            "_id": "qh8LFXVLWjILfZZx",
-            "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Sunlight Powerlessness",
-            "sort": 800000,
+            "_id": "AWNveQn0EQ1aYORU",
+            "img": "systems/pf2e/icons/actions/Reaction.webp",
+            "name": "Rise Up",
+            "sort": 600000,
             "system": {
                 "actionCategory": {
                     "value": "defensive"
                 },
                 "actionType": {
-                    "value": "passive"
+                    "value": "reaction"
                 },
                 "actions": {
                     "value": null
                 },
                 "description": {
-                    "value": "<p>A specter caught in sunlight is @UUID[Compendium.pf2e.conditionitems.Clumsy]{Clumsy 2} and @UUID[Compendium.pf2e.conditionitems.Slowed]{Slowed 2} for as long as it remains in the sunlight.</p>"
+                    "value": "<p><strong>Trigger</strong> A creature walks on top of a bog mummy that lies buried in the mud or peat below</p>\n<p><strong>Requirements</strong> Initiative has not yet been rolled</p>\n<hr />\n<p><strong>Effect</strong> The bog mummy automatically notices the creature and Burrows before rolling initiative.</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -371,22 +273,22 @@
             "type": "action"
         },
         {
-            "_id": "OSiq1CXChzTT7udW",
-            "img": "systems/pf2e/icons/actions/TwoActions.webp",
-            "name": "Spectral Corruption",
-            "sort": 900000,
+            "_id": "XmKUjz23s0dNFOYW",
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Bog Rot",
+            "sort": 700000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
                 },
                 "actionType": {
-                    "value": "action"
+                    "value": "passive"
                 },
                 "actions": {
-                    "value": 2
+                    "value": null
                 },
                 "description": {
-                    "value": "<p>The specter makes a vile touch Strike. If it damages a living creature, the specter gains 5 temporary Hit Points and the target creature must attempt a @Check[type:will|dc:24] save to avoid becoming corrupted.</p>\n<hr />\n<p><strong>Critical Success</strong> The creature is unaffected and is temporarily immune to spectral corruption for 1 minute.</p>\n<p><strong>Success</strong> The creature is @UUID[Compendium.pf2e.conditionitems.Stupefied]{Stupefied 2} for 1 hour.</p>\n<p><strong>Failure</strong> The creature succumbs to the corruption and becomes a spectral thrall temporarily. The creature is @UUID[Compendium.pf2e.conditionitems.Controlled]{Controlled} by the specter, obeying the specter's telepathic or spoken orders, though a spectral thrall does not obey obviously self-destructive orders. This lasts until the end of the thrall's next turn, at which point it is no longer controlled but becomes @UUID[Compendium.pf2e.conditionitems.Stupefied]{Stupefied 2} for 1 hour.</p>\n<p><strong>Critical Failure</strong> As failure, but the duration is unlimited. The thrall can attempt a new Will save at the end of each of its turns; on a success, it is no longer controlled by the specter but becomes @UUID[Compendium.pf2e.conditionitems.Stupefied]{Stupefied 2} for 1 hour.</p>"
+                    "value": "<p>This affliction can't be reduced below stage 1, nor can the damage from it be healed, until it's successfully treated with <em>@UUID[Compendium.pf2e.spells-srd.Remove Curse]{Remove Curse}</em> or a similar effect; the affliction can then be removed as normal for a disease. A creature killed by bog rot melts into a noxious sludge and can't be resurrected except by a 7th‑level <em>@UUID[Compendium.pf2e.spells-srd.Resurrect]{Resurrect}</em> ritual or similar magic</p>\n<hr />\n<p><strong>Saving Throw</strong> @Check[type:fortitude|dc:21]</p>\n<hr />\n<p><strong>Stage 1</strong> carrier with no ill effect (1 minute)</p>\n<p><strong>Stage 2</strong> [[/r 3d6[negative]]] damage and @UUID[Compendium.pf2e.conditionitems.Clumsy]{Clumsy 1} (1 day)</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -401,10 +303,10 @@
                     "rarity": "common",
                     "value": [
                         "curse",
+                        "disease",
                         "divine",
-                        "enchantment",
-                        "incapacitation",
-                        "mental"
+                        "necromancy",
+                        "negative"
                     ]
                 },
                 "trigger": {
@@ -417,16 +319,16 @@
             "type": "action"
         },
         {
-            "_id": "R9IAepGCjja3f9FP",
+            "_id": "3IrzjRB89Xfvuqf2",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Acrobatics",
-            "sort": 1000000,
+            "name": "Athletics",
+            "sort": 800000,
             "system": {
                 "description": {
                     "value": ""
                 },
                 "mod": {
-                    "value": 17
+                    "value": 12
                 },
                 "proficient": {
                     "value": 0
@@ -445,49 +347,31 @@
             "type": "lore"
         },
         {
-            "_id": "7Sy3VLJjVY7IdW0F",
-            "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Intimidation",
-            "sort": 1100000,
-            "system": {
-                "description": {
-                    "value": ""
-                },
-                "mod": {
-                    "value": 15
-                },
-                "proficient": {
-                    "value": 0
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                }
-            },
-            "type": "lore"
-        },
-        {
-            "_id": "C1gCdCYUAoqjpkXr",
+            "_id": "bo6bsp0fKrJ9ddNK",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Stealth",
-            "sort": 1200000,
+            "sort": 900000,
             "system": {
                 "description": {
                     "value": ""
                 },
                 "mod": {
-                    "value": 17
+                    "value": 11
                 },
                 "proficient": {
                     "value": 0
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "label": "PF2E.SkillVariant.Buried",
+                        "predicate": [
+                            "buried"
+                        ],
+                        "selector": "stealth",
+                        "value": 2
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""
@@ -496,49 +380,52 @@
                     "custom": "",
                     "rarity": "common",
                     "value": []
+                },
+                "variants": {
+                    "0": {
+                        "label": "+13 while buried in a bog",
+                        "options": "buried"
+                    }
                 }
             },
             "type": "lore"
         }
     ],
-    "name": "Specter (AV C2)",
-    "prototypeToken": {
-        "name": "Specter"
-    },
+    "name": "Child of Belcorra",
     "system": {
         "abilities": {
             "cha": {
-                "mod": 4
+                "mod": 0
             },
             "con": {
-                "mod": 4
+                "mod": 0
             },
             "dex": {
-                "mod": 6
+                "mod": 2
             },
             "int": {
                 "mod": 0
             },
             "str": {
-                "mod": -5
+                "mod": 5
             },
             "wis": {
-                "mod": 4
+                "mod": 1
             }
         },
         "attributes": {
             "ac": {
                 "details": "",
-                "value": 25
+                "value": 21
             },
             "allSaves": {
                 "value": ""
             },
             "hp": {
                 "details": "negative healing",
-                "max": 95,
+                "max": 85,
                 "temp": 0,
-                "value": 95
+                "value": 85
             },
             "immunities": [
                 {
@@ -554,9 +441,6 @@
                     "type": "poison"
                 },
                 {
-                    "type": "precision"
-                },
-                {
                     "type": "unconscious"
                 }
             ],
@@ -564,45 +448,44 @@
                 "ability": "perception"
             },
             "perception": {
-                "value": 15
+                "value": 12
             },
             "resistances": [
                 {
-                    "doubleVs": [
-                        "non-magical"
-                    ],
-                    "exceptions": [
-                        "force",
-                        "ghost-touch",
-                        "positive"
-                    ],
-                    "type": "all-damage",
+                    "type": "fire",
                     "value": 5
                 }
             ],
             "speed": {
                 "otherSpeeds": [
                     {
-                        "type": "fly",
-                        "value": 40
+                        "type": "burrow",
+                        "value": 15
                     }
                 ],
-                "value": 0
-            }
+                "value": 20
+            },
+            "weaknesses": [
+                {
+                    "type": "cold",
+                    "value": 5
+                }
+            ]
         },
         "details": {
             "alignment": {
                 "value": "LE"
             },
-            "blurb": "",
-            "creatureType": "Undead",
+            "blurb": "Bog mummy (Pathfinder Bestiary 2 177)",
+            "creatureType": "",
             "level": {
-                "value": 7
+                "value": 5
             },
             "privateNotes": "",
-            "publicNotes": "<p>When an evil mortal creature dies, it sometimes returns to haunt the area of its death as a specter, a hateful remnant, always seeking to slay others-particularly humanoids-in an attempt to distribute its pain among as many souls as it can. A specter maintains a strange semblance of its prior identity, but with a corrupted sense of purpose. It cannot be reasoned with.</p>\n<p>A specter denied the opportunity to harm living humanoids grows increasingly agonized and irrational, akin to the mindset of a starving person forever denied a release from agony through death.</p>",
+            "publicNotes": "<p>The cultural practice of mummifying the dead is not the only way a body can become preserved, nor is it the only route that gives rise to these disease-spreading undead monstrosities.</p>\n<p>Bog mummies (also called peat mummies or mire mummies) rarely, if ever, leave their marshy realms. Less powerful than their more notorious artificially preserved kin, bog mummies are preserved not by agents introduced during rituals but by the natural elements present in the airless, acidic morass of a peat bog or muddy swamp. While corpses preserved in this manner can certainly rise from the mire as bog mummies as the result of a curse by fell powers or the directed influence of a necromancer, the vast majority of them animate from a seething need for vengeance or to pursue some dire agenda left unfinished at the time of death-often because the creature was slain or otherwise betrayed. The nature of tthis emotional tie to life and the emotional power of the deceased compel unlife beyond death, while the preservative qualities of the bog within which the body was disposed of does the rest.</p>\n<p>Although most bog mummies are motivated by vengeance, many fulfill their dark yearnings with general violence. Filled with wrath and hatred for the living, they mercilessly attack any living creatures that dare to venture into their dismal domains. Their agonized moans echo over their putrid homes, driving away most natural life dwelling therein and often alerting travelers to the potential danger that lies beneath the surface.</p>",
             "source": {
-                "value": "Pathfinder #165: Eyes of Empty Death"
+                "author": "",
+                "value": "Pathfinder Abomination Vaults Hardcover Compilation"
             }
         },
         "resources": {},
@@ -613,11 +496,11 @@
             },
             "reflex": {
                 "saveDetail": "",
-                "value": 17
+                "value": 9
             },
             "will": {
                 "saveDetail": "",
-                "value": 15
+                "value": 14
             }
         },
         "traits": {
@@ -625,22 +508,23 @@
                 "value": "hostile"
             },
             "languages": {
-                "custom": "Telepathy 100 feet (with spectral thralls only)",
+                "custom": "",
                 "selected": [],
                 "value": [
                     "common",
-                    "necril"
+                    "gnomish",
+                    "undercommon"
                 ]
             },
-            "rarity": "common",
+            "rarity": "uncommon",
             "senses": {
-                "value": "darkvision"
+                "value": "darkvision, tremorsense (imprecise) 30 feet"
             },
             "size": {
-                "value": "med"
+                "value": "sm"
             },
             "value": [
-                "incorporeal",
+                "mummy",
                 "undead"
             ]
         }

--- a/packs/data/abomination-vaults-bestiary.db/cynemi.json
+++ b/packs/data/abomination-vaults-bestiary.db/cynemi.json
@@ -1,0 +1,1063 @@
+{
+    "_id": "wpbX9U3IQCLNMgnu",
+    "img": "systems/pf2e/icons/default-icons/npc.svg",
+    "items": [
+        {
+            "_id": "arDGZY8hNXNpXdzm",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.equipment-srd.62nnVQvGhoVLLl2K"
+                }
+            },
+            "img": "systems/pf2e/icons/equipment/weapons/crossbow.webp",
+            "name": "Crossbow",
+            "sort": 100000,
+            "system": {
+                "MAP": {
+                    "value": ""
+                },
+                "baseItem": "crossbow",
+                "bonus": {
+                    "value": 0
+                },
+                "bonusDamage": {
+                    "value": 0
+                },
+                "category": "simple",
+                "containerId": null,
+                "damage": {
+                    "damageType": "piercing",
+                    "dice": 1,
+                    "die": "d8",
+                    "value": ""
+                },
+                "description": {
+                    "value": "<p>This ranged weapon has a bow-like assembly mounted on a handled frame called a tiller. The tiller has a mechanism to lock the bowstring in place, attached to a trigger mechanism that releases the tension and launches a bolt.</p>"
+                },
+                "equipped": {
+                    "carryType": "worn",
+                    "handsHeld": 2,
+                    "invested": null
+                },
+                "equippedBulk": {
+                    "value": ""
+                },
+                "group": "bow",
+                "hardness": 0,
+                "hp": {
+                    "brokenThreshold": 0,
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "potencyRune": {
+                    "value": null
+                },
+                "preciousMaterial": {
+                    "value": null
+                },
+                "preciousMaterialGrade": {
+                    "value": null
+                },
+                "price": {
+                    "value": {
+                        "gp": 3
+                    }
+                },
+                "propertyRune1": {
+                    "value": ""
+                },
+                "propertyRune2": {
+                    "value": ""
+                },
+                "propertyRune3": {
+                    "value": ""
+                },
+                "propertyRune4": {
+                    "value": ""
+                },
+                "quantity": 1,
+                "range": 120,
+                "reload": {
+                    "value": "1"
+                },
+                "rules": [],
+                "size": "med",
+                "slug": "crossbow",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "specific": {
+                    "value": false
+                },
+                "splashDamage": {
+                    "value": 0
+                },
+                "stackGroup": null,
+                "strikingRune": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "usage": {
+                    "value": "held-in-two-hands"
+                },
+                "weight": {
+                    "value": "1"
+                }
+            },
+            "type": "weapon"
+        },
+        {
+            "_id": "3pl6hjblsvIsJ7Xy",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.equipment-srd.XGtIUZ4ZNKuFx1uL"
+                }
+            },
+            "img": "systems/pf2e/icons/equipment/weapons/falchion.webp",
+            "name": "Falchion",
+            "sort": 200000,
+            "system": {
+                "MAP": {
+                    "value": ""
+                },
+                "baseItem": "falchion",
+                "bonus": {
+                    "value": 0
+                },
+                "bonusDamage": {
+                    "value": 0
+                },
+                "category": "martial",
+                "containerId": null,
+                "damage": {
+                    "damageType": "slashing",
+                    "dice": 1,
+                    "die": "d10",
+                    "value": ""
+                },
+                "description": {
+                    "value": "<p>This weapon is a heavier, two‑handed version of the curved‑bladed scimitar. It is weighted toward the blade's end, making it a powerful slashing weapon.</p>"
+                },
+                "equipped": {
+                    "carryType": "worn",
+                    "handsHeld": 2,
+                    "invested": null
+                },
+                "equippedBulk": {
+                    "value": ""
+                },
+                "group": "sword",
+                "hardness": 0,
+                "hp": {
+                    "brokenThreshold": 0,
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "potencyRune": {
+                    "value": null
+                },
+                "preciousMaterial": {
+                    "value": null
+                },
+                "preciousMaterialGrade": {
+                    "value": null
+                },
+                "price": {
+                    "value": {
+                        "gp": 3
+                    }
+                },
+                "propertyRune1": {
+                    "value": ""
+                },
+                "propertyRune2": {
+                    "value": ""
+                },
+                "propertyRune3": {
+                    "value": ""
+                },
+                "propertyRune4": {
+                    "value": ""
+                },
+                "quantity": 1,
+                "range": null,
+                "reload": {
+                    "value": ""
+                },
+                "rules": [],
+                "size": "med",
+                "slug": "falchion",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "specific": {
+                    "value": false
+                },
+                "splashDamage": {
+                    "value": 0
+                },
+                "stackGroup": null,
+                "strikingRune": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "forceful",
+                        "sweep"
+                    ]
+                },
+                "usage": {
+                    "value": "held-in-two-hands"
+                },
+                "weight": {
+                    "value": "2"
+                }
+            },
+            "type": "weapon"
+        },
+        {
+            "_id": "ZtaTXGSRwSp84X9P",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.equipment-srd.ewQZ0VeL38v3qFnN"
+                }
+            },
+            "img": "systems/pf2e/icons/equipment/armor/studded-leather-armor.webp",
+            "name": "Studded Leather Armor",
+            "sort": 300000,
+            "system": {
+                "armor": {
+                    "value": 2
+                },
+                "baseItem": "studded-leather-armor",
+                "category": "light",
+                "check": {
+                    "value": -1
+                },
+                "containerId": null,
+                "description": {
+                    "value": "<p>This leather armor is reinforced with metal studs and sometimes small metal plates, providing most of the flexibility of leather armor with more robust protection.</p>"
+                },
+                "dex": {
+                    "value": 3
+                },
+                "equipped": {
+                    "carryType": "worn",
+                    "inSlot": true,
+                    "invested": null
+                },
+                "equippedBulk": {
+                    "value": "1"
+                },
+                "group": "leather",
+                "hardness": 0,
+                "hp": {
+                    "brokenThreshold": 0,
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "potency": {},
+                "potencyRune": {
+                    "value": 0
+                },
+                "preciousMaterial": {
+                    "value": ""
+                },
+                "preciousMaterialGrade": {
+                    "value": ""
+                },
+                "price": {
+                    "value": {
+                        "gp": 3
+                    }
+                },
+                "propertyRune1": {
+                    "value": ""
+                },
+                "propertyRune2": {
+                    "value": ""
+                },
+                "propertyRune3": {
+                    "value": ""
+                },
+                "propertyRune4": {
+                    "value": ""
+                },
+                "quantity": 1,
+                "resiliencyRune": {
+                    "value": ""
+                },
+                "rules": [],
+                "size": "med",
+                "slug": "studded-leather-armor",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "speed": {
+                    "value": 0
+                },
+                "stackGroup": null,
+                "strength": {
+                    "value": 12
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "usage": {
+                    "value": "wornarmor"
+                },
+                "weight": {
+                    "value": "2"
+                }
+            },
+            "type": "armor"
+        },
+        {
+            "_id": "rv36OpZSFSkUYFxn",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.equipment-srd.ckGYDocGEaelHfXF"
+                }
+            },
+            "img": "systems/pf2e/icons/equipment/adventuring-gear/manacles.webp",
+            "name": "Manacles (Simple)",
+            "sort": 400000,
+            "system": {
+                "baseItem": null,
+                "containerId": null,
+                "description": {
+                    "value": "<p>You can manacle someone who is willing or otherwise at your mercy as an exploration activity taking 10-30 seconds depending on the creature's size and how many manacles you apply. A two‑legged creature with its legs bound takes a -15‑foot circumstance penalty to its Speeds, and a two‑handed creature with its wrists bound has to succeed at a @Check[type:flat|dc:5] any time it uses a manipulate action or else that action fails. This DC may be higher depending on how tightly the manacles constrain the hands. A creature bound to a stationary object is immobilized. For creatures with more or fewer limbs, the GM determines what effect manacles have, if any. Freeing a creature from simple manacles requires three successful @Check[type:thievery|dc:22|traits:action:pick-a-lock] checks.</p>"
+                },
+                "equipped": {
+                    "carryType": "worn",
+                    "handsHeld": 1,
+                    "invested": null
+                },
+                "equippedBulk": {
+                    "value": ""
+                },
+                "hardness": 0,
+                "hp": {
+                    "brokenThreshold": 0,
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 1
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "preciousMaterial": {
+                    "value": ""
+                },
+                "preciousMaterialGrade": {
+                    "value": ""
+                },
+                "price": {
+                    "value": {
+                        "gp": 3
+                    }
+                },
+                "quantity": 1,
+                "rules": [],
+                "size": "med",
+                "slug": "manacles-simple",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "stackGroup": null,
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "usage": {
+                    "value": "held-in-one-hand"
+                },
+                "weight": {
+                    "value": "-"
+                }
+            },
+            "type": "equipment"
+        },
+        {
+            "_id": "WFjlJ6mxuYpYbPzh",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.equipment-srd.AITVZmakiu3RgfKo"
+                }
+            },
+            "img": "systems/pf2e/icons/equipment/weapons/bolts.webp",
+            "name": "Bolts",
+            "sort": 500000,
+            "system": {
+                "autoDestroy": {
+                    "_deprecated": true,
+                    "value": true
+                },
+                "baseItem": null,
+                "charges": {
+                    "max": 0,
+                    "value": 0
+                },
+                "consumableType": {
+                    "value": "ammo"
+                },
+                "consume": {
+                    "value": ""
+                },
+                "containerId": null,
+                "description": {
+                    "value": "<p>Shorter than traditional arrows but similar in construction, bolts are the ammunition used by crossbows.</p>"
+                },
+                "equipped": {
+                    "carryType": "worn",
+                    "handsHeld": 1
+                },
+                "equippedBulk": {
+                    "value": ""
+                },
+                "hardness": 0,
+                "hp": {
+                    "brokenThreshold": 0,
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "preciousMaterial": {
+                    "value": ""
+                },
+                "preciousMaterialGrade": {
+                    "value": ""
+                },
+                "price": {
+                    "per": 10,
+                    "value": {
+                        "sp": 1
+                    }
+                },
+                "quantity": 10,
+                "rules": [],
+                "size": "med",
+                "slug": "bolts",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "stackGroup": "bolts",
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "usage": {
+                    "value": "held-in-one-hand"
+                },
+                "weight": {
+                    "value": "L"
+                }
+            },
+            "type": "consumable"
+        },
+        {
+            "_id": "erMgbyNlTUBjOhqo",
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Falchion",
+            "sort": 600000,
+            "system": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "value": []
+                },
+                "bonus": {
+                    "value": 13
+                },
+                "damageRolls": {
+                    "0": {
+                        "damage": "1d10+6",
+                        "damageType": "slashing"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "forceful",
+                        "sweep"
+                    ]
+                },
+                "weaponType": {
+                    "value": "melee"
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "MpZVk32vk8f54dFz",
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Crossbow",
+            "sort": 700000,
+            "system": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "value": []
+                },
+                "bonus": {
+                    "value": 14
+                },
+                "damageRolls": {
+                    "0": {
+                        "damage": "1d10+5",
+                        "damageType": "piercing"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "range-increment-120",
+                        "reload-1"
+                    ]
+                },
+                "weaponType": {
+                    "value": "ranged"
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "zGmpKyEbryTC7eYm",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.qCCLZhnp2HhP3Ex6"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Darkvision",
+            "sort": 800000,
+            "system": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Darkvision]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "darkvision",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "mCWRIeeB6PFExTmR",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Hunt Prey",
+            "sort": 900000,
+            "system": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "description": {
+                    "value": "<p>The bounty hunter designates a single creature they can see and hear, or one they're @UUID[Compendium.pf2e.actionspf2e.Track]{Tracking}, as their prey. The bounty hunter gains a +2 circumstance bonus to Perception checks to @UUID[Compendium.pf2e.actionspf2e.Seek]{Seek} the prey and to Survival checks to @UUID[Compendium.pf2e.actionspf2e.Track]{Track} the prey. This effect lasts until the bounty hunter uses again.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [
+                    {
+                        "domain": "all",
+                        "key": "RollOption",
+                        "label": "Target is your Hunted Prey",
+                        "option": "hunted-prey",
+                        "toggleable": true
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "label": "To Seek hunted prey",
+                        "predicate": [
+                            "action:seek",
+                            "hunted-prey"
+                        ],
+                        "selector": "perception",
+                        "type": "circumstance",
+                        "value": 2
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "label": "To Track hunted prey",
+                        "predicate": [
+                            "action:track",
+                            "hunted-prey"
+                        ],
+                        "selector": "survival",
+                        "type": "circumstance",
+                        "value": 2
+                    }
+                ],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "concentrate"
+                    ]
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "LvkfpNccs65oqyIV",
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Precision Edge",
+            "sort": 1000000,
+            "system": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>The first time the bounty hunter hits their hunted prey in a round, they deal an additional [[/r {1d8}[precision]]]{1d8 precision damage}.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [
+                    {
+                        "domain": "all",
+                        "key": "RollOption",
+                        "label": "First attack on hunted prey this round",
+                        "option": "first-attack",
+                        "toggleable": true
+                    },
+                    {
+                        "category": "precision",
+                        "diceNumber": 1,
+                        "dieSize": "d8",
+                        "key": "DamageDice",
+                        "predicate": [
+                            "first-attack"
+                        ],
+                        "selector": "strike-damage"
+                    }
+                ],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "hyLN8l8Z2WSxFAXC",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Running Reload",
+            "sort": 1100000,
+            "system": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "description": {
+                    "value": "<p>The bounty hunter Strides, Steps, or Sneaks, and then Interacts to reload.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "lqqJDGw4bC8Rh91b",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Athletics",
+            "sort": 1200000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 9
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "lore"
+        },
+        {
+            "_id": "7MFFqJUN71HMDRPO",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Deception",
+            "sort": 1300000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 10
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "lore"
+        },
+        {
+            "_id": "xZUuNnLSlhxJDPXp",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Diplomacy",
+            "sort": 1400000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 8
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "lore"
+        },
+        {
+            "_id": "Q1rcAhFn2e8Eg1u6",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Intimidation",
+            "sort": 1500000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 8
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "lore"
+        },
+        {
+            "_id": "MW6uskSg6bn9Et9M",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Stealth",
+            "sort": 1600000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 12
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "lore"
+        },
+        {
+            "_id": "VFWz95hTWjVaRyQL",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Survival",
+            "sort": 1700000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 10
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "lore"
+        }
+    ],
+    "name": "Cynemi",
+    "system": {
+        "abilities": {
+            "cha": {
+                "mod": 1
+            },
+            "con": {
+                "mod": 1
+            },
+            "dex": {
+                "mod": 4
+            },
+            "int": {
+                "mod": 0
+            },
+            "str": {
+                "mod": 3
+            },
+            "wis": {
+                "mod": 4
+            }
+        },
+        "attributes": {
+            "ac": {
+                "details": "",
+                "value": 21
+            },
+            "allSaves": {
+                "value": ""
+            },
+            "hp": {
+                "details": "",
+                "max": 60,
+                "temp": 0,
+                "value": 60
+            },
+            "initiative": {
+                "ability": "perception"
+            },
+            "perception": {
+                "value": 14
+            },
+            "speed": {
+                "otherSpeeds": [],
+                "value": 25
+            }
+        },
+        "details": {
+            "alignment": {
+                "value": "NE"
+            },
+            "blurb": "",
+            "creatureType": "",
+            "level": {
+                "value": 4
+            },
+            "privateNotes": "",
+            "publicNotes": "<p>Bounty hunters are constantly on the move, whether within city walls or the wilderness, trailing their fugitive quarries for capture... or disposal. Often relying on stealth or deception as much as martial skill, bounty hunters employ a vast array of talents to accomplish their goals, not to mention to collect the hefty payout that follows.</p>\n<hr />\n<p>A broad category that includes those wielding arms, spells, or even guile and cunning, mercenaries hire themselves and their expertise to those with the gold to pay for it.</p>",
+            "source": {
+                "author": "",
+                "value": "Pathfinder Abomination Vaults Hardcover Compilation"
+            }
+        },
+        "resources": {},
+        "saves": {
+            "fortitude": {
+                "saveDetail": "",
+                "value": 9
+            },
+            "reflex": {
+                "saveDetail": "",
+                "value": 12
+            },
+            "will": {
+                "saveDetail": "",
+                "value": 12
+            }
+        },
+        "traits": {
+            "languages": {
+                "custom": "",
+                "selected": [],
+                "value": [
+                    "common"
+                ]
+            },
+            "rarity": "common",
+            "senses": {
+                "value": "Darkvision"
+            },
+            "size": {
+                "value": "med"
+            },
+            "value": [
+                "human",
+                "humanoid"
+            ]
+        }
+    },
+    "type": "npc"
+}

--- a/packs/data/abomination-vaults-bestiary.db/deadtide-skeleton-guard.json
+++ b/packs/data/abomination-vaults-bestiary.db/deadtide-skeleton-guard.json
@@ -199,7 +199,7 @@
             "type": "lore"
         }
     ],
-    "name": "Skeleton Guard (AV-Graveyard)",
+    "name": "Deadtide Skeleton Guard",
     "prototypeToken": {
         "name": "Skeleton Guard"
     },
@@ -300,7 +300,8 @@
             "privateNotes": "",
             "publicNotes": "<p>The most common skeletal minions are mere guardians.</p>\n<hr />\n<p>Made from bones held together by foul necromancy, skeletons are among the most common types of undead, found haunting old dungeons and forgotten cemeteries.</p>",
             "source": {
-                "value": "Pathfinder #163: Ruins of Gauntlight"
+                "author": "",
+                "value": "Pathfinder Abomination Vaults Hardcover Compilation"
             }
         },
         "resources": {},

--- a/packs/data/abomination-vaults-bestiary.db/deep-end-sarglagon.json
+++ b/packs/data/abomination-vaults-bestiary.db/deep-end-sarglagon.json
@@ -1,11 +1,11 @@
 {
-    "_id": "lMCEVxKkQ7XK6Nid",
+    "_id": "To0MLA0arpkiE6Cz",
     "img": "systems/pf2e/icons/default-icons/npc.svg",
     "items": [
         {
-            "_id": "72UcADd2WTnoNikm",
+            "_id": "xxK8rXRDWK5Rwj9i",
             "img": "systems/pf2e/icons/default-icons/spellcastingEntry.svg",
-            "name": "Occult Prepared Spells",
+            "name": "Divine Innate Spells",
             "sort": 100000,
             "system": {
                 "autoHeightenLevel": {
@@ -17,50 +17,27 @@
                 "displayLevels": {},
                 "prepared": {
                     "flexible": false,
-                    "value": "prepared"
+                    "value": "innate"
                 },
                 "proficiency": {
                     "value": 0
                 },
                 "rules": [],
                 "showSlotlessLevels": {
-                    "value": true
+                    "value": false
                 },
                 "showUnpreparedSpells": {
-                    "value": false
+                    "value": true
                 },
                 "slots": {
                     "slot0": {
-                        "max": 4,
-                        "prepared": {
-                            "0": {
-                                "id": "FRpITFNe7xRIVZP2"
-                            },
-                            "1": {
-                                "id": "862lyQvkK6EvVa2L"
-                            },
-                            "2": {
-                                "id": "xiPg19A6nSvNNq01"
-                            },
-                            "3": {
-                                "id": "MeKNMAkmYZr95eiD"
-                            }
-                        },
+                        "max": 0,
+                        "prepared": [],
                         "value": 0
                     },
                     "slot1": {
-                        "max": 3,
-                        "prepared": {
-                            "0": {
-                                "id": "0yFEddWFSXXoDRWf"
-                            },
-                            "1": {
-                                "id": "JTeXI3EO1DL4s7la"
-                            },
-                            "2": {
-                                "id": "GROhmkvgbl3r5dcX"
-                            }
-                        },
+                        "max": 0,
+                        "prepared": [],
                         "value": 0
                     },
                     "slot10": {
@@ -74,15 +51,8 @@
                         "value": 0
                     },
                     "slot2": {
-                        "max": 2,
-                        "prepared": {
-                            "0": {
-                                "id": "ByttjgQGaNt4eCid"
-                            },
-                            "1": {
-                                "id": "fOxB5yFfPicIwgcO"
-                            }
-                        },
+                        "max": 0,
+                        "prepared": [],
                         "value": 0
                     },
                     "slot3": {
@@ -126,13 +96,12 @@
                     "value": ""
                 },
                 "spelldc": {
-                    "dc": 20,
-                    "item": 0,
+                    "dc": 23,
                     "mod": 0,
-                    "value": 12
+                    "value": 18
                 },
                 "tradition": {
-                    "value": "occult"
+                    "value": "divine"
                 },
                 "traits": {
                     "custom": "",
@@ -143,136 +112,123 @@
             "type": "spellcastingEntry"
         },
         {
-            "_id": "FRpITFNe7xRIVZP2",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.mAMEt4FFbdqoRnkN"
-                }
-            },
-            "img": "systems/pf2e/icons/spells/chill-touch.webp",
-            "name": "Chill Touch",
+            "_id": "ioqicnfviMKvXg9T",
+            "img": "systems/pf2e/icons/default-icons/spellcastingEntry.svg",
+            "name": "Rituals",
             "sort": 200000,
             "system": {
-                "ability": {
-                    "value": ""
-                },
-                "area": null,
-                "category": {
-                    "value": "spell"
-                },
-                "components": {
-                    "focus": false,
-                    "material": false,
-                    "somatic": true,
-                    "verbal": true
-                },
-                "cost": {
-                    "value": ""
-                },
-                "damage": {
-                    "value": {
-                        "0": {
-                            "applyMod": true,
-                            "type": {
-                                "categories": [],
-                                "subtype": "",
-                                "value": "negative"
-                            },
-                            "value": "1d4"
-                        }
-                    }
+                "autoHeightenLevel": {
+                    "value": null
                 },
                 "description": {
-                    "value": "<p>Siphoning negative energy into yourself, your hand radiates a pale darkness. Your touch weakens the living and disorients undead, possibly even causing them to flee. The effect depends on whether the target is living or undead.</p>\n<ul>\n<li><strong>Living Creature</strong> The spell deals negative damage equal to 1d4 plus your spellcasting modifier. The target attempts a basic Fortitude save, but is also @UUID[Compendium.pf2e.conditionitems.Enfeebled]{Enfeebled 1} for 1 round on a critical failure.</li>\n<li><strong>Undead Creature</strong> The target is @UUID[Compendium.pf2e.conditionitems.Flat-Footed]{Flat-Footed} for 1 round on a failed Fortitude save. On a critical failure, the target is also @UUID[Compendium.pf2e.conditionitems.Fleeing]{Fleeing} for 1 round unless it succeeds at a Will save.</li>\n</ul>\n<hr />\n<p><strong>Heightened (+1)</strong> The negative damage to living creatures increases by 1d4.</p>"
-                },
-                "duration": {
                     "value": ""
                 },
-                "hasCounteractCheck": {
-                    "value": false
-                },
-                "heightening": {
-                    "damage": {
-                        "0": "1d4"
-                    },
-                    "interval": 1,
-                    "type": "interval"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": {
-                    "value": "72UcADd2WTnoNikm"
-                },
-                "materials": {
-                    "value": ""
-                },
+                "displayLevels": {},
                 "prepared": {
-                    "value": ""
+                    "flexible": false,
+                    "value": "ritual"
                 },
-                "primarycheck": {
-                    "value": ""
-                },
-                "range": {
-                    "value": "touch"
+                "proficiency": {
+                    "value": 0
                 },
                 "rules": [],
-                "save": {
-                    "basic": "basic",
-                    "value": "fortitude"
+                "showSlotlessLevels": {
+                    "value": true
                 },
-                "school": {
-                    "value": "necromancy"
+                "showUnpreparedSpells": {
+                    "value": true
                 },
-                "secondarycasters": {
-                    "value": ""
+                "slots": {
+                    "slot0": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot1": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot10": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot11": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot2": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot3": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot4": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot5": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot6": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot7": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot8": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot9": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    }
                 },
-                "secondarycheck": {
-                    "value": ""
-                },
-                "slug": "chill-touch",
+                "slug": null,
                 "source": {
-                    "value": "Pathfinder Core Rulebook"
+                    "value": ""
                 },
-                "spellType": {
-                    "value": "save"
+                "spelldc": {
+                    "dc": 23,
+                    "mod": 0,
+                    "value": 18
                 },
-                "sustained": {
-                    "value": false
-                },
-                "target": {
-                    "value": "1 living or undead creature"
-                },
-                "time": {
-                    "value": "2"
-                },
-                "traditions": {
-                    "value": [
-                        "arcane",
-                        "divine",
-                        "occult"
-                    ]
+                "tradition": {
+                    "value": ""
                 },
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": [
-                        "cantrip",
-                        "negative"
-                    ]
+                    "value": []
                 }
             },
-            "type": "spell"
+            "type": "spellcastingEntry"
         },
         {
-            "_id": "0yFEddWFSXXoDRWf",
+            "_id": "ofhb2Xpvv2O62InP",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.aIHY2DArKFweIrpf"
+                    "sourceId": "Compendium.pf2e.spells-srd.zfn5RqAdF63neqpP"
                 }
             },
-            "img": "systems/pf2e/icons/spells/command.webp",
-            "name": "Command",
+            "img": "systems/pf2e/icons/spells/control-water.webp",
+            "name": "Control Water",
             "sort": 300000,
             "system": {
                 "ability": {
@@ -295,19 +251,20 @@
                     "value": {}
                 },
                 "description": {
-                    "value": "<p>You shout a command that's hard to ignore. You can command the target to approach you, run away (as if it had the @UUID[Compendium.pf2e.conditionitems.Fleeing]{Fleeing} condition), release what it's holding, drop @UUID[Compendium.pf2e.conditionitems.Prone]{Prone}, or stand in place. It can't Delay or take any reactions until it has obeyed your command. The effects depend on the target's Will save.</p>\n<hr /><strong>Success</strong> The creature is unaffected.\n<p><strong>Failure</strong> For the first action on its next turn, the creature must use a single action to do as you command.</p>\n<p><strong>Critical Failure</strong> The target must use all its actions on its next turn to obey your command.</p>\n<hr /><strong>Heightened (5th)</strong> You can target up to 10 creatures."
+                    "value": "<p>By imposing your will upon the water, you can raise or lower the level of water in the chosen area by 10 feet. Water creatures in the area are subjected to the effects of <em>@UUID[Compendium.pf2e.spells-srd.Slow]{Slow}</em>.</p>\n<hr />\n<p><strong>Area</strong> 50 ft long by 50 ft wide</p>"
                 },
                 "duration": {
-                    "value": "until the end of the target's next turn"
+                    "value": ""
                 },
                 "hasCounteractCheck": {
                     "value": false
                 },
                 "level": {
-                    "value": 1
+                    "value": 5
                 },
                 "location": {
-                    "value": "72UcADd2WTnoNikm"
+                    "heightenedLevel": 5,
+                    "value": "xxK8rXRDWK5Rwj9i"
                 },
                 "materials": {
                     "value": ""
@@ -319,15 +276,15 @@
                     "value": ""
                 },
                 "range": {
-                    "value": "30 feet"
+                    "value": "500 feet"
                 },
                 "rules": [],
                 "save": {
                     "basic": "",
-                    "value": "will"
+                    "value": ""
                 },
                 "school": {
-                    "value": "enchantment"
+                    "value": "evocation"
                 },
                 "secondarycasters": {
                     "value": ""
@@ -335,18 +292,18 @@
                 "secondarycheck": {
                     "value": ""
                 },
-                "slug": "command",
+                "slug": "control-water",
                 "source": {
                     "value": "Pathfinder Core Rulebook"
                 },
                 "spellType": {
-                    "value": "save"
+                    "value": "utility"
                 },
                 "sustained": {
                     "value": false
                 },
                 "target": {
-                    "value": "1 creature"
+                    "value": ""
                 },
                 "time": {
                     "value": "2"
@@ -354,31 +311,28 @@
                 "traditions": {
                     "value": [
                         "arcane",
-                        "divine",
-                        "occult"
+                        "primal"
                     ]
                 },
                 "traits": {
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "auditory",
-                        "linguistic",
-                        "mental"
+                        "water"
                     ]
                 }
             },
             "type": "spell"
         },
         {
-            "_id": "862lyQvkK6EvVa2L",
+            "_id": "D0vga6qR9JJs237o",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.4gBIw4IDrSfFHik4"
+                    "sourceId": "Compendium.pf2e.spells-srd.VlNcjmYyu95vOUe8"
                 }
             },
-            "img": "systems/pf2e/icons/spells/daze.webp",
-            "name": "Daze",
+            "img": "systems/pf2e/icons/spells/dimension-door.webp",
+            "name": "Dimension Door",
             "sort": 400000,
             "system": {
                 "ability": {
@@ -398,39 +352,23 @@
                     "value": ""
                 },
                 "damage": {
-                    "value": {
-                        "0": {
-                            "applyMod": true,
-                            "type": {
-                                "categories": [],
-                                "subtype": "",
-                                "value": "mental"
-                            },
-                            "value": "0"
-                        }
-                    }
+                    "value": {}
                 },
                 "description": {
-                    "value": "<p>You cloud the target's mind and daze it with a mental jolt. The jolt deals mental damage equal to your spellcasting ability modifier; the target must attempt a basic Will save. If the target critically fails the save, it is also @UUID[Compendium.pf2e.conditionitems.Stunned]{Stunned 1}.</p>\n<hr />\n<p><strong>Heightened (+2)</strong> The damage increases by 1d6.</p>"
+                    "value": "<p>Opening a door that bypasses normal space, you instantly transport yourself and any items you're wearing and holding from your current space to a clear space within range you can see. If this would bring another creature with you-even if you're carrying it in an extradimensional container-the spell is lost.</p>\n<hr />\n<p><strong>Heightened (5th)</strong> The range increases to 1 mile. You don't need to be able to see your destination, as long as you have been there in the past and know its relative location and distance from you. You are temporarily immune for 1 hour.</p>"
                 },
                 "duration": {
-                    "value": "1 round"
+                    "value": ""
                 },
                 "hasCounteractCheck": {
                     "value": false
                 },
-                "heightening": {
-                    "damage": {
-                        "0": "1d6"
-                    },
-                    "interval": 2,
-                    "type": "interval"
-                },
                 "level": {
-                    "value": 1
+                    "value": 4
                 },
                 "location": {
-                    "value": "72UcADd2WTnoNikm"
+                    "heightenedLevel": 5,
+                    "value": "xxK8rXRDWK5Rwj9i"
                 },
                 "materials": {
                     "value": ""
@@ -442,141 +380,15 @@
                     "value": ""
                 },
                 "range": {
-                    "value": "60 feet"
-                },
-                "rules": [],
-                "save": {
-                    "basic": "basic",
-                    "value": "will"
-                },
-                "school": {
-                    "value": "enchantment"
-                },
-                "secondarycasters": {
-                    "value": ""
-                },
-                "secondarycheck": {
-                    "value": ""
-                },
-                "slug": "daze",
-                "source": {
-                    "value": "Pathfinder Core Rulebook"
-                },
-                "spellType": {
-                    "value": "save"
-                },
-                "sustained": {
-                    "value": false
-                },
-                "target": {
-                    "value": "1 creature"
-                },
-                "time": {
-                    "value": "2"
-                },
-                "traditions": {
-                    "value": [
-                        "arcane",
-                        "divine",
-                        "occult"
-                    ]
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": [
-                        "cantrip",
-                        "mental",
-                        "nonlethal"
-                    ]
-                }
-            },
-            "type": "spell"
-        },
-        {
-            "_id": "JTeXI3EO1DL4s7la",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.k34hDOfIIMAxNL4a"
-                }
-            },
-            "img": "systems/pf2e/icons/spells/grim-tendrils.webp",
-            "name": "Grim Tendrils",
-            "sort": 500000,
-            "system": {
-                "ability": {
-                    "value": ""
-                },
-                "area": {
-                    "type": "line",
-                    "value": 30
-                },
-                "category": {
-                    "value": "spell"
-                },
-                "components": {
-                    "focus": false,
-                    "material": false,
-                    "somatic": true,
-                    "verbal": true
-                },
-                "cost": {
-                    "value": ""
-                },
-                "damage": {
-                    "value": {
-                        "0": {
-                            "applyMod": false,
-                            "type": {
-                                "categories": [],
-                                "subtype": "",
-                                "value": "negative"
-                            },
-                            "value": "2d4"
-                        }
-                    }
-                },
-                "description": {
-                    "value": "<p>Tendrils of darkness curl out from your fingertips and race through the air. You deal 2d4 negative damage and [[/r 1[persistent,bleed]]] damage to living creatures in the line. Each living creature in the line must attempt a Fortitude save.</p>\n<hr /><strong>Critical Success</strong> The creature is unaffected.\n<p><strong>Success</strong> The creature takes half the negative damage and no persistent bleed damage.</p>\n<p><strong>Failure</strong> The creature takes full damage.</p>\n<p><strong>Critical Failure</strong> The creature takes double negative damage and double persistent bleed damage.</p>\n<hr /><strong>Heightened (+1)</strong> The negative damage increases by 2d4, and the persistent bleed damage increases by 1."
-                },
-                "duration": {
-                    "value": ""
-                },
-                "hasCounteractCheck": {
-                    "value": false
-                },
-                "heightening": {
-                    "damage": {
-                        "0": "2d4"
-                    },
-                    "interval": 1,
-                    "type": "interval"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": {
-                    "value": "72UcADd2WTnoNikm"
-                },
-                "materials": {
-                    "value": ""
-                },
-                "prepared": {
-                    "value": ""
-                },
-                "primarycheck": {
-                    "value": ""
-                },
-                "range": {
-                    "value": ""
+                    "value": "120 feet"
                 },
                 "rules": [],
                 "save": {
                     "basic": "",
-                    "value": "fortitude"
+                    "value": ""
                 },
                 "school": {
-                    "value": "necromancy"
+                    "value": "conjuration"
                 },
                 "secondarycasters": {
                     "value": ""
@@ -584,12 +396,12 @@
                 "secondarycheck": {
                     "value": ""
                 },
-                "slug": "grim-tendrils",
+                "slug": "dimension-door",
                 "source": {
                     "value": "Pathfinder Core Rulebook"
                 },
                 "spellType": {
-                    "value": "save"
+                    "value": "utility"
                 },
                 "sustained": {
                     "value": false
@@ -610,145 +422,22 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "negative"
+                        "teleportation"
                     ]
                 }
             },
             "type": "spell"
         },
         {
-            "_id": "ByttjgQGaNt4eCid",
+            "_id": "mxpkzQTw0tzSwaUL",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.wdA52JJnsuQWeyqz"
+                    "sourceId": "Compendium.pf2e.spells-srd.VlNcjmYyu95vOUe8"
                 }
             },
-            "img": "systems/pf2e/icons/spells/harm.webp",
-            "name": "Harm",
-            "sort": 600000,
-            "system": {
-                "ability": {
-                    "value": ""
-                },
-                "area": {
-                    "details": "varies",
-                    "type": "emanation",
-                    "value": 30
-                },
-                "category": {
-                    "value": "spell"
-                },
-                "components": {
-                    "focus": false,
-                    "material": false,
-                    "somatic": false,
-                    "verbal": false
-                },
-                "cost": {
-                    "value": ""
-                },
-                "damage": {
-                    "value": {
-                        "0": {
-                            "applyMod": false,
-                            "type": {
-                                "categories": [],
-                                "subtype": "",
-                                "value": "negative"
-                            },
-                            "value": "1d8"
-                        }
-                    }
-                },
-                "description": {
-                    "value": "<p>You channel negative energy to harm the living or heal the undead. If the target is a living creature, you deal 1d8 negative damage to it, and it gets a basic Fortitude save. If the target is a willing undead creature, you restore that amount of Hit Points. The number of actions you spend when Casting this Spell determines its targets, range, area, and other parameters.</p>\n<p><span class=\"pf2-icon\">1</span> (somatic) The spell has a range of touch.</p>\n<p><span class=\"pf2-icon\">2</span> (verbal, somatic) The spell has a range of 30 feet. If you're healing an undead creature, increase the Hit Points restored by 8.</p>\n<p><span class=\"pf2-icon\">3</span> (material, verbal, somatic) You disperse negative energy in a 30-foot emanation. This targets all living and undead creatures in the area.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The amount of healing or damage increases by 1d8, and the extra healing for the 2-action version increases by 8.</p>"
-                },
-                "duration": {
-                    "value": ""
-                },
-                "hasCounteractCheck": {
-                    "value": false
-                },
-                "heightening": {
-                    "damage": {
-                        "0": "1d8"
-                    },
-                    "interval": 1,
-                    "type": "interval"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": {
-                    "value": "72UcADd2WTnoNikm"
-                },
-                "materials": {
-                    "value": ""
-                },
-                "prepared": {
-                    "value": ""
-                },
-                "primarycheck": {
-                    "value": ""
-                },
-                "range": {
-                    "value": "varies"
-                },
-                "rules": [],
-                "save": {
-                    "basic": "basic",
-                    "value": "fortitude"
-                },
-                "school": {
-                    "value": "necromancy"
-                },
-                "secondarycasters": {
-                    "value": ""
-                },
-                "secondarycheck": {
-                    "value": ""
-                },
-                "slug": "harm",
-                "source": {
-                    "value": "Pathfinder Core Rulebook"
-                },
-                "spellType": {
-                    "value": "save"
-                },
-                "sustained": {
-                    "value": false
-                },
-                "target": {
-                    "value": "1 living creature or 1 willing undead creature"
-                },
-                "time": {
-                    "value": "1 to 3"
-                },
-                "traditions": {
-                    "value": [
-                        "divine"
-                    ]
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": [
-                        "negative"
-                    ]
-                }
-            },
-            "type": "spell"
-        },
-        {
-            "_id": "xiPg19A6nSvNNq01",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.pwzdSlJgYqN7bs2w"
-                }
-            },
-            "img": "systems/pf2e/icons/spells/mage-hand.webp",
-            "name": "Mage Hand",
-            "sort": 700000,
+            "img": "systems/pf2e/icons/spells/dimension-door.webp",
+            "name": "Dimension Door (At Will)",
+            "sort": 500000,
             "system": {
                 "ability": {
                     "value": ""
@@ -770,19 +459,20 @@
                     "value": {}
                 },
                 "description": {
-                    "value": "<p>You create a single magical hand, either invisible or ghostlike, that grasps the target object and moves it slowly up to 20 feet. Because you're levitating the object, you can move it in any direction. When you Sustain the Spell, you can move the object an additional 20 feet. If the object is in the air when the spell ends, the object falls.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You can target an unattended object with a Bulk of 1 or less.</p>\n<p><strong>Heightened (5th)</strong> The range increases to 60 feet, and you can target an unattended object with a Bulk of 1 or less.</p>\n<p><strong>Heightened (7th)</strong> The range increases to 60 feet, and you can target an unattended object with a Bulk of 2 or less.</p>"
+                    "value": "<p>Opening a door that bypasses normal space, you instantly transport yourself and any items you're wearing and holding from your current space to a clear space within range you can see. If this would bring another creature with you-even if you're carrying it in an extradimensional container-the spell is lost.</p>\n<hr />\n<p><strong>Heightened (5th)</strong> The range increases to 1 mile. You don't need to be able to see your destination, as long as you have been there in the past and know its relative location and distance from you. You are temporarily immune for 1 hour.</p>"
                 },
                 "duration": {
-                    "value": "sustained"
+                    "value": ""
                 },
                 "hasCounteractCheck": {
                     "value": false
                 },
                 "level": {
-                    "value": 1
+                    "value": 4
                 },
                 "location": {
-                    "value": "72UcADd2WTnoNikm"
+                    "heightenedLevel": 4,
+                    "value": "xxK8rXRDWK5Rwj9i"
                 },
                 "materials": {
                     "value": ""
@@ -794,7 +484,7 @@
                     "value": ""
                 },
                 "range": {
-                    "value": "30 feet"
+                    "value": "120 feet"
                 },
                 "rules": [],
                 "save": {
@@ -802,7 +492,7 @@
                     "value": ""
                 },
                 "school": {
-                    "value": "evocation"
+                    "value": "conjuration"
                 },
                 "secondarycasters": {
                     "value": ""
@@ -810,7 +500,7 @@
                 "secondarycheck": {
                     "value": ""
                 },
-                "slug": "mage-hand",
+                "slug": "dimension-door",
                 "source": {
                     "value": "Pathfinder Core Rulebook"
                 },
@@ -821,7 +511,7 @@
                     "value": false
                 },
                 "target": {
-                    "value": "1 unattended object of light Bulk or less"
+                    "value": ""
                 },
                 "time": {
                     "value": "2"
@@ -836,21 +526,245 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "cantrip"
+                        "teleportation"
                     ]
                 }
             },
             "type": "spell"
         },
         {
-            "_id": "fOxB5yFfPicIwgcO",
+            "_id": "f6wcd2reTGcarw33",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.R8bqnYiThB6MYTxD"
+                    "sourceId": "Compendium.pf2e.spells-srd.aqRYNoSvxsVfqglH"
                 }
             },
-            "img": "systems/pf2e/icons/spells/phantom-pain.webp",
-            "name": "Phantom Pain",
+            "img": "systems/pf2e/icons/spells/freedom-of-movement.webp",
+            "name": "Freedom of Movement",
+            "sort": 600000,
+            "system": {
+                "ability": {
+                    "value": ""
+                },
+                "area": null,
+                "category": {
+                    "value": "spell"
+                },
+                "components": {
+                    "focus": false,
+                    "material": false,
+                    "somatic": true,
+                    "verbal": true
+                },
+                "cost": {
+                    "value": ""
+                },
+                "damage": {
+                    "value": {}
+                },
+                "description": {
+                    "value": "<p>You repel effects that would hinder a creature or slow its movement. While under this spell's effect, the target ignores effects that would give them a circumstance penalty to Speed. When they attempt to @UUID[Compendium.pf2e.actionspf2e.Escape]{Escape} an effect that has them @UUID[Compendium.pf2e.conditionitems.Immobilized]{Immobilized}, @UUID[Compendium.pf2e.conditionitems.Grabbed]{Grabbed}, or @UUID[Compendium.pf2e.conditionitems.Restrained]{Restrained}, they automatically succeed unless the effect is magical and of a higher level than the freedom of movement spell.</p>"
+                },
+                "duration": {
+                    "value": "10 minutes"
+                },
+                "hasCounteractCheck": {
+                    "value": false
+                },
+                "level": {
+                    "value": 4
+                },
+                "location": {
+                    "heightenedLevel": 4,
+                    "value": "xxK8rXRDWK5Rwj9i"
+                },
+                "materials": {
+                    "value": ""
+                },
+                "prepared": {
+                    "value": ""
+                },
+                "primarycheck": {
+                    "value": ""
+                },
+                "range": {
+                    "value": "touch"
+                },
+                "rules": [],
+                "save": {
+                    "basic": "",
+                    "value": ""
+                },
+                "school": {
+                    "value": "abjuration"
+                },
+                "secondarycasters": {
+                    "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "freedom-of-movement",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "spellType": {
+                    "value": "utility"
+                },
+                "sustained": {
+                    "value": false
+                },
+                "target": {
+                    "value": "1 creature touched"
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traditions": {
+                    "value": [
+                        "arcane",
+                        "divine",
+                        "primal"
+                    ]
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "spell"
+        },
+        {
+            "_id": "Vah9RFP70HLmi2n5",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.Y3G6Y6EDgCY0s3fq"
+                }
+            },
+            "img": "systems/pf2e/icons/spells/hydraulic-torrent.webp",
+            "name": "Hydraulic Torrent",
+            "sort": 700000,
+            "system": {
+                "ability": {
+                    "value": ""
+                },
+                "area": {
+                    "type": "line",
+                    "value": 60
+                },
+                "category": {
+                    "value": "spell"
+                },
+                "components": {
+                    "focus": false,
+                    "material": false,
+                    "somatic": true,
+                    "verbal": true
+                },
+                "cost": {
+                    "value": ""
+                },
+                "damage": {
+                    "value": {
+                        "0": {
+                            "type": {
+                                "categories": [],
+                                "value": "bludgeoning"
+                            },
+                            "value": "8d6"
+                        }
+                    }
+                },
+                "description": {
+                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures that fail the save are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
+                },
+                "duration": {
+                    "value": ""
+                },
+                "hasCounteractCheck": {
+                    "value": false
+                },
+                "heightening": {
+                    "damage": {
+                        "0": "2d6"
+                    },
+                    "interval": 1,
+                    "type": "interval"
+                },
+                "level": {
+                    "value": 4
+                },
+                "location": {
+                    "heightenedLevel": 4,
+                    "value": "xxK8rXRDWK5Rwj9i"
+                },
+                "materials": {
+                    "value": ""
+                },
+                "prepared": {
+                    "value": ""
+                },
+                "primarycheck": {
+                    "value": ""
+                },
+                "range": {
+                    "value": ""
+                },
+                "rules": [],
+                "save": {
+                    "basic": "",
+                    "value": "fortitude"
+                },
+                "school": {
+                    "value": "evocation"
+                },
+                "secondarycasters": {
+                    "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "hydraulic-torrent",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "spellType": {
+                    "value": "save"
+                },
+                "sustained": {
+                    "value": false
+                },
+                "target": {
+                    "value": ""
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traditions": {
+                    "value": [
+                        "primal"
+                    ]
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "water"
+                    ]
+                }
+            },
+            "type": "spell"
+        },
+        {
+            "_id": "oIJY4ycXpaF4IjIM",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.jwK43yKsHTkJQvQ9"
+                }
+            },
+            "img": "systems/pf2e/icons/spells/see-invisibility.webp",
+            "name": "See Invisibility (Constant)",
             "sort": 800000,
             "system": {
                 "ability": {
@@ -870,152 +784,23 @@
                     "value": ""
                 },
                 "damage": {
-                    "value": {
-                        "0": {
-                            "applyMod": false,
-                            "type": {
-                                "categories": [],
-                                "subtype": "",
-                                "value": "mental"
-                            },
-                            "value": "2d4"
-                        },
-                        "1": {
-                            "applyMod": false,
-                            "type": {
-                                "categories": [],
-                                "subtype": "persistent",
-                                "value": "mental"
-                            },
-                            "value": "1d4"
-                        }
-                    }
-                },
-                "description": {
-                    "value": "<p>Illusory pain wracks the target, dealing 2d4 mental damage and @Localize[PF2E.PersistentDamage.Mental1d4.success]. The target must attempt a Will save.</p>\n<hr />\n<p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target takes full initial damage but no @UUID[Compendium.pf2e.conditionitems.Persistent Damage]{Persistent Mental Damage}, and the spell ends immediately.</p>\n<p><strong>Failure</strong> The target takes full initial and Persistent Damage, and the target is @UUID[Compendium.pf2e.conditionitems.Sickened]{Sickened 1}. If the target recovers from being Sickened, the Persistent Damage ends and the spell ends.</p>\n<p><strong>Critical Failure</strong> As failure, but the target is @UUID[Compendium.pf2e.conditionitems.Sickened]{Sickened 2}.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d4 and the Persistent Damage by 1d4.</p>"
-                },
-                "duration": {
-                    "value": "1 minute"
-                },
-                "hasCounteractCheck": {
-                    "value": false
-                },
-                "heightening": {
-                    "damage": {
-                        "0": "2d4",
-                        "1": "1d4"
-                    },
-                    "interval": 1,
-                    "type": "interval"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": {
-                    "value": "72UcADd2WTnoNikm"
-                },
-                "materials": {
-                    "value": ""
-                },
-                "prepared": {
-                    "value": ""
-                },
-                "primarycheck": {
-                    "value": ""
-                },
-                "range": {
-                    "value": "30 feet"
-                },
-                "rules": [],
-                "save": {
-                    "basic": "",
-                    "value": "will"
-                },
-                "school": {
-                    "value": "illusion"
-                },
-                "secondarycasters": {
-                    "value": ""
-                },
-                "secondarycheck": {
-                    "value": ""
-                },
-                "slug": "phantom-pain",
-                "source": {
-                    "value": "Pathfinder Core Rulebook"
-                },
-                "spellType": {
-                    "value": "save"
-                },
-                "sustained": {
-                    "value": false
-                },
-                "target": {
-                    "value": "1 creature"
-                },
-                "time": {
-                    "value": "2"
-                },
-                "traditions": {
-                    "value": [
-                        "occult"
-                    ]
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": [
-                        "mental",
-                        "nonlethal"
-                    ]
-                }
-            },
-            "type": "spell"
-        },
-        {
-            "_id": "GROhmkvgbl3r5dcX",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.J7Y7tl0bbdz7TcCc"
-                }
-            },
-            "img": "systems/pf2e/icons/spells/ray-of-enfeeblement.webp",
-            "name": "Ray of Enfeeblement",
-            "sort": 900000,
-            "system": {
-                "ability": {
-                    "value": ""
-                },
-                "area": null,
-                "category": {
-                    "value": "spell"
-                },
-                "components": {
-                    "focus": false,
-                    "material": false,
-                    "somatic": true,
-                    "verbal": true
-                },
-                "cost": {
-                    "value": ""
-                },
-                "damage": {
                     "value": {}
                 },
                 "description": {
-                    "value": "<p>A ray that saps a foe's strength flashes from your hand. Attempt a ranged spell attack against the target. If you succeed, that creature attempts a Fortitude save to determine the spell's effect. If your attack roll is a critical success, use the outcome for one degree of success worse than the result of its save.</p>\n<hr />\n<p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target becomes @UUID[Compendium.pf2e.conditionitems.Enfeebled]{Enfeebled 1}.</p>\n<p><strong>Failure</strong> The target becomes @UUID[Compendium.pf2e.conditionitems.Enfeebled]{Enfeebled 2}.</p>\n<p><strong>Critical Failure</strong> The target becomes @UUID[Compendium.pf2e.conditionitems.Enfeebled]{Enfeebled 3}.</p>"
+                    "value": "<p>You can see @UUID[Compendium.pf2e.conditionitems.Invisible]{Invisible} creatures and objects. They appear to you as translucent shapes, and they are @UUID[Compendium.pf2e.conditionitems.Concealed]{Concealed} to you.</p>\n<hr />\n<p><strong>Heightened (5th)</strong> The spell has a duration of 8 hours.</p>"
                 },
                 "duration": {
-                    "value": "1 minute"
+                    "value": "10 minutes"
                 },
                 "hasCounteractCheck": {
                     "value": false
                 },
                 "level": {
-                    "value": 1
+                    "value": 2
                 },
                 "location": {
-                    "value": "72UcADd2WTnoNikm"
+                    "heightenedLevel": 2,
+                    "value": "xxK8rXRDWK5Rwj9i"
                 },
                 "materials": {
                     "value": ""
@@ -1027,15 +812,15 @@
                     "value": ""
                 },
                 "range": {
-                    "value": "30 feet"
+                    "value": ""
                 },
                 "rules": [],
                 "save": {
                     "basic": "",
-                    "value": "fortitude"
+                    "value": ""
                 },
                 "school": {
-                    "value": "necromancy"
+                    "value": "divination"
                 },
                 "secondarycasters": {
                     "value": ""
@@ -1043,18 +828,18 @@
                 "secondarycheck": {
                     "value": ""
                 },
-                "slug": "ray-of-enfeeblement",
+                "slug": "see-invisibility",
                 "source": {
                     "value": "Pathfinder Core Rulebook"
                 },
                 "spellType": {
-                    "value": "attack"
+                    "value": "utility"
                 },
                 "sustained": {
                     "value": false
                 },
                 "target": {
-                    "value": "1 creature"
+                    "value": ""
                 },
                 "time": {
                     "value": "2"
@@ -1070,54 +855,44 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "attack"
+                        "revelation"
                     ]
                 }
             },
             "type": "spell"
         },
         {
-            "_id": "MeKNMAkmYZr95eiD",
+            "_id": "H2wGlqKKN7W5qqTm",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.60sgbuMWN0268dB7"
+                    "sourceId": "Compendium.pf2e.spells-srd.30BBep9U4BDV0EgQ"
                 }
             },
-            "img": "systems/pf2e/icons/spells/telekinetic-projectile.webp",
-            "name": "Telekinetic Projectile",
-            "sort": 1000000,
+            "img": "systems/pf2e/icons/spells/infernal-pact.webp",
+            "name": "Infernal Pact",
+            "sort": 900000,
             "system": {
                 "ability": {
                     "value": ""
                 },
                 "area": null,
                 "category": {
-                    "value": "spell"
+                    "value": "ritual"
                 },
                 "components": {
                     "focus": false,
                     "material": false,
-                    "somatic": true,
-                    "verbal": true
+                    "somatic": false,
+                    "verbal": false
                 },
                 "cost": {
                     "value": ""
                 },
                 "damage": {
-                    "value": {
-                        "0": {
-                            "applyMod": true,
-                            "type": {
-                                "categories": [],
-                                "subtype": "",
-                                "value": "untyped"
-                            },
-                            "value": "1d6"
-                        }
-                    }
+                    "value": {}
                 },
                 "description": {
-                    "value": "<p>You hurl a loose, unattended object that is within range and that has 1 Bulk or less at the target. Make a spell attack roll against the target. If you hit, you deal bludgeoning, piercing, or slashing damage-as appropriate for the object you hurled-equal to 1d6 plus your spellcasting ability modifier. No specific traits or magic properties of the hurled item affect the attack or the damage.</p>\n<hr />\n<p><strong>Critical Success</strong> You deal double damage.</p>\n<p><strong>Success</strong> You deal full damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 1d6.</p>"
+                    "value": "<p>You make an appeal to a powerful devil, asking it to bind some of its subordinates to your service. If you succeed, the devil sends you its choice of one devil whose level is no more than double <em>infernal pact's</em> level, two devils whose levels are each at least 2 less than double the spell level, or three devils whose levels are each at least 3 less than double the spell level.</p>\n<hr />\n<p><strong>Critical Success</strong> The devils are sent to you and serve you for [[/r 1d4 #weeks]]{1d4 weeks}.</p>\n<p><strong>Success</strong> The devils are sent to you and serve you for [[/r 1d4 #days]]{1d4 days}.</p>\n<p><strong>Failure</strong> Your request is denied.</p>\n<p><strong>Critical Failure</strong> Not only is your request denied, but the powerful devil sends word of its displeasure to your master.</p>"
                 },
                 "duration": {
                     "value": ""
@@ -1125,18 +900,11 @@
                 "hasCounteractCheck": {
                     "value": false
                 },
-                "heightening": {
-                    "damage": {
-                        "0": "1d6"
-                    },
-                    "interval": 1,
-                    "type": "interval"
-                },
                 "level": {
                     "value": 1
                 },
                 "location": {
-                    "value": "72UcADd2WTnoNikm"
+                    "value": "ioqicnfviMKvXg9T"
                 },
                 "materials": {
                     "value": ""
@@ -1145,10 +913,10 @@
                     "value": ""
                 },
                 "primarycheck": {
-                    "value": ""
+                    "value": "Religion (expert; you must be a devil)"
                 },
                 "range": {
-                    "value": "30 feet"
+                    "value": ""
                 },
                 "rules": [],
                 "save": {
@@ -1156,7 +924,7 @@
                     "value": ""
                 },
                 "school": {
-                    "value": "evocation"
+                    "value": "conjuration"
                 },
                 "secondarycasters": {
                     "value": ""
@@ -1164,47 +932,41 @@
                 "secondarycheck": {
                     "value": ""
                 },
-                "slug": "telekinetic-projectile",
+                "slug": "infernal-pact",
                 "source": {
-                    "value": "Pathfinder Core Rulebook"
+                    "value": "Pathfinder Bestiary"
                 },
                 "spellType": {
-                    "value": "attack"
+                    "value": "utility"
                 },
                 "sustained": {
                     "value": false
                 },
                 "target": {
-                    "value": "1 creature"
+                    "value": ""
                 },
                 "time": {
-                    "value": "2"
+                    "value": "1 day"
                 },
                 "traditions": {
-                    "value": [
-                        "arcane",
-                        "occult"
-                    ]
+                    "value": []
                 },
                 "traits": {
                     "custom": "",
-                    "rarity": "common",
-                    "value": [
-                        "attack",
-                        "cantrip"
-                    ]
+                    "rarity": "uncommon",
+                    "value": []
                 }
             },
             "type": "spell"
         },
         {
-            "_id": "VssG55TESDIyaiPP",
-            "img": "systems/pf2e/icons/spells/create-skinstitch.webp",
-            "name": "Lump of Decayed Flesh Strung on a Necklace",
-            "sort": 1100000,
+            "_id": "JCCJdKRetmUpfNFn",
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/aluum-charm.webp",
+            "name": "Fragment of Urevian's Pendant",
+            "sort": 1000000,
             "system": {
                 "baseItem": null,
-                "containerId": null,
+                "containerId": "null",
                 "description": {
                     "value": ""
                 },
@@ -1229,15 +991,15 @@
                     "value": "0"
                 },
                 "preciousMaterial": {
-                    "value": ""
+                    "value": null
                 },
                 "preciousMaterialGrade": {
-                    "value": ""
+                    "value": null
                 },
                 "price": {
                     "value": {}
                 },
-                "quantity": 2,
+                "quantity": 1,
                 "rules": [],
                 "size": "med",
                 "slug": null,
@@ -1260,9 +1022,57 @@
             "type": "equipment"
         },
         {
-            "_id": "aSbHK3DUVAsb8eW6",
+            "_id": "LbkW4zjvlyreuGX1",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "Jaws",
+            "name": "Fangs",
+            "sort": 1100000,
+            "system": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "custom": "",
+                    "value": []
+                },
+                "bonus": {
+                    "value": 20
+                },
+                "damageRolls": {
+                    "589ofmp1gxuypvnb4x7i": {
+                        "damage": "2d12+9",
+                        "damageType": "piercing"
+                    },
+                    "unhztp8iu335uhghi4gr": {
+                        "damage": "1d6",
+                        "damageType": "evil"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "evil",
+                        "magical"
+                    ]
+                },
+                "weaponType": {
+                    "value": "melee"
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "TfHuj8LvtfwsXfXQ",
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Tentacle Arm",
             "sort": 1200000,
             "system": {
                 "attack": {
@@ -1271,17 +1081,20 @@
                 "attackEffects": {
                     "custom": "",
                     "value": [
-                        "ghoul-ghoul-fever",
-                        "ghoul-paralysis"
+                        "sarglagon-venom"
                     ]
                 },
                 "bonus": {
-                    "value": 12
+                    "value": 20
                 },
                 "damageRolls": {
-                    "w937k83iw7dp0cetamq2": {
-                        "damage": "1d8+6",
-                        "damageType": "piercing"
+                    "pjlrdhtwociy4agitatv": {
+                        "damage": "2d8+9",
+                        "damageType": "bludgeoning"
+                    },
+                    "pjr2qdzqzhjjivvrtu2e": {
+                        "damage": "1d6",
+                        "damageType": "evil"
                     }
                 },
                 "description": {
@@ -1291,72 +1104,76 @@
                 "slug": null,
                 "source": {
                     "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "agile",
+                        "evil",
+                        "magical"
+                    ]
+                },
+                "weaponType": {
+                    "value": "melee"
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "BMv1jkvT4dSbEL8X",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.4Ho2xMPEC05aSxzr"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Greater Darkvision",
+            "sort": 1300000,
+            "system": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.GreaterDarkvision]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "greater-darkvision",
+                "source": {
+                    "value": "Pathfinder Bestiary"
                 },
                 "traits": {
                     "custom": "",
                     "rarity": "common",
                     "value": []
                 },
-                "weaponType": {
-                    "value": "melee"
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
                 }
             },
-            "type": "melee"
+            "type": "action"
         },
         {
-            "_id": "eltHO3xRIKJCfFcF",
-            "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "Claw",
-            "sort": 1300000,
-            "system": {
-                "attack": {
-                    "value": ""
-                },
-                "attackEffects": {
-                    "custom": "",
-                    "value": [
-                        "ghoul-paralysis"
-                    ]
-                },
-                "bonus": {
-                    "value": 12
-                },
-                "damageRolls": {
-                    "3t5z824lx45zgkb3f2ej": {
-                        "damage": "1d4+6",
-                        "damageType": "slashing"
-                    }
-                },
-                "description": {
-                    "value": ""
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": [
-                        "agile"
-                    ]
-                },
-                "weaponType": {
-                    "value": "melee"
-                }
-            },
-            "type": "melee"
-        },
-        {
-            "_id": "kcKV8At9w2cFZz1T",
+            "_id": "7NjsgQKMg0FvxDmJ",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.qCCLZhnp2HhP3Ex6"
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.kdhbPaBMK1d1fpbA"
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Darkvision",
+            "name": "Telepathy 100 feet",
             "sort": 1400000,
             "system": {
                 "actionCategory": {
@@ -1369,13 +1186,62 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Darkvision]</p>"
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Telepathy]</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
                 "rules": [],
-                "slug": "darkvision",
+                "slug": "telepathy",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "aura",
+                        "divination",
+                        "magical"
+                    ]
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "kUtQvCE4ePTqjluS",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.2YRDYVnC1eljaXKK"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "At-Will Spells",
+            "sort": 1500000,
+            "system": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.AtWillSpells]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "at-will-spells",
                 "source": {
                     "value": "Pathfinder Bestiary"
                 },
@@ -1394,15 +1260,60 @@
             "type": "action"
         },
         {
-            "_id": "XvsfsnZoPvQNu6Be",
+            "_id": "tIvtO7TbZgSNlr3F",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.TTCw5NusiSSkJU1x"
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.kakyXBG5WA8c6Zfd"
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Negative Healing",
-            "sort": 1500000,
+            "name": "Constant Spells",
+            "sort": 1600000,
+            "system": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.ConstantSpells]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "constant-spells",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "GoYV1mj4XKxDiBOM",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.kquBnQ0kObZztnBc"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "+1 Status to All Saves vs. Magic",
+            "sort": 1700000,
             "system": {
                 "actionCategory": {
                     "value": "defensive"
@@ -1414,22 +1325,33 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.NegativeHealing]</p>"
+                    "value": ""
                 },
                 "requirements": {
                     "value": ""
                 },
                 "rules": [
                     {
-                        "key": "ActiveEffectLike",
-                        "mode": "override",
-                        "path": "system.attributes.hp.negativeHealing",
-                        "value": true
+                        "key": "FlatModifier",
+                        "predicate": [
+                            {
+                                "or": [
+                                    "magical",
+                                    "arcane",
+                                    "divine",
+                                    "primal",
+                                    "occult"
+                                ]
+                            }
+                        ],
+                        "selector": "saving-throw",
+                        "type": "status",
+                        "value": 1
                     }
                 ],
-                "slug": "negative-healing",
+                "slug": "1-status-to-all-saves-vs-magic",
                 "source": {
-                    "value": "Pathfinder Bestiary 2"
+                    "value": ""
                 },
                 "traits": {
                     "custom": "",
@@ -1446,111 +1368,141 @@
             "type": "action"
         },
         {
-            "_id": "qtILk42sO65XzDmW",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.bestiary-family-ability-glossary.ixPqVlqLaYTB1b23"
-                }
-            },
-            "img": "systems/pf2e/icons/actions/OneAction.webp",
-            "name": "Consume Flesh",
-            "sort": 1600000,
-            "system": {
-                "actionCategory": {
-                    "value": "offensive"
-                },
-                "actionType": {
-                    "value": "action"
-                },
-                "actions": {
-                    "value": 1
-                },
-                "description": {
-                    "value": "<p><strong>Requirements</strong> The Canker cultist is adjacent to the corpse of a creature that died within the last hour, or is carrying a specially prepared lump of decaying flesh.</p>\n<hr />\n<p><strong>Effect</strong> The Canker cultist devours a chunk of the corpse or the lump of decaying flesh and regains Hit Points. They regain [[/r 1d6[healing]]]{1d6 Hit Points} from consuming the flesh of a creature that died within the last hour, and [[/r 2d6[healing]]]{2d6 Hit Points} from the lump.</p>\n<p>The cultist can regain Hit Points from any given corpse only once.</p>"
-                },
-                "requirements": {
-                    "value": ""
-                },
-                "rules": [],
-                "slug": "ghoul-consume-flesh",
-                "source": {
-                    "value": "Pathfinder Bestiary"
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": [
-                        "manipulate"
-                    ]
-                },
-                "trigger": {
-                    "value": ""
-                },
-                "weapon": {
-                    "value": ""
-                }
-            },
-            "type": "action"
-        },
-        {
-            "_id": "YsiUbsAWRxZMjaWA",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.bestiary-family-ability-glossary.N7UV5CZXtcoxDxCF"
-                }
-            },
+            "_id": "tqSmdxFVDmY2CLns",
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Ghoul Fever",
-            "sort": 1700000,
-            "system": {
-                "actionCategory": {
-                    "value": "offensive"
-                },
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "description": {
-                    "value": "<p><strong>Saving Throw</strong> @Check[type:fortitude|dc:20]</p>\n<hr />\n<p><strong>Stage 1</strong> carrier with no ill effect (1 day)</p>\n<p><strong>Stage 2</strong> [[/r 2d6[negative]]] damage and regains half as many Hit Points from all healing (1 day)</p>\n<p><strong>Stage 3</strong> as stage 2 (1 day)</p>\n<p><strong>Stage 4</strong> [[/r 2d6[negative]]] damage and gains no benefit from healing (1 day)</p>\n<p><strong>Stage 5</strong> as stage 4 (1 day)</p>\n<p><strong>Stage 6</strong> dead, and rises as a @UUID[Compendium.pf2e.pathfinder-bestiary.Ghoul]{Ghoul} the next midnight.</p>"
-                },
-                "requirements": {
-                    "value": ""
-                },
-                "rules": [],
-                "slug": "ghoul-ghoul-fever",
-                "source": {
-                    "value": "Pathfinder Bestiary"
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": [
-                        "disease"
-                    ]
-                },
-                "trigger": {
-                    "value": ""
-                },
-                "weapon": {
-                    "value": ""
-                }
-            },
-            "type": "action"
-        },
-        {
-            "_id": "y4um9lgRgEVJYHeJ",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.bestiary-family-ability-glossary.FW4KAUHb7r8WkxUc"
-                }
-            },
-            "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Paralysis",
+            "name": "Heavy Aura",
             "sort": 1800000,
             "system": {
                 "actionCategory": {
+                    "value": "defensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Template[type:emanation|distance:10]{10 feet} @UUID[Compendium.pf2e.bestiary-ability-glossary-srd.Aura]{Aura}</p>\n<hr />\n<p>A creature that enters the heavy aura must attempt a @Check[type:will|dc:23] save. It is then temporarily immune for 10 minutes.</p>\n<hr />\n<p><strong>Success</strong> The creature is unaffected.</p>\n<p><strong>Failure</strong> The creature is @UUID[Compendium.pf2e.conditionitems.Encumbered]{Encumbered} while it remains in the area. If the creature is already encumbered, it is @UUID[Compendium.pf2e.conditionitems.Immobilized]{Immobilized} while it remains within the aura.</p>\n<p><strong>Critical Failure</strong> As failure, but the effect persists for 3 rounds after leaving the aura.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "aura",
+                        "divine",
+                        "incapacitation",
+                        "transmutation"
+                    ]
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "myXt3SwrT2L8VMW4",
+            "img": "systems/pf2e/icons/actions/Reaction.webp",
+            "name": "Stygian Guardian",
+            "sort": 1900000,
+            "system": {
+                "actionCategory": {
+                    "value": "defensive"
+                },
+                "actionType": {
+                    "value": "reaction"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p><strong>Trigger</strong> A creature or object within the sarglagon's reach is targeted by an attack</p>\n<hr />\n<p><strong>Effect</strong> The sarglagon interposes themself, giving the creature or object @UUID[Compendium.pf2e.other-effects.Effect: Cover]{Standard Cover} against the attack (+2 circumstance bonus to AC), or @UUID[Compendium.pf2e.other-effects.Effect: Cover]{Greater Cover} (+4 circumstance bonus to AC) if the sarglagon was already granting it lesser cover.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "nBbFutvNlcdf1cgZ",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Drown",
+            "sort": 2000000,
+            "system": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "description": {
+                    "value": "<p>The sarglagon conjures murky water to fill the lungs of a creature that can't breathe water within 30 feet. The target must attempt a @Check[type:fortitude|dc:26] save.</p>\n<hr />\n<p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target coughs up water and is @UUID[Compendium.pf2e.conditionitems.Sickened]{Sickened 1}.</p>\n<p><strong>Failure</strong> The target is holding its breath. The only action it can take is to attempt a Fortitude save against Drown to expel the water, which is a single action.</p>\n<p><strong>Critical Failure</strong> The target falls @UUID[Compendium.pf2e.conditionitems.Unconscious]{Unconscious} and begins suffocating. If the target succeeds at its Fortitude save while suffocating, it coughs up the water and can breathe again.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "conjuration",
+                        "divine",
+                        "incapacitation"
+                    ]
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "5Vw9VTB3I1sie1g1",
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Sarglagon Venom",
+            "sort": 2100000,
+            "system": {
+                "actionCategory": {
                     "value": "offensive"
                 },
                 "actionType": {
@@ -1560,23 +1512,21 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>Any living, non-elf creature hit by a Canker cultist's attack must succeed at a @Check[type:fortitude|dc:20] save or become @UUID[Compendium.pf2e.conditionitems.Paralyzed]{Paralyzed}. It can attempt a new save at the end of each of its turns, and the DC cumulatively decreases by 1 on each such save.</p>"
+                    "value": "<p><strong>Saving Throw</strong> @Check[type:fortitude|dc:26]</p>\n<hr />\n<p><strong>Maximum Duration</strong> 6 rounds</p>\n<p><strong>Stage 1</strong>[[/r 2d6[poison]]] damage and @UUID[Compendium.pf2e.conditionitems.Clumsy]{Clumsy 1} (1 round)</p>\n<p><strong>Stage 2</strong>[[/r 3d6[poison]]] damage and @UUID[Compendium.pf2e.conditionitems.Clumsy]{Clumsy 2} (1 round)</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
                 "rules": [],
-                "slug": "ghoul-paralysis",
+                "slug": null,
                 "source": {
-                    "value": "Pathfinder Bestiary"
+                    "value": ""
                 },
                 "traits": {
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "incapacitation",
-                        "necromancy",
-                        "occult"
+                        "poison"
                     ]
                 },
                 "trigger": {
@@ -1589,119 +1539,16 @@
             "type": "action"
         },
         {
-            "_id": "n2w1C4HwH3QTV7dw",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.bestiary-family-ability-glossary.UU1Fp3PRuTFONjC9"
-                }
-            },
-            "img": "systems/pf2e/icons/actions/OneAction.webp",
-            "name": "Swift Leap",
-            "sort": 1900000,
-            "system": {
-                "actionCategory": {
-                    "value": "offensive"
-                },
-                "actionType": {
-                    "value": "action"
-                },
-                "actions": {
-                    "value": 1
-                },
-                "description": {
-                    "value": "<p>The cultist jumps up to half its Speed. This movement doesn't trigger reactions.</p>"
-                },
-                "requirements": {
-                    "value": ""
-                },
-                "rules": [],
-                "slug": "ghoul-swift-leap",
-                "source": {
-                    "value": "Pathfinder Bestiary"
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": [
-                        "move"
-                    ]
-                },
-                "trigger": {
-                    "value": ""
-                },
-                "weapon": {
-                    "value": ""
-                }
-            },
-            "type": "action"
-        },
-        {
-            "_id": "HIpbjl6ZtfPnRHK3",
+            "_id": "cziWyGkXTKOzxWfA",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Acrobatics",
-            "sort": 2000000,
-            "system": {
-                "description": {
-                    "value": ""
-                },
-                "mod": {
-                    "value": 9
-                },
-                "proficient": {
-                    "value": 0
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                }
-            },
-            "type": "lore"
-        },
-        {
-            "_id": "aNkgDg3gCEyPL8Zu",
-            "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Athletics",
-            "sort": 2100000,
-            "system": {
-                "description": {
-                    "value": ""
-                },
-                "mod": {
-                    "value": 10
-                },
-                "proficient": {
-                    "value": 0
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                }
-            },
-            "type": "lore"
-        },
-        {
-            "_id": "giWHZioZrhbDDKB2",
-            "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Intimidation",
+            "name": "Arcana",
             "sort": 2200000,
             "system": {
                 "description": {
                     "value": ""
                 },
                 "mod": {
-                    "value": 10
+                    "value": 14
                 },
                 "proficient": {
                     "value": 0
@@ -1720,16 +1567,16 @@
             "type": "lore"
         },
         {
-            "_id": "ELYIOXruUYgC9mEA",
+            "_id": "FrvH9Qjm4Ddo8J4J",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Occultism",
+            "name": "Athletics",
             "sort": 2300000,
             "system": {
                 "description": {
                     "value": ""
                 },
                 "mod": {
-                    "value": 8
+                    "value": 18
                 },
                 "proficient": {
                     "value": 0
@@ -1748,16 +1595,16 @@
             "type": "lore"
         },
         {
-            "_id": "ajK8dJDxE5V7razk",
+            "_id": "dmFxBvhl0Mwqt8u5",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Religion",
+            "name": "Deception",
             "sort": 2400000,
             "system": {
                 "description": {
                     "value": ""
                 },
                 "mod": {
-                    "value": 8
+                    "value": 15
                 },
                 "proficient": {
                     "value": 0
@@ -1776,16 +1623,72 @@
             "type": "lore"
         },
         {
-            "_id": "A5maqn4xdlUdYkCp",
+            "_id": "x75GI6dZABMCrzl8",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Stealth",
+            "name": "Diplomacy",
             "sort": 2500000,
             "system": {
                 "description": {
                     "value": ""
                 },
                 "mod": {
-                    "value": 9
+                    "value": 15
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "lore"
+        },
+        {
+            "_id": "O2Iy6hHlVcoWCJFF",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Intimidation",
+            "sort": 2600000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 17
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "lore"
+        },
+        {
+            "_id": "AqkCZNXs44e7j33l",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Stealth",
+            "sort": 2700000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 15
                 },
                 "proficient": {
                     "value": 0
@@ -1804,89 +1707,103 @@
             "type": "lore"
         }
     ],
-    "name": "Canker Cultist",
+    "name": "Deep End Sarglagon",
+    "prototypeToken": {
+        "name": "Sarglagon"
+    },
     "system": {
         "abilities": {
             "cha": {
                 "mod": 3
             },
             "con": {
-                "mod": 1
+                "mod": 4
             },
             "dex": {
                 "mod": 3
             },
             "int": {
-                "mod": 1
+                "mod": 2
             },
             "str": {
-                "mod": 4
+                "mod": 6
             },
             "wis": {
-                "mod": 3
+                "mod": 4
             }
         },
         "attributes": {
             "ac": {
                 "details": "",
-                "value": 19
+                "value": 27
             },
             "allSaves": {
-                "value": ""
+                "value": "+1 status to all saves vs. magic"
             },
             "hp": {
-                "details": "negative healing",
-                "max": 45,
+                "details": "",
+                "max": 120,
                 "temp": 0,
-                "value": 45
+                "value": 120
             },
             "immunities": [
                 {
-                    "type": "death-effects"
-                },
-                {
-                    "type": "disease"
-                },
-                {
-                    "type": "paralyzed"
-                },
-                {
-                    "type": "poison"
-                },
-                {
-                    "type": "unconscious"
+                    "type": "fire"
                 }
             ],
             "initiative": {
                 "ability": "perception"
             },
             "perception": {
-                "value": 11
+                "value": 18
             },
+            "resistances": [
+                {
+                    "exceptions": [
+                        "silver"
+                    ],
+                    "type": "physical",
+                    "value": 5
+                },
+                {
+                    "type": "poison",
+                    "value": 10
+                }
+            ],
             "speed": {
                 "otherSpeeds": [
                     {
-                        "type": "burrow",
-                        "value": 5
+                        "type": "fly",
+                        "value": 25
+                    },
+                    {
+                        "type": "swim",
+                        "value": 30
                     }
                 ],
-                "value": 30
-            }
+                "value": 25
+            },
+            "weaknesses": [
+                {
+                    "type": "good",
+                    "value": 5
+                }
+            ]
         },
         "details": {
             "alignment": {
-                "value": "CE"
+                "value": "LE"
             },
-            "blurb": "Ghoul zealot",
-            "creatureType": "",
+            "blurb": "",
+            "creatureType": "Fiend",
             "level": {
-                "value": 3
+                "value": 8
             },
             "privateNotes": "",
-            "publicNotes": "",
+            "publicNotes": "<p>Sarglagons dwell in Hell's myriad waterways, lakes, and oceans. They serve as guardians of the Academy of Lies-the repository of secrets in Stygia, the fifth layer of Hell. Sarglagons breathe water and air with equal ease, and can move through water, land, and even air with uncanny swiftness. Few fiends travel the waterways of the multiverse, but where a river crosses the planes, odds are sarglagons have traveled it to further their infernal machinations. The only body of water they avoid is the River Styx, as the fiends have yet to develop any defense against that waterway's memory-sapping qualities. Mortal spellcasters sometimes bind sarglagons as guardians of precious secrets or treasures, particularly in aquatic areas. Most strangely, sarglagons sometimes act as unnerving caretakers to mortals who have no idea what they did to earn their unwanted protectors' attention. The constant uninvited vigilance of these devils is often disturbing and stifling to their wards.</p>\n<hr />\n<p>Each type of devil plays a particular role in Hell's bureaucracies and hierarchies, though some have far more specialized functions than others.</p>",
             "source": {
                 "author": "",
-                "value": "Pathfinder #163: Ruins of Gauntlight"
+                "value": "Pathfinder #164: Hands of the Devil"
             }
         },
         "resources": {
@@ -1898,38 +1815,40 @@
         "saves": {
             "fortitude": {
                 "saveDetail": "",
-                "value": 7
+                "value": 18
             },
             "reflex": {
                 "saveDetail": "",
-                "value": 9
+                "value": 13
             },
             "will": {
                 "saveDetail": "",
-                "value": 12
+                "value": 16
             }
         },
         "traits": {
+            "attitude": {
+                "value": "hostile"
+            },
             "languages": {
-                "custom": "",
+                "custom": "Telepathy 100 feet",
                 "selected": [],
                 "value": [
-                    "aklo",
-                    "common",
-                    "necril",
-                    "undercommon"
+                    "celestial",
+                    "infernal"
                 ]
             },
-            "rarity": "uncommon",
+            "rarity": "common",
             "senses": {
-                "value": "darkvision"
+                "value": "greater darkvision; see invisibility"
             },
             "size": {
-                "value": "med"
+                "value": "lg"
             },
             "value": [
-                "ghoul",
-                "undead"
+                "amphibious",
+                "devil",
+                "fiend"
             ]
         }
     },

--- a/packs/data/abomination-vaults-bestiary.db/drill-field-barbazu.json
+++ b/packs/data/abomination-vaults-bestiary.db/drill-field-barbazu.json
@@ -1,5 +1,5 @@
 {
-    "_id": "4bznEiwsJvInwZwA",
+    "_id": "A4MusxxoLxwMVZua",
     "img": "systems/pf2e/icons/default-icons/npc.svg",
     "items": [
         {
@@ -527,14 +527,14 @@
             "type": "spell"
         },
         {
-            "_id": "jiUi7cG1ldGKfHsM",
+            "_id": "A1xgZ8YYwgXBIYfH",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.equipment-srd.vlnzTSsRmWeSkt9O"
                 }
             },
             "img": "systems/pf2e/icons/equipment/weapons/glaive.webp",
-            "name": "Hellforged Glaive",
+            "name": "Glaive",
             "sort": 600000,
             "system": {
                 "MAP": {
@@ -548,7 +548,7 @@
                     "value": 0
                 },
                 "category": "martial",
-                "containerId": "null",
+                "containerId": null,
                 "damage": {
                     "damageType": "slashing",
                     "dice": 1,
@@ -630,7 +630,6 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "agile",
                         "deadly-d8",
                         "forceful",
                         "reach"
@@ -646,10 +645,85 @@
             "type": "weapon"
         },
         {
+            "_id": "PPYXbrsH1dtpkcYA",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.equipment-srd.hBGFCZbI9nAjSdfE"
+                }
+            },
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/droverss_band.webp",
+            "name": "Drover's Band",
+            "sort": 700000,
+            "system": {
+                "baseItem": null,
+                "containerId": null,
+                "description": {
+                    "value": "<p>This black leather wrist guard has a bright red gem on the inside of the wrist. Faint glyphs and words of domination in Infernal swim inside the gem. Your words become harsh and clipped when you have this magic item invested.</p>\n<hr />\n<p><strong>Activate</strong> <span class=\"pf2-icon\">3</span> command</p>\n<p><strong>Frequency</strong> once per day</p>\n<hr />\n<p><strong>Effect</strong> You exert your will over a mindless creature within 30 feet. If the target is a mindless creature of 3rd level or lower, it must attempt a @Check[type:will|dc:20] save. If you are a devil, the target uses an outcome one degree of success worse than the result of its saving throw.</p>\n<hr />\n<p><strong>Critical Success</strong> The target creature is unaffected.</p>\n<p><strong>Success</strong> The target creature is @UUID[Compendium.pf2e.conditionitems.Slowed]{Slowed 1} for 1 round as its responses are muddled by your commands.</p>\n<p><strong>Failure</strong> The creature is @UUID[Compendium.pf2e.conditionitems.Controlled]{Controlled} by you for 1 hour, although it doesn't follow commands that are obviously self-destructive.</p>\n<p><strong>Critical Failure</strong> As failure, but the duration is 1 day.</p>"
+                },
+                "equipped": {
+                    "carryType": "worn",
+                    "handsHeld": 0,
+                    "inSlot": false,
+                    "invested": null
+                },
+                "equippedBulk": {
+                    "value": ""
+                },
+                "hardness": 0,
+                "hp": {
+                    "brokenThreshold": 0,
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 7
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "preciousMaterial": {
+                    "value": ""
+                },
+                "preciousMaterialGrade": {
+                    "value": ""
+                },
+                "price": {
+                    "value": {
+                        "gp": 675
+                    }
+                },
+                "quantity": 1,
+                "rules": [],
+                "size": "med",
+                "slug": "drovers-band",
+                "source": {
+                    "value": "Pathfinder #164: Hands of the Devil"
+                },
+                "stackGroup": null,
+                "traits": {
+                    "custom": "",
+                    "rarity": "rare",
+                    "value": [
+                        "enchantment",
+                        "incapacitation",
+                        "invested",
+                        "magical"
+                    ]
+                },
+                "usage": {
+                    "value": "wornbracers"
+                },
+                "weight": {
+                    "value": "L"
+                }
+            },
+            "type": "equipment"
+        },
+        {
             "_id": "DzJcNWKMqkWqtgAX",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "Hellforged Glaive",
-            "sort": 700000,
+            "name": "Glaive",
+            "sort": 800000,
             "system": {
                 "attack": {
                     "value": ""
@@ -685,7 +759,6 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "agile",
                         "deadly-d8",
                         "evil",
                         "forceful",
@@ -703,7 +776,7 @@
             "_id": "99jBJtnLmD48VOSS",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Claw",
-            "sort": 800000,
+            "sort": 900000,
             "system": {
                 "attack": {
                     "value": ""
@@ -752,7 +825,7 @@
             "_id": "kwMV2uj1jCdvIm7J",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Beard",
-            "sort": 900000,
+            "sort": 1000000,
             "system": {
                 "attack": {
                     "value": ""
@@ -802,7 +875,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Greater Darkvision",
-            "sort": 1000000,
+            "sort": 1100000,
             "system": {
                 "actionCategory": {
                     "value": "interaction"
@@ -847,7 +920,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Telepathy 100 feet",
-            "sort": 1100000,
+            "sort": 1200000,
             "system": {
                 "actionCategory": {
                     "value": "interaction"
@@ -896,7 +969,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "At-Will Spells",
-            "sort": 1200000,
+            "sort": 1300000,
             "system": {
                 "actionCategory": {
                     "value": "interaction"
@@ -941,7 +1014,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "+1 Status to All Saves vs. Magic",
-            "sort": 1300000,
+            "sort": 1400000,
             "system": {
                 "actionCategory": {
                     "value": "defensive"
@@ -1004,7 +1077,7 @@
             },
             "img": "systems/pf2e/icons/actions/Reaction.webp",
             "name": "Attack of Opportunity",
-            "sort": 1400000,
+            "sort": 1500000,
             "system": {
                 "actionCategory": {
                     "value": "defensive"
@@ -1044,7 +1117,7 @@
             "_id": "GZ55vWFhwaHyhnfM",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Avernal Fever",
-            "sort": 1500000,
+            "sort": 1600000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -1083,10 +1156,47 @@
             "type": "action"
         },
         {
+            "_id": "Vo6AHVWsAnxqkwLW",
+            "img": "systems/pf2e/icons/actions/ThreeActions.webp",
+            "name": "Drover's Band",
+            "sort": 1700000,
+            "system": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 3
+                },
+                "description": {
+                    "value": "<p><strong>Activate</strong> command</p>\n<p><strong>Frequency</strong> once per day</p>\n<hr />\n<p><strong>Effect</strong> The Barbazu exerts his will over a mindless creature within 30 feet. If the target is a mindless creature of 3rd level or lower, it must attempt a @Check[type:will|dc:20] save and uses an outcome one degree of success worse than the result of its saving throw.</p>\n<hr />\n<p><strong>Critical Success</strong> The target creature is unaffected.</p>\n<p><strong>Success</strong> The target creature is @UUID[Compendium.pf2e.conditionitems.Slowed]{Slowed 1} for 1 round as its responses are muddled by the Barbazu's commands.</p>\n<p><strong>Failure</strong> The creature is @UUID[Compendium.pf2e.conditionitems.Controlled]{Controlled} by the Barbazu for 1 hour, although it doesn't follow commands that are obviously self-destructive.</p>\n<p><strong>Critical Failure</strong> As failure, but the duration is 1 day.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
             "_id": "SNJ0RSCREyP9YYKY",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Infernal Wound",
-            "sort": 1600000,
+            "sort": 1800000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -1129,7 +1239,7 @@
             "_id": "zQUhdB7kvudfGv5Z",
             "img": "systems/pf2e/icons/actions/FreeAction.webp",
             "name": "Reposition",
-            "sort": 1700000,
+            "sort": 1900000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -1169,7 +1279,7 @@
             "_id": "6zbiPHhWaAV5pJd6",
             "img": "systems/pf2e/icons/actions/OneAction.webp",
             "name": "Wriggling Beard",
-            "sort": 1800000,
+            "sort": 2000000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -1209,7 +1319,7 @@
             "_id": "qzignK7W4KJGlwa5",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Acrobatics",
-            "sort": 1900000,
+            "sort": 2100000,
             "system": {
                 "description": {
                     "value": ""
@@ -1237,7 +1347,7 @@
             "_id": "pBx2ddMMhFIWUJbf",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Athletics",
-            "sort": 2000000,
+            "sort": 2200000,
             "system": {
                 "description": {
                     "value": ""
@@ -1265,7 +1375,7 @@
             "_id": "F1ixTyn5kKmtvWSc",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Intimidation",
-            "sort": 2100000,
+            "sort": 2300000,
             "system": {
                 "description": {
                     "value": ""
@@ -1293,7 +1403,7 @@
             "_id": "ClNedV0QbWHxm3sT",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Religion",
-            "sort": 2200000,
+            "sort": 2400000,
             "system": {
                 "description": {
                     "value": ""
@@ -1321,7 +1431,7 @@
             "_id": "7XWYtzSCDAvmS3Mh",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Stealth",
-            "sort": 2300000,
+            "sort": 2500000,
             "system": {
                 "description": {
                     "value": ""
@@ -1346,7 +1456,7 @@
             "type": "lore"
         }
     ],
-    "name": "Barbazu (AV-C24)",
+    "name": "Drill Field Barbazu",
     "prototypeToken": {
         "name": "Barbazu"
     },
@@ -1432,6 +1542,7 @@
             "privateNotes": "",
             "publicNotes": "<p>Barbazus, known also as bearded devils or infantry devils, are murderous fiends who satiate their lust for annihilation by serving as the foot soldiers of Hell's armies, often leading hordes of lesser devils such as imps and lemures into battle. Bearded devils wield serrated glaives to inflict jagged gashes that resist healing magic, resulting in tremendous blood loss. When enemies come too close, bearded devils strike with the spines of their wriggling beards to deliver a wretched contagion called Avernal fever, savoring the sight of their victim's strength being slowly devoured from within.</p>\n<p>Barbazus can be found savagely indulging the whims of evil infernal lords from all layers of Hell, rejoicing as they disseminate murder, misery, and anguish as they see fit.</p>\n<hr />\n<p>Masters of corruption and architects of conquest, devils seek both to tempt mortal life to join in their pursuit of all things profane and to spread tyranny throughout all worlds. The temptations they offer mortals range from great powers granted by the signing of an infernal contract to twisted favors following a whispered pledge to a diabolic patron, or any number of even subtler exchanges. Those who succumb to these temptations find themselves consigned to an afterlife of endless torment in the pits of Hell, wherein the only hope of escape lies in the chance of being promoted to become a devil in the infernal ranks. Every devil has a specific role to play in the upkeep of the remorseless bureaucratic machine that is Hell, from soldiers and scholars to inquisitors, lawyers, judges, and executioners. Lowly lemures and imps perform subservient labor to more powerful and specialized devils, such as contract devils and erinyes, while the greatest pit fiends command entire infernal armies.</p>",
             "source": {
+                "author": "",
                 "value": "Pathfinder #164: Hands of the Devil"
             }
         },

--- a/packs/data/abomination-vaults-bestiary.db/falxi-orshendiel.json
+++ b/packs/data/abomination-vaults-bestiary.db/falxi-orshendiel.json
@@ -1,15 +1,15 @@
 {
-    "_id": "bif3iQcDPi27rx6x",
+    "_id": "LRf1h9oIF32FUaOZ",
     "img": "systems/pf2e/icons/default-icons/npc.svg",
     "items": [
         {
-            "_id": "VJFdV0JcVaaqVlyL",
+            "_id": "mU73p7EYpTXgNAqN",
             "img": "systems/pf2e/icons/default-icons/spellcastingEntry.svg",
             "name": "Divine Innate Spells",
             "sort": 100000,
             "system": {
                 "autoHeightenLevel": {
-                    "value": null
+                    "value": 2
                 },
                 "description": {
                     "value": ""
@@ -27,13 +27,13 @@
                     "value": true
                 },
                 "showUnpreparedSpells": {
-                    "value": false
+                    "value": true
                 },
                 "slots": {
                     "slot0": {
-                        "max": 1,
+                        "max": 0,
                         "prepared": [],
-                        "value": 1
+                        "value": 0
                     },
                     "slot1": {
                         "max": 0,
@@ -96,9 +96,9 @@
                     "value": ""
                 },
                 "spelldc": {
-                    "dc": 28,
+                    "dc": 16,
                     "mod": 0,
-                    "value": 18
+                    "value": 8
                 },
                 "tradition": {
                     "value": "divine"
@@ -112,14 +112,14 @@
             "type": "spellcastingEntry"
         },
         {
-            "_id": "fL540WJoPfl2yEVm",
+            "_id": "N0tdBKYLEcJAPSBf",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.4GE2ZdODgIQtg51c"
                 }
             },
             "img": "systems/pf2e/icons/spells/darkness.webp",
-            "name": "Darkness (at will)",
+            "name": "Darkness (At Will)",
             "sort": 200000,
             "system": {
                 "ability": {
@@ -157,7 +157,8 @@
                     "value": 2
                 },
                 "location": {
-                    "value": "VJFdV0JcVaaqVlyL"
+                    "heightenedLevel": 2,
+                    "value": "mU73p7EYpTXgNAqN"
                 },
                 "materials": {
                     "value": ""
@@ -187,7 +188,7 @@
                 },
                 "slug": "darkness",
                 "source": {
-                    "value": ""
+                    "value": "Pathfinder Core Rulebook"
                 },
                 "spellType": {
                     "value": "utility"
@@ -220,14 +221,14 @@
             "type": "spell"
         },
         {
-            "_id": "c9PJ35ELMYksO3fR",
+            "_id": "ABhY9VZVaL77tgAg",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.HRb2doyaLtaoCfi3"
                 }
             },
             "img": "systems/pf2e/icons/spells/faerie-fire.webp",
-            "name": "Faerie Fire (at will)",
+            "name": "Faerie Fire (At Will)",
             "sort": 300000,
             "system": {
                 "ability": {
@@ -265,7 +266,8 @@
                     "value": 2
                 },
                 "location": {
-                    "value": "VJFdV0JcVaaqVlyL"
+                    "heightenedLevel": 2,
+                    "value": "mU73p7EYpTXgNAqN"
                 },
                 "materials": {
                     "value": ""
@@ -295,7 +297,7 @@
                 },
                 "slug": "faerie-fire",
                 "source": {
-                    "value": ""
+                    "value": "Pathfinder Core Rulebook"
                 },
                 "spellType": {
                     "value": "utility"
@@ -327,7 +329,7 @@
             "type": "spell"
         },
         {
-            "_id": "h1JuyLNI2Mab7OJK",
+            "_id": "GDaBzRX7gdxnuWIr",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.kl2q6JvBZwed4B6v"
@@ -369,7 +371,7 @@
                     "value": 1
                 },
                 "location": {
-                    "value": "VJFdV0JcVaaqVlyL"
+                    "value": "mU73p7EYpTXgNAqN"
                 },
                 "materials": {
                     "value": ""
@@ -399,7 +401,7 @@
                 },
                 "slug": "dancing-lights",
                 "source": {
-                    "value": ""
+                    "value": "Pathfinder Core Rulebook"
                 },
                 "spellType": {
                     "value": "utility"
@@ -433,7 +435,7 @@
             "type": "spell"
         },
         {
-            "_id": "6Fbb5m3k2ejjHr0f",
+            "_id": "oGkewc5MP1qP4IPz",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.equipment-srd.XyA6PKV46aNlLXOd"
@@ -465,8 +467,8 @@
                     "value": "<p>Sometimes referred to as an alley bow by rogues or ruffians, this small crossbow fires small bolts that are sometimes used to deliver poison to the target. It's small enough to be shot one-handed, but it still requires two hands to load.</p>"
                 },
                 "equipped": {
-                    "carryType": "worn",
-                    "handsHeld": 0,
+                    "carryType": "held",
+                    "handsHeld": 1,
                     "invested": null
                 },
                 "equippedBulk": {
@@ -520,7 +522,7 @@
                 "size": "med",
                 "slug": "hand-crossbow",
                 "source": {
-                    "value": ""
+                    "value": "Pathfinder Core Rulebook"
                 },
                 "specific": {
                     "value": false
@@ -547,20 +549,20 @@
             "type": "weapon"
         },
         {
-            "_id": "6sz5Y1Ptd0vhrLiM",
+            "_id": "ohcSBFPjPRBQWZKd",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.equipment-srd.LJdbVTOZog39EEbi"
+                    "sourceId": "Compendium.pf2e.equipment-srd.7tKkkF8eZ4iCLJtp"
                 }
             },
-            "img": "systems/pf2e/icons/equipment/weapons/longsword.webp",
-            "name": "+1 Striking Corrosive Longsword",
+            "img": "systems/pf2e/icons/equipment/weapons/shortsword.webp",
+            "name": "Shortsword",
             "sort": 600000,
             "system": {
                 "MAP": {
                     "value": ""
                 },
-                "baseItem": "longsword",
+                "baseItem": "shortsword",
                 "bonus": {
                     "value": 0
                 },
@@ -570,17 +572,17 @@
                 "category": "martial",
                 "containerId": null,
                 "damage": {
-                    "damageType": "slashing",
+                    "damageType": "piercing",
                     "dice": 1,
-                    "die": "d8",
+                    "die": "d6",
                     "value": ""
                 },
                 "description": {
-                    "value": "<p>Longswords can be one‑edged or two‑edged swords. Their blades are heavy and they're between 3 and 4 feet in length.</p>"
+                    "value": "<p>These blades come in a variety of shapes and styles, but they are typically 2 feet long.</p>"
                 },
                 "equipped": {
-                    "carryType": "worn",
-                    "handsHeld": 0,
+                    "carryType": "held",
+                    "handsHeld": 1,
                     "invested": null
                 },
                 "equippedBulk": {
@@ -600,7 +602,7 @@
                     "value": "0"
                 },
                 "potencyRune": {
-                    "value": 1
+                    "value": null
                 },
                 "preciousMaterial": {
                     "value": null
@@ -610,11 +612,11 @@
                 },
                 "price": {
                     "value": {
-                        "gp": 1
+                        "sp": 9
                     }
                 },
                 "propertyRune1": {
-                    "value": "corrosive"
+                    "value": ""
                 },
                 "propertyRune2": {
                     "value": ""
@@ -632,9 +634,9 @@
                 },
                 "rules": [],
                 "size": "med",
-                "slug": "longsword",
+                "slug": "shortsword",
                 "source": {
-                    "value": ""
+                    "value": "Pathfinder Core Rulebook"
                 },
                 "specific": {
                     "value": false
@@ -644,59 +646,61 @@
                 },
                 "stackGroup": null,
                 "strikingRune": {
-                    "value": "striking"
+                    "value": ""
                 },
                 "traits": {
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "versatile-p"
+                        "agile",
+                        "finesse",
+                        "versatile-s"
                     ]
                 },
                 "usage": {
                     "value": "held-in-one-hand"
                 },
                 "weight": {
-                    "value": "1"
+                    "value": "L"
                 }
             },
             "type": "weapon"
         },
         {
-            "_id": "olhVw6swCM3iI62M",
+            "_id": "H3BXO2ICYX5WlTsN",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.equipment-srd.r0ifJfoz8aqf0mwk"
+                    "sourceId": "Compendium.pf2e.equipment-srd.ewQZ0VeL38v3qFnN"
                 }
             },
-            "img": "systems/pf2e/icons/equipment/armor/breastplate.webp",
-            "name": "Breastplate",
+            "img": "systems/pf2e/icons/equipment/armor/studded-leather-armor.webp",
+            "name": "Studded Leather Armor",
             "sort": 700000,
             "system": {
                 "armor": {
-                    "value": 4
+                    "value": 2
                 },
-                "baseItem": "breastplate",
-                "category": "medium",
+                "baseItem": "studded-leather-armor",
+                "category": "light",
                 "check": {
-                    "value": -2
+                    "value": -1
                 },
                 "containerId": null,
                 "description": {
-                    "value": "<p>Though referred to as a breastplate, this type of armor consists of several pieces of plate or half‑plate armor that protect the torso, chest, neck, and sometimes the hips and lower legs. It strategically grants some of the protection of plate while allowing greater flexibility and speed.</p>"
+                    "value": "<p>This leather armor is reinforced with metal studs and sometimes small metal plates, providing most of the flexibility of leather armor with more robust protection.</p>"
                 },
                 "dex": {
-                    "value": 1
+                    "value": 3
                 },
                 "equipped": {
                     "carryType": "worn",
-                    "inSlot": false,
+                    "inSlot": true,
                     "invested": null
                 },
                 "equippedBulk": {
-                    "value": "2"
+                    "value": "1"
                 },
-                "group": "plate",
+                "group": "leather",
                 "hardness": 0,
                 "hp": {
                     "brokenThreshold": 0,
@@ -721,7 +725,7 @@
                 },
                 "price": {
                     "value": {
-                        "gp": 8
+                        "gp": 3
                     }
                 },
                 "propertyRune1": {
@@ -742,16 +746,16 @@
                 },
                 "rules": [],
                 "size": "med",
-                "slug": "breastplate",
+                "slug": "studded-leather-armor",
                 "source": {
-                    "value": ""
+                    "value": "Pathfinder Core Rulebook"
                 },
                 "speed": {
-                    "value": -5
+                    "value": 0
                 },
                 "stackGroup": null,
                 "strength": {
-                    "value": 16
+                    "value": 12
                 },
                 "traits": {
                     "custom": "",
@@ -762,13 +766,13 @@
                     "value": "wornarmor"
                 },
                 "weight": {
-                    "value": "3"
+                    "value": "2"
                 }
             },
             "type": "armor"
         },
         {
-            "_id": "j2H8qQeOpPZdE3Tp",
+            "_id": "8ECuChVILpMetIvX",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.equipment-srd.AITVZmakiu3RgfKo"
@@ -798,8 +802,8 @@
                     "value": "<p>Shorter than traditional arrows but similar in construction, bolts are the ammunition used by crossbows.</p>"
                 },
                 "equipped": {
-                    "carryType": "worn",
-                    "handsHeld": 0
+                    "carryType": "held",
+                    "handsHeld": 1
                 },
                 "equippedBulk": {
                     "value": ""
@@ -833,7 +837,7 @@
                 "size": "med",
                 "slug": "bolts",
                 "source": {
-                    "value": ""
+                    "value": "Pathfinder Core Rulebook"
                 },
                 "stackGroup": "bolts",
                 "traits": {
@@ -851,14 +855,14 @@
             "type": "consumable"
         },
         {
-            "_id": "wWhcYOVX82VD2T44",
+            "_id": "DHgWWE7syBFkaVud",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.equipment-srd.nn2HAN1XKkKHfVnM"
+                    "sourceId": "Compendium.pf2e.equipment-srd.zo0ophqfKunJFxZN"
                 }
             },
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons/stupor-poison.webp",
-            "name": "Stupor Poison",
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons/lethargy-poison.webp",
+            "name": "Lethargy Poison",
             "sort": 900000,
             "system": {
                 "autoDestroy": {
@@ -867,8 +871,8 @@
                 },
                 "baseItem": null,
                 "charges": {
-                    "max": 0,
-                    "value": 0
+                    "max": 1,
+                    "value": 1
                 },
                 "consumableType": {
                     "value": "poison"
@@ -878,11 +882,11 @@
                 },
                 "containerId": null,
                 "description": {
-                    "value": "<p><strong>Activate</strong> <span class=\"pf2-icon\">2</span> Interact</p>\n<p>Stupor poison is a more potent distillation of @UUID[Compendium.pf2e.equipment-srd.Lethargy Poison]{Lethargy Poison}. Further exposure to stupor poison doesn't require the target to attempt additional saving throws; only failing a saving throw against an ongoing exposure can progress its stage.</p>\n<hr />\n<p><strong>Saving Throw</strong> @Check[type:fortitude|dc:20]</p>\n<p><strong>Maximum Duration</strong> 6 hours</p>\n<p><strong>Stage 1</strong> @UUID[Compendium.pf2e.conditionitems.Slowed]{Slowed 1} and @UUID[Compendium.pf2e.conditionitems.Flat-Footed]{Flat-Footed} (1 round)</p>\n<p><strong>Stage 2</strong> @UUID[Compendium.pf2e.conditionitems.Slowed]{Slowed 2} and flat-footed (1 round)</p>\n<p><strong>Stage 3</strong> @UUID[Compendium.pf2e.conditionitems.Unconscious]{Unconscious} with no Perception check to wake up (1 round)</p>\n<p><strong>Stage 4</strong> unconscious with no Perception check to wake up ([[/r 1d6 #hours]]{1d6 hours})</p>"
+                    "value": "<p>Lethargy poison is commonly used in hit-and-run tactics by drow and others who want their victims alive; the ambusher retreats until the poison sets in and the victim falls unconscious. Further exposure to lethargy poison does not require the target to attempt additional saving throws; only failing an saving throw against an ongoing exposure can progress its stage.</p>\n<hr />\n<p><strong>Activate</strong> <span class=\"pf2-icon\">D</span> Interact (Injury)</p>\n<p><strong>Saving Throw</strong> @Check[type:fortitude|dc:18]</p>\n<p><strong>Maximum Duration</strong> 4 hours</p>\n<p><strong>Stage 1</strong> @UUID[Compendium.pf2e.conditionitems.Slowed]{Slowed 1} (1 round)</p>\n<p><strong>Stage 2</strong> slowed 1 (1 minute)</p>\n<p><strong>Stage 3</strong> @UUID[Compendium.pf2e.conditionitems.Unconscious]{Unconscious} with no Perception check to wake up (1 round)</p>\n<p><strong>Stage 4</strong> unconscious with no Perception check to wake up ([[/br 1d4 #hours]]{1d4 hours}).</p>"
                 },
                 "equipped": {
-                    "carryType": "worn",
-                    "handsHeld": 0
+                    "carryType": "held",
+                    "handsHeld": 1
                 },
                 "equippedBulk": {
                     "value": ""
@@ -894,7 +898,7 @@
                     "value": 0
                 },
                 "level": {
-                    "value": 4
+                    "value": 2
                 },
                 "negateBulk": {
                     "value": "0"
@@ -907,15 +911,15 @@
                 },
                 "price": {
                     "value": {
-                        "gp": 16
+                        "gp": 7
                     }
                 },
-                "quantity": 3,
+                "quantity": 2,
                 "rules": [],
                 "size": "med",
-                "slug": "stupor-poison",
+                "slug": "lethargy-poison",
                 "source": {
-                    "value": "Pathfinder #165: Eyes of Empty Death"
+                    "value": "Pathfinder Core Rulebook"
                 },
                 "stackGroup": null,
                 "traits": {
@@ -923,7 +927,7 @@
                     "rarity": "uncommon",
                     "value": [
                         "alchemical",
-                        "consumable",
+                        "conjuration",
                         "incapacitation",
                         "injury",
                         "poison",
@@ -931,7 +935,7 @@
                     ]
                 },
                 "usage": {
-                    "value": "held-in-two-hands"
+                    "value": "held-in-one-hand"
                 },
                 "weight": {
                     "value": "L"
@@ -940,124 +944,11 @@
             "type": "consumable"
         },
         {
-            "_id": "2agkr9lAnWdxtLza",
-            "flags": {
-                "core": {
-                    "sourceId": "Item.zpO5nbGIdKogFPy0"
-                }
-            },
-            "img": "systems/pf2e/icons/equipment/held-items/key-jeweled-gold-purple.webp",
-            "name": "Salaisa's Key",
+            "_id": "jvZUoPLS8OA1SQTw",
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Shortsword",
             "sort": 1000000,
             "system": {
-                "baseItem": null,
-                "containerId": null,
-                "description": {
-                    "value": ""
-                },
-                "equipped": {
-                    "-=inSlot": null,
-                    "carryType": "worn",
-                    "handsHeld": 0
-                },
-                "equippedBulk": {
-                    "value": ""
-                },
-                "hardness": 0,
-                "hp": {
-                    "brokenThreshold": 0,
-                    "max": 0,
-                    "value": 0
-                },
-                "level": {
-                    "value": 0
-                },
-                "negateBulk": {
-                    "value": "0"
-                },
-                "preciousMaterial": {
-                    "value": null
-                },
-                "preciousMaterialGrade": {
-                    "value": null
-                },
-                "price": {
-                    "value": {}
-                },
-                "quantity": 1,
-                "rules": [],
-                "size": "med",
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "stackGroup": null,
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                },
-                "usage": {
-                    "value": ""
-                },
-                "weight": {
-                    "value": "-"
-                }
-            },
-            "type": "treasure"
-        },
-        {
-            "_id": "R0x59cKzEcWsxbbV",
-            "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "Longsword",
-            "sort": 1100000,
-            "system": {
-                "attack": {
-                    "value": ""
-                },
-                "attackEffects": {
-                    "value": []
-                },
-                "bonus": {
-                    "value": 24
-                },
-                "damageRolls": {
-                    "0": {
-                        "damage": "2d8+9",
-                        "damageType": "slashing"
-                    },
-                    "1": {
-                        "damage": "1d6",
-                        "damageType": "acid"
-                    }
-                },
-                "description": {
-                    "value": ""
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": [
-                        "versatile-p"
-                    ]
-                },
-                "weaponType": {
-                    "value": "melee"
-                }
-            },
-            "type": "melee"
-        },
-        {
-            "_id": "C9dM7wrOpqtQgkOP",
-            "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "Hand Crossbow",
-            "sort": 1200000,
-            "system": {
                 "attack": {
                     "value": ""
                 },
@@ -1066,11 +957,11 @@
                     "value": []
                 },
                 "bonus": {
-                    "value": 22
+                    "value": 10
                 },
                 "damageRolls": {
-                    "9mmm7wn4brp4ra7fwkj5": {
-                        "damage": "1d6+8",
+                    "ngdnt2m13cjxv6aeb52q": {
+                        "damage": "1d6+4",
                         "damageType": "piercing"
                     }
                 },
@@ -1085,7 +976,57 @@
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "agile",
+                        "finesse",
+                        "versatile-s"
+                    ]
+                },
+                "weaponType": {
+                    "value": "melee"
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "EajnVKV3NKyICaQ8",
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Hand Crossbow",
+            "sort": 1100000,
+            "system": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "custom": "",
+                    "value": [
+                        "lethargy-poison"
+                    ]
+                },
+                "bonus": {
+                    "value": 10
+                },
+                "damageRolls": {
+                    "fkdsrt40g6p4fjmpoj1g": {
+                        "damage": "1d6",
+                        "damageType": "piercing"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "range-increment-60",
+                        "reload-1"
+                    ]
                 },
                 "weaponType": {
                     "value": "ranged"
@@ -1094,7 +1035,7 @@
             "type": "melee"
         },
         {
-            "_id": "eIBT42KNs5UfO41v",
+            "_id": "5IHmSdZpGxrw76lc",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.qCCLZhnp2HhP3Ex6"
@@ -1102,7 +1043,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Darkvision",
-            "sort": 1300000,
+            "sort": 1200000,
             "system": {
                 "actionCategory": {
                     "value": "interaction"
@@ -1139,52 +1080,7 @@
             "type": "action"
         },
         {
-            "_id": "CcTlJ52vSeJqkx5b",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.I0HYG0ctCLP5JRsW"
-                }
-            },
-            "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Light Blindness",
-            "sort": 1400000,
-            "system": {
-                "actionCategory": {
-                    "value": "interaction"
-                },
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "description": {
-                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.LightBlindness]</p>"
-                },
-                "requirements": {
-                    "value": ""
-                },
-                "rules": [],
-                "slug": "light-blindness",
-                "source": {
-                    "value": "Pathfinder Bestiary"
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                },
-                "trigger": {
-                    "value": ""
-                },
-                "weapon": {
-                    "value": ""
-                }
-            },
-            "type": "action"
-        },
-        {
-            "_id": "65o1CNgkOxBuaZU6",
+            "_id": "Adq96cMm6jUHjnw3",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.2YRDYVnC1eljaXKK"
@@ -1192,7 +1088,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "At-Will Spells",
-            "sort": 1500000,
+            "sort": 1300000,
             "system": {
                 "actionCategory": {
                     "value": "interaction"
@@ -1229,10 +1125,15 @@
             "type": "action"
         },
         {
-            "_id": "01CKBc5uwpZchw7t",
+            "_id": "2u5CXi7tZODYDpbJ",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.kquBnQ0kObZztnBc"
+                }
+            },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "+1 Status to All Saves vs. Magic",
-            "sort": 1600000,
+            "sort": 1400000,
             "system": {
                 "actionCategory": {
                     "value": "defensive"
@@ -1257,9 +1158,9 @@
                                 "or": [
                                     "magical",
                                     "arcane",
+                                    "divine",
                                     "primal",
-                                    "occult",
-                                    "divine"
+                                    "occult"
                                 ]
                             }
                         ],
@@ -1268,7 +1169,7 @@
                         "value": 1
                     }
                 ],
-                "slug": null,
+                "slug": "1-status-to-all-saves-vs-magic",
                 "source": {
                     "value": ""
                 },
@@ -1287,10 +1188,15 @@
             "type": "action"
         },
         {
-            "_id": "UI4pCPb4yqFcryJ6",
+            "_id": "GEvdLrMrI8fbxU9C",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.kquBnQ0kObZztnBc"
+                }
+            },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "+2 Status To All Saves vs. Mental",
-            "sort": 1700000,
+            "name": "+2 Status to All Saves vs. Mental",
+            "sort": 1500000,
             "system": {
                 "actionCategory": {
                     "value": "defensive"
@@ -1318,7 +1224,7 @@
                         "value": 2
                     }
                 ],
-                "slug": null,
+                "slug": "1-status-to-all-saves-vs-magic",
                 "source": {
                     "value": ""
                 },
@@ -1337,33 +1243,33 @@
             "type": "action"
         },
         {
-            "_id": "IopEu45YRMrLuNzn",
+            "_id": "ufap97U4FyUOrJZF",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.hFtNbo1LKYCoDy2O"
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.I0HYG0ctCLP5JRsW"
                 }
             },
-            "img": "systems/pf2e/icons/actions/Reaction.webp",
-            "name": "Attack of Opportunity",
-            "sort": 1800000,
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Light Blindness",
+            "sort": 1600000,
             "system": {
                 "actionCategory": {
                     "value": "defensive"
                 },
                 "actionType": {
-                    "value": "reaction"
+                    "value": "passive"
                 },
                 "actions": {
                     "value": null
                 },
                 "description": {
-                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.AttackOfOpportunity]</p>"
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.LightBlindness]</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
                 "rules": [],
-                "slug": "attack-of-opportunity",
+                "slug": "light-blindness",
                 "source": {
                     "value": "Pathfinder Bestiary"
                 },
@@ -1382,10 +1288,63 @@
             "type": "action"
         },
         {
-            "_id": "nvaQh9xjojojnL27",
+            "_id": "6gO1vT5DmiULZ2Bv",
+            "img": "systems/pf2e/icons/actions/Reaction.webp",
+            "name": "Nimble Dodge",
+            "sort": 1700000,
+            "system": {
+                "actionCategory": {
+                    "value": "defensive"
+                },
+                "actionType": {
+                    "value": "reaction"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p><strong>Requirements</strong> A drow rogue can't use this reaction while @UUID[Compendium.pf2e.conditionitems.Encumbered]{Encumbered}.</p>\n<p><strong>Trigger</strong> The drow rogue is hit or critically hit by an attack made by a creature the drow rogue can see.</p>\n<hr />\n<p><strong>Effect</strong> The drow rogue gains a +2 circumstance bonus to their Armor Class against the triggering attack.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [
+                    {
+                        "domain": "ac",
+                        "key": "RollOption",
+                        "option": "nimble-dodge",
+                        "toggleable": true
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "predicate": [
+                            "nimble-dodge"
+                        ],
+                        "selector": "ac",
+                        "type": "circumstance",
+                        "value": 2
+                    }
+                ],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "9nfzrmPzAAStRjAe",
             "img": "systems/pf2e/icons/actions/OneAction.webp",
-            "name": "Attack Now!",
-            "sort": 1900000,
+            "name": "Quick Draw",
+            "sort": 1800000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -1397,7 +1356,7 @@
                     "value": 1
                 },
                 "description": {
-                    "value": "<p>Salaisa shouts, and a drow ally within 30 feet that can see or hear Salaisa makes a melee or ranged Strike as a reaction.</p>"
+                    "value": "<p>The drow rogue draws a weapon using the Interact action, then Strikes with that weapon.</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -1422,50 +1381,15 @@
             "type": "action"
         },
         {
-            "_id": "lVTp2LJQAZzKNaIY",
-            "img": "systems/pf2e/icons/actions/TwoActions.webp",
-            "name": "Storm of Blades",
-            "sort": 2000000,
-            "system": {
-                "actionCategory": {
-                    "value": "offensive"
-                },
-                "actionType": {
-                    "value": "action"
-                },
-                "actions": {
-                    "value": 2
-                },
-                "description": {
-                    "value": "<p>Salaisa Strides up to her Speed. She can make up to three longsword Strikes at any point during this movement, each against a different target within reach. These attacks count toward her multiple attack penalty, but the multiple attack penalty doesn't increase until after she makes all of her attacks. If she moves half her speed or less during , that movement doesn't trigger reactions.</p>"
-                },
-                "requirements": {
-                    "value": ""
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                },
-                "trigger": {
-                    "value": ""
-                },
-                "weapon": {
-                    "value": ""
+            "_id": "NS7yHszQCqQS0Bfj",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.AWvNPE4U0kEJSL1T"
                 }
             },
-            "type": "action"
-        },
-        {
-            "_id": "4GEUTovCKhSoT0PD",
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Stupor Poison",
-            "sort": 2100000,
+            "name": "Sneak Attack",
+            "sort": 1900000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -1477,15 +1401,47 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>Stupor poison is a more potent distillation of @UUID[Compendium.pf2e.equipment-srd.Lethargy Poison]{Lethargy Poison}. Further exposure to stupor poison doesn't require the target to attempt additional saving throws; only failing a saving throw against an ongoing exposure can progress its stage.</p>\n<hr />\n<p><strong>Saving Throw</strong> @Check[type:fortitude|dc:20|traits:alchemical,incapacitation,injury,poison,sleep]</p>\n<p><strong>Maximum Duration</strong> 6 hours</p>\n<p><strong>Stage 1</strong> @UUID[Compendium.pf2e.conditionitems.Slowed]{Slowed 1} and @UUID[Compendium.pf2e.conditionitems.Flat-Footed]{Flat-Footed} (1 round)</p>\n<p><strong>Stage 2</strong> @UUID[Compendium.pf2e.conditionitems.Slowed]{Slowed 2} and flat-footed (1 round)</p>\n<p><strong>Stage 3</strong> @UUID[Compendium.pf2e.conditionitems.Unconscious]{Unconscious} with no Perception check to wake up (1 round)</p>\n<p><strong>Stage 4</strong> unconscious with no Perception check to wake up ([[/r 1d6 #hours]]{1d6 hours})</p>"
+                    "value": "<p>The drow rogue deals 1d6 extra precision damage to flat-footed creatures.</p>\n<hr />\n<p>@Localize[PF2E.NPC.Abilities.Glossary.SneakAttack]</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
-                "slug": null,
+                "rules": [
+                    {
+                        "category": "precision",
+                        "diceNumber": 1,
+                        "dieSize": "d6",
+                        "key": "DamageDice",
+                        "predicate": [
+                            "target:condition:flat-footed",
+                            {
+                                "or": [
+                                    "item:trait:agile",
+                                    "item:trait:finesse",
+                                    {
+                                        "and": [
+                                            "item:ranged",
+                                            {
+                                                "not": "item:thrown-melee"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ],
+                        "selector": "strike-damage"
+                    },
+                    {
+                        "domain": "all",
+                        "key": "RollOption",
+                        "label": "PF2E.SpecificRule.TOTMToggle.FlatFooted",
+                        "option": "target:condition:flat-footed",
+                        "toggleable": "totm"
+                    }
+                ],
+                "slug": "sneak-attack",
                 "source": {
-                    "value": ""
+                    "value": "Pathfinder Bestiary"
                 },
                 "traits": {
                     "custom": "",
@@ -1502,16 +1458,72 @@
             "type": "action"
         },
         {
-            "_id": "grsAbUgxmgObApLm",
+            "_id": "CksfzTlFvUL6YitC",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Acrobatics",
+            "sort": 2000000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 8
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "lore"
+        },
+        {
+            "_id": "9uHSH0UE5MEepbT8",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Deception",
+            "sort": 2100000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 7
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "lore"
+        },
+        {
+            "_id": "FnneQapbLEf65BCz",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Society",
             "sort": 2200000,
             "system": {
                 "description": {
                     "value": ""
                 },
                 "mod": {
-                    "value": 21
+                    "value": 4
                 },
                 "proficient": {
                     "value": 0
@@ -1530,16 +1542,16 @@
             "type": "lore"
         },
         {
-            "_id": "QS9hpSFj2sYsk0gX",
+            "_id": "4ErGKW8KpdFP1EtF",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Athletics",
+            "name": "Stealth",
             "sort": 2300000,
             "system": {
                 "description": {
                     "value": ""
                 },
                 "mod": {
-                    "value": 22
+                    "value": 10
                 },
                 "proficient": {
                     "value": 0
@@ -1558,72 +1570,16 @@
             "type": "lore"
         },
         {
-            "_id": "lzMGjNtKgx0zTHxe",
+            "_id": "KKZFf7lRlrcLJlm0",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Intimidation",
+            "name": "Thievery",
             "sort": 2400000,
             "system": {
                 "description": {
                     "value": ""
                 },
                 "mod": {
-                    "value": 20
-                },
-                "proficient": {
-                    "value": 0
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                }
-            },
-            "type": "lore"
-        },
-        {
-            "_id": "kR8oXoOPE6ZJYN6r",
-            "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Stealth",
-            "sort": 2500000,
-            "system": {
-                "description": {
-                    "value": ""
-                },
-                "mod": {
-                    "value": 21
-                },
-                "proficient": {
-                    "value": 0
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                }
-            },
-            "type": "lore"
-        },
-        {
-            "_id": "23fxDfSsWz3YN1lQ",
-            "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Survival",
-            "sort": 2600000,
-            "system": {
-                "description": {
-                    "value": ""
-                },
-                "mod": {
-                    "value": 20
+                    "value": 8
                 },
                 "proficient": {
                     "value": 0
@@ -1642,14 +1598,14 @@
             "type": "lore"
         }
     ],
-    "name": "Salaisa Malthulas",
+    "name": "Falxi Orshendiel",
     "system": {
         "abilities": {
             "cha": {
                 "mod": 1
             },
             "con": {
-                "mod": 3
+                "mod": 2
             },
             "dex": {
                 "mod": 4
@@ -1658,25 +1614,25 @@
                 "mod": 0
             },
             "str": {
-                "mod": 5
+                "mod": 2
             },
             "wis": {
-                "mod": 3
+                "mod": 0
             }
         },
         "attributes": {
             "ac": {
                 "details": "",
-                "value": 31
+                "value": 19
             },
             "allSaves": {
                 "value": "+1 status to all saves vs. magic, +2 status to all saves vs. mental"
             },
             "hp": {
                 "details": "",
-                "max": 200,
+                "max": 26,
                 "temp": 0,
-                "value": 200
+                "value": 26
             },
             "immunities": [
                 {
@@ -1687,7 +1643,7 @@
                 "ability": "perception"
             },
             "perception": {
-                "value": 22
+                "value": 6
             },
             "speed": {
                 "otherSpeeds": [],
@@ -1696,18 +1652,18 @@
         },
         "details": {
             "alignment": {
-                "value": "N"
+                "value": "CN"
             },
-            "blurb": "Female drow head warden",
-            "creatureType": "",
+            "blurb": "CN male drow rogue (Pathfinder Bestiary 137)",
+            "creatureType": "Humanoid",
             "level": {
-                "value": 11
+                "value": 2
             },
             "privateNotes": "",
-            "publicNotes": "",
+            "publicNotes": "<p>Loners at heart, drow rogues trust no one-least of all fellow slayers. Thees drow rely on awareness and adaptation to survive the cutthroat nature of their society.</p>\n<hr />\n<p>The first drow were elves who fled into the depths of the world from a devastating cataclysm thousands of years ago. In their journey below, they fell to bickering and in-fighting, drawing the attention of sinister intelligences beyond their own. Whether it was the influence of a specific demon lord, the Rough Beast Rovagug, or some other fell force is unknown, but in that time the elves transformed both spiritually and physically, tainting their hearts with desires for cruelty, sadism, and violence. The hues of their eyes became sinister red or bleached white, and their flesh adopted an unearthly lavender sheen that made the drow instantly recognizable. The drow also developed potent magical abilities and resistances that further empowered them, if at the cost of their souls.</p>\n<p>Over the centuries to follow, the drow developed into a powerful, if violently dysfunctional society, influenced by the worship of demon lords and focused on providing power and glory to a relatively small collection of noble houses. Many of these noble houses are matriarchal in nature and all hold allegiance to a specific demon lord patron-but traditions of worship, warfare, and wizardry help to bind the oft-bickering houses together enough that drow society doesn't simply consume itself from within. Fear of earning the wrath of one's superior-be it a teacher, a parent, a commander, or the demon one worships-is the real bond holding drow society together, and this system is held in esteem by the lowliest drow servant and by the most powerful drow priestess alike.</p>\n<p>The drow are infamous throughout the world, but until recently most assumed stories of demon-worshipping, underground-dwelling elves were spooky legends crafted to share around a campfire. Today, the existence of drow is an understood truth, and while their presence in the dark caverns deep below is unsettling, they seem content to leave the surface world alone for now.</p>",
             "source": {
                 "author": "",
-                "value": "Pathfinder #165: Eyes of Empty Death"
+                "value": "Abomination Vaults"
             }
         },
         "resources": {
@@ -1719,15 +1675,15 @@
         "saves": {
             "fortitude": {
                 "saveDetail": "",
-                "value": 20
+                "value": 6
             },
             "reflex": {
                 "saveDetail": "",
-                "value": 21
+                "value": 10
             },
             "will": {
                 "saveDetail": "",
-                "value": 22
+                "value": 6
             }
         },
         "traits": {
@@ -1739,7 +1695,7 @@
                     "undercommon"
                 ]
             },
-            "rarity": "unique",
+            "rarity": "common",
             "senses": {
                 "value": "darkvision"
             },

--- a/packs/data/abomination-vaults-bestiary.db/galudu.json
+++ b/packs/data/abomination-vaults-bestiary.db/galudu.json
@@ -3909,7 +3909,7 @@
                 }
             },
             "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-continuation.webp",
-            "name": "Wand of Continuation (Stoneskin)",
+            "name": "Wand of Continuation (4th-Level Spell)",
             "sort": 3600000,
             "system": {
                 "baseItem": null,

--- a/packs/data/abomination-vaults-bestiary.db/hellforge-barbazu.json
+++ b/packs/data/abomination-vaults-bestiary.db/hellforge-barbazu.json
@@ -1351,7 +1351,7 @@
             "type": "lore"
         }
     ],
-    "name": "Barbazu (AV-D5)",
+    "name": "Hellforge Barbazu",
     "prototypeToken": {
         "name": "Barbazu"
     },
@@ -1437,6 +1437,7 @@
             "privateNotes": "",
             "publicNotes": "<p>Barbazus, known also as bearded devils or infantry devils, are murderous fiends who satiate their lust for annihilation by serving as the foot soldiers of Hell's armies, often leading hordes of lesser devils such as imps and lemures into battle. Bearded devils wield serrated glaives to inflict jagged gashes that resist healing magic, resulting in tremendous blood loss. When enemies come too close, bearded devils strike with the spines of their wriggling beards to deliver a wretched contagion called Avernal fever, savoring the sight of their victim's strength being slowly devoured from within.</p>\n<p>Barbazus can be found savagely indulging the whims of evil infernal lords from all layers of Hell, rejoicing as they disseminate murder, misery, and anguish as they see fit.</p>\n<hr />\n<p>Masters of corruption and architects of conquest, devils seek both to tempt mortal life to join in their pursuit of all things profane and to spread tyranny throughout all worlds. The temptations they offer mortals range from great powers granted by the signing of an infernal contract to twisted favors following a whispered pledge to a diabolic patron, or any number of even subtler exchanges. Those who succumb to these temptations find themselves consigned to an afterlife of endless torment in the pits of Hell, wherein the only hope of escape lies in the chance of being promoted to become a devil in the infernal ranks. Every devil has a specific role to play in the upkeep of the remorseless bureaucratic machine that is Hell, from soldiers and scholars to inquisitors, lawyers, judges, and executioners. Lowly lemures and imps perform subservient labor to more powerful and specialized devils, such as contract devils and erinyes, while the greatest pit fiends command entire infernal armies.</p>",
             "source": {
+                "author": "",
                 "value": "Pathfinder #164: Hands of the Devil"
             }
         },

--- a/packs/data/abomination-vaults-bestiary.db/jafaki.json
+++ b/packs/data/abomination-vaults-bestiary.db/jafaki.json
@@ -2374,11 +2374,6 @@
         },
         {
             "_id": "uoAX9IiZSNNfElFr",
-            "flags": {
-                "core": {
-                    "sourceId": "Item.XMNqir7oUGoFemFM"
-                }
-            },
             "img": "systems/pf2e/icons/equipment/held-items/key-purple.webp",
             "name": "Jafaki's Four-pronged Key",
             "sort": 2200000,

--- a/packs/data/abomination-vaults-bestiary.db/jafaki.json
+++ b/packs/data/abomination-vaults-bestiary.db/jafaki.json
@@ -1571,130 +1571,6 @@
             "type": "equipment"
         },
         {
-            "_id": "FkGBWHbn2dqoIsH4",
-            "img": "systems/pf2e/icons/equipment/held-items/key-purple.webp",
-            "name": "Key",
-            "sort": 1500000,
-            "system": {
-                "baseItem": null,
-                "containerId": "null",
-                "description": {
-                    "value": "<p>key to area <strong>B11</strong></p>"
-                },
-                "equipped": {
-                    "carryType": "worn",
-                    "handsHeld": 0,
-                    "invested": null
-                },
-                "equippedBulk": {
-                    "value": ""
-                },
-                "hardness": 0,
-                "hp": {
-                    "brokenThreshold": 0,
-                    "max": 0,
-                    "value": 0
-                },
-                "level": {
-                    "value": 0
-                },
-                "negateBulk": {
-                    "value": "0"
-                },
-                "preciousMaterial": {
-                    "value": null
-                },
-                "preciousMaterialGrade": {
-                    "value": null
-                },
-                "price": {
-                    "value": {}
-                },
-                "quantity": 1,
-                "rules": [],
-                "size": "med",
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "stackGroup": null,
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                },
-                "usage": {
-                    "value": "held-in-one-hand"
-                },
-                "weight": {
-                    "value": "-"
-                }
-            },
-            "type": "equipment"
-        },
-        {
-            "_id": "DoBnrcP58XGu4U1c",
-            "img": "systems/pf2e/icons/equipment/held-items/key-purple.webp",
-            "name": "Key",
-            "sort": 1600000,
-            "system": {
-                "baseItem": null,
-                "containerId": "null",
-                "description": {
-                    "value": "<p>key to area <strong>C7</strong></p>"
-                },
-                "equipped": {
-                    "carryType": "worn",
-                    "handsHeld": 0,
-                    "invested": null
-                },
-                "equippedBulk": {
-                    "value": ""
-                },
-                "hardness": 0,
-                "hp": {
-                    "brokenThreshold": 0,
-                    "max": 0,
-                    "value": 0
-                },
-                "level": {
-                    "value": 0
-                },
-                "negateBulk": {
-                    "value": "0"
-                },
-                "preciousMaterial": {
-                    "value": null
-                },
-                "preciousMaterialGrade": {
-                    "value": null
-                },
-                "price": {
-                    "value": {}
-                },
-                "quantity": 1,
-                "rules": [],
-                "size": "med",
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "stackGroup": null,
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                },
-                "usage": {
-                    "value": "held-in-one-hand"
-                },
-                "weight": {
-                    "value": "-"
-                }
-            },
-            "type": "equipment"
-        },
-        {
             "_id": "cNM2OqWLz3u5w7ai",
             "flags": {
                 "core": {
@@ -1703,7 +1579,7 @@
             },
             "img": "systems/pf2e/icons/equipment/wands/magic-wands/magic-wand.webp",
             "name": "Wand of Gentle Repose (Level 2)",
-            "sort": 1700000,
+            "sort": 1500000,
             "system": {
                 "autoDestroy": {
                     "_deprecated": true,
@@ -1895,7 +1771,7 @@
             },
             "img": "systems/pf2e/icons/equipment/wands/magic-wands/magic-wand.webp",
             "name": "Wand of Magic Missile (Level 2)",
-            "sort": 1800000,
+            "sort": 1600000,
             "system": {
                 "autoDestroy": {
                     "_deprecated": true,
@@ -2093,7 +1969,7 @@
             },
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons/wyvern-poison.webp",
             "name": "Infused Wyvern Poison",
-            "sort": 1900000,
+            "sort": 1700000,
             "system": {
                 "autoDestroy": {
                     "_deprecated": true,
@@ -2180,7 +2056,7 @@
             },
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/cognitive-mutagen.webp",
             "name": "Infused Cognitive Mutagen (Moderate)",
-            "sort": 2000000,
+            "sort": 1800000,
             "system": {
                 "autoDestroy": {
                     "_deprecated": true,
@@ -2268,7 +2144,7 @@
             },
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/elixir-of-life.webp",
             "name": "Infused Elixir of Life (Lesser)",
-            "sort": 2100000,
+            "sort": 1900000,
             "system": {
                 "autoDestroy": {
                     "_deprecated": true,
@@ -2355,7 +2231,7 @@
             },
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/mistform-elixir.webp",
             "name": "Infused Mistform Elixir (Moderate)",
-            "sort": 2200000,
+            "sort": 2000000,
             "system": {
                 "autoDestroy": {
                     "_deprecated": true,
@@ -2433,6 +2309,135 @@
                 }
             },
             "type": "consumable"
+        },
+        {
+            "_id": "mfK2z6yvALRHoI2f",
+            "img": "systems/pf2e/icons/equipment/held-items/key-copper.webp",
+            "name": "Jafaki's Round Key",
+            "sort": 2100000,
+            "system": {
+                "baseItem": null,
+                "containerId": null,
+                "description": {
+                    "value": "<p>This unusual key has a round shaft tipped with several teeth of varying length.</p>"
+                },
+                "equipped": {
+                    "-=inSlot": null,
+                    "carryType": "worn",
+                    "handsHeld": 0
+                },
+                "equippedBulk": {
+                    "value": ""
+                },
+                "hardness": 0,
+                "hp": {
+                    "brokenThreshold": 0,
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "preciousMaterial": {
+                    "value": null
+                },
+                "preciousMaterialGrade": {
+                    "value": null
+                },
+                "price": {
+                    "value": {}
+                },
+                "quantity": 1,
+                "rules": [],
+                "size": "med",
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "stackGroup": null,
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "usage": {
+                    "value": ""
+                },
+                "weight": {
+                    "value": "-"
+                }
+            },
+            "type": "treasure"
+        },
+        {
+            "_id": "uoAX9IiZSNNfElFr",
+            "flags": {
+                "core": {
+                    "sourceId": "Item.XMNqir7oUGoFemFM"
+                }
+            },
+            "img": "systems/pf2e/icons/equipment/held-items/key-purple.webp",
+            "name": "Jafaki's Four-pronged Key",
+            "sort": 2200000,
+            "system": {
+                "baseItem": null,
+                "containerId": null,
+                "description": {
+                    "value": "<p>This elaborate key has a four-pronged design.</p>"
+                },
+                "equipped": {
+                    "-=inSlot": null,
+                    "carryType": "worn",
+                    "handsHeld": 0
+                },
+                "equippedBulk": {
+                    "value": ""
+                },
+                "hardness": 0,
+                "hp": {
+                    "brokenThreshold": 0,
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "preciousMaterial": {
+                    "value": null
+                },
+                "preciousMaterialGrade": {
+                    "value": null
+                },
+                "price": {
+                    "value": {}
+                },
+                "quantity": 1,
+                "rules": [],
+                "size": "med",
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "stackGroup": null,
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "usage": {
+                    "value": ""
+                },
+                "weight": {
+                    "value": "-"
+                }
+            },
+            "type": "treasure"
         },
         {
             "_id": "7sBSRQrV9kFrhQxu",
@@ -3423,6 +3428,7 @@
             "privateNotes": "",
             "publicNotes": "",
             "source": {
+                "author": "",
                 "value": "Pathfinder #164: Hands of the Devil"
             }
         },

--- a/packs/data/abomination-vaults-bestiary.db/khurfel.json
+++ b/packs/data/abomination-vaults-bestiary.db/khurfel.json
@@ -1296,25 +1296,25 @@
             "type": "armor"
         },
         {
-            "_id": "ihK7bZ8otOxZ6REW",
+            "_id": "3E75McvHGkYxKMWR",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.equipment-srd.IS1P6er2hLyKXAss"
                 }
             },
-            "img": "systems/pf2e/icons/default-icons/equipment.svg",
+            "img": "systems/pf2e/icons/equipment/other/emerald-fulcrum-lenses.webp",
             "name": "Emerald Fulcrum Lens",
             "sort": 1300000,
             "system": {
                 "baseItem": null,
                 "containerId": null,
                 "description": {
-                    "value": "<p>This concave green lens is pitted and flawed; its jagged edges can cut those who don't handle it with care. While you have the Emerald Fulcrum Lens invested, your flesh appears waxen and pallid. You gain negative healing and <em>@UUID[Compendium.pf2e.spells-srd.Harm]{Harm}</em> spells gain a +4 status bonus to the Hit Points they restore to you. You can also activate the lens in the following ways.</p>\n<hr />\n<p><strong>Activate</strong> <span class=\"pf2-icon\">2</span> Interact (healing)</p>\n<p><strong>Frequency</strong> once per day</p>\n<hr />\n<p><strong>Effect</strong> You grasp the Emerald Fulcrum Lens in one hand, regain 30 Hit Points, and gain a +2 item bonus to saving throws against magic for 1 round.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Effect: Emerald Fulcrum Lens (Saving Throw)]{Effect: Emerald Fulcrum Lens (Saving Throw)}</p>\n<hr />\n<p><strong>Activate</strong> <span class=\"pf2-icon\">2</span> Interact (attack, possession)</p>\n<p>While grasping the lens, make a melee spell attack roll with a modifier of +20. On a hit, you force the splinter of Nhimbaloth's essence from the lens to possess the target. You're no longer invested in the lens, and the target gains the benefits as though it had invested the lens but can't activate the lens's other abilities. This effect is permanent, but it can be ended by any effect that removes a possession effect. The lens doesn't have any magical abilities until the possession effect ends; when it does, the essence returns to the lens.</p>"
+                    "value": "<p>This concave green lens is pitted and flawed; its jagged edges can cut those who don't handle it with care. While you have the Emerald Fulcrum Lens invested, your flesh appears waxen and pallid. You gain negative healing and <em>@UUID[Compendium.pf2e.spells-srd.Harm]{Harm}</em> spells gain a +4 status bonus to the Hit Points they restore to you. You can also activate the lens in the following ways.</p>\n<hr />\n<p><strong>Activate</strong> <span class=\"pf2-icon\">2</span> Interact (healing)</p>\n<p><strong>Frequency</strong> once per day</p>\n<hr />\n<p><strong>Effect</strong> You grasp the Emerald Fulcrum Lens in one hand, regain 30 Hit Points, and gain a +2 item bonus to saving throws against magic for 1 round.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Effect: Emerald Fulcrum Lens (Saving Throw)]{Effect: Emerald Fulcrum Lens (Saving Throw)}</p>\n<hr />\n<p><strong>Activate</strong> <span class=\"pf2-icon\">2</span> Interact (attack, possession)</p>\n<p>While grasping the lens, make a melee spell attack roll with a modifier of [[/r d20+20]]{+20}. On a hit, you force the splinter of Nhimbaloth's essence from the lens to possess the target. You're no longer invested in the lens, and the target gains the benefits as though it had invested the lens but can't activate the lens's other abilities. This effect is permanent, but it can be ended by any effect that removes a possession effect. The lens doesn't have any magical abilities until the possession effect ends; when it does, the essence returns to the lens.</p>"
                 },
                 "equipped": {
                     "carryType": "held",
                     "handsHeld": 1,
-                    "invested": false
+                    "invested": null
                 },
                 "equippedBulk": {
                     "value": ""
@@ -1347,7 +1347,7 @@
                 "size": "med",
                 "slug": "emerald-fulcrum-lens",
                 "source": {
-                    "value": ""
+                    "value": "Pathfinder #165: Eyes of Empty Death"
                 },
                 "stackGroup": null,
                 "traits": {
@@ -1453,10 +1453,74 @@
             "type": "consumable"
         },
         {
+            "_id": "MhayCkEUA2ErJ0HR",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.equipment-effects.rH6RHxy6sNTLusKX"
+                }
+            },
+            "img": "systems/pf2e/icons/equipment/other/emerald-fulcrum-lenses.webp",
+            "name": "Effect: Emerald Fulcrum Lens (Saving Throw)",
+            "sort": 1500000,
+            "system": {
+                "badge": null,
+                "description": {
+                    "value": "<p>For 1 round you gain a +1 item bonus to attack rolls, saving throws, and DCs.</p>"
+                },
+                "duration": {
+                    "expiry": "turn-start",
+                    "sustained": false,
+                    "unit": "rounds",
+                    "value": 1
+                },
+                "level": {
+                    "value": 1
+                },
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "predicate": [
+                            {
+                                "or": [
+                                    "magical",
+                                    "arcane",
+                                    "primal",
+                                    "occult",
+                                    "divine"
+                                ]
+                            }
+                        ],
+                        "selector": "saving-throw",
+                        "type": "item",
+                        "value": 2
+                    }
+                ],
+                "slug": "effect-emerald-fulcrum-lens-saving-throw",
+                "source": {
+                    "value": "Pathfinder #165: Eyes of Empty Death"
+                },
+                "start": {
+                    "initiative": null,
+                    "value": 0
+                },
+                "target": null,
+                "tokenIcon": {
+                    "show": true
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "unidentified": false
+            },
+            "type": "effect"
+        },
+        {
             "_id": "Qmj5gqP1YgGLr1W3",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Rhoka Sword",
-            "sort": 1500000,
+            "sort": 1600000,
             "system": {
                 "attack": {
                     "value": ""
@@ -1519,7 +1583,7 @@
             "_id": "5OrtHpltPsigs3A8",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Jaws",
-            "sort": 1600000,
+            "sort": 1700000,
             "system": {
                 "attack": {
                     "value": ""
@@ -1562,7 +1626,7 @@
             "_id": "KkhGaZRJP4cnQSOE",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Heavy Crossbow",
-            "sort": 1700000,
+            "sort": 1800000,
             "system": {
                 "attack": {
                     "value": ""
@@ -1610,7 +1674,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Greater Darkvision",
-            "sort": 1800000,
+            "sort": 1900000,
             "system": {
                 "actionCategory": {
                     "value": "interaction"
@@ -1655,7 +1719,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "At-Will Spells",
-            "sort": 1900000,
+            "sort": 2000000,
             "system": {
                 "actionCategory": {
                     "value": "interaction"
@@ -1700,7 +1764,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Negative Healing",
-            "sort": 2000000,
+            "sort": 2100000,
             "system": {
                 "actionCategory": {
                     "value": "defensive"
@@ -1752,7 +1816,7 @@
             },
             "img": "systems/pf2e/icons/actions/Reaction.webp",
             "name": "Attack of Opportunity",
-            "sort": 2100000,
+            "sort": 2200000,
             "system": {
                 "actionCategory": {
                     "value": "defensive"
@@ -1792,7 +1856,7 @@
             "_id": "l18iYVUpNZjCrvzG",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Necrotic Decay",
-            "sort": 2200000,
+            "sort": 2300000,
             "system": {
                 "actionCategory": {
                     "value": "defensive"
@@ -1837,7 +1901,7 @@
             "_id": "qykfSUOQXBbtu4gM",
             "img": "systems/pf2e/icons/actions/TwoActions.webp",
             "name": "Frenzied Attack",
-            "sort": 2300000,
+            "sort": 2400000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -1877,7 +1941,7 @@
             "_id": "qTIxm70Zd6ETxfgu",
             "img": "systems/pf2e/icons/actions/TwoActions.webp",
             "name": "Insightful Swing",
-            "sort": 2400000,
+            "sort": 2500000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -1917,7 +1981,7 @@
             "_id": "XrEqDkgs6eaCAzhM",
             "img": "systems/pf2e/icons/actions/OneAction.webp",
             "name": "Wicked Bite",
-            "sort": 2500000,
+            "sort": 2600000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -1959,7 +2023,7 @@
             "_id": "aQl0ZCRMV90035rO",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Athletics",
-            "sort": 2600000,
+            "sort": 2700000,
             "system": {
                 "description": {
                     "value": ""
@@ -1987,7 +2051,7 @@
             "_id": "6mG1Og8D3AzWcbCC",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Intimidation",
-            "sort": 2700000,
+            "sort": 2800000,
             "system": {
                 "description": {
                     "value": ""
@@ -2015,7 +2079,7 @@
             "_id": "CfouYIty7hs5fIPF",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Survival",
-            "sort": 2800000,
+            "sort": 2900000,
             "system": {
                 "description": {
                     "value": ""
@@ -2116,6 +2180,7 @@
             "privateNotes": "",
             "publicNotes": "<p>Khurfel leads the largest and most active group of adversaries the heroes face in the Abomination Vaults. His fated confrontation with the heroes is necessary because he holds the Emerald Fulcrum Lens and refuses to give it up as long as he lives, as it symbolizes the leadership of his cult. Khurfel's vision of falling at the heroes' hands doesn't inspire fear-it inspires fury, and he fights against his prophesized enemies as long as breath remains in his body.</p>",
             "source": {
+                "author": "",
                 "value": "Pathfinder #165: Eyes of Empty Death"
             }
         },

--- a/packs/data/abomination-vaults-bestiary.db/ladys-whisper.json
+++ b/packs/data/abomination-vaults-bestiary.db/ladys-whisper.json
@@ -3910,7 +3910,7 @@
                 "details": "negative healing",
                 "max": 195,
                 "temp": 0,
-                "value": "195"
+                "value": 195
             },
             "immunities": [
                 {
@@ -3952,6 +3952,7 @@
             "privateNotes": "",
             "publicNotes": "",
             "source": {
+                "author": "",
                 "value": "Pathfinder #165: Eyes of Empty Death"
             }
         },

--- a/packs/data/abomination-vaults-bestiary.db/murmur.json
+++ b/packs/data/abomination-vaults-bestiary.db/murmur.json
@@ -1,0 +1,1003 @@
+{
+    "_id": "mlifDVJJWwjFtUxv",
+    "img": "systems/pf2e/icons/default-icons/npc.svg",
+    "items": [
+        {
+            "_id": "G0WFBGJRBnL3fapV",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.equipment-srd.e4NwsnPnpQKbDZ9F"
+                }
+            },
+            "img": "systems/pf2e/icons/equipment/weapons/composite-shortbow.webp",
+            "name": "Composite Shortbow",
+            "sort": 100000,
+            "system": {
+                "MAP": {
+                    "value": ""
+                },
+                "baseItem": "composite-shortbow",
+                "bonus": {
+                    "value": 0
+                },
+                "bonusDamage": {
+                    "value": 0
+                },
+                "category": "martial",
+                "containerId": null,
+                "damage": {
+                    "damageType": "piercing",
+                    "dice": 1,
+                    "die": "d6",
+                    "value": ""
+                },
+                "description": {
+                    "value": "<p>This shortbow is made from horn, wood, and sinew laminated together to increase the power of its pull and the force of its projectile. Its compact size and power make it a favorite of mounted archers. Any time an ability is specifically restricted to a shortbow, it also applies to composite shortbows unless otherwise stated.</p>"
+                },
+                "equipped": {
+                    "carryType": "held",
+                    "handsHeld": 1,
+                    "invested": null
+                },
+                "equippedBulk": {
+                    "value": ""
+                },
+                "group": "bow",
+                "hardness": 0,
+                "hp": {
+                    "brokenThreshold": 0,
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "potencyRune": {
+                    "value": 1
+                },
+                "preciousMaterial": {
+                    "value": null
+                },
+                "preciousMaterialGrade": {
+                    "value": null
+                },
+                "price": {
+                    "value": {
+                        "gp": 14
+                    }
+                },
+                "propertyRune1": {
+                    "value": null
+                },
+                "propertyRune2": {
+                    "value": null
+                },
+                "propertyRune3": {
+                    "value": null
+                },
+                "propertyRune4": {
+                    "value": null
+                },
+                "quantity": 1,
+                "range": 60,
+                "reload": {
+                    "value": "0"
+                },
+                "rules": [],
+                "size": "med",
+                "slug": "composite-shortbow",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "specific": {
+                    "value": false
+                },
+                "splashDamage": {
+                    "value": 0
+                },
+                "stackGroup": null,
+                "strikingRune": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "deadly-d10",
+                        "propulsive"
+                    ]
+                },
+                "usage": {
+                    "value": "held-in-one-plus-hands"
+                },
+                "weight": {
+                    "value": "1"
+                }
+            },
+            "type": "weapon"
+        },
+        {
+            "_id": "4tat8stpB3Q8gsxD",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.equipment-srd.7tKkkF8eZ4iCLJtp"
+                }
+            },
+            "img": "systems/pf2e/icons/equipment/weapons/shortsword.webp",
+            "name": "Shortsword",
+            "sort": 200000,
+            "system": {
+                "MAP": {
+                    "value": ""
+                },
+                "baseItem": "shortsword",
+                "bonus": {
+                    "value": 0
+                },
+                "bonusDamage": {
+                    "value": 0
+                },
+                "category": "martial",
+                "containerId": null,
+                "damage": {
+                    "damageType": "piercing",
+                    "dice": 1,
+                    "die": "d6",
+                    "value": ""
+                },
+                "description": {
+                    "value": "<p>These blades come in a variety of shapes and styles, but they are typically 2 feet long.</p>"
+                },
+                "equipped": {
+                    "carryType": "held",
+                    "handsHeld": 1,
+                    "invested": null
+                },
+                "equippedBulk": {
+                    "value": ""
+                },
+                "group": "sword",
+                "hardness": 0,
+                "hp": {
+                    "brokenThreshold": 0,
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "potencyRune": {
+                    "value": null
+                },
+                "preciousMaterial": {
+                    "value": null
+                },
+                "preciousMaterialGrade": {
+                    "value": null
+                },
+                "price": {
+                    "value": {
+                        "sp": 9
+                    }
+                },
+                "propertyRune1": {
+                    "value": ""
+                },
+                "propertyRune2": {
+                    "value": ""
+                },
+                "propertyRune3": {
+                    "value": ""
+                },
+                "propertyRune4": {
+                    "value": ""
+                },
+                "quantity": 1,
+                "range": null,
+                "reload": {
+                    "value": ""
+                },
+                "rules": [],
+                "size": "med",
+                "slug": "shortsword",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "specific": {
+                    "value": false
+                },
+                "splashDamage": {
+                    "value": 0
+                },
+                "stackGroup": null,
+                "strikingRune": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "agile",
+                        "finesse",
+                        "versatile-s"
+                    ]
+                },
+                "usage": {
+                    "value": "held-in-one-hand"
+                },
+                "weight": {
+                    "value": "L"
+                }
+            },
+            "type": "weapon"
+        },
+        {
+            "_id": "nMrjjrW4q3ui6tWU",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.equipment-srd.w2ENw2VMPcsbif8g"
+                }
+            },
+            "img": "systems/pf2e/icons/equipment/weapons/arrows.webp",
+            "name": "Arrows",
+            "sort": 300000,
+            "system": {
+                "autoDestroy": {
+                    "_deprecated": true,
+                    "value": true
+                },
+                "baseItem": null,
+                "charges": {
+                    "max": 0,
+                    "value": 0
+                },
+                "consumableType": {
+                    "value": "ammo"
+                },
+                "consume": {
+                    "value": ""
+                },
+                "containerId": null,
+                "description": {
+                    "value": "<p>These projectiles are the ammunition for bows. The shaft of an arrow is made of wood. It is stabilized in flight by fletching at one end and bears a metal head on the other.</p>"
+                },
+                "equipped": {
+                    "carryType": "held",
+                    "handsHeld": 1
+                },
+                "equippedBulk": {
+                    "value": ""
+                },
+                "hardness": 0,
+                "hp": {
+                    "brokenThreshold": 0,
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "preciousMaterial": {
+                    "value": ""
+                },
+                "preciousMaterialGrade": {
+                    "value": ""
+                },
+                "price": {
+                    "per": 10,
+                    "value": {
+                        "sp": 1
+                    }
+                },
+                "quantity": 60,
+                "rules": [],
+                "size": "med",
+                "slug": "arrows",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "stackGroup": "arrows",
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "usage": {
+                    "value": "held-in-one-hand"
+                },
+                "weight": {
+                    "value": "L"
+                }
+            },
+            "type": "consumable"
+        },
+        {
+            "_id": "Kc5YV0VavUVwSpHl",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.conditionitems.e1XGnhKNSQIm5IXg"
+                },
+                "pf2e": {
+                    "condition": true
+                }
+            },
+            "img": "systems/pf2e/icons/conditions/stupefied.webp",
+            "name": "Stupefied",
+            "sort": 400000,
+            "system": {
+                "active": true,
+                "alsoApplies": {
+                    "linked": [],
+                    "unlinked": []
+                },
+                "base": "Stupefied",
+                "description": {
+                    "value": "<p>Your thoughts and instincts are clouded. Stupefied always includes a value. You take a status penalty equal to this value on Intelligence-, Wisdom-, and Charisma-based checks and DCs, including Will saving throws, spell attack rolls, spell DCs, and skill checks that use these ability scores. Any time you attempt to @UUID[Compendium.pf2e.actionspf2e.Cast a Spell]{Cast a Spell} while stupefied, the spell is disrupted unless you succeed at a flat check with a DC equal to 5 + your stupefied value.</p>"
+                },
+                "duration": {
+                    "perpetual": true,
+                    "text": "",
+                    "value": 0
+                },
+                "group": "abilities",
+                "hud": {
+                    "img": {
+                        "useStatusName": true,
+                        "value": "systems/pf2e/icons/conditions-2/stupefied.webp"
+                    },
+                    "selectable": true,
+                    "statusName": "stupefied"
+                },
+                "modifiers": [],
+                "overrides": [],
+                "references": {
+                    "children": [],
+                    "immunityFrom": [],
+                    "overriddenBy": [],
+                    "overrides": []
+                },
+                "removable": true,
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "selector": [
+                            "cha-based",
+                            "int-based",
+                            "wis-based"
+                        ],
+                        "slug": "stupefied",
+                        "type": "status",
+                        "value": "-@item.badge.value"
+                    }
+                ],
+                "slug": "stupefied",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "sources": {
+                    "hud": true,
+                    "values": []
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "value": {
+                    "immutable": false,
+                    "isValued": true,
+                    "modifiers": [],
+                    "value": 4
+                }
+            },
+            "type": "condition"
+        },
+        {
+            "_id": "z9bTah65DoASEDhP",
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Shortsword",
+            "sort": 500000,
+            "system": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "custom": "",
+                    "value": [
+                        "serpent-venom"
+                    ]
+                },
+                "bonus": {
+                    "value": 18
+                },
+                "damageRolls": {
+                    "8vifthuqwag8dw6e4xnl": {
+                        "damage": "1d6+8",
+                        "damageType": "piercing"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "agile",
+                        "finesse",
+                        "versatile-s"
+                    ]
+                },
+                "weaponType": {
+                    "value": "melee"
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "ltvMN7K0itu2l3WZ",
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Snake Fangs",
+            "sort": 600000,
+            "system": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "custom": "",
+                    "value": [
+                        "serpent-venom"
+                    ]
+                },
+                "bonus": {
+                    "value": 16
+                },
+                "damageRolls": {
+                    "6ofsourtuiris927jxiu": {
+                        "damage": "1d4+8",
+                        "damageType": "piercing"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "agile",
+                        "finesse"
+                    ]
+                },
+                "weaponType": {
+                    "value": "melee"
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "F8wXzsUNliJVU8bv",
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Composite Shortbow",
+            "sort": 700000,
+            "system": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "custom": "",
+                    "value": [
+                        "serpent-venom"
+                    ]
+                },
+                "bonus": {
+                    "value": 19
+                },
+                "damageRolls": {
+                    "vk7p3e37uiwdoit8louy": {
+                        "damage": "1d6+7",
+                        "damageType": "piercing"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "deadly-d10",
+                        "magical",
+                        "propulsive",
+                        "range-increment-60",
+                        "reload-0"
+                    ]
+                },
+                "weaponType": {
+                    "value": "ranged"
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "NcZMn3pf8nbMeY8x",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.qCCLZhnp2HhP3Ex6"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Darkvision",
+            "sort": 800000,
+            "system": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Darkvision]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "darkvision",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "SaMUZistsZa0Bskd",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.9qV49KjZujZnSp6w"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "All-Around Vision",
+            "sort": 900000,
+            "system": {
+                "actionCategory": {
+                    "value": "defensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.AllAroundVision]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "system.attributes.flanking.flankable",
+                        "value": false
+                    }
+                ],
+                "slug": "all-around-vision",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "zGXZKhk95VPsSdKN",
+            "img": "systems/pf2e/icons/actions/Reaction.webp",
+            "name": "Biting Snakes",
+            "sort": 1000000,
+            "system": {
+                "actionCategory": {
+                    "value": "defensive"
+                },
+                "actionType": {
+                    "value": "reaction"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p><strong>Trigger</strong> A creature ends its turn adjacent to the medusa.</p>\n<hr />\n<p><strong>Effect</strong> The medusa makes a snake fangs Strike against the creature.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "hSGaU1UT8mzmPFWl",
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Petrifying Gaze",
+            "sort": 1100000,
+            "system": {
+                "actionCategory": {
+                    "value": "defensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Template[type:emanation|distance:30]{30 feet} @UUID[Compendium.pf2e.bestiary-ability-glossary-srd.Aura]{Aura}</p>\n<hr />\n<p>When a creature ends its turn in the aura, it must attempt a @Check[type:fortitude|dc:25] save. If the creature fails, it becomes @UUID[Compendium.pf2e.conditionitems.Slowed]{Slowed 1} for 1 minute. The medusa can deactivate or activate this aura by using a single action, which has the concentrate trait.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "arcane",
+                        "aura",
+                        "transmutation",
+                        "visual"
+                    ]
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "2lGYb3ZO8pwxgMhD",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Focus Gaze",
+            "sort": 1200000,
+            "system": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "description": {
+                    "value": "<p>The medusa fixes their glare at a creature they can see within 30 feet. The target must immediately attempt a @Check[type:fortitude|dc:25] save against the medusa's petrifying gaze. If the creature was already @UUID[Compendium.pf2e.conditionitems.Slowed]{Slowed} by petrifying gaze before attempting its save, a failed save causes it to be @UUID[Compendium.pf2e.conditionitems.Petrified]{Petrified} permanently.</p>\n<p>After attempting its save, the creature is then temporarily immune until the start of the medusa's next turn.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "arcane",
+                        "concentrate",
+                        "incapacitation",
+                        "transmutation",
+                        "visual"
+                    ]
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "FuDdgAP7wwq6LCFO",
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Serpent Venom",
+            "sort": 1300000,
+            "system": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p><strong>Saving Throw</strong> @Check[type:fortitude|dc:25]</p>\n<hr />\n<p><strong>Maximum Duration</strong> 6 rounds</p>\n<p><strong>Stage 1</strong> [[/r 1d6[poison]]] damage and @UUID[Compendium.pf2e.conditionitems.Enfeebled]{Enfeebled 1} (1 round)</p>\n<p><strong>Stage 2</strong> [[/r 2d6[poison]]] damage and @UUID[Compendium.pf2e.conditionitems.Enfeebled]{Enfeebled 2} (1 round)</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "poison"
+                    ]
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "aB3Eiwm7lKulxfZ4",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Deception",
+            "sort": 1400000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 16
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "lore"
+        },
+        {
+            "_id": "0AVXTu0IQeCK9qy9",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Diplomacy",
+            "sort": 1500000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 14
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "lore"
+        },
+        {
+            "_id": "1V6Ipqd0JqILUKar",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Stealth",
+            "sort": 1600000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 16
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "lore"
+        }
+    ],
+    "name": "Murmur",
+    "system": {
+        "abilities": {
+            "cha": {
+                "mod": 2
+            },
+            "con": {
+                "mod": 4
+            },
+            "dex": {
+                "mod": 5
+            },
+            "int": {
+                "mod": 2
+            },
+            "str": {
+                "mod": 2
+            },
+            "wis": {
+                "mod": 1
+            }
+        },
+        "attributes": {
+            "ac": {
+                "details": "all-around vision",
+                "value": 25
+            },
+            "allSaves": {
+                "value": ""
+            },
+            "hp": {
+                "details": "",
+                "max": 105,
+                "temp": 0,
+                "value": 105
+            },
+            "initiative": {
+                "ability": "perception"
+            },
+            "perception": {
+                "value": 14
+            },
+            "speed": {
+                "otherSpeeds": [],
+                "value": 25
+            }
+        },
+        "details": {
+            "alignment": {
+                "value": "LE"
+            },
+            "blurb": "Female feebleminded medusa (Pathfinder Bestiary 234)",
+            "creatureType": "Humanoid",
+            "level": {
+                "value": 7
+            },
+            "privateNotes": "",
+            "publicNotes": "<p>Monstrous humanoids that resemble humans with snakes instead of hair, medusas are best known for their petrifying gazes that-if lingered upon-can permanently transform mortals to stone. Medusas are shrewd and manipulative adversaries who collect and covet secrets, and who use threats and guile to exploit the fears of weaker creatures. A medusa may seek out powerful magic items, use divination magic to discover secret knowledge and unlock forbidden power, or infiltrate a society to beguile influential politicians. Their ability to worm their way into powerful organizations makes them natural leaders of criminal outfits and thieves' guilds, and their interest in magical phenomena leads some to pursue careers as oracles who offer to help adventurers find what they seek-for a price. Of course, if wit and deception proves insufficient, a medusa can always simply turn rivals into ornate stone decorations with little more than a glare.</p>\n<p>Exceptionally agile and surprisingly hardy, a medusa rarely backs down from a conflict even when cornered. Many adventurers who thought themselves readied to resist the effects of a medusa's gaze have nevertheless fallen to a medusa, as these creatures are also often deadly archers able to riddle their foes with venom-coated arrows from a distance. Still, a medusa may barter for their life if no alternatives remain, and the secrets carried by these powerful villains often make it more than worth sparing the monster's life.</p>",
+            "source": {
+                "author": "",
+                "value": "Pathfinder Abomination Vaults Hardcover Compilation"
+            }
+        },
+        "resources": {},
+        "saves": {
+            "fortitude": {
+                "saveDetail": "",
+                "value": 15
+            },
+            "reflex": {
+                "saveDetail": "",
+                "value": 16
+            },
+            "will": {
+                "saveDetail": "",
+                "value": 14
+            }
+        },
+        "traits": {
+            "attitude": {
+                "value": "hostile"
+            },
+            "languages": {
+                "custom": "",
+                "selected": [],
+                "value": [
+                    "common"
+                ]
+            },
+            "rarity": "common",
+            "senses": {
+                "value": "darkvision"
+            },
+            "size": {
+                "value": "med"
+            },
+            "value": [
+                "humanoid"
+            ]
+        }
+    },
+    "type": "npc"
+}

--- a/packs/data/abomination-vaults-bestiary.db/nyzuros.json
+++ b/packs/data/abomination-vaults-bestiary.db/nyzuros.json
@@ -1,9 +1,9 @@
 {
-    "_id": "bif3iQcDPi27rx6x",
+    "_id": "ZFP8RyQW4SNtJ3AE",
     "img": "systems/pf2e/icons/default-icons/npc.svg",
     "items": [
         {
-            "_id": "VJFdV0JcVaaqVlyL",
+            "_id": "zYMKuVB2VBXOtrfe",
             "img": "systems/pf2e/icons/default-icons/spellcastingEntry.svg",
             "name": "Divine Innate Spells",
             "sort": 100000,
@@ -20,20 +20,20 @@
                     "value": "innate"
                 },
                 "proficiency": {
-                    "value": 0
+                    "value": 1
                 },
                 "rules": [],
                 "showSlotlessLevels": {
-                    "value": true
+                    "value": false
                 },
                 "showUnpreparedSpells": {
-                    "value": false
+                    "value": true
                 },
                 "slots": {
                     "slot0": {
-                        "max": 1,
+                        "max": 0,
                         "prepared": [],
-                        "value": 1
+                        "value": 0
                     },
                     "slot1": {
                         "max": 0,
@@ -96,9 +96,9 @@
                     "value": ""
                 },
                 "spelldc": {
-                    "dc": 28,
+                    "dc": 23,
                     "mod": 0,
-                    "value": 18
+                    "value": 15
                 },
                 "tradition": {
                     "value": "divine"
@@ -112,14 +112,14 @@
             "type": "spellcastingEntry"
         },
         {
-            "_id": "fL540WJoPfl2yEVm",
+            "_id": "1M3Chy2EO0WvLGrF",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.4GE2ZdODgIQtg51c"
                 }
             },
             "img": "systems/pf2e/icons/spells/darkness.webp",
-            "name": "Darkness (at will)",
+            "name": "Darkness (At Will)",
             "sort": 200000,
             "system": {
                 "ability": {
@@ -157,7 +157,8 @@
                     "value": 2
                 },
                 "location": {
-                    "value": "VJFdV0JcVaaqVlyL"
+                    "heightenedLevel": 2,
+                    "value": "zYMKuVB2VBXOtrfe"
                 },
                 "materials": {
                     "value": ""
@@ -187,7 +188,7 @@
                 },
                 "slug": "darkness",
                 "source": {
-                    "value": ""
+                    "value": "Pathfinder Core Rulebook"
                 },
                 "spellType": {
                     "value": "utility"
@@ -220,14 +221,14 @@
             "type": "spell"
         },
         {
-            "_id": "c9PJ35ELMYksO3fR",
+            "_id": "VYGdMMY84xwadkDM",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.HRb2doyaLtaoCfi3"
                 }
             },
             "img": "systems/pf2e/icons/spells/faerie-fire.webp",
-            "name": "Faerie Fire (at will)",
+            "name": "Faerie Fire (At Will)",
             "sort": 300000,
             "system": {
                 "ability": {
@@ -265,7 +266,8 @@
                     "value": 2
                 },
                 "location": {
-                    "value": "VJFdV0JcVaaqVlyL"
+                    "heightenedLevel": 2,
+                    "value": "zYMKuVB2VBXOtrfe"
                 },
                 "materials": {
                     "value": ""
@@ -295,7 +297,7 @@
                 },
                 "slug": "faerie-fire",
                 "source": {
-                    "value": ""
+                    "value": "Pathfinder Core Rulebook"
                 },
                 "spellType": {
                     "value": "utility"
@@ -327,7 +329,7 @@
             "type": "spell"
         },
         {
-            "_id": "h1JuyLNI2Mab7OJK",
+            "_id": "SooxYL7HXNeypteI",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.kl2q6JvBZwed4B6v"
@@ -369,7 +371,7 @@
                     "value": 1
                 },
                 "location": {
-                    "value": "VJFdV0JcVaaqVlyL"
+                    "value": "zYMKuVB2VBXOtrfe"
                 },
                 "materials": {
                     "value": ""
@@ -399,7 +401,7 @@
                 },
                 "slug": "dancing-lights",
                 "source": {
-                    "value": ""
+                    "value": "Pathfinder Core Rulebook"
                 },
                 "spellType": {
                     "value": "utility"
@@ -433,40 +435,40 @@
             "type": "spell"
         },
         {
-            "_id": "6Fbb5m3k2ejjHr0f",
+            "_id": "LuDFjIGjFpp0GFmQ",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.equipment-srd.XyA6PKV46aNlLXOd"
+                    "sourceId": "Compendium.pf2e.equipment-srd.dUC8Fsa6FZtVikS3"
                 }
             },
-            "img": "systems/pf2e/icons/equipment/weapons/hand-crossbow.webp",
-            "name": "Hand Crossbow",
+            "img": "systems/pf2e/icons/equipment/weapons/composite-longbow.webp",
+            "name": "Composite Longbow",
             "sort": 500000,
             "system": {
                 "MAP": {
                     "value": ""
                 },
-                "baseItem": "hand-crossbow",
+                "baseItem": "composite-longbow",
                 "bonus": {
                     "value": 0
                 },
                 "bonusDamage": {
                     "value": 0
                 },
-                "category": "simple",
+                "category": "martial",
                 "containerId": null,
                 "damage": {
                     "damageType": "piercing",
                     "dice": 1,
-                    "die": "d6",
+                    "die": "d8",
                     "value": ""
                 },
                 "description": {
-                    "value": "<p>Sometimes referred to as an alley bow by rogues or ruffians, this small crossbow fires small bolts that are sometimes used to deliver poison to the target. It's small enough to be shot one-handed, but it still requires two hands to load.</p>"
+                    "value": "<p>This projectile weapon is made from horn, wood, and sinew laminated together to increase the power of its pull and the force of its projectile. Like all longbows, its great size also increases the bow's range and power. You must use two hands to fire it, and it cannot be used while mounted. Any time an ability is specifically restricted to a longbow, such as Erastil's favored weapon, it also applies to composite longbows unless otherwise stated.</p>"
                 },
                 "equipped": {
-                    "carryType": "worn",
-                    "handsHeld": 0,
+                    "carryType": "held",
+                    "handsHeld": 1,
                     "invested": null
                 },
                 "equippedBulk": {
@@ -486,7 +488,7 @@
                     "value": "0"
                 },
                 "potencyRune": {
-                    "value": null
+                    "value": 1
                 },
                 "preciousMaterial": {
                     "value": null
@@ -496,31 +498,31 @@
                 },
                 "price": {
                     "value": {
-                        "gp": 3
+                        "gp": 20
                     }
                 },
                 "propertyRune1": {
-                    "value": ""
+                    "value": null
                 },
                 "propertyRune2": {
-                    "value": ""
+                    "value": null
                 },
                 "propertyRune3": {
-                    "value": ""
+                    "value": null
                 },
                 "propertyRune4": {
-                    "value": ""
+                    "value": null
                 },
                 "quantity": 1,
-                "range": 60,
+                "range": 100,
                 "reload": {
-                    "value": "1"
+                    "value": "0"
                 },
                 "rules": [],
                 "size": "med",
-                "slug": "hand-crossbow",
+                "slug": "composite-longbow",
                 "source": {
-                    "value": ""
+                    "value": "Pathfinder Core Rulebook"
                 },
                 "specific": {
                     "value": false
@@ -535,26 +537,30 @@
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "deadly-d10",
+                        "propulsive",
+                        "volley-30"
+                    ]
                 },
                 "usage": {
-                    "value": "held-in-one-hand"
+                    "value": "held-in-one-plus-hands"
                 },
                 "weight": {
-                    "value": "L"
+                    "value": "2"
                 }
             },
             "type": "weapon"
         },
         {
-            "_id": "6sz5Y1Ptd0vhrLiM",
+            "_id": "GCwWHlv9vvy71XFt",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.equipment-srd.LJdbVTOZog39EEbi"
                 }
             },
             "img": "systems/pf2e/icons/equipment/weapons/longsword.webp",
-            "name": "+1 Striking Corrosive Longsword",
+            "name": "Longsword",
             "sort": 600000,
             "system": {
                 "MAP": {
@@ -579,8 +585,8 @@
                     "value": "<p>Longswords can be one‑edged or two‑edged swords. Their blades are heavy and they're between 3 and 4 feet in length.</p>"
                 },
                 "equipped": {
-                    "carryType": "worn",
-                    "handsHeld": 0,
+                    "carryType": "held",
+                    "handsHeld": 1,
                     "invested": null
                 },
                 "equippedBulk": {
@@ -600,7 +606,7 @@
                     "value": "0"
                 },
                 "potencyRune": {
-                    "value": 1
+                    "value": null
                 },
                 "preciousMaterial": {
                     "value": null
@@ -614,7 +620,7 @@
                     }
                 },
                 "propertyRune1": {
-                    "value": "corrosive"
+                    "value": ""
                 },
                 "propertyRune2": {
                     "value": ""
@@ -634,7 +640,7 @@
                 "size": "med",
                 "slug": "longsword",
                 "source": {
-                    "value": ""
+                    "value": "Pathfinder Core Rulebook"
                 },
                 "specific": {
                     "value": false
@@ -644,7 +650,7 @@
                 },
                 "stackGroup": null,
                 "strikingRune": {
-                    "value": "striking"
+                    "value": ""
                 },
                 "traits": {
                     "custom": "",
@@ -663,30 +669,30 @@
             "type": "weapon"
         },
         {
-            "_id": "olhVw6swCM3iI62M",
+            "_id": "MmS5sGk28Pnjhi7i",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.equipment-srd.r0ifJfoz8aqf0mwk"
+                    "sourceId": "Compendium.pf2e.equipment-srd.MPcM4Wt6KmWE2kGL"
                 }
             },
-            "img": "systems/pf2e/icons/equipment/armor/breastplate.webp",
-            "name": "Breastplate",
+            "img": "systems/pf2e/icons/equipment/armor/chainshirt.webp",
+            "name": "Chain Shirt",
             "sort": 700000,
             "system": {
                 "armor": {
-                    "value": 4
+                    "value": 2
                 },
-                "baseItem": "breastplate",
-                "category": "medium",
+                "baseItem": "chain-shirt",
+                "category": "light",
                 "check": {
-                    "value": -2
+                    "value": -1
                 },
                 "containerId": null,
                 "description": {
-                    "value": "<p>Though referred to as a breastplate, this type of armor consists of several pieces of plate or half‑plate armor that protect the torso, chest, neck, and sometimes the hips and lower legs. It strategically grants some of the protection of plate while allowing greater flexibility and speed.</p>"
+                    "value": "<p>Sometimes called a hauberk, this is a long shirt constructed of the same metal rings as chainmail. However, it is much lighter than chainmail and protects only the torso, upper arms, and upper legs of its wearer.</p>"
                 },
                 "dex": {
-                    "value": 1
+                    "value": 3
                 },
                 "equipped": {
                     "carryType": "worn",
@@ -694,9 +700,9 @@
                     "invested": null
                 },
                 "equippedBulk": {
-                    "value": "2"
+                    "value": "1"
                 },
-                "group": "plate",
+                "group": "chain",
                 "hardness": 0,
                 "hp": {
                     "brokenThreshold": 0,
@@ -714,14 +720,14 @@
                     "value": 0
                 },
                 "preciousMaterial": {
-                    "value": ""
+                    "value": null
                 },
                 "preciousMaterialGrade": {
-                    "value": ""
+                    "value": null
                 },
                 "price": {
                     "value": {
-                        "gp": 8
+                        "gp": 5
                     }
                 },
                 "propertyRune1": {
@@ -742,40 +748,43 @@
                 },
                 "rules": [],
                 "size": "med",
-                "slug": "breastplate",
+                "slug": "chain-shirt",
                 "source": {
-                    "value": ""
+                    "value": "Pathfinder Core Rulebook"
                 },
                 "speed": {
-                    "value": -5
+                    "value": 0
                 },
                 "stackGroup": null,
                 "strength": {
-                    "value": 16
+                    "value": 12
                 },
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "flexible",
+                        "noisy"
+                    ]
                 },
                 "usage": {
                     "value": "wornarmor"
                 },
                 "weight": {
-                    "value": "3"
+                    "value": "2"
                 }
             },
             "type": "armor"
         },
         {
-            "_id": "j2H8qQeOpPZdE3Tp",
+            "_id": "eCW5yoUxTnyQIdI5",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.equipment-srd.AITVZmakiu3RgfKo"
+                    "sourceId": "Compendium.pf2e.equipment-srd.w2ENw2VMPcsbif8g"
                 }
             },
-            "img": "systems/pf2e/icons/equipment/weapons/bolts.webp",
-            "name": "Bolts",
+            "img": "systems/pf2e/icons/equipment/weapons/arrows.webp",
+            "name": "Arrows",
             "sort": 800000,
             "system": {
                 "autoDestroy": {
@@ -795,7 +804,7 @@
                 },
                 "containerId": null,
                 "description": {
-                    "value": "<p>Shorter than traditional arrows but similar in construction, bolts are the ammunition used by crossbows.</p>"
+                    "value": "<p>These projectiles are the ammunition for bows. The shaft of an arrow is made of wood. It is stabilized in flight by fletching at one end and bears a metal head on the other.</p>"
                 },
                 "equipped": {
                     "carryType": "worn",
@@ -828,14 +837,14 @@
                         "sp": 1
                     }
                 },
-                "quantity": 10,
+                "quantity": 20,
                 "rules": [],
                 "size": "med",
-                "slug": "bolts",
+                "slug": "arrows",
                 "source": {
-                    "value": ""
+                    "value": "Pathfinder Core Rulebook"
                 },
-                "stackGroup": "bolts",
+                "stackGroup": "arrows",
                 "traits": {
                     "custom": "",
                     "rarity": "common",
@@ -851,104 +860,15 @@
             "type": "consumable"
         },
         {
-            "_id": "wWhcYOVX82VD2T44",
+            "_id": "384uraaz7360Y99M",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.equipment-srd.nn2HAN1XKkKHfVnM"
-                }
-            },
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons/stupor-poison.webp",
-            "name": "Stupor Poison",
-            "sort": 900000,
-            "system": {
-                "autoDestroy": {
-                    "_deprecated": true,
-                    "value": true
-                },
-                "baseItem": null,
-                "charges": {
-                    "max": 0,
-                    "value": 0
-                },
-                "consumableType": {
-                    "value": "poison"
-                },
-                "consume": {
-                    "value": ""
-                },
-                "containerId": null,
-                "description": {
-                    "value": "<p><strong>Activate</strong> <span class=\"pf2-icon\">2</span> Interact</p>\n<p>Stupor poison is a more potent distillation of @UUID[Compendium.pf2e.equipment-srd.Lethargy Poison]{Lethargy Poison}. Further exposure to stupor poison doesn't require the target to attempt additional saving throws; only failing a saving throw against an ongoing exposure can progress its stage.</p>\n<hr />\n<p><strong>Saving Throw</strong> @Check[type:fortitude|dc:20]</p>\n<p><strong>Maximum Duration</strong> 6 hours</p>\n<p><strong>Stage 1</strong> @UUID[Compendium.pf2e.conditionitems.Slowed]{Slowed 1} and @UUID[Compendium.pf2e.conditionitems.Flat-Footed]{Flat-Footed} (1 round)</p>\n<p><strong>Stage 2</strong> @UUID[Compendium.pf2e.conditionitems.Slowed]{Slowed 2} and flat-footed (1 round)</p>\n<p><strong>Stage 3</strong> @UUID[Compendium.pf2e.conditionitems.Unconscious]{Unconscious} with no Perception check to wake up (1 round)</p>\n<p><strong>Stage 4</strong> unconscious with no Perception check to wake up ([[/r 1d6 #hours]]{1d6 hours})</p>"
-                },
-                "equipped": {
-                    "carryType": "worn",
-                    "handsHeld": 0
-                },
-                "equippedBulk": {
-                    "value": ""
-                },
-                "hardness": 0,
-                "hp": {
-                    "brokenThreshold": 0,
-                    "max": 0,
-                    "value": 0
-                },
-                "level": {
-                    "value": 4
-                },
-                "negateBulk": {
-                    "value": "0"
-                },
-                "preciousMaterial": {
-                    "value": ""
-                },
-                "preciousMaterialGrade": {
-                    "value": ""
-                },
-                "price": {
-                    "value": {
-                        "gp": 16
-                    }
-                },
-                "quantity": 3,
-                "rules": [],
-                "size": "med",
-                "slug": "stupor-poison",
-                "source": {
-                    "value": "Pathfinder #165: Eyes of Empty Death"
-                },
-                "stackGroup": null,
-                "traits": {
-                    "custom": "",
-                    "rarity": "uncommon",
-                    "value": [
-                        "alchemical",
-                        "consumable",
-                        "incapacitation",
-                        "injury",
-                        "poison",
-                        "sleep"
-                    ]
-                },
-                "usage": {
-                    "value": "held-in-two-hands"
-                },
-                "weight": {
-                    "value": "L"
-                }
-            },
-            "type": "consumable"
-        },
-        {
-            "_id": "2agkr9lAnWdxtLza",
-            "flags": {
-                "core": {
-                    "sourceId": "Item.zpO5nbGIdKogFPy0"
+                    "sourceId": "Item.K0HaZDQKcABuhbWO"
                 }
             },
             "img": "systems/pf2e/icons/equipment/held-items/key-jeweled-gold-purple.webp",
-            "name": "Salaisa's Key",
-            "sort": 1000000,
+            "name": "Nyzuros's Keys",
+            "sort": 900000,
             "system": {
                 "baseItem": null,
                 "containerId": null,
@@ -1007,28 +927,25 @@
             "type": "treasure"
         },
         {
-            "_id": "R0x59cKzEcWsxbbV",
+            "_id": "Vq09pyw5K2mb3YeT",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Longsword",
-            "sort": 1100000,
+            "sort": 1000000,
             "system": {
                 "attack": {
                     "value": ""
                 },
                 "attackEffects": {
+                    "custom": "",
                     "value": []
                 },
                 "bonus": {
-                    "value": 24
+                    "value": 16
                 },
                 "damageRolls": {
                     "0": {
-                        "damage": "2d8+9",
+                        "damage": "1d8+7",
                         "damageType": "slashing"
-                    },
-                    "1": {
-                        "damage": "1d6",
-                        "damageType": "acid"
                     }
                 },
                 "description": {
@@ -1053,10 +970,10 @@
             "type": "melee"
         },
         {
-            "_id": "C9dM7wrOpqtQgkOP",
+            "_id": "YEnM0GJZ6D2RdXBg",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "Hand Crossbow",
-            "sort": 1200000,
+            "name": "Composite Longbow",
+            "sort": 1100000,
             "system": {
                 "attack": {
                     "value": ""
@@ -1066,11 +983,11 @@
                     "value": []
                 },
                 "bonus": {
-                    "value": 22
+                    "value": 18
                 },
                 "damageRolls": {
-                    "9mmm7wn4brp4ra7fwkj5": {
-                        "damage": "1d6+8",
+                    "0": {
+                        "damage": "1d8+7",
                         "damageType": "piercing"
                     }
                 },
@@ -1085,7 +1002,13 @@
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "deadly-d10",
+                        "propulsive",
+                        "range-increment-100",
+                        "reload-0",
+                        "volley-30"
+                    ]
                 },
                 "weaponType": {
                     "value": "ranged"
@@ -1094,7 +1017,7 @@
             "type": "melee"
         },
         {
-            "_id": "eIBT42KNs5UfO41v",
+            "_id": "YvmZQz32k7hFcqzM",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.qCCLZhnp2HhP3Ex6"
@@ -1102,7 +1025,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Darkvision",
-            "sort": 1300000,
+            "sort": 1200000,
             "system": {
                 "actionCategory": {
                     "value": "interaction"
@@ -1139,7 +1062,7 @@
             "type": "action"
         },
         {
-            "_id": "CcTlJ52vSeJqkx5b",
+            "_id": "ACtqtCeexz93EgK9",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.I0HYG0ctCLP5JRsW"
@@ -1147,7 +1070,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Light Blindness",
-            "sort": 1400000,
+            "sort": 1300000,
             "system": {
                 "actionCategory": {
                     "value": "interaction"
@@ -1184,7 +1107,7 @@
             "type": "action"
         },
         {
-            "_id": "65o1CNgkOxBuaZU6",
+            "_id": "7VBvaubtWnbIVsZ9",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.2YRDYVnC1eljaXKK"
@@ -1192,7 +1115,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "At-Will Spells",
-            "sort": 1500000,
+            "sort": 1400000,
             "system": {
                 "actionCategory": {
                     "value": "interaction"
@@ -1229,10 +1152,15 @@
             "type": "action"
         },
         {
-            "_id": "01CKBc5uwpZchw7t",
+            "_id": "y4g9ZcRWSHKAxsUe",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.kquBnQ0kObZztnBc"
+                }
+            },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "+1 Status to All Saves vs. Magic",
-            "sort": 1600000,
+            "sort": 1500000,
             "system": {
                 "actionCategory": {
                     "value": "defensive"
@@ -1257,9 +1185,9 @@
                                 "or": [
                                     "magical",
                                     "arcane",
+                                    "divine",
                                     "primal",
-                                    "occult",
-                                    "divine"
+                                    "occult"
                                 ]
                             }
                         ],
@@ -1268,7 +1196,7 @@
                         "value": 1
                     }
                 ],
-                "slug": null,
+                "slug": "1-status-to-all-saves-vs-magic",
                 "source": {
                     "value": ""
                 },
@@ -1287,10 +1215,15 @@
             "type": "action"
         },
         {
-            "_id": "UI4pCPb4yqFcryJ6",
+            "_id": "CtYG2Idf6Es4FDCt",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.kquBnQ0kObZztnBc"
+                }
+            },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "+2 Status To All Saves vs. Mental",
-            "sort": 1700000,
+            "name": "+2 Status to All Saves vs. Mental",
+            "sort": 1600000,
             "system": {
                 "actionCategory": {
                     "value": "defensive"
@@ -1318,6 +1251,64 @@
                         "value": 2
                     }
                 ],
+                "slug": "1-status-to-all-saves-vs-magic",
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "ohL0OcnbucaAroHs",
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Deft Evasion",
+            "sort": 1700000,
+            "system": {
+                "actionCategory": {
+                    "value": "defensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>When the hunter rolls a success on a Reflex save, they get a critical success instead.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [
+                    {
+                        "adjustment": {
+                            "success": "one-degree-better"
+                        },
+                        "key": "AdjustDegreeOfSuccess",
+                        "selector": "reflex",
+                        "type": "save"
+                    },
+                    {
+                        "key": "Note",
+                        "outcome": [
+                            "success"
+                        ],
+                        "selector": "reflex",
+                        "text": "{item|system.description.value}",
+                        "title": "{item|name}"
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""
@@ -1337,35 +1328,30 @@
             "type": "action"
         },
         {
-            "_id": "IopEu45YRMrLuNzn",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.hFtNbo1LKYCoDy2O"
-                }
-            },
-            "img": "systems/pf2e/icons/actions/Reaction.webp",
-            "name": "Attack of Opportunity",
+            "_id": "DIqlApNIdzR6Eh6H",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Hunter's Wound",
             "sort": 1800000,
             "system": {
                 "actionCategory": {
-                    "value": "defensive"
+                    "value": "offensive"
                 },
                 "actionType": {
-                    "value": "reaction"
+                    "value": "action"
                 },
                 "actions": {
-                    "value": null
+                    "value": 1
                 },
                 "description": {
-                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.AttackOfOpportunity]</p>"
+                    "value": "<p><strong>Frequency</strong> once per round</p>\n<p><strong>Prerequisites</strong> The hunter is wielding a ranged weapon with a reload of 0</p>\n<hr />\n<p><strong>Effect</strong> The hunter makes two ranged Strikes against their prey. If both hit and deal damage, the target takes an additional @Localize[PF2E.PersistentDamage.Bleed1d8.success].</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
                 "rules": [],
-                "slug": "attack-of-opportunity",
+                "slug": null,
                 "source": {
-                    "value": "Pathfinder Bestiary"
+                    "value": ""
                 },
                 "traits": {
                     "custom": "",
@@ -1382,9 +1368,9 @@
             "type": "action"
         },
         {
-            "_id": "nvaQh9xjojojnL27",
+            "_id": "Q43gFqCqgbv9y5VO",
             "img": "systems/pf2e/icons/actions/OneAction.webp",
-            "name": "Attack Now!",
+            "name": "Skirmish Strike",
             "sort": 1900000,
             "system": {
                 "actionCategory": {
@@ -1397,7 +1383,7 @@
                     "value": 1
                 },
                 "description": {
-                    "value": "<p>Salaisa shouts, and a drow ally within 30 feet that can see or hear Salaisa makes a melee or ranged Strike as a reaction.</p>"
+                    "value": "<p>The hunter can Step and then Strike, or Strike and then Step.</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -1422,25 +1408,19 @@
             "type": "action"
         },
         {
-            "_id": "lVTp2LJQAZzKNaIY",
-            "img": "systems/pf2e/icons/actions/TwoActions.webp",
-            "name": "Storm of Blades",
+            "_id": "qThnOv3gR3isdLBK",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Athletics",
             "sort": 2000000,
             "system": {
-                "actionCategory": {
-                    "value": "offensive"
-                },
-                "actionType": {
-                    "value": "action"
-                },
-                "actions": {
-                    "value": 2
-                },
                 "description": {
-                    "value": "<p>Salaisa Strides up to her Speed. She can make up to three longsword Strikes at any point during this movement, each against a different target within reach. These attacks count toward her multiple attack penalty, but the multiple attack penalty doesn't increase until after she makes all of her attacks. If she moves half her speed or less during , that movement doesn't trigger reactions.</p>"
-                },
-                "requirements": {
                     "value": ""
+                },
+                "mod": {
+                    "value": 14
+                },
+                "proficient": {
+                    "value": 0
                 },
                 "rules": [],
                 "slug": null,
@@ -1451,36 +1431,24 @@
                     "custom": "",
                     "rarity": "common",
                     "value": []
-                },
-                "trigger": {
-                    "value": ""
-                },
-                "weapon": {
-                    "value": ""
                 }
             },
-            "type": "action"
+            "type": "lore"
         },
         {
-            "_id": "4GEUTovCKhSoT0PD",
-            "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Stupor Poison",
+            "_id": "5asIkMyEk14MthBD",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Nature",
             "sort": 2100000,
             "system": {
-                "actionCategory": {
-                    "value": "offensive"
-                },
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
                 "description": {
-                    "value": "<p>Stupor poison is a more potent distillation of @UUID[Compendium.pf2e.equipment-srd.Lethargy Poison]{Lethargy Poison}. Further exposure to stupor poison doesn't require the target to attempt additional saving throws; only failing a saving throw against an ongoing exposure can progress its stage.</p>\n<hr />\n<p><strong>Saving Throw</strong> @Check[type:fortitude|dc:20|traits:alchemical,incapacitation,injury,poison,sleep]</p>\n<p><strong>Maximum Duration</strong> 6 hours</p>\n<p><strong>Stage 1</strong> @UUID[Compendium.pf2e.conditionitems.Slowed]{Slowed 1} and @UUID[Compendium.pf2e.conditionitems.Flat-Footed]{Flat-Footed} (1 round)</p>\n<p><strong>Stage 2</strong> @UUID[Compendium.pf2e.conditionitems.Slowed]{Slowed 2} and flat-footed (1 round)</p>\n<p><strong>Stage 3</strong> @UUID[Compendium.pf2e.conditionitems.Unconscious]{Unconscious} with no Perception check to wake up (1 round)</p>\n<p><strong>Stage 4</strong> unconscious with no Perception check to wake up ([[/r 1d6 #hours]]{1d6 hours})</p>"
-                },
-                "requirements": {
                     "value": ""
+                },
+                "mod": {
+                    "value": 14
+                },
+                "proficient": {
+                    "value": 0
                 },
                 "rules": [],
                 "slug": null,
@@ -1491,27 +1459,21 @@
                     "custom": "",
                     "rarity": "common",
                     "value": []
-                },
-                "trigger": {
-                    "value": ""
-                },
-                "weapon": {
-                    "value": ""
                 }
             },
-            "type": "action"
+            "type": "lore"
         },
         {
-            "_id": "grsAbUgxmgObApLm",
+            "_id": "rAqaf4lfnLZ2pzRP",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Acrobatics",
+            "name": "Stealth",
             "sort": 2200000,
             "system": {
                 "description": {
                     "value": ""
                 },
                 "mod": {
-                    "value": 21
+                    "value": 15
                 },
                 "proficient": {
                     "value": 0
@@ -1530,21 +1492,31 @@
             "type": "lore"
         },
         {
-            "_id": "QS9hpSFj2sYsk0gX",
+            "_id": "JvcM7bdEkBwNZbGd",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Athletics",
+            "name": "Survival",
             "sort": 2300000,
             "system": {
                 "description": {
                     "value": ""
                 },
                 "mod": {
-                    "value": 22
+                    "value": 16
                 },
                 "proficient": {
                     "value": 0
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "label": "PF2E.SkillVariant.Subsist",
+                        "predicate": [
+                            "action:subsist"
+                        ],
+                        "selector": "survival",
+                        "value": 2
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""
@@ -1553,103 +1525,25 @@
                     "custom": "",
                     "rarity": "common",
                     "value": []
-                }
-            },
-            "type": "lore"
-        },
-        {
-            "_id": "lzMGjNtKgx0zTHxe",
-            "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Intimidation",
-            "sort": 2400000,
-            "system": {
-                "description": {
-                    "value": ""
                 },
-                "mod": {
-                    "value": 20
-                },
-                "proficient": {
-                    "value": 0
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                }
-            },
-            "type": "lore"
-        },
-        {
-            "_id": "kR8oXoOPE6ZJYN6r",
-            "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Stealth",
-            "sort": 2500000,
-            "system": {
-                "description": {
-                    "value": ""
-                },
-                "mod": {
-                    "value": 21
-                },
-                "proficient": {
-                    "value": 0
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                }
-            },
-            "type": "lore"
-        },
-        {
-            "_id": "23fxDfSsWz3YN1lQ",
-            "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Survival",
-            "sort": 2600000,
-            "system": {
-                "description": {
-                    "value": ""
-                },
-                "mod": {
-                    "value": 20
-                },
-                "proficient": {
-                    "value": 0
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
+                "variants": {
+                    "0": {
+                        "label": "+18 to Subsist",
+                        "options": "action:subsist"
+                    }
                 }
             },
             "type": "lore"
         }
     ],
-    "name": "Salaisa Malthulas",
+    "name": "Nyzuros",
     "system": {
         "abilities": {
             "cha": {
                 "mod": 1
             },
             "con": {
-                "mod": 3
+                "mod": 2
             },
             "dex": {
                 "mod": 4
@@ -1658,7 +1552,7 @@
                 "mod": 0
             },
             "str": {
-                "mod": 5
+                "mod": 3
             },
             "wis": {
                 "mod": 3
@@ -1667,16 +1561,16 @@
         "attributes": {
             "ac": {
                 "details": "",
-                "value": 31
+                "value": 25
             },
             "allSaves": {
                 "value": "+1 status to all saves vs. magic, +2 status to all saves vs. mental"
             },
             "hp": {
                 "details": "",
-                "max": 200,
+                "max": 115,
                 "temp": 0,
-                "value": 200
+                "value": 115
             },
             "immunities": [
                 {
@@ -1687,7 +1581,7 @@
                 "ability": "perception"
             },
             "perception": {
-                "value": 22
+                "value": 16
             },
             "speed": {
                 "otherSpeeds": [],
@@ -1696,18 +1590,18 @@
         },
         "details": {
             "alignment": {
-                "value": "N"
+                "value": "CN"
             },
-            "blurb": "Female drow head warden",
+            "blurb": "Male Drow Hunter",
             "creatureType": "",
             "level": {
-                "value": 11
+                "value": 7
             },
             "privateNotes": "",
-            "publicNotes": "",
+            "publicNotes": "<p>Hunters seek out game to keep drow communities fed and functioning.</p>\n<hr />\n<p>Drow have a reputation for evil due to demon worship in their major settlements. However, like members of any ancestry, drow can have any alignment, especially when removed from the demon lords' sinister influence.</p>",
             "source": {
                 "author": "",
-                "value": "Pathfinder #165: Eyes of Empty Death"
+                "value": "Pathfinder Abomination Vaults Hardcover Compilation"
             }
         },
         "resources": {
@@ -1719,15 +1613,15 @@
         "saves": {
             "fortitude": {
                 "saveDetail": "",
-                "value": 20
+                "value": 15
             },
             "reflex": {
                 "saveDetail": "",
-                "value": 21
+                "value": 15
             },
             "will": {
                 "saveDetail": "",
-                "value": 22
+                "value": 14
             }
         },
         "traits": {
@@ -1739,7 +1633,7 @@
                     "undercommon"
                 ]
             },
-            "rarity": "unique",
+            "rarity": "uncommon",
             "senses": {
                 "value": "darkvision"
             },

--- a/packs/data/abomination-vaults-bestiary.db/observation-deck-seugathi-researcher.json
+++ b/packs/data/abomination-vaults-bestiary.db/observation-deck-seugathi-researcher.json
@@ -1,11 +1,11 @@
 {
-    "_id": "njfwxMPXTPA5AegD",
+    "_id": "TiAzR8SnYwhACWbj",
     "img": "systems/pf2e/icons/default-icons/npc.svg",
     "items": [
         {
-            "_id": "h2qxWUvI0fbg4RxB",
+            "_id": "ZnFe1AJx67Diyerp",
             "img": "systems/pf2e/icons/default-icons/spellcastingEntry.svg",
-            "name": "Divine Innate Spells",
+            "name": "Occult Innate Spells",
             "sort": 100000,
             "system": {
                 "autoHeightenLevel": {
@@ -96,12 +96,12 @@
                     "value": ""
                 },
                 "spelldc": {
-                    "dc": 26,
+                    "dc": 24,
                     "mod": 0,
-                    "value": 18
+                    "value": 16
                 },
                 "tradition": {
-                    "value": "divine"
+                    "value": "occult"
                 },
                 "traits": {
                     "custom": "",
@@ -112,124 +112,15 @@
             "type": "spellcastingEntry"
         },
         {
-            "_id": "Gix3fftNAeuJS7zt",
-            "img": "systems/pf2e/icons/default-icons/spellcastingEntry.svg",
-            "name": "Rituals",
-            "sort": 200000,
-            "system": {
-                "autoHeightenLevel": {
-                    "value": null
-                },
-                "description": {
-                    "value": ""
-                },
-                "displayLevels": {},
-                "prepared": {
-                    "flexible": false,
-                    "value": "ritual"
-                },
-                "proficiency": {
-                    "value": 0
-                },
-                "rules": [],
-                "showSlotlessLevels": {
-                    "value": true
-                },
-                "showUnpreparedSpells": {
-                    "value": true
-                },
-                "slots": {
-                    "slot0": {
-                        "max": 0,
-                        "prepared": [],
-                        "value": 0
-                    },
-                    "slot1": {
-                        "max": 0,
-                        "prepared": [],
-                        "value": 0
-                    },
-                    "slot10": {
-                        "max": 0,
-                        "prepared": [],
-                        "value": 0
-                    },
-                    "slot11": {
-                        "max": 0,
-                        "prepared": [],
-                        "value": 0
-                    },
-                    "slot2": {
-                        "max": 0,
-                        "prepared": [],
-                        "value": 0
-                    },
-                    "slot3": {
-                        "max": 0,
-                        "prepared": [],
-                        "value": 0
-                    },
-                    "slot4": {
-                        "max": 0,
-                        "prepared": [],
-                        "value": 0
-                    },
-                    "slot5": {
-                        "max": 0,
-                        "prepared": [],
-                        "value": 0
-                    },
-                    "slot6": {
-                        "max": 0,
-                        "prepared": [],
-                        "value": 0
-                    },
-                    "slot7": {
-                        "max": 0,
-                        "prepared": [],
-                        "value": 0
-                    },
-                    "slot8": {
-                        "max": 0,
-                        "prepared": [],
-                        "value": 0
-                    },
-                    "slot9": {
-                        "max": 0,
-                        "prepared": [],
-                        "value": 0
-                    }
-                },
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "spelldc": {
-                    "dc": 26,
-                    "mod": 0,
-                    "value": 18
-                },
-                "tradition": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                }
-            },
-            "type": "spellcastingEntry"
-        },
-        {
-            "_id": "fpyaGQ7nPlsCH1nc",
+            "_id": "euIa0xTcIyQOBwOC",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.uqlxMQQeSGWEVjki"
+                    "sourceId": "Compendium.pf2e.spells-srd.ZYoC630tNGutgbE0"
                 }
             },
-            "img": "systems/pf2e/icons/spells/true-seeing.webp",
-            "name": "True Seeing (Constant)",
-            "sort": 300000,
+            "img": "systems/pf2e/icons/spells/hypercognition.webp",
+            "name": "Hypercognition",
+            "sort": 200000,
             "system": {
                 "ability": {
                     "value": ""
@@ -241,7 +132,7 @@
                 "components": {
                     "focus": false,
                     "material": false,
-                    "somatic": true,
+                    "somatic": false,
                     "verbal": true
                 },
                 "cost": {
@@ -251,20 +142,20 @@
                     "value": {}
                 },
                 "description": {
-                    "value": "<p>You see things within 60 feet as they actually are. The GM rolls a secret counteract check against any illusion or transmutation in the area, but only for the purpose of determining whether you see through it (for instance, if the check succeeds against a polymorph spell, you can see the creature's true form, but you don't end the polymorph spell).</p>"
+                    "value": "<p>You rapidly catalog and collate information relevant to your current situation. You can instantly use up to 6 Recall Knowledge actions as part of Casting this Spell. For these actions, you can't use any special abilities, reactions, or free actions that trigger when you Recall Knowledge.</p>"
                 },
                 "duration": {
-                    "value": "10 minutes"
+                    "value": ""
                 },
                 "hasCounteractCheck": {
-                    "value": true
+                    "value": false
                 },
                 "level": {
-                    "value": 6
+                    "value": 3
                 },
                 "location": {
-                    "heightenedLevel": 6,
-                    "value": "h2qxWUvI0fbg4RxB"
+                    "heightenedLevel": 3,
+                    "value": "ZnFe1AJx67Diyerp"
                 },
                 "materials": {
                     "value": ""
@@ -292,7 +183,7 @@
                 "secondarycheck": {
                     "value": ""
                 },
-                "slug": "true-seeing",
+                "slug": "hypercognition",
                 "source": {
                     "value": "Pathfinder Core Rulebook"
                 },
@@ -306,35 +197,132 @@
                     "value": ""
                 },
                 "time": {
-                    "value": "2"
+                    "value": "1"
                 },
                 "traditions": {
                     "value": [
-                        "arcane",
-                        "divine",
-                        "occult",
-                        "primal"
+                        "occult"
                     ]
                 },
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": [
-                        "revelation"
-                    ]
+                    "value": []
                 }
             },
             "type": "spell"
         },
         {
-            "_id": "E6dar3cARRfBL0qZ",
+            "_id": "9FfhrCy7X6C19XbP",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.VlNcjmYyu95vOUe8"
+                    "sourceId": "Compendium.pf2e.spells-srd.fI20AVwOzJMHXRdo"
                 }
             },
-            "img": "systems/pf2e/icons/spells/dimension-door.webp",
-            "name": "Dimension Door",
+            "img": "systems/pf2e/icons/spells/levitate.webp",
+            "name": "Levitate",
+            "sort": 300000,
+            "system": {
+                "ability": {
+                    "value": ""
+                },
+                "area": null,
+                "category": {
+                    "value": "spell"
+                },
+                "components": {
+                    "focus": false,
+                    "material": false,
+                    "somatic": true,
+                    "verbal": true
+                },
+                "cost": {
+                    "value": ""
+                },
+                "damage": {
+                    "value": {}
+                },
+                "description": {
+                    "value": "<p>You defy gravity and levitate the target 5 feet off the ground. For the duration of the spell, you can move the target up or down 10 feet with a single action, which has the concentrate trait. A creature floating in the air from levitate takes a -2 circumstance penalty to attack rolls. A floating creature can spend an Interact action to stabilize itself and negate this penalty for the remainder of its turn. If the target is adjacent to a fixed object or terrain of suitable stability, it can move across the surface by climbing (if the surface is vertical, like a wall) or crawling (if the surface is horizontal, such as a ceiling). The GM determines which surfaces can be climbed or crawled across.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Spell Effect: Levitate]{Spell Effect: Levitate}</p>"
+                },
+                "duration": {
+                    "value": "5 minutes"
+                },
+                "hasCounteractCheck": {
+                    "value": false
+                },
+                "level": {
+                    "value": 3
+                },
+                "location": {
+                    "heightenedLevel": 3,
+                    "value": "ZnFe1AJx67Diyerp"
+                },
+                "materials": {
+                    "value": ""
+                },
+                "prepared": {
+                    "value": ""
+                },
+                "primarycheck": {
+                    "value": ""
+                },
+                "range": {
+                    "value": "touch"
+                },
+                "rules": [],
+                "save": {
+                    "basic": "",
+                    "value": ""
+                },
+                "school": {
+                    "value": "evocation"
+                },
+                "secondarycasters": {
+                    "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "levitate",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "spellType": {
+                    "value": "utility"
+                },
+                "sustained": {
+                    "value": false
+                },
+                "target": {
+                    "value": "1 unattended object or willing creature"
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traditions": {
+                    "value": [
+                        "arcane",
+                        "occult"
+                    ]
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "spell"
+        },
+        {
+            "_id": "im296JOSVQ5enGfj",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.KHnhPHL4x1AQHfbC"
+                }
+            },
+            "img": "systems/pf2e/icons/spells/mind-reading.webp",
+            "name": "Mind Reading",
             "sort": 400000,
             "system": {
                 "ability": {
@@ -357,449 +345,24 @@
                     "value": {}
                 },
                 "description": {
-                    "value": "<p>Opening a door that bypasses normal space, you instantly transport yourself and any items you're wearing and holding from your current space to a clear space within range you can see. If this would bring another creature with you-even if you're carrying it in an extradimensional container-the spell is lost.</p>\n<hr />\n<p><strong>Heightened (5th)</strong> The range increases to 1 mile. You don't need to be able to see your destination, as long as you have been there in the past and know its relative location and distance from you. You are temporarily immune for 1 hour.</p>"
+                    "value": "<p>With a cursory mental touch, you attempt to read the target's mind. It must attempt a Will save. The target then becomes temporarily immune to your mind reading for 1 hour.</p>\n<hr /><strong>Critical Success</strong> The target perceives vague surface thoughts from you when you Cast the Spell.\n<p><strong>Success</strong> You find out whether the target's Intelligence modifier is higher than, equal to, or lower than yours.</p>\n<p><strong>Failure</strong> You perceive vague surface thoughts from the target when you Cast the Spell, and you find out whether its Intelligence modifier is higher than, equal to, or lower than yours.</p>\n<p><strong>Critical Failure</strong> As failure, and for the duration of the spell, you can Sustain the Spell to detect the target's surface thoughts again. The target doesn't receive any additional saves.</p>"
                 },
                 "duration": {
-                    "value": ""
+                    "value": "1 round or sustained up to 1 minute"
                 },
                 "hasCounteractCheck": {
                     "value": false
                 },
                 "level": {
-                    "value": 4
-                },
-                "location": {
-                    "heightenedLevel": 5,
-                    "value": "h2qxWUvI0fbg4RxB"
-                },
-                "materials": {
-                    "value": ""
-                },
-                "prepared": {
-                    "value": ""
-                },
-                "primarycheck": {
-                    "value": ""
-                },
-                "range": {
-                    "value": "120 feet"
-                },
-                "rules": [],
-                "save": {
-                    "basic": "",
-                    "value": ""
-                },
-                "school": {
-                    "value": "conjuration"
-                },
-                "secondarycasters": {
-                    "value": ""
-                },
-                "secondarycheck": {
-                    "value": ""
-                },
-                "slug": "dimension-door",
-                "source": {
-                    "value": "Pathfinder Core Rulebook"
-                },
-                "spellType": {
-                    "value": "utility"
-                },
-                "sustained": {
-                    "value": false
-                },
-                "target": {
-                    "value": ""
-                },
-                "time": {
-                    "value": "2"
-                },
-                "traditions": {
-                    "value": [
-                        "arcane",
-                        "occult"
-                    ]
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": [
-                        "teleportation"
-                    ]
-                }
-            },
-            "type": "spell"
-        },
-        {
-            "_id": "lntTBnW0tn7XEMPJ",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.VlNcjmYyu95vOUe8"
-                }
-            },
-            "img": "systems/pf2e/icons/spells/dimension-door.webp",
-            "name": "Dimension Door (At Will)",
-            "sort": 500000,
-            "system": {
-                "ability": {
-                    "value": ""
-                },
-                "area": null,
-                "category": {
-                    "value": "spell"
-                },
-                "components": {
-                    "focus": false,
-                    "material": false,
-                    "somatic": true,
-                    "verbal": true
-                },
-                "cost": {
-                    "value": ""
-                },
-                "damage": {
-                    "value": {}
-                },
-                "description": {
-                    "value": "<p>Opening a door that bypasses normal space, you instantly transport yourself and any items you're wearing and holding from your current space to a clear space within range you can see. If this would bring another creature with you-even if you're carrying it in an extradimensional container-the spell is lost.</p>\n<hr />\n<p><strong>Heightened (5th)</strong> The range increases to 1 mile. You don't need to be able to see your destination, as long as you have been there in the past and know its relative location and distance from you. You are temporarily immune for 1 hour.</p>"
-                },
-                "duration": {
-                    "value": ""
-                },
-                "hasCounteractCheck": {
-                    "value": false
-                },
-                "level": {
-                    "value": 4
-                },
-                "location": {
-                    "heightenedLevel": 4,
-                    "value": "h2qxWUvI0fbg4RxB"
-                },
-                "materials": {
-                    "value": ""
-                },
-                "prepared": {
-                    "value": ""
-                },
-                "primarycheck": {
-                    "value": ""
-                },
-                "range": {
-                    "value": "120 feet"
-                },
-                "rules": [],
-                "save": {
-                    "basic": "",
-                    "value": ""
-                },
-                "school": {
-                    "value": "conjuration"
-                },
-                "secondarycasters": {
-                    "value": ""
-                },
-                "secondarycheck": {
-                    "value": ""
-                },
-                "slug": "dimension-door",
-                "source": {
-                    "value": "Pathfinder Core Rulebook"
-                },
-                "spellType": {
-                    "value": "utility"
-                },
-                "sustained": {
-                    "value": false
-                },
-                "target": {
-                    "value": ""
-                },
-                "time": {
-                    "value": "2"
-                },
-                "traditions": {
-                    "value": [
-                        "arcane",
-                        "occult"
-                    ]
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": [
-                        "teleportation"
-                    ]
-                }
-            },
-            "type": "spell"
-        },
-        {
-            "_id": "Ziz4KcgSnDlWnrOC",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.hVU9msO9yGkxKZ3J"
-                }
-            },
-            "img": "systems/pf2e/icons/spells/divine-wrath.webp",
-            "name": "Divine Wrath",
-            "sort": 600000,
-            "system": {
-                "ability": {
-                    "value": ""
-                },
-                "area": {
-                    "type": "burst",
-                    "value": 20
-                },
-                "category": {
-                    "value": "spell"
-                },
-                "components": {
-                    "focus": false,
-                    "material": false,
-                    "somatic": true,
-                    "verbal": true
-                },
-                "cost": {
-                    "value": ""
-                },
-                "damage": {
-                    "value": {
-                        "0": {
-                            "type": {
-                                "categories": [],
-                                "value": "untyped"
-                            },
-                            "value": "4d10"
-                        }
-                    }
-                },
-                "description": {
-                    "value": "<p>You can channel the fury of your deity against foes of opposed alignment. Choose an alignment your deity has (chaotic, evil, good, or lawful). You can't cast this spell if you don't have a deity or your deity is true neutral. This spell gains the trait of the alignment you chose. You deal 4d10 damage of the alignment you chose; each creature in the area must attempt a Fortitude save. Creatures that match the alignment you chose are unaffected. Those that neither match nor oppose it treat the result of their saving throw as one degree better.</p>\n<hr />\n<p><strong>Critical Success</strong> The creature is unaffected.</p>\n<p><strong>Success</strong> The creature takes half damage.</p>\n<p><strong>Failure</strong> The creature takes full damage and is @UUID[Compendium.pf2e.conditionitems.Sickened]{Sickened 1}.</p>\n<p><strong>Critical Failure</strong> The creature takes full damage and is @UUID[Compendium.pf2e.conditionitems.Sickened]{Sickened 2}; while it is sickened, it is also @UUID[Compendium.pf2e.conditionitems.Slowed]{Slowed 1}.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 1d10.</p>"
-                },
-                "duration": {
-                    "value": ""
-                },
-                "hasCounteractCheck": {
-                    "value": false
-                },
-                "heightening": {
-                    "damage": {
-                        "0": "1d10"
-                    },
-                    "interval": 1,
-                    "type": "interval"
-                },
-                "level": {
-                    "value": 4
-                },
-                "location": {
-                    "heightenedLevel": 4,
-                    "value": "h2qxWUvI0fbg4RxB"
-                },
-                "materials": {
-                    "value": ""
-                },
-                "prepared": {
-                    "value": ""
-                },
-                "primarycheck": {
-                    "value": ""
-                },
-                "range": {
-                    "value": "120 feet"
-                },
-                "rules": [],
-                "save": {
-                    "basic": "",
-                    "value": "fortitude"
-                },
-                "school": {
-                    "value": "evocation"
-                },
-                "secondarycasters": {
-                    "value": ""
-                },
-                "secondarycheck": {
-                    "value": ""
-                },
-                "slug": "divine-wrath",
-                "source": {
-                    "value": "Pathfinder Core Rulebook"
-                },
-                "spellType": {
-                    "value": "save"
-                },
-                "sustained": {
-                    "value": false
-                },
-                "target": {
-                    "value": ""
-                },
-                "time": {
-                    "value": "2"
-                },
-                "traditions": {
-                    "value": [
-                        "divine"
-                    ]
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                }
-            },
-            "type": "spell"
-        },
-        {
-            "_id": "tSbx4aVJWl4zlKbG",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.SSsUC7rZo0CwayPn"
-                }
-            },
-            "img": "systems/pf2e/icons/spells/retributive-pain.webp",
-            "name": "Retributive Pain",
-            "sort": 700000,
-            "system": {
-                "ability": {
-                    "value": ""
-                },
-                "area": null,
-                "category": {
-                    "value": "focus"
-                },
-                "components": {
-                    "focus": false,
-                    "material": false,
-                    "somatic": true,
-                    "verbal": false
-                },
-                "cost": {
-                    "value": ""
-                },
-                "damage": {
-                    "value": {}
-                },
-                "description": {
-                    "value": "<p><strong>Trigger</strong> A creature in range damages you.</p>\n<hr />\n<p>You vengefully reflect your pain upon your tormentor. The target takes mental damage equal to half the amount it dealt to you when it triggered the spell.</p>"
-                },
-                "duration": {
-                    "value": ""
-                },
-                "hasCounteractCheck": {
-                    "value": false
-                },
-                "level": {
-                    "value": 4
-                },
-                "location": {
-                    "value": "h2qxWUvI0fbg4RxB"
-                },
-                "materials": {
-                    "value": ""
-                },
-                "prepared": {
-                    "value": ""
-                },
-                "primarycheck": {
-                    "value": ""
-                },
-                "range": {
-                    "value": "30 feet"
-                },
-                "rules": [],
-                "save": {
-                    "basic": "basic",
-                    "value": "fortitude"
-                },
-                "school": {
-                    "value": "abjuration"
-                },
-                "secondarycasters": {
-                    "value": ""
-                },
-                "secondarycheck": {
-                    "value": ""
-                },
-                "slug": "retributive-pain",
-                "source": {
-                    "value": "Pathfinder Core Rulebook"
-                },
-                "spellType": {
-                    "value": "save"
-                },
-                "sustained": {
-                    "value": false
-                },
-                "target": {
-                    "value": "the triggering creature"
-                },
-                "time": {
-                    "value": "reaction"
-                },
-                "traditions": {
-                    "value": []
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "uncommon",
-                    "value": [
-                        "cleric",
-                        "mental",
-                        "nonlethal"
-                    ]
-                }
-            },
-            "type": "spell"
-        },
-        {
-            "_id": "mqqrqczmNE7FLbro",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.4koZzrnMXhhosn0D"
-                }
-            },
-            "img": "systems/pf2e/icons/spells/fear.webp",
-            "name": "Fear (At Will)",
-            "sort": 800000,
-            "system": {
-                "ability": {
-                    "value": ""
-                },
-                "area": null,
-                "category": {
-                    "value": "spell"
-                },
-                "components": {
-                    "focus": false,
-                    "material": false,
-                    "somatic": true,
-                    "verbal": true
-                },
-                "cost": {
-                    "value": ""
-                },
-                "damage": {
-                    "value": {}
-                },
-                "description": {
-                    "value": "<p>You plant fear in the target; it must attempt a Will save.</p>\n<hr />\n<p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target is @UUID[Compendium.pf2e.conditionitems.Frightened]{Frightened 1}.</p>\n<p><strong>Failure</strong> The target is @UUID[Compendium.pf2e.conditionitems.Frightened]{Frightened 2}.</p>\n<p><strong>Critical Failure</strong> The target is @UUID[Compendium.pf2e.conditionitems.Frightened]{Frightened 3} and @UUID[Compendium.pf2e.conditionitems.Fleeing]{Fleeing} for 1 round.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You can target up to five creatures.</p>"
-                },
-                "duration": {
-                    "value": "varies"
-                },
-                "hasCounteractCheck": {
-                    "value": false
-                },
-                "level": {
-                    "value": 1
+                    "value": 3
                 },
                 "location": {
                     "heightenedLevel": 3,
-                    "value": "h2qxWUvI0fbg4RxB"
+                    "uses": {
+                        "max": 3,
+                        "value": 3
+                    },
+                    "value": "ZnFe1AJx67Diyerp"
                 },
                 "materials": {
                     "value": ""
@@ -819,6 +382,126 @@
                     "value": "will"
                 },
                 "school": {
+                    "value": "divination"
+                },
+                "secondarycasters": {
+                    "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "mind-reading",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "spellType": {
+                    "value": "save"
+                },
+                "sustained": {
+                    "value": false
+                },
+                "target": {
+                    "value": "1 creature"
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traditions": {
+                    "value": [
+                        "arcane",
+                        "occult"
+                    ]
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "uncommon",
+                    "value": [
+                        "detection",
+                        "mental"
+                    ]
+                }
+            },
+            "type": "spell"
+        },
+        {
+            "_id": "XAInYyDm0DWjUckv",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.4gBIw4IDrSfFHik4"
+                }
+            },
+            "img": "systems/pf2e/icons/spells/daze.webp",
+            "name": "Daze",
+            "sort": 500000,
+            "system": {
+                "ability": {
+                    "value": ""
+                },
+                "area": null,
+                "category": {
+                    "value": "spell"
+                },
+                "components": {
+                    "focus": false,
+                    "material": false,
+                    "somatic": true,
+                    "verbal": true
+                },
+                "cost": {
+                    "value": ""
+                },
+                "damage": {
+                    "value": {
+                        "0": {
+                            "applyMod": true,
+                            "type": {
+                                "categories": [],
+                                "value": "mental"
+                            },
+                            "value": "0"
+                        }
+                    }
+                },
+                "description": {
+                    "value": "<p>You cloud the target's mind and daze it with a mental jolt. The jolt deals mental damage equal to your spellcasting ability modifier; the target must attempt a basic Will save. If the target critically fails the save, it is also @UUID[Compendium.pf2e.conditionitems.Stunned]{Stunned 1}.</p>\n<hr />\n<p><strong>Heightened (+2)</strong> The damage increases by 1d6.</p>"
+                },
+                "duration": {
+                    "value": "1 round"
+                },
+                "hasCounteractCheck": {
+                    "value": false
+                },
+                "heightening": {
+                    "damage": {
+                        "0": "1d6"
+                    },
+                    "interval": 2,
+                    "type": "interval"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": {
+                    "value": "ZnFe1AJx67Diyerp"
+                },
+                "materials": {
+                    "value": ""
+                },
+                "prepared": {
+                    "value": ""
+                },
+                "primarycheck": {
+                    "value": ""
+                },
+                "range": {
+                    "value": "60 feet"
+                },
+                "rules": [],
+                "save": {
+                    "basic": "basic",
+                    "value": "will"
+                },
+                "school": {
                     "value": "enchantment"
                 },
                 "secondarycasters": {
@@ -827,7 +510,7 @@
                 "secondarycheck": {
                     "value": ""
                 },
-                "slug": "fear",
+                "slug": "daze",
                 "source": {
                     "value": "Pathfinder Core Rulebook"
                 },
@@ -847,6 +530,116 @@
                     "value": [
                         "arcane",
                         "divine",
+                        "occult"
+                    ]
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "cantrip",
+                        "mental",
+                        "nonlethal"
+                    ]
+                }
+            },
+            "type": "spell"
+        },
+        {
+            "_id": "f6kzW4hcOJrD3PVp",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.gpzpAAAJ1Lza2JVl"
+                }
+            },
+            "img": "systems/pf2e/icons/spells/detect-magic.webp",
+            "name": "Detect Magic",
+            "sort": 600000,
+            "system": {
+                "ability": {
+                    "value": ""
+                },
+                "area": {
+                    "type": "emanation",
+                    "value": 30
+                },
+                "category": {
+                    "value": "spell"
+                },
+                "components": {
+                    "focus": false,
+                    "material": false,
+                    "somatic": true,
+                    "verbal": true
+                },
+                "cost": {
+                    "value": ""
+                },
+                "damage": {
+                    "value": {}
+                },
+                "description": {
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies.</p>\n<p>You detect illusion magic only if that magic's effect has a lower level than the level of your detect magic spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an invisibility potion) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the school of magic for the highest-level effect within range that the spell detects. If multiple effects are equally strong, the GM determines which you learn.</p>\n<p><strong>Heightened (4th)</strong> As 3rd level, but you also pinpoint the source of the highest-level magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                },
+                "duration": {
+                    "value": ""
+                },
+                "hasCounteractCheck": {
+                    "value": false
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": {
+                    "value": "ZnFe1AJx67Diyerp"
+                },
+                "materials": {
+                    "value": ""
+                },
+                "prepared": {
+                    "value": ""
+                },
+                "primarycheck": {
+                    "value": ""
+                },
+                "range": {
+                    "value": ""
+                },
+                "rules": [],
+                "save": {
+                    "basic": "",
+                    "value": ""
+                },
+                "school": {
+                    "value": "divination"
+                },
+                "secondarycasters": {
+                    "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "detect-magic",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "spellType": {
+                    "value": "utility"
+                },
+                "sustained": {
+                    "value": false
+                },
+                "target": {
+                    "value": ""
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traditions": {
+                    "custom": "",
+                    "value": [
+                        "arcane",
+                        "divine",
                         "occult",
                         "primal"
                     ]
@@ -855,24 +648,23 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "emotion",
-                        "fear",
-                        "mental"
+                        "detection",
+                        "cantrip"
                     ]
                 }
             },
             "type": "spell"
         },
         {
-            "_id": "ZZcgAENc8VCfxb7e",
+            "_id": "zWWtMMDuuVs4aqcp",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.i35dpZFI7jZcRoBo"
+                    "sourceId": "Compendium.pf2e.spells-srd.pwzdSlJgYqN7bs2w"
                 }
             },
-            "img": "systems/pf2e/icons/spells/illusory-disguise.webp",
-            "name": "Illusory Disguise (At Will)",
-            "sort": 900000,
+            "img": "systems/pf2e/icons/spells/mage-hand.webp",
+            "name": "Mage Hand",
+            "sort": 700000,
             "system": {
                 "ability": {
                     "value": ""
@@ -894,10 +686,10 @@
                     "value": {}
                 },
                 "description": {
-                    "value": "<p>You create an illusion that causes you to appear as another creature of the same body shape, and with roughly similar height (within 6 inches) and weight (within 50 pounds), as yourself. The disguise is typically good enough to hide your identity, but not to impersonate a specific individual. The spell doesn't change your voice, scent, or mannerisms. You can change the appearance of your clothing and worn items, such as making your armor look like a dress. Held items are unaffected, and any worn item you remove returns to its true appearance.</p>\n<p>Casting illusory disguise counts as setting up a disguise for the @UUID[Compendium.pf2e.action-macros.Impersonate: Deception]{Impersonate} use of Deception; it ignores any circumstance penalties you might take for disguising yourself as a dissimilar creature, it gives you a +4 status bonus to Deception checks to prevent others from seeing through your disguise, and you add your level even if you're untrained. You can Dismiss this spell.</p>\n<hr />\n<p><strong>Heightened (2nd)</strong> The spell also disguises your voice and scent, and it gains the auditory and olfactory traits.</p>\n<p><strong>Heightened (3rd)</strong> You can appear as any creature of the same size, even a specific individual. You must have seen an individual to take on their appearance. The spell also disguises your voice and scent, and it gains the auditory and olfactory traits.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Spell Effect: Illusory Disguise]{Spell Effect: Illusory Disguise}</p>"
+                    "value": "<p>You create a single magical hand, either invisible or ghostlike, that grasps the target object and moves it slowly up to 20 feet. Because you're levitating the object, you can move it in any direction. When you Sustain the Spell, you can move the object an additional 20 feet. If the object is in the air when the spell ends, the object falls.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You can target an unattended object with a Bulk of 1 or less.</p>\n<p><strong>Heightened (5th)</strong> The range increases to 60 feet, and you can target an unattended object with a Bulk of 1 or less.</p>\n<p><strong>Heightened (7th)</strong> The range increases to 60 feet, and you can target an unattended object with a Bulk of 2 or less.</p>"
                 },
                 "duration": {
-                    "value": "1 hour"
+                    "value": "sustained"
                 },
                 "hasCounteractCheck": {
                     "value": false
@@ -906,8 +698,7 @@
                     "value": 1
                 },
                 "location": {
-                    "heightenedLevel": 2,
-                    "value": "h2qxWUvI0fbg4RxB"
+                    "value": "ZnFe1AJx67Diyerp"
                 },
                 "materials": {
                     "value": ""
@@ -919,7 +710,7 @@
                     "value": ""
                 },
                 "range": {
-                    "value": ""
+                    "value": "30 feet"
                 },
                 "rules": [],
                 "save": {
@@ -927,7 +718,7 @@
                     "value": ""
                 },
                 "school": {
-                    "value": "illusion"
+                    "value": "evocation"
                 },
                 "secondarycasters": {
                     "value": ""
@@ -935,7 +726,7 @@
                 "secondarycheck": {
                     "value": ""
                 },
-                "slug": "illusory-disguise",
+                "slug": "mage-hand",
                 "source": {
                     "value": "Pathfinder Core Rulebook"
                 },
@@ -946,7 +737,7 @@
                     "value": false
                 },
                 "target": {
-                    "value": ""
+                    "value": "1 unattended object of light Bulk or less"
                 },
                 "time": {
                     "value": "2"
@@ -961,30 +752,27 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "visual"
+                        "cantrip"
                     ]
                 }
             },
             "type": "spell"
         },
         {
-            "_id": "dyiZulNVinuIheiG",
+            "_id": "YmaEutO1beFphbjE",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.2oH5IufzdESuYxat"
+                    "sourceId": "Compendium.pf2e.spells-srd.60sgbuMWN0268dB7"
                 }
             },
-            "img": "systems/pf2e/icons/spells/illusory-object.webp",
-            "name": "Illusory Object",
-            "sort": 1000000,
+            "img": "systems/pf2e/icons/spells/telekinetic-projectile.webp",
+            "name": "Telekinetic Projectile",
+            "sort": 800000,
             "system": {
                 "ability": {
                     "value": ""
                 },
-                "area": {
-                    "type": "burst",
-                    "value": 20
-                },
+                "area": null,
                 "category": {
                     "value": "spell"
                 },
@@ -998,300 +786,100 @@
                     "value": ""
                 },
                 "damage": {
-                    "value": {}
-                },
-                "description": {
-                    "value": "<p>You create an illusory visual image of a stationary object. The entire image must fit within the spell's area. The object appears to animate naturally, but it doesn't make sounds or generate smells. For example, water would appear to pour down an illusory waterfall, but it would be silent.</p>\n<p>Any creature that touches the image or uses the Seek action to examine it can attempt to disbelieve your illusion.</p>\n<hr />\n<p><strong>Heightened (2nd)</strong> Your image makes appropriate sounds, generates normal smells, and feels right to the touch. The spell gains the auditory trait. The duration increases to 1 hour.</p>\n<p><strong>Heightened (5th)</strong> As the 2nd-level version, but the duration is unlimited.</p>"
-                },
-                "duration": {
-                    "value": "10 minutes"
-                },
-                "hasCounteractCheck": {
-                    "value": false
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": {
-                    "heightenedLevel": 2,
-                    "value": "h2qxWUvI0fbg4RxB"
-                },
-                "materials": {
-                    "value": ""
-                },
-                "prepared": {
-                    "value": ""
-                },
-                "primarycheck": {
-                    "value": ""
-                },
-                "range": {
-                    "value": "500 feet"
-                },
-                "rules": [],
-                "save": {
-                    "basic": "",
-                    "value": ""
-                },
-                "school": {
-                    "value": "illusion"
-                },
-                "secondarycasters": {
-                    "value": ""
-                },
-                "secondarycheck": {
-                    "value": ""
-                },
-                "slug": "illusory-object",
-                "source": {
-                    "value": "Pathfinder Core Rulebook"
-                },
-                "spellType": {
-                    "value": "utility"
-                },
-                "sustained": {
-                    "value": false
-                },
-                "target": {
-                    "value": ""
-                },
-                "time": {
-                    "value": "2"
-                },
-                "traditions": {
-                    "value": [
-                        "arcane",
-                        "occult"
-                    ]
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": [
-                        "visual"
-                    ]
-                }
-            },
-            "type": "spell"
-        },
-        {
-            "_id": "96lESscH6vRcwpYW",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.30BBep9U4BDV0EgQ"
-                }
-            },
-            "img": "systems/pf2e/icons/spells/infernal-pact.webp",
-            "name": "Infernal Pact",
-            "sort": 1100000,
-            "system": {
-                "ability": {
-                    "value": ""
-                },
-                "area": null,
-                "category": {
-                    "value": "ritual"
-                },
-                "components": {
-                    "focus": false,
-                    "material": false,
-                    "somatic": false,
-                    "verbal": false
-                },
-                "cost": {
-                    "value": ""
-                },
-                "damage": {
-                    "value": {}
-                },
-                "description": {
-                    "value": "<p>You make an appeal to a powerful devil, asking it to bind some of its subordinates to your service. If you succeed, the devil sends you its choice of one devil whose level is no more than double <em>infernal pact's</em> level, two devils whose levels are each at least 2 less than double the spell level, or three devils whose levels are each at least 3 less than double the spell level.</p>\n<hr />\n<p><strong>Critical Success</strong> The devils are sent to you and serve you for [[/r 1d4 #weeks]]{1d4 weeks}.</p>\n<p><strong>Success</strong> The devils are sent to you and serve you for [[/r 1d4 #days]]{1d4 days}.</p>\n<p><strong>Failure</strong> Your request is denied.</p>\n<p><strong>Critical Failure</strong> Not only is your request denied, but the powerful devil sends word of its displeasure to your master.</p>"
-                },
-                "duration": {
-                    "value": ""
-                },
-                "hasCounteractCheck": {
-                    "value": false
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": {
-                    "value": "Gix3fftNAeuJS7zt"
-                },
-                "materials": {
-                    "value": ""
-                },
-                "prepared": {
-                    "value": ""
-                },
-                "primarycheck": {
-                    "value": "Religion (expert; you must be a devil)"
-                },
-                "range": {
-                    "value": ""
-                },
-                "rules": [],
-                "save": {
-                    "basic": "",
-                    "value": ""
-                },
-                "school": {
-                    "value": "conjuration"
-                },
-                "secondarycasters": {
-                    "value": ""
-                },
-                "secondarycheck": {
-                    "value": ""
-                },
-                "slug": "infernal-pact",
-                "source": {
-                    "value": "Pathfinder Bestiary"
-                },
-                "spellType": {
-                    "value": "utility"
-                },
-                "sustained": {
-                    "value": false
-                },
-                "target": {
-                    "value": ""
-                },
-                "time": {
-                    "value": "1 day"
-                },
-                "traditions": {
-                    "value": []
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "uncommon",
-                    "value": []
-                }
-            },
-            "type": "spell"
-        },
-        {
-            "_id": "OjH9zugdZf9plsD2",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.equipment-srd.dUC8Fsa6FZtVikS3"
-                }
-            },
-            "img": "systems/pf2e/icons/equipment/weapons/composite-longbow.webp",
-            "name": "Composite Longbow",
-            "sort": 1200000,
-            "system": {
-                "MAP": {
-                    "value": ""
-                },
-                "baseItem": "composite-longbow",
-                "bonus": {
-                    "value": 0
-                },
-                "bonusDamage": {
-                    "value": 0
-                },
-                "category": "martial",
-                "containerId": null,
-                "damage": {
-                    "damageType": "piercing",
-                    "dice": 1,
-                    "die": "d8",
-                    "value": ""
-                },
-                "description": {
-                    "value": "<p>This projectile weapon is made from horn, wood, and sinew laminated together to increase the power of its pull and the force of its projectile. Like all longbows, its great size also increases the bow's range and power. You must use two hands to fire it, and it cannot be used while mounted. Any time an ability is specifically restricted to a longbow, such as Erastil's favored weapon, it also applies to composite longbows unless otherwise stated.</p>"
-                },
-                "equipped": {
-                    "carryType": "held",
-                    "handsHeld": 1,
-                    "invested": null
-                },
-                "equippedBulk": {
-                    "value": ""
-                },
-                "group": "bow",
-                "hardness": 0,
-                "hp": {
-                    "brokenThreshold": 0,
-                    "max": 0,
-                    "value": 0
-                },
-                "level": {
-                    "value": 0
-                },
-                "negateBulk": {
-                    "value": "0"
-                },
-                "potencyRune": {
-                    "value": 1
-                },
-                "preciousMaterial": {
-                    "value": null
-                },
-                "preciousMaterialGrade": {
-                    "value": null
-                },
-                "price": {
                     "value": {
-                        "gp": 20
+                        "0": {
+                            "applyMod": true,
+                            "type": {
+                                "categories": [],
+                                "value": "untyped"
+                            },
+                            "value": "1d6"
+                        }
                     }
                 },
-                "propertyRune1": {
-                    "value": null
+                "description": {
+                    "value": "<p>You hurl a loose, unattended object that is within range and that has 1 Bulk or less at the target. Make a spell attack roll against the target. If you hit, you deal bludgeoning, piercing, or slashing damage-as appropriate for the object you hurled-equal to 1d6 plus your spellcasting ability modifier. No specific traits or magic properties of the hurled item affect the attack or the damage.</p>\n<hr />\n<p><strong>Critical Success</strong> You deal double damage.</p>\n<p><strong>Success</strong> You deal full damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 1d6.</p>"
                 },
-                "propertyRune2": {
-                    "value": null
+                "duration": {
+                    "value": ""
                 },
-                "propertyRune3": {
-                    "value": null
+                "hasCounteractCheck": {
+                    "value": false
                 },
-                "propertyRune4": {
-                    "value": null
+                "heightening": {
+                    "damage": {
+                        "0": "1d6"
+                    },
+                    "interval": 1,
+                    "type": "interval"
                 },
-                "quantity": 1,
-                "range": 100,
-                "reload": {
-                    "value": "0"
+                "level": {
+                    "value": 1
+                },
+                "location": {
+                    "value": "ZnFe1AJx67Diyerp"
+                },
+                "materials": {
+                    "value": ""
+                },
+                "prepared": {
+                    "value": ""
+                },
+                "primarycheck": {
+                    "value": ""
+                },
+                "range": {
+                    "value": "30 feet"
                 },
                 "rules": [],
-                "size": "med",
-                "slug": "composite-longbow",
+                "save": {
+                    "basic": "",
+                    "value": ""
+                },
+                "school": {
+                    "value": "evocation"
+                },
+                "secondarycasters": {
+                    "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "telekinetic-projectile",
                 "source": {
                     "value": "Pathfinder Core Rulebook"
                 },
-                "specific": {
+                "spellType": {
+                    "value": "attack"
+                },
+                "sustained": {
                     "value": false
                 },
-                "splashDamage": {
-                    "value": 0
+                "target": {
+                    "value": "1 creature"
                 },
-                "stackGroup": null,
-                "strikingRune": {
-                    "value": "striking"
+                "time": {
+                    "value": "2"
+                },
+                "traditions": {
+                    "value": [
+                        "arcane",
+                        "occult"
+                    ]
                 },
                 "traits": {
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "deadly-d10",
-                        "propulsive",
-                        "volley-30"
+                        "attack",
+                        "cantrip"
                     ]
-                },
-                "usage": {
-                    "value": "held-in-one-plus-hands"
-                },
-                "weight": {
-                    "value": "2"
                 }
             },
-            "type": "weapon"
+            "type": "spell"
         },
         {
-            "_id": "qQyKvk6u3S9vDGzo",
+            "_id": "VJh6hBmylHWPU8hN",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.equipment-srd.LJdbVTOZog39EEbi"
@@ -1299,7 +887,7 @@
             },
             "img": "systems/pf2e/icons/equipment/weapons/longsword.webp",
             "name": "Longsword",
-            "sort": 1300000,
+            "sort": 900000,
             "system": {
                 "MAP": {
                     "value": ""
@@ -1323,8 +911,8 @@
                     "value": "<p>Longswords can be one‑edged or two‑edged swords. Their blades are heavy and they're between 3 and 4 feet in length.</p>"
                 },
                 "equipped": {
-                    "carryType": "held",
-                    "handsHeld": 1,
+                    "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "equippedBulk": {
@@ -1375,7 +963,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "size": "med",
+                "size": "lg",
                 "slug": "longsword",
                 "source": {
                     "value": "Pathfinder Core Rulebook"
@@ -1407,276 +995,20 @@
             "type": "weapon"
         },
         {
-            "_id": "d1NLDUJL2CAqdBvW",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.equipment-srd.r0ifJfoz8aqf0mwk"
-                }
-            },
-            "img": "systems/pf2e/icons/equipment/armor/breastplate.webp",
-            "name": "Breastplate",
-            "sort": 1400000,
-            "system": {
-                "armor": {
-                    "value": 4
-                },
-                "baseItem": "breastplate",
-                "category": "medium",
-                "check": {
-                    "value": -2
-                },
-                "containerId": null,
-                "description": {
-                    "value": "<p>Though referred to as a breastplate, this type of armor consists of several pieces of plate or half‑plate armor that protect the torso, chest, neck, and sometimes the hips and lower legs. It strategically grants some of the protection of plate while allowing greater flexibility and speed.</p>"
-                },
-                "dex": {
-                    "value": 1
-                },
-                "equipped": {
-                    "carryType": "worn",
-                    "inSlot": true,
-                    "invested": null
-                },
-                "equippedBulk": {
-                    "value": "2"
-                },
-                "group": "plate",
-                "hardness": 0,
-                "hp": {
-                    "brokenThreshold": 0,
-                    "max": 0,
-                    "value": 0
-                },
-                "level": {
-                    "value": 0
-                },
-                "negateBulk": {
-                    "value": "0"
-                },
-                "potency": {},
-                "potencyRune": {
-                    "value": 0
-                },
-                "preciousMaterial": {
-                    "value": null
-                },
-                "preciousMaterialGrade": {
-                    "value": null
-                },
-                "price": {
-                    "value": {
-                        "gp": 8
-                    }
-                },
-                "propertyRune1": {
-                    "value": ""
-                },
-                "propertyRune2": {
-                    "value": ""
-                },
-                "propertyRune3": {
-                    "value": ""
-                },
-                "propertyRune4": {
-                    "value": ""
-                },
-                "quantity": 1,
-                "resiliencyRune": {
-                    "value": ""
-                },
-                "rules": [],
-                "size": "med",
-                "slug": "breastplate",
-                "source": {
-                    "value": "Pathfinder Core Rulebook"
-                },
-                "speed": {
-                    "value": -5
-                },
-                "stackGroup": null,
-                "strength": {
-                    "value": 16
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                },
-                "usage": {
-                    "value": "wornarmor"
-                },
-                "weight": {
-                    "value": "3"
-                }
-            },
-            "type": "armor"
-        },
-        {
-            "_id": "Ir7VUc4vTn1TT3EX",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.equipment-srd.fyYnQf1NAx9fWFaS"
-                }
-            },
-            "img": "systems/pf2e/icons/equipment/adventuring-gear/rope.webp",
-            "name": "100 feet of Erinys-Hair Rope",
-            "sort": 1500000,
+            "_id": "8HBlAYPbdVvURrBC",
+            "img": "systems/pf2e/icons/equipment/adventuring-gear/pathfinder-chronicle.webp",
+            "name": "Research Book",
+            "sort": 1000000,
             "system": {
                 "baseItem": null,
-                "containerId": null,
-                "description": {
-                    "value": "<p>100 feet of rope.</p>"
-                },
-                "equipped": {
-                    "carryType": "held",
-                    "handsHeld": 1,
-                    "invested": null
-                },
-                "equippedBulk": {
-                    "value": ""
-                },
-                "hardness": 0,
-                "hp": {
-                    "brokenThreshold": 0,
-                    "max": 0,
-                    "value": 0
-                },
-                "level": {
-                    "value": 0
-                },
-                "negateBulk": {
-                    "value": ""
-                },
-                "preciousMaterial": {
-                    "value": ""
-                },
-                "preciousMaterialGrade": {
-                    "value": ""
-                },
-                "price": {
-                    "value": {
-                        "sp": 5
-                    }
-                },
-                "quantity": 1,
-                "rules": [],
-                "size": "med",
-                "slug": "rope",
-                "source": {
-                    "value": "Pathfinder Core Rulebook"
-                },
-                "stackGroup": null,
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                },
-                "usage": {
-                    "value": "held-in-one-hand"
-                },
-                "weight": {
-                    "value": "L"
-                }
-            },
-            "type": "equipment"
-        },
-        {
-            "_id": "CIRHLHAH2o7JU8SV",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.equipment-srd.w2ENw2VMPcsbif8g"
-                }
-            },
-            "img": "systems/pf2e/icons/equipment/weapons/arrows.webp",
-            "name": "Arrows",
-            "sort": 1600000,
-            "system": {
-                "autoDestroy": {
-                    "_deprecated": true,
-                    "value": true
-                },
-                "baseItem": null,
-                "charges": {
-                    "max": 0,
-                    "value": 0
-                },
-                "consumableType": {
-                    "value": "ammo"
-                },
-                "consume": {
-                    "value": ""
-                },
-                "containerId": null,
-                "description": {
-                    "value": "<p>These projectiles are the ammunition for bows. The shaft of an arrow is made of wood. It is stabilized in flight by fletching at one end and bears a metal head on the other.</p>"
-                },
-                "equipped": {
-                    "carryType": "held",
-                    "handsHeld": 1
-                },
-                "equippedBulk": {
-                    "value": ""
-                },
-                "hardness": 0,
-                "hp": {
-                    "brokenThreshold": 0,
-                    "max": 0,
-                    "value": 0
-                },
-                "level": {
-                    "value": 0
-                },
-                "negateBulk": {
-                    "value": "0"
-                },
-                "preciousMaterial": {
-                    "value": ""
-                },
-                "preciousMaterialGrade": {
-                    "value": ""
-                },
-                "price": {
-                    "per": 10,
-                    "value": {
-                        "sp": 1
-                    }
-                },
-                "quantity": 60,
-                "rules": [],
-                "size": "med",
-                "slug": "arrows",
-                "source": {
-                    "value": "Pathfinder Core Rulebook"
-                },
-                "stackGroup": "arrows",
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                },
-                "usage": {
-                    "value": "held-in-one-hand"
-                },
-                "weight": {
-                    "value": "L"
-                }
-            },
-            "type": "consumable"
-        },
-        {
-            "_id": "M9wEcuvNMW8Uu4hV",
-            "img": "systems/pf2e/icons/equipment/artifacts/arodens-hearthstone.webp",
-            "name": "Fragment of Urevian's Pendant",
-            "sort": 1700000,
-            "system": {
-                "baseItem": null,
-                "containerId": null,
+                "containerId": "null",
                 "description": {
                     "value": ""
                 },
                 "equipped": {
                     "carryType": "worn",
-                    "handsHeld": 0
+                    "handsHeld": 0,
+                    "invested": null
                 },
                 "equippedBulk": {
                     "value": ""
@@ -1716,42 +1048,352 @@
                     "value": []
                 },
                 "usage": {
-                    "value": ""
+                    "value": "held-in-one-hand"
                 },
                 "weight": {
                     "value": "-"
                 }
             },
-            "type": "treasure"
+            "type": "equipment"
         },
         {
-            "_id": "upJaEvHTKGpsW57H",
+            "_id": "VK6P3hNaRnT5JPUT",
+            "img": "systems/pf2e/icons/equipment/held-items/quill-of-passage.webp",
+            "name": "Quill",
+            "sort": 1100000,
+            "system": {
+                "baseItem": null,
+                "containerId": "null",
+                "description": {
+                    "value": ""
+                },
+                "equipped": {
+                    "carryType": "worn",
+                    "handsHeld": 0,
+                    "invested": null
+                },
+                "equippedBulk": {
+                    "value": ""
+                },
+                "hardness": 0,
+                "hp": {
+                    "brokenThreshold": 0,
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "preciousMaterial": {
+                    "value": null
+                },
+                "preciousMaterialGrade": {
+                    "value": null
+                },
+                "price": {
+                    "value": {}
+                },
+                "quantity": 1,
+                "rules": [],
+                "size": "med",
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "stackGroup": null,
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "usage": {
+                    "value": "held-in-one-hand"
+                },
+                "weight": {
+                    "value": "-"
+                }
+            },
+            "type": "equipment"
+        },
+        {
+            "_id": "mj7RC0aTfmNbGcIT",
+            "img": "systems/pf2e/icons/equipment/held-items/key-purple.webp",
+            "name": "Seugathi's Key",
+            "sort": 1200000,
+            "system": {
+                "baseItem": null,
+                "containerId": "null",
+                "description": {
+                    "value": ""
+                },
+                "equipped": {
+                    "carryType": "worn",
+                    "handsHeld": 0,
+                    "invested": null
+                },
+                "equippedBulk": {
+                    "value": ""
+                },
+                "hardness": 0,
+                "hp": {
+                    "brokenThreshold": 0,
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "preciousMaterial": {
+                    "value": null
+                },
+                "preciousMaterialGrade": {
+                    "value": null
+                },
+                "price": {
+                    "value": {}
+                },
+                "quantity": 1,
+                "rules": [],
+                "size": "med",
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "stackGroup": null,
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "usage": {
+                    "value": "held-in-one-hand"
+                },
+                "weight": {
+                    "value": "-"
+                }
+            },
+            "type": "equipment"
+        },
+        {
+            "_id": "q2sYrbAFzwVFBmAZ",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.equipment-srd.vJZ49cgi8szuQXAD"
+                }
+            },
+            "img": "systems/pf2e/icons/equipment/wands/magic-wands/magic-wand.webp",
+            "name": "Wand of Illusory Creature (Level 2)",
+            "sort": 1300000,
+            "system": {
+                "autoDestroy": {
+                    "_deprecated": true,
+                    "value": false
+                },
+                "baseItem": null,
+                "charges": {
+                    "max": 1,
+                    "value": 1
+                },
+                "consumableType": {
+                    "value": "wand"
+                },
+                "consume": {
+                    "value": ""
+                },
+                "containerId": null,
+                "description": {
+                    "value": "<p>@UUID[Compendium.pf2e.spells-srd.Illusory Creature]</p><hr /><p>This baton is about a foot long and contains a single spell. The appearance typically relates to the spell within.</p>\n<p><strong>Activate</strong> Cast a Spell</p>\n<p><strong>Frequency</strong> once per day, plus overcharge</p>\n<hr />\n<p><strong>Effect</strong> You Cast the Spell at the indicated level.</p>\n<p><strong>Craft Requirements</strong> Supply a listed-level casting of the spell.</p>\n<hr />\n<p><em>Note: To create a scroll or wand of a specific spell, drag the spell from the compendium or compendium browser into the inventory of a PC, NPC, or loot actor.</em></p>"
+                },
+                "equipped": {
+                    "carryType": "worn"
+                },
+                "equippedBulk": {
+                    "value": ""
+                },
+                "hardness": 0,
+                "hp": {
+                    "brokenThreshold": 0,
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 5
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "preciousMaterial": {
+                    "value": ""
+                },
+                "preciousMaterialGrade": {
+                    "value": ""
+                },
+                "price": {
+                    "value": {
+                        "gp": 160
+                    }
+                },
+                "quantity": 1,
+                "rules": [],
+                "size": "med",
+                "slug": "magic-wand-2nd-level-spell",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "spell": {
+                    "_id": "f8SBoXiXQjlCKqly",
+                    "flags": {
+                        "core": {
+                            "sourceId": "Compendium.pf2e.spells-srd.f8SBoXiXQjlCKqly"
+                        }
+                    },
+                    "img": "systems/pf2e/icons/spells/illusory-creature.webp",
+                    "name": "Illusory Creature",
+                    "sort": 0,
+                    "system": {
+                        "ability": {
+                            "value": ""
+                        },
+                        "area": null,
+                        "category": {
+                            "value": "spell"
+                        },
+                        "components": {
+                            "focus": false,
+                            "material": false,
+                            "somatic": true,
+                            "verbal": true
+                        },
+                        "cost": {
+                            "value": ""
+                        },
+                        "damage": {
+                            "value": {}
+                        },
+                        "description": {
+                            "value": "<p>You create an illusory image of a Large or smaller creature. It generates the appropriate sounds, smells, and feels believable to the touch. If you and the image are ever farther than 500 feet apart, the spell ends.</p>\n<p>The image can't speak, but you can use your actions to speak through the creature, with the spell disguising your voice as appropriate. You might need to attempt a Deception or Performance check to mimic the creature, as determined by the GM. This is especially likely if you're trying to imitate a specific person and engage with someone that person knows.</p>\n<p>In combat, the illusion can use 2 actions per turn, which it uses when you Sustain the Spell. It uses your spell attack roll for attack rolls and your spell DC for its AC. Its saving throw modifiers are equal to your spell DC - 10. It is substantial enough that it can flank other creatures. If the image is hit by an attack or fails a save, the spell ends.</p>\n<p>The illusion can cause damage by making the target believe the illusion's attacks are real, but it cannot otherwise directly affect the physical world. If the illusory creature hits with a Strike, the target takes mental damage equal to 1d4 plus your spellcasting ability modifier. This is a mental effect. The illusion's Strikes are nonlethal. If the damage doesn't correspond to the image of the monster-for example, if an illusory Large dragon deals only 5 damage-the GM might allow the target to attempt an immediate Perception check to disbelieve the spell. Any relevant resistances and weaknesses apply if the target thinks they do, as judged by the GM. For example, if the illusion wields a warhammer and attacks a creature resistant to bludgeoning damage, the creature would take less mental damage. However, illusory damage does not deactivate regeneration or trigger other effects that require a certain damage type. The GM should track illusory damage dealt by the illusion.</p>\n<p>Any creature that touches the image or uses the Seek action to examine it can attempt to disbelieve your illusion. When a creature disbelieves the illusion, it recovers from half the damage it had taken from it (if any) and doesn't take any further damage from it.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage of the image's Strikes increases by 1d4, and the maximum size of creature you can create increases by one (to a maximum of Gargantuan).</p>"
+                        },
+                        "duration": {
+                            "value": "sustained"
+                        },
+                        "hasCounteractCheck": {
+                            "value": false
+                        },
+                        "level": {
+                            "value": 2
+                        },
+                        "location": {
+                            "heightenedLevel": 2,
+                            "value": ""
+                        },
+                        "materials": {
+                            "value": ""
+                        },
+                        "prepared": {
+                            "value": ""
+                        },
+                        "primarycheck": {
+                            "value": ""
+                        },
+                        "range": {
+                            "value": "500 feet"
+                        },
+                        "rules": [],
+                        "save": {
+                            "basic": "",
+                            "value": ""
+                        },
+                        "school": {
+                            "value": "illusion"
+                        },
+                        "secondarycasters": {
+                            "value": ""
+                        },
+                        "secondarycheck": {
+                            "value": ""
+                        },
+                        "slug": "illusory-creature",
+                        "source": {
+                            "value": "Pathfinder Core Rulebook"
+                        },
+                        "spellType": {
+                            "value": "utility"
+                        },
+                        "sustained": {
+                            "value": false
+                        },
+                        "target": {
+                            "value": ""
+                        },
+                        "time": {
+                            "value": "2"
+                        },
+                        "traditions": {
+                            "value": [
+                                "arcane",
+                                "occult"
+                            ]
+                        },
+                        "traits": {
+                            "custom": "",
+                            "rarity": "common",
+                            "value": [
+                                "auditory",
+                                "olfactory",
+                                "visual"
+                            ]
+                        }
+                    },
+                    "type": "spell"
+                },
+                "stackGroup": null,
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "magical",
+                        "wand",
+                        "arcane",
+                        "occult"
+                    ]
+                },
+                "usage": {
+                    "value": "held-in-one-hand"
+                },
+                "weight": {
+                    "value": "L"
+                }
+            },
+            "type": "consumable"
+        },
+        {
+            "_id": "nzWpj7yo8PguGBFG",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "Flaming Longsword",
-            "sort": 1800000,
+            "name": "Bite",
+            "sort": 1400000,
             "system": {
                 "attack": {
                     "value": ""
                 },
                 "attackEffects": {
                     "custom": "",
-                    "value": []
+                    "value": [
+                        "seugathi-venom"
+                    ]
                 },
                 "bonus": {
-                    "value": 19
+                    "value": 17
                 },
                 "damageRolls": {
-                    "jq6gucy2ezjy28wuotil": {
-                        "damage": "1d8+8",
-                        "damageType": "slashing"
-                    },
-                    "u8y72xfoq0cm453hiw8q": {
-                        "damage": "1d6",
-                        "damageType": "evil"
-                    },
-                    "4t8x4f2zccvreho2vef1": {
-                        "damage": "1d6",
-                        "damageType": "fire"
+                    "7mouzbmbtpfs7v063fwh": {
+                        "damage": "2d6+5",
+                        "damageType": "piercing"
                     }
                 },
                 "description": {
@@ -1766,9 +1408,51 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "evil",
-                        "fire",
-                        "magical",
+                        "agile",
+                        "finesse"
+                    ]
+                },
+                "weaponType": {
+                    "value": "melee"
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "htwDT7obXSlNmWpU",
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Longsword",
+            "sort": 1500000,
+            "system": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "custom": "",
+                    "value": []
+                },
+                "bonus": {
+                    "value": 14
+                },
+                "damageRolls": {
+                    "6fms5dftz9p6th6dy2ab": {
+                        "damage": "1d8+5",
+                        "damageType": "piercing"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "reach-10",
                         "versatile-p"
                     ]
                 },
@@ -1779,113 +1463,15 @@
             "type": "melee"
         },
         {
-            "_id": "Hor4EOQfUGAkFak1",
-            "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "Flaming Composite Longbow",
-            "sort": 1900000,
-            "system": {
-                "attack": {
-                    "value": ""
-                },
-                "attackEffects": {
-                    "custom": "",
-                    "value": []
-                },
-                "bonus": {
-                    "value": 20
-                },
-                "damageRolls": {
-                    "6s0rutrsib85hnnorwft": {
-                        "damage": "2d8+4",
-                        "damageType": "piercing"
-                    },
-                    "qj7c6kozsaiwufg2uvdr": {
-                        "damage": "1d6",
-                        "damageType": "evil"
-                    },
-                    "rraf034dphcxxz4yxe1j": {
-                        "damage": "1d6",
-                        "damageType": "fire"
-                    }
-                },
-                "description": {
-                    "value": ""
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": [
-                        "deadly-d10",
-                        "evil",
-                        "fire",
-                        "magical",
-                        "range-increment-100",
-                        "reload-0",
-                        "volley-30"
-                    ]
-                },
-                "weaponType": {
-                    "value": "ranged"
-                }
-            },
-            "type": "melee"
-        },
-        {
-            "_id": "UakPnn8jYjY9gCdo",
-            "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "Rope",
-            "sort": 2000000,
-            "system": {
-                "attack": {
-                    "value": ""
-                },
-                "attackEffects": {
-                    "custom": "",
-                    "value": [
-                        "rope-snare"
-                    ]
-                },
-                "bonus": {
-                    "value": 19
-                },
-                "damageRolls": {},
-                "description": {
-                    "value": ""
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": [
-                        "magical",
-                        "range-increment-30"
-                    ]
-                },
-                "weaponType": {
-                    "value": "ranged"
-                }
-            },
-            "type": "melee"
-        },
-        {
-            "_id": "cQrkrn9uX9hV860V",
+            "_id": "Qkqj9KzvAaoHkxjH",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.4Ho2xMPEC05aSxzr"
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.qCCLZhnp2HhP3Ex6"
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Greater Darkvision",
-            "sort": 2100000,
+            "name": "Darkvision",
+            "sort": 1600000,
             "system": {
                 "actionCategory": {
                     "value": "interaction"
@@ -1897,13 +1483,13 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.GreaterDarkvision]</p>"
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Darkvision]</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
                 "rules": [],
-                "slug": "greater-darkvision",
+                "slug": "darkvision",
                 "source": {
                     "value": "Pathfinder Bestiary"
                 },
@@ -1922,7 +1508,52 @@
             "type": "action"
         },
         {
-            "_id": "LGBzL3vv4QNzTFJ1",
+            "_id": "cj3wll0YeOYjYWaL",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.j2wsK6IsW5yMW1jW"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Tremorsense (Imprecise) 30 feet",
+            "sort": 1700000,
+            "system": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Tremorsense]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "tremorsense",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "1lJU8hzSml2TMM3M",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.kdhbPaBMK1d1fpbA"
@@ -1930,7 +1561,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Telepathy 100 feet",
-            "sort": 2200000,
+            "sort": 1800000,
             "system": {
                 "actionCategory": {
                     "value": "interaction"
@@ -1971,97 +1602,7 @@
             "type": "action"
         },
         {
-            "_id": "8aYfDhAzJOdFBLKs",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.2YRDYVnC1eljaXKK"
-                }
-            },
-            "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "At-Will Spells",
-            "sort": 2300000,
-            "system": {
-                "actionCategory": {
-                    "value": "interaction"
-                },
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "description": {
-                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.AtWillSpells]</p>"
-                },
-                "requirements": {
-                    "value": ""
-                },
-                "rules": [],
-                "slug": "at-will-spells",
-                "source": {
-                    "value": "Pathfinder Bestiary"
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                },
-                "trigger": {
-                    "value": ""
-                },
-                "weapon": {
-                    "value": ""
-                }
-            },
-            "type": "action"
-        },
-        {
-            "_id": "NwuVG96DJON1Txro",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.kakyXBG5WA8c6Zfd"
-                }
-            },
-            "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Constant Spells",
-            "sort": 2400000,
-            "system": {
-                "actionCategory": {
-                    "value": "interaction"
-                },
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "description": {
-                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.ConstantSpells]</p>"
-                },
-                "requirements": {
-                    "value": ""
-                },
-                "rules": [],
-                "slug": "constant-spells",
-                "source": {
-                    "value": "Pathfinder Bestiary"
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                },
-                "trigger": {
-                    "value": ""
-                },
-                "weapon": {
-                    "value": ""
-                }
-            },
-            "type": "action"
-        },
-        {
-            "_id": "PrsRCxi6j7SHJeMu",
+            "_id": "j1CfaIqiOES2OC3Y",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.kquBnQ0kObZztnBc"
@@ -2069,7 +1610,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "+1 Status to All Saves vs. Magic",
-            "sort": 2500000,
+            "sort": 1900000,
             "system": {
                 "actionCategory": {
                     "value": "defensive"
@@ -2124,38 +1665,27 @@
             "type": "action"
         },
         {
-            "_id": "vKdhNyXTKHDMUfAc",
-            "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Flames of Fury",
-            "sort": 2600000,
+            "_id": "VkmU3zCSF1tm61N6",
+            "img": "systems/pf2e/icons/actions/Reaction.webp",
+            "name": "Command Confusion",
+            "sort": 2000000,
             "system": {
                 "actionCategory": {
-                    "value": "offensive"
+                    "value": "defensive"
                 },
                 "actionType": {
-                    "value": "passive"
+                    "value": "reaction"
                 },
                 "actions": {
                     "value": null
                 },
                 "description": {
-                    "value": "<p>Any weapon an erinys holds gains the effects of a <em>@UUID[Compendium.pf2e.equipment-srd.Flaming]{Flaming}</em> rune while they hold it.</p>"
+                    "value": "<p><strong>Trigger</strong> A creature fails its save against the seugathi's mindfog aura</p>\n<hr />\n<p><strong>Effect</strong> The seugathi determines who the @UUID[Compendium.pf2e.conditionitems.Confused]{Confused} creature attacks for that round, instead of the target being randomly determined by the GM.</p>\n<p>If the chosen target is the confused creature's ally, the creature can immediately attempt a @Check[type:will|dc:21] save; on a success, its target is determined randomly as normal for confusion, and on a critical success the target is no longer confused.</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
-                "rules": [
-                    {
-                        "key": "Note",
-                        "outcome": [
-                            "criticalSuccess"
-                        ],
-                        "selector": "attack",
-                        "text": "PF2E.WeaponPropertyRune.flaming.Note.criticalSuccess",
-                        "title": "{item|name}",
-                        "visibility": "gm"
-                    }
-                ],
+                "rules": [],
                 "slug": null,
                 "source": {
                     "value": ""
@@ -2175,10 +1705,53 @@
             "type": "action"
         },
         {
-            "_id": "pKPJ4u9g0HQyU7b6",
-            "img": "systems/pf2e/icons/actions/ThreeActions.webp",
-            "name": "Furious Fusillade",
-            "sort": 2700000,
+            "_id": "7tCu8SPq0TpF1lJX",
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Mindfog Aura",
+            "sort": 2100000,
+            "system": {
+                "actionCategory": {
+                    "value": "defensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Template[type:emanation|distance:20]{20 feet} @UUID[Compendium.pf2e.bestiary-ability-glossary-srd.Aura]{Aura}</p>\n<hr />\n<p>A creature that starts its turn in the aura must succeed at a @Check[type:will|dc:21] save or become @UUID[Compendium.pf2e.conditionitems.Confused]{Confused} for 1 round; on a success, that creature is temporarily immune for 1 minute. A seugathi can suppress or activate this aura as a with the concentrate trait.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "enchantment",
+                        "mental"
+                    ]
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "tNfhf1JnOxOHfY86",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Envenom Weapon",
+            "sort": 2200000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -2187,10 +1760,10 @@
                     "value": "action"
                 },
                 "actions": {
-                    "value": 3
+                    "value": 1
                 },
                 "description": {
-                    "value": "<p>The erinys hovers in place if they are flying and fires one arrow at any number of creatures in a @Template[type:cone|distance:30]. Each attack is rolled separately. This counts as one attack for the purpose of the erinys's multiple attack penalty.</p>"
+                    "value": "<p>The seugathi applies their seugathi venom to one weapon they wield.</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -2203,7 +1776,9 @@
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "manipulate"
+                    ]
                 },
                 "trigger": {
                     "value": ""
@@ -2215,10 +1790,10 @@
             "type": "action"
         },
         {
-            "_id": "PVrWJHEarOi9LFbD",
+            "_id": "MnAW3prtfTZxnv7T",
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Rope Snare",
-            "sort": 2800000,
+            "name": "Magic Item Mastery",
+            "sort": 2300000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -2230,7 +1805,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>An erinys carries a coil of rope woven of their hair (use the statistics for @UUID[Compendium.pf2e.equipment-srd.Rope]{Rope}) that animates in their hands.</p>\n<p>When a creature is hit by the erinys's rope, a segment of the rope tears loose and wraps itself around the creature, imposing a 10-foot circumstance penalty to Speed. The piece that tears off is 10 feet long for a Medium or smaller creature, and doubles in length for each size larger than Medium.</p>\n<p>When a creature @UUID[Compendium.pf2e.actionspf2e.Escape]{Escapes} the effect (DC 26), the detached segment of rope withers away into useless black sludge.</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Effect: Rope Snare]{Effect: Rope Snare}</p>"
+                    "value": "<p>A seugathi can Cast a Spell from a magic item even if the spell isn't on their spell list. All such spells are occult spells and use the seugathi's innate spell DC and attack modifier.</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -2255,94 +1830,52 @@
             "type": "action"
         },
         {
-            "_id": "Zui4bhvANe1dVGUQ",
+            "_id": "1tb7DMhGgvu0yKi2",
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Seugathi Venom",
+            "sort": 2400000,
+            "system": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p><strong>Saving Throw</strong> @Check[type:fortitude|dc:21]</p>\n<hr />\n<p><strong>Maximum Duration</strong> 6 rounds</p>\n<p><strong>Stage 1</strong> [[/r 1d6[poison]]] damage and @UUID[Compendium.pf2e.conditionitems.Stupefied]{Stupefied 1} (1 round)</p>\n<p><strong>Stage 2</strong> [[/r 2d6[poison]]] damage and @UUID[Compendium.pf2e.conditionitems.Deafened]{Deafened} and @UUID[Compendium.pf2e.conditionitems.Stupefied]{Stupefied 2} (1 round)</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "poison"
+                    ]
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "jLbg1YorL43XtXr8",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Acrobatics",
-            "sort": 2900000,
-            "system": {
-                "description": {
-                    "value": ""
-                },
-                "mod": {
-                    "value": 17
-                },
-                "proficient": {
-                    "value": 0
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                }
-            },
-            "type": "lore"
-        },
-        {
-            "_id": "dl27Nh1hZdxXfx4f",
-            "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Crafting",
-            "sort": 3000000,
-            "system": {
-                "description": {
-                    "value": ""
-                },
-                "mod": {
-                    "value": 14
-                },
-                "proficient": {
-                    "value": 0
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                }
-            },
-            "type": "lore"
-        },
-        {
-            "_id": "SPsWoaTwVPa6PiBY",
-            "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Deception",
-            "sort": 3100000,
-            "system": {
-                "description": {
-                    "value": ""
-                },
-                "mod": {
-                    "value": 19
-                },
-                "proficient": {
-                    "value": 0
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                }
-            },
-            "type": "lore"
-        },
-        {
-            "_id": "swxCxmxGd58iO57u",
-            "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Diplomacy",
-            "sort": 3200000,
+            "sort": 2500000,
             "system": {
                 "description": {
                     "value": ""
@@ -2367,16 +1900,44 @@
             "type": "lore"
         },
         {
-            "_id": "NkQlnzg2MoJdQmqa",
+            "_id": "GZ30fJU5FHDsnaLu",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Crafting",
+            "sort": 2600000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 12
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "lore"
+        },
+        {
+            "_id": "YEI9CIUnmNxrth19",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Intimidation",
-            "sort": 3300000,
+            "sort": 2700000,
             "system": {
                 "description": {
                     "value": ""
                 },
                 "mod": {
-                    "value": 19
+                    "value": 15
                 },
                 "proficient": {
                     "value": 0
@@ -2395,16 +1956,16 @@
             "type": "lore"
         },
         {
-            "_id": "XqTrrm1rk0afLzmv",
+            "_id": "8TmJKtpOBNZCQgWv",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Religion",
-            "sort": 3400000,
+            "name": "Occultism",
+            "sort": 2800000,
             "system": {
                 "description": {
                     "value": ""
                 },
                 "mod": {
-                    "value": 16
+                    "value": 12
                 },
                 "proficient": {
                     "value": 0
@@ -2423,16 +1984,44 @@
             "type": "lore"
         },
         {
-            "_id": "2OFIjqEQkaoehnSx",
+            "_id": "fI7hSCpYGpbN4Mwq",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Stealth",
-            "sort": 3500000,
+            "sort": 2900000,
             "system": {
                 "description": {
                     "value": ""
                 },
                 "mod": {
-                    "value": 17
+                    "value": 13
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "lore"
+        },
+        {
+            "_id": "hjcRFLhxhWeO7Qvv",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Survival",
+            "sort": 3000000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 10
                 },
                 "proficient": {
                     "value": 0
@@ -2451,9 +2040,9 @@
             "type": "lore"
         }
     ],
-    "name": "Erinys (AV-D7)",
+    "name": "Observation Deck Seugathi Researcher",
     "prototypeToken": {
-        "name": "Erinys"
+        "name": "Seugathi Researcher"
     },
     "system": {
         "abilities": {
@@ -2461,7 +2050,7 @@
                 "mod": 5
             },
             "con": {
-                "mod": 5
+                "mod": 2
             },
             "dex": {
                 "mod": 5
@@ -2470,7 +2059,7 @@
                 "mod": 2
             },
             "str": {
-                "mod": 5
+                "mod": 2
             },
             "wis": {
                 "mod": 4
@@ -2479,69 +2068,55 @@
         "attributes": {
             "ac": {
                 "details": "",
-                "value": 27
+                "value": 23
             },
             "allSaves": {
                 "value": "+1 status to all saves vs. magic"
             },
             "hp": {
                 "details": "",
-                "max": 120,
+                "max": 75,
                 "temp": 0,
-                "value": 120
+                "value": 75
             },
             "immunities": [
                 {
-                    "type": "fire"
+                    "type": "mental"
+                },
+                {
+                    "type": "poison"
                 }
             ],
             "initiative": {
                 "ability": "perception"
             },
             "perception": {
-                "value": 18
+                "value": 14
             },
             "resistances": [
                 {
-                    "exceptions": [
-                        "silver"
-                    ],
-                    "type": "physical",
+                    "type": "bludgeoning",
                     "value": 5
-                },
-                {
-                    "type": "poison",
-                    "value": 10
                 }
             ],
             "speed": {
-                "otherSpeeds": [
-                    {
-                        "type": "fly",
-                        "value": 40
-                    }
-                ],
+                "otherSpeeds": [],
                 "value": 25
-            },
-            "weaknesses": [
-                {
-                    "type": "good",
-                    "value": 5
-                }
-            ]
+            }
         },
         "details": {
             "alignment": {
-                "value": "LE"
+                "value": "CE"
             },
-            "blurb": "",
-            "creatureType": "Fiend",
+            "blurb": "Seugathi servant",
+            "creatureType": "",
             "level": {
-                "value": 8
+                "value": 6
             },
             "privateNotes": "",
-            "publicNotes": "<p>Erinyes exact vengeance and bloody justice for a creature's crimes, torturing and punishing their victims in ironic fashion before allowing them the escape of death. While an erinys appears as a fallen angel and the first erinyes shared that origin, erinyes now originate in myriad ways, some promoted from lesser devils and others shaped from lemures themselves forged from the souls of torturers and persecutors. The erinyes' origin is entwined with Eiseth, herself a fallen angel and one of Hell's most powerful demigods. The first erinyes were all considered to be Eiseth's metaphorical daughters, but erinyes formed since that time are no longer limited to a single gender.</p>\n<hr />\n<p>Masters of corruption and architects of conquest, devils seek both to tempt mortal life to join in their pursuit of all things profane and to spread tyranny throughout all worlds. The temptations they offer mortals range from great powers granted by the signing of an infernal contract to twisted favors following a whispered pledge to a diabolic patron, or any number of even subtler exchanges. Those who succumb to these temptations find themselves consigned to an afterlife of endless torment in the pits of Hell, wherein the only hope of escape lies in the chance of being promoted to become a devil in the infernal ranks. Every devil has a specific role to play in the upkeep of the remorseless bureaucratic machine that is Hell, from soldiers and scholars to inquisitors, lawyers, judges, and executioners. Lowly lemures and imps perform subservient labor to more powerful and specialized devils, such as contract devils and erinyes, while the greatest pit fiends command entire infernal armies.</p>",
+            "publicNotes": "<p>The most common seugathis spawned by neothelids are seugathi servants. Their masters equip them with tools useful in their tasks (often a wand and a weapon), and they rarely value other material things beyond their usefulness in completing their imprinted mission.</p>\n<hr />\n<p>The wicked, alien @UUID[Compendium.pf2e.pathfinder-bestiary-2.Neothelid]{Neothelids} impregnate themselves through ritualistic magic to produce wormlike servitor creatures called seugathis. These creatures spawn with a strong psychic drive to complete some task on behalf of the neothelids' far-reaching plans. These directives are diverse, strange, and usually cruel toward humanoid life.</p>",
             "source": {
+                "author": "",
                 "value": "Pathfinder #164: Hands of the Devil"
             }
         },
@@ -2554,15 +2129,15 @@
         "saves": {
             "fortitude": {
                 "saveDetail": "",
-                "value": 17
+                "value": 14
             },
             "reflex": {
                 "saveDetail": "",
-                "value": 19
+                "value": 17
             },
             "will": {
                 "saveDetail": "",
-                "value": 16
+                "value": 12
             }
         },
         "traits": {
@@ -2570,22 +2145,20 @@
                 "custom": "Telepathy 100 feet",
                 "selected": [],
                 "value": [
-                    "celestial",
-                    "common",
-                    "draconic",
-                    "infernal"
+                    "aklo",
+                    "undercommon"
                 ]
             },
-            "rarity": "common",
+            "rarity": "uncommon",
             "senses": {
-                "value": "greater darkvision, true seeing"
+                "value": "darkvision, tremorsense 30 feet"
             },
             "size": {
-                "value": "med"
+                "value": "lg"
             },
             "value": [
-                "devil",
-                "fiend"
+                "aberration",
+                "seugathi"
             ]
         }
     },

--- a/packs/data/abomination-vaults-bestiary.db/padli.json
+++ b/packs/data/abomination-vaults-bestiary.db/padli.json
@@ -1762,73 +1762,6 @@
             "type": "armor"
         },
         {
-            "_id": "ulW0wOc7MAyKJ3Hi",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.equipment-srd.fprUZviW8khm2BLo"
-                }
-            },
-            "img": "systems/pf2e/icons/equipment/held-items/skeleton-key.webp",
-            "name": "Key to area A7",
-            "sort": 1700000,
-            "system": {
-                "baseItem": null,
-                "containerId": null,
-                "description": {
-                    "value": "<p>Key to Area A7</p>"
-                },
-                "equipped": {
-                    "carryType": "worn",
-                    "handsHeld": 0,
-                    "invested": null
-                },
-                "equippedBulk": {
-                    "value": ""
-                },
-                "hardness": 0,
-                "hp": {
-                    "brokenThreshold": 0,
-                    "max": 0,
-                    "value": 0
-                },
-                "level": {
-                    "value": 1
-                },
-                "negateBulk": {
-                    "value": "0"
-                },
-                "preciousMaterial": {
-                    "value": ""
-                },
-                "preciousMaterialGrade": {
-                    "value": ""
-                },
-                "price": {
-                    "value": {}
-                },
-                "quantity": 1,
-                "rules": [],
-                "size": "med",
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "stackGroup": null,
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                },
-                "usage": {
-                    "value": "held-in-one-hand"
-                },
-                "weight": {
-                    "value": "-"
-                }
-            },
-            "type": "equipment"
-        },
-        {
             "_id": "faxsM9HLLEPrf5fu",
             "flags": {
                 "core": {
@@ -1837,7 +1770,7 @@
             },
             "img": "systems/pf2e/icons/equipment/wands/magic-wands/magic-wand.webp",
             "name": "Wand of Magic Missile (Level 3)",
-            "sort": 1800000,
+            "sort": 1700000,
             "system": {
                 "autoDestroy": {
                     "_deprecated": true,
@@ -2024,6 +1957,73 @@
                 }
             },
             "type": "consumable"
+        },
+        {
+            "_id": "UnpIdfQqjGGuWR70",
+            "flags": {
+                "core": {
+                    "sourceId": "Item.SUrUpFSC7eOVG0Yf"
+                }
+            },
+            "img": "systems/pf2e/icons/equipment/held-items/key-steel.webp",
+            "name": "Padli's Key",
+            "sort": 1800000,
+            "system": {
+                "baseItem": null,
+                "containerId": null,
+                "description": {
+                    "value": ""
+                },
+                "equipped": {
+                    "-=inSlot": null,
+                    "carryType": "worn",
+                    "handsHeld": 0
+                },
+                "equippedBulk": {
+                    "value": ""
+                },
+                "hardness": 0,
+                "hp": {
+                    "brokenThreshold": 0,
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "preciousMaterial": {
+                    "value": null
+                },
+                "preciousMaterialGrade": {
+                    "value": null
+                },
+                "price": {
+                    "value": {}
+                },
+                "quantity": 1,
+                "rules": [],
+                "size": "med",
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "stackGroup": null,
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "usage": {
+                    "value": ""
+                },
+                "weight": {
+                    "value": "-"
+                }
+            },
+            "type": "treasure"
         },
         {
             "_id": "yxXEQaBGVF13c0rW",
@@ -2608,6 +2608,7 @@
             "privateNotes": "",
             "publicNotes": "",
             "source": {
+                "author": "",
                 "value": "Pathfinder #165: Eyes of Empty Death"
             }
         },

--- a/packs/data/abomination-vaults-bestiary.db/padli.json
+++ b/packs/data/abomination-vaults-bestiary.db/padli.json
@@ -1960,11 +1960,6 @@
         },
         {
             "_id": "UnpIdfQqjGGuWR70",
-            "flags": {
-                "core": {
-                    "sourceId": "Item.SUrUpFSC7eOVG0Yf"
-                }
-            },
             "img": "systems/pf2e/icons/equipment/held-items/key-steel.webp",
             "name": "Padli's Key",
             "sort": 1800000,

--- a/packs/data/abomination-vaults-bestiary.db/poisoning-room-specter.json
+++ b/packs/data/abomination-vaults-bestiary.db/poisoning-room-specter.json
@@ -1,0 +1,658 @@
+{
+    "_id": "BOaM3pAuWl06Q6IZ",
+    "img": "systems/pf2e/icons/default-icons/npc.svg",
+    "items": [
+        {
+            "_id": "zjVbARImBBAx6EKv",
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Vile Touch",
+            "sort": 100000,
+            "system": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "custom": "",
+                    "value": []
+                },
+                "bonus": {
+                    "value": 16
+                },
+                "damageRolls": {
+                    "0": {
+                        "damage": "2d8+8",
+                        "damageType": "negative"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "finesse"
+                    ]
+                },
+                "weaponType": {
+                    "value": "melee"
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "C46qe4d4dQ5DqKp4",
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Vile Blowgun",
+            "sort": 200000,
+            "system": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "custom": "Range Increment 20ft",
+                    "value": [
+                        "spectral-corruption"
+                    ]
+                },
+                "bonus": {
+                    "value": 18
+                },
+                "damageRolls": {
+                    "nq95y207zrc43huqu4a9": {
+                        "damage": "3d6",
+                        "damageType": "negative"
+                    },
+                    "7pdb71okxfbcs5j9jn50": {
+                        "damage": "3d6",
+                        "damageType": "poison"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": "Pathfinder #165: Eyes of Empty Death"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "range-increment-20"
+                    ]
+                },
+                "weaponType": {
+                    "value": "ranged"
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "VzobMtkoa82xICPm",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.qCCLZhnp2HhP3Ex6"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Darkvision",
+            "sort": 300000,
+            "system": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Darkvision]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "darkvision",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "9yk5MBYML8Z0OmtD",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.kdhbPaBMK1d1fpbA"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Telepathy (with spectral thralls only)",
+            "sort": 400000,
+            "system": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Telepathy]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "telepathy",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "aura",
+                        "divination",
+                        "magical"
+                    ]
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "ZqBQutg0Cvs5YcxR",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.TTCw5NusiSSkJU1x"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Negative Healing",
+            "sort": 500000,
+            "system": {
+                "actionCategory": {
+                    "value": "defensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.NegativeHealing]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "system.attributes.hp.negativeHealing",
+                        "value": true
+                    }
+                ],
+                "slug": "negative-healing",
+                "source": {
+                    "value": "Pathfinder Bestiary 2"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "BPJS4QzIXUC3Zmwf",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.etMnv73EIdEZrYYu"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Frightful Presence",
+            "sort": 600000,
+            "system": {
+                "actionCategory": {
+                    "value": "defensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Template[type:emanation|distance:30]{30 feet} @UUID[Compendium.pf2e.bestiary-ability-glossary-srd.Aura]{Aura} @Check[type:will|dc:22]</p>\n<hr />\n<p>@Localize[PF2E.NPC.Abilities.Glossary.FrightfulPresence]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "frightful-presence",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "aura",
+                        "emotion",
+                        "fear",
+                        "mental"
+                    ]
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "RGaUdIjwMpgnNYGg",
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Pain Starvation",
+            "sort": 700000,
+            "system": {
+                "actionCategory": {
+                    "value": "defensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>A specter that goes for more than a month without dealing negative damage to a living humanoid becomes desperate and almost feral. It changes alignment from lawful evil to chaotic evil, loses control of any corrupted thralls it might have, and becomes @UUID[Compendium.pf2e.conditionitems.Quickened]{Quickened}. It can use its additional action only to make vile touch Strikes against humanoid targets. At the end of any turn in which it deals any amount of negative damage to a living humanoid, it reverts to lawful evil and is no longer quickened, but any thralls it lost control of remain free.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "humanoid"
+                    ]
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "qh8LFXVLWjILfZZx",
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Sunlight Powerlessness",
+            "sort": 800000,
+            "system": {
+                "actionCategory": {
+                    "value": "defensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>A specter caught in sunlight is @UUID[Compendium.pf2e.conditionitems.Clumsy]{Clumsy 2} and @UUID[Compendium.pf2e.conditionitems.Slowed]{Slowed 2} for as long as it remains in the sunlight.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "OSiq1CXChzTT7udW",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Spectral Corruption",
+            "sort": 900000,
+            "system": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "description": {
+                    "value": "<p>The specter makes a vile touch Strike. If it damages a living creature, the specter gains 5 temporary Hit Points and the target creature must attempt a @Check[type:will|dc:24] save to avoid becoming corrupted.</p>\n<hr />\n<p><strong>Critical Success</strong> The creature is unaffected and is temporarily immune to spectral corruption for 1 minute.</p>\n<p><strong>Success</strong> The creature is @UUID[Compendium.pf2e.conditionitems.Stupefied]{Stupefied 2} for 1 hour.</p>\n<p><strong>Failure</strong> The creature succumbs to the corruption and becomes a spectral thrall temporarily. The creature is @UUID[Compendium.pf2e.conditionitems.Controlled]{Controlled} by the specter, obeying the specter's telepathic or spoken orders, though a spectral thrall does not obey obviously self-destructive orders. This lasts until the end of the thrall's next turn, at which point it is no longer controlled but becomes @UUID[Compendium.pf2e.conditionitems.Stupefied]{Stupefied 2} for 1 hour.</p>\n<p><strong>Critical Failure</strong> As failure, but the duration is unlimited. The thrall can attempt a new Will save at the end of each of its turns; on a success, it is no longer controlled by the specter but becomes @UUID[Compendium.pf2e.conditionitems.Stupefied]{Stupefied 2} for 1 hour.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "curse",
+                        "divine",
+                        "enchantment",
+                        "incapacitation",
+                        "mental"
+                    ]
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "R9IAepGCjja3f9FP",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Acrobatics",
+            "sort": 1000000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 17
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "lore"
+        },
+        {
+            "_id": "7Sy3VLJjVY7IdW0F",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Intimidation",
+            "sort": 1100000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 15
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "lore"
+        },
+        {
+            "_id": "C1gCdCYUAoqjpkXr",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Stealth",
+            "sort": 1200000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 17
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "variants": {
+                    "0": {
+                        "label": "+21 in the shooting gallery",
+                        "options": ""
+                    }
+                }
+            },
+            "type": "lore"
+        }
+    ],
+    "name": "Poisoning Room Specter",
+    "prototypeToken": {
+        "name": "Specter"
+    },
+    "system": {
+        "abilities": {
+            "cha": {
+                "mod": 4
+            },
+            "con": {
+                "mod": 4
+            },
+            "dex": {
+                "mod": 6
+            },
+            "int": {
+                "mod": 0
+            },
+            "str": {
+                "mod": -5
+            },
+            "wis": {
+                "mod": 4
+            }
+        },
+        "attributes": {
+            "ac": {
+                "details": "",
+                "value": 25
+            },
+            "allSaves": {
+                "value": ""
+            },
+            "hp": {
+                "details": "negative healing",
+                "max": 95,
+                "temp": 0,
+                "value": 95
+            },
+            "immunities": [
+                {
+                    "type": "death-effects"
+                },
+                {
+                    "type": "disease"
+                },
+                {
+                    "type": "paralyzed"
+                },
+                {
+                    "type": "poison"
+                },
+                {
+                    "type": "precision"
+                },
+                {
+                    "type": "unconscious"
+                }
+            ],
+            "initiative": {
+                "ability": "perception"
+            },
+            "perception": {
+                "value": 15
+            },
+            "resistances": [
+                {
+                    "doubleVs": [
+                        "non-magical"
+                    ],
+                    "exceptions": [
+                        "force",
+                        "ghost-touch",
+                        "positive"
+                    ],
+                    "type": "all-damage",
+                    "value": 5
+                }
+            ],
+            "speed": {
+                "otherSpeeds": [
+                    {
+                        "type": "fly",
+                        "value": 40
+                    }
+                ],
+                "value": 0
+            }
+        },
+        "details": {
+            "alignment": {
+                "value": "LE"
+            },
+            "blurb": "",
+            "creatureType": "Undead",
+            "level": {
+                "value": 7
+            },
+            "privateNotes": "",
+            "publicNotes": "<p>When an evil mortal creature dies, it sometimes returns to haunt the area of its death as a specter, a hateful remnant, always seeking to slay others-particularly humanoids-in an attempt to distribute its pain among as many souls as it can. A specter maintains a strange semblance of its prior identity, but with a corrupted sense of purpose. It cannot be reasoned with.</p>\n<p>A specter denied the opportunity to harm living humanoids grows increasingly agonized and irrational, akin to the mindset of a starving person forever denied a release from agony through death.</p>",
+            "source": {
+                "author": "",
+                "value": "Pathfinder #165: Eyes of Empty Death"
+            }
+        },
+        "resources": {},
+        "saves": {
+            "fortitude": {
+                "saveDetail": "",
+                "value": 13
+            },
+            "reflex": {
+                "saveDetail": "",
+                "value": 17
+            },
+            "will": {
+                "saveDetail": "",
+                "value": 15
+            }
+        },
+        "traits": {
+            "attitude": {
+                "value": "hostile"
+            },
+            "languages": {
+                "custom": "Telepathy 100 feet (with spectral thralls only)",
+                "selected": [],
+                "value": [
+                    "common",
+                    "necril"
+                ]
+            },
+            "rarity": "common",
+            "senses": {
+                "value": "darkvision"
+            },
+            "size": {
+                "value": "med"
+            },
+            "value": [
+                "incorporeal",
+                "undead"
+            ]
+        }
+    },
+    "type": "npc"
+}

--- a/packs/data/abomination-vaults-bestiary.db/quara-orshendiel.json
+++ b/packs/data/abomination-vaults-bestiary.db/quara-orshendiel.json
@@ -433,122 +433,6 @@
             "type": "spell"
         },
         {
-            "_id": "dvfXNZwJv76Th8vW",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.equipment-srd.zcrIuILnp6oh4dr9"
-                }
-            },
-            "img": "systems/pf2e/icons/default-icons/weapon.svg",
-            "name": "+1 Striking Repeating Hand Crossbow",
-            "sort": 500000,
-            "system": {
-                "MAP": {
-                    "value": ""
-                },
-                "baseItem": "repeating-hand-crossbow",
-                "bonus": {
-                    "value": 0
-                },
-                "bonusDamage": {
-                    "value": 0
-                },
-                "category": "advanced",
-                "containerId": null,
-                "damage": {
-                    "damageType": "piercing",
-                    "dice": 1,
-                    "die": "d6",
-                    "value": ""
-                },
-                "description": {
-                    "value": "<p>This weapon features an ingeniously designed catch mechanism at the top of the flight grove, just in front of the latch, which automatically loads a bolt from a magazine and resets the string each time the weapon is fired. A typical repeating hand crossbow magazine holds five bolts.</p>"
-                },
-                "equipped": {
-                    "carryType": "held",
-                    "handsHeld": 1,
-                    "invested": null
-                },
-                "equippedBulk": {
-                    "value": ""
-                },
-                "group": "bow",
-                "hardness": 0,
-                "hp": {
-                    "brokenThreshold": 0,
-                    "max": 0,
-                    "value": 0
-                },
-                "level": {
-                    "value": 0
-                },
-                "negateBulk": {
-                    "value": "0"
-                },
-                "potencyRune": {
-                    "value": 1
-                },
-                "preciousMaterial": {
-                    "value": null
-                },
-                "preciousMaterialGrade": {
-                    "value": null
-                },
-                "price": {
-                    "value": {
-                        "gp": 10
-                    }
-                },
-                "propertyRune1": {
-                    "value": ""
-                },
-                "propertyRune2": {
-                    "value": ""
-                },
-                "propertyRune3": {
-                    "value": ""
-                },
-                "propertyRune4": {
-                    "value": ""
-                },
-                "quantity": 2,
-                "range": 60,
-                "reload": {
-                    "value": "0"
-                },
-                "rules": [],
-                "size": "med",
-                "slug": "repeating-hand-crossbow",
-                "source": {
-                    "value": ""
-                },
-                "specific": {
-                    "value": false
-                },
-                "splashDamage": {
-                    "value": 0
-                },
-                "stackGroup": null,
-                "strikingRune": {
-                    "value": "striking"
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": [
-                        "repeating"
-                    ]
-                },
-                "usage": {
-                    "value": "held-in-one-hand"
-                },
-                "weight": {
-                    "value": "L"
-                }
-            },
-            "type": "weapon"
-        },
-        {
             "_id": "94npIYAEHcak0YRt",
             "flags": {
                 "core": {
@@ -557,7 +441,7 @@
             },
             "img": "systems/pf2e/icons/equipment/weapons/kukri.webp",
             "name": "+1 Striking Kukri",
-            "sort": 600000,
+            "sort": 500000,
             "system": {
                 "MAP": {
                     "value": ""
@@ -655,6 +539,122 @@
                         "agile",
                         "finesse",
                         "trip"
+                    ]
+                },
+                "usage": {
+                    "value": "held-in-one-hand"
+                },
+                "weight": {
+                    "value": "L"
+                }
+            },
+            "type": "weapon"
+        },
+        {
+            "_id": "mUBZliZ2MS11im0F",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.equipment-srd.zcrIuILnp6oh4dr9"
+                }
+            },
+            "img": "systems/pf2e/icons/equipment/weapons/repeating-hand-crossbow.webp",
+            "name": "Repeating Hand Crossbow",
+            "sort": 600000,
+            "system": {
+                "MAP": {
+                    "value": ""
+                },
+                "baseItem": "repeating-hand-crossbow",
+                "bonus": {
+                    "value": 0
+                },
+                "bonusDamage": {
+                    "value": 0
+                },
+                "category": "advanced",
+                "containerId": null,
+                "damage": {
+                    "damageType": "piercing",
+                    "dice": 1,
+                    "die": "d6",
+                    "value": ""
+                },
+                "description": {
+                    "value": "<p>This handheld crossbow features an ingeniously designed catch mechanism at the top of the flight groove, just in front of the latch, which automatically loads a bolt from a magazine and resets the string each time the weapon is fired. A typical repeating hand crossbow magazine holds five bolts.</p>"
+                },
+                "equipped": {
+                    "carryType": "held",
+                    "handsHeld": 1,
+                    "invested": null
+                },
+                "equippedBulk": {
+                    "value": ""
+                },
+                "group": "bow",
+                "hardness": 0,
+                "hp": {
+                    "brokenThreshold": 0,
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 1
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "potencyRune": {
+                    "value": 1
+                },
+                "preciousMaterial": {
+                    "value": null
+                },
+                "preciousMaterialGrade": {
+                    "value": null
+                },
+                "price": {
+                    "value": {
+                        "gp": 10
+                    }
+                },
+                "propertyRune1": {
+                    "value": null
+                },
+                "propertyRune2": {
+                    "value": null
+                },
+                "propertyRune3": {
+                    "value": null
+                },
+                "propertyRune4": {
+                    "value": null
+                },
+                "quantity": 1,
+                "range": 60,
+                "reload": {
+                    "value": "0"
+                },
+                "rules": [],
+                "size": "med",
+                "slug": "repeating-hand-crossbow",
+                "source": {
+                    "value": "Pathfinder Guns & Gears"
+                },
+                "specific": {
+                    "value": false
+                },
+                "splashDamage": {
+                    "value": 0
+                },
+                "stackGroup": null,
+                "strikingRune": {
+                    "value": "striking"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "uncommon",
+                    "value": [
+                        "repeating"
                     ]
                 },
                 "usage": {
@@ -781,7 +781,7 @@
                     "sourceId": "Compendium.pf2e.equipment-srd.oJZe5rRitvioUgRh"
                 }
             },
-            "img": "systems/pf2e/icons/default-icons/equipment.svg",
+            "img": "systems/pf2e/icons/equipment/adventuring-gear/belt-pouch.webp",
             "name": "Shootist Bandolier",
             "sort": 800000,
             "system": {
@@ -844,14 +844,14 @@
             "type": "equipment"
         },
         {
-            "_id": "9PrTJ2heKKsQSYCf",
+            "_id": "p0YKYixgeSqZxDVT",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.equipment-srd.9w8MrBhFtvM7RrYN"
+                    "sourceId": "Compendium.pf2e.equipment-srd.xk9bw9ccupAIx7xT"
                 }
             },
-            "img": "systems/pf2e/icons/default-icons/consumable.svg",
-            "name": "Magazine with 5 Bolts",
+            "img": "systems/pf2e/icons/equipment/weapons/magazine-with-5-bolts.webp",
+            "name": "Repeating Hand Crossbow Magazine",
             "sort": 900000,
             "system": {
                 "autoDestroy": {
@@ -860,8 +860,8 @@
                 },
                 "baseItem": null,
                 "charges": {
-                    "max": 0,
-                    "value": 0
+                    "max": 5,
+                    "value": 5
                 },
                 "consumableType": {
                     "value": "ammo"
@@ -871,11 +871,11 @@
                 },
                 "containerId": null,
                 "description": {
-                    "value": "<p>Magazine with 5 bolts for use with the @UUID[Compendium.pf2e.equipment-srd.Repeating Hand Crossbow]{Repeating Hand Crossbow}.</p>"
+                    "value": ""
                 },
                 "equipped": {
-                    "carryType": "held",
-                    "handsHeld": 1
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "equippedBulk": {
                     "value": ""
@@ -893,22 +893,22 @@
                     "value": "0"
                 },
                 "preciousMaterial": {
-                    "value": ""
+                    "value": null
                 },
                 "preciousMaterialGrade": {
-                    "value": ""
+                    "value": null
                 },
                 "price": {
                     "value": {
                         "sp": 9
                     }
                 },
-                "quantity": 3,
+                "quantity": 1,
                 "rules": [],
                 "size": "med",
-                "slug": "magazine-with-5-bolts",
+                "slug": "repeating-hand-crossbow-magazine",
                 "source": {
-                    "value": ""
+                    "value": "Pathfinder Guns & Gears"
                 },
                 "stackGroup": null,
                 "traits": {
@@ -920,19 +920,19 @@
                     "value": "held-in-one-hand"
                 },
                 "weight": {
-                    "value": "-"
+                    "value": "L"
                 }
             },
             "type": "consumable"
         },
         {
-            "_id": "jxdKN83QfOAptc7n",
+            "_id": "iVTeyuWxtumKvgfY",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.equipment-srd.nn2HAN1XKkKHfVnM"
                 }
             },
-            "img": "systems/pf2e/icons/default-icons/consumable.svg",
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons/stupor-poison.webp",
             "name": "Stupor Poison",
             "sort": 1000000,
             "system": {
@@ -953,11 +953,11 @@
                 },
                 "containerId": null,
                 "description": {
-                    "value": "<p><strong>Activate</strong> <span class=\"pf2-icon\">2</span> Interact</p>\n<p>Stupor poison is a more potent distillation of @UUID[Compendium.pf2e.equipment-srd.Lethargy Poison]{Lethargy Poison}. Further exposure to stupor poison doesn't require the target to attempt additional saving throws; only failing a saving throw against an ongoing exposure can progress its stage.</p>\n<hr />\n<p><strong>Saving Throw</strong> DC 20 Fortitude</p>\n<p><strong>Maximum Duration</strong> 6 hours</p>\n<p><strong>Stage 1</strong> @UUID[Compendium.pf2e.conditionitems.Slowed]{Slowed 1} and @UUID[Compendium.pf2e.conditionitems.Flat-Footed]{Flat-Footed} (1 round)</p>\n<p><strong>Stage 2</strong> @UUID[Compendium.pf2e.conditionitems.Slowed]{Slowed 2} and flat-footed (1 round)</p>\n<p><strong>Stage 3</strong> @UUID[Compendium.pf2e.conditionitems.Unconscious]{Unconscious} with no Perception check to wake up (1 round)</p>\n<p><strong>Stage 4</strong> unconscious with no Perception check to wake up ([[/r 1d6 #hours]]{1d6 hours})</p>"
+                    "value": "<p><strong>Activate</strong> <span class=\"pf2-icon\">2</span> Interact</p>\n<p>Stupor poison is a more potent distillation of @UUID[Compendium.pf2e.equipment-srd.Lethargy Poison]{Lethargy Poison}. Further exposure to stupor poison doesn't require the target to attempt additional saving throws; only failing a saving throw against an ongoing exposure can progress its stage.</p>\n<hr />\n<p><strong>Saving Throw</strong> @Check[type:fortitude|dc:20]</p>\n<p><strong>Maximum Duration</strong> 6 hours</p>\n<p><strong>Stage 1</strong> @UUID[Compendium.pf2e.conditionitems.Slowed]{Slowed 1} and @UUID[Compendium.pf2e.conditionitems.Flat-Footed]{Flat-Footed} (1 round)</p>\n<p><strong>Stage 2</strong> @UUID[Compendium.pf2e.conditionitems.Slowed]{Slowed 2} and flat-footed (1 round)</p>\n<p><strong>Stage 3</strong> @UUID[Compendium.pf2e.conditionitems.Unconscious]{Unconscious} with no Perception check to wake up (1 round)</p>\n<p><strong>Stage 4</strong> unconscious with no Perception check to wake up ([[/r 1d6 #hours]]{1d6 hours})</p>"
                 },
                 "equipped": {
-                    "carryType": "held",
-                    "handsHeld": 2
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "equippedBulk": {
                     "value": ""
@@ -990,7 +990,7 @@
                 "size": "med",
                 "slug": "stupor-poison",
                 "source": {
-                    "value": ""
+                    "value": "Pathfinder #165: Eyes of Empty Death"
                 },
                 "stackGroup": null,
                 "traits": {
@@ -1015,10 +1015,77 @@
             "type": "consumable"
         },
         {
+            "_id": "kXOMAE7DzvqwCD6S",
+            "flags": {
+                "core": {
+                    "sourceId": "Item.5uNJHNJpXf07z53G"
+                }
+            },
+            "img": "systems/pf2e/icons/equipment/held-items/key-jeweled-gold-purple.webp",
+            "name": "Quara's Key",
+            "sort": 1100000,
+            "system": {
+                "baseItem": null,
+                "containerId": null,
+                "description": {
+                    "value": ""
+                },
+                "equipped": {
+                    "-=inSlot": null,
+                    "carryType": "worn",
+                    "handsHeld": 0
+                },
+                "equippedBulk": {
+                    "value": ""
+                },
+                "hardness": 0,
+                "hp": {
+                    "brokenThreshold": 0,
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "preciousMaterial": {
+                    "value": null
+                },
+                "preciousMaterialGrade": {
+                    "value": null
+                },
+                "price": {
+                    "value": {}
+                },
+                "quantity": 1,
+                "rules": [],
+                "size": "med",
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "stackGroup": null,
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "usage": {
+                    "value": ""
+                },
+                "weight": {
+                    "value": "-"
+                }
+            },
+            "type": "treasure"
+        },
+        {
             "_id": "JEA54JYtf51IHnRH",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Kukri",
-            "sort": 1100000,
+            "sort": 1200000,
             "system": {
                 "attack": {
                     "value": ""
@@ -1062,16 +1129,14 @@
             "_id": "mC6jPQk1bRvlBdvh",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Repeating Hand Crossbow",
-            "sort": 1200000,
+            "sort": 1300000,
             "system": {
                 "attack": {
                     "value": ""
                 },
                 "attackEffects": {
                     "custom": "",
-                    "value": [
-                        "stupor-poison"
-                    ]
+                    "value": []
                 },
                 "bonus": {
                     "value": 24
@@ -1114,7 +1179,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Darkvision",
-            "sort": 1300000,
+            "sort": 1400000,
             "system": {
                 "actionCategory": {
                     "value": "interaction"
@@ -1159,7 +1224,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Light Blindness",
-            "sort": 1400000,
+            "sort": 1500000,
             "system": {
                 "actionCategory": {
                     "value": "interaction"
@@ -1204,7 +1269,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "At-Will Spells",
-            "sort": 1500000,
+            "sort": 1600000,
             "system": {
                 "actionCategory": {
                     "value": "interaction"
@@ -1244,7 +1309,7 @@
             "_id": "VQXGCkNvdRLDuyH1",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "+1 Status to All Saves vs. Magic",
-            "sort": 1600000,
+            "sort": 1700000,
             "system": {
                 "actionCategory": {
                     "value": "defensive"
@@ -1302,7 +1367,7 @@
             "_id": "e2TItLJ7Ia5jTsir",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "+2 Status To All Saves vs. Mental",
-            "sort": 1700000,
+            "sort": 1800000,
             "system": {
                 "actionCategory": {
                     "value": "defensive"
@@ -1352,7 +1417,7 @@
             "_id": "hvENSxQhO8lwlD1Y",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Commanding Aura",
-            "sort": 1800000,
+            "sort": 1900000,
             "system": {
                 "actionCategory": {
                     "value": "defensive"
@@ -1396,7 +1461,7 @@
             "_id": "GpoVeh1bdg8JH2SG",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Deny Advantage",
-            "sort": 1900000,
+            "sort": 2000000,
             "system": {
                 "actionCategory": {
                     "value": "defensive"
@@ -1443,7 +1508,7 @@
             "_id": "f50ST8T8gY3pQJfx",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Evasion",
-            "sort": 2000000,
+            "sort": 2100000,
             "system": {
                 "actionCategory": {
                     "value": "defensive"
@@ -1490,7 +1555,7 @@
             "_id": "x13RVTp5gtE3XOTa",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Defensive Shooter",
-            "sort": 2100000,
+            "sort": 2200000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -1530,7 +1595,7 @@
             "_id": "od2Tpdqgyx5vuTIw",
             "img": "systems/pf2e/icons/actions/OneAction.webp",
             "name": "Poison Weapon",
-            "sort": 2200000,
+            "sort": 2300000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -1572,7 +1637,7 @@
             "_id": "vdPooFytAas2OzRw",
             "img": "systems/pf2e/icons/actions/OneAction.webp",
             "name": "Reloading Trick",
-            "sort": 2300000,
+            "sort": 2400000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -1612,7 +1677,7 @@
             "_id": "ckEhVhjZnjMqhSjZ",
             "img": "systems/pf2e/icons/actions/OneAction.webp",
             "name": "Shootist's Draw",
-            "sort": 2400000,
+            "sort": 2500000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -1652,7 +1717,7 @@
             "_id": "4mS9YqseWjLaRiQq",
             "img": "systems/pf2e/icons/actions/TwoActions.webp",
             "name": "Skirmishing Dash",
-            "sort": 2500000,
+            "sort": 2600000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -1692,7 +1757,7 @@
             "_id": "hw9SLn99zC7mqeTR",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Stupor Poison",
-            "sort": 2600000,
+            "sort": 2700000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -1732,7 +1797,7 @@
             "_id": "n0SITnxQS6KTSJcY",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Acrobatics",
-            "sort": 2700000,
+            "sort": 2800000,
             "system": {
                 "description": {
                     "value": ""
@@ -1760,7 +1825,7 @@
             "_id": "fNhqa8wnkscsNrjA",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Athletics",
-            "sort": 2800000,
+            "sort": 2900000,
             "system": {
                 "description": {
                     "value": ""
@@ -1788,7 +1853,7 @@
             "_id": "Pesh5zbL9mAiD0mq",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Deception",
-            "sort": 2900000,
+            "sort": 3000000,
             "system": {
                 "description": {
                     "value": ""
@@ -1816,7 +1881,7 @@
             "_id": "qDTenfxdlLqTupA4",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Diplomacy",
-            "sort": 3000000,
+            "sort": 3100000,
             "system": {
                 "description": {
                     "value": ""
@@ -1844,7 +1909,7 @@
             "_id": "0FanuCQ63k8GByVk",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Intimidation",
-            "sort": 3100000,
+            "sort": 3200000,
             "system": {
                 "description": {
                     "value": ""
@@ -1872,7 +1937,7 @@
             "_id": "8WVnXKq5RXTgmH4t",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Stealth",
-            "sort": 3200000,
+            "sort": 3300000,
             "system": {
                 "description": {
                     "value": ""
@@ -1900,7 +1965,7 @@
             "_id": "VJryHk6rlsDEYPun",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Survival",
-            "sort": 3300000,
+            "sort": 3400000,
             "system": {
                 "description": {
                     "value": ""
@@ -1989,6 +2054,7 @@
             "privateNotes": "",
             "publicNotes": "<p>Quara will likely become an ally of the heroes, as she knows useful partners when she sees them. She's interested in avenging her father and sister, but she knows that whatever goal her father was pursuing with the Ochre Fulcrum Lens could prove critical in freeing Yldaris from Belcorra's control forever. She has learned that the ochre lens was only one of three lenses that Belcorra entrusted to allies in the region centuries ago, and she sets the heroes on the trail of recovering them and finding out more. The most important lead Quara provides to the heroes is that her father was headed toward an ancient vault at the edge of the lake, so the heroes can find out more at that location.</p>\n<p>The heroes might see drow as enemies and assault Yldaris. In this case, Quara does her best to protect her people, relying on the shootist training that still lingers in her quick fingers. She likely won't trust the heroes with any information after such aggressions, but they might find some clues in her quarters.</p>",
             "source": {
+                "author": "",
                 "value": "Pathfinder #165: Eyes of Empty Death"
             }
         },

--- a/packs/data/abomination-vaults-bestiary.db/salaisa-malthulas.json
+++ b/packs/data/abomination-vaults-bestiary.db/salaisa-malthulas.json
@@ -941,11 +941,6 @@
         },
         {
             "_id": "2agkr9lAnWdxtLza",
-            "flags": {
-                "core": {
-                    "sourceId": "Item.zpO5nbGIdKogFPy0"
-                }
-            },
             "img": "systems/pf2e/icons/equipment/held-items/key-jeweled-gold-purple.webp",
             "name": "Salaisa's Key",
             "sort": 1000000,

--- a/packs/data/abomination-vaults-bestiary.db/stonescale-spirits.json
+++ b/packs/data/abomination-vaults-bestiary.db/stonescale-spirits.json
@@ -54,6 +54,7 @@
             "ac": {
                 "value": 0
             },
+            "emitsSound": "encounter",
             "hardness": 0,
             "hasHealth": true,
             "hp": {
@@ -94,6 +95,7 @@
             }
         },
         "source": {
+            "author": "",
             "value": "Pathfinder #163: Ruins of Gauntlight"
         },
         "statusEffects": [],

--- a/packs/data/abomination-vaults-bestiary.db/summoning-chamber-erinys.json
+++ b/packs/data/abomination-vaults-bestiary.db/summoning-chamber-erinys.json
@@ -1,11 +1,11 @@
 {
-    "_id": "TiAzR8SnYwhACWbj",
+    "_id": "njfwxMPXTPA5AegD",
     "img": "systems/pf2e/icons/default-icons/npc.svg",
     "items": [
         {
-            "_id": "ZnFe1AJx67Diyerp",
+            "_id": "h2qxWUvI0fbg4RxB",
             "img": "systems/pf2e/icons/default-icons/spellcastingEntry.svg",
-            "name": "Occult Innate Spells",
+            "name": "Divine Innate Spells",
             "sort": 100000,
             "system": {
                 "autoHeightenLevel": {
@@ -96,12 +96,12 @@
                     "value": ""
                 },
                 "spelldc": {
-                    "dc": 24,
+                    "dc": 26,
                     "mod": 0,
-                    "value": 16
+                    "value": 18
                 },
                 "tradition": {
-                    "value": "occult"
+                    "value": "divine"
                 },
                 "traits": {
                     "custom": "",
@@ -112,97 +112,105 @@
             "type": "spellcastingEntry"
         },
         {
-            "_id": "euIa0xTcIyQOBwOC",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.ZYoC630tNGutgbE0"
-                }
-            },
-            "img": "systems/pf2e/icons/spells/hypercognition.webp",
-            "name": "Hypercognition",
+            "_id": "Gix3fftNAeuJS7zt",
+            "img": "systems/pf2e/icons/default-icons/spellcastingEntry.svg",
+            "name": "Rituals",
             "sort": 200000,
             "system": {
-                "ability": {
-                    "value": ""
-                },
-                "area": null,
-                "category": {
-                    "value": "spell"
-                },
-                "components": {
-                    "focus": false,
-                    "material": false,
-                    "somatic": false,
-                    "verbal": true
-                },
-                "cost": {
-                    "value": ""
-                },
-                "damage": {
-                    "value": {}
+                "autoHeightenLevel": {
+                    "value": null
                 },
                 "description": {
-                    "value": "<p>You rapidly catalog and collate information relevant to your current situation. You can instantly use up to 6 Recall Knowledge actions as part of Casting this Spell. For these actions, you can't use any special abilities, reactions, or free actions that trigger when you Recall Knowledge.</p>"
-                },
-                "duration": {
                     "value": ""
                 },
-                "hasCounteractCheck": {
-                    "value": false
-                },
-                "level": {
-                    "value": 3
-                },
-                "location": {
-                    "heightenedLevel": 3,
-                    "value": "ZnFe1AJx67Diyerp"
-                },
-                "materials": {
-                    "value": ""
-                },
+                "displayLevels": {},
                 "prepared": {
-                    "value": ""
+                    "flexible": false,
+                    "value": "ritual"
                 },
-                "primarycheck": {
-                    "value": ""
-                },
-                "range": {
-                    "value": ""
+                "proficiency": {
+                    "value": 0
                 },
                 "rules": [],
-                "save": {
-                    "basic": "",
-                    "value": ""
+                "showSlotlessLevels": {
+                    "value": true
                 },
-                "school": {
-                    "value": "divination"
+                "showUnpreparedSpells": {
+                    "value": true
                 },
-                "secondarycasters": {
-                    "value": ""
+                "slots": {
+                    "slot0": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot1": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot10": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot11": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot2": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot3": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot4": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot5": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot6": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot7": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot8": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    },
+                    "slot9": {
+                        "max": 0,
+                        "prepared": [],
+                        "value": 0
+                    }
                 },
-                "secondarycheck": {
-                    "value": ""
-                },
-                "slug": "hypercognition",
+                "slug": null,
                 "source": {
-                    "value": "Pathfinder Core Rulebook"
-                },
-                "spellType": {
-                    "value": "utility"
-                },
-                "sustained": {
-                    "value": false
-                },
-                "target": {
                     "value": ""
                 },
-                "time": {
-                    "value": "1"
+                "spelldc": {
+                    "dc": 26,
+                    "mod": 0,
+                    "value": 18
                 },
-                "traditions": {
-                    "value": [
-                        "occult"
-                    ]
+                "tradition": {
+                    "value": ""
                 },
                 "traits": {
                     "custom": "",
@@ -210,17 +218,17 @@
                     "value": []
                 }
             },
-            "type": "spell"
+            "type": "spellcastingEntry"
         },
         {
-            "_id": "9FfhrCy7X6C19XbP",
+            "_id": "fpyaGQ7nPlsCH1nc",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.fI20AVwOzJMHXRdo"
+                    "sourceId": "Compendium.pf2e.spells-srd.uqlxMQQeSGWEVjki"
                 }
             },
-            "img": "systems/pf2e/icons/spells/levitate.webp",
-            "name": "Levitate",
+            "img": "systems/pf2e/icons/spells/true-seeing.webp",
+            "name": "True Seeing (Constant)",
             "sort": 300000,
             "system": {
                 "ability": {
@@ -243,20 +251,20 @@
                     "value": {}
                 },
                 "description": {
-                    "value": "<p>You defy gravity and levitate the target 5 feet off the ground. For the duration of the spell, you can move the target up or down 10 feet with a single action, which has the concentrate trait. A creature floating in the air from levitate takes a -2 circumstance penalty to attack rolls. A floating creature can spend an Interact action to stabilize itself and negate this penalty for the remainder of its turn. If the target is adjacent to a fixed object or terrain of suitable stability, it can move across the surface by climbing (if the surface is vertical, like a wall) or crawling (if the surface is horizontal, such as a ceiling). The GM determines which surfaces can be climbed or crawled across.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Spell Effect: Levitate]{Spell Effect: Levitate}</p>"
+                    "value": "<p>You see things within 60 feet as they actually are. The GM rolls a secret counteract check against any illusion or transmutation in the area, but only for the purpose of determining whether you see through it (for instance, if the check succeeds against a polymorph spell, you can see the creature's true form, but you don't end the polymorph spell).</p>"
                 },
                 "duration": {
-                    "value": "5 minutes"
+                    "value": "10 minutes"
                 },
                 "hasCounteractCheck": {
-                    "value": false
+                    "value": true
                 },
                 "level": {
-                    "value": 3
+                    "value": 6
                 },
                 "location": {
-                    "heightenedLevel": 3,
-                    "value": "ZnFe1AJx67Diyerp"
+                    "heightenedLevel": 6,
+                    "value": "h2qxWUvI0fbg4RxB"
                 },
                 "materials": {
                     "value": ""
@@ -268,7 +276,7 @@
                     "value": ""
                 },
                 "range": {
-                    "value": "touch"
+                    "value": ""
                 },
                 "rules": [],
                 "save": {
@@ -276,7 +284,7 @@
                     "value": ""
                 },
                 "school": {
-                    "value": "evocation"
+                    "value": "divination"
                 },
                 "secondarycasters": {
                     "value": ""
@@ -284,7 +292,7 @@
                 "secondarycheck": {
                     "value": ""
                 },
-                "slug": "levitate",
+                "slug": "true-seeing",
                 "source": {
                     "value": "Pathfinder Core Rulebook"
                 },
@@ -295,7 +303,7 @@
                     "value": false
                 },
                 "target": {
-                    "value": "1 unattended object or willing creature"
+                    "value": ""
                 },
                 "time": {
                     "value": "2"
@@ -303,26 +311,30 @@
                 "traditions": {
                     "value": [
                         "arcane",
-                        "occult"
+                        "divine",
+                        "occult",
+                        "primal"
                     ]
                 },
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "revelation"
+                    ]
                 }
             },
             "type": "spell"
         },
         {
-            "_id": "im296JOSVQ5enGfj",
+            "_id": "E6dar3cARRfBL0qZ",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.KHnhPHL4x1AQHfbC"
+                    "sourceId": "Compendium.pf2e.spells-srd.VlNcjmYyu95vOUe8"
                 }
             },
-            "img": "systems/pf2e/icons/spells/mind-reading.webp",
-            "name": "Mind Reading",
+            "img": "systems/pf2e/icons/spells/dimension-door.webp",
+            "name": "Dimension Door",
             "sort": 400000,
             "system": {
                 "ability": {
@@ -345,24 +357,20 @@
                     "value": {}
                 },
                 "description": {
-                    "value": "<p>With a cursory mental touch, you attempt to read the target's mind. It must attempt a Will save. The target then becomes temporarily immune to your mind reading for 1 hour.</p>\n<hr /><strong>Critical Success</strong> The target perceives vague surface thoughts from you when you Cast the Spell.\n<p><strong>Success</strong> You find out whether the target's Intelligence modifier is higher than, equal to, or lower than yours.</p>\n<p><strong>Failure</strong> You perceive vague surface thoughts from the target when you Cast the Spell, and you find out whether its Intelligence modifier is higher than, equal to, or lower than yours.</p>\n<p><strong>Critical Failure</strong> As failure, and for the duration of the spell, you can Sustain the Spell to detect the target's surface thoughts again. The target doesn't receive any additional saves.</p>"
+                    "value": "<p>Opening a door that bypasses normal space, you instantly transport yourself and any items you're wearing and holding from your current space to a clear space within range you can see. If this would bring another creature with you-even if you're carrying it in an extradimensional container-the spell is lost.</p>\n<hr />\n<p><strong>Heightened (5th)</strong> The range increases to 1 mile. You don't need to be able to see your destination, as long as you have been there in the past and know its relative location and distance from you. You are temporarily immune for 1 hour.</p>"
                 },
                 "duration": {
-                    "value": "1 round or sustained up to 1 minute"
+                    "value": ""
                 },
                 "hasCounteractCheck": {
                     "value": false
                 },
                 "level": {
-                    "value": 3
+                    "value": 4
                 },
                 "location": {
-                    "heightenedLevel": 3,
-                    "uses": {
-                        "max": 3,
-                        "value": 3
-                    },
-                    "value": "ZnFe1AJx67Diyerp"
+                    "heightenedLevel": 5,
+                    "value": "h2qxWUvI0fbg4RxB"
                 },
                 "materials": {
                     "value": ""
@@ -374,15 +382,15 @@
                     "value": ""
                 },
                 "range": {
-                    "value": "30 feet"
+                    "value": "120 feet"
                 },
                 "rules": [],
                 "save": {
                     "basic": "",
-                    "value": "will"
+                    "value": ""
                 },
                 "school": {
-                    "value": "divination"
+                    "value": "conjuration"
                 },
                 "secondarycasters": {
                     "value": ""
@@ -390,18 +398,18 @@
                 "secondarycheck": {
                     "value": ""
                 },
-                "slug": "mind-reading",
+                "slug": "dimension-door",
                 "source": {
                     "value": "Pathfinder Core Rulebook"
                 },
                 "spellType": {
-                    "value": "save"
+                    "value": "utility"
                 },
                 "sustained": {
                     "value": false
                 },
                 "target": {
-                    "value": "1 creature"
+                    "value": ""
                 },
                 "time": {
                     "value": "2"
@@ -414,24 +422,23 @@
                 },
                 "traits": {
                     "custom": "",
-                    "rarity": "uncommon",
+                    "rarity": "common",
                     "value": [
-                        "detection",
-                        "mental"
+                        "teleportation"
                     ]
                 }
             },
             "type": "spell"
         },
         {
-            "_id": "XAInYyDm0DWjUckv",
+            "_id": "lntTBnW0tn7XEMPJ",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.4gBIw4IDrSfFHik4"
+                    "sourceId": "Compendium.pf2e.spells-srd.VlNcjmYyu95vOUe8"
                 }
             },
-            "img": "systems/pf2e/icons/spells/daze.webp",
-            "name": "Daze",
+            "img": "systems/pf2e/icons/spells/dimension-door.webp",
+            "name": "Dimension Door (At Will)",
             "sort": 500000,
             "system": {
                 "ability": {
@@ -451,135 +458,10 @@
                     "value": ""
                 },
                 "damage": {
-                    "value": {
-                        "0": {
-                            "applyMod": true,
-                            "type": {
-                                "categories": [],
-                                "value": "mental"
-                            },
-                            "value": "0"
-                        }
-                    }
-                },
-                "description": {
-                    "value": "<p>You cloud the target's mind and daze it with a mental jolt. The jolt deals mental damage equal to your spellcasting ability modifier; the target must attempt a basic Will save. If the target critically fails the save, it is also @UUID[Compendium.pf2e.conditionitems.Stunned]{Stunned 1}.</p>\n<hr />\n<p><strong>Heightened (+2)</strong> The damage increases by 1d6.</p>"
-                },
-                "duration": {
-                    "value": "1 round"
-                },
-                "hasCounteractCheck": {
-                    "value": false
-                },
-                "heightening": {
-                    "damage": {
-                        "0": "1d6"
-                    },
-                    "interval": 2,
-                    "type": "interval"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": {
-                    "value": "ZnFe1AJx67Diyerp"
-                },
-                "materials": {
-                    "value": ""
-                },
-                "prepared": {
-                    "value": ""
-                },
-                "primarycheck": {
-                    "value": ""
-                },
-                "range": {
-                    "value": "60 feet"
-                },
-                "rules": [],
-                "save": {
-                    "basic": "basic",
-                    "value": "will"
-                },
-                "school": {
-                    "value": "enchantment"
-                },
-                "secondarycasters": {
-                    "value": ""
-                },
-                "secondarycheck": {
-                    "value": ""
-                },
-                "slug": "daze",
-                "source": {
-                    "value": "Pathfinder Core Rulebook"
-                },
-                "spellType": {
-                    "value": "save"
-                },
-                "sustained": {
-                    "value": false
-                },
-                "target": {
-                    "value": "1 creature"
-                },
-                "time": {
-                    "value": "2"
-                },
-                "traditions": {
-                    "value": [
-                        "arcane",
-                        "divine",
-                        "occult"
-                    ]
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": [
-                        "cantrip",
-                        "mental",
-                        "nonlethal"
-                    ]
-                }
-            },
-            "type": "spell"
-        },
-        {
-            "_id": "f6kzW4hcOJrD3PVp",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.gpzpAAAJ1Lza2JVl"
-                }
-            },
-            "img": "systems/pf2e/icons/spells/detect-magic.webp",
-            "name": "Detect Magic",
-            "sort": 600000,
-            "system": {
-                "ability": {
-                    "value": ""
-                },
-                "area": {
-                    "type": "emanation",
-                    "value": 30
-                },
-                "category": {
-                    "value": "spell"
-                },
-                "components": {
-                    "focus": false,
-                    "material": false,
-                    "somatic": true,
-                    "verbal": true
-                },
-                "cost": {
-                    "value": ""
-                },
-                "damage": {
                     "value": {}
                 },
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies.</p>\n<p>You detect illusion magic only if that magic's effect has a lower level than the level of your detect magic spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an invisibility potion) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the school of magic for the highest-level effect within range that the spell detects. If multiple effects are equally strong, the GM determines which you learn.</p>\n<p><strong>Heightened (4th)</strong> As 3rd level, but you also pinpoint the source of the highest-level magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>Opening a door that bypasses normal space, you instantly transport yourself and any items you're wearing and holding from your current space to a clear space within range you can see. If this would bring another creature with you-even if you're carrying it in an extradimensional container-the spell is lost.</p>\n<hr />\n<p><strong>Heightened (5th)</strong> The range increases to 1 mile. You don't need to be able to see your destination, as long as you have been there in the past and know its relative location and distance from you. You are temporarily immune for 1 hour.</p>"
                 },
                 "duration": {
                     "value": ""
@@ -588,10 +470,11 @@
                     "value": false
                 },
                 "level": {
-                    "value": 1
+                    "value": 4
                 },
                 "location": {
-                    "value": "ZnFe1AJx67Diyerp"
+                    "heightenedLevel": 4,
+                    "value": "h2qxWUvI0fbg4RxB"
                 },
                 "materials": {
                     "value": ""
@@ -603,7 +486,7 @@
                     "value": ""
                 },
                 "range": {
-                    "value": ""
+                    "value": "120 feet"
                 },
                 "rules": [],
                 "save": {
@@ -611,7 +494,7 @@
                     "value": ""
                 },
                 "school": {
-                    "value": "divination"
+                    "value": "conjuration"
                 },
                 "secondarycasters": {
                     "value": ""
@@ -619,7 +502,7 @@
                 "secondarycheck": {
                     "value": ""
                 },
-                "slug": "detect-magic",
+                "slug": "dimension-door",
                 "source": {
                     "value": "Pathfinder Core Rulebook"
                 },
@@ -636,40 +519,39 @@
                     "value": "2"
                 },
                 "traditions": {
-                    "custom": "",
                     "value": [
                         "arcane",
-                        "divine",
-                        "occult",
-                        "primal"
+                        "occult"
                     ]
                 },
                 "traits": {
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "detection",
-                        "cantrip"
+                        "teleportation"
                     ]
                 }
             },
             "type": "spell"
         },
         {
-            "_id": "zWWtMMDuuVs4aqcp",
+            "_id": "Ziz4KcgSnDlWnrOC",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.pwzdSlJgYqN7bs2w"
+                    "sourceId": "Compendium.pf2e.spells-srd.hVU9msO9yGkxKZ3J"
                 }
             },
-            "img": "systems/pf2e/icons/spells/mage-hand.webp",
-            "name": "Mage Hand",
-            "sort": 700000,
+            "img": "systems/pf2e/icons/spells/divine-wrath.webp",
+            "name": "Divine Wrath",
+            "sort": 600000,
             "system": {
                 "ability": {
                     "value": ""
                 },
-                "area": null,
+                "area": {
+                    "type": "burst",
+                    "value": 20
+                },
                 "category": {
                     "value": "spell"
                 },
@@ -683,22 +565,138 @@
                     "value": ""
                 },
                 "damage": {
+                    "value": {
+                        "0": {
+                            "type": {
+                                "categories": [],
+                                "value": "untyped"
+                            },
+                            "value": "4d10"
+                        }
+                    }
+                },
+                "description": {
+                    "value": "<p>You can channel the fury of your deity against foes of opposed alignment. Choose an alignment your deity has (chaotic, evil, good, or lawful). You can't cast this spell if you don't have a deity or your deity is true neutral. This spell gains the trait of the alignment you chose. You deal 4d10 damage of the alignment you chose; each creature in the area must attempt a Fortitude save. Creatures that match the alignment you chose are unaffected. Those that neither match nor oppose it treat the result of their saving throw as one degree better.</p>\n<hr />\n<p><strong>Critical Success</strong> The creature is unaffected.</p>\n<p><strong>Success</strong> The creature takes half damage.</p>\n<p><strong>Failure</strong> The creature takes full damage and is @UUID[Compendium.pf2e.conditionitems.Sickened]{Sickened 1}.</p>\n<p><strong>Critical Failure</strong> The creature takes full damage and is @UUID[Compendium.pf2e.conditionitems.Sickened]{Sickened 2}; while it is sickened, it is also @UUID[Compendium.pf2e.conditionitems.Slowed]{Slowed 1}.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 1d10.</p>"
+                },
+                "duration": {
+                    "value": ""
+                },
+                "hasCounteractCheck": {
+                    "value": false
+                },
+                "heightening": {
+                    "damage": {
+                        "0": "1d10"
+                    },
+                    "interval": 1,
+                    "type": "interval"
+                },
+                "level": {
+                    "value": 4
+                },
+                "location": {
+                    "heightenedLevel": 4,
+                    "value": "h2qxWUvI0fbg4RxB"
+                },
+                "materials": {
+                    "value": ""
+                },
+                "prepared": {
+                    "value": ""
+                },
+                "primarycheck": {
+                    "value": ""
+                },
+                "range": {
+                    "value": "120 feet"
+                },
+                "rules": [],
+                "save": {
+                    "basic": "",
+                    "value": "fortitude"
+                },
+                "school": {
+                    "value": "evocation"
+                },
+                "secondarycasters": {
+                    "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "divine-wrath",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "spellType": {
+                    "value": "save"
+                },
+                "sustained": {
+                    "value": false
+                },
+                "target": {
+                    "value": ""
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traditions": {
+                    "value": [
+                        "divine"
+                    ]
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "spell"
+        },
+        {
+            "_id": "tSbx4aVJWl4zlKbG",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.SSsUC7rZo0CwayPn"
+                }
+            },
+            "img": "systems/pf2e/icons/spells/retributive-pain.webp",
+            "name": "Retributive Pain",
+            "sort": 700000,
+            "system": {
+                "ability": {
+                    "value": ""
+                },
+                "area": null,
+                "category": {
+                    "value": "focus"
+                },
+                "components": {
+                    "focus": false,
+                    "material": false,
+                    "somatic": true,
+                    "verbal": false
+                },
+                "cost": {
+                    "value": ""
+                },
+                "damage": {
                     "value": {}
                 },
                 "description": {
-                    "value": "<p>You create a single magical hand, either invisible or ghostlike, that grasps the target object and moves it slowly up to 20 feet. Because you're levitating the object, you can move it in any direction. When you Sustain the Spell, you can move the object an additional 20 feet. If the object is in the air when the spell ends, the object falls.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You can target an unattended object with a Bulk of 1 or less.</p>\n<p><strong>Heightened (5th)</strong> The range increases to 60 feet, and you can target an unattended object with a Bulk of 1 or less.</p>\n<p><strong>Heightened (7th)</strong> The range increases to 60 feet, and you can target an unattended object with a Bulk of 2 or less.</p>"
+                    "value": "<p><strong>Trigger</strong> A creature in range damages you.</p>\n<hr />\n<p>You vengefully reflect your pain upon your tormentor. The target takes mental damage equal to half the amount it dealt to you when it triggered the spell.</p>"
                 },
                 "duration": {
-                    "value": "sustained"
+                    "value": ""
                 },
                 "hasCounteractCheck": {
                     "value": false
                 },
                 "level": {
-                    "value": 1
+                    "value": 4
                 },
                 "location": {
-                    "value": "ZnFe1AJx67Diyerp"
+                    "value": "h2qxWUvI0fbg4RxB"
                 },
                 "materials": {
                     "value": ""
@@ -714,11 +712,11 @@
                 },
                 "rules": [],
                 "save": {
-                    "basic": "",
-                    "value": ""
+                    "basic": "basic",
+                    "value": "fortitude"
                 },
                 "school": {
-                    "value": "evocation"
+                    "value": "abjuration"
                 },
                 "secondarycasters": {
                     "value": ""
@@ -726,47 +724,46 @@
                 "secondarycheck": {
                     "value": ""
                 },
-                "slug": "mage-hand",
+                "slug": "retributive-pain",
                 "source": {
                     "value": "Pathfinder Core Rulebook"
                 },
                 "spellType": {
-                    "value": "utility"
+                    "value": "save"
                 },
                 "sustained": {
                     "value": false
                 },
                 "target": {
-                    "value": "1 unattended object of light Bulk or less"
+                    "value": "the triggering creature"
                 },
                 "time": {
-                    "value": "2"
+                    "value": "reaction"
                 },
                 "traditions": {
-                    "value": [
-                        "arcane",
-                        "occult"
-                    ]
+                    "value": []
                 },
                 "traits": {
                     "custom": "",
-                    "rarity": "common",
+                    "rarity": "uncommon",
                     "value": [
-                        "cantrip"
+                        "cleric",
+                        "mental",
+                        "nonlethal"
                     ]
                 }
             },
             "type": "spell"
         },
         {
-            "_id": "YmaEutO1beFphbjE",
+            "_id": "mqqrqczmNE7FLbro",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.60sgbuMWN0268dB7"
+                    "sourceId": "Compendium.pf2e.spells-srd.4koZzrnMXhhosn0D"
                 }
             },
-            "img": "systems/pf2e/icons/spells/telekinetic-projectile.webp",
-            "name": "Telekinetic Projectile",
+            "img": "systems/pf2e/icons/spells/fear.webp",
+            "name": "Fear (At Will)",
             "sort": 800000,
             "system": {
                 "ability": {
@@ -786,38 +783,23 @@
                     "value": ""
                 },
                 "damage": {
-                    "value": {
-                        "0": {
-                            "applyMod": true,
-                            "type": {
-                                "categories": [],
-                                "value": "untyped"
-                            },
-                            "value": "1d6"
-                        }
-                    }
+                    "value": {}
                 },
                 "description": {
-                    "value": "<p>You hurl a loose, unattended object that is within range and that has 1 Bulk or less at the target. Make a spell attack roll against the target. If you hit, you deal bludgeoning, piercing, or slashing damage-as appropriate for the object you hurled-equal to 1d6 plus your spellcasting ability modifier. No specific traits or magic properties of the hurled item affect the attack or the damage.</p>\n<hr />\n<p><strong>Critical Success</strong> You deal double damage.</p>\n<p><strong>Success</strong> You deal full damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 1d6.</p>"
+                    "value": "<p>You plant fear in the target; it must attempt a Will save.</p>\n<hr />\n<p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target is @UUID[Compendium.pf2e.conditionitems.Frightened]{Frightened 1}.</p>\n<p><strong>Failure</strong> The target is @UUID[Compendium.pf2e.conditionitems.Frightened]{Frightened 2}.</p>\n<p><strong>Critical Failure</strong> The target is @UUID[Compendium.pf2e.conditionitems.Frightened]{Frightened 3} and @UUID[Compendium.pf2e.conditionitems.Fleeing]{Fleeing} for 1 round.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You can target up to five creatures.</p>"
                 },
                 "duration": {
-                    "value": ""
+                    "value": "varies"
                 },
                 "hasCounteractCheck": {
                     "value": false
-                },
-                "heightening": {
-                    "damage": {
-                        "0": "1d6"
-                    },
-                    "interval": 1,
-                    "type": "interval"
                 },
                 "level": {
                     "value": 1
                 },
                 "location": {
-                    "value": "ZnFe1AJx67Diyerp"
+                    "heightenedLevel": 3,
+                    "value": "h2qxWUvI0fbg4RxB"
                 },
                 "materials": {
                     "value": ""
@@ -834,10 +816,10 @@
                 "rules": [],
                 "save": {
                     "basic": "",
-                    "value": ""
+                    "value": "will"
                 },
                 "school": {
-                    "value": "evocation"
+                    "value": "enchantment"
                 },
                 "secondarycasters": {
                     "value": ""
@@ -845,18 +827,126 @@
                 "secondarycheck": {
                     "value": ""
                 },
-                "slug": "telekinetic-projectile",
+                "slug": "fear",
                 "source": {
                     "value": "Pathfinder Core Rulebook"
                 },
                 "spellType": {
-                    "value": "attack"
+                    "value": "save"
                 },
                 "sustained": {
                     "value": false
                 },
                 "target": {
                     "value": "1 creature"
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traditions": {
+                    "value": [
+                        "arcane",
+                        "divine",
+                        "occult",
+                        "primal"
+                    ]
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "emotion",
+                        "fear",
+                        "mental"
+                    ]
+                }
+            },
+            "type": "spell"
+        },
+        {
+            "_id": "ZZcgAENc8VCfxb7e",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.i35dpZFI7jZcRoBo"
+                }
+            },
+            "img": "systems/pf2e/icons/spells/illusory-disguise.webp",
+            "name": "Illusory Disguise (At Will)",
+            "sort": 900000,
+            "system": {
+                "ability": {
+                    "value": ""
+                },
+                "area": null,
+                "category": {
+                    "value": "spell"
+                },
+                "components": {
+                    "focus": false,
+                    "material": false,
+                    "somatic": true,
+                    "verbal": true
+                },
+                "cost": {
+                    "value": ""
+                },
+                "damage": {
+                    "value": {}
+                },
+                "description": {
+                    "value": "<p>You create an illusion that causes you to appear as another creature of the same body shape, and with roughly similar height (within 6 inches) and weight (within 50 pounds), as yourself. The disguise is typically good enough to hide your identity, but not to impersonate a specific individual. The spell doesn't change your voice, scent, or mannerisms. You can change the appearance of your clothing and worn items, such as making your armor look like a dress. Held items are unaffected, and any worn item you remove returns to its true appearance.</p>\n<p>Casting illusory disguise counts as setting up a disguise for the @UUID[Compendium.pf2e.action-macros.Impersonate: Deception]{Impersonate} use of Deception; it ignores any circumstance penalties you might take for disguising yourself as a dissimilar creature, it gives you a +4 status bonus to Deception checks to prevent others from seeing through your disguise, and you add your level even if you're untrained. You can Dismiss this spell.</p>\n<hr />\n<p><strong>Heightened (2nd)</strong> The spell also disguises your voice and scent, and it gains the auditory and olfactory traits.</p>\n<p><strong>Heightened (3rd)</strong> You can appear as any creature of the same size, even a specific individual. You must have seen an individual to take on their appearance. The spell also disguises your voice and scent, and it gains the auditory and olfactory traits.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Spell Effect: Illusory Disguise]{Spell Effect: Illusory Disguise}</p>"
+                },
+                "duration": {
+                    "value": "1 hour"
+                },
+                "hasCounteractCheck": {
+                    "value": false
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": {
+                    "heightenedLevel": 2,
+                    "value": "h2qxWUvI0fbg4RxB"
+                },
+                "materials": {
+                    "value": ""
+                },
+                "prepared": {
+                    "value": ""
+                },
+                "primarycheck": {
+                    "value": ""
+                },
+                "range": {
+                    "value": ""
+                },
+                "rules": [],
+                "save": {
+                    "basic": "",
+                    "value": ""
+                },
+                "school": {
+                    "value": "illusion"
+                },
+                "secondarycasters": {
+                    "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "illusory-disguise",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "spellType": {
+                    "value": "utility"
+                },
+                "sustained": {
+                    "value": false
+                },
+                "target": {
+                    "value": ""
                 },
                 "time": {
                     "value": "2"
@@ -871,15 +961,337 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "attack",
-                        "cantrip"
+                        "visual"
                     ]
                 }
             },
             "type": "spell"
         },
         {
-            "_id": "VJh6hBmylHWPU8hN",
+            "_id": "dyiZulNVinuIheiG",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.2oH5IufzdESuYxat"
+                }
+            },
+            "img": "systems/pf2e/icons/spells/illusory-object.webp",
+            "name": "Illusory Object",
+            "sort": 1000000,
+            "system": {
+                "ability": {
+                    "value": ""
+                },
+                "area": {
+                    "type": "burst",
+                    "value": 20
+                },
+                "category": {
+                    "value": "spell"
+                },
+                "components": {
+                    "focus": false,
+                    "material": false,
+                    "somatic": true,
+                    "verbal": true
+                },
+                "cost": {
+                    "value": ""
+                },
+                "damage": {
+                    "value": {}
+                },
+                "description": {
+                    "value": "<p>You create an illusory visual image of a stationary object. The entire image must fit within the spell's area. The object appears to animate naturally, but it doesn't make sounds or generate smells. For example, water would appear to pour down an illusory waterfall, but it would be silent.</p>\n<p>Any creature that touches the image or uses the Seek action to examine it can attempt to disbelieve your illusion.</p>\n<hr />\n<p><strong>Heightened (2nd)</strong> Your image makes appropriate sounds, generates normal smells, and feels right to the touch. The spell gains the auditory trait. The duration increases to 1 hour.</p>\n<p><strong>Heightened (5th)</strong> As the 2nd-level version, but the duration is unlimited.</p>"
+                },
+                "duration": {
+                    "value": "10 minutes"
+                },
+                "hasCounteractCheck": {
+                    "value": false
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": {
+                    "heightenedLevel": 2,
+                    "value": "h2qxWUvI0fbg4RxB"
+                },
+                "materials": {
+                    "value": ""
+                },
+                "prepared": {
+                    "value": ""
+                },
+                "primarycheck": {
+                    "value": ""
+                },
+                "range": {
+                    "value": "500 feet"
+                },
+                "rules": [],
+                "save": {
+                    "basic": "",
+                    "value": ""
+                },
+                "school": {
+                    "value": "illusion"
+                },
+                "secondarycasters": {
+                    "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "illusory-object",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "spellType": {
+                    "value": "utility"
+                },
+                "sustained": {
+                    "value": false
+                },
+                "target": {
+                    "value": ""
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traditions": {
+                    "value": [
+                        "arcane",
+                        "occult"
+                    ]
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "visual"
+                    ]
+                }
+            },
+            "type": "spell"
+        },
+        {
+            "_id": "96lESscH6vRcwpYW",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.30BBep9U4BDV0EgQ"
+                }
+            },
+            "img": "systems/pf2e/icons/spells/infernal-pact.webp",
+            "name": "Infernal Pact",
+            "sort": 1100000,
+            "system": {
+                "ability": {
+                    "value": ""
+                },
+                "area": null,
+                "category": {
+                    "value": "ritual"
+                },
+                "components": {
+                    "focus": false,
+                    "material": false,
+                    "somatic": false,
+                    "verbal": false
+                },
+                "cost": {
+                    "value": ""
+                },
+                "damage": {
+                    "value": {}
+                },
+                "description": {
+                    "value": "<p>You make an appeal to a powerful devil, asking it to bind some of its subordinates to your service. If you succeed, the devil sends you its choice of one devil whose level is no more than double <em>infernal pact's</em> level, two devils whose levels are each at least 2 less than double the spell level, or three devils whose levels are each at least 3 less than double the spell level.</p>\n<hr />\n<p><strong>Critical Success</strong> The devils are sent to you and serve you for [[/r 1d4 #weeks]]{1d4 weeks}.</p>\n<p><strong>Success</strong> The devils are sent to you and serve you for [[/r 1d4 #days]]{1d4 days}.</p>\n<p><strong>Failure</strong> Your request is denied.</p>\n<p><strong>Critical Failure</strong> Not only is your request denied, but the powerful devil sends word of its displeasure to your master.</p>"
+                },
+                "duration": {
+                    "value": ""
+                },
+                "hasCounteractCheck": {
+                    "value": false
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": {
+                    "value": "Gix3fftNAeuJS7zt"
+                },
+                "materials": {
+                    "value": ""
+                },
+                "prepared": {
+                    "value": ""
+                },
+                "primarycheck": {
+                    "value": "Religion (expert; you must be a devil)"
+                },
+                "range": {
+                    "value": ""
+                },
+                "rules": [],
+                "save": {
+                    "basic": "",
+                    "value": ""
+                },
+                "school": {
+                    "value": "conjuration"
+                },
+                "secondarycasters": {
+                    "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "infernal-pact",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "spellType": {
+                    "value": "utility"
+                },
+                "sustained": {
+                    "value": false
+                },
+                "target": {
+                    "value": ""
+                },
+                "time": {
+                    "value": "1 day"
+                },
+                "traditions": {
+                    "value": []
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "uncommon",
+                    "value": []
+                }
+            },
+            "type": "spell"
+        },
+        {
+            "_id": "OjH9zugdZf9plsD2",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.equipment-srd.dUC8Fsa6FZtVikS3"
+                }
+            },
+            "img": "systems/pf2e/icons/equipment/weapons/composite-longbow.webp",
+            "name": "Composite Longbow",
+            "sort": 1200000,
+            "system": {
+                "MAP": {
+                    "value": ""
+                },
+                "baseItem": "composite-longbow",
+                "bonus": {
+                    "value": 0
+                },
+                "bonusDamage": {
+                    "value": 0
+                },
+                "category": "martial",
+                "containerId": null,
+                "damage": {
+                    "damageType": "piercing",
+                    "dice": 1,
+                    "die": "d8",
+                    "value": ""
+                },
+                "description": {
+                    "value": "<p>This projectile weapon is made from horn, wood, and sinew laminated together to increase the power of its pull and the force of its projectile. Like all longbows, its great size also increases the bow's range and power. You must use two hands to fire it, and it cannot be used while mounted. Any time an ability is specifically restricted to a longbow, such as Erastil's favored weapon, it also applies to composite longbows unless otherwise stated.</p>"
+                },
+                "equipped": {
+                    "carryType": "held",
+                    "handsHeld": 1,
+                    "invested": null
+                },
+                "equippedBulk": {
+                    "value": ""
+                },
+                "group": "bow",
+                "hardness": 0,
+                "hp": {
+                    "brokenThreshold": 0,
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "potencyRune": {
+                    "value": 1
+                },
+                "preciousMaterial": {
+                    "value": null
+                },
+                "preciousMaterialGrade": {
+                    "value": null
+                },
+                "price": {
+                    "value": {
+                        "gp": 20
+                    }
+                },
+                "propertyRune1": {
+                    "value": null
+                },
+                "propertyRune2": {
+                    "value": null
+                },
+                "propertyRune3": {
+                    "value": null
+                },
+                "propertyRune4": {
+                    "value": null
+                },
+                "quantity": 1,
+                "range": 100,
+                "reload": {
+                    "value": "0"
+                },
+                "rules": [],
+                "size": "med",
+                "slug": "composite-longbow",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "specific": {
+                    "value": false
+                },
+                "splashDamage": {
+                    "value": 0
+                },
+                "stackGroup": null,
+                "strikingRune": {
+                    "value": "striking"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "deadly-d10",
+                        "propulsive",
+                        "volley-30"
+                    ]
+                },
+                "usage": {
+                    "value": "held-in-one-plus-hands"
+                },
+                "weight": {
+                    "value": "2"
+                }
+            },
+            "type": "weapon"
+        },
+        {
+            "_id": "qQyKvk6u3S9vDGzo",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.equipment-srd.LJdbVTOZog39EEbi"
@@ -887,7 +1299,7 @@
             },
             "img": "systems/pf2e/icons/equipment/weapons/longsword.webp",
             "name": "Longsword",
-            "sort": 900000,
+            "sort": 1300000,
             "system": {
                 "MAP": {
                     "value": ""
@@ -911,8 +1323,8 @@
                     "value": "<p>Longswords can be one‑edged or two‑edged swords. Their blades are heavy and they're between 3 and 4 feet in length.</p>"
                 },
                 "equipped": {
-                    "carryType": "worn",
-                    "handsHeld": 0,
+                    "carryType": "held",
+                    "handsHeld": 1,
                     "invested": null
                 },
                 "equippedBulk": {
@@ -963,7 +1375,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "size": "lg",
+                "size": "med",
                 "slug": "longsword",
                 "source": {
                     "value": "Pathfinder Core Rulebook"
@@ -995,223 +1407,130 @@
             "type": "weapon"
         },
         {
-            "_id": "8HBlAYPbdVvURrBC",
-            "img": "systems/pf2e/icons/equipment/adventuring-gear/pathfinder-chronicle.webp",
-            "name": "Research Book",
-            "sort": 1000000,
-            "system": {
-                "baseItem": null,
-                "containerId": "null",
-                "description": {
-                    "value": ""
-                },
-                "equipped": {
-                    "carryType": "worn",
-                    "handsHeld": 0,
-                    "invested": null
-                },
-                "equippedBulk": {
-                    "value": ""
-                },
-                "hardness": 0,
-                "hp": {
-                    "brokenThreshold": 0,
-                    "max": 0,
-                    "value": 0
-                },
-                "level": {
-                    "value": 0
-                },
-                "negateBulk": {
-                    "value": "0"
-                },
-                "preciousMaterial": {
-                    "value": null
-                },
-                "preciousMaterialGrade": {
-                    "value": null
-                },
-                "price": {
-                    "value": {}
-                },
-                "quantity": 1,
-                "rules": [],
-                "size": "med",
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "stackGroup": null,
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                },
-                "usage": {
-                    "value": "held-in-one-hand"
-                },
-                "weight": {
-                    "value": "-"
-                }
-            },
-            "type": "equipment"
-        },
-        {
-            "_id": "VK6P3hNaRnT5JPUT",
-            "img": "systems/pf2e/icons/equipment/held-items/quill-of-passage.webp",
-            "name": "Quill",
-            "sort": 1100000,
-            "system": {
-                "baseItem": null,
-                "containerId": "null",
-                "description": {
-                    "value": ""
-                },
-                "equipped": {
-                    "carryType": "worn",
-                    "handsHeld": 0,
-                    "invested": null
-                },
-                "equippedBulk": {
-                    "value": ""
-                },
-                "hardness": 0,
-                "hp": {
-                    "brokenThreshold": 0,
-                    "max": 0,
-                    "value": 0
-                },
-                "level": {
-                    "value": 0
-                },
-                "negateBulk": {
-                    "value": "0"
-                },
-                "preciousMaterial": {
-                    "value": null
-                },
-                "preciousMaterialGrade": {
-                    "value": null
-                },
-                "price": {
-                    "value": {}
-                },
-                "quantity": 1,
-                "rules": [],
-                "size": "med",
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "stackGroup": null,
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                },
-                "usage": {
-                    "value": "held-in-one-hand"
-                },
-                "weight": {
-                    "value": "-"
-                }
-            },
-            "type": "equipment"
-        },
-        {
-            "_id": "mj7RC0aTfmNbGcIT",
-            "img": "systems/pf2e/icons/equipment/held-items/key-purple.webp",
-            "name": "Key",
-            "sort": 1200000,
-            "system": {
-                "baseItem": null,
-                "containerId": "null",
-                "description": {
-                    "value": "<p>key to area <strong>C25</strong></p>"
-                },
-                "equipped": {
-                    "carryType": "worn",
-                    "handsHeld": 0,
-                    "invested": null
-                },
-                "equippedBulk": {
-                    "value": ""
-                },
-                "hardness": 0,
-                "hp": {
-                    "brokenThreshold": 0,
-                    "max": 0,
-                    "value": 0
-                },
-                "level": {
-                    "value": 0
-                },
-                "negateBulk": {
-                    "value": "0"
-                },
-                "preciousMaterial": {
-                    "value": null
-                },
-                "preciousMaterialGrade": {
-                    "value": null
-                },
-                "price": {
-                    "value": {}
-                },
-                "quantity": 1,
-                "rules": [],
-                "size": "med",
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "stackGroup": null,
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                },
-                "usage": {
-                    "value": "held-in-one-hand"
-                },
-                "weight": {
-                    "value": "-"
-                }
-            },
-            "type": "equipment"
-        },
-        {
-            "_id": "q2sYrbAFzwVFBmAZ",
+            "_id": "d1NLDUJL2CAqdBvW",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.equipment-srd.vJZ49cgi8szuQXAD"
+                    "sourceId": "Compendium.pf2e.equipment-srd.r0ifJfoz8aqf0mwk"
                 }
             },
-            "img": "systems/pf2e/icons/equipment/wands/magic-wands/magic-wand.webp",
-            "name": "Wand of Illusory Creature (Level 2)",
-            "sort": 1300000,
+            "img": "systems/pf2e/icons/equipment/armor/breastplate.webp",
+            "name": "Breastplate",
+            "sort": 1400000,
             "system": {
-                "autoDestroy": {
-                    "_deprecated": true,
-                    "value": false
+                "armor": {
+                    "value": 4
                 },
-                "baseItem": null,
-                "charges": {
-                    "max": 1,
-                    "value": 1
-                },
-                "consumableType": {
-                    "value": "wand"
-                },
-                "consume": {
-                    "value": ""
+                "baseItem": "breastplate",
+                "category": "medium",
+                "check": {
+                    "value": -2
                 },
                 "containerId": null,
                 "description": {
-                    "value": "<p>@UUID[Compendium.pf2e.spells-srd.Illusory Creature]</p><hr /><p>This baton is about a foot long and contains a single spell. The appearance typically relates to the spell within.</p>\n<p><strong>Activate</strong> Cast a Spell</p>\n<p><strong>Frequency</strong> once per day, plus overcharge</p>\n<hr />\n<p><strong>Effect</strong> You Cast the Spell at the indicated level.</p>\n<p><strong>Craft Requirements</strong> Supply a listed-level casting of the spell.</p>\n<hr />\n<p><em>Note: To create a scroll or wand of a specific spell, drag the spell from the compendium or compendium browser into the inventory of a PC, NPC, or loot actor.</em></p>"
+                    "value": "<p>Though referred to as a breastplate, this type of armor consists of several pieces of plate or half‑plate armor that protect the torso, chest, neck, and sometimes the hips and lower legs. It strategically grants some of the protection of plate while allowing greater flexibility and speed.</p>"
+                },
+                "dex": {
+                    "value": 1
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "inSlot": true,
+                    "invested": null
+                },
+                "equippedBulk": {
+                    "value": "2"
+                },
+                "group": "plate",
+                "hardness": 0,
+                "hp": {
+                    "brokenThreshold": 0,
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "potency": {},
+                "potencyRune": {
+                    "value": 0
+                },
+                "preciousMaterial": {
+                    "value": null
+                },
+                "preciousMaterialGrade": {
+                    "value": null
+                },
+                "price": {
+                    "value": {
+                        "gp": 8
+                    }
+                },
+                "propertyRune1": {
+                    "value": ""
+                },
+                "propertyRune2": {
+                    "value": ""
+                },
+                "propertyRune3": {
+                    "value": ""
+                },
+                "propertyRune4": {
+                    "value": ""
+                },
+                "quantity": 1,
+                "resiliencyRune": {
+                    "value": ""
+                },
+                "rules": [],
+                "size": "med",
+                "slug": "breastplate",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "speed": {
+                    "value": -5
+                },
+                "stackGroup": null,
+                "strength": {
+                    "value": 16
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "usage": {
+                    "value": "wornarmor"
+                },
+                "weight": {
+                    "value": "3"
+                }
+            },
+            "type": "armor"
+        },
+        {
+            "_id": "Ir7VUc4vTn1TT3EX",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.equipment-srd.fyYnQf1NAx9fWFaS"
+                }
+            },
+            "img": "systems/pf2e/icons/equipment/adventuring-gear/rope.webp",
+            "name": "100 feet of Erinys-Hair Rope",
+            "sort": 1500000,
+            "system": {
+                "baseItem": null,
+                "containerId": null,
+                "description": {
+                    "value": "<p>100 feet of rope.</p>"
+                },
+                "equipped": {
+                    "carryType": "held",
+                    "handsHeld": 1,
+                    "invested": null
                 },
                 "equippedBulk": {
                     "value": ""
@@ -1223,10 +1542,10 @@
                     "value": 0
                 },
                 "level": {
-                    "value": 5
+                    "value": 0
                 },
                 "negateBulk": {
-                    "value": "0"
+                    "value": ""
                 },
                 "preciousMaterial": {
                     "value": ""
@@ -1236,132 +1555,104 @@
                 },
                 "price": {
                     "value": {
-                        "gp": 160
+                        "sp": 5
                     }
                 },
                 "quantity": 1,
                 "rules": [],
                 "size": "med",
-                "slug": "magic-wand-2nd-level-spell",
+                "slug": "rope",
                 "source": {
                     "value": "Pathfinder Core Rulebook"
-                },
-                "spell": {
-                    "_id": "f8SBoXiXQjlCKqly",
-                    "flags": {
-                        "core": {
-                            "sourceId": "Compendium.pf2e.spells-srd.f8SBoXiXQjlCKqly"
-                        }
-                    },
-                    "img": "systems/pf2e/icons/spells/illusory-creature.webp",
-                    "name": "Illusory Creature",
-                    "sort": 0,
-                    "system": {
-                        "ability": {
-                            "value": ""
-                        },
-                        "area": null,
-                        "category": {
-                            "value": "spell"
-                        },
-                        "components": {
-                            "focus": false,
-                            "material": false,
-                            "somatic": true,
-                            "verbal": true
-                        },
-                        "cost": {
-                            "value": ""
-                        },
-                        "damage": {
-                            "value": {}
-                        },
-                        "description": {
-                            "value": "<p>You create an illusory image of a Large or smaller creature. It generates the appropriate sounds, smells, and feels believable to the touch. If you and the image are ever farther than 500 feet apart, the spell ends.</p>\n<p>The image can't speak, but you can use your actions to speak through the creature, with the spell disguising your voice as appropriate. You might need to attempt a Deception or Performance check to mimic the creature, as determined by the GM. This is especially likely if you're trying to imitate a specific person and engage with someone that person knows.</p>\n<p>In combat, the illusion can use 2 actions per turn, which it uses when you Sustain the Spell. It uses your spell attack roll for attack rolls and your spell DC for its AC. Its saving throw modifiers are equal to your spell DC - 10. It is substantial enough that it can flank other creatures. If the image is hit by an attack or fails a save, the spell ends.</p>\n<p>The illusion can cause damage by making the target believe the illusion's attacks are real, but it cannot otherwise directly affect the physical world. If the illusory creature hits with a Strike, the target takes mental damage equal to 1d4 plus your spellcasting ability modifier. This is a mental effect. The illusion's Strikes are nonlethal. If the damage doesn't correspond to the image of the monster-for example, if an illusory Large dragon deals only 5 damage-the GM might allow the target to attempt an immediate Perception check to disbelieve the spell. Any relevant resistances and weaknesses apply if the target thinks they do, as judged by the GM. For example, if the illusion wields a warhammer and attacks a creature resistant to bludgeoning damage, the creature would take less mental damage. However, illusory damage does not deactivate regeneration or trigger other effects that require a certain damage type. The GM should track illusory damage dealt by the illusion.</p>\n<p>Any creature that touches the image or uses the Seek action to examine it can attempt to disbelieve your illusion. When a creature disbelieves the illusion, it recovers from half the damage it had taken from it (if any) and doesn't take any further damage from it.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage of the image's Strikes increases by 1d4, and the maximum size of creature you can create increases by one (to a maximum of Gargantuan).</p>"
-                        },
-                        "duration": {
-                            "value": "sustained"
-                        },
-                        "hasCounteractCheck": {
-                            "value": false
-                        },
-                        "level": {
-                            "value": 2
-                        },
-                        "location": {
-                            "heightenedLevel": 2,
-                            "value": ""
-                        },
-                        "materials": {
-                            "value": ""
-                        },
-                        "prepared": {
-                            "value": ""
-                        },
-                        "primarycheck": {
-                            "value": ""
-                        },
-                        "range": {
-                            "value": "500 feet"
-                        },
-                        "rules": [],
-                        "save": {
-                            "basic": "",
-                            "value": ""
-                        },
-                        "school": {
-                            "value": "illusion"
-                        },
-                        "secondarycasters": {
-                            "value": ""
-                        },
-                        "secondarycheck": {
-                            "value": ""
-                        },
-                        "slug": "illusory-creature",
-                        "source": {
-                            "value": "Pathfinder Core Rulebook"
-                        },
-                        "spellType": {
-                            "value": "utility"
-                        },
-                        "sustained": {
-                            "value": false
-                        },
-                        "target": {
-                            "value": ""
-                        },
-                        "time": {
-                            "value": "2"
-                        },
-                        "traditions": {
-                            "value": [
-                                "arcane",
-                                "occult"
-                            ]
-                        },
-                        "traits": {
-                            "custom": "",
-                            "rarity": "common",
-                            "value": [
-                                "auditory",
-                                "olfactory",
-                                "visual"
-                            ]
-                        }
-                    },
-                    "type": "spell"
                 },
                 "stackGroup": null,
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": [
-                        "magical",
-                        "wand",
-                        "arcane",
-                        "occult"
-                    ]
+                    "value": []
+                },
+                "usage": {
+                    "value": "held-in-one-hand"
+                },
+                "weight": {
+                    "value": "L"
+                }
+            },
+            "type": "equipment"
+        },
+        {
+            "_id": "CIRHLHAH2o7JU8SV",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.equipment-srd.w2ENw2VMPcsbif8g"
+                }
+            },
+            "img": "systems/pf2e/icons/equipment/weapons/arrows.webp",
+            "name": "Arrows",
+            "sort": 1600000,
+            "system": {
+                "autoDestroy": {
+                    "_deprecated": true,
+                    "value": true
+                },
+                "baseItem": null,
+                "charges": {
+                    "max": 0,
+                    "value": 0
+                },
+                "consumableType": {
+                    "value": "ammo"
+                },
+                "consume": {
+                    "value": ""
+                },
+                "containerId": null,
+                "description": {
+                    "value": "<p>These projectiles are the ammunition for bows. The shaft of an arrow is made of wood. It is stabilized in flight by fletching at one end and bears a metal head on the other.</p>"
+                },
+                "equipped": {
+                    "carryType": "held",
+                    "handsHeld": 1
+                },
+                "equippedBulk": {
+                    "value": ""
+                },
+                "hardness": 0,
+                "hp": {
+                    "brokenThreshold": 0,
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "preciousMaterial": {
+                    "value": ""
+                },
+                "preciousMaterialGrade": {
+                    "value": ""
+                },
+                "price": {
+                    "per": 10,
+                    "value": {
+                        "sp": 1
+                    }
+                },
+                "quantity": 60,
+                "rules": [],
+                "size": "med",
+                "slug": "arrows",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "stackGroup": "arrows",
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
                 },
                 "usage": {
                     "value": "held-in-one-hand"
@@ -1373,56 +1664,71 @@
             "type": "consumable"
         },
         {
-            "_id": "nzWpj7yo8PguGBFG",
-            "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "Bite",
-            "sort": 1400000,
+            "_id": "M9wEcuvNMW8Uu4hV",
+            "img": "systems/pf2e/icons/equipment/artifacts/arodens-hearthstone.webp",
+            "name": "Fragment of Urevian's Pendant",
+            "sort": 1700000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
-                "attackEffects": {
-                    "custom": "",
-                    "value": [
-                        "seugathi-venom"
-                    ]
-                },
-                "bonus": {
-                    "value": 17
-                },
-                "damageRolls": {
-                    "7mouzbmbtpfs7v063fwh": {
-                        "damage": "2d6+5",
-                        "damageType": "piercing"
-                    }
-                },
+                "baseItem": null,
+                "containerId": null,
                 "description": {
                     "value": ""
                 },
+                "equipped": {
+                    "carryType": "worn",
+                    "handsHeld": 0
+                },
+                "equippedBulk": {
+                    "value": ""
+                },
+                "hardness": 0,
+                "hp": {
+                    "brokenThreshold": 0,
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "preciousMaterial": {
+                    "value": null
+                },
+                "preciousMaterialGrade": {
+                    "value": null
+                },
+                "price": {
+                    "value": {}
+                },
+                "quantity": 1,
                 "rules": [],
+                "size": "med",
                 "slug": null,
                 "source": {
                     "value": ""
                 },
+                "stackGroup": null,
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": [
-                        "agile",
-                        "finesse"
-                    ]
+                    "value": []
                 },
-                "weaponType": {
-                    "value": "melee"
+                "usage": {
+                    "value": ""
+                },
+                "weight": {
+                    "value": "-"
                 }
             },
-            "type": "melee"
+            "type": "treasure"
         },
         {
-            "_id": "htwDT7obXSlNmWpU",
+            "_id": "upJaEvHTKGpsW57H",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "Longsword",
-            "sort": 1500000,
+            "name": "Flaming Longsword",
+            "sort": 1800000,
             "system": {
                 "attack": {
                     "value": ""
@@ -1432,12 +1738,20 @@
                     "value": []
                 },
                 "bonus": {
-                    "value": 14
+                    "value": 19
                 },
                 "damageRolls": {
-                    "6fms5dftz9p6th6dy2ab": {
-                        "damage": "1d8+5",
-                        "damageType": "piercing"
+                    "jq6gucy2ezjy28wuotil": {
+                        "damage": "1d8+8",
+                        "damageType": "slashing"
+                    },
+                    "u8y72xfoq0cm453hiw8q": {
+                        "damage": "1d6",
+                        "damageType": "evil"
+                    },
+                    "4t8x4f2zccvreho2vef1": {
+                        "damage": "1d6",
+                        "damageType": "fire"
                     }
                 },
                 "description": {
@@ -1452,7 +1766,9 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
-                        "reach-10",
+                        "evil",
+                        "fire",
+                        "magical",
                         "versatile-p"
                     ]
                 },
@@ -1463,15 +1779,113 @@
             "type": "melee"
         },
         {
-            "_id": "Qkqj9KzvAaoHkxjH",
+            "_id": "Hor4EOQfUGAkFak1",
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Flaming Composite Longbow",
+            "sort": 1900000,
+            "system": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "custom": "",
+                    "value": []
+                },
+                "bonus": {
+                    "value": 20
+                },
+                "damageRolls": {
+                    "6s0rutrsib85hnnorwft": {
+                        "damage": "2d8+4",
+                        "damageType": "piercing"
+                    },
+                    "qj7c6kozsaiwufg2uvdr": {
+                        "damage": "1d6",
+                        "damageType": "evil"
+                    },
+                    "rraf034dphcxxz4yxe1j": {
+                        "damage": "1d6",
+                        "damageType": "fire"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "deadly-d10",
+                        "evil",
+                        "fire",
+                        "magical",
+                        "range-increment-100",
+                        "reload-0",
+                        "volley-30"
+                    ]
+                },
+                "weaponType": {
+                    "value": "ranged"
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "UakPnn8jYjY9gCdo",
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Rope",
+            "sort": 2000000,
+            "system": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "custom": "",
+                    "value": [
+                        "rope-snare"
+                    ]
+                },
+                "bonus": {
+                    "value": 19
+                },
+                "damageRolls": {},
+                "description": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "magical",
+                        "range-increment-30"
+                    ]
+                },
+                "weaponType": {
+                    "value": "ranged"
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "cQrkrn9uX9hV860V",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.qCCLZhnp2HhP3Ex6"
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.4Ho2xMPEC05aSxzr"
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Darkvision",
-            "sort": 1600000,
+            "name": "Greater Darkvision",
+            "sort": 2100000,
             "system": {
                 "actionCategory": {
                     "value": "interaction"
@@ -1483,13 +1897,13 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Darkvision]</p>"
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.GreaterDarkvision]</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
                 "rules": [],
-                "slug": "darkvision",
+                "slug": "greater-darkvision",
                 "source": {
                     "value": "Pathfinder Bestiary"
                 },
@@ -1508,52 +1922,7 @@
             "type": "action"
         },
         {
-            "_id": "cj3wll0YeOYjYWaL",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.j2wsK6IsW5yMW1jW"
-                }
-            },
-            "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense (Imprecise) 30 feet",
-            "sort": 1700000,
-            "system": {
-                "actionCategory": {
-                    "value": "interaction"
-                },
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "description": {
-                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Tremorsense]</p>"
-                },
-                "requirements": {
-                    "value": ""
-                },
-                "rules": [],
-                "slug": "tremorsense",
-                "source": {
-                    "value": "Pathfinder Bestiary"
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                },
-                "trigger": {
-                    "value": ""
-                },
-                "weapon": {
-                    "value": ""
-                }
-            },
-            "type": "action"
-        },
-        {
-            "_id": "1lJU8hzSml2TMM3M",
+            "_id": "LGBzL3vv4QNzTFJ1",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.kdhbPaBMK1d1fpbA"
@@ -1561,7 +1930,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Telepathy 100 feet",
-            "sort": 1800000,
+            "sort": 2200000,
             "system": {
                 "actionCategory": {
                     "value": "interaction"
@@ -1602,7 +1971,97 @@
             "type": "action"
         },
         {
-            "_id": "j1CfaIqiOES2OC3Y",
+            "_id": "8aYfDhAzJOdFBLKs",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.2YRDYVnC1eljaXKK"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "At-Will Spells",
+            "sort": 2300000,
+            "system": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.AtWillSpells]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "at-will-spells",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "NwuVG96DJON1Txro",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.kakyXBG5WA8c6Zfd"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Constant Spells",
+            "sort": 2400000,
+            "system": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.ConstantSpells]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "constant-spells",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "PrsRCxi6j7SHJeMu",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.kquBnQ0kObZztnBc"
@@ -1610,7 +2069,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "+1 Status to All Saves vs. Magic",
-            "sort": 1900000,
+            "sort": 2500000,
             "system": {
                 "actionCategory": {
                     "value": "defensive"
@@ -1665,27 +2124,38 @@
             "type": "action"
         },
         {
-            "_id": "VkmU3zCSF1tm61N6",
-            "img": "systems/pf2e/icons/actions/Reaction.webp",
-            "name": "Command Confusion",
-            "sort": 2000000,
+            "_id": "vKdhNyXTKHDMUfAc",
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Flames of Fury",
+            "sort": 2600000,
             "system": {
                 "actionCategory": {
-                    "value": "defensive"
+                    "value": "offensive"
                 },
                 "actionType": {
-                    "value": "reaction"
+                    "value": "passive"
                 },
                 "actions": {
                     "value": null
                 },
                 "description": {
-                    "value": "<p><strong>Trigger</strong> A creature fails its save against the seugathi's mindfog aura</p>\n<hr />\n<p><strong>Effect</strong> The seugathi determines who the @UUID[Compendium.pf2e.conditionitems.Confused]{Confused} creature attacks for that round, instead of the target being randomly determined by the GM.</p>\n<p>If the chosen target is the confused creature's ally, the creature can immediately attempt a @Check[type:will|dc:21] save; on a success, its target is determined randomly as normal for confusion, and on a critical success the target is no longer confused.</p>"
+                    "value": "<p>Any weapon an erinys holds gains the effects of a <em>@UUID[Compendium.pf2e.equipment-srd.Flaming]{Flaming}</em> rune while they hold it.</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "key": "Note",
+                        "outcome": [
+                            "criticalSuccess"
+                        ],
+                        "selector": "attack",
+                        "text": "PF2E.WeaponPropertyRune.flaming.Note.criticalSuccess",
+                        "title": "{item|name}",
+                        "visibility": "gm"
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""
@@ -1705,53 +2175,10 @@
             "type": "action"
         },
         {
-            "_id": "7tCu8SPq0TpF1lJX",
-            "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Mindfog Aura",
-            "sort": 2100000,
-            "system": {
-                "actionCategory": {
-                    "value": "defensive"
-                },
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "description": {
-                    "value": "<p>@Template[type:emanation|distance:20]{20 feet} @UUID[Compendium.pf2e.bestiary-ability-glossary-srd.Aura]{Aura}</p>\n<hr />\n<p>A creature that starts its turn in the aura must succeed at a @Check[type:will|dc:21] save or become @UUID[Compendium.pf2e.conditionitems.Confused]{Confused} for 1 round; on a success, that creature is temporarily immune for 1 minute. A seugathi can suppress or activate this aura as a with the concentrate trait.</p>"
-                },
-                "requirements": {
-                    "value": ""
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": [
-                        "enchantment",
-                        "mental"
-                    ]
-                },
-                "trigger": {
-                    "value": ""
-                },
-                "weapon": {
-                    "value": ""
-                }
-            },
-            "type": "action"
-        },
-        {
-            "_id": "tNfhf1JnOxOHfY86",
-            "img": "systems/pf2e/icons/actions/OneAction.webp",
-            "name": "Envenom Weapon",
-            "sort": 2200000,
+            "_id": "pKPJ4u9g0HQyU7b6",
+            "img": "systems/pf2e/icons/actions/ThreeActions.webp",
+            "name": "Furious Fusillade",
+            "sort": 2700000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -1760,10 +2187,10 @@
                     "value": "action"
                 },
                 "actions": {
-                    "value": 1
+                    "value": 3
                 },
                 "description": {
-                    "value": "<p>The seugathi applies their seugathi venom to one weapon they wield.</p>"
+                    "value": "<p>The erinys hovers in place if they are flying and fires one arrow at any number of creatures in a @Template[type:cone|distance:30]. Each attack is rolled separately. This counts as one attack for the purpose of the erinys's multiple attack penalty.</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -1776,9 +2203,7 @@
                 "traits": {
                     "custom": "",
                     "rarity": "common",
-                    "value": [
-                        "manipulate"
-                    ]
+                    "value": []
                 },
                 "trigger": {
                     "value": ""
@@ -1790,185 +2215,25 @@
             "type": "action"
         },
         {
-            "_id": "MnAW3prtfTZxnv7T",
+            "_id": "PVrWJHEarOi9LFbD",
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Magic Item Mastery",
-            "sort": 2300000,
-            "system": {
-                "actionCategory": {
-                    "value": "offensive"
-                },
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "description": {
-                    "value": "<p>A seugathi can Cast a Spell from a magic item even if the spell isn't on their spell list. All such spells are occult spells and use the seugathi's innate spell DC and attack modifier.</p>"
-                },
-                "requirements": {
-                    "value": ""
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                },
-                "trigger": {
-                    "value": ""
-                },
-                "weapon": {
-                    "value": ""
-                }
-            },
-            "type": "action"
-        },
-        {
-            "_id": "1tb7DMhGgvu0yKi2",
-            "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Seugathi Venom",
-            "sort": 2400000,
-            "system": {
-                "actionCategory": {
-                    "value": "offensive"
-                },
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "description": {
-                    "value": "<p><strong>Saving Throw</strong> @Check[type:fortitude|dc:21]</p>\n<hr />\n<p><strong>Maximum Duration</strong> 6 rounds</p>\n<p><strong>Stage 1</strong> [[/r 1d6[poison]]] damage and @UUID[Compendium.pf2e.conditionitems.Stupefied]{Stupefied 1} (1 round)</p>\n<p><strong>Stage 2</strong> [[/r 2d6[poison]]] damage and @UUID[Compendium.pf2e.conditionitems.Deafened]{Deafened} and @UUID[Compendium.pf2e.conditionitems.Stupefied]{Stupefied 2} (1 round)</p>"
-                },
-                "requirements": {
-                    "value": ""
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": [
-                        "poison"
-                    ]
-                },
-                "trigger": {
-                    "value": ""
-                },
-                "weapon": {
-                    "value": ""
-                }
-            },
-            "type": "action"
-        },
-        {
-            "_id": "jLbg1YorL43XtXr8",
-            "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Acrobatics",
-            "sort": 2500000,
-            "system": {
-                "description": {
-                    "value": ""
-                },
-                "mod": {
-                    "value": 15
-                },
-                "proficient": {
-                    "value": 0
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                }
-            },
-            "type": "lore"
-        },
-        {
-            "_id": "GZ30fJU5FHDsnaLu",
-            "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Crafting",
-            "sort": 2600000,
-            "system": {
-                "description": {
-                    "value": ""
-                },
-                "mod": {
-                    "value": 12
-                },
-                "proficient": {
-                    "value": 0
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                }
-            },
-            "type": "lore"
-        },
-        {
-            "_id": "YEI9CIUnmNxrth19",
-            "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Intimidation",
-            "sort": 2700000,
-            "system": {
-                "description": {
-                    "value": ""
-                },
-                "mod": {
-                    "value": 15
-                },
-                "proficient": {
-                    "value": 0
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                }
-            },
-            "type": "lore"
-        },
-        {
-            "_id": "8TmJKtpOBNZCQgWv",
-            "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Occultism",
+            "name": "Rope Snare",
             "sort": 2800000,
             "system": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
                 "description": {
+                    "value": "<p>An erinys carries a coil of rope woven of their hair (use the statistics for @UUID[Compendium.pf2e.equipment-srd.Rope]{Rope}) that animates in their hands.</p>\n<p>When a creature is hit by the erinys's rope, a segment of the rope tears loose and wraps itself around the creature, imposing a 10-foot circumstance penalty to Speed. The piece that tears off is 10 feet long for a Medium or smaller creature, and doubles in length for each size larger than Medium.</p>\n<p>When a creature @UUID[Compendium.pf2e.actionspf2e.Escape]{Escapes} the effect (DC 26), the detached segment of rope withers away into useless black sludge.</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Effect: Rope Snare]{Effect: Rope Snare}</p>"
+                },
+                "requirements": {
                     "value": ""
-                },
-                "mod": {
-                    "value": 12
-                },
-                "proficient": {
-                    "value": 0
                 },
                 "rules": [],
                 "slug": null,
@@ -1979,21 +2244,27 @@
                     "custom": "",
                     "rarity": "common",
                     "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
                 }
             },
-            "type": "lore"
+            "type": "action"
         },
         {
-            "_id": "fI7hSCpYGpbN4Mwq",
+            "_id": "Zui4bhvANe1dVGUQ",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Stealth",
+            "name": "Acrobatics",
             "sort": 2900000,
             "system": {
                 "description": {
                     "value": ""
                 },
                 "mod": {
-                    "value": 13
+                    "value": 17
                 },
                 "proficient": {
                     "value": 0
@@ -2012,16 +2283,156 @@
             "type": "lore"
         },
         {
-            "_id": "hjcRFLhxhWeO7Qvv",
+            "_id": "dl27Nh1hZdxXfx4f",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
-            "name": "Survival",
+            "name": "Crafting",
             "sort": 3000000,
             "system": {
                 "description": {
                     "value": ""
                 },
                 "mod": {
-                    "value": 10
+                    "value": 14
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "lore"
+        },
+        {
+            "_id": "SPsWoaTwVPa6PiBY",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Deception",
+            "sort": 3100000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 19
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "lore"
+        },
+        {
+            "_id": "swxCxmxGd58iO57u",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Diplomacy",
+            "sort": 3200000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 15
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "lore"
+        },
+        {
+            "_id": "NkQlnzg2MoJdQmqa",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Intimidation",
+            "sort": 3300000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 19
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "lore"
+        },
+        {
+            "_id": "XqTrrm1rk0afLzmv",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Religion",
+            "sort": 3400000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 16
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "lore"
+        },
+        {
+            "_id": "2OFIjqEQkaoehnSx",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Stealth",
+            "sort": 3500000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 17
                 },
                 "proficient": {
                     "value": 0
@@ -2040,9 +2451,9 @@
             "type": "lore"
         }
     ],
-    "name": "Seugathi Researcher (C20)",
+    "name": "Summoning Chamber Erinys",
     "prototypeToken": {
-        "name": "Seugathi Researcher"
+        "name": "Erinys"
     },
     "system": {
         "abilities": {
@@ -2050,7 +2461,7 @@
                 "mod": 5
             },
             "con": {
-                "mod": 2
+                "mod": 5
             },
             "dex": {
                 "mod": 5
@@ -2059,7 +2470,7 @@
                 "mod": 2
             },
             "str": {
-                "mod": 2
+                "mod": 5
             },
             "wis": {
                 "mod": 4
@@ -2068,54 +2479,70 @@
         "attributes": {
             "ac": {
                 "details": "",
-                "value": 23
+                "value": 27
             },
             "allSaves": {
                 "value": "+1 status to all saves vs. magic"
             },
             "hp": {
                 "details": "",
-                "max": 75,
+                "max": 120,
                 "temp": 0,
-                "value": 75
+                "value": 120
             },
             "immunities": [
                 {
-                    "type": "mental"
-                },
-                {
-                    "type": "poison"
+                    "type": "fire"
                 }
             ],
             "initiative": {
                 "ability": "perception"
             },
             "perception": {
-                "value": 14
+                "value": 18
             },
             "resistances": [
                 {
-                    "type": "bludgeoning",
+                    "exceptions": [
+                        "silver"
+                    ],
+                    "type": "physical",
                     "value": 5
+                },
+                {
+                    "type": "poison",
+                    "value": 10
                 }
             ],
             "speed": {
-                "otherSpeeds": [],
+                "otherSpeeds": [
+                    {
+                        "type": "fly",
+                        "value": 40
+                    }
+                ],
                 "value": 25
-            }
+            },
+            "weaknesses": [
+                {
+                    "type": "good",
+                    "value": 5
+                }
+            ]
         },
         "details": {
             "alignment": {
-                "value": "CE"
+                "value": "LE"
             },
-            "blurb": "Seugathi servant",
-            "creatureType": "",
+            "blurb": "",
+            "creatureType": "Fiend",
             "level": {
-                "value": 6
+                "value": 8
             },
             "privateNotes": "",
-            "publicNotes": "<p>The most common seugathis spawned by neothelids are seugathi servants. Their masters equip them with tools useful in their tasks (often a wand and a weapon), and they rarely value other material things beyond their usefulness in completing their imprinted mission.</p>\n<hr />\n<p>The wicked, alien @UUID[Compendium.pf2e.pathfinder-bestiary-2.Neothelid]{Neothelids} impregnate themselves through ritualistic magic to produce wormlike servitor creatures called seugathis. These creatures spawn with a strong psychic drive to complete some task on behalf of the neothelids' far-reaching plans. These directives are diverse, strange, and usually cruel toward humanoid life.</p>",
+            "publicNotes": "<p>Erinyes exact vengeance and bloody justice for a creature's crimes, torturing and punishing their victims in ironic fashion before allowing them the escape of death. While an erinys appears as a fallen angel and the first erinyes shared that origin, erinyes now originate in myriad ways, some promoted from lesser devils and others shaped from lemures themselves forged from the souls of torturers and persecutors. The erinyes' origin is entwined with Eiseth, herself a fallen angel and one of Hell's most powerful demigods. The first erinyes were all considered to be Eiseth's metaphorical daughters, but erinyes formed since that time are no longer limited to a single gender.</p>\n<hr />\n<p>Masters of corruption and architects of conquest, devils seek both to tempt mortal life to join in their pursuit of all things profane and to spread tyranny throughout all worlds. The temptations they offer mortals range from great powers granted by the signing of an infernal contract to twisted favors following a whispered pledge to a diabolic patron, or any number of even subtler exchanges. Those who succumb to these temptations find themselves consigned to an afterlife of endless torment in the pits of Hell, wherein the only hope of escape lies in the chance of being promoted to become a devil in the infernal ranks. Every devil has a specific role to play in the upkeep of the remorseless bureaucratic machine that is Hell, from soldiers and scholars to inquisitors, lawyers, judges, and executioners. Lowly lemures and imps perform subservient labor to more powerful and specialized devils, such as contract devils and erinyes, while the greatest pit fiends command entire infernal armies.</p>",
             "source": {
+                "author": "",
                 "value": "Pathfinder #164: Hands of the Devil"
             }
         },
@@ -2128,15 +2555,15 @@
         "saves": {
             "fortitude": {
                 "saveDetail": "",
-                "value": 14
+                "value": 17
             },
             "reflex": {
                 "saveDetail": "",
-                "value": 17
+                "value": 19
             },
             "will": {
                 "saveDetail": "",
-                "value": 12
+                "value": 16
             }
         },
         "traits": {
@@ -2144,20 +2571,22 @@
                 "custom": "Telepathy 100 feet",
                 "selected": [],
                 "value": [
-                    "aklo",
-                    "undercommon"
+                    "celestial",
+                    "common",
+                    "draconic",
+                    "infernal"
                 ]
             },
-            "rarity": "uncommon",
+            "rarity": "common",
             "senses": {
-                "value": "darkvision, tremorsense 30 feet"
+                "value": "greater darkvision, true seeing"
             },
             "size": {
-                "value": "lg"
+                "value": "med"
             },
             "value": [
-                "aberration",
-                "seugathi"
+                "devil",
+                "fiend"
             ]
         }
     },

--- a/packs/data/abomination-vaults-bestiary.db/torture-chamber-barbazu.json
+++ b/packs/data/abomination-vaults-bestiary.db/torture-chamber-barbazu.json
@@ -1,5 +1,5 @@
 {
-    "_id": "A4MusxxoLxwMVZua",
+    "_id": "4bznEiwsJvInwZwA",
     "img": "systems/pf2e/icons/default-icons/npc.svg",
     "items": [
         {
@@ -527,14 +527,14 @@
             "type": "spell"
         },
         {
-            "_id": "A1xgZ8YYwgXBIYfH",
+            "_id": "jiUi7cG1ldGKfHsM",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.equipment-srd.vlnzTSsRmWeSkt9O"
                 }
             },
             "img": "systems/pf2e/icons/equipment/weapons/glaive.webp",
-            "name": "Glaive",
+            "name": "Hellforged Glaive",
             "sort": 600000,
             "system": {
                 "MAP": {
@@ -548,7 +548,7 @@
                     "value": 0
                 },
                 "category": "martial",
-                "containerId": null,
+                "containerId": "null",
                 "damage": {
                     "damageType": "slashing",
                     "dice": 1,
@@ -630,6 +630,7 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
+                        "agile",
                         "deadly-d8",
                         "forceful",
                         "reach"
@@ -645,85 +646,10 @@
             "type": "weapon"
         },
         {
-            "_id": "PPYXbrsH1dtpkcYA",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.equipment-srd.hBGFCZbI9nAjSdfE"
-                }
-            },
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/droverss_band.webp",
-            "name": "Drover's Band",
-            "sort": 700000,
-            "system": {
-                "baseItem": null,
-                "containerId": null,
-                "description": {
-                    "value": "<p>This black leather wrist guard has a bright red gem on the inside of the wrist. Faint glyphs and words of domination in Infernal swim inside the gem. Your words become harsh and clipped when you have this magic item invested.</p>\n<hr />\n<p><strong>Activate</strong> <span class=\"pf2-icon\">3</span> command</p>\n<p><strong>Frequency</strong> once per day</p>\n<hr />\n<p><strong>Effect</strong> You exert your will over a mindless creature within 30 feet. If the target is a mindless creature of 3rd level or lower, it must attempt a @Check[type:will|dc:20] save. If you are a devil, the target uses an outcome one degree of success worse than the result of its saving throw.</p>\n<hr />\n<p><strong>Critical Success</strong> The target creature is unaffected.</p>\n<p><strong>Success</strong> The target creature is @UUID[Compendium.pf2e.conditionitems.Slowed]{Slowed 1} for 1 round as its responses are muddled by your commands.</p>\n<p><strong>Failure</strong> The creature is @UUID[Compendium.pf2e.conditionitems.Controlled]{Controlled} by you for 1 hour, although it doesn't follow commands that are obviously self-destructive.</p>\n<p><strong>Critical Failure</strong> As failure, but the duration is 1 day.</p>"
-                },
-                "equipped": {
-                    "carryType": "worn",
-                    "handsHeld": 0,
-                    "inSlot": false,
-                    "invested": null
-                },
-                "equippedBulk": {
-                    "value": ""
-                },
-                "hardness": 0,
-                "hp": {
-                    "brokenThreshold": 0,
-                    "max": 0,
-                    "value": 0
-                },
-                "level": {
-                    "value": 7
-                },
-                "negateBulk": {
-                    "value": "0"
-                },
-                "preciousMaterial": {
-                    "value": ""
-                },
-                "preciousMaterialGrade": {
-                    "value": ""
-                },
-                "price": {
-                    "value": {
-                        "gp": 675
-                    }
-                },
-                "quantity": 1,
-                "rules": [],
-                "size": "med",
-                "slug": "drovers-band",
-                "source": {
-                    "value": "Pathfinder #164: Hands of the Devil"
-                },
-                "stackGroup": null,
-                "traits": {
-                    "custom": "",
-                    "rarity": "rare",
-                    "value": [
-                        "enchantment",
-                        "incapacitation",
-                        "invested",
-                        "magical"
-                    ]
-                },
-                "usage": {
-                    "value": "wornbracers"
-                },
-                "weight": {
-                    "value": "L"
-                }
-            },
-            "type": "equipment"
-        },
-        {
             "_id": "DzJcNWKMqkWqtgAX",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "Glaive",
-            "sort": 800000,
+            "name": "Hellforged Glaive",
+            "sort": 700000,
             "system": {
                 "attack": {
                     "value": ""
@@ -759,6 +685,7 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
+                        "agile",
                         "deadly-d8",
                         "evil",
                         "forceful",
@@ -776,7 +703,7 @@
             "_id": "99jBJtnLmD48VOSS",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Claw",
-            "sort": 900000,
+            "sort": 800000,
             "system": {
                 "attack": {
                     "value": ""
@@ -825,7 +752,7 @@
             "_id": "kwMV2uj1jCdvIm7J",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Beard",
-            "sort": 1000000,
+            "sort": 900000,
             "system": {
                 "attack": {
                     "value": ""
@@ -875,7 +802,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Greater Darkvision",
-            "sort": 1100000,
+            "sort": 1000000,
             "system": {
                 "actionCategory": {
                     "value": "interaction"
@@ -920,7 +847,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Telepathy 100 feet",
-            "sort": 1200000,
+            "sort": 1100000,
             "system": {
                 "actionCategory": {
                     "value": "interaction"
@@ -969,7 +896,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "At-Will Spells",
-            "sort": 1300000,
+            "sort": 1200000,
             "system": {
                 "actionCategory": {
                     "value": "interaction"
@@ -1014,7 +941,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "+1 Status to All Saves vs. Magic",
-            "sort": 1400000,
+            "sort": 1300000,
             "system": {
                 "actionCategory": {
                     "value": "defensive"
@@ -1077,7 +1004,7 @@
             },
             "img": "systems/pf2e/icons/actions/Reaction.webp",
             "name": "Attack of Opportunity",
-            "sort": 1500000,
+            "sort": 1400000,
             "system": {
                 "actionCategory": {
                     "value": "defensive"
@@ -1117,7 +1044,7 @@
             "_id": "GZ55vWFhwaHyhnfM",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Avernal Fever",
-            "sort": 1600000,
+            "sort": 1500000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -1156,47 +1083,10 @@
             "type": "action"
         },
         {
-            "_id": "Vo6AHVWsAnxqkwLW",
-            "img": "systems/pf2e/icons/actions/ThreeActions.webp",
-            "name": "Drover's Band",
-            "sort": 1700000,
-            "system": {
-                "actionCategory": {
-                    "value": "offensive"
-                },
-                "actionType": {
-                    "value": "action"
-                },
-                "actions": {
-                    "value": 3
-                },
-                "description": {
-                    "value": "<p><strong>Activate</strong> command</p>\n<p><strong>Frequency</strong> once per day</p>\n<hr />\n<p><strong>Effect</strong> The Barbazu exerts his will over a mindless creature within 30 feet. If the target is a mindless creature of 3rd level or lower, it must attempt a @Check[type:will|dc:20] save and uses an outcome one degree of success worse than the result of its saving throw.</p>\n<hr />\n<p><strong>Critical Success</strong> The target creature is unaffected.</p>\n<p><strong>Success</strong> The target creature is @UUID[Compendium.pf2e.conditionitems.Slowed]{Slowed 1} for 1 round as its responses are muddled by the Barbazu's commands.</p>\n<p><strong>Failure</strong> The creature is @UUID[Compendium.pf2e.conditionitems.Controlled]{Controlled} by the Barbazu for 1 hour, although it doesn't follow commands that are obviously self-destructive.</p>\n<p><strong>Critical Failure</strong> As failure, but the duration is 1 day.</p>"
-                },
-                "requirements": {
-                    "value": ""
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": []
-                },
-                "trigger": {
-                    "value": ""
-                }
-            },
-            "type": "action"
-        },
-        {
             "_id": "SNJ0RSCREyP9YYKY",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Infernal Wound",
-            "sort": 1800000,
+            "sort": 1600000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -1239,7 +1129,7 @@
             "_id": "zQUhdB7kvudfGv5Z",
             "img": "systems/pf2e/icons/actions/FreeAction.webp",
             "name": "Reposition",
-            "sort": 1900000,
+            "sort": 1700000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -1279,7 +1169,7 @@
             "_id": "6zbiPHhWaAV5pJd6",
             "img": "systems/pf2e/icons/actions/OneAction.webp",
             "name": "Wriggling Beard",
-            "sort": 2000000,
+            "sort": 1800000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -1319,7 +1209,7 @@
             "_id": "qzignK7W4KJGlwa5",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Acrobatics",
-            "sort": 2100000,
+            "sort": 1900000,
             "system": {
                 "description": {
                     "value": ""
@@ -1347,7 +1237,7 @@
             "_id": "pBx2ddMMhFIWUJbf",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Athletics",
-            "sort": 2200000,
+            "sort": 2000000,
             "system": {
                 "description": {
                     "value": ""
@@ -1375,7 +1265,7 @@
             "_id": "F1ixTyn5kKmtvWSc",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Intimidation",
-            "sort": 2300000,
+            "sort": 2100000,
             "system": {
                 "description": {
                     "value": ""
@@ -1403,7 +1293,7 @@
             "_id": "ClNedV0QbWHxm3sT",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Religion",
-            "sort": 2400000,
+            "sort": 2200000,
             "system": {
                 "description": {
                     "value": ""
@@ -1431,7 +1321,7 @@
             "_id": "7XWYtzSCDAvmS3Mh",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Stealth",
-            "sort": 2500000,
+            "sort": 2300000,
             "system": {
                 "description": {
                     "value": ""
@@ -1456,7 +1346,7 @@
             "type": "lore"
         }
     ],
-    "name": "Barbazu (AV-D3)",
+    "name": "Torture Chamber Barbazu",
     "prototypeToken": {
         "name": "Barbazu"
     },
@@ -1542,6 +1432,7 @@
             "privateNotes": "",
             "publicNotes": "<p>Barbazus, known also as bearded devils or infantry devils, are murderous fiends who satiate their lust for annihilation by serving as the foot soldiers of Hell's armies, often leading hordes of lesser devils such as imps and lemures into battle. Bearded devils wield serrated glaives to inflict jagged gashes that resist healing magic, resulting in tremendous blood loss. When enemies come too close, bearded devils strike with the spines of their wriggling beards to deliver a wretched contagion called Avernal fever, savoring the sight of their victim's strength being slowly devoured from within.</p>\n<p>Barbazus can be found savagely indulging the whims of evil infernal lords from all layers of Hell, rejoicing as they disseminate murder, misery, and anguish as they see fit.</p>\n<hr />\n<p>Masters of corruption and architects of conquest, devils seek both to tempt mortal life to join in their pursuit of all things profane and to spread tyranny throughout all worlds. The temptations they offer mortals range from great powers granted by the signing of an infernal contract to twisted favors following a whispered pledge to a diabolic patron, or any number of even subtler exchanges. Those who succumb to these temptations find themselves consigned to an afterlife of endless torment in the pits of Hell, wherein the only hope of escape lies in the chance of being promoted to become a devil in the infernal ranks. Every devil has a specific role to play in the upkeep of the remorseless bureaucratic machine that is Hell, from soldiers and scholars to inquisitors, lawyers, judges, and executioners. Lowly lemures and imps perform subservient labor to more powerful and specialized devils, such as contract devils and erinyes, while the greatest pit fiends command entire infernal armies.</p>",
             "source": {
+                "author": "",
                 "value": "Pathfinder #164: Hands of the Devil"
             }
         },

--- a/packs/data/abomination-vaults-bestiary.db/urthagul.json
+++ b/packs/data/abomination-vaults-bestiary.db/urthagul.json
@@ -1,0 +1,686 @@
+{
+    "_id": "0jvmec4yJH1ASfRy",
+    "img": "systems/pf2e/icons/default-icons/npc.svg",
+    "items": [
+        {
+            "_id": "Kc9RfQ1ZLqepop3p",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.equipment-srd.yAqGhT0GuZrkvWZl"
+                }
+            },
+            "img": "systems/pf2e/icons/equipment/other/crimson-fulcrum-lenses.webp",
+            "name": "Crimson Fulcrum Lens",
+            "sort": 100000,
+            "system": {
+                "baseItem": null,
+                "containerId": null,
+                "description": {
+                    "value": "<p>This concave lens has a drifting crimson cloud resembling slowly swirling blood within it. While you have the Crimson Fulcrum Lens invested, you seethe with malevolent fury you can barely contain. You gain a +2 item bonus to saving throws against fear effects and a +2 item bonus to your melee Strike damage (this increases to a +4 item bonus to damage if the melee Strike is a jaws attack). You can also activate the lens in the following ways.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Effect: Crimson Fulcrum Lens]{Effect: Crimson Fulcrum Lens}</p>\n<hr />\n<p><strong>Activate</strong> <span class=\"pf2-icon\">2</span> Interact</p>\n<p><strong>Frequency</strong> once per day</p>\n<hr />\n<p><strong>Effect</strong> You grasp the Crimson Fulcrum Lens in one hand and make a Strike that doesn't require that hand. The Strike deals an additional 1d8 precision damage (or 2d8 precision damage if you make a jaws Strike) and doesn't count toward your multiple attack penalty.</p>\n<p><strong>Activate</strong> <span class=\"pf2-icon\">2</span> Interact (attack, possession)</p>\n<hr />\n<p><strong>Effect</strong> While grasping the lens, make a melee spell attack roll with a modifier of +18. On a hit, you force the splinter of Nhimbaloth's essence from the lens to possess the target. You're no longer invested in the lens, and the target gains the benefits as though it had invested the lens but can't activate the lens's other abilities. This effect is permanent, but it can be ended by any effect that removes a possession effect. The lens doesn't have any magical abilities until the possession effect ends; when it does, the essence returns to the lens.</p>"
+                },
+                "equipped": {
+                    "carryType": "worn",
+                    "invested": null
+                },
+                "equippedBulk": {
+                    "value": ""
+                },
+                "hardness": 0,
+                "hp": {
+                    "brokenThreshold": 0,
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 9
+                },
+                "negateBulk": {
+                    "value": "0"
+                },
+                "preciousMaterial": {
+                    "value": ""
+                },
+                "preciousMaterialGrade": {
+                    "value": ""
+                },
+                "price": {
+                    "value": {
+                        "gp": 700
+                    }
+                },
+                "quantity": 1,
+                "rules": [],
+                "size": "lg",
+                "slug": "crimson-fulcrum-lens",
+                "source": {
+                    "value": "Pathfinder #165: Eyes of Empty Death"
+                },
+                "stackGroup": null,
+                "traits": {
+                    "custom": "",
+                    "rarity": "unique",
+                    "value": [
+                        "enchantment",
+                        "invested",
+                        "occult"
+                    ]
+                },
+                "usage": {
+                    "value": "held-in-one-hand"
+                },
+                "weight": {
+                    "value": "1"
+                }
+            },
+            "type": "equipment"
+        },
+        {
+            "_id": "JuUN4gbsoB92ylTF",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.equipment-effects.ytqvHyF0oMKbo65P"
+                }
+            },
+            "img": "systems/pf2e/icons/equipment/other/crimson-fulcrum-lenses.webp",
+            "name": "Effect: Crimson Fulcrum Lens",
+            "sort": 200000,
+            "system": {
+                "badge": null,
+                "description": {
+                    "value": "<p>Granted by @UUID[Compendium.pf2e.equipment-srd.Crimson Fulcrum Lens]{Crimson Fulcrum Lens}</p>\n<p>You gain a +2 item bonus to saving throws against fear effects and a +2 item bonus to your melee Strike damage (this increases to a +4 item bonus to damage if the melee Strike is a jaws attack).</p>"
+                },
+                "duration": {
+                    "expiry": "turn-start",
+                    "sustained": false,
+                    "unit": "unlimited",
+                    "value": -1
+                },
+                "level": {
+                    "value": 9
+                },
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "predicate": [
+                            "fear"
+                        ],
+                        "selector": "saving-throw",
+                        "type": "item",
+                        "value": 2
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "predicate": [
+                            "melee"
+                        ],
+                        "selector": "strike-damage",
+                        "type": "item",
+                        "value": 2
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "predicate": [
+                            "melee"
+                        ],
+                        "selector": "jaws-damage",
+                        "type": "item",
+                        "value": 4
+                    }
+                ],
+                "slug": "effect-crimson-fulcrum-lens",
+                "source": {
+                    "value": "Pathfinder #165: Eyes of Empty Death"
+                },
+                "start": {
+                    "initiative": null,
+                    "value": 0
+                },
+                "target": null,
+                "tokenIcon": {
+                    "show": true
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "unidentified": false
+            },
+            "type": "effect"
+        },
+        {
+            "_id": "iwppReF9hEA7igPO",
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Jaws",
+            "sort": 300000,
+            "system": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "custom": "",
+                    "value": []
+                },
+                "bonus": {
+                    "value": 23
+                },
+                "damageRolls": {
+                    "69q3icwohrlwwe927bd0": {
+                        "damage": "2d12+13",
+                        "damageType": "piercing"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "reach-15"
+                    ]
+                },
+                "weaponType": {
+                    "value": "melee"
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "VgEW660oBhpCgGPZ",
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Claw",
+            "sort": 400000,
+            "system": {
+                "attack": {
+                    "value": ""
+                },
+                "attackEffects": {
+                    "custom": "",
+                    "value": []
+                },
+                "bonus": {
+                    "value": 23
+                },
+                "damageRolls": {
+                    "x85q3awqsvk8t9klp5di": {
+                        "damage": "2d8+13",
+                        "damageType": "slashing"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "agile",
+                        "reach-15"
+                    ]
+                },
+                "weaponType": {
+                    "value": "melee"
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "JQ3FZtUvvt6RRRXF",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.qCCLZhnp2HhP3Ex6"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Darkvision",
+            "sort": 500000,
+            "system": {
+                "actionCategory": {
+                    "value": "interaction"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Darkvision]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "darkvision",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "kFeAtCbycBHyIGcR",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.hFtNbo1LKYCoDy2O"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Reaction.webp",
+            "name": "Attack of Opportunity",
+            "sort": 600000,
+            "system": {
+                "actionCategory": {
+                    "value": "defensive"
+                },
+                "actionType": {
+                    "value": "reaction"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.AttackOfOpportunity]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "attack-of-opportunity",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "fIssfjOuDo0yfwLc",
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Eerie Flexibility",
+            "sort": 700000,
+            "system": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "description": {
+                    "value": "<p>Despite its size, the gug's multiple joints allow it to fit through tight spaces as if it were a Medium creature. While @UUID[Compendium.pf2e.actionspf2e.Squeeze]{Squeezing}, it can move at its full Speed.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "b1w5wps2XBnNPOls",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Furious Claws",
+            "sort": 800000,
+            "system": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "description": {
+                    "value": "<p>The gug makes up to four claw Strikes, each against a different target. These attacks all count toward the gug's multiple attack penalty, but the penalty doesn't increase until after the gug makes all its attacks.</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "yTXiHzmRavI1BmKJ",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.3JOi2cMcGhT3eze1"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Rend",
+            "sort": 900000,
+            "system": {
+                "actionCategory": {
+                    "value": "offensive"
+                },
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "description": {
+                    "value": "<p>Claw</p>\n<hr />\n<p>@Localize[PF2E.NPC.Abilities.Glossary.Rend]</p>"
+                },
+                "requirements": {
+                    "value": ""
+                },
+                "rules": [],
+                "slug": "rend",
+                "source": {
+                    "value": "Pathfinder Bestiary"
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "trigger": {
+                    "value": ""
+                },
+                "weapon": {
+                    "value": ""
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "JCTMNa7QfednvGsM",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Acrobatics",
+            "sort": 1000000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 19
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "label": "PF2E.SkillVariant.Squeeze",
+                        "predicate": [
+                            "action:squeeze"
+                        ],
+                        "selector": "acrobatics",
+                        "value": 4
+                    }
+                ],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                },
+                "variants": {
+                    "0": {
+                        "label": "+23 to Squeeze",
+                        "options": "action:squeeze"
+                    }
+                }
+            },
+            "type": "lore"
+        },
+        {
+            "_id": "8GVmc51lbdbhk1Ut",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Athletics",
+            "sort": 1100000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 23
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "lore"
+        },
+        {
+            "_id": "L0uJFTbWLzEKIPMb",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Stealth",
+            "sort": 1200000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 19
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "lore"
+        },
+        {
+            "_id": "bK2Bmyz4Gs9v8nTE",
+            "img": "systems/pf2e/icons/default-icons/lore.svg",
+            "name": "Survival",
+            "sort": 1300000,
+            "system": {
+                "description": {
+                    "value": ""
+                },
+                "mod": {
+                    "value": 17
+                },
+                "proficient": {
+                    "value": 0
+                },
+                "rules": [],
+                "slug": null,
+                "source": {
+                    "value": ""
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "lore"
+        }
+    ],
+    "name": "Urthagul",
+    "system": {
+        "abilities": {
+            "cha": {
+                "mod": 0
+            },
+            "con": {
+                "mod": 6
+            },
+            "dex": {
+                "mod": 3
+            },
+            "int": {
+                "mod": 0
+            },
+            "str": {
+                "mod": 7
+            },
+            "wis": {
+                "mod": 3
+            }
+        },
+        "attributes": {
+            "ac": {
+                "details": "",
+                "value": 30
+            },
+            "allSaves": {
+                "value": ""
+            },
+            "hp": {
+                "details": "",
+                "max": 175,
+                "temp": 0,
+                "value": 175
+            },
+            "initiative": {
+                "ability": "perception"
+            },
+            "perception": {
+                "value": 19
+            },
+            "speed": {
+                "otherSpeeds": [
+                    {
+                        "type": "climb",
+                        "value": 20
+                    }
+                ],
+                "value": 40
+            }
+        },
+        "details": {
+            "alignment": {
+                "value": "CE"
+            },
+            "blurb": "Male gug (Pathfinder Bestiary 198)",
+            "creatureType": "Aberration",
+            "level": {
+                "value": 10
+            },
+            "privateNotes": "",
+            "publicNotes": "<p>A gug's most horrid feature is its barrel-shaped head, which splits vertically to reveal numerous rows of sharp, yellow teeth and an open throat. Its eyes on either side of its head-jaw are small but keen. Bony ridges protect its eyes from the frantic flailing of its prey, as it prefers meals of raw and writhing meat over fungi and molds. It grips said prey with powerful arms that split at the elbow into a pair of forearms, giving it four clawed paws. These monstrous brutes are covered with shaggy black fur, often crusted with blood and gore.</p>\n<p>Although gugs may seem bestial, they have keen and wicked intellects. Gugs lair far underground, but they sometimes come to the surface to hunt during dark nights, either alone or in small groups. As they possess voracious appetites, most gugs consume the creatures they catch, but some instead kidnap their victims and retreat below the surface, leaving only a lingering stench and odd, clawed paw-prints. Victims are taken to rancid lairs marked with strange runes and sacrificed to the gugs' wicked gods of blood, darkness, and nightmares. Dire rumors tell of lightless gug cities made of titanic blocks of stone far underground, where powerful gug leaders preach their vile doctrines to mobs of howling gugs.</p>\n<p>Gugs have a strange relationship with ghouls, which seems to date from their shared origin in a distant subterranean world. Gugs live in fear of ghouls, despite towering over them; however, this strange fear doesn't apply to ghasts, whom gugs consume as voraciously as they do other creatures.</p>\n<p>Gugs stand 16 feet tall and weigh 2,000 pounds, although they have an eerie, graceful gait that belies their immense size. Their light step and ability to squeeze through very small crannies makes gugs common bogeymen in tales of strange disappearances or bloody massacres.</p>\n<p>Some particularly bloodthirsty gugs gain awful powers as gifts from their eldritch patrons. These monsters are known as savants, are never less than 12th level in power, and gain several occult innate spells. Though each savant's precise mix of spells varies, normally, these spells grant invisibility, offer power to manipulate and change rock, or invoke awful and destructive energies upon living flesh.</p>",
+            "source": {
+                "author": "",
+                "value": "Pathfinder Abomination Vaults Hardcover Compilation"
+            }
+        },
+        "resources": {},
+        "saves": {
+            "fortitude": {
+                "saveDetail": "",
+                "value": 22
+            },
+            "reflex": {
+                "saveDetail": "",
+                "value": 17
+            },
+            "will": {
+                "saveDetail": "",
+                "value": 19
+            }
+        },
+        "traits": {
+            "languages": {
+                "custom": "",
+                "selected": [],
+                "value": [
+                    "undercommon"
+                ]
+            },
+            "rarity": "common",
+            "senses": {
+                "value": "darkvision"
+            },
+            "size": {
+                "value": "lg"
+            },
+            "value": [
+                "aberration"
+            ]
+        }
+    },
+    "type": "npc"
+}

--- a/packs/data/abomination-vaults-bestiary.db/warped-brew-morlock.json
+++ b/packs/data/abomination-vaults-bestiary.db/warped-brew-morlock.json
@@ -3,124 +3,10 @@
     "img": "systems/pf2e/icons/default-icons/npc.svg",
     "items": [
         {
-            "_id": "3wXaoTh5a7RPagBa",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.equipment-srd.c58wczIzH2gzeXQL"
-                }
-            },
-            "img": "systems/pf2e/icons/equipment/weapons/club.webp",
-            "name": "Club",
-            "sort": 100000,
-            "system": {
-                "MAP": {
-                    "value": ""
-                },
-                "baseItem": "club",
-                "bonus": {
-                    "value": 0
-                },
-                "bonusDamage": {
-                    "value": 0
-                },
-                "category": "simple",
-                "containerId": null,
-                "damage": {
-                    "damageType": "bludgeoning",
-                    "dice": 1,
-                    "die": "d6",
-                    "value": ""
-                },
-                "description": {
-                    "value": "<p>This is a piece of stout wood shaped or repurposed to bludgeon an enemy. Clubs can be intricately carved pieces of martial art or as simple as a tree branch or piece of wood.</p>"
-                },
-                "equipped": {
-                    "carryType": "held",
-                    "handsHeld": 1,
-                    "invested": null
-                },
-                "equippedBulk": {
-                    "value": ""
-                },
-                "group": "club",
-                "hardness": 0,
-                "hp": {
-                    "brokenThreshold": 0,
-                    "max": 0,
-                    "value": 0
-                },
-                "level": {
-                    "value": 0
-                },
-                "negateBulk": {
-                    "value": "0"
-                },
-                "potencyRune": {
-                    "value": null
-                },
-                "preciousMaterial": {
-                    "value": null
-                },
-                "preciousMaterialGrade": {
-                    "value": null
-                },
-                "price": {
-                    "value": {}
-                },
-                "propertyRune1": {
-                    "value": ""
-                },
-                "propertyRune2": {
-                    "value": ""
-                },
-                "propertyRune3": {
-                    "value": ""
-                },
-                "propertyRune4": {
-                    "value": ""
-                },
-                "quantity": 1,
-                "range": null,
-                "reload": {
-                    "value": "-"
-                },
-                "rules": [],
-                "size": "med",
-                "slug": "club",
-                "source": {
-                    "value": "Pathfinder Core Rulebook"
-                },
-                "specific": {
-                    "value": false
-                },
-                "splashDamage": {
-                    "value": 0
-                },
-                "stackGroup": null,
-                "strikingRune": {
-                    "value": ""
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": [
-                        "thrown-10"
-                    ]
-                },
-                "usage": {
-                    "value": "held-in-one-hand"
-                },
-                "weight": {
-                    "value": "1"
-                }
-            },
-            "type": "weapon"
-        },
-        {
             "_id": "sdsJsKNzbvVK8R4I",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Wooden Chair",
-            "sort": 200000,
+            "sort": 100000,
             "system": {
                 "attack": {
                     "value": ""
@@ -162,7 +48,7 @@
             "_id": "7Y7vl4vBRBKsb6wB",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Jaws",
-            "sort": 300000,
+            "sort": 200000,
             "system": {
                 "attack": {
                     "value": ""
@@ -204,7 +90,7 @@
             "_id": "W2nnShEx9f5pWTjq",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Pewter Mug",
-            "sort": 400000,
+            "sort": 300000,
             "system": {
                 "attack": {
                     "value": ""
@@ -251,7 +137,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Darkvision",
-            "sort": 500000,
+            "sort": 400000,
             "system": {
                 "actionCategory": {
                     "value": "interaction"
@@ -296,7 +182,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Light Blindness",
-            "sort": 600000,
+            "sort": 500000,
             "system": {
                 "actionCategory": {
                     "value": "interaction"
@@ -341,7 +227,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "+2 Status to All Saves vs. Disease and Poison",
-            "sort": 700000,
+            "sort": 600000,
             "system": {
                 "actionCategory": {
                     "value": "defensive"
@@ -396,7 +282,7 @@
             "_id": "3vycv9ThXOQbgNBf",
             "img": "systems/pf2e/icons/actions/TwoActions.webp",
             "name": "Instinctual Tinker",
-            "sort": 800000,
+            "sort": 700000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -436,7 +322,7 @@
             "_id": "HaYQ8Cd4C0hYSFdc",
             "img": "systems/pf2e/icons/actions/TwoActions.webp",
             "name": "Leap Attack",
-            "sort": 900000,
+            "sort": 800000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -481,7 +367,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Sneak Attack",
-            "sort": 1000000,
+            "sort": 900000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -553,7 +439,7 @@
             "_id": "Y6Rqq2ahFM07WKRm",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Swarming Stance",
-            "sort": 1100000,
+            "sort": 1000000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -609,7 +495,7 @@
             "_id": "XzaLoiUlsO70ko1e",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Acrobatics",
-            "sort": 1200000,
+            "sort": 1100000,
             "system": {
                 "description": {
                     "value": ""
@@ -637,7 +523,7 @@
             "_id": "rET5SfCVJHTK7d5a",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Athletics",
-            "sort": 1300000,
+            "sort": 1200000,
             "system": {
                 "description": {
                     "value": ""
@@ -681,7 +567,7 @@
             "_id": "1gu2mF6EgXl6v3eM",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Crafting",
-            "sort": 1400000,
+            "sort": 1300000,
             "system": {
                 "description": {
                     "value": ""
@@ -715,7 +601,7 @@
             "_id": "XUXBrT0KGQKkyY1x",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Stealth",
-            "sort": 1500000,
+            "sort": 1400000,
             "system": {
                 "description": {
                     "value": ""
@@ -740,7 +626,7 @@
             "type": "lore"
         }
     ],
-    "name": "Morlock (AV)",
+    "name": "Warped Brew Morlock",
     "prototypeToken": {
         "name": "Morlock"
     },
@@ -807,6 +693,7 @@
             "privateNotes": "",
             "publicNotes": "<p>Originating from humans long lost from the world of light, morlocks are brutal monsters that dwell in the tangled tunnels of the upper reaches of the Darklands. Their wiry frames mask the strength of their limbs and their swift reactions, and their arms are long enough that they can drop into an uncanny, four-limbed shuffle for speed or stealth. They no longer remember the lives their ancestors led on the surface, although many morlocks still dwell in the shattered ruins of their ancient homes. Some morlocks worship the statues of humans from these bygone eras as gods, but others now worship Lamashtu, Rovagug, or other violent deities.</p>\n<p>Morlock young are insatiable and clamor for even the slightest morsel of food, even consuming their siblings if no other meal presents itself. Most morlocks encourage the practice to ensure their ancestral group as a whole grows stronger.</p>\n<p>A typical morlock stands just over 5 feet tall and weighs roughly 150 pounds.</p>",
             "source": {
+                "author": "",
                 "value": "Pathfinder #164: Hands of the Devil"
             }
         },


### PR DESCRIPTION
These are mostly "item refreshes" since some of these used old versions of items with no art, or no items at all. The main true change intended was to remove the key from Padli's inventory, so if the quality of this MR is not up to par, feel free to axe the other changes and only include that one.