### PR TITLE
Adding slugs to attack effects (Bestiary 1)

### DIFF
--- a/packs/data/pathfinder-bestiary.db/adamantine-golem.json
+++ b/packs/data/pathfinder-bestiary.db/adamantine-golem.json
@@ -287,7 +287,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "destructive-strike",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/alchemical-golem.json
+++ b/packs/data/pathfinder-bestiary.db/alchemical-golem.json
@@ -321,7 +321,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "alchemical-injection",
                 "source": {
                     "value": ""
                 },
@@ -397,7 +397,7 @@
                     "value": 0
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "generate-bomb",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/alghollthu-master.json
+++ b/packs/data/pathfinder-bestiary.db/alghollthu-master.json
@@ -1053,7 +1053,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "slime",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/animated-broom.json
+++ b/packs/data/pathfinder-bestiary.db/animated-broom.json
@@ -182,7 +182,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "dust",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/ankylosaurus.json
+++ b/packs/data/pathfinder-bestiary.db/ankylosaurus.json
@@ -203,7 +203,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "punishing-tail",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/astradaemon.json
+++ b/packs/data/pathfinder-bestiary.db/astradaemon.json
@@ -1482,7 +1482,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "essence-drain",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/azure-worm.json
+++ b/packs/data/pathfinder-bestiary.db/azure-worm.json
@@ -330,7 +330,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "azure-worm-venom",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/balor.json
+++ b/packs/data/pathfinder-bestiary.db/balor.json
@@ -1911,7 +1911,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "whip-reposition",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/banshee.json
+++ b/packs/data/pathfinder-bestiary.db/banshee.json
@@ -330,7 +330,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "terrifying-touch",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/barbazu.json
+++ b/packs/data/pathfinder-bestiary.db/barbazu.json
@@ -1056,7 +1056,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "avernal-fever",
                 "source": {
                     "value": ""
                 },
@@ -1098,7 +1098,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "infernal-wound",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/black-pudding.json
+++ b/packs/data/pathfinder-bestiary.db/black-pudding.json
@@ -239,7 +239,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "corrosive-touch",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/bloodseeker.json
+++ b/packs/data/pathfinder-bestiary.db/bloodseeker.json
@@ -154,7 +154,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "attach",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/boggard-scout.json
+++ b/packs/data/pathfinder-bestiary.db/boggard-scout.json
@@ -691,7 +691,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "tongue-grab",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/boggard-swampseer.json
+++ b/packs/data/pathfinder-bestiary.db/boggard-swampseer.json
@@ -1581,7 +1581,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "tongue-grab",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/boggard-warrior.json
+++ b/packs/data/pathfinder-bestiary.db/boggard-warrior.json
@@ -647,7 +647,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "tongue-grab",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/brain-collector.json
+++ b/packs/data/pathfinder-bestiary.db/brain-collector.json
@@ -2251,7 +2251,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "brain-collector-venom",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/cacodaemon.json
+++ b/packs/data/pathfinder-bestiary.db/cacodaemon.json
@@ -855,7 +855,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "cacodaemonia",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/ceustodaemon.json
+++ b/packs/data/pathfinder-bestiary.db/ceustodaemon.json
@@ -1142,7 +1142,7 @@
                         "selector": "strike-damage"
                     }
                 ],
-                "slug": null,
+                "slug": "vicious-wounds",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/choral.json
+++ b/packs/data/pathfinder-bestiary.db/choral.json
@@ -2472,7 +2472,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "deafening-aria",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/clay-golem.json
+++ b/packs/data/pathfinder-bestiary.db/clay-golem.json
@@ -358,7 +358,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "cursed-wound",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/cloud-giant.json
+++ b/packs/data/pathfinder-bestiary.db/cloud-giant.json
@@ -657,7 +657,7 @@
                 "quantity": 5,
                 "rules": [],
                 "size": "med",
-                "slug": null,
+                "slug": "rock",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/cockatrice.json
+++ b/packs/data/pathfinder-bestiary.db/cockatrice.json
@@ -115,7 +115,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "calcification",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/crag-linnorm.json
+++ b/packs/data/pathfinder-bestiary.db/crag-linnorm.json
@@ -899,7 +899,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "crag-linnorm-venom",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/crimson-worm.json
+++ b/packs/data/pathfinder-bestiary.db/crimson-worm.json
@@ -429,7 +429,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "crimson-worm-venom",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/dark-naga.json
+++ b/packs/data/pathfinder-bestiary.db/dark-naga.json
@@ -2213,7 +2213,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "dark-naga-venom",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/dezullon.json
+++ b/packs/data/pathfinder-bestiary.db/dezullon.json
@@ -263,7 +263,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "amnesia-venom",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/drider.json
+++ b/packs/data/pathfinder-bestiary.db/drider.json
@@ -2757,7 +2757,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "drider-venom",
                 "source": {
                     "value": ""
                 },
@@ -2799,7 +2799,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "web-trap",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/dullahan.json
+++ b/packs/data/pathfinder-bestiary.db/dullahan.json
@@ -736,7 +736,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "head-hunter",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/electric-eel.json
+++ b/packs/data/pathfinder-bestiary.db/electric-eel.json
@@ -159,7 +159,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "stunning-shock",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/elephant.json
+++ b/packs/data/pathfinder-bestiary.db/elephant.json
@@ -285,7 +285,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "grabbing-trunk",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/envyspawn.json
+++ b/packs/data/pathfinder-bestiary.db/envyspawn.json
@@ -515,7 +515,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "sinful-bite",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/erinys.json
+++ b/packs/data/pathfinder-bestiary.db/erinys.json
@@ -2166,7 +2166,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "rope-snare",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/ether-spider.json
+++ b/packs/data/pathfinder-bestiary.db/ether-spider.json
@@ -156,7 +156,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "ether-spider-venom",
                 "source": {
                     "value": ""
                 },
@@ -238,7 +238,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "ethereal-web-trap",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/fire-giant.json
+++ b/packs/data/pathfinder-bestiary.db/fire-giant.json
@@ -336,7 +336,7 @@
                 "quantity": 5,
                 "rules": [],
                 "size": "med",
-                "slug": null,
+                "slug": "rock",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/frost-giant.json
+++ b/packs/data/pathfinder-bestiary.db/frost-giant.json
@@ -336,7 +336,7 @@
                 "quantity": 5,
                 "rules": [],
                 "size": "med",
-                "slug": null,
+                "slug": "rock",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/fungus-leshy.json
+++ b/packs/data/pathfinder-bestiary.db/fungus-leshy.json
@@ -505,7 +505,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "spores",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/gelatinous-cube.json
+++ b/packs/data/pathfinder-bestiary.db/gelatinous-cube.json
@@ -192,7 +192,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "paralysis",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/gelugon.json
+++ b/packs/data/pathfinder-bestiary.db/gelugon.json
@@ -1764,7 +1764,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "slowing-frost",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/giant-centipede.json
+++ b/packs/data/pathfinder-bestiary.db/giant-centipede.json
@@ -114,7 +114,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "giant-centipede-venom",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/giant-monitor-lizard.json
+++ b/packs/data/pathfinder-bestiary.db/giant-monitor-lizard.json
@@ -254,7 +254,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "monitor-lizard-venom",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/giant-octopus.json
+++ b/packs/data/pathfinder-bestiary.db/giant-octopus.json
@@ -243,7 +243,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "giant-octopus-venom",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/giant-rat.json
+++ b/packs/data/pathfinder-bestiary.db/giant-rat.json
@@ -160,7 +160,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "filth-fever",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/giant-scorpion.json
+++ b/packs/data/pathfinder-bestiary.db/giant-scorpion.json
@@ -295,7 +295,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "giant-scorpion-venom",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/giant-tarantula.json
+++ b/packs/data/pathfinder-bestiary.db/giant-tarantula.json
@@ -157,7 +157,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "giant-tarantula-venom",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/giant-viper.json
+++ b/packs/data/pathfinder-bestiary.db/giant-viper.json
@@ -244,7 +244,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "giant-viper-venom",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/giant-wasp.json
+++ b/packs/data/pathfinder-bestiary.db/giant-wasp.json
@@ -114,7 +114,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "giant-wasp-venom",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/gibbering-mouther.json
+++ b/packs/data/pathfinder-bestiary.db/gibbering-mouther.json
@@ -333,7 +333,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "burn-eyes",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/gimmerling.json
+++ b/packs/data/pathfinder-bestiary.db/gimmerling.json
@@ -587,7 +587,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "disarm",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/gluttonyspawn.json
+++ b/packs/data/pathfinder-bestiary.db/gluttonyspawn.json
@@ -515,7 +515,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "sinful-bite",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/goblin-dog.json
+++ b/packs/data/pathfinder-bestiary.db/goblin-dog.json
@@ -282,7 +282,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "goblin-pox",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/goliath-spider.json
+++ b/packs/data/pathfinder-bestiary.db/goliath-spider.json
@@ -278,7 +278,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "goliath-spider-venom",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/gourd-leshy.json
+++ b/packs/data/pathfinder-bestiary.db/gourd-leshy.json
@@ -508,7 +508,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "ensnare",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/greedspawn.json
+++ b/packs/data/pathfinder-bestiary.db/greedspawn.json
@@ -516,7 +516,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "sinful-bite",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/grikkitog.json
+++ b/packs/data/pathfinder-bestiary.db/grikkitog.json
@@ -285,7 +285,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "barbed-maw",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/grim-reaper.json
+++ b/packs/data/pathfinder-bestiary.db/grim-reaper.json
@@ -1295,7 +1295,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "death-strike",
                 "source": {
                     "value": ""
                 },
@@ -1337,7 +1337,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "energy-drain",
                 "source": {
                     "value": ""
                 },
@@ -1417,7 +1417,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "infuse-weapon",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/guardian-naga.json
+++ b/packs/data/pathfinder-bestiary.db/guardian-naga.json
@@ -3102,7 +3102,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "guardian-naga-venom",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/hill-giant.json
+++ b/packs/data/pathfinder-bestiary.db/hill-giant.json
@@ -337,7 +337,7 @@
                 "quantity": 5,
                 "rules": [],
                 "size": "med",
-                "slug": null,
+                "slug": "rock",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/hobgoblin-archer.json
+++ b/packs/data/pathfinder-bestiary.db/hobgoblin-archer.json
@@ -663,7 +663,7 @@
                         "selector": "crossbow-damage"
                     }
                 ],
-                "slug": null,
+                "slug": "crossbow-precision",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/homunculus.json
+++ b/packs/data/pathfinder-bestiary.db/homunculus.json
@@ -159,7 +159,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "homunculus-poison",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/hunting-spider.json
+++ b/packs/data/pathfinder-bestiary.db/hunting-spider.json
@@ -278,7 +278,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "hunting-spider-venom",
                 "source": {
                     "value": ""
                 },
@@ -320,7 +320,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "web-trap",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/hyaenodon.json
+++ b/packs/data/pathfinder-bestiary.db/hyaenodon.json
@@ -158,7 +158,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "bonecrunching-bite",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/ice-linnorm.json
+++ b/packs/data/pathfinder-bestiary.db/ice-linnorm.json
@@ -901,7 +901,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "ice-linnorm-venom",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/imp.json
+++ b/packs/data/pathfinder-bestiary.db/imp.json
@@ -949,7 +949,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "imp-venom",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/jungle-drake.json
+++ b/packs/data/pathfinder-bestiary.db/jungle-drake.json
@@ -282,7 +282,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "jungle-drake-venom",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/keketar.json
+++ b/packs/data/pathfinder-bestiary.db/keketar.json
@@ -2738,7 +2738,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "warpwave-strike",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/krooth.json
+++ b/packs/data/pathfinder-bestiary.db/krooth.json
@@ -432,7 +432,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "poison-tooth",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/leaf-leshy.json
+++ b/packs/data/pathfinder-bestiary.db/leaf-leshy.json
@@ -574,7 +574,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "deafening-blow",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/leukodaemon.json
+++ b/packs/data/pathfinder-bestiary.db/leukodaemon.json
@@ -1168,7 +1168,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "daemonic-pestilence",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/lizardfolk-scout.json
+++ b/packs/data/pathfinder-bestiary.db/lizardfolk-scout.json
@@ -392,7 +392,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "giant-centipede-venom",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/lustspawn.json
+++ b/packs/data/pathfinder-bestiary.db/lustspawn.json
@@ -515,7 +515,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "sinful-bite",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/mammoth.json
+++ b/packs/data/pathfinder-bestiary.db/mammoth.json
@@ -420,7 +420,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "grabbing-trunk",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/medusa.json
+++ b/packs/data/pathfinder-bestiary.db/medusa.json
@@ -725,7 +725,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "serpent-venom",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/mimic.json
+++ b/packs/data/pathfinder-bestiary.db/mimic.json
@@ -112,7 +112,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "adhesive",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/morrigna.json
+++ b/packs/data/pathfinder-bestiary.db/morrigna.json
@@ -3930,7 +3930,7 @@
                         "selector": "strike-damage"
                     }
                 ],
-                "slug": null,
+                "slug": "spirit-touch",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/mummy-guardian.json
+++ b/packs/data/pathfinder-bestiary.db/mummy-guardian.json
@@ -227,7 +227,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "mummy-rot",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/mummy-pharaoh.json
+++ b/packs/data/pathfinder-bestiary.db/mummy-pharaoh.json
@@ -566,7 +566,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "insidious-mummy-rot",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/naunet.json
+++ b/packs/data/pathfinder-bestiary.db/naunet.json
@@ -1487,7 +1487,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "confounding-slam",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/nosoi.json
+++ b/packs/data/pathfinder-bestiary.db/nosoi.json
@@ -822,7 +822,7 @@
                         "selector": "strike-damage"
                     }
                 ],
-                "slug": null,
+                "slug": "spirit-touch",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/ofalth.json
+++ b/packs/data/pathfinder-bestiary.db/ofalth.json
@@ -306,7 +306,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "wretched-weeps",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/ogre-glutton.json
+++ b/packs/data/pathfinder-bestiary.db/ogre-glutton.json
@@ -374,7 +374,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "gluttons-feast",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/otyugh.json
+++ b/packs/data/pathfinder-bestiary.db/otyugh.json
@@ -301,7 +301,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "filth-fever",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/phistophilus.json
+++ b/packs/data/pathfinder-bestiary.db/phistophilus.json
@@ -2426,7 +2426,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "infernal-wound",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/pit-fiend.json
+++ b/packs/data/pathfinder-bestiary.db/pit-fiend.json
@@ -2469,7 +2469,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "pit-fiend-venom",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/plague-zombie.json
+++ b/packs/data/pathfinder-bestiary.db/plague-zombie.json
@@ -317,7 +317,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "zombie-rot",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/pleroma.json
+++ b/packs/data/pathfinder-bestiary.db/pleroma.json
@@ -2090,7 +2090,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "sphere-of-oblivion",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/pridespawn.json
+++ b/packs/data/pathfinder-bestiary.db/pridespawn.json
@@ -513,7 +513,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "sinful-bite",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/purple-worm.json
+++ b/packs/data/pathfinder-bestiary.db/purple-worm.json
@@ -411,7 +411,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "purple-worm-venom",
                 "source": {
                     "value": ""
                 },
@@ -453,7 +453,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "regurgitate",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/quasit.json
+++ b/packs/data/pathfinder-bestiary.db/quasit.json
@@ -1031,7 +1031,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "quasit-venom",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/reefclaw.json
+++ b/packs/data/pathfinder-bestiary.db/reefclaw.json
@@ -201,7 +201,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "reefclaw-venom",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/roper.json
+++ b/packs/data/pathfinder-bestiary.db/roper.json
@@ -389,7 +389,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "sticky-strand",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/rust-monster.json
+++ b/packs/data/pathfinder-bestiary.db/rust-monster.json
@@ -317,7 +317,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "rust",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/sea-serpent.json
+++ b/packs/data/pathfinder-bestiary.db/sea-serpent.json
@@ -337,7 +337,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "sea-serpent-algae",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/shaitan.json
+++ b/packs/data/pathfinder-bestiary.db/shaitan.json
@@ -1198,7 +1198,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "shove-into-stone",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/shemhazian.json
+++ b/packs/data/pathfinder-bestiary.db/shemhazian.json
@@ -1821,7 +1821,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "enfeebling-bite",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/shuln.json
+++ b/packs/data/pathfinder-bestiary.db/shuln.json
@@ -243,7 +243,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "shuln-saliva",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/simurgh.json
+++ b/packs/data/pathfinder-bestiary.db/simurgh.json
@@ -1495,7 +1495,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "banishing-swipe",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/skulltaker.json
+++ b/packs/data/pathfinder-bestiary.db/skulltaker.json
@@ -1240,7 +1240,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "energy-drain",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/slothspawn.json
+++ b/packs/data/pathfinder-bestiary.db/slothspawn.json
@@ -513,7 +513,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "sinful-bite",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/slurk.json
+++ b/packs/data/pathfinder-bestiary.db/slurk.json
@@ -251,7 +251,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "entangling-slime",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/stone-giant.json
+++ b/packs/data/pathfinder-bestiary.db/stone-giant.json
@@ -232,7 +232,7 @@
                 "quantity": 5,
                 "rules": [],
                 "size": "med",
-                "slug": null,
+                "slug": "rock",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/storm-giant.json
+++ b/packs/data/pathfinder-bestiary.db/storm-giant.json
@@ -769,7 +769,7 @@
                 "quantity": 5,
                 "rules": [],
                 "size": "med",
-                "slug": null,
+                "slug": "rock",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/tarn-linnorm.json
+++ b/packs/data/pathfinder-bestiary.db/tarn-linnorm.json
@@ -1034,7 +1034,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "tarn-linnorm-venom",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/terotricus.json
+++ b/packs/data/pathfinder-bestiary.db/terotricus.json
@@ -423,7 +423,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "spore-blight",
                 "source": {
                     "value": ""
                 },
@@ -465,7 +465,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "sticky-spores",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/tor-linnorm.json
+++ b/packs/data/pathfinder-bestiary.db/tor-linnorm.json
@@ -981,7 +981,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "tor-linnorm-venom",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/veiled-master.json
+++ b/packs/data/pathfinder-bestiary.db/veiled-master.json
@@ -2151,7 +2151,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "consume-memories",
                 "source": {
                     "value": ""
                 },
@@ -2237,7 +2237,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "slime",
                 "source": {
                     "value": ""
                 },
@@ -2321,7 +2321,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "thoughtlance",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/viper.json
+++ b/packs/data/pathfinder-bestiary.db/viper.json
@@ -200,7 +200,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "viper-venom",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/voidworm.json
+++ b/packs/data/pathfinder-bestiary.db/voidworm.json
@@ -1400,7 +1400,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "confounding-lash",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/warsworn.json
+++ b/packs/data/pathfinder-bestiary.db/warsworn.json
@@ -508,7 +508,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "energy-drain",
                 "source": {
                     "value": ""
                 },
@@ -551,7 +551,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "plummet",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/web-lurker.json
+++ b/packs/data/pathfinder-bestiary.db/web-lurker.json
@@ -320,7 +320,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "web-lurker-venom",
                 "source": {
                     "value": ""
                 },
@@ -362,7 +362,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "web-trap",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/wight.json
+++ b/packs/data/pathfinder-bestiary.db/wight.json
@@ -205,7 +205,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "drain-life",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/wraith.json
+++ b/packs/data/pathfinder-bestiary.db/wraith.json
@@ -354,7 +354,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "drain-life",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/wrathspawn.json
+++ b/packs/data/pathfinder-bestiary.db/wrathspawn.json
@@ -515,7 +515,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "sinful-bite",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/wyvern.json
+++ b/packs/data/pathfinder-bestiary.db/wyvern.json
@@ -427,7 +427,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "wyvern-venom",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/xulgath-leader.json
+++ b/packs/data/pathfinder-bestiary.db/xulgath-leader.json
@@ -625,7 +625,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "weakening-strike",
                 "source": {
                     "value": ""
                 },


### PR DESCRIPTION
This is linked to issue #3584

Forcing slugs on Attack Effects item prevent links from breaking when the items are translated. This is the situation before the PR:
![image](https://user-images.githubusercontent.com/63196064/213940264-26477e3c-39fb-477e-b6c2-a7956628b08b.png)

And this is what happens when slugs are added:
![image](https://user-images.githubusercontent.com/63196064/213940260-da87094e-0803-4e15-8862-c80c56df86f1.png)
