### PR TITLE
Fix newly created kits erroring on sheet open

### DIFF
--- a/static/template.json
+++ b/static/template.json
@@ -1100,7 +1100,10 @@
             "templates": [
                 "common"
             ],
-            "items": {}
+            "items": {},
+            "price": {
+                "value": {}
+            }
         },
         "condition": {
             "templates": [


### PR DESCRIPTION
How did this ever work at any point after the entire coins refactor? Wondering if it was some change in template.json I didn't notice.