### PR TITLE
Allow token images on other hosts to be default

### DIFF
--- a/src/module/scene/token-document/document.ts
+++ b/src/module/scene/token-document/document.ts
@@ -144,7 +144,7 @@ class TokenDocumentPF2e<TActor extends ActorPF2e = ActorPF2e> extends TokenDocum
         const tokenImgIsDefault = [
             ActorPF2e.DEFAULT_ICON,
             `systems/pf2e/icons/default-icons/${this.actor.type}.svg`,
-        ].includes(this.texture.src);
+        ].some((path) => this.texture.src?.endsWith(path));
         if (tokenImgIsDefault) {
             this.texture.src = this.actor._source.img;
         }


### PR DESCRIPTION
I can't guarantee that this will fix forge. But looking at their PR, I have a decent amount of faith this will work (though perhaps we'll have to do the same in more locations as well).