### PR TITLE
Allow for decimal scales in TokenImage

### DIFF
--- a/src/module/rules/rule-element/token-image.ts
+++ b/src/module/rules/rule-element/token-image.ts
@@ -21,7 +21,7 @@ export class TokenImageRuleElement extends RuleElementPF2e {
             this.value = null;
         }
 
-        if (typeof data.scale === "number" && Number.isInteger(data.scale)) {
+        if (typeof data.scale === "number" && Number(data.scale)) {
             this.scale = data.scale;
         }
     }

--- a/src/module/rules/rule-element/token-image.ts
+++ b/src/module/rules/rule-element/token-image.ts
@@ -21,7 +21,7 @@ export class TokenImageRuleElement extends RuleElementPF2e {
             this.value = null;
         }
 
-        if (typeof data.scale === "number" && Number(data.scale)) {
+        if (typeof data.scale === "number" && data.scale > 0) {
             this.scale = data.scale;
         }
     }


### PR DESCRIPTION
Currently `scale` only takes integers, which can be hard to set up properly for tokens with pop-out elements.