### PR TITLE
Remove all domain from flat checks

### DIFF
--- a/src/module/chat-message/document.ts
+++ b/src/module/chat-message/document.ts
@@ -246,7 +246,7 @@ class ChatMessagePF2e extends ChatMessage<ActorPF2e> {
                         name: condition.name,
                     }),
                     check: { type: "flat-check" },
-                    domains: ["all", "flat-check"],
+                    domains: [],
                 }).roll({ dc: { value: dc }, skipDialog: true });
 
                 if ((result?.degreeOfSuccess ?? 0) >= DegreeOfSuccess.SUCCESS) {

--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -131,7 +131,7 @@ export const InlineRollLinks = {
                             slug: "flat-check",
                             modifiers: [],
                             check: { type: "flat-check" },
-                            domains: ["all", "flat-check"],
+                            domains: ["flat-check"],
                         });
                         if (flatCheck) {
                             const dc = Number.isInteger(Number(pf2Dc))


### PR DESCRIPTION
I'd like to leave the inline link flat-check domain for now in case anyone is still using it, though I think once we get new roll types it'll be on consideration for chopping block.