### PR TITLE
Add resistance REs to Armor Expertise

### DIFF
--- a/packs/data/classfeatures.db/armor-expertise.json
+++ b/packs/data/classfeatures.db/armor-expertise.json
@@ -45,6 +45,60 @@
                 "mode": "upgrade",
                 "path": "system.martial.heavy.rank",
                 "value": 2
+            },
+            {
+                "key": "Resistance",
+                "predicate": [
+                    "armor:category:medium",
+                    "armor:group:composite"
+                ],
+                "type": "piercing",
+                "value": "1 + @armor.system.runes.potency"
+            },
+            {
+                "key": "Resistance",
+                "predicate": [
+                    "armor:category:medium",
+                    "armor:group:leather"
+                ],
+                "type": "bludgeoning",
+                "value": "1 + @armor.system.runes.potency"
+            },
+            {
+                "key": "Resistance",
+                "predicate": [
+                    "armor:category:medium",
+                    "armor:group:plate"
+                ],
+                "type": "slashing",
+                "value": "1 + @armor.system.runes.potency"
+            },
+            {
+                "key": "Resistance",
+                "predicate": [
+                    "armor:category:heavy",
+                    "armor:group:composite"
+                ],
+                "type": "piercing",
+                "value": "2 + @armor.system.runes.potency"
+            },
+            {
+                "key": "Resistance",
+                "predicate": [
+                    "armor:category:heavy",
+                    "armor:group:leather"
+                ],
+                "type": "bludgeoning",
+                "value": "2 + @armor.system.runes.potency"
+            },
+            {
+                "key": "Resistance",
+                "predicate": [
+                    "armor:category:heavy",
+                    "armor:group:plate"
+                ],
+                "type": "slashing",
+                "value": "2 + @armor.system.runes.potency"
             }
         ],
         "source": {


### PR DESCRIPTION
Note that this doesn't include chain's critical damage reduction. I suppose we could implement that as a resistance, but it'll take some additional work.