### PR TITLE
Autoroll affliction damage on stage change

### DIFF
--- a/src/module/item/affliction/data.ts
+++ b/src/module/item/affliction/data.ts
@@ -41,9 +41,9 @@ interface AfflictionOnset {
 }
 
 interface AfflictionDamage {
-    value: string;
+    formula: string;
     type: DamageType;
-    category?: DamageCategoryUnique;
+    category?: DamageCategoryUnique | null;
 }
 
 interface AfflictionStageData {

--- a/src/module/item/affliction/document.ts
+++ b/src/module/item/affliction/document.ts
@@ -2,6 +2,14 @@ import { ActorPF2e } from "@actor";
 import { AbstractEffectPF2e, EffectBadge } from "@item/abstract-effect/index.ts";
 import { UserPF2e } from "@module/user/index.ts";
 import { AfflictionFlags, AfflictionSource, AfflictionSystemData } from "./data.ts";
+import {
+    AfflictionDamageTemplate,
+    DamagePF2e,
+    DamageRollContext,
+    DynamicBaseDamageData,
+} from "@system/damage/index.ts";
+import { createDamageFormula, parseTermsFromSimpleFormula } from "@system/damage/formula.ts";
+import { DamageRoll } from "@system/damage/roll.ts";
 
 class AfflictionPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends AbstractEffectPF2e<TParent> {
     override get badge(): EffectBadge {
@@ -44,6 +52,70 @@ class AfflictionPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extend
         }
     }
 
+    /** Retrieves the damage for a specific stage */
+    getStageDamage(stage: number): AfflictionDamage | null {
+        const stageData = Object.values(this.system.stages).at(stage - 1);
+
+        const base: DynamicBaseDamageData[] = [];
+        for (const data of Object.values(stageData?.damage ?? {})) {
+            const { formula, type: damageType, category } = data;
+            const terms = parseTermsFromSimpleFormula(formula);
+            base.push({ terms, damageType, category: category ?? null });
+        }
+
+        if (!base.length) return null;
+
+        try {
+            const { formula, breakdown } = createDamageFormula({
+                base,
+                modifiers: [],
+                dice: [],
+                ignoredResistances: [],
+            });
+
+            const roll = new DamageRoll(formula);
+            const stageLabel = game.i18n.format("PF2E.Item.Affliction.Stage", { stage: this.stage });
+            const template: AfflictionDamageTemplate = {
+                name: `${this.name} - ${stageLabel}`,
+                damage: { roll, breakdown },
+                notes: [],
+                materials: [],
+                traits: this.system.traits.value,
+                modifiers: [],
+            };
+
+            // Context isn't used for affliction damage rolls, but we still need it for creating messages
+            const context: DamageRollContext = {
+                type: "damage-roll",
+                sourceType: "save",
+                outcome: "failure",
+                domains: [],
+                options: new Set(),
+                self: null,
+            };
+
+            return { template, context };
+        } catch (err) {
+            console.error(err);
+        }
+
+        return null;
+    }
+
+    async createStageMessage(): Promise<void> {
+        const actor = this.actor;
+        if (!actor) return;
+
+        const currentStage = Object.values(this.system.stages).at(this.stage - 1);
+        if (!currentStage) return;
+
+        const damage = this.getStageDamage(this.stage);
+        if (damage) {
+            const { template, context } = damage;
+            await DamagePF2e.roll(template, context);
+        }
+    }
+
     protected override async _preUpdate(
         changed: DeepPartial<this["_source"]>,
         options: DocumentModificationContext<TParent>,
@@ -56,12 +128,39 @@ class AfflictionPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extend
 
         return super._preUpdate(changed, options, user);
     }
+
+    protected override _onCreate(
+        data: AfflictionSource,
+        options: DocumentModificationContext<TParent>,
+        userId: string
+    ): void {
+        super._onCreate(data, options, userId);
+        this.createStageMessage();
+    }
+
+    override _onUpdate(
+        changed: DeepPartial<this["_source"]>,
+        options: DocumentModificationContext<TParent>,
+        userId: string
+    ): void {
+        super._onUpdate(changed, options, userId);
+
+        // If the stage changed, perform stage change events
+        if (changed.system?.stage && game.user === this.actor?.primaryUpdater) {
+            this.createStageMessage();
+        }
+    }
 }
 
 interface AfflictionPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends AbstractEffectPF2e<TParent> {
     flags: AfflictionFlags;
     readonly _source: AfflictionSource;
     system: AfflictionSystemData;
+}
+
+interface AfflictionDamage {
+    template: AfflictionDamageTemplate;
+    context: DamageRollContext;
 }
 
 export { AfflictionPF2e };

--- a/src/module/item/affliction/sheet.ts
+++ b/src/module/item/affliction/sheet.ts
@@ -104,7 +104,7 @@ class AfflictionSheetPF2e extends ItemSheetPF2e<AfflictionPF2e> {
                 const stageId = htmlClosest(event.target, "[data-stage-id]")?.dataset.stageId;
                 if (!this.item.system.stages[stageId ?? ""]) return;
 
-                const damage: AfflictionDamage = { value: "", type: "untyped" };
+                const damage: AfflictionDamage = { formula: "", type: "untyped" };
                 this.item.update({ [`system.stages.${stageId}.damage.${randomID()}`]: damage });
             });
         }
@@ -197,6 +197,18 @@ class AfflictionSheetPF2e extends ItemSheetPF2e<AfflictionPF2e> {
         } else {
             ui.notifications.error("PF2E.Item.Affliction.Error.RestrictedStageItem", { localize: true });
         }
+    }
+
+    protected override async _updateObject(event: Event, formData: Record<string, unknown>): Promise<void> {
+        // Set empty-string damage categories to `null`
+        const categories = Object.keys(formData).filter((k) =>
+            /^system\.stages\.[a-z0-9]+\.damage\.[a-z0-9]+\.category$/i.test(k)
+        );
+        for (const key of categories) {
+            formData[key] ||= null;
+        }
+
+        return super._updateObject(event, formData);
     }
 }
 

--- a/src/module/system/damage/types.ts
+++ b/src/module/system/damage/types.ts
@@ -115,9 +115,12 @@ interface SpellDamageTemplate extends BaseDamageTemplate {
     };
 }
 
-type DamageTemplate = WeaponDamageTemplate | SpellDamageTemplate;
+type AfflictionDamageTemplate = SpellDamageTemplate;
+
+type DamageTemplate = WeaponDamageTemplate | SpellDamageTemplate | AfflictionDamageTemplate;
 
 export {
+    AfflictionDamageTemplate,
     BaseDamageData,
     CriticalInclusion,
     DamageCategory,

--- a/static/templates/items/affliction-details.hbs
+++ b/static/templates/items/affliction-details.hbs
@@ -34,7 +34,7 @@
             {{#each stage.damage as |damage id|}}
                 <div class="formula-section">
                     <div class="details-container-flex-row">
-                        <input type="text" name="system.stages.{{stageId}}.damage.{{id}}.value" value="{{damage.value}}" placeholder="{{localize "PF2E.FormulaPlaceholder"}}" />
+                        <input type="text" name="system.stages.{{stageId}}.damage.{{id}}.formula" value="{{damage.formula}}" placeholder="{{localize "PF2E.FormulaPlaceholder"}}" />
                         <select name="system.stages.{{stageId}}.damage.{{id}}.category">
                             {{#select damage.category}}
                                 <option></option>


### PR DESCRIPTION
Also refactors spell damage construction (though I'm still iffy on whether build should throw or warn and return null) and fixes some affliction issues.

Once we decide what the selectors should be, we can add retrieving modifiers and what-not.