### PR TITLE
Add a dialog to modifiy damage roll modifiers

### DIFF
--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -104,6 +104,7 @@ import { CharacterFeats } from "./feats";
 import { createForceOpenPenalty, createShoddyPenalty, StrikeWeaponTraits } from "./helpers";
 import { CharacterHitPointsSummary, CharacterSkills, CreateAuxiliaryParams, DexterityModifierCapData } from "./types";
 import { CHARACTER_SHEET_TABS } from "./values";
+import { eventToRollParams } from "@scripts/sheet-util";
 
 class CharacterPF2e extends CreaturePF2e {
     /** Core singular embeds for PCs */
@@ -1815,32 +1816,37 @@ class CharacterPF2e extends CreaturePF2e {
                     return "";
                 }
 
-                const damage = WeaponDamagePF2e.calculate({
+                const outcome = method === "damage" ? "success" : "criticalSuccess";
+                const { self, target, options } = context;
+                const damageContext: DamageRollContext = {
+                    type: "damage-roll",
+                    sourceType: "attack",
+                    self,
+                    target,
+                    outcome,
+                    options,
+                    domains,
+                    ...eventToRollParams(params.event),
+                };
+
+                if (params.getFormula) {
+                    damageContext.skipDialog = true;
+                }
+
+                const damage = await WeaponDamagePF2e.calculate({
                     weapon: context.self.item,
                     actor: context.self.actor,
                     actionTraits: context.traits,
                     proficiencyRank,
-                    options: context.options,
                     weaponPotency,
+                    context: damageContext,
                 });
                 if (!damage) return null;
 
-                const outcome = method === "damage" ? "success" : "criticalSuccess";
                 if (params.getFormula) {
                     const formula = damage.damage.formula[outcome];
                     return formula ? new DamageRoll(formula).formula : "";
                 } else {
-                    const { self, target, options } = context;
-                    const damageContext: DamageRollContext = {
-                        type: "damage-roll",
-                        sourceType: "attack",
-                        self,
-                        target,
-                        outcome,
-                        options,
-                        domains: damage.domains,
-                    };
-
                     return DamagePF2e.roll(damage, damageContext, params.callback);
                 }
             };

--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -37,17 +37,10 @@ import { SpellOverlayCollection } from "./overlay";
 import { EffectAreaSize, MagicSchool, MagicTradition, SpellComponent, SpellTrait } from "./types";
 import { DamageInstance, DamageRoll } from "@system/damage/roll";
 import { InstancePool } from "@system/damage/terms";
+import { DamageModifierDialog } from "@system/damage/modifier-dialog";
 
 interface SpellConstructionContext extends ItemConstructionContextPF2e {
     fromConsumable?: boolean;
-}
-
-interface SpellDamage {
-    roll: DamageRoll;
-    domains: string[];
-    options: Set<string>;
-    modifiers: (ModifierPF2e | DamageDicePF2e)[];
-    breakdownTags: string[];
 }
 
 class SpellPF2e extends ItemPF2e {
@@ -200,9 +193,9 @@ class SpellPF2e extends ItemPF2e {
         return rollData;
     }
 
-    get damage(): SpellDamage | null {
+    async getDamage(damageOptions: SpellDamageOptions = { skipDialog: true }): Promise<SpellDamage | null> {
         // Return early if the spell doesn't deal damage
-        if (!Object.keys(this.system.damage.value).length) {
+        if (!Object.keys(this.system.damage.value).length || !this.actor) {
             return null;
         }
 
@@ -272,6 +265,21 @@ class SpellPF2e extends ItemPF2e {
             [actor?.getRollOptions(domains) ?? [], this.getRollOptions("item"), [...this.traits]].flat()
         );
 
+        const context: DamageRollContext = {
+            type: "damage-roll",
+            sourceType: this.isAttack ? "attack" : "save",
+            outcome: this.isAttack ? "success" : "failure", // we'll need to support other outcomes later
+            domains,
+            options,
+            self: {
+                actor: this.actor,
+                item: this,
+                token: this.actor.token,
+                modifiers: [],
+            },
+            rollMode: damageOptions.rollMode,
+        };
+
         // Add modifiers and damage die adjustments
         const modifiers: ModifierPF2e[] = [];
         const damageDice: DamageDicePF2e[] = [];
@@ -309,11 +317,25 @@ class SpellPF2e extends ItemPF2e {
                 })
             );
 
+            if (BUILD_MODE === "development" && !damageOptions.skipDialog) {
+                const baseDamageType = Object.values(this.system.damage.value)[0]?.type.value;
+                const rolled = await new DamageModifierDialog({
+                    modifiers: testedModifiers,
+                    dice: damageDice,
+                    context,
+                    baseDamageType,
+                }).resolve();
+                if (!rolled) return null;
+            }
+
             // Apply any damage dice upgrades (such as harmful font)
             applyDamageDiceOverrides(Object.values(formulas), damageDice);
 
             // Add modifiers to instances
             for (const modifier of testedModifiers) {
+                // Skip modifiers that were ignored in the dialog
+                if (modifier.ignored) continue;
+
                 const firstInstance = Object.values(formulas)[0];
                 const damageCategory = modifier.damageCategory;
                 const damageType = modifier.damageType ?? (damageCategory ? firstInstance.damageType : null);
@@ -323,7 +345,7 @@ class SpellPF2e extends ItemPF2e {
 
             // Add damage dice to instances
             for (const dice of damageDice) {
-                if (dice.override) continue;
+                if (dice.override || dice.ignored) continue;
                 const firstInstance = Object.values(formulas)[0];
                 const damageCategory = dice.category;
                 const damageType = dice.damageType ?? (damageCategory ? firstInstance.damageType : null);
@@ -394,7 +416,20 @@ class SpellPF2e extends ItemPF2e {
                     ({ formula, flavor }) => new DamageInstance(formula, {}, { flavor, critRule })
                 );
                 const roll = DamageRoll.fromTerms([InstancePool.fromRolls(instances)], { critRule });
-                return { roll, breakdownTags, domains, options, modifiers: [...modifiers, ...damageDice] };
+
+                const damage: SpellDamageTemplate = {
+                    name: this.name,
+                    damage: { roll, breakdownTags },
+                    notes: [],
+                    materials: roll.materials,
+                    traits: this.castingTraits,
+                    modifiers,
+                };
+
+                return {
+                    template: damage,
+                    context,
+                };
             }
         } catch (err) {
             console.error(err);
@@ -652,6 +687,7 @@ class SpellPF2e extends ItemPF2e {
     }
 
     override async getChatData(
+        this: Embedded<SpellPF2e>,
         htmlOptions: EnrichHTMLOptionsPF2e = {},
         rollOptions: { castLevel?: number | string; slotLevel?: number | string } = {}
     ): Promise<Omit<ItemSummaryData, "traits">> {
@@ -711,7 +747,7 @@ class SpellPF2e extends ItemPF2e {
         const statisticChatData = statistic.getChatData({ item: this });
         const spellDC = statisticChatData.dc.value;
         const isSave = systemData.spellType.value === "save" || systemData.save.value !== "";
-        const damage = this.damage;
+        const damage = await this.getDamage();
         const hasDamage = !!damage; // needs new check // formula && formula !== "0";
 
         // Spell save label
@@ -782,7 +818,7 @@ class SpellPF2e extends ItemPF2e {
             slotLevel,
             levelLabel,
             damageLabel,
-            formula: damage?.roll.formula,
+            formula: damage?.template.damage.roll.formula,
             properties,
             spellTraits,
             traits: spellTraits,
@@ -826,34 +862,12 @@ class SpellPF2e extends ItemPF2e {
             if (variant) return variant.rollDamage(event);
         }
 
-        const spellDamage = this.damage;
+        const spellDamage = await this.getDamage(eventToRollParams(event));
         if (!spellDamage) return null;
 
-        const { roll, domains, options, modifiers, breakdownTags } = spellDamage;
-        const damage: SpellDamageTemplate = {
-            name: this.name,
-            damage: { roll, breakdownTags },
-            notes: [],
-            materials: roll.materials,
-            traits: this.castingTraits,
-            modifiers,
-        };
+        const { template, context } = spellDamage;
 
-        const context: DamageRollContext = {
-            type: "damage-roll",
-            sourceType: this.isAttack ? "attack" : "save",
-            outcome: this.isAttack ? "success" : "failure", // we'll need to support other outcomes later
-            domains,
-            options,
-            self: {
-                actor: this.actor,
-                item: this,
-                token: this.actor.token,
-                modifiers: [],
-            },
-        };
-
-        return DamagePF2e.roll(damage, context);
+        return DamagePF2e.roll(template, context);
     }
 
     /** Roll counteract check */
@@ -968,6 +982,11 @@ interface SpellPF2e {
     overlays: SpellOverlayCollection;
 }
 
+interface SpellDamage {
+    template: SpellDamageTemplate;
+    context: DamageRollContext;
+}
+
 interface SpellVariantChatData {
     actions: ImageFilePath | null;
     name: string;
@@ -979,6 +998,11 @@ interface SpellToMessageOptions {
     create?: boolean;
     rollMode?: RollMode;
     data?: { castLevel?: number };
+}
+
+interface SpellDamageOptions {
+    rollMode?: RollMode | "roll";
+    skipDialog?: boolean;
 }
 
 export { SpellPF2e, SpellToMessageOptions };

--- a/src/module/system/damage/modifier-dialog.ts
+++ b/src/module/system/damage/modifier-dialog.ts
@@ -1,0 +1,350 @@
+import { ModifierPF2e, MODIFIER_TYPES, DamageDicePF2e, applyStackingRules } from "@actor/modifiers";
+import {
+    ErrorPF2e,
+    htmlQuery,
+    htmlQueryAll,
+    pick,
+    setHasElement,
+    sluggify,
+    sortStringRecord,
+    tupleHasValue,
+} from "@util";
+import { DamageCategoryUnique, DamageDieSize, DamageRollContext, DamageType } from "./types";
+import { DAMAGE_CATEGORIES_UNIQUE, DAMAGE_TYPE_ICONS } from "./values";
+// import { LocalizePF2e } from "../localize";
+
+/**
+ * Dialog for excluding certain modifiers before rolling damage.
+ * @category Other
+ */
+class DamageModifierDialog extends Application {
+    /** The modifiers which are being edited. */
+    modifiers: ModifierPF2e[];
+    /** The damage dice which are being edited. */
+    dice: DamageDicePF2e[];
+    /** The base damage type of this damage roll */
+    baseDamageType: DamageType;
+    /** Relevant context for this roll, like roll options. */
+    context: Partial<DamageRollContext>;
+    /** Is this critical damage? */
+    isCritical: boolean;
+    /** A Promise resolve method */
+    #resolve?: (value: boolean) => void;
+    /** Was the roll button pressed? */
+    isRolled = false;
+
+    constructor(params: DamageDialogParams) {
+        super();
+
+        this.modifiers = params.modifiers ?? [];
+        this.dice = params.dice ?? [];
+        this.baseDamageType = params.baseDamageType;
+        this.context = params.context ?? {};
+        this.isCritical = this.context.outcome === "criticalSuccess";
+    }
+
+    static override get defaultOptions(): ApplicationOptions {
+        return {
+            ...super.defaultOptions,
+            template: "systems/pf2e/templates/chat/damage/damage-modifier-dialog.hbs",
+            classes: ["damage-dialog", "dialog"],
+            popOut: true,
+            width: 480,
+            height: "auto",
+        };
+    }
+
+    override get title(): string {
+        return this.isCritical
+            ? game.i18n.localize("PF2E.Damage.Dialog.CriticalDamageRoll")
+            : game.i18n.localize("PF2E.Damage.Dialog.DamageRoll");
+    }
+
+    #getDamageIcon(type: DamageType | null): string | null {
+        if (!type) return null;
+        const icon = DAMAGE_TYPE_ICONS[type];
+        if (icon) {
+            return `fa-fw fa-solid fa-${icon} icon`;
+        }
+        return null;
+    }
+
+    #getCategoryIcon(category: DamageCategoryUnique | string | null, damageType: DamageType | null): string | null {
+        switch (category) {
+            case "persistent":
+                return damageType === "bleed" ? null : "fa-fw fa-duotone fa-hourglass icon";
+            case "precision":
+                return "fa-fw fa-solid fa-crosshairs icon";
+            case "splash":
+                return "fa-fw fa-solid fa-burst icon";
+            default:
+                return null;
+        }
+    }
+
+    #getTypeLabel(damageType: DamageType | null, category: DamageCategoryUnique | null): string | null {
+        if (category === "precision") {
+            return game.i18n.localize("PF2E.Damage.Precision");
+        }
+        if (!damageType) return null;
+        const typeLabel = game.i18n.localize(CONFIG.PF2E.damageTypes[damageType]);
+
+        switch (category) {
+            case "persistent":
+                return game.i18n.format("PF2E.Damage.PersistentTooltip", { damageType: typeLabel });
+            case "splash":
+                return game.i18n.format("PF2E.Damage.Dialog.Splash", { damageType: typeLabel });
+            default:
+                return typeLabel;
+        }
+    }
+
+    #getDiceLabel(dice: DamageDicePF2e): string {
+        if (!dice.diceNumber || !dice.dieSize) return "";
+
+        const facesLabel = game.i18n.localize(`PF2E.DamageDie${dice.dieSize.toUpperCase()}`);
+        return `${dice.diceNumber}${facesLabel}`;
+    }
+
+    override async getData(): Promise<DamageDialogData> {
+        const modifiers: ModifierData[] = this.modifiers.map((m) => {
+            const damageType = m.damageType ?? this.baseDamageType;
+
+            return {
+                label: m.label,
+                category: m.category,
+                type: m.type,
+                modifier: m.modifier,
+                hideIfDisabled: m.hideIfDisabled,
+                damageType,
+                typeLabel: this.#getTypeLabel(damageType, m.damageCategory),
+                enabled: m.enabled,
+                ignored: m.ignored,
+                critical: m.critical,
+                show: this.isCritical || !m.critical,
+                icon: this.#getDamageIcon(damageType),
+                categoryIcon: this.#getCategoryIcon(m.category, damageType),
+            } satisfies ModifierData;
+        });
+
+        const dice: DamageDiceData[] = this.dice.map((d) => ({
+            label: d.label,
+            category: d.category,
+            damageType: d.damageType,
+            typeLabel: this.#getTypeLabel(d.damageType, d.category),
+            diceLabel: this.#getDiceLabel(d),
+            enabled: d.enabled,
+            ignored: d.ignored,
+            critical: d.critical,
+            show: !d.override && (this.isCritical || !d.critical),
+            icon: this.#getDamageIcon(d.damageType),
+            categoryIcon: this.#getCategoryIcon(d.category, d.damageType),
+        }));
+
+        const hasVisibleModifiers = modifiers.filter((m) => m.show).length > 0;
+        const hasVisibleDice = dice.filter((d) => d.show).length > 0;
+
+        return {
+            appId: this.id,
+            modifiers,
+            dice,
+            isCritical: this.isCritical,
+            hasVisibleDice,
+            hasVisibleModifiers,
+            damageTypes: sortStringRecord(CONFIG.PF2E.damageTypes),
+            damageSubtypes: sortStringRecord(pick(CONFIG.PF2E.damageCategories, DAMAGE_CATEGORIES_UNIQUE)),
+            rollModes: CONFIG.Dice.rollModes,
+            rollMode: this.context?.rollMode,
+        };
+    }
+
+    override activateListeners($html: JQuery): void {
+        const html = $html[0];
+
+        htmlQuery<HTMLButtonElement>(html, "button.roll")?.addEventListener("click", () => {
+            this.isRolled = true;
+            this.close();
+        });
+
+        for (const checkbox of htmlQueryAll<HTMLInputElement>(html, ".modifier-container input[type=checkbox]")) {
+            checkbox.addEventListener("click", () => {
+                const modIndex = Number(checkbox.dataset.modifierIndex);
+                const dieIndex = Number(checkbox.dataset.diceIndex);
+                if (!Number.isNaN(modIndex)) {
+                    this.modifiers[modIndex].ignored = !checkbox.checked;
+                    applyStackingRules(this.modifiers);
+                } else if (!Number.isNaN(dieIndex)) {
+                    this.dice[dieIndex].ignored = !checkbox.checked;
+                    this.dice[dieIndex].enabled = checkbox.checked;
+                }
+                this.render();
+            });
+        }
+
+        const categorySelect = htmlQuery<HTMLSelectElement>(html, "select.add-dice-category");
+        const damageTypeSelect = htmlQuery<HTMLSelectElement>(html, "select.add-dice-type");
+        categorySelect?.addEventListener("change", () => {
+            if (damageTypeSelect) {
+                if (categorySelect.value === "precision") {
+                    damageTypeSelect.value = "";
+                    damageTypeSelect.disabled = true;
+                } else {
+                    damageTypeSelect.disabled = false;
+                    damageTypeSelect.value = (damageTypeSelect.firstElementChild as HTMLOptionElement)?.value ?? "acid";
+                }
+            }
+        });
+
+        const addModifierButton = htmlQuery<HTMLButtonElement>(html, "button.add-modifier");
+        addModifierButton?.addEventListener("click", () => {
+            const parent = addModifierButton.parentElement as HTMLDivElement;
+            const value = Number(parent.querySelector<HTMLInputElement>(".add-modifier-value")?.value || 1);
+            const type = String(parent.querySelector<HTMLSelectElement>(".add-modifier-type")?.value);
+            const damageType = (parent.querySelector<HTMLSelectElement>(".add-modifier-damage-type")?.value ??
+                null) as DamageType;
+            const category = (parent.querySelector<HTMLSelectElement>(".add-modifier-category")?.value ??
+                null) as DamageCategoryUnique;
+
+            let name = String(parent.querySelector<HTMLInputElement>(".add-modifier-name")?.value);
+            const errors: string[] = [];
+            if (Number.isNaN(value)) {
+                errors.push("Modifier value must be a number.");
+            } else if (value === 0) {
+                errors.push("Modifier value must not be zero.");
+            }
+            if (!setHasElement(MODIFIER_TYPES, type)) {
+                // Select menu should make this impossible
+                throw ErrorPF2e("Unexpected invalid modifier type");
+            }
+            if (!name || !name.trim()) {
+                name = game.i18n.localize(value < 0 ? `PF2E.PenaltyLabel.${type}` : `PF2E.BonusLabel.${type}`);
+            }
+            if (errors.length > 0) {
+                ui.notifications.error(errors.join(" "));
+            } else {
+                this.modifiers.push(
+                    new ModifierPF2e({
+                        label: name,
+                        modifier: value,
+                        type,
+                        damageType,
+                        damageCategory: category,
+                    })
+                );
+                applyStackingRules(this.modifiers);
+                this.render();
+            }
+        });
+
+        const addDiceButton = htmlQuery<HTMLButtonElement>(html, "button.add-dice");
+        addDiceButton?.addEventListener("click", () => {
+            const parent = addDiceButton.parentElement as HTMLDivElement;
+            const count = Number(parent.querySelector<HTMLInputElement>(".add-dice-count")?.value || 1);
+            const faces = (parent.querySelector<HTMLSelectElement>(".add-dice-faces")?.value ?? "d4") as DamageDieSize;
+            const category = parent.querySelector<HTMLSelectElement>(".add-dice-category")?.value || null;
+            const type = (parent.querySelector<HTMLSelectElement>(".add-dice-type")?.value || null) as DamageType;
+
+            if (Number.isNaN(count)) {
+                ui.notifications.error("Damage dice count must be a number.");
+                return;
+            } else if (count < 1) {
+                ui.notifications.error("Damage dice count must be greater than zero.");
+                return;
+            }
+            if (!tupleHasValue(["persistent", "precision", "splash", null] as const, category)) {
+                ui.notifications.error(`Unkown damage category: ${category}.`);
+                return;
+            }
+            const faceLabel = game.i18n.localize(`PF2E.DamageDie${faces.toUpperCase()}`);
+            const label = game.i18n.format("PF2E.Damage.Dialog.Bonus", { dice: `+${count}${faceLabel}` });
+            const slug = sluggify(`${label}-${type}`);
+            this.dice.push(
+                new DamageDicePF2e({
+                    label,
+                    category,
+                    diceNumber: count,
+                    dieSize: faces,
+                    damageType: type,
+                    slug,
+                    selector: "damage",
+                })
+            );
+            this.render();
+        });
+
+        const rollModeInput = htmlQuery<HTMLSelectElement>(html, "select[name=rollmode]");
+        rollModeInput?.addEventListener("change", () => {
+            const rollMode = rollModeInput.value;
+            if (!tupleHasValue(Object.values(CONST.DICE_ROLL_MODES), rollMode)) {
+                throw ErrorPF2e("Unexpected roll mode");
+            }
+            this.context.rollMode = rollMode;
+        });
+    }
+
+    /** Show the damage roll dialog and wait for it to close */
+    async resolve(): Promise<boolean> {
+        this.render(true);
+        return new Promise((resolve) => {
+            this.#resolve = resolve;
+        });
+    }
+
+    override async close(options?: { force?: boolean }): Promise<void> {
+        this.#resolve?.(this.isRolled);
+        super.close(options);
+    }
+
+    /** Overriden to add some additional first-render behavior */
+    protected override _injectHTML($html: JQuery<HTMLElement>): void {
+        super._injectHTML($html);
+
+        // Since this is an initial render, focus the roll button
+        $html[0]?.querySelector<HTMLElement>("button.roll")?.focus();
+    }
+}
+
+interface DamageDialogParams {
+    modifiers: ModifierPF2e[];
+    dice: DamageDicePF2e[];
+    baseDamageType: DamageType;
+    context: Partial<DamageRollContext>;
+}
+
+interface BaseData {
+    label: string;
+    enabled: boolean;
+    ignored: boolean;
+    critical: boolean | null;
+    damageType: string | null;
+    typeLabel: string | null;
+    category: DamageCategoryUnique | string | null;
+    categoryIcon: string | null;
+    show: boolean;
+    icon: string | null;
+}
+
+interface DamageDiceData extends BaseData {
+    diceLabel: string;
+}
+
+interface ModifierData extends BaseData {
+    type: string | null;
+    modifier: number;
+    hideIfDisabled: boolean;
+}
+
+interface DamageDialogData {
+    appId: string;
+    modifiers: ModifierData[];
+    dice: DamageDiceData[];
+    isCritical: boolean;
+    hasVisibleDice: boolean;
+    hasVisibleModifiers: boolean;
+    damageTypes: typeof CONFIG.PF2E.damageTypes;
+    damageSubtypes: Pick<ConfigPF2e["PF2E"]["damageCategories"], DamageCategoryUnique>;
+    rollModes: Record<RollMode, string>;
+    rollMode: RollMode | "roll" | undefined;
+}
+
+export { DamageModifierDialog };

--- a/src/scripts/sheet-util.ts
+++ b/src/scripts/sheet-util.ts
@@ -3,8 +3,10 @@ import { BaseRollContext } from "@system/rolls";
 /** Returns statistic dialog roll parameters based on held keys */
 type ParamsFromEvent = Pick<BaseRollContext, "rollMode" | "skipDialog">;
 
-export function eventToRollParams(event: JQuery.TriggeredEvent | MouseEvent): ParamsFromEvent {
+export function eventToRollParams(event?: JQuery.TriggeredEvent | MouseEvent): ParamsFromEvent {
     const skipDefault = !game.user.settings.showRollDialogs;
+    if (!event) return { skipDialog: skipDefault };
+
     const params: ParamsFromEvent = { skipDialog: event.shiftKey ? !skipDefault : skipDefault };
     if (event.ctrlKey || event.metaKey) params.rollMode = "blindroll";
 

--- a/src/styles/ui/_damage-dialog.scss
+++ b/src/styles/ui/_damage-dialog.scss
@@ -1,0 +1,386 @@
+.damage-dialog {
+    background: none;
+    box-shadow: none;
+
+    .window-header {
+        @include inset-gold-border;
+        background: linear-gradient(
+            90deg,
+            var(--secondary) 0%,
+            lighten($secondary-color, 10) 50%,
+            var(--secondary) 100%
+        );
+        border-radius: 0;
+        margin-bottom: 2px;
+        font-size: var(--font-size-13);
+    }
+
+    .window-content {
+        @include corner-boxes;
+        padding-top: 0;
+
+        button {
+            @include button;
+            background-color: var(--alt);
+            border-radius: 2px;
+            color: white;
+            cursor: pointer;
+            font-family: var(--sans-serif);
+
+            &:hover {
+                text-shadow: 0 0 2px var(--tertiary);
+            }
+        }
+
+        .dialog-row {
+            align-items: center;
+            display: grid;
+            grid: "mod type value exclude" 1fr
+                  / 1.5fr 1fr 60px 55px;
+            padding: 8px 0;
+
+            &.header {
+                font-size: var(--font-size-13);
+                font-weight: 700;
+                padding-bottom: 0;
+
+                & + hr {
+                    margin-bottom: 0;
+                }
+            }
+
+            .type {
+                grid-area: type;
+                text-transform: capitalize;
+            }
+
+            .dice-type {
+                margin-right: 10px;
+            }
+
+            .dice-type, .modifier-type {
+                display: flex;
+
+                .value {
+                    margin-right: 8px;
+                }
+
+                .icon-container {
+                    display: table;
+                    width: 35px;
+
+                    i {
+                        display: table-cell;
+                        vertical-align: middle;
+                        text-align: start;
+
+                        font-size: 1rem;
+                    }
+                }
+            }
+
+            .mod {
+                grid-area: mod;
+            }
+
+            .no-mod {
+                filter: opacity(0.7);
+            }
+
+            .value {
+                grid-area: value;
+                justify-self: center;
+            }
+
+            .exclude {
+                grid-area: exclude;
+                justify-self: right;
+
+                &.toggle {
+                    background: var(--secondary);
+                    border-radius: 50px;
+                    box-shadow: inset 0px 1px 1px rgba(0, 0, 0, 0.5),
+                                0px 1px 0px rgba(255, 255, 255, 0.2);
+                    cursor: pointer;
+                    height: 19px;
+                    margin: 4px auto;
+                    position: relative;
+                    width: 46px;
+
+                    &::before {
+                        color: white;
+                        content: "ON";
+                        left: 6px;
+                        position: absolute;
+                        z-index: 0;
+                    }
+
+                    &::after {
+                        color: black;
+                        content: "OFF";
+                        position: absolute;
+                        right: 4px;
+                        text-shadow: 1px 1px 0px rgba(255, 255, 255, 0.15);
+                        z-index: 0;
+                    }
+
+                    &::after, &::before {
+                        @include micro;
+                        top: 4px;
+                    }
+
+                    label {
+                        background: #fcfff4;
+                        background: linear-gradient(
+                            to bottom,
+                            #fcfff4 0%,
+                            #dfe5d7 40%,
+                            #b3bead 100%
+                        );
+                        border-radius: 50px;
+                        box-shadow: 0 0 0 1px rgba(black, 0.2),
+                                    0px 2px 5px 0px rgba(0, 0, 0, 0.3);
+                        cursor: pointer;
+                        display: block;
+                        height: 16px;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        transition: all 0.4s ease;
+                        width: 19px;
+                        z-index: 1;
+                    }
+
+                    input[type=checkbox] {
+                        visibility: hidden;
+                        &:not(:checked) + label {
+                            right: 23px;
+                        }
+                    }
+                }
+            }
+
+            .acid {
+                color: $damage-acid;
+            }
+
+            .bleed {
+                color: $damage-bleed;
+            }
+
+            .bludgeoning {
+                color: $damage-bludgeoning;
+            }
+
+            .chaotic {
+                color: $damage-chaotic;
+            }
+
+            .cold {
+                color: $damage-cold;
+            }
+
+            .electricity {
+                color: $damage-electricity;
+            }
+
+            .evil {
+                color: $damage-evil;
+            }
+
+            .fire {
+                color: $damage-fire;
+            }
+
+            .force {
+                color: $damage-force;
+            }
+
+            .good {
+                color: $damage-good;
+            }
+
+            .lawful {
+                color: $damage-lawful;
+            }
+
+            .mental {
+                color: $damage-mental;
+            }
+
+            .negative {
+                color: $damage-negative;
+            }
+
+            .piercing {
+                color: $damage-piercing;
+            }
+
+            .poision {
+                color: $damage-poison;
+            }
+
+            .positive {
+                color: $damage-positive;
+            }
+
+            .slashing {
+                color: $damage-slashing;
+            }
+
+            .sonic {
+                color: $damage-sonic;
+            }
+        }
+
+        .modifier-container {
+            display: flex;
+            flex-direction: column;
+
+            .dialog-row {
+                border-bottom: 1px solid rgba(black, 0.1);
+
+                &:last-child {
+                    border-bottom: none;
+                }
+
+                .tag {
+                    background-color: var(--sub);
+                    border-radius: 2px;
+                    box-shadow: inset 0 0 0 1px rgba(black, 0.25);
+                    color: white;
+                    font-family: var(--sans-serif);
+                    font-size: var(--font-size-10);
+                    letter-spacing: 0.5px;
+                    padding: 4px 8px;
+                    text-transform: uppercase;
+                    width: fit-content;
+                }
+
+                &.disabled {
+                    text-decoration: line-through;
+
+                    span, div {
+                        filter: opacity(0.5);
+
+                        i {
+                            color: black;
+                        }
+                    }
+
+                    .toggle {
+                        background: rgba(black, 0.4);
+                        input[type=checkbox] + label {
+                            right: 26px;
+                        }
+                    }
+
+                    &.hidden {
+                        display: none;
+                    }
+                }
+            }
+
+            & + hr {
+                margin-top: 0;
+            }
+        }
+
+        .total-mod {
+            font-weight: 700;
+            padding: 0;
+        }
+
+        .add-modifier-panel {
+            display: grid;
+            grid-template-columns: 100px 4.5fr 4.5fr 3.5fr 32px 50px;
+            column-gap: 4px;
+            justify-items: center;
+
+            select,
+            input {
+                height: auto;
+            }
+
+            .add-modifier-type {
+                cursor: pointer;
+                width: 100%;
+            }
+            .add-modifier-category {
+                cursor: pointer;
+                width: 100%;
+            }
+            .add-modifier-damage-type {
+                cursor: pointer;
+                width: 100%;
+            }
+            .add-modifier {
+                line-height: 1;
+                margin: 0;
+                padding: 4px 0;
+                text-transform: uppercase;
+                font-weight: 700;
+                font-size: 0.75rem;
+            }
+        }
+
+        .add-dice-panel {
+            display: grid;
+            grid-template-columns: 100px 32px 1.5fr 3.5fr 3fr 50px;
+            column-gap: 4px;
+            justify-items: center;
+
+            select,
+            input {
+                height: auto;
+            }
+            select:disabled {
+                cursor: default;
+            }
+
+            .add-dice-faces {
+                cursor: pointer;
+            }
+            .add-dice-type {
+                cursor: pointer;
+                width: 100%;
+            }
+            .add-dice-category {
+                cursor: pointer;
+                width: 100%;
+            }
+            .add-dice {
+                line-height: 1;
+                margin: 0;
+                padding: 4px 0;
+                text-transform: uppercase;
+                font-weight: 700;
+                font-size: 0.75rem;
+            }
+        }
+
+        .roll-mode-panel {
+            display: flex;
+            flex-wrap: nowrap;
+            align-items: stretch;
+
+            .label {
+                flex: 1 40%;
+            }
+
+            select {
+                flex: 2 60%;
+                height: auto;
+                width: 100%;
+                margin-right: 4px;
+                border-radius: 2px;
+                cursor: pointer;
+            }
+        }
+
+        .roll {
+            color: white;
+            background-color: var(--secondary);
+        }
+    }
+}

--- a/src/styles/ui/_index.scss
+++ b/src/styles/ui/_index.scss
@@ -1,1 +1,1 @@
-@import "windows", "sidebar", "combat", "hover", "dialog", "icons", "token-hud", "traits";
+@import "windows", "sidebar", "combat", "hover", "damage-dialog", "dialog", "icons", "token-hud", "traits";

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1363,6 +1363,15 @@
         "CurrentStaminaTitle": "The amount of stamina points you have",
         "Damage": {
             "Base": "Base",
+            "Dialog": {
+                "Bonus": "Bonus {dice}",
+                "BonusDice": "Bonus Dice",
+                "CriticalDamageRoll": "Critical Damage Roll",
+                "DamageRoll": "Damage Roll",
+                "Label": "Label",
+                "None": "None",
+                "Splash": "{damageType} Splash"
+            },
             "IncreasedFrom": "Increased from {original} to minimum of 1",
             "IWR": {
                 "ActorIsImmune": "{actor} is immune to {effect}.",

--- a/static/templates/chat/damage/damage-modifier-dialog.hbs
+++ b/static/templates/chat/damage/damage-modifier-dialog.hbs
@@ -1,0 +1,156 @@
+<form class="check-modifiers-content" autocomplete="off" spellcheck="off">
+    <div class="dialog-row header">
+        <span class="type">{{localize "PF2E.Roll.Type"}}</span>
+        <span class="mod">{{localize "PF2E.Roll.Modifier"}}</span>
+        <span class="exclude"></span>
+    </div>
+    <div class="modifier-container">
+        {{#if hasVisibleModifiers}}
+            {{#each modifiers as |modifier idx|}}
+                {{#if modifier.show}}
+                    {{> modifier-row modifier=modifier idx=idx}}
+                {{/if}}
+            {{/each}}
+        {{else}}
+            <div class="dialog-row">
+                <span class="no-mod">{{localize "PF2E.Damage.Dialog.None"}}</span>
+            </div>
+        {{/if}}
+    </div>
+    <hr />
+
+    <div class="add-modifier-panel">
+        <input type="text" class="add-modifier-name" placeholder={{localize "PF2E.Damage.Dialog.Label"}}>
+        <select class="add-modifier-type">
+            <option value="circumstance" selected>{{localize "PF2E.ModifierType.circumstance"}}</option>
+            <option value="item">{{localize "PF2E.ModifierType.item"}}</option>
+            <option value="status">{{localize "PF2E.ModifierType.status"}}</option>
+            <option value="untyped">{{localize "PF2E.ModifierType.untyped"}}</option>
+            <option value="ability">{{localize "PF2E.ModifierType.ability"}}</option>
+            <option value="proficiency">{{localize "PF2E.ModifierType.proficiency"}}</option>
+        </select>
+        <select class="add-modifier-category">
+            <option value=""></option>
+            {{#each damageSubtypes as |name type|}}
+                <option value="{{type}}">{{localize name}}</option>
+            {{/each}}
+        </select>
+        <select class="add-modifier-damage-type">
+            <option value=""></option>
+            {{#each damageTypes as |name type|}}
+                <option value="{{type}}">{{localize name}}</option>
+            {{/each}}
+        </select>
+        <input type="number" class="add-modifier-value" placeholder="+1">
+        <button type="button" class="add-modifier">+{{localize "PF2E.Roll.Add"}}</button>
+    </div>
+    <hr />
+
+    <div class="dialog-row header">
+        <span class="type"></span>
+        <span class="mod">{{localize "PF2E.Damage.Dialog.BonusDice"}}</span>
+        <span class="exclude"></span>
+    </div>
+    <div class="modifier-container">
+        {{#if hasVisibleDice}}
+            {{#each dice as |die idx|}}
+                {{#if die.show}}
+                    {{> dice-row dice=die idx=idx}}
+                {{/if}}
+            {{/each}}
+        {{else}}
+            <div class="dialog-row">
+                <span class="no-mod">{{localize "PF2E.Damage.Dialog.None"}}</span>
+            </div>
+        {{/if}}
+    </div>
+    <hr/>
+
+    <div class="add-dice-panel">
+        <input type="text" class="add-dice-name" placeholder="{{localize "PF2E.Damage.Dialog.Label"}}">
+        <input type="text" class="add-dice-count" placeholder="1">
+        <select class="add-dice-faces">
+            <option value="d4">{{localize "PF2E.DamageDieD4"}}</option>
+            <option value="d6">{{localize "PF2E.DamageDieD6"}}</option>
+            <option value="d8">{{localize "PF2E.DamageDieD8"}}</option>
+            <option value="d10">{{localize "PF2E.DamageDieD10"}}</option>
+            <option value="d12">{{localize "PF2E.DamageDieD12"}}</option>
+        </select>
+        <select class="add-dice-category">
+            <option value="" selected></option>
+            {{#each damageSubtypes as |name type|}}
+                <option value="{{type}}">{{localize name}}</option>
+            {{/each}}
+        </select>
+        <select class="add-dice-type">
+            {{#each damageTypes as |name type|}}
+                <option value="{{type}}">{{localize name}}</option>
+            {{/each}}
+        </select>
+        <button type="button" class="add-dice">+{{localize "PF2E.Roll.Add"}}</button>
+    </div>
+    <hr />
+
+    <div class="roll-mode-panel">
+        <span class="label">{{localize "PF2E.RollModeLabel"}}</span>
+        <select name="rollmode">
+            {{#select rollMode}}
+                {{#each rollModes as |label key|}}
+                    <option value="{{key}}">{{localize label}}</option>
+                {{/each}}
+            {{/select}}
+        </select>
+    </div>
+    <hr />
+
+    <button type="button" class="roll">{{localize "PF2E.Roll.Roll"}}</button>
+</form>
+
+{{#*inline "icon-container"}}
+    <div class="icon-container">
+        {{#if (eq modifier.category "splash")}}
+            {{#if modifier.icon}}
+                <i class="{{modifier.icon}}"></i>
+            {{/if}}
+            {{#if modifier.categoryIcon}}
+                <i class="{{modifier.categoryIcon}} category"></i>
+            {{/if}}
+        {{else}}
+            {{#if modifier.categoryIcon}}
+                <i class="{{modifier.categoryIcon}} category"></i>
+            {{/if}}
+            {{#if modifier.icon}}
+                <i class="{{modifier.icon}}"></i>
+            {{/if}}
+        {{/if}}
+    </div>
+{{/inline}}
+
+{{#*inline "modifier-row"}}
+    <div class="dialog-row{{#unless modifier.enabled}} disabled{{#if modifier.hideIfDisabled}} hidden{{/if}}{{/unless}}">
+        <span class="mod">{{modifier.label}}</span>
+        <span class="type tag">{{localize (concat "PF2E.ModifierType." modifier.type)}}</span>
+        <div class="modifier-type{{#if modifier.damageType}} {{modifier.damageType}}{{/if}}" title="{{modifier.typeLabel}}">
+            <span class="value">{{numberFormat modifier.modifier decimals=0 sign=true}}</span>
+            {{> icon-container modifier=modifier}}
+        </div>
+        <label class="exclude toggle">
+            <input type="checkbox" id="{{@root.appId}}-modifier-{{idx}}" data-modifier-index="{{idx}}" {{checked (not modifier.ignored)}} />
+            <label for="{{@root.appId}}-modifier-{{idx}}"></label>
+        </label>
+    </div>
+{{/inline}}
+
+{{#*inline "dice-row"}}
+    <div class="dialog-row{{#unless dice.enabled}} disabled{{/unless}}">
+        <span class="mod">{{dice.label}}</span>
+        <div class="dice-type value{{#if dice.damageType}} {{dice.damageType}}{{/if}}" title="{{dice.typeLabel}}">
+            <span class="value">{{dice.diceLabel}}</span>
+            {{> icon-container modifier=dice}}
+        </div>
+        <label class="exclude toggle">
+            <input type="checkbox" id="{{@root.appId}}-dice-{{idx}}" data-dice-index="{{idx}}" data-slug="{{dice.slug}}" {{checked (not dice.ignored)}} />
+            <label for="{{@root.appId}}-dice-{{idx}}"></label>
+        </label>
+    </div>
+{{/inline}}


### PR DESCRIPTION
It's only enabled in development  for now and can be opened by holding shift while pressing a damage button.
The UI could still use some refinement but it's looking ok in my opinion.

Weapon Damage:

![Weapon_Normal](https://user-images.githubusercontent.com/41452412/213908990-e24d3574-60da-4300-9cd1-191d21694721.png)

![Weapon_Critical](https://user-images.githubusercontent.com/41452412/213908988-3cfb6a9b-c2ce-4514-b0fb-2c96b0b3e862.png)

![Weapon_Sneak](https://user-images.githubusercontent.com/41452412/213908991-36312aae-73a7-4ac5-8a12-5d789f6d80f9.png)

![Weapon_Deadly](https://user-images.githubusercontent.com/41452412/213908989-2e834799-48a7-40e3-af7b-645ab0547d92.png)

![Splash_Persistent](https://user-images.githubusercontent.com/41452412/213908986-ff3bd21a-3628-4936-b024-77ee9e6fd01e.png)

Spell Damage:

![Spell_Damage](https://user-images.githubusercontent.com/41452412/213908984-ea4a128f-f4df-46b0-8b74-9b972b255b2b.png)

![Spell_Damage2](https://user-images.githubusercontent.com/41452412/213908985-db2945d9-9575-48b6-8a61-f9dc70e6178e.png)
