### PR TITLE
Remove Serrating Critical Success Note

### DIFF
--- a/src/module/item/physical/runes.ts
+++ b/src/module/item/physical/runes.ts
@@ -927,7 +927,7 @@ export const WEAPON_PROPERTY_RUNES: Record<WeaponPropertyRuneType, WeaponPropert
     },
     serrating: {
         damage: {
-            dice: [{ damageType: "slashing", diceNumber: 1, dieSize: "d4" }]
+            dice: [{ damageType: "slashing", diceNumber: 1, dieSize: "d4" }],
         },
         level: 10,
         name: "PF2E.WeaponPropertyRune.serrating.Name",

--- a/src/module/item/physical/runes.ts
+++ b/src/module/item/physical/runes.ts
@@ -927,14 +927,7 @@ export const WEAPON_PROPERTY_RUNES: Record<WeaponPropertyRuneType, WeaponPropert
     },
     serrating: {
         damage: {
-            dice: [{ damageType: "slashing", diceNumber: 1, dieSize: "d4" }],
-            notes: [
-                {
-                    outcome: ["criticalSuccess"],
-                    title: "PF2E.WeaponPropertyRune.serrating.Name",
-                    text: "PF2E.WeaponPropertyRune.serrating.Note.criticalSuccess",
-                },
-            ],
+            dice: [{ damageType: "slashing", diceNumber: 1, dieSize: "d4" }]
         },
         level: 10,
         name: "PF2E.WeaponPropertyRune.serrating.Name",


### PR DESCRIPTION
Rune doesn't proc on any kind of hit.