### PR TITLE
Have `RuleElementPF2e` extend `DataModel`

### DIFF
--- a/src/module/rules/index.ts
+++ b/src/module/rules/index.ts
@@ -95,23 +95,22 @@ class RuleElements {
 
     static fromOwnedItem(item: Embedded<ItemPF2e>, options?: RuleElementOptions): RuleElementPF2e[] {
         const rules: RuleElementPF2e[] = [];
-        for (const [sourceIndex, data] of item.system.rules.entries()) {
-            if (typeof data.key !== "string") {
+        for (const [sourceIndex, source] of item.system.rules.entries()) {
+            if (typeof source.key !== "string") {
                 console.error(
-                    `PF2e System | Missing key in rule element ${data.key} on item ${item.name} (${item.uuid})`
+                    `PF2e System | Missing key in rule element ${source.key} on item ${item.name} (${item.uuid})`
                 );
                 continue;
             }
-            const key = data.key.replace(/^PF2E\.RuleElement\./, "");
-            const REConstructor = this.custom[key] ?? this.custom[data.key] ?? this.builtin[key];
+            const REConstructor = this.custom[source.key] ?? this.custom[source.key] ?? this.builtin[source.key];
             if (REConstructor) {
                 const rule = ((): RuleElementPF2e | null => {
                     try {
-                        return new REConstructor(data, item, { ...(options ?? {}), sourceIndex });
+                        return new REConstructor(source, item, { ...(options ?? {}), sourceIndex });
                     } catch (error) {
                         if (!options?.suppressWarnings) {
                             console.warn(
-                                `PF2e System | Failed to construct rule element ${data.key} on item ${item.name}`,
+                                `PF2e System | Failed to construct rule element ${source.key} on item ${item.name}`,
                                 `(${item.uuid})`
                             );
                             console.warn(error);
@@ -122,7 +121,7 @@ class RuleElements {
                 if (rule) rules.push(rule);
             } else {
                 const { name, uuid } = item;
-                console.warn(`PF2e System | Unrecognized rule element ${data.key} on item ${name} (${uuid})`);
+                console.warn(`PF2e System | Unrecognized rule element ${source.key} on item ${name} (${uuid})`);
             }
         }
         return rules;

--- a/src/module/rules/rule-element/aura.ts
+++ b/src/module/rules/rule-element/aura.ts
@@ -24,19 +24,16 @@ export class AuraRuleElement extends RuleElementPF2e {
      */
     colors: AuraColors | null;
 
-    constructor(data: AuraRuleElementSource, item: Embedded<ItemPF2e>, options?: RuleElementOptions) {
-        super(data, item, options);
+    constructor(source: AuraRuleElementSource, item: Embedded<ItemPF2e>, options?: RuleElementOptions) {
+        super(source, item, options);
 
-        data.effects ??= [];
-        data.traits ??= [];
-        data.colors ??= null;
-        this.slug = typeof data.slug === "string" ? sluggify(data.slug) : this.item.slug ?? sluggify(this.item.name);
+        this.slug ??= this.item.slug ?? sluggify(this.item.name);
 
-        if (this.#isValid(data)) {
-            this.radius = data.radius;
-            this.effects = deepClone(data.effects);
-            this.traits = deepClone(data.traits);
-            this.colors = data.colors;
+        if (this.#isValid(source)) {
+            this.radius = source.radius;
+            this.effects = deepClone(source.effects ?? []);
+            this.traits = deepClone(source.traits ?? []);
+            this.colors = source.colors ?? null;
         } else {
             this.radius = 0;
             this.effects = [];
@@ -67,7 +64,7 @@ export class AuraRuleElement extends RuleElementPF2e {
             predicate: PredicatePF2e.isValid(data.predicate ?? []),
             radius: ["number", "string"].includes(typeof data.radius),
             effects: Array.isArray(data.effects) && data.effects.every(this.#isEffectData),
-            colors: data.colors === null || this.#isAuraColors(data.colors),
+            colors: !("colors" in data) || data.colors === null || this.#isAuraColors(data.colors),
         };
         const properties = ["predicate", "radius", "effects", "colors"] as const;
         for (const property of properties) {
@@ -121,9 +118,9 @@ interface AuraRuleElementSource extends RuleElementSource {
 
 interface AuraRuleElementData extends RuleElementSource {
     radius: string | number;
-    effects: AuraREEffectData[];
-    traits: ItemTrait[];
-    colors: AuraColors | null;
+    effects?: AuraREEffectData[];
+    traits?: ItemTrait[];
+    colors?: AuraColors | null;
 }
 
 interface AuraREEffectData extends Omit<AuraEffectData, "level"> {

--- a/src/module/rules/rule-element/base.ts
+++ b/src/module/rules/rule-element/base.ts
@@ -3,11 +3,15 @@ import { ActorType } from "@actor/data";
 import { DiceModifierPF2e, ModifierPF2e } from "@actor/modifiers";
 import { ItemPF2e, PhysicalItemPF2e, WeaponPF2e } from "@item";
 import { ItemSourcePF2e } from "@item/data";
+import { LaxSchemaField, PredicateField, SlugField } from "@system/schema-data-fields";
 import { TokenDocumentPF2e } from "@scene";
 import { CheckRoll } from "@system/check";
 import { PredicatePF2e } from "@system/predication";
-import { isObject, sluggify, tupleHasValue } from "@util";
-import { BracketedValue, RuleElementData, RuleElementSource, RuleValue } from "./data";
+import { isObject, tupleHasValue } from "@util";
+import { BracketedValue, RuleElementData, RuleElementSchema, RuleElementSource, RuleValue } from "./data";
+
+const { DataModel } = foundry.abstract;
+const { fields } = foundry.data;
 
 /**
  * Rule Elements allow you to modify actorData and tokenData values when present on items. They can be configured
@@ -15,36 +19,47 @@ import { BracketedValue, RuleElementData, RuleElementSource, RuleValue } from ".
  *
  * @category RuleElement
  */
-abstract class RuleElementPF2e {
+abstract class RuleElementPF2e<TSchema extends RuleElementSchema = RuleElementSchema> extends DataModel<null, TSchema> {
+    static override defineSchema(): RuleElementSchema {
+        return {
+            key: new fields.StringField({ required: true, blank: false }),
+            slug: new SlugField({ required: true }),
+            label: new fields.StringField({ required: false, initial: undefined }),
+            priority: new fields.NumberField({ required: false, nullable: false, integer: true, initial: 100 }),
+            ignored: new fields.BooleanField({ required: false }),
+            predicate: new PredicateField(),
+            requiresEquipped: new fields.BooleanField({ required: false, nullable: true, initial: undefined }),
+            requiresInvestment: new fields.BooleanField({ required: false, nullable: true, initial: undefined }),
+        };
+    }
+
+    /** Use a "lax" schema field that preserves properties not defined in the `DataSchema` */
+    static override get schema(): LaxSchemaField {
+        if (Object.hasOwn(this, "_schema")) return this._schema as unknown as LaxSchemaField;
+
+        const schema = new LaxSchemaField(Object.freeze(this.defineSchema()));
+        schema.name = this.name;
+        Object.defineProperty(this, "_schema", { value: schema, writable: false });
+
+        return schema;
+    }
+
     data: RuleElementData;
-
-    key: string;
-
-    slug: string | null;
 
     sourceIndex: number | null;
 
     protected suppressWarnings: boolean;
 
-    /** Must the parent item be equipped for this rule element to apply (`null` for non-physical items)? */
-    requiresEquipped: boolean | null = null;
-
-    /** Must the parent item be invested for this rule element to apply (`null` unless an investable physical item)? */
-    requiresInvestment: boolean | null = null;
-
     /** A list of actor types on which this rule element can operate (all unless overridden) */
     protected static validActorTypes: ActorType[] = ["character", "npc", "familiar", "hazard", "loot", "vehicle"];
 
-    /** A test of whether the rules element is to be applied */
-    readonly predicate: PredicatePF2e;
-
     /**
-     * @param data unserialized JSON data from the actual rule input
+     * @param source unserialized JSON data from the actual rule input
      * @param item where the rule is persisted on
      */
-    constructor(data: RuleElementSource, public item: Embedded<ItemPF2e>, options: RuleElementOptions = {}) {
-        this.key = String(data.key);
-        this.slug = typeof data.slug === "string" ? sluggify(data.slug) : null;
+    constructor(source: RuleElementSource, public item: Embedded<ItemPF2e>, options: RuleElementOptions = {}) {
+        super(source, { strict: false });
+
         this.suppressWarnings = options.suppressWarnings ?? false;
         this.sourceIndex = options.sourceIndex ?? null;
 
@@ -53,18 +68,20 @@ abstract class RuleElementPF2e {
             const ruleName = game.i18n.localize(`PF2E.RuleElement.${this.key}`);
             const actorType = game.i18n.localize(`ACTOR.Type${item.actor.type.titleCase()}`);
             console.warn(`PF2e System | A ${ruleName} rules element may not be applied to a ${actorType}`);
-            data.ignored = true;
+            source.ignored = true;
         }
-        const label = typeof data.label === "string" ? data.label : item.name;
+
+        this.label =
+            typeof source.label === "string"
+                ? game.i18n.localize(this.resolveInjectedProperties(source.label))
+                : item.name;
 
         this.data = {
-            priority: 100,
-            ...data,
+            ...source,
             key: this.key,
-            predicate: Array.isArray(data.predicate) ? data.predicate : undefined,
-            label: game.i18n.localize(this.resolveInjectedProperties(label)),
-            ignored: Boolean(data.ignored ?? false),
-            removeUponCreate: Boolean(data.removeUponCreate ?? false),
+            predicate: Array.isArray(source.predicate) ? source.predicate : undefined,
+            label: this.label,
+            removeUponCreate: Boolean(source.removeUponCreate ?? false),
         } as RuleElementData;
 
         this.predicate = new PredicatePF2e(...(this.data.predicate ?? []));
@@ -74,10 +91,18 @@ abstract class RuleElementPF2e {
         }
 
         if (item instanceof PhysicalItemPF2e) {
-            this.requiresEquipped = !!(data.requiresEquipped ?? true);
+            this.requiresEquipped = !!(source.requiresEquipped ?? true);
             this.requiresInvestment =
-                item.isInvested === null ? null : !!(data.requiresInvestment ?? this.requiresEquipped);
+                item.isInvested === null ? null : !!(source.requiresInvestment ?? this.requiresEquipped);
+            this.ignored ??=
+                (!!this.requiresEquipped && !item.isEquipped) || (!!this.requiresInvestment && !item.isInvested);
+        } else {
+            this.requiresEquipped = null;
+            this.requiresInvestment = null;
+            this.ignored ??= false;
         }
+
+        if (this.invalid) this.ignored = true;
     }
 
     get actor(): ActorPF2e {
@@ -92,30 +117,6 @@ abstract class RuleElementPF2e {
         const tokens = actor.getActiveTokens();
         const controlled = tokens.find((token) => token.controlled);
         return controlled?.document ?? tokens.shift()?.document ?? null;
-    }
-
-    get label(): string {
-        return this.data.label;
-    }
-
-    /** The place in order of application (ascending), among an actor's list of rule elements */
-    get priority(): number {
-        return this.data.priority;
-    }
-
-    /** Globally ignore this rule element. */
-    get ignored(): boolean {
-        if (this.data.ignored) return true;
-
-        const { item } = this;
-        if (!(item instanceof PhysicalItemPF2e)) return (this.data.ignored = false);
-
-        return (this.data.ignored =
-            (!!this.requiresEquipped && !item.isEquipped) || (!!this.requiresInvestment && !item.isInvested));
-    }
-
-    set ignored(value: boolean) {
-        this.data.ignored = value;
     }
 
     /** Test this rule element's predicate, if present */
@@ -304,46 +305,9 @@ abstract class RuleElementPF2e {
     }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-namespace
-namespace RuleElementPF2e {
-    export interface PreCreateParams<T extends RuleElementSource = RuleElementSource> {
-        /** The source partial of the rule element's parent item to be created */
-        itemSource: PreCreate<ItemSourcePF2e>;
-        /** The source of the rule in `itemSource`'s `system.rules` array */
-        ruleSource: T;
-        /** All items pending creation in a `ItemPF2e.createDocuments` call */
-        pendingItems: PreCreate<ItemSourcePF2e>[];
-        /** The context object from the `ItemPF2e.createDocuments` call */
-        context: DocumentModificationContext<ItemPF2e>;
-        /** Whether this preCreate run is from a pre-update reevaluation */
-        reevaluation?: boolean;
-    }
-
-    export interface PreDeleteParams {
-        /** All items pending deletion in a `ItemPF2e.deleteDocuments` call */
-        pendingItems: Embedded<ItemPF2e>[];
-        /** The context object from the `ItemPF2e.deleteDocuments` call */
-        context: DocumentModificationContext<ItemPF2e>;
-    }
-
-    export interface AfterRollParams {
-        roll: Rolled<CheckRoll> | null;
-        selectors: string[];
-        domains: string[];
-        rollOptions: Set<string>;
-    }
-
-    export type UserInput<T extends RuleElementData> = { [K in keyof T]?: unknown } & RuleElementSource;
-}
-
-interface RuleElementOptions {
-    /** If created from an item, the index in the source data */
-    sourceIndex?: number;
-    /** If data validation fails for any reason, do not emit console warnings */
-    suppressWarnings?: boolean;
-}
-
-interface RuleElementPF2e {
+interface RuleElementPF2e<TSchema extends RuleElementSchema>
+    extends foundry.abstract.DataModel<null, TSchema>,
+        foundry.data.fields.ModelPropsFromSchema<RuleElementSchema> {
     constructor: typeof RuleElementPF2e;
 
     /**
@@ -432,6 +396,45 @@ interface RuleElementPF2e {
 
     /** An optional method for excluding damage modifiers and extra dice */
     applyDamageExclusion?(weapon: WeaponPF2e, modifiers: (DiceModifierPF2e | ModifierPF2e)[]): void;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+namespace RuleElementPF2e {
+    export interface PreCreateParams<T extends RuleElementSource = RuleElementSource> {
+        /** The source partial of the rule element's parent item to be created */
+        itemSource: PreCreate<ItemSourcePF2e>;
+        /** The source of the rule in `itemSource`'s `system.rules` array */
+        ruleSource: T;
+        /** All items pending creation in a `ItemPF2e.createDocuments` call */
+        pendingItems: PreCreate<ItemSourcePF2e>[];
+        /** The context object from the `ItemPF2e.createDocuments` call */
+        context: DocumentModificationContext<ItemPF2e>;
+        /** Whether this preCreate run is from a pre-update reevaluation */
+        reevaluation?: boolean;
+    }
+
+    export interface PreDeleteParams {
+        /** All items pending deletion in a `ItemPF2e.deleteDocuments` call */
+        pendingItems: Embedded<ItemPF2e>[];
+        /** The context object from the `ItemPF2e.deleteDocuments` call */
+        context: DocumentModificationContext<ItemPF2e>;
+    }
+
+    export interface AfterRollParams {
+        roll: Rolled<CheckRoll> | null;
+        selectors: string[];
+        domains: string[];
+        rollOptions: Set<string>;
+    }
+
+    export type UserInput<T extends RuleElementData> = { [K in keyof T]?: unknown } & RuleElementSource;
+}
+
+interface RuleElementOptions {
+    /** If created from an item, the index in the source data */
+    sourceIndex?: number;
+    /** If data validation fails for any reason, do not emit console warnings */
+    suppressWarnings?: boolean;
 }
 
 export { RuleElementPF2e, RuleElementOptions };

--- a/src/module/rules/rule-element/data.ts
+++ b/src/module/rules/rule-element/data.ts
@@ -1,4 +1,6 @@
+import { PredicateField, SlugField } from "@system/schema-data-fields";
 import { RawPredicate } from "@system/predication";
+import { BooleanField, NumberField, StringField } from "types/foundry/common/data/fields.mjs";
 
 type RuleElementSource = {
     key?: unknown;
@@ -39,4 +41,22 @@ interface BracketedValue<T extends object | number | string = object | number | 
     brackets: Bracket<T>[];
 }
 
-export { Bracket, BracketedValue, RuleElementData, RuleElementSource, RuleValue };
+type RuleElementSchema = {
+    key: StringField;
+    /** An identifying slug for the rule element: its significance and restrictions are determined per RE type */
+    slug: SlugField;
+    /** A label for use by any rule element for display in an interface */
+    label: StringField;
+    /** The place in order of application (ascending), among an actor's list of rule elements */
+    priority: NumberField<number, number, false>;
+    /** A test of whether the rules element is to be applied */
+    predicate: PredicateField;
+    /** Whether the rule element is ignored and deactivated */
+    ignored: BooleanField;
+    /** Whether the rule element requires that the parent item (if physical) be equipped */
+    requiresEquipped: BooleanField<boolean, boolean, true>;
+    /** Whether the rule element requires that the parent item (if physical) be invested */
+    requiresInvestment: BooleanField<boolean, boolean, true>;
+};
+
+export { Bracket, BracketedValue, RuleElementData, RuleElementSchema, RuleElementSource, RuleValue };

--- a/src/module/rules/rule-element/index.ts
+++ b/src/module/rules/rule-element/index.ts
@@ -1,2 +1,2 @@
 export { RuleElementPF2e, RuleElementOptions } from "./base";
-export { RuleElementSource, RuleElementData, RuleValue, BracketedValue } from "./data";
+export { RuleElementSource, RuleElementSchema, RuleElementData, RuleValue, BracketedValue } from "./data";

--- a/src/module/rules/rule-element/iwr/base.ts
+++ b/src/module/rules/rule-element/iwr/base.ts
@@ -37,7 +37,7 @@ abstract class IWRRuleElement extends RuleElementPF2e {
 
     abstract get property(): unknown[];
 
-    validate(value: unknown): boolean {
+    #isValid(value: unknown): boolean {
         if (this.type.length === 0) {
             this.failValidation("A type must be provided");
             return false;
@@ -75,7 +75,7 @@ abstract class IWRRuleElement extends RuleElementPF2e {
         this.type = this.resolveInjectedProperties(this.type);
 
         const value = Math.floor(Number(this.resolveValue()));
-        if (!this.validate(value)) {
+        if (!this.#isValid(value)) {
             this.ignored = true;
             return;
         }

--- a/src/module/rules/rule-element/substitute-roll.ts
+++ b/src/module/rules/rule-element/substitute-roll.ts
@@ -16,13 +16,12 @@ class SubstituteRollRuleElement extends RuleElementPF2e {
     constructor(data: SubstituteRollSource, item: Embedded<ItemPF2e>, options?: RuleElementOptions) {
         super(data, item, options);
 
-        data.required ??= false;
         if (this.#isValid(data)) {
             this.selector = data.selector;
-            this.required = data.required;
+            this.required = data.required ?? false;
         }
 
-        this.slug = typeof data.slug === "string" ? data.slug : sluggify(this.item.name);
+        this.slug ??= item.slug ?? sluggify(item.name);
 
         this.effectType = tupleHasValue(["fortune", "misfortune"] as const, data.effectType)
             ? data.effectType
@@ -30,7 +29,7 @@ class SubstituteRollRuleElement extends RuleElementPF2e {
     }
 
     #isValid(data: SubstituteRollSource): data is SubstituteRollData {
-        return typeof data.selector === "string" && typeof data.required === "boolean";
+        return typeof data.selector === "string" && (!("required" in data) || typeof data.required === "boolean");
     }
 
     override beforePrepareData(): void {
@@ -66,7 +65,7 @@ interface SubstituteRollSource extends RuleElementSource {
 interface SubstituteRollData {
     key: "SubstituteRoll";
     selector: string;
-    required: boolean;
+    required?: boolean;
 }
 
 export { SubstituteRollRuleElement };

--- a/src/module/system/predication.ts
+++ b/src/module/system/predication.ts
@@ -26,7 +26,7 @@ class PredicatePF2e extends Array<PredicateStatement> {
 
     /** Is this an array of predicatation statements? */
     static override isArray(statements: unknown): statements is PredicateStatement[] {
-        return super.isArray(statements) && statements.every((s) => StatementValidator.validate(s));
+        return super.isArray(statements) && statements.every((s) => StatementValidator.isStatement(s));
     }
 
     /** Test if the given predicate passes for the given list of options. */
@@ -131,11 +131,7 @@ class PredicatePF2e extends Array<PredicateStatement> {
 }
 
 class StatementValidator {
-    static validate(statement: unknown): statement is PredicateStatement {
-        return this.isStatement(statement);
-    }
-
-    private static isStatement(statement: unknown): statement is PredicateStatement {
+    static isStatement(statement: unknown): statement is PredicateStatement {
         return statement instanceof Object
             ? this.isCompound(statement) || this.isBinaryOp(statement)
             : typeof statement === "string"
@@ -268,4 +264,4 @@ type PredicateStatement = Atom | CompoundStatement;
 
 type RawPredicate = PredicateStatement[];
 
-export { PredicatePF2e, PredicateStatement, RawPredicate, convertLegacyData };
+export { PredicatePF2e, PredicateStatement, RawPredicate, StatementValidator, convertLegacyData };

--- a/src/module/system/schema-data-fields.ts
+++ b/src/module/system/schema-data-fields.ts
@@ -1,0 +1,95 @@
+import { PredicatePF2e, PredicateStatement, RawPredicate, StatementValidator } from "@system/predication";
+import { sluggify } from "@util";
+import { DataModel } from "types/foundry/common/abstract/data.mjs";
+import {
+    ArrayFieldOptions,
+    CleanFieldOptions,
+    DataFieldOptions,
+    DataSchema,
+    StringFieldOptions,
+} from "types/foundry/common/data/fields.mjs";
+
+/* -------------------------------------------- */
+/*  System `DataSchema` `DataField`s            */
+/* -------------------------------------------- */
+
+const { fields } = foundry.data;
+
+/** A sluggified string field */
+class SlugField<TNullable extends boolean = true> extends fields.StringField<string, string, TNullable> {
+    protected static override get _defaults(): StringFieldOptions {
+        return mergeObject(super._defaults, {
+            initial: null,
+            nullable: true,
+        });
+    }
+
+    protected override _cleanType(value: Maybe<string>, options?: CleanFieldOptions): Maybe<string> {
+        const slug = super._cleanType(value, options);
+        return typeof slug === "string" ? sluggify(slug) : slug;
+    }
+}
+
+class PredicateStatementField extends fields.DataField<PredicateStatement, PredicateStatement> {
+    /** A `PredicateStatement` is always required (not `undefined`) and never nullable */
+    constructor(options: DataFieldOptions<PredicateStatement, false> = {}) {
+        super({ ...options, required: true, nullable: false });
+    }
+
+    protected override _validateType(value: unknown): boolean {
+        return StatementValidator.isStatement(value);
+    }
+
+    /** No casting is available for a predicate statement */
+    protected _cast(value: unknown): unknown {
+        return value;
+    }
+
+    protected override _cleanType(value: PredicateStatement): PredicateStatement {
+        return typeof value === "string" ? value.trim() : value;
+    }
+}
+
+class PredicateField<TNullable extends boolean = false> extends fields.ArrayField<
+    PredicateStatementField,
+    RawPredicate,
+    RawPredicate,
+    TNullable
+> {
+    constructor(options: Pick<ArrayFieldOptions<PredicateStatementField, TNullable>, "initial" | "nullable"> = {}) {
+        super(new PredicateStatementField(), options);
+    }
+
+    /** Construct a `PredicatePF2e` from the initialized `PredicateStatement[]` */
+    override initialize(
+        value: RawPredicate,
+        model: ConstructorOf<DataModel>,
+        options?: ArrayFieldOptions<PredicateStatementField, TNullable>
+    ): TNullable extends true ? PredicatePF2e | null : PredicatePF2e;
+    override initialize(
+        value: RawPredicate,
+        model: ConstructorOf<DataModel>,
+        options: ArrayFieldOptions<PredicateStatementField, TNullable>
+    ): PredicatePF2e | null {
+        const statements = super.initialize(value, model, options);
+        return statements ? new PredicatePF2e(...statements) : statements;
+    }
+}
+
+/** A `SchemaField` that preserves fields not declared in its `DataSchema` */
+class LaxSchemaField<TSourceProp extends DataSchema = DataSchema> extends fields.SchemaField<TSourceProp> {
+    protected override _cleanType(data: Record<string, unknown>, options: CleanFieldOptions = {}): TSourceProp {
+        options.source = options.source || data;
+
+        // Clean each field that belongs to the schema
+        for (const [name, field] of this.entries()) {
+            if (!(name in data) && options.partial) continue;
+            data[name] = field.clean(data[name], options);
+            if (data[name] === undefined) delete data[name];
+        }
+
+        return data as TSourceProp;
+    }
+}
+
+export { LaxSchemaField, PredicateField, SlugField };

--- a/types/foundry/common/abstract/data.d.ts
+++ b/types/foundry/common/abstract/data.d.ts
@@ -1,8 +1,11 @@
-export {};
+import * as AbstractDataModel from "./data.mjs";
 
 declare global {
     module foundry {
         module abstract {
+            export import DataModel = AbstractDataModel.DataModel;
+            export import _DataModel = AbstractDataModel._DataModel;
+
             /**
              * A schema entry which describes a field of DocumentData
              * @property type           An object which defines the data type of this field

--- a/types/foundry/common/data/fields.d.mts
+++ b/types/foundry/common/data/fields.d.mts
@@ -17,12 +17,12 @@ import { DataModel, EmbeddedCollection } from "../abstract/module.mjs";
  * @property [validationError] A custom validation error string. When displayed will be prepended with the
  *                             document name, field name, and candidate value.
  */
-export interface DataFieldOptions<TSourceProp extends unknown = unknown, TNullable extends boolean = false> {
+export interface DataFieldOptions<TSourceProp extends unknown, TNullable extends boolean> {
     required?: boolean;
     nullable?: TNullable;
     initial?: unknown;
     validate?: (value: unknown) => Error | void;
-    choices?: TSourceProp[] | object | Function;
+    choices?: readonly TSourceProp[] | Record<string, string> | Function;
     label?: string;
     hint?: string;
     validationError?: string;
@@ -55,7 +55,7 @@ export abstract class DataField<
     parent: DataSchema | undefined;
 
     /** Default parameters for this field type */
-    static get _defaults(): DataFieldOptions<unknown, boolean>;
+    protected static get _defaults(): DataFieldOptions<unknown, boolean>;
 
     /** A dot-separated string representation of the field path within the parent schema. */
     get fieldPath(): string;
@@ -95,14 +95,14 @@ export abstract class DataField<
      * @param [options] Additional options for how the field is cleaned.
      * @returns The cleaned value.
      */
-    protected _cleanType(value?: unknown, options?: CleanFieldOptions): unknown;
+    protected _cleanType(value?: unknown, options?: CleanFieldOptions): Maybe<TSourceProp>;
 
     /**
      * Cast a non-default value to ensure it is the correct type for the field
      * @param value The provided non-default value
      * @returns The standardized value
      */
-    protected abstract _cast(value?: unknown): TSourceProp;
+    protected abstract _cast(value?: unknown): unknown;
 
     /**
      * Attempt to retrieve a valid initial value for the DataField.
@@ -151,13 +151,14 @@ export abstract class DataField<
 
     /**
      * Initialize the original source data into a mutable copy for the DataModel instance.
-     * @param value The source value of the field
-     * @param model The DataModel instance that this field belongs to
-     * @returns An initialized copy of the source data
+     * @param value     The source value of the field
+     * @param model     The DataModel instance that this field belongs to
+     * @param [options] Initialization options
      */
     initialize(
         value: unknown,
-        model?: ConstructorOf<DataModel>
+        model?: ConstructorOf<DataModel>,
+        options?: object
     ): TNullable extends true ? TModelProp | null : TModelProp;
 
     /**
@@ -172,7 +173,7 @@ export abstract class DataField<
 /*  Data Schema Field                           */
 /* -------------------------------------------- */
 
-export type DataSchema = Record<string, DataField>;
+export type DataSchema = Record<string, DataField<unknown, unknown, boolean>>;
 
 /** A special class of {@link DataField} which defines a data schema. */
 export class SchemaField<
@@ -186,7 +187,7 @@ export class SchemaField<
      */
     constructor(fields: DataSchema, options?: DataFieldOptions<TSourceProp, TNullable>);
 
-    static override get _defaults(): DataFieldOptions<DataSchema, boolean>;
+    protected static override get _defaults(): DataFieldOptions<DataSchema, boolean>;
 
     /** The contained field definitions. */
     fields: DataSchema;
@@ -234,10 +235,10 @@ export class SchemaField<
 
     protected override _cast(value: unknown): TSourceProp;
 
-    protected override _cleanType(data: object, options?: CleanFieldOptions): unknown;
+    protected override _cleanType(data: object, options?: CleanFieldOptions): Maybe<TSourceProp>;
 
     override initialize(
-        value: unknown,
+        value: TSourceProp,
         model: ConstructorOf<DataModel>
     ): TNullable extends true ? TModelProp | null : TModelProp;
 
@@ -252,7 +253,7 @@ export class SchemaField<
     ): TSourceProp;
 }
 
-interface CleanFieldOptions {
+export interface CleanFieldOptions {
     partial?: boolean;
     source?: object;
 }
@@ -272,9 +273,9 @@ export class BooleanField<
     TModelProp = TSourceProp,
     TNullable extends boolean = false
 > extends DataField<TSourceProp, TModelProp, TNullable> {
-    static override get _defaults(): BooleanFieldOptions<boolean, boolean>;
+    protected static override get _defaults(): BooleanFieldOptions<boolean, boolean>;
 
-    protected override _cast(value: unknown): TSourceProp;
+    protected override _cast(value: unknown): TNullable extends true ? TSourceProp | null : TSourceProp;
 
     protected override _validateType(value: unknown): value is boolean;
 }
@@ -307,11 +308,11 @@ export class NumberField<
     /** @param options  Options which configure the behavior of the field */
     constructor(options?: NumberFieldOptions<TSourceProp>);
 
-    static override get _defaults(): NumberFieldOptions;
+    protected static override get _defaults(): NumberFieldOptions;
 
     protected override _cast(value: unknown): TSourceProp;
 
-    protected override _cleanType(value: unknown, options?: CleanFieldOptions): unknown;
+    protected override _cleanType(value: unknown, options?: CleanFieldOptions): Maybe<TSourceProp>;
 
     protected override _validateType(value: unknown): void;
 }
@@ -323,6 +324,7 @@ export class NumberField<
  */
 interface StringFieldOptions<TSourceProp extends string = string, TNullable extends boolean = boolean>
     extends DataFieldOptions<TSourceProp, TNullable> {
+    choices?: readonly TSourceProp[] | Record<TSourceProp, string> | Function;
     blank?: boolean;
     trim?: boolean;
 }
@@ -334,12 +336,12 @@ export class StringField<
         TNullable extends boolean = false
     >
     extends DataField<TSourceProp, TModelProp, TNullable>
-    implements StringFieldOptions<TSourceProp>
+    implements StringFieldOptions<TSourceProp, TNullable>
 {
     /** @param options  Options which configure the behavior of the field */
-    constructor(options?: StringFieldOptions<TSourceProp>);
+    constructor(options?: StringFieldOptions<TSourceProp, TNullable>);
 
-    static override get _defaults(): StringFieldOptions;
+    protected static override get _defaults(): StringFieldOptions<string, boolean>;
 
     override clean(
         value: unknown,
@@ -363,7 +365,7 @@ export class ObjectField<TSourceProp extends object, TModelProp = TSourceProp, T
     extends DataField<TSourceProp, TModelProp, TNullable>
     implements Omit<ObjectFieldOptions<TSourceProp, TNullable>, "initial">
 {
-    static override get _defaults(): ObjectFieldOptions<object, boolean>;
+    protected static override get _defaults(): ObjectFieldOptions<object, boolean>;
 
     protected override _cast(value: unknown): TSourceProp;
 
@@ -402,11 +404,7 @@ export type ModelPropFromDataField<TDataField extends DataField> = TDataField ex
     ? TSchemaNullable extends true
         ? ModelPropsFromSchema<TSchemaSourceProp> | null
         : ModelPropsFromSchema<TSchemaSourceProp>
-    : TDataField extends DataField<infer _TSourceProp, infer TModelProp, infer TNullable>
-    ? TNullable extends true
-        ? TModelProp | null
-        : TModelProp
-    : never;
+    : ReturnType<TDataField["initialize"]>;
 
 type ModelPropsFromSchema<TDataSchema extends DataSchema> = {
     [K in keyof TDataSchema]: ModelPropFromDataField<TDataSchema[K]>;
@@ -421,7 +419,7 @@ type ArrayFieldOptions<TElementField extends DataField, TNullable extends boolea
 export class ArrayField<
         TElementField extends DataField,
         TSourceProp extends SourcePropFromDataField<TElementField>[] = SourcePropFromDataField<TElementField>[],
-        TModelProp = TSourceProp,
+        TModelProp extends object = TSourceProp,
         TNullable extends boolean = false
     >
     extends DataField<TSourceProp, TModelProp, TNullable>
@@ -431,7 +429,7 @@ export class ArrayField<
      * @param element A DataField instance which defines the type of element contained in the Array.
      * @param options Options which configure the behavior of the field
      */
-    constructor(element: TSourceProp[number], options?: ArrayFieldOptions<TElementField, TNullable>);
+    constructor(element: DataField, options?: ArrayFieldOptions<TElementField, TNullable>);
 
     /** The data type of each element in this array */
     element: TElementField;
@@ -444,7 +442,7 @@ export class ArrayField<
      */
     protected static _validateElementType(element: unknown): unknown;
 
-    static override get _defaults(): ArrayFieldOptions<DataField, boolean>;
+    protected static override get _defaults(): ArrayFieldOptions<DataField, boolean>;
 
     protected override _cast(value: unknown): TSourceProp;
 
@@ -462,7 +460,8 @@ export class ArrayField<
 
     override initialize(
         value: TSourceProp,
-        model: ConstructorOf<DataModel>
+        model: ConstructorOf<DataModel>,
+        options: ArrayFieldOptions<TElementField, TNullable>
     ): TNullable extends true ? TModelProp | null : TModelProp;
 
     override toObject(value: TModelProp): TNullable extends true ? TSourceProp | null : TSourceProp;
@@ -570,7 +569,7 @@ export class DocumentIdField<
     TModelProp extends string | DataModel = string,
     TNullable extends boolean = true
 > extends StringField<string, TModelProp, TNullable> {
-    static override get _defaults(): StringFieldOptions;
+    protected static override get _defaults(): StringFieldOptions;
 
     protected override _cast(value: unknown): string;
 
@@ -594,7 +593,7 @@ export class ForeignDocumentField<
     /** A reference to the model class which is stored in this field */
     model: DataModel;
 
-    static override get _defaults(): StringFieldOptions;
+    protected static override get _defaults(): StringFieldOptions;
 
     _cast(value: unknown): string;
 
@@ -620,7 +619,7 @@ export class SystemDataField<TSourceProp extends object = object, TModelProp = T
     /** The canonical document name of the document type which belongs in this field */
     document: ConstructorOf<DataModel>;
 
-    static override get _defaults(): ObjectFieldOptions<object>;
+    protected static override get _defaults(): ObjectFieldOptions<object>;
 
     /** A convenience accessor for the name of the document type associated with this SystemDataField */
     get documentName(): string;
@@ -634,7 +633,7 @@ export class SystemDataField<TSourceProp extends object = object, TModelProp = T
 
     getInitialValue(data: unknown): TSourceProp;
 
-    protected override _cleanType(value: unknown, options?: CleanFieldOptions): DeepPartial<TSourceProp>;
+    protected override _cleanType(value: unknown, options?: CleanFieldOptions): TSourceProp;
 
     override initialize(value: string, model?: ConstructorOf<DataModel>): TModelProp;
 
@@ -647,7 +646,7 @@ export class ColorField<TNullable extends boolean = true> extends StringField<
     HexColorString,
     TNullable
 > {
-    static override get _defaults(): StringFieldOptions<HexColorString, boolean>;
+    protected static override get _defaults(): StringFieldOptions<HexColorString, boolean>;
 
     protected override _validateType(value: unknown): boolean;
 }
@@ -672,7 +671,7 @@ export class FilePathField<
     /** @param options  Options which configure the behavior of the field */
     constructor(options?: FilePathFieldOptions);
 
-    static override get _defaults(): FilePathFieldOptions;
+    protected static override get _defaults(): FilePathFieldOptions;
 
     protected override _validateType(value: unknown): void;
 }
@@ -682,19 +681,19 @@ export class FilePathField<
  * @property base Whether the base angle should be treated as 360 or as 0
  */
 export class AngleField<TNullable extends boolean = false> extends NumberField<number, number, TNullable> {
-    static override get _defaults(): NumberFieldOptions & { base: 360 | 0 };
+    protected static override get _defaults(): NumberFieldOptions & { base: 360 | 0 };
 
     protected override _cast(value: unknown): number;
 }
 
 /** A special `NumberField` represents a number between 0 and 1. */
 export class AlphaField<TNullable extends boolean = false> extends NumberField<number, number, TNullable> {
-    static get _defaults(): NumberFieldOptions;
+    protected static get _defaults(): NumberFieldOptions;
 }
 
 /** A special `ObjectField` which captures a mapping of User IDs to Document permission levels. */
 export class DocumentOwnershipField extends ObjectField<Record<string, DocumentOwnershipLevel>> {
-    static override get _defaults(): ObjectFieldOptions<Record<string, DocumentOwnershipLevel>>;
+    protected static override get _defaults(): ObjectFieldOptions<Record<string, DocumentOwnershipLevel>>;
 
     protected override _validateType(value: object): boolean | void;
 }
@@ -707,7 +706,7 @@ export class JSONField<TModelProp = object, TNullable extends boolean = false> e
     TModelProp,
     TNullable
 > {
-    static override get _defaults(): StringFieldOptions;
+    protected static override get _defaults(): StringFieldOptions;
 
     override clean(value: unknown, options?: CleanFieldOptions): TNullable extends true ? string | null : string;
 
@@ -728,12 +727,12 @@ export class HTMLField<
     TModelProp = TSourceProp,
     TNullable extends boolean = false
 > extends StringField<TSourceProp, TModelProp, TNullable> {
-    static override get _defaults(): StringFieldOptions;
+    protected static override get _defaults(): StringFieldOptions;
 }
 
 /** A subclass of `NumberField` which is used for storing integer sort keys. */
 export class IntegerSortField<TNullable extends boolean = true> extends NumberField<number, number, TNullable> {
-    static override get _defaults(): NumberFieldOptions;
+    protected static override get _defaults(): NumberFieldOptions;
 }
 
 /* ---------------------------------------- */

--- a/types/foundry/common/data/index.d.ts
+++ b/types/foundry/common/data/index.d.ts
@@ -1,0 +1,9 @@
+import * as Fields from "./fields.mjs";
+
+declare global {
+    module foundry {
+        module data {
+            export import fields = Fields;
+        }
+    }
+}

--- a/types/foundry/common/index.d.ts
+++ b/types/foundry/common/index.d.ts
@@ -1,4 +1,5 @@
 import * as Constants from "./constants.mjs";
+import "./data";
 
 declare global {
     const CONST: typeof Constants;

--- a/types/foundry/index.d.ts
+++ b/types/foundry/index.d.ts
@@ -114,6 +114,7 @@ import "./client/ui";
 import "./common";
 import "./common/abstract";
 import "./common/constants.mjs";
+import "./common/data";
 import "./common/data/data";
 import "./common/data/validators";
 import "./common/documents";

--- a/types/foundry/util.d.ts
+++ b/types/foundry/util.d.ts
@@ -8,6 +8,8 @@ declare global {
         readonly dataTransfer: DataTransfer;
     }
 
+    type Maybe<T> = T | null | undefined;
+
     type DeepPartial<T> = {
         [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
     };


### PR DESCRIPTION
This includes both `RuleElementPF2e` getting a `DataModel` parent as well as initial work on writing schema definitions for subclasses. It makes use of a `LaxSchemaField` class that doesn't prune unrecognized fields so that the remaining conversion work can be done over time.