### PR TITLE
Cache result of character/creature skills

### DIFF
--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -129,6 +129,9 @@ class CharacterPF2e extends CreaturePF2e {
     /** All class DCs regardless of whether or not its the primary */
     classDCs!: Record<string, Statistic>;
 
+    // Internal cached value of character skills
+    protected override _skills: CharacterSkills | null = null;
+
     override get allowedItemTypes(): (ItemType | "physical")[] {
         const buildItems = ["ancestry", "heritage", "background", "class", "deity", "feat"] as const;
         return [...super.allowedItemTypes, ...buildItems, "physical", "spellcastingEntry", "spell", "action", "lore"];
@@ -152,6 +155,8 @@ class CharacterPF2e extends CreaturePF2e {
     }
 
     override get skills(): CharacterSkills {
+        if (this._skills) return this._skills;
+
         const skills = super.skills;
         for (const [key, skill] of Object.entries(skills)) {
             if (!skill) continue;
@@ -167,7 +172,8 @@ class CharacterPF2e extends CreaturePF2e {
             });
         }
 
-        return skills as CharacterSkills;
+        this._skills = skills as CharacterSkills;
+        return this._skills;
     }
 
     get heroPoints(): { value: number; max: number } {

--- a/src/module/actor/creature/document.ts
+++ b/src/module/actor/creature/document.ts
@@ -59,9 +59,14 @@ import { setTraitIWR } from "./helpers";
 
 /** An "actor" in a Pathfinder sense rather than a Foundry one: all should contain attributes and abilities */
 abstract class CreaturePF2e extends ActorPF2e {
+    // Internal cached value for creature skills
+    protected _skills: CreatureSkills | null = null;
+
     /** Skill `Statistic`s for the creature */
     get skills(): CreatureSkills {
-        return Object.entries(this.system.skills).reduce((current, [shortForm, skill]: [string, SkillData]) => {
+        if (this._skills) return this._skills;
+
+        this._skills = Object.entries(this.system.skills).reduce((current, [shortForm, skill]: [string, SkillData]) => {
             if (!objectHasKey(this.system.skills, shortForm)) return current;
             const longForm = skill.slug;
             const skillName = game.i18n.localize(skill.label ?? CONFIG.PF2E.skills[shortForm]) || skill.slug;
@@ -92,6 +97,8 @@ abstract class CreaturePF2e extends ActorPF2e {
 
             return current;
         }, {} as CreatureSkills);
+
+        return this._skills;
     }
 
     /** The creature's position on the alignment axes */
@@ -261,6 +268,7 @@ abstract class CreaturePF2e extends ActorPF2e {
     /** Setup base ephemeral data to be modified by active effects and derived-data preparation */
     override prepareBaseData(): void {
         super.prepareBaseData();
+        this._skills = null;
 
         const attributes = this.system.attributes;
         attributes.hp = mergeObject(attributes.hp ?? {}, { negativeHealing: false });


### PR DESCRIPTION
This is a massive performance improvement for a workbench feature that I actually made worse with a PR by removing support for deprecated skills (as in, 800ms improvement....), but I suspect it'll lead to marginal ones for anything referencing @actor.skills.

We can completely get rid of this silly cache solution once its fully converted to statistic. The final holdout is initiative and encounter stuff....