### PR TITLE
Add more specificity to the CSS selectors for Critical Hit/Fumble Journals

### DIFF
--- a/src/styles/system/journal/_index.scss
+++ b/src/styles/system/journal/_index.scss
@@ -1,5 +1,6 @@
-@import "critical-fumble-deck";
-
-.journal-page-content {
-    @include tinymce-system-specific;
+.journal-entry-page {
+    .journal-page-content {
+        @include tinymce-system-specific;
+        @import "critical-fumble-deck";
+    }
 }

--- a/src/styles/system/journal/critical-fumble-deck.scss
+++ b/src/styles/system/journal/critical-fumble-deck.scss
@@ -1,115 +1,152 @@
-.fumble-deck {
-    h1 {
-        border: 2px solid;
-        border-radius: 15px;
-        font-size: 1.75em;
-        font-weight: bold;
-        text-transform: uppercase;
-        padding: 0 0 0 1.5em;
-        background-size: 1.22em;
-        background-repeat: no-repeat;
-        background-color: #e5bf85;
-        position: relative;
-        top: 1em;
-        width: 80%;
-        &:first-child {
-            background-image: url("../icons/equipment/weapons/gnome-hooked-hammer.webp");
+.journal-entry-page {
+    .journal-page-content {
+        .fumble-deck {
+            h1 {
+                font-family: var(--font-primary);
+                font-size: 1.75em;
+                font-weight: bold;
+                line-height: normal;
+                text-transform: uppercase;
+                color: black;
+                border: 2px solid;
+                border-radius: 15px;
+                padding: 0 0 0 1.5em;
+                background-size: 1.22em;
+                background-repeat: no-repeat;
+                background-color: #e5bf85;
+                position: relative;
+                top: 1em;
+                width: 80%;
+
+                &:first-child {
+                    background-image: url("../icons/equipment/weapons/gnome-hooked-hammer.webp");
+                }
+
+                &:nth-of-type(2) {
+                    background-image: url("../icons/equipment/weapons/longbow.webp");
+                }
+
+                &:nth-of-type(3) {
+                    background-image: url("../icons/equipment/weapons/fist.webp");
+                }
+
+                &:nth-of-type(4) {
+                    background-image: url("../icons/spells/chain-lightning.webp");
+                }
+            }
+
+            blockquote {
+                font-family: var(--font-primary);
+                border-left: none;
+                background-color: #000059;
+                color: white;
+                font-size: 120%;
+                margin-left: 0.7em;
+                padding: 1.2em 1.25em 0.75em;
+                border-radius: 8px;
+
+                a {
+                    color: black;
+                }
+
+                span.with-repost {
+                    color: black;
+                }
+            }
+
+            code {
+                font-family: var(--font-primary);
+                font-weight: bold;
+                font-size: 100%;
+                line-height: normal;
+                background-image: url("../assets/critfumble-banner.webp");
+                background-size: 100% 100%;
+                box-shadow: 5px 5px 10px 3px #282a2d;
+                display: inline-block;
+                float: right;
+                text-align: center;
+                margin-top: -1.75em;
+                margin-right: 0.75em;
+                width: 7em;
+                padding: 0.5em;
+            }
         }
-        &:nth-of-type(2) {
-            background-image: url("../icons/equipment/weapons/longbow.webp");
-        }
-        &:nth-of-type(3) {
-            background-image: url("../icons/equipment/weapons/fist.webp");
-        }
-        &:nth-of-type(4) {
-            background-image: url("../icons/spells/chain-lightning.webp");
-        }
-    }
-    blockquote {
-        border-left: none;
-        background-color: #000059;
-        color: white;
-        font-size: 120%;
-        padding-top: 1.2em;
-        padding-bottom: 0.75em;
-        padding-right: 1.25em;
-        a {
-            color: black;
-        }
-        span.with-repost {
-            color: black;
-        }
-    }
-    code {
-        font-family: Arial, Helvetica, sans-serif;
-        font-weight: bold;
-        background-image: url("../assets/critfumble-banner.webp");
-        background-size: 100% 100%;
-        box-shadow: 5px 5px 10px 3px #282a2d;
-        display: inline-block;
-        float: right;
-        text-align: center;
-        margin-top: -1.75em;
-        margin-right: 0.75em;
-        width: 7em;
-        padding: 0.5em;
     }
 }
-.critical-deck {
-    h1 {
-        border: 2px solid;
-        border-radius: 15px;
-        font-size: 1.75em;
-        font-weight: bold;
-        text-transform: uppercase;
-        padding: 0 0 0 1.5em;
-        background-size: 1.22em;
-        background-repeat: no-repeat;
-        background-color: #e5bf85;
-        position: relative;
-        top: 1em;
-        width: 80%;
-        &:first-child {
-            background-image: url("../icons/equipment/weapons/light-hammer.webp");
+
+.journal-entry-page {
+    .journal-page-content {
+        .critical-deck {
+            h1 {
+                font-family: var(--font-primary);
+                font-size: 1.75em;
+                font-weight: bold;
+                line-height: normal;
+                text-transform: uppercase;
+                color: black;
+                border: 2px solid;
+                border-radius: 15px;
+                padding: 0 0 0 1.5em;
+                background-size: 1.22em;
+                background-repeat: no-repeat;
+                background-color: #e5bf85;
+                position: relative;
+                top: 1em;
+                width: 80%;
+
+                &:first-child {
+                    background-image: url("../icons/equipment/weapons/light-hammer.webp");
+                }
+
+                &:nth-of-type(2) {
+                    background-image: url("/icons/weapons/polearms/javelin.webp");
+                }
+
+                &:nth-of-type(3) {
+                    background-image: url("/icons/weapons/axes/axe-battle-worn.webp");
+                }
+
+                &:nth-of-type(4) {
+                    background-image: url("/icons/weapons/thrown/bomb-fuse-cloth-pink.webp");
+                }
+            }
+
+            blockquote {
+                font-family: var(--font-primary);
+                border-left: none;
+                background: rgb(14, 40, 17);
+                background: radial-gradient(circle, rgba(14, 40, 17, 1) 10%, rgba(20, 59, 25, 1) 50%, rgba(14, 40, 17, 1) 90%);
+                color: white;
+                font-size: 120%;
+                margin-left: 0.7em;
+                padding: 1.2em 1.25em 0.75em;
+                border-radius: 8px;
+
+                a {
+                    color: black;
+                }
+
+                span.with-repost {
+                    color: black;
+                }
+            }
+
+            code {
+                font-family: var(--font-primary);
+                font-weight: bold;
+                font-size: 100%;
+                line-height: normal;
+                background-image: url("../assets/critfumble-banner.webp");
+                background-size: 100% 100%;
+                box-shadow: 5px 5px 10px 3px #282a2d;
+                display: inline-block;
+                float: right;
+                text-align: center;
+                margin-top: -1.75em;
+                margin-right: 0.75em;
+                width: 9em;
+                padding: 0.5em;
+            }
         }
-        &:nth-of-type(2) {
-            background-image: url("/icons/weapons/polearms/javelin.webp");
-        }
-        &:nth-of-type(3) {
-            background-image: url("/icons/weapons/axes/axe-battle-worn.webp");
-        }
-        &:nth-of-type(4) {
-            background-image: url("/icons/weapons/thrown/bomb-fuse-cloth-pink.webp");
-        }
-    }
-    blockquote {
-        border-left: none;
-        background: rgb(14, 40, 17);
-        background: radial-gradient(circle, rgba(14, 40, 17, 1) 10%, rgba(20, 59, 25, 1) 50%, rgba(14, 40, 17, 1) 90%);
-        color: white;
-        font-size: 120%;
-        padding-top: 1.2em;
-        padding-bottom: 0.75em;
-        padding-right: 1.25em;
-        a {
-            color: black;
-        }
-        span.with-repost {
-            color: black;
-        }
-    }
-    code {
-        font-family: Arial, Helvetica, sans-serif;
-        font-weight: bold;
-        background-image: url("../assets/critfumble-banner.webp");
-        background-size: 100% 100%;
-        box-shadow: 5px 5px 10px 3px #282a2d;
-        display: inline-block;
-        float: right;
-        text-align: center;
-        margin-top: -1.75em;
-        margin-right: 0.75em;
-        width: 9em;
-        padding: 0.5em;
     }
 }

--- a/src/styles/system/journal/critical-fumble-deck.scss
+++ b/src/styles/system/journal/critical-fumble-deck.scss
@@ -1,152 +1,144 @@
-.journal-entry-page {
-    .journal-page-content {
-        .fumble-deck {
-            h1 {
-                font-family: var(--font-primary);
-                font-size: 1.75em;
-                font-weight: bold;
-                line-height: normal;
-                text-transform: uppercase;
-                color: black;
-                border: 2px solid;
-                border-radius: 15px;
-                padding: 0 0 0 1.5em;
-                background-size: 1.22em;
-                background-repeat: no-repeat;
-                background-color: #e5bf85;
-                position: relative;
-                top: 1em;
-                width: 80%;
+.fumble-deck {
+    h1 {
+        font-family: var(--font-primary);
+        font-size: 1.75em;
+        font-weight: bold;
+        line-height: normal;
+        text-transform: uppercase;
+        color: black;
+        border: 2px solid;
+        border-radius: 15px;
+        padding: 0 0 0 1.5em;
+        background-size: 1.22em;
+        background-repeat: no-repeat;
+        background-color: #e5bf85;
+        position: relative;
+        top: 1em;
+        width: 80%;
 
-                &:first-child {
-                    background-image: url("../icons/equipment/weapons/gnome-hooked-hammer.webp");
-                }
-
-                &:nth-of-type(2) {
-                    background-image: url("../icons/equipment/weapons/longbow.webp");
-                }
-
-                &:nth-of-type(3) {
-                    background-image: url("../icons/equipment/weapons/fist.webp");
-                }
-
-                &:nth-of-type(4) {
-                    background-image: url("../icons/spells/chain-lightning.webp");
-                }
-            }
-
-            blockquote {
-                font-family: var(--font-primary);
-                border-left: none;
-                background-color: #000059;
-                color: white;
-                font-size: 120%;
-                margin-left: 0.7em;
-                padding: 1.2em 1.25em 0.75em;
-                border-radius: 8px;
-
-                a {
-                    color: black;
-                }
-
-                span.with-repost {
-                    color: black;
-                }
-            }
-
-            code {
-                font-family: var(--font-primary);
-                font-weight: bold;
-                font-size: 100%;
-                line-height: normal;
-                background-image: url("../assets/critfumble-banner.webp");
-                background-size: 100% 100%;
-                box-shadow: 5px 5px 10px 3px #282a2d;
-                display: inline-block;
-                float: right;
-                text-align: center;
-                margin-top: -1.75em;
-                margin-right: 0.75em;
-                width: 7em;
-                padding: 0.5em;
-            }
+        &:first-child {
+            background-image: url("../icons/equipment/weapons/gnome-hooked-hammer.webp");
         }
+
+        &:nth-of-type(2) {
+            background-image: url("../icons/equipment/weapons/longbow.webp");
+        }
+
+        &:nth-of-type(3) {
+            background-image: url("../icons/equipment/weapons/fist.webp");
+        }
+
+        &:nth-of-type(4) {
+            background-image: url("../icons/spells/chain-lightning.webp");
+        }
+    }
+
+    blockquote {
+        font-family: var(--font-primary);
+        border-left: none;
+        background-color: #000059;
+        color: white;
+        font-size: 120%;
+        margin-left: 0.7em;
+        padding: 1.2em 1.25em 0.75em;
+        border-radius: 8px;
+
+        a {
+            color: black;
+        }
+
+        span.with-repost {
+            color: black;
+        }
+    }
+
+    code {
+        font-family: var(--font-primary);
+        font-weight: bold;
+        font-size: 100%;
+        line-height: normal;
+        background-image: url("../assets/critfumble-banner.webp");
+        background-size: 100% 100%;
+        box-shadow: 5px 5px 10px 3px #282a2d;
+        display: inline-block;
+        float: right;
+        text-align: center;
+        margin-top: -1.75em;
+        margin-right: 0.75em;
+        width: 7em;
+        padding: 0.5em;
     }
 }
 
-.journal-entry-page {
-    .journal-page-content {
-        .critical-deck {
-            h1 {
-                font-family: var(--font-primary);
-                font-size: 1.75em;
-                font-weight: bold;
-                line-height: normal;
-                text-transform: uppercase;
-                color: black;
-                border: 2px solid;
-                border-radius: 15px;
-                padding: 0 0 0 1.5em;
-                background-size: 1.22em;
-                background-repeat: no-repeat;
-                background-color: #e5bf85;
-                position: relative;
-                top: 1em;
-                width: 80%;
+.critical-deck {
+    h1 {
+        font-family: var(--font-primary);
+        font-size: 1.75em;
+        font-weight: bold;
+        line-height: normal;
+        text-transform: uppercase;
+        color: black;
+        border: 2px solid;
+        border-radius: 15px;
+        padding: 0 0 0 1.5em;
+        background-size: 1.22em;
+        background-repeat: no-repeat;
+        background-color: #e5bf85;
+        position: relative;
+        top: 1em;
+        width: 80%;
 
-                &:first-child {
-                    background-image: url("../icons/equipment/weapons/light-hammer.webp");
-                }
-
-                &:nth-of-type(2) {
-                    background-image: url("/icons/weapons/polearms/javelin.webp");
-                }
-
-                &:nth-of-type(3) {
-                    background-image: url("/icons/weapons/axes/axe-battle-worn.webp");
-                }
-
-                &:nth-of-type(4) {
-                    background-image: url("/icons/weapons/thrown/bomb-fuse-cloth-pink.webp");
-                }
-            }
-
-            blockquote {
-                font-family: var(--font-primary);
-                border-left: none;
-                background: rgb(14, 40, 17);
-                background: radial-gradient(circle, rgba(14, 40, 17, 1) 10%, rgba(20, 59, 25, 1) 50%, rgba(14, 40, 17, 1) 90%);
-                color: white;
-                font-size: 120%;
-                margin-left: 0.7em;
-                padding: 1.2em 1.25em 0.75em;
-                border-radius: 8px;
-
-                a {
-                    color: black;
-                }
-
-                span.with-repost {
-                    color: black;
-                }
-            }
-
-            code {
-                font-family: var(--font-primary);
-                font-weight: bold;
-                font-size: 100%;
-                line-height: normal;
-                background-image: url("../assets/critfumble-banner.webp");
-                background-size: 100% 100%;
-                box-shadow: 5px 5px 10px 3px #282a2d;
-                display: inline-block;
-                float: right;
-                text-align: center;
-                margin-top: -1.75em;
-                margin-right: 0.75em;
-                width: 9em;
-                padding: 0.5em;
-            }
+        &:first-child {
+            background-image: url("../icons/equipment/weapons/light-hammer.webp");
         }
+
+        &:nth-of-type(2) {
+            background-image: url("/icons/weapons/polearms/javelin.webp");
+        }
+
+        &:nth-of-type(3) {
+            background-image: url("/icons/weapons/axes/axe-battle-worn.webp");
+        }
+
+        &:nth-of-type(4) {
+            background-image: url("/icons/weapons/thrown/bomb-fuse-cloth-pink.webp");
+        }
+    }
+
+    blockquote {
+        font-family: var(--font-primary);
+        border-left: none;
+        background: rgb(14, 40, 17);
+        background: radial-gradient(circle, rgba(14, 40, 17, 1) 10%, rgba(20, 59, 25, 1) 50%, rgba(14, 40, 17, 1) 90%);
+        color: white;
+        font-size: 120%;
+        margin-left: 0.7em;
+        padding: 1.2em 1.25em 0.75em;
+        border-radius: 8px;
+
+        a {
+            color: black;
+        }
+
+        span.with-repost {
+            color: black;
+        }
+    }
+
+    code {
+        font-family: var(--font-primary);
+        font-weight: bold;
+        font-size: 100%;
+        line-height: normal;
+        background-image: url("../assets/critfumble-banner.webp");
+        background-size: 100% 100%;
+        box-shadow: 5px 5px 10px 3px #282a2d;
+        display: inline-block;
+        float: right;
+        text-align: center;
+        margin-top: -1.75em;
+        margin-right: 0.75em;
+        width: 9em;
+        padding: 0.5em;
     }
 }


### PR DESCRIPTION
More specificity to the CSS selectors added so the more generic CRB Journal Styles in Dorako UI do not override the look and feel of Critical Hit/Fumble cards.

Also allows the System to specify CSS for Journals without overriding the these specific types of journal entries.

Before:
![image](https://user-images.githubusercontent.com/8051654/212446251-0fa0312f-a038-4576-ba8f-20b9382da29f.png)

After:
![image](https://user-images.githubusercontent.com/8051654/212446321-112a366e-667e-4308-857e-b53357688117.png)
