### PR TITLE
Add persistent recovery button and auto-recover on success

### DIFF
--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1814,10 +1814,17 @@
                 "PersistentDamage": {
                     "Name": "Persistent Damage ({formula} {damageType})",
                     "NameWithDC": "Persistent Damage ({formula} DC{dc})",
+                    "Chat": {
+                        "Recover": "Roll Recovery Check",
+                        "RecoverLabel": "Recovery: {name}"
+                    },
                     "Dialog": {
                         "Title": "Persistent Damage ({actor})",
                         "Add": "Add Persistent Damage",
                         "Remove": "Remove Persistent Damage"
+                    },
+                    "Error": {
+                        "DoesNotExist": "No persistent {damageType} damage exists on the actor"
                     }
                 },
                 "Flanked": "Flat-Footed (Flanked)"

--- a/static/templates/chat/persistent-damage-recovery.hbs
+++ b/static/templates/chat/persistent-damage-recovery.hbs
@@ -1,0 +1,7 @@
+<div>
+    <hr/>
+    <button data-action="recover-persistent-damage">
+        <i class="fas fa-dice-d20"></i>
+        {{localize "PF2E.Item.Condition.PersistentDamage.Chat.Recover"}}
+    </button>
+</div>


### PR DESCRIPTION
I stab my own module. I will miss trolling people by calling it `pf2e Persistent Damage`.

![image](https://user-images.githubusercontent.com/1286721/211744617-69d25e9b-11a3-4395-a46d-4046cff6da56.png)

I will have to fix the title name separately, I believe that's an issue with Statistic.