### PR TITLE
Cache the first `TokenAura.squares` getter result instead of recreating it each time it is called

### DIFF
--- a/src/module/scene/token-document/aura/index.ts
+++ b/src/module/scene/token-document/aura/index.ts
@@ -67,8 +67,7 @@ class TokenAura implements TokenAuraData {
 
     /** The squares covered by this aura */
     get squares(): EffectAreaSquare[] {
-        this.#squares ??= getAreaSquares(this);
-        return this.#squares;
+        return (this.#squares ??= getAreaSquares(this));
     }
 
     /** Does this aura overlap with (at least part of) a token? */

--- a/src/module/scene/token-document/aura/index.ts
+++ b/src/module/scene/token-document/aura/index.ts
@@ -23,6 +23,8 @@ class TokenAura implements TokenAuraData {
     /** Does this aura affect its emanating token? */
     private includesSelf: boolean;
 
+    #squares?: EffectAreaSquare[];
+
     constructor(args: TokenAuraParams) {
         this.slug = args.slug;
         this.token = args.token;
@@ -65,7 +67,8 @@ class TokenAura implements TokenAuraData {
 
     /** The squares covered by this aura */
     get squares(): EffectAreaSquare[] {
-        return getAreaSquares(this);
+        this.#squares ??= getAreaSquares(this);
+        return this.#squares;
     }
 
     /** Does this aura overlap with (at least part of) a token? */


### PR DESCRIPTION
I'm not 100% sure this has no negative side effects but it seems to be working fine.

Closes #5905 