### PR TITLE
Fix Tzitzimitl spellcasting DC for innate spells

### DIFF
--- a/packs/data/pathfinder-bestiary-3.db/tzitzimitl.json
+++ b/packs/data/pathfinder-bestiary-3.db/tzitzimitl.json
@@ -95,8 +95,8 @@
                     "value": ""
                 },
                 "spelldc": {
-                    "dc": 0,
-                    "value": 0
+                    "dc": 38,
+                    "value": 30
                 },
                 "tradition": {
                     "value": "occult"


### PR DESCRIPTION
The [Tzitzimitl](https://2e.aonprd.com/Monsters.aspx?ID=1353) was missing the DC / modifier for the innate spells, ritual was set correctly.