### PR TITLE
Fix AdjustStrike trait upgrade

### DIFF
--- a/src/module/rules/rule-element/adjust-strike.ts
+++ b/src/module/rules/rule-element/adjust-strike.ts
@@ -159,6 +159,7 @@ class AdjustStrikeRuleElement extends AELikeRuleElement {
                                     if (changeTraitScore > existingTraitScore) {
                                         traits.findSplice((trait) => trait === existingTraitMatch[0], change);
                                     }
+
                                     return;
                                 }
                             }

--- a/src/module/rules/rule-element/adjust-strike.ts
+++ b/src/module/rules/rule-element/adjust-strike.ts
@@ -158,9 +158,9 @@ class AdjustStrikeRuleElement extends AELikeRuleElement {
                                     // (lesser) trait
                                     if (changeTraitScore > existingTraitScore) {
                                         traits.findSplice((trait) => trait === existingTraitMatch[0]);
+                                    } else {
+                                        return;
                                     }
-
-                                    return;
                                 }
                             }
 

--- a/src/module/rules/rule-element/adjust-strike.ts
+++ b/src/module/rules/rule-element/adjust-strike.ts
@@ -157,10 +157,9 @@ class AdjustStrikeRuleElement extends AELikeRuleElement {
                                     // the existing one otherwise just return out as we don't want to add the new
                                     // (lesser) trait
                                     if (changeTraitScore > existingTraitScore) {
-                                        traits.findSplice((trait) => trait === existingTraitMatch[0]);
-                                    } else {
-                                        return;
+                                        traits.findSplice((trait) => trait === existingTraitMatch[0], change);
                                     }
+                                    return;
                                 }
                             }
 


### PR DESCRIPTION
In the recent update to allow `remove` and `subtract` weapon traits using the `AdjustStrike` rule element, an issue was introduced where, if a scorable trait was added (e.g. fatal-d12) and there was already a trait with the same name (e.g. fatal-d10) on the weapon, then the existing trait would be removed but the new trait would not be added.

Fixes #5775.