### PR TITLE
Add persistent damage to alchemical bombs

### DIFF
--- a/packs/data/equipment.db/blight-bomb-greater.json
+++ b/packs/data/equipment.db/blight-bomb-greater.json
@@ -11,14 +11,19 @@
             "value": 2
         },
         "bonusDamage": {
-            "value": null
+            "value": 0
         },
         "category": "martial",
         "containerId": null,
         "damage": {
             "damageType": "poison",
             "dice": 3,
-            "die": "d6"
+            "die": "d6",
+            "persistent": {
+                "faces": 4,
+                "number": 3,
+                "type": "poison"
+            }
         },
         "description": {
             "value": "<p><strong>Usage</strong> held in 1 hand</p>\n<p><strong>Activate</strong> <span class=\"pf2-icon\">A</span> Strike</p>\n<p>Blight bombs contain volatile toxic chemicals that rot flesh. A blight bomb deals 3d6 poison damage, 3d4 persistent poison damage, and 3 poison splash damage. You gain a +2 item bonus to attack rolls.</p>"
@@ -40,7 +45,7 @@
             "value": "0"
         },
         "potencyRune": {
-            "value": 0
+            "value": null
         },
         "preciousMaterial": {
             "value": null
@@ -70,24 +75,7 @@
         "reload": {
             "value": "-"
         },
-        "rules": [
-            {
-                "key": "Note",
-                "outcome": [
-                    "success"
-                ],
-                "selector": "{item|_id}-damage",
-                "text": "PF2E.BombNotes.BlightBomb.Greater.success"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "{item|_id}-damage",
-                "text": "PF2E.BombNotes.BlightBomb.Greater.criticalSuccess"
-            }
-        ],
+        "rules": [],
         "size": "med",
         "source": {
             "value": "Pathfinder Advanced Player's Guide"
@@ -97,7 +85,7 @@
         },
         "stackGroup": null,
         "strikingRune": {
-            "value": ""
+            "value": null
         },
         "traits": {
             "custom": "",

--- a/packs/data/equipment.db/blight-bomb-lesser.json
+++ b/packs/data/equipment.db/blight-bomb-lesser.json
@@ -11,14 +11,19 @@
             "value": null
         },
         "bonusDamage": {
-            "value": null
+            "value": 0
         },
         "category": "martial",
         "containerId": null,
         "damage": {
             "damageType": "poison",
             "dice": 1,
-            "die": "d6"
+            "die": "d6",
+            "persistent": {
+                "faces": 4,
+                "number": 1,
+                "type": "poison"
+            }
         },
         "description": {
             "value": "<p><strong>Usage</strong> held in 1 hand</p>\n<p><strong>Activate</strong> <span class=\"pf2-icon\">A</span> Strike</p>\n<p>Blight bombs contain volatile toxic chemicals that rot flesh. A blight bomb deals 1d6 poison damage, 1d4 persistent poison damage, and 1 poison splash damage.</p>"
@@ -40,7 +45,7 @@
             "value": "0"
         },
         "potencyRune": {
-            "value": 0
+            "value": null
         },
         "preciousMaterial": {
             "value": null
@@ -70,24 +75,7 @@
         "reload": {
             "value": "-"
         },
-        "rules": [
-            {
-                "key": "Note",
-                "outcome": [
-                    "success"
-                ],
-                "selector": "{item|_id}-damage",
-                "text": "PF2E.BombNotes.BlightBomb.Lesser.success"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "{item|_id}-damage",
-                "text": "PF2E.BombNotes.BlightBomb.Lesser.criticalSuccess"
-            }
-        ],
+        "rules": [],
         "size": "med",
         "source": {
             "value": "Pathfinder Advanced Player's Guide"
@@ -97,7 +85,7 @@
         },
         "stackGroup": null,
         "strikingRune": {
-            "value": ""
+            "value": null
         },
         "traits": {
             "custom": "",

--- a/packs/data/equipment.db/blight-bomb-major.json
+++ b/packs/data/equipment.db/blight-bomb-major.json
@@ -11,14 +11,19 @@
             "value": 3
         },
         "bonusDamage": {
-            "value": null
+            "value": 0
         },
         "category": "martial",
         "containerId": null,
         "damage": {
             "damageType": "poison",
             "dice": 4,
-            "die": "d6"
+            "die": "d6",
+            "persistent": {
+                "faces": 4,
+                "number": 4,
+                "type": "poison"
+            }
         },
         "description": {
             "value": "<p><strong>Usage</strong> held in 1 hand</p>\n<p><strong>Activate</strong> <span class=\"pf2-icon\">A</span> Strike</p>\n<p>Blight bombs contain volatile toxic chemicals that rot flesh. A blight bomb deals 4d6 poison damage, 4d4 persistent poison damage, and 4 poison splash damage. You gain a +3 item bonus to attack rolls.</p>"
@@ -40,7 +45,7 @@
             "value": "0"
         },
         "potencyRune": {
-            "value": 0
+            "value": null
         },
         "preciousMaterial": {
             "value": null
@@ -70,24 +75,7 @@
         "reload": {
             "value": "-"
         },
-        "rules": [
-            {
-                "key": "Note",
-                "outcome": [
-                    "success"
-                ],
-                "selector": "{item|_id}-damage",
-                "text": "PF2E.BombNotes.BlightBomb.Major.success"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "{item|_id}-damage",
-                "text": "PF2E.BombNotes.BlightBomb.Major.criticalSuccess"
-            }
-        ],
+        "rules": [],
         "size": "med",
         "source": {
             "value": "Pathfinder Advanced Player's Guide"
@@ -97,7 +85,7 @@
         },
         "stackGroup": null,
         "strikingRune": {
-            "value": ""
+            "value": null
         },
         "traits": {
             "custom": "",

--- a/packs/data/equipment.db/blight-bomb-moderate.json
+++ b/packs/data/equipment.db/blight-bomb-moderate.json
@@ -11,14 +11,19 @@
             "value": 1
         },
         "bonusDamage": {
-            "value": null
+            "value": 0
         },
         "category": "martial",
         "containerId": null,
         "damage": {
             "damageType": "poison",
             "dice": 2,
-            "die": "d6"
+            "die": "d6",
+            "persistent": {
+                "faces": 4,
+                "number": 2,
+                "type": "poison"
+            }
         },
         "description": {
             "value": "<p><strong>Usage</strong> held in 1 hand</p>\n<p><strong>Activate</strong> <span class=\"pf2-icon\">A</span> Strike</p>\n<p>Blight bombs contain volatile toxic chemicals that rot flesh. A blight bomb deals 2d6 poison damage, 2d4 persistent poison damage, and 2 poison splash damage. You gain a +1 item bonus to attack rolls.</p>"
@@ -40,7 +45,7 @@
             "value": "0"
         },
         "potencyRune": {
-            "value": 0
+            "value": null
         },
         "preciousMaterial": {
             "value": null
@@ -70,24 +75,7 @@
         "reload": {
             "value": "-"
         },
-        "rules": [
-            {
-                "key": "Note",
-                "outcome": [
-                    "success"
-                ],
-                "selector": "{item|_id}-damage",
-                "text": "PF2E.BombNotes.BlightBomb.Moderate.success"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "{item|_id}-damage",
-                "text": "PF2E.BombNotes.BlightBomb.Moderate.criticalSuccess"
-            }
-        ],
+        "rules": [],
         "size": "med",
         "source": {
             "value": "Pathfinder Advanced Player's Guide"
@@ -97,7 +85,7 @@
         },
         "stackGroup": null,
         "strikingRune": {
-            "value": ""
+            "value": null
         },
         "traits": {
             "custom": "",

--- a/packs/data/equipment.db/goo-grenade-greater.json
+++ b/packs/data/equipment.db/goo-grenade-greater.json
@@ -18,7 +18,12 @@
         "damage": {
             "damageType": "acid",
             "dice": 3,
-            "die": "d4"
+            "die": "d4",
+            "persistent": {
+                "faces": null,
+                "number": 3,
+                "type": "acid"
+            }
         },
         "description": {
             "value": "<p><strong>Activate</strong> <span class=\"pf2-icon\">1</span> Strike</p>\n<p>A goo grenade is a flask filled with a fast-growing, short-lived alchemical ooze. When you hit a creature with a goo grenade, that creature takes 3d4 acid damage, 3 persistent acid damage, and 3 acid splash damage, and a -10 circumstance penalty to its Speeds from the clinging goo. You gain a +2 item bonus to attack rolls. The target can end any penalties, conditions, and persistent damage caused by the bomb by Escaping (DC 26) or spending a total of 3 Interact actions to pry themselves free of the ooze. These Interact actions don't have to be consecutive, and other creatures can provide the actions as well.</p>"

--- a/packs/data/equipment.db/goo-grenade-lesser.json
+++ b/packs/data/equipment.db/goo-grenade-lesser.json
@@ -18,7 +18,12 @@
         "damage": {
             "damageType": "acid",
             "dice": 1,
-            "die": "d4"
+            "die": "d4",
+            "persistent": {
+                "faces": null,
+                "number": 1,
+                "type": "acid"
+            }
         },
         "description": {
             "value": "<p><strong>Activate</strong> <span class=\"pf2-icon\">1</span> Strike</p>\n<p>A goo grenade is a flask filled with a fast-growing, short-lived alchemical ooze. When you hit a creature with a goo grenade, that creature takes 1d4 acid damage, 1 persistent acid damage, and 1 acid splash damage, and a -5 circumstance penalty to its Speeds from the clinging goo. The target can end any penalties, conditions, and persistent damage caused by the bomb by Escaping (DC 15) or spending a total of 3 Interact actions to pry themselves free of the ooze. These Interact actions don't have to be consecutive, and other creatures can provide the actions as well.</p>"

--- a/packs/data/equipment.db/goo-grenade-major.json
+++ b/packs/data/equipment.db/goo-grenade-major.json
@@ -18,7 +18,12 @@
         "damage": {
             "damageType": "acid",
             "dice": 4,
-            "die": "d4"
+            "die": "d4",
+            "persistent": {
+                "faces": null,
+                "number": 4,
+                "type": "acid"
+            }
         },
         "description": {
             "value": "<p><strong>Activate</strong> <span class=\"pf2-icon\">1</span> Strike</p>\n<p>A goo grenade is a flask filled with a fast-growing, short-lived alchemical ooze. When you hit a creature with a goo grenade, that creature takes 4d4 acid damage, 4 persistent acid damage, and 4 acid splash damage, and a -10 circumstance penalty to its Speeds from the clinging goo. You gain a +3 item bonus to attack rolls. The target can end any penalties, conditions, and persistent damage caused by the bomb by Escaping (DC 35) or spending a total of 3 Interact actions to pry themselves free of the ooze. These Interact actions don't have to be consecutive, and other creatures can provide the actions as well.</p>"

--- a/packs/data/equipment.db/goo-grenade-moderate.json
+++ b/packs/data/equipment.db/goo-grenade-moderate.json
@@ -18,7 +18,12 @@
         "damage": {
             "damageType": "acid",
             "dice": 2,
-            "die": "d4"
+            "die": "d4",
+            "persistent": {
+                "faces": null,
+                "number": 2,
+                "type": "acid"
+            }
         },
         "description": {
             "value": "<p><strong>Activate</strong> <span class=\"pf2-icon\">1</span> Strike</p>\n<p>A goo grenade is a flask filled with a fast-growing, short-lived alchemical ooze. When you hit a creature with a goo grenade, that creature takes 2d4 acid damage, 2 persistent acid damage, and 2 acid splash damage, and a -5 circumstance penalty to its Speeds from the clinging goo. You gain a +1 item bonus to attack rolls. The target can end any penalties, conditions, and persistent damage caused by the bomb by Escaping (DC 17) or spending a total of 3 Interact actions to pry themselves free of the ooze. These Interact actions don't have to be consecutive, and other creatures can provide the actions as well.</p>"

--- a/packs/data/equipment.db/junk-bomb-greater.json
+++ b/packs/data/equipment.db/junk-bomb-greater.json
@@ -18,7 +18,12 @@
         "damage": {
             "damageType": "slashing",
             "dice": 3,
-            "die": "d8"
+            "die": "d8",
+            "persistent": {
+                "faces": null,
+                "number": 3,
+                "type": "bleed"
+            }
         },
         "description": {
             "value": "<p>This volatile-looking bomb is cobbled together from jagged metal scrap, broken glass, and other bits of razor-sharp fragments, lashed around a core of explosive alchemical slag. A junk bomb deals [[/r 3d8[slashing]]] damage, [[/r 3[persistent,bleed]]] damage, and [[/r {3}[splash,slashing]]]{3 slashing splash damage}.</p>\n<p>You gain a +2 item bonus to attack rolls.</p>"
@@ -40,7 +45,7 @@
             "value": "0"
         },
         "potencyRune": {
-            "value": 0
+            "value": null
         },
         "preciousMaterial": {
             "value": null
@@ -70,24 +75,7 @@
         "reload": {
             "value": "-"
         },
-        "rules": [
-            {
-                "key": "Note",
-                "outcome": [
-                    "success"
-                ],
-                "selector": "{item|_id}-damage",
-                "text": "PF2E.BombNotes.JunkBomb.Greater.success"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "{item|_id}-damage",
-                "text": "PF2E.BombNotes.JunkBomb.Greater.criticalSuccess"
-            }
-        ],
+        "rules": [],
         "size": "med",
         "source": {
             "value": "Pathfinder Special: Fumbus!"
@@ -97,7 +85,7 @@
         },
         "stackGroup": null,
         "strikingRune": {
-            "value": ""
+            "value": null
         },
         "traits": {
             "custom": "",

--- a/packs/data/equipment.db/junk-bomb-lesser.json
+++ b/packs/data/equipment.db/junk-bomb-lesser.json
@@ -18,7 +18,12 @@
         "damage": {
             "damageType": "slashing",
             "dice": 1,
-            "die": "d8"
+            "die": "d8",
+            "persistent": {
+                "faces": null,
+                "number": 1,
+                "type": "bleed"
+            }
         },
         "description": {
             "value": "<p>This volatile-looking bomb is cobbled together from jagged metal scrap, broken glass, and other bits of razor-sharp fragments, lashed around a core of explosive alchemical slag. A junk bomb deals [[/r 1d8[slashing]]] damage, [[/r 1[persistent,bleed]]] damage, and [[/r {1}[splash,slashing]]]{1 slashing splash damage}.</p>"
@@ -40,7 +45,7 @@
             "value": "0"
         },
         "potencyRune": {
-            "value": 0
+            "value": null
         },
         "preciousMaterial": {
             "value": null
@@ -70,24 +75,7 @@
         "reload": {
             "value": "-"
         },
-        "rules": [
-            {
-                "key": "Note",
-                "outcome": [
-                    "success"
-                ],
-                "selector": "{item|_id}-damage",
-                "text": "PF2E.BombNotes.JunkBomb.Lesser.success"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "{item|_id}-damage",
-                "text": "PF2E.BombNotes.JunkBomb.Lesser.criticalSuccess"
-            }
-        ],
+        "rules": [],
         "size": "med",
         "source": {
             "value": "Pathfinder Special: Fumbus!"
@@ -97,7 +85,7 @@
         },
         "stackGroup": null,
         "strikingRune": {
-            "value": ""
+            "value": null
         },
         "traits": {
             "custom": "",

--- a/packs/data/equipment.db/junk-bomb-major.json
+++ b/packs/data/equipment.db/junk-bomb-major.json
@@ -18,7 +18,12 @@
         "damage": {
             "damageType": "slashing",
             "dice": 4,
-            "die": "d8"
+            "die": "d8",
+            "persistent": {
+                "faces": null,
+                "number": 4,
+                "type": "bleed"
+            }
         },
         "description": {
             "value": "<p>This volatile-looking bomb is cobbled together from jagged metal scrap, broken glass, and other bits of razor-sharp fragments, lashed around a core of explosive alchemical slag. A junk bomb deals [[/r 4d8[slashing]]] damage, [[/r 4[persistent,bleed]]] damage, and [[/r {4}[splash,slashing]]]{4 slashing splash damage}.</p>\n<p>You gain a +3 item bonus to attack rolls.</p>"
@@ -40,7 +45,7 @@
             "value": "0"
         },
         "potencyRune": {
-            "value": 0
+            "value": null
         },
         "preciousMaterial": {
             "value": null
@@ -70,24 +75,7 @@
         "reload": {
             "value": "-"
         },
-        "rules": [
-            {
-                "key": "Note",
-                "outcome": [
-                    "success"
-                ],
-                "selector": "{item|_id}-damage",
-                "text": "PF2E.BombNotes.JunkBomb.Major.success"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "{item|_id}-damage",
-                "text": "PF2E.BombNotes.JunkBomb.Major.criticalSuccess"
-            }
-        ],
+        "rules": [],
         "size": "med",
         "source": {
             "value": "Pathfinder Special: Fumbus!"
@@ -97,7 +85,7 @@
         },
         "stackGroup": null,
         "strikingRune": {
-            "value": ""
+            "value": null
         },
         "traits": {
             "custom": "",

--- a/packs/data/equipment.db/junk-bomb-moderate.json
+++ b/packs/data/equipment.db/junk-bomb-moderate.json
@@ -18,7 +18,12 @@
         "damage": {
             "damageType": "slashing",
             "dice": 2,
-            "die": "d8"
+            "die": "d8",
+            "persistent": {
+                "faces": null,
+                "number": 2,
+                "type": "bleed"
+            }
         },
         "description": {
             "value": "<p>This volatile-looking bomb is cobbled together from jagged metal scrap, broken glass, and other bits of razor-sharp fragments, lashed around a core of explosive alchemical slag. A junk bomb deals [[/r 2d8[slashing]]] damage, [[/r 2[persistent,bleed]]] damage, and [[/r {2}[splash,slashing]]]{2 slashing splash damage}.</p>\n<p>You gain a +1 item bonus to attack rolls.</p>"
@@ -40,7 +45,7 @@
             "value": "0"
         },
         "potencyRune": {
-            "value": 0
+            "value": null
         },
         "preciousMaterial": {
             "value": null
@@ -70,24 +75,7 @@
         "reload": {
             "value": "-"
         },
-        "rules": [
-            {
-                "key": "Note",
-                "outcome": [
-                    "success"
-                ],
-                "selector": "{item|_id}-damage",
-                "text": "PF2E.BombNotes.JunkBomb.Moderate.success"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "{item|_id}-damage",
-                "text": "PF2E.BombNotes.JunkBomb.Moderate.criticalSuccess"
-            }
-        ],
+        "rules": [],
         "size": "med",
         "source": {
             "value": "Pathfinder Special: Fumbus!"
@@ -97,7 +85,7 @@
         },
         "stackGroup": null,
         "strikingRune": {
-            "value": ""
+            "value": null
         },
         "traits": {
             "custom": "",

--- a/packs/data/equipment.db/pernicious-spore-bomb-greater.json
+++ b/packs/data/equipment.db/pernicious-spore-bomb-greater.json
@@ -18,7 +18,12 @@
         "damage": {
             "damageType": "poison",
             "dice": 3,
-            "die": ""
+            "die": "",
+            "persistent": {
+                "faces": 4,
+                "number": 3,
+                "type": "piercing"
+            }
         },
         "description": {
             "value": "<p>This flask contains fast-growing mold spores, which quickly take root but just as quickly rot away. You gain a +2 item bonus to attack rolls. The bomb deals [[/r 3[poison]]] damage, [[/r 3d4[persistent,piercing]]] damage, and [[/r {3}[splash,poison]]]{3 poison splash damage}. Except on a critical failure, the bomb's splash area is coated in vegetation, becoming difficult terrain for 1 round.</p>"
@@ -40,7 +45,7 @@
             "value": "0"
         },
         "potencyRune": {
-            "value": 0
+            "value": null
         },
         "preciousMaterial": {
             "value": null
@@ -97,7 +102,7 @@
         },
         "stackGroup": null,
         "strikingRune": {
-            "value": ""
+            "value": null
         },
         "traits": {
             "custom": "",

--- a/packs/data/equipment.db/pernicious-spore-bomb-lesser.json
+++ b/packs/data/equipment.db/pernicious-spore-bomb-lesser.json
@@ -18,7 +18,12 @@
         "damage": {
             "damageType": "poison",
             "dice": 1,
-            "die": ""
+            "die": "",
+            "persistent": {
+                "faces": 4,
+                "number": 1,
+                "type": "piercing"
+            }
         },
         "description": {
             "value": "<p>This flask contains fast-growing mold spores, which quickly take root but just as quickly rot away. The bomb deals [[/r 1[poison]]] damage, [[/r 1d4[persistent,piercing]]] damage, and [[/r {1}[splash,poison]]]{1 poison splash damage}. Except on a critical failure, the bomb's splash area is coated in vegetation, becoming difficult terrain for 1 round.</p>"
@@ -40,7 +45,7 @@
             "value": "0"
         },
         "potencyRune": {
-            "value": 0
+            "value": null
         },
         "preciousMaterial": {
             "value": null
@@ -97,7 +102,7 @@
         },
         "stackGroup": null,
         "strikingRune": {
-            "value": ""
+            "value": null
         },
         "traits": {
             "custom": "",

--- a/packs/data/equipment.db/pernicious-spore-bomb-major.json
+++ b/packs/data/equipment.db/pernicious-spore-bomb-major.json
@@ -18,7 +18,12 @@
         "damage": {
             "damageType": "poison",
             "dice": 4,
-            "die": ""
+            "die": "",
+            "persistent": {
+                "faces": 4,
+                "number": 4,
+                "type": "piercing"
+            }
         },
         "description": {
             "value": "<p>This flask contains fast-growing mold spores, which quickly take root but just as quickly rot away. You gain a +3 item bonus to attack rolls. The bomb deals [[/r 4[poison]]] damage, [[/r 4d4[persistent,piercing]]] damage, and [[/r {4}[splash,poison]]]{4 poison splash damage}. Except on a critical failure, the bomb's splash area is coated in vegetation, becoming difficult terrain for 1 minute.</p>"
@@ -40,7 +45,7 @@
             "value": "0"
         },
         "potencyRune": {
-            "value": 0
+            "value": null
         },
         "preciousMaterial": {
             "value": null
@@ -97,7 +102,7 @@
         },
         "stackGroup": null,
         "strikingRune": {
-            "value": ""
+            "value": null
         },
         "traits": {
             "custom": "",

--- a/packs/data/equipment.db/pernicious-spore-bomb-moderate.json
+++ b/packs/data/equipment.db/pernicious-spore-bomb-moderate.json
@@ -18,7 +18,12 @@
         "damage": {
             "damageType": "poison",
             "dice": 2,
-            "die": ""
+            "die": "",
+            "persistent": {
+                "faces": 4,
+                "number": 2,
+                "type": "piercing"
+            }
         },
         "description": {
             "value": "<p>This flask contains fast-growing mold spores, which quickly take root but just as quickly rot away. You gain a +1 item bonus to attack rolls. The bomb deals [[/r 2[poison]]] damage, [[/r 2d4[persistent,piercing]]] damage, and [[/r {2}[splash,poison]]]{2 poison splash damage}. Except on a critical failure, the bomb's splash area is coated in vegetation, becoming difficult terrain for 1 round.</p>"
@@ -40,7 +45,7 @@
             "value": "0"
         },
         "potencyRune": {
-            "value": 0
+            "value": null
         },
         "preciousMaterial": {
             "value": null
@@ -97,7 +102,7 @@
         },
         "stackGroup": null,
         "strikingRune": {
-            "value": ""
+            "value": null
         },
         "traits": {
             "custom": "",

--- a/packs/data/equipment.db/redpitch-bomb-greater.json
+++ b/packs/data/equipment.db/redpitch-bomb-greater.json
@@ -18,7 +18,12 @@
         "damage": {
             "damageType": "fire",
             "dice": 3,
-            "die": ""
+            "die": "",
+            "persistent": {
+                "faces": 4,
+                "number": 3,
+                "type": "fire"
+            }
         },
         "description": {
             "value": "<p><strong>Usage</strong> held in 1 hand</p>\n<p><strong>Activate <span class=\"pf2-icon\">1</span></strong> Strike</p>\n<p>Sap from redpitch pines, if properly distilled into a gummy, incendiary mass, ignites when exposed to the air. A redpitch bomb deals the listed fire damage, persistent fire damage, and splash damage. Many types grant an item bonus to attack rolls.</p>\n<p>You gain a +2 bonus on attack rolls. The bomb deals 3 fire damage, 3d4 persistent fire damage, and 3 fire splash damage. On a critical hit, the target is @UUID[Compendium.pf2e.conditionitems.Clumsy]{Clumsy 2} until the start of your next turn.</p>"
@@ -40,7 +45,7 @@
             "value": "0"
         },
         "potencyRune": {
-            "value": 0
+            "value": null
         },
         "preciousMaterial": {
             "value": null
@@ -97,7 +102,7 @@
         },
         "stackGroup": null,
         "strikingRune": {
-            "value": ""
+            "value": null
         },
         "traits": {
             "custom": "",

--- a/packs/data/equipment.db/redpitch-bomb-lesser.json
+++ b/packs/data/equipment.db/redpitch-bomb-lesser.json
@@ -11,14 +11,19 @@
             "value": 0
         },
         "bonusDamage": {
-            "value": null
+            "value": 0
         },
         "category": "martial",
         "containerId": null,
         "damage": {
             "damageType": "fire",
             "dice": 1,
-            "die": ""
+            "die": "",
+            "persistent": {
+                "faces": 4,
+                "number": 1,
+                "type": "fire"
+            }
         },
         "description": {
             "value": "<p><strong>Usage</strong> held in 1 hand</p>\n<p><strong>Activate <span class=\"pf2-icon\">1</span></strong> Strike</p>\n<p>Sap from redpitch pines, if properly distilled into a gummy, incendiary mass, ignites when exposed to the air. A redpitch bomb deals the listed fire damage, persistent fire damage, and splash damage. Many types grant an item bonus to attack rolls.</p>\n<p>The bomb deals 1 fire damage, 1d4 persistent fire damage, and 1 fire splash damage. On a critical hit, the target is @UUID[Compendium.pf2e.conditionitems.Clumsy]{Clumsy 1} until the start of your next turn.</p>"
@@ -40,7 +45,7 @@
             "value": "0"
         },
         "potencyRune": {
-            "value": 0
+            "value": null
         },
         "preciousMaterial": {
             "value": null
@@ -97,7 +102,7 @@
         },
         "stackGroup": null,
         "strikingRune": {
-            "value": ""
+            "value": null
         },
         "traits": {
             "custom": "",

--- a/packs/data/equipment.db/redpitch-bomb-major.json
+++ b/packs/data/equipment.db/redpitch-bomb-major.json
@@ -18,7 +18,12 @@
         "damage": {
             "damageType": "fire",
             "dice": 4,
-            "die": ""
+            "die": "",
+            "persistent": {
+                "faces": 4,
+                "number": 4,
+                "type": "fire"
+            }
         },
         "description": {
             "value": "<p><strong>Usage</strong> held in 1 hand</p>\n<p><strong>Activate <span class=\"pf2-icon\">1</span></strong> Strike</p>\n<p>Sap from redpitch pines, if properly distilled into a gummy, incendiary mass, ignites when exposed to the air. A redpitch bomb deals the listed fire damage, persistent fire damage, and splash damage. Many types grant an item bonus to attack rolls.</p>\n<p>You gain a +3 bonus on attack rolls. The bomb deals 4 fire damage, 4d4 persistent fire damage, and 4 fire splash damage. On a critical hit, the target is @UUID[Compendium.pf2e.conditionitems.Clumsy]{Clumsy 3} until the start of your next turn.</p>"
@@ -40,7 +45,7 @@
             "value": "0"
         },
         "potencyRune": {
-            "value": 0
+            "value": null
         },
         "preciousMaterial": {
             "value": null
@@ -97,7 +102,7 @@
         },
         "stackGroup": null,
         "strikingRune": {
-            "value": ""
+            "value": null
         },
         "traits": {
             "custom": "",

--- a/packs/data/equipment.db/redpitch-bomb-moderate.json
+++ b/packs/data/equipment.db/redpitch-bomb-moderate.json
@@ -11,14 +11,19 @@
             "value": 1
         },
         "bonusDamage": {
-            "value": null
+            "value": 0
         },
         "category": "martial",
         "containerId": null,
         "damage": {
             "damageType": "fire",
             "dice": 2,
-            "die": ""
+            "die": "",
+            "persistent": {
+                "faces": 4,
+                "number": 2,
+                "type": "fire"
+            }
         },
         "description": {
             "value": "<p><strong>Usage</strong> held in 1 hand</p>\n<p><strong>Activate <span class=\"pf2-icon\">1</span></strong> Strike</p>\n<p>Sap from redpitch pines, if properly distilled into a gummy, incendiary mass, ignites when exposed to the air. A redpitch bomb deals the listed fire damage, persistent fire damage, and splash damage. Many types grant an item bonus to attack rolls.</p>\n<p>You gain a +1 item bonus to attack rolls. The bomb deals 2 fire damage, 2d4 persistent fire damage, and 2 fire splash damage. On a critical hit, the target is @UUID[Compendium.pf2e.conditionitems.Clumsy]{Clumsy 1} until the start of your next turn.</p>"
@@ -40,7 +45,7 @@
             "value": "0"
         },
         "potencyRune": {
-            "value": 0
+            "value": null
         },
         "preciousMaterial": {
             "value": null
@@ -97,7 +102,7 @@
         },
         "stackGroup": null,
         "strikingRune": {
-            "value": ""
+            "value": null
         },
         "traits": {
             "custom": "",

--- a/packs/data/equipment.db/tallow-bomb-greater.json
+++ b/packs/data/equipment.db/tallow-bomb-greater.json
@@ -70,7 +70,12 @@
         "damage": {
             "damageType": "fire",
             "dice": 0,
-            "die": ""
+            "die": "",
+            "persistent": {
+                "faces": 4,
+                "number": 3,
+                "type": "fire"
+            }
         },
         "description": {
             "value": "<p><strong>Activate</strong> <span class=\"pf2-icon\">A</span> Strike</p>\n<p>A mixture of rendered animal fat and acids designed to ignite the fat when exposed to air, a tallow bomb creates a splash of burning oil that adheres to skin, clothes, and hair. A tallow bomb deals the listed fire damage, persistent fire damage, and splash damage.</p>\n<p>On a critical hit, a living creature taking persistent fire damage from a tallow bomb is @UUID[Compendium.pf2e.conditionitems.Sickened]{Sickened 1} from the stench of burning fat and can't reduce its sickened value below 1 while the persistent fire damage lasts.</p>\n<p>You gain a +2 item bonus to attack rolls. The bomb deals 3d4 persistent fire damage and 3 fire splash damage.</p>"
@@ -92,7 +97,7 @@
             "value": "0"
         },
         "potencyRune": {
-            "value": 0
+            "value": null
         },
         "preciousMaterial": {
             "value": null
@@ -149,7 +154,7 @@
         },
         "stackGroup": null,
         "strikingRune": {
-            "value": ""
+            "value": null
         },
         "traits": {
             "custom": "",

--- a/packs/data/equipment.db/tallow-bomb-lesser.json
+++ b/packs/data/equipment.db/tallow-bomb-lesser.json
@@ -18,7 +18,12 @@
         "damage": {
             "damageType": "fire",
             "dice": 0,
-            "die": ""
+            "die": "",
+            "persistent": {
+                "faces": 4,
+                "number": 1,
+                "type": "fire"
+            }
         },
         "description": {
             "value": "<p><strong>Activate</strong> <span class=\"pf2-icon\">A</span> Strike</p>\n<p>A mixture of rendered animal fat and acids designed to ignite the fat when exposed to air, a tallow bomb creates a splash of burning oil that adheres to skin, clothes, and hair. A tallow bomb deals the listed fire damage, persistent fire damage, and splash damage.</p>\n<p>On a critical hit, a living creature taking persistent fire damage from a tallow bomb is @UUID[Compendium.pf2e.conditionitems.Sickened]{Sickened 1} from the stench of burning fat and can't reduce its sickened value below 1 while the persistent fire damage lasts.</p>\n<p>The bomb deals 1d4 persistent fire damage and 1 fire splash damage.</p>"
@@ -40,7 +45,7 @@
             "value": "0"
         },
         "potencyRune": {
-            "value": 0
+            "value": null
         },
         "preciousMaterial": {
             "value": null
@@ -97,7 +102,7 @@
         },
         "stackGroup": null,
         "strikingRune": {
-            "value": ""
+            "value": null
         },
         "traits": {
             "custom": "",

--- a/packs/data/equipment.db/tallow-bomb-major.json
+++ b/packs/data/equipment.db/tallow-bomb-major.json
@@ -70,7 +70,12 @@
         "damage": {
             "damageType": "fire",
             "dice": 0,
-            "die": ""
+            "die": "",
+            "persistent": {
+                "faces": 4,
+                "number": 4,
+                "type": "fire"
+            }
         },
         "description": {
             "value": "<p><strong>Activate</strong> <span class=\"pf2-icon\">A</span> Strike</p>\n<p>A mixture of rendered animal fat and acids designed to ignite the fat when exposed to air, a tallow bomb creates a splash of burning oil that adheres to skin, clothes, and hair. A tallow bomb deals the listed fire damage, persistent fire damage, and splash damage.</p>\n<p>On a critical hit, a living creature taking persistent fire damage from a tallow bomb is @UUID[Compendium.pf2e.conditionitems.Sickened]{Sickened 1} from the stench of burning fat and can't reduce its sickened value below 1 while the persistent fire damage lasts.</p>\n<p>You gain a +3 item bonus to attack rolls. The bomb deals 4d4 persistent fire damage and 4 fire splash damage.</p>"
@@ -92,7 +97,7 @@
             "value": "0"
         },
         "potencyRune": {
-            "value": 0
+            "value": null
         },
         "preciousMaterial": {
             "value": null
@@ -149,7 +154,7 @@
         },
         "stackGroup": null,
         "strikingRune": {
-            "value": ""
+            "value": null
         },
         "traits": {
             "custom": "",

--- a/packs/data/equipment.db/tallow-bomb-moderate.json
+++ b/packs/data/equipment.db/tallow-bomb-moderate.json
@@ -45,7 +45,12 @@
         "damage": {
             "damageType": "fire",
             "dice": 0,
-            "die": ""
+            "die": "",
+            "persistent": {
+                "faces": 4,
+                "number": 2,
+                "type": "fire"
+            }
         },
         "description": {
             "value": "<p><strong>Activate</strong> <span class=\"pf2-icon\">A</span> Strike</p>\n<p>A mixture of rendered animal fat and acids designed to ignite the fat when exposed to air, a tallow bomb creates a splash of burning oil that adheres to skin, clothes, and hair. A tallow bomb deals the listed fire damage, persistent fire damage, and splash damage.</p>\n<p>On a critical hit, a living creature taking persistent fire damage from a tallow bomb is @UUID[Compendium.pf2e.conditionitems.Sickened]{Sickened 1} from the stench of burning fat and can't reduce its sickened value below 1 while the persistent fire damage lasts.</p>\n<p>You gain a +1 item bonus to attack rolls. The bomb deals 2d4 persistent fire damage and 2 fire splash damage.</p>"
@@ -67,7 +72,7 @@
             "value": "0"
         },
         "potencyRune": {
-            "value": 0
+            "value": null
         },
         "preciousMaterial": {
             "value": null
@@ -124,7 +129,7 @@
         },
         "stackGroup": null,
         "strikingRune": {
-            "value": ""
+            "value": null
         },
         "traits": {
             "custom": "",

--- a/packs/data/equipment.db/twigjack-sack-greater.json
+++ b/packs/data/equipment.db/twigjack-sack-greater.json
@@ -45,7 +45,12 @@
         "damage": {
             "damageType": "piercing",
             "dice": 3,
-            "die": "d6"
+            "die": "d6",
+            "persistent": {
+                "faces": null,
+                "number": 4,
+                "type": "bleed"
+            }
         },
         "description": {
             "value": "<p><strong>Activate</strong> <span class=\"pf2-icon\">1</span> Strike</p>\n<p>Sharp, flexible brambles poke from this sack made of intricately intertwined plant fibers. The sack's contents creak under the strain of the tightly compressed bundle.</p>\n<p>When thrown, a twigjack sack bursts open, spraying brambles in all directions that gouge and slash nearby creatures. A twigjack sack deals the listed piercing damage, persistent bleed damage, and splash damage.</p>\n<p>You gain a +2 item bonus to attack rolls. The bomb deals 3d6 piercing damage, 4 persistent bleed damage, and 3 piercing splash damage.</p>"
@@ -67,7 +72,7 @@
             "value": "0"
         },
         "potencyRune": {
-            "value": 0
+            "value": null
         },
         "preciousMaterial": {
             "value": null
@@ -97,24 +102,7 @@
         "reload": {
             "value": "-"
         },
-        "rules": [
-            {
-                "key": "Note",
-                "outcome": [
-                    "success"
-                ],
-                "selector": "{item|_id}-damage",
-                "text": "PF2E.BombNotes.TwigjackSack.Greater.success"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "{item|_id}-damage",
-                "text": "PF2E.BombNotes.TwigjackSack.Greater.criticalSuccess"
-            }
-        ],
+        "rules": [],
         "size": "med",
         "source": {
             "value": "Pathfinder #175: Broken Tusk Moon"
@@ -124,7 +112,7 @@
         },
         "stackGroup": null,
         "strikingRune": {
-            "value": ""
+            "value": null
         },
         "traits": {
             "custom": "",

--- a/packs/data/equipment.db/twigjack-sack-lesser.json
+++ b/packs/data/equipment.db/twigjack-sack-lesser.json
@@ -45,7 +45,12 @@
         "damage": {
             "damageType": "piercing",
             "dice": 1,
-            "die": "d6"
+            "die": "d6",
+            "persistent": {
+                "faces": null,
+                "number": 1,
+                "type": "bleed"
+            }
         },
         "description": {
             "value": "<p><strong>Activate</strong> <span class=\"pf2-icon\">1</span> Strike</p>\n<p>Sharp, flexible brambles poke from this sack made of intricately intertwined plant fibers. The sack's contents creak under the strain of the tightly compressed bundle.</p>\n<p>When thrown, a twigjack sack bursts open, spraying brambles in all directions that gouge and slash nearby creatures. A twigjack sack deals the listed piercing damage, persistent bleed damage, and splash damage.</p>\n<p>The bomb deals 1d6 piercing damage, 1 persistent bleed damage, and 1 piercing splash damage.</p>"
@@ -67,7 +72,7 @@
             "value": "0"
         },
         "potencyRune": {
-            "value": 0
+            "value": null
         },
         "preciousMaterial": {
             "value": null
@@ -97,24 +102,7 @@
         "reload": {
             "value": "-"
         },
-        "rules": [
-            {
-                "key": "Note",
-                "outcome": [
-                    "success"
-                ],
-                "selector": "{item|_id}-damage",
-                "text": "PF2E.BombNotes.TwigjackSack.Lesser.success"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "{item|_id}-damage",
-                "text": "PF2E.BombNotes.TwigjackSack.Lesser.criticalSuccess"
-            }
-        ],
+        "rules": [],
         "size": "med",
         "source": {
             "value": "Pathfinder #175: Broken Tusk Moon"
@@ -124,7 +112,7 @@
         },
         "stackGroup": null,
         "strikingRune": {
-            "value": ""
+            "value": null
         },
         "traits": {
             "custom": "",

--- a/packs/data/equipment.db/twigjack-sack-major.json
+++ b/packs/data/equipment.db/twigjack-sack-major.json
@@ -70,7 +70,12 @@
         "damage": {
             "damageType": "piercing",
             "dice": 4,
-            "die": "d6"
+            "die": "d6",
+            "persistent": {
+                "faces": null,
+                "number": 5,
+                "type": "bleed"
+            }
         },
         "description": {
             "value": "<p><strong>Activate</strong> <span class=\"pf2-icon\">1</span> Strike</p>\n<p>Sharp, flexible brambles poke from this sack made of intricately intertwined plant fibers. The sack's contents creak under the strain of the tightly compressed bundle.</p>\n<p>When thrown, a twigjack sack bursts open, spraying brambles in all directions that gouge and slash nearby creatures. A twigjack sack deals the listed piercing damage, persistent bleed damage, and splash damage.</p>\n<p>You gain a +3 item bonus to attack rolls. The bomb deals 4d6 piercing damage, 5 persistent bleed damage, and 4 piercing splash damage.</p>"
@@ -92,7 +97,7 @@
             "value": "0"
         },
         "potencyRune": {
-            "value": 0
+            "value": null
         },
         "preciousMaterial": {
             "value": null
@@ -122,24 +127,7 @@
         "reload": {
             "value": "-"
         },
-        "rules": [
-            {
-                "key": "Note",
-                "outcome": [
-                    "success"
-                ],
-                "selector": "{item|_id}-damage",
-                "text": "PF2E.BombNotes.TwigjackSack.Major.success"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "{item|_id}-damage",
-                "text": "PF2E.BombNotes.TwigjackSack.Major.criticalSuccess"
-            }
-        ],
+        "rules": [],
         "size": "med",
         "source": {
             "value": "Pathfinder #175: Broken Tusk Moon"
@@ -149,7 +137,7 @@
         },
         "stackGroup": null,
         "strikingRune": {
-            "value": ""
+            "value": null
         },
         "traits": {
             "custom": "",

--- a/packs/data/equipment.db/twigjack-sack-moderate.json
+++ b/packs/data/equipment.db/twigjack-sack-moderate.json
@@ -45,7 +45,12 @@
         "damage": {
             "damageType": "piercing",
             "dice": 2,
-            "die": "d6"
+            "die": "d6",
+            "persistent": {
+                "faces": null,
+                "number": 3,
+                "type": "bleed"
+            }
         },
         "description": {
             "value": "<p><strong>Activate</strong> <span class=\"pf2-icon\">1</span> Strike</p>\n<p>Sharp, flexible brambles poke from this sack made of intricately intertwined plant fibers. The sack's contents creak under the strain of the tightly compressed bundle.</p>\n<p>When thrown, a twigjack sack bursts open, spraying brambles in all directions that gouge and slash nearby creatures. A twigjack sack deals the listed piercing damage, persistent bleed damage, and splash damage.</p>\n<p>You gain a +1 item bonus to attack rolls. The bomb deals 2d6 piercing damage, 3 persistent bleed damage, and 2 piercing splash damage.</p>"
@@ -67,7 +72,7 @@
             "value": "0"
         },
         "potencyRune": {
-            "value": 0
+            "value": null
         },
         "preciousMaterial": {
             "value": null
@@ -97,24 +102,7 @@
         "reload": {
             "value": "-"
         },
-        "rules": [
-            {
-                "key": "Note",
-                "outcome": [
-                    "success"
-                ],
-                "selector": "{item|_id}-damage",
-                "text": "PF2E.BombNotes.TwigjackSack.Moderate.success"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "{item|_id}-damage",
-                "text": "PF2E.BombNotes.TwigjackSack.Moderate.criticalSuccess"
-            }
-        ],
+        "rules": [],
         "size": "med",
         "source": {
             "value": "Pathfinder #175: Broken Tusk Moon"
@@ -124,7 +112,7 @@
         },
         "stackGroup": null,
         "strikingRune": {
-            "value": ""
+            "value": null
         },
         "traits": {
             "custom": "",


### PR DESCRIPTION
Some notes:

Goo Grenade: Missing note and effect for speed penalty.

I left the notes for these bombs for now, as they contain extra info:

Pernicious Spore Bomb: "The bomb's splash area is coated in vegetation, becoming difficult terrain for 1 round."
Redpitch Bomb: "On a critical hit, the target is Clumsy until the start of my next turn."
Tallow Bomb: "the target is Sickened from the stench of burning fat. The creature can't reduce its sickened value below 1 while the persistent fire damage lasts."