### PR TITLE
Prevent focus spells from being added to other spellcasting collections

### DIFF
--- a/src/module/item/spellcasting-entry/collection.ts
+++ b/src/module/item/spellcasting-entry/collection.ts
@@ -44,6 +44,17 @@ export class SpellCollection extends Collection<Embedded<SpellPF2e>> {
             return null;
         }
 
+        // Don't allow focus spells in non-focus casting entries
+        if (spell.isFocusSpell && !this.entry.isFocusPool) {
+            const focusTypeLabel = game.i18n.format("PF2E.SpellFocusLabel");
+            ui.notifications.warn(
+                game.i18n.format("PF2E.Item.Spell.Warning.WrongSpellType", {
+                    spellType: focusTypeLabel,
+                })
+            );
+            return null;
+        }
+
         // Warn if the level being dragged to is lower than spell's level
         if (spell.baseLevel > heightenLevel && this.id === spell.system.location?.value) {
             const targetLevelLabel = game.i18n.format("PF2E.SpellLevel", { level: ordinal(heightenLevel) });

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2294,7 +2294,8 @@
                     "SheetTitle": "{originalName} (Variant)"
                 },
                 "Warning": {
-                    "InvalidLevel": "Attempted to add spell {name} at {targetLevel}, but spell is {baseLevel}."
+                    "InvalidLevel": "Attempted to add spell {name} at {targetLevel}, but spell is {baseLevel}.",
+                    "WrongSpellType": "Cannot add {spellType} spell to this casting entry."
                 }
             },
             "Weapon": {


### PR DESCRIPTION
Starting some work on better integrating psychic into the system, this seemed a good first step to stop people from putting amped spells into normal spellcasting entries.