### PR TITLE
Always add class DCs for PCs, refine appearance

### DIFF
--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -1246,6 +1246,10 @@ class CharacterPF2e extends CreaturePF2e {
         classDC.ability ??= "str";
         classDC.rank ??= 0;
         classDC.primary ??= false;
+
+        const classNames: Record<string, string | undefined> = CONFIG.PF2E.classTraits;
+        classDC.label = classDC.label ?? classNames[slug] ?? slug.titleCase();
+
         return new Statistic(this, {
             slug,
             label: classDC.label,

--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -103,7 +103,9 @@ class CharacterSheetPF2e extends CreatureSheetPF2e<CharacterPF2e> {
         );
 
         // Class DCs
-        const classDCs = Object.values(sheetData.data.proficiencies.classDCs)
+        const allClassDCs = Object.values(sheetData.data.proficiencies.classDCs);
+        const classDCs = allClassDCs
+            .filter((cdc) => cdc.rank > 0 || allClassDCs.length > 1)
             .map(
                 (classDC): ClassDCSheetData => ({
                     ...classDC,

--- a/src/module/actor/sheet/spellcasting-dialog.ts
+++ b/src/module/actor/sheet/spellcasting-dialog.ts
@@ -1,4 +1,5 @@
 import { ActorPF2e } from "@actor";
+import { ClassDCData } from "@actor/character/data";
 import { SpellcastingEntryPF2e } from "@item";
 import { SpellcastingEntrySource, SpellcastingEntrySystemData } from "@item/spellcasting-entry/data";
 import { pick } from "@util";
@@ -44,9 +45,16 @@ class SpellcastingCreateAndEditDialog extends FormApplication<Embedded<Spellcast
     }
 
     override async getData(): Promise<SpellcastingCreateAndEditDialogSheetData> {
+        const { actor } = this;
+
+        const classDCs = actor.isOfType("character")
+            ? Object.values(actor.system.proficiencies.classDCs).filter((cdc) => cdc.rank > 0)
+            : [];
+
         return {
             ...(await super.getData()),
-            actor: this.actor,
+            actor,
+            classDCs,
             data: this.object.toObject().system,
             magicTraditions: CONFIG.PF2E.magicTraditions,
             spellcastingTypes: CONFIG.PF2E.preparationType,
@@ -153,6 +161,7 @@ class SpellcastingCreateAndEditDialog extends FormApplication<Embedded<Spellcast
 interface SpellcastingCreateAndEditDialogSheetData extends FormApplicationData<Embedded<SpellcastingEntryPF2e>> {
     actor: ActorPF2e;
     data: SpellcastingEntrySystemData;
+    classDCs: ClassDCData[];
     magicTraditions: ConfigPF2e["PF2E"]["magicTraditions"];
     spellcastingTypes: ConfigPF2e["PF2E"]["preparationType"];
     abilities: ConfigPF2e["PF2E"]["abilities"];

--- a/src/module/item/class/document.ts
+++ b/src/module/item/class/document.ts
@@ -112,19 +112,17 @@ class ClassPF2e extends ABCItemPF2e {
         attributes.perception.rank = Math.max(attributes.perception.rank, this.perception) as ZeroToFour;
         this.logAutoChange("system.attributes.perception.rank", this.perception);
 
-        // Set class DC if trained
-        if (this.classDC > 0) {
-            type PartialClassDCs = Record<string, Pick<ClassDCData, "label" | "ability" | "rank" | "primary">>;
-            const classDCs: PartialClassDCs = proficiencies.classDCs;
-            classDCs[slug] = {
-                label: this.name,
-                rank: this.classDC,
-                ability: this.system.keyAbility.selected ?? "str",
-                primary: true,
-            };
+        // Set class DC
+        type PartialClassDCs = Record<string, Pick<ClassDCData, "label" | "ability" | "rank" | "primary">>;
+        const classDCs: PartialClassDCs = proficiencies.classDCs;
+        classDCs[slug] = {
+            label: this.name,
+            rank: this.classDC,
+            ability: this.system.keyAbility.selected ?? "str",
+            primary: true,
+        };
 
-            this.logAutoChange(`system.proficiencies.classDCs.${slug}.rank`, this.classDC);
-        }
+        this.logAutoChange(`system.proficiencies.classDCs.${slug}.rank`, this.classDC);
 
         for (const category of ARMOR_CATEGORIES) {
             martial[category].rank = Math.max(martial[category].rank, this.defenses[category]) as ZeroToFour;

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -719,6 +719,7 @@
                 "AncestryClass": "{ancestry} {class}",
                 "ClassDC": {
                     "Label": "Class DC",
+                    "LabelSpecific": "Class DC ({class})",
                     "Plural": "Class DCs"
                 },
                 "Configure": {

--- a/static/templates/actors/spellcasting-dialog.hbs
+++ b/static/templates/actors/spellcasting-dialog.hbs
@@ -47,15 +47,14 @@
                 <div class="form-group">
                     <label>{{localize "PF2E.ProficiencyLabel"}}</label>
                     <select name="system.proficiency.slug">
-                    {{#select data.proficiency.slug}}
-                        {{#if data.tradition.value}}
-                            <option value="">{{localize "PF2E.MagicTraditionLabel"}}</option>
-                        {{/if}}
-                        <option value="classDC">{{localize "PF2E.Actor.Character.ClassDC.Label"}}</option>
-                        {{#each actor.classDCs as |classDC|}}
-                            <option value="{{classDC.slug}}">{{classDC.label}}</option>
-                        {{/each}}
-                    {{/select}}
+                        {{#select data.proficiency.slug}}
+                            {{#if data.tradition.value}}
+                                <option value="">{{localize "PF2E.MagicTraditionLabel"}}</option>
+                            {{/if}}
+                            {{#each classDCs as |classDC|}}
+                                <option value="{{classDC.slug}}">{{localize "PF2E.Actor.Character.ClassDC.LabelSpecific" class=classDC.label}}</option>
+                            {{/each}}
+                        {{/select}}
                     </select>
                 </div>
             {{/if}}


### PR DESCRIPTION
This removes the exclusion of untrained class DCs when populating `system.proficiencies.classDCs`. A character with only a single untrained class DC won't have it appear on their sheet, but it will be present and available for the occasional mechanical necessity. Class DC options when creating spellcasting entries will only include trained (or better) class DCs, and will appear as "Class DC ([class name])"