### PR TITLE
Fix Grendel Tooth grind ability

### DIFF
--- a/packs/data/pathfinder-bestiary-2.db/grendel.json
+++ b/packs/data/pathfinder-bestiary-2.db/grendel.json
@@ -513,7 +513,7 @@
                     "value": 1
                 },
                 "description": {
-                    "value": "<p><strong>Requirements</strong> Grendel is grabbing a creature</p>\n<hr />\n<p><strong>Effect</strong> Grendel makes a bludgeoning jaws Strike against the creature he's grabbing. On a hit, the creature also takes [[/r 2d6]] damage and becomes @UUID[Compendium.pf2e.conditionitems.Wounded]{Wounded 1}, or increases its wounded value by 1 if already wounded. On a critical hit, the creature instead becomes wounded 2, or increases its wounded value by 2 if already wounded. If a creature dies from Tooth Grind, Grendel regains 40 HP; this is a healing effect.</p>"
+                    "value": "<p><strong>Requirements</strong> Grendel is grabbing a creature</p>\n<hr />\n<p><strong>Effect</strong> Grendel makes a bludgeoning jaws Strike against the creature he's grabbing. On a hit, the creature also takes [[/r 2d6[bleed]]] damage and becomes @UUID[Compendium.pf2e.conditionitems.Wounded]{Wounded 1}, or increases its wounded value by 1 if already wounded. On a critical hit, the creature instead becomes wounded 2, or increases its wounded value by 2 if already wounded. If a creature dies from Tooth Grind, Grendel regains 40 HP; this is a healing effect.</p>"
                 },
                 "requirements": {
                     "value": ""


### PR DESCRIPTION
damage are 2d6 persistent bleed damage according to the book and AoN.