### PR TITLE
Add Bazaar paths to default-icons list

### DIFF
--- a/src/module/scene/token-document/document.ts
+++ b/src/module/scene/token-document/document.ts
@@ -144,6 +144,7 @@ class TokenDocumentPF2e<TActor extends ActorPF2e = ActorPF2e> extends TokenDocum
         const tokenImgIsDefault = [
             ActorPF2e.DEFAULT_ICON,
             `systems/pf2e/icons/default-icons/${this.actor.type}.svg`,
+            `https://assets.forge-vtt.com/bazaar/systems/pf2e/assets/icons/default-icons/${this.actor.type}.svg`,
         ].includes(this.texture.src);
         if (tokenImgIsDefault) {
             this.texture.src = this.actor._source.img;


### PR DESCRIPTION
Hey there

This addition is necessary because entity path migration to Bazaar hosted file paths on The Forge may cause some `pf2e` packs to show `token.texture.src` rather than `actor.img` since Bazaar path `token.texture.src` is not included in `tokenImgIsDefault` array.

The Forge Assets Library prefix URL is available in the variable `ForgeVTT.ASSETS_LIBRARY_URL_PREFIX` if running on The Forge, meaning that a more complete check could be 
```ts
        const defaultIcons = [ActorPF2e.DEFAULT_ICON, `systems/pf2e/icons/default-icons/${this.actor.type}.svg`];
        // Users on The Forge may have paths that point to Bazaar hosted system assets
        // @ts-ignore
        if (typeof ForgeVTT !== "undefined" && ForgeVTT.usingTheForge) {
            defaultIcons.push(
                // @ts-ignore
                `${ForgeVTT.ASSETS_LIBRARY_URL_PREFIX}bazaar/systems/pf2e/assets/icons/default-icons/${this.actor.type}.svg`,
            );
        }
        const tokenImgIsDefault = defaultIcons.includes(this.texture.src);
```
However, with TypeScript in play and the full URL already appearing [elsewhere](https://github.com/foundryvtt/pf2e/blob/master/packs/scripts/extract.ts#L141), I imagine that it is simpler to add it in as it appears in the commit. 

Solves https://github.com/foundryvtt/foundryvtt-premium-content/issues/219