### PR TITLE
Add effect with an RE for critical fumble deck cards that cause Deafened or Dazzled until the end of next turn.

### DIFF
--- a/packs/data/criticaldeck.db/critical-fumble-deck-41.json
+++ b/packs/data/criticaldeck.db/critical-fumble-deck-41.json
@@ -13,8 +13,9 @@
             "src": null,
             "system": {},
             "text": {
-                "content": "<section class=\"fumble-deck\">\n<h1>All or Nothing</h1>\n<blockquote>\n<p>You take a @UUID[Compendium.pf2e.other-effects.Effect: -1 circumstance penalty to attack rolls until you score a critical hit]{-1 circumstance penalty to attack rolls until you score a critical hit}.</p>\n</blockquote>\n<p><code>Melee</code></p>\n<h1>Close to the Ear</h1>\n<blockquote>\n<p>You are @UUID[Compendium.pf2e.conditionitems.Deafened]{Deafened} until the end of your next turn.</p>\n</blockquote>\n<p><code>Ranged</code></p>\n<h1>Pins and Needles</h1>\n<blockquote>\n<p>You are @UUID[Compendium.pf2e.conditionitems.Sickened]{Sickened 3}.</p>\n</blockquote>\n<p><code>Unarmed</code></p>\n<h1>Why Me?</h1>\n<blockquote>\n<p>You provoke reactions as if you used a move action.</p>\n</blockquote>\n<p><code>Spell</code></p>\n</section>",
-                "format": 1
+                "content": "<section class=\"fumble-deck\"><h1>All or Nothing</h1><blockquote><p>You take a @UUID[Compendium.pf2e.other-effects.Effect: -1 circumstance penalty to attack rolls until you score a critical hit]{-1 circumstance penalty to attack rolls until you score a critical hit}.</p></blockquote><p><code>Melee</code></p><h1>Close to the Ear</h1><blockquote><p>You are @UUID[Compendium.pf2e.other-effects.Effect: Deafened until end of your next turn]{Effect: Deafened until end of your next turn}.</p></blockquote><p><code>Ranged</code></p><h1>Pins and Needles</h1><blockquote><p>You are @UUID[Compendium.pf2e.conditionitems.Sickened]{Sickened 3}.</p></blockquote><p><code>Unarmed</code></p><h1>Why Me?</h1><blockquote><p>You provoke reactions as if you used a move action.</p></blockquote><p><code>Spell</code></p></section>",
+                "format": 1,
+                "markdown": ""
             },
             "title": {
                 "level": 1,

--- a/packs/data/criticaldeck.db/critical-fumble-deck-51.json
+++ b/packs/data/criticaldeck.db/critical-fumble-deck-51.json
@@ -13,8 +13,9 @@
             "src": null,
             "system": {},
             "text": {
-                "content": "<section class=\"fumble-deck\">\n<h1>Fog of War</h1>\n<blockquote>\n<p>You are @UUID[Compendium.pf2e.conditionitems.Dazzled]{Dazzled} until the end of your next turn.</p>\n</blockquote>\n<p><code>Melee</code></p>\n<h1>Bull's Eye</h1>\n<blockquote>\n<p>Your attack ricochets and hits you near the eye. You are @UUID[Compendium.pf2e.conditionitems.Blinded]{Blinded} until the end of your next turn.</p>\n</blockquote>\n<p><code>Ranged</code></p>\n<h1>Jam a Finger</h1>\n<blockquote>\n<p>You the the target for the minimum amount of damage you can deal with the attack. You take the attack's normal damage.</p>\n</blockquote>\n<p><code>Unarmed</code></p>\n<h1>Everything to Fear</h1>\n<blockquote>\n<p>You are @UUID[Compendium.pf2e.conditionitems.Frightened]{Frightened 3}.</p>\n</blockquote>\n<p><code>Spell</code></p>\n</section>",
-                "format": 1
+                "content": "<section class=\"fumble-deck\"><h1>Fog of War</h1><blockquote><p>You are @UUID[Compendium.pf2e.other-effects.Effect: Dazzled until end of your next turn]{Effect: Dazzled until end of your next turn}.</p></blockquote><p><code>Melee</code></p><h1>Bull's Eye</h1><blockquote><p>Your attack ricochets and hits you near the eye. You are @UUID[Compendium.pf2e.conditionitems.Blinded]{Blinded} until the end of your next turn.</p></blockquote><p><code>Ranged</code></p><h1>Jam a Finger</h1><blockquote><p>You the the target for the minimum amount of damage you can deal with the attack. You take the attack's normal damage.</p></blockquote><p><code>Unarmed</code></p><h1>Everything to Fear</h1><blockquote><p>You are @UUID[Compendium.pf2e.conditionitems.Frightened]{Frightened 3}.</p></blockquote><p><code>Spell</code></p></section>",
+                "format": 1,
+                "markdown": ""
             },
             "title": {
                 "level": 1,

--- a/packs/data/criticaldeck.db/critical-fumble-deck-52.json
+++ b/packs/data/criticaldeck.db/critical-fumble-deck-52.json
@@ -13,8 +13,9 @@
             "src": null,
             "system": {},
             "text": {
-                "content": "<section class=\"fumble-deck\">\n<h1>Go for the Eyes</h1>\n<blockquote>\n<p>You are @UUID[Compendium.pf2e.conditionitems.Dazzled]{Dazzled} until the end of your next turn.</p>\n</blockquote>\n<p><code>Melee</code></p>\n<h1>Pinch a Finger</h1>\n<blockquote>\n<p>You take @Localize[PF2E.PersistentDamage.Bleed1d6.success].</p>\n</blockquote>\n<p><code>Ranged</code></p>\n<h1>Winds of Change</h1>\n<blockquote>\n<p>You can't attack the same target again until the end of your next turn.</p>\n</blockquote>\n<p><code>Unarmed</code></p>\n<h1>Now I see You...</h1>\n<blockquote>\n<p>Your target becomes @UUID[Compendium.pf2e.conditionitems.Invisible]{Invisible} until the end of its next turn or uses a hostile action.</p>\n</blockquote>\n<p><code>Spell</code></p>\n</section>",
-                "format": 1
+                "content": "<section class=\"fumble-deck\"><h1>Go for the Eyes</h1><blockquote><p>You are @UUID[Compendium.pf2e.other-effects.Effect: Dazzled until end of your next turn]{Effect: Dazzled until end of your next turn}.</p></blockquote><p><code>Melee</code></p><h1>Pinch a Finger</h1><blockquote><p>You take @Localize[PF2E.PersistentDamage.Bleed1d6.success].</p></blockquote><p><code>Ranged</code></p><h1>Winds of Change</h1><blockquote><p>You can't attack the same target again until the end of your next turn.</p></blockquote><p><code>Unarmed</code></p><h1>Now I see You...</h1><blockquote><p>Your target becomes @UUID[Compendium.pf2e.conditionitems.Invisible]{Invisible} until the end of its next turn or uses a hostile action.</p></blockquote><p><code>Spell</code></p></section>",
+                "format": 1,
+                "markdown": ""
             },
             "title": {
                 "level": 1,

--- a/packs/data/other-effects.db/effect-dazzled-until-end-of-your-next-turn.json
+++ b/packs/data/other-effects.db/effect-dazzled-until-end-of-your-next-turn.json
@@ -1,0 +1,47 @@
+{
+    "_id": "uwYGEeqvt8pwjhXa",
+    "img": "systems/pf2e/icons/effects/critical-effect.webp",
+    "name": "Effect: Dazzled until end of your next turn",
+    "system": {
+        "badge": null,
+        "description": {
+            "value": "<p><strong>Effect applied by @UUID[Compendium.pf2e.criticaldeck.Critical Fumble Deck #51]{Critical Fumble Deck #51}, @UUID[Compendium.pf2e.criticaldeck.Critical Fumble Deck #52]{Critical Fumble Deck #52}</strong></p>\n<p>You are @UUID[Compendium.pf2e.conditionitems.Dazzled]{Dazzled} until the end of your next turn.</p>"
+        },
+        "duration": {
+            "expiry": "turn-end",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "rules": [
+            {
+                "key": "GrantItem",
+                "onDeleteActions": {
+                    "grantee": "restrict"
+                },
+                "uuid": "Compendium.pf2e.conditionitems.Deafened"
+            }
+        ],
+        "source": {
+            "value": "Pathfinder Critical Decks"
+        },
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "target": null,
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        },
+        "unidentified": false
+    },
+    "type": "effect"
+}

--- a/packs/data/other-effects.db/effect-deafened-until-end-of-your-next-turn.json
+++ b/packs/data/other-effects.db/effect-deafened-until-end-of-your-next-turn.json
@@ -1,0 +1,47 @@
+{
+    "_id": "W2OF7VeLHqc7p3DO",
+    "img": "systems/pf2e/icons/effects/critical-effect.webp",
+    "name": "Effect: Deafened until end of your next turn",
+    "system": {
+        "badge": null,
+        "description": {
+            "value": "<p><strong>Effect applied by @UUID[Compendium.pf2e.criticaldeck.Critical Fumble Deck #41]{Critical Fumble Deck #41}</strong></p>\n<p data-pm-slice=\"1 1 [&quot;section&quot;,{&quot;_preserve&quot;:{&quot;class&quot;:&quot;fumble-deck&quot;}},&quot;blockquote&quot;,{&quot;_preserve&quot;:{}}]\">You are @UUID[Compendium.pf2e.conditionitems.Deafened]{Deafened} until the end of your next turn.</p>"
+        },
+        "duration": {
+            "expiry": "turn-end",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "rules": [
+            {
+                "key": "GrantItem",
+                "onDeleteActions": {
+                    "grantee": "restrict"
+                },
+                "uuid": "Compendium.pf2e.conditionitems.Deafened"
+            }
+        ],
+        "source": {
+            "value": "Pathfinder Critical Decks"
+        },
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "target": null,
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "custom": "",
+            "rarity": "common",
+            "value": []
+        },
+        "unidentified": false
+    },
+    "type": "effect"
+}


### PR DESCRIPTION
Specifically fumble cards 41, 51 and 52.
The remaining cards that give conditions till end of next turn give numerical conditions (e.g. Slowed 2) so aren't suitable to grant like this.