### PR TITLE
Add second open ability boost to Harrow-Led and raised by Belief backgrounds

### DIFF
--- a/packs/data/backgrounds.db/harrow-led.json
+++ b/packs/data/backgrounds.db/harrow-led.json
@@ -5,7 +5,14 @@
     "system": {
         "boosts": {
             "0": {
-                "value": []
+                "value": [
+                    "cha",
+                    "con",
+                    "dex",
+                    "int",
+                    "str",
+                    "wis"
+                ]
             },
             "1": {
                 "value": [

--- a/packs/data/backgrounds.db/raised-by-belief.json
+++ b/packs/data/backgrounds.db/raised-by-belief.json
@@ -5,7 +5,14 @@
     "system": {
         "boosts": {
             "0": {
-                "value": []
+                "value": [
+                    "cha",
+                    "con",
+                    "dex",
+                    "int",
+                    "str",
+                    "wis"
+                ]
             },
             "1": {
                 "value": [


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/5790