### PR TITLE
Add item level display to item directory

### DIFF
--- a/src/module/apps/sidebar/index.ts
+++ b/src/module/apps/sidebar/index.ts
@@ -1,4 +1,5 @@
 export { ActorDirectoryPF2e } from "./actor-directory";
+export { ItemDirectoryPF2e } from "./item-directory";
 export { ChatLogPF2e } from "./chat-log";
 export { CompendiumDirectoryPF2e } from "./compendium-directory";
 export { EncounterTrackerPF2e } from "./encounter-tracker";

--- a/src/module/apps/sidebar/item-directory.ts
+++ b/src/module/apps/sidebar/item-directory.ts
@@ -1,0 +1,42 @@
+// import { ItemPF2e } from "@item/base";
+import { htmlQueryAll } from "@util";
+
+/** Extend ItemDirectory to show more information */
+export class ItemDirectoryPF2e<TItem extends Item> extends ItemDirectory<TItem> {
+    static override get defaultOptions(): SidebarDirectoryOptions {
+        const options = super.defaultOptions;
+        options.renderUpdateKeys.push("system.details.level.value", "system.attributes.adjustment");
+        return options;
+    }
+
+    override async getData(): Promise<object> {
+        return {
+            ...(await super.getData()),
+            documentPartial: "systems/pf2e/templates/sidebar/item-document-partial.hbs",
+        };
+    }
+
+    override activateListeners($html: JQuery<HTMLElement>): void {
+        super.activateListeners($html);
+        const html = $html[0];
+
+        for (const element of htmlQueryAll(html, "li.directory-item.item")) {
+            const item = game.items.get(element.dataset.documentId ?? "");
+            if (!item?.testUserPermission(game.user, "OBSERVER")) {
+                element.querySelector("span.item-level")?.remove();
+            }
+        }
+    }
+
+    /** Include flattened update data so parent method can read nested update keys */
+    protected override async _render(force?: boolean, context: SidebarDirectoryRenderOptions = {}): Promise<void> {
+        // Create new reference in case other applications are using the same context object
+        context = deepClone(context);
+
+        if (context.action === "update" && context.documentType === "Item" && context.data) {
+            context.data = context.data.map((d) => ({ ...d, ...flattenObject(d) }));
+        }
+
+        return super._render(force, context);
+    }
+}

--- a/src/module/apps/sidebar/item-directory.ts
+++ b/src/module/apps/sidebar/item-directory.ts
@@ -4,7 +4,7 @@ import { htmlQueryAll } from "@util";
 export class ItemDirectoryPF2e<TItem extends Item> extends ItemDirectory<TItem> {
     static override get defaultOptions(): SidebarDirectoryOptions {
         const options = super.defaultOptions;
-        options.renderUpdateKeys.push("system.details.level.value", "system.attributes.adjustment");
+        options.renderUpdateKeys.push("system.details.level.value");
         return options;
     }
 

--- a/src/module/apps/sidebar/item-directory.ts
+++ b/src/module/apps/sidebar/item-directory.ts
@@ -1,4 +1,3 @@
-// import { ItemPF2e } from "@item/base";
 import { htmlQueryAll } from "@util";
 
 /** Extend ItemDirectory to show more information */

--- a/src/scripts/hooks/init.ts
+++ b/src/scripts/hooks/init.ts
@@ -1,6 +1,12 @@
 import { MystifiedTraits } from "@item/data/values";
 import { HotbarPF2e } from "@module/apps/hotbar";
-import { ActorDirectoryPF2e, ChatLogPF2e, CompendiumDirectoryPF2e, EncounterTrackerPF2e } from "@module/apps/sidebar";
+import {
+    ActorDirectoryPF2e,
+    ItemDirectoryPF2e,
+    ChatLogPF2e,
+    CompendiumDirectoryPF2e,
+    EncounterTrackerPF2e,
+} from "@module/apps/sidebar";
 import {
     AmbientLightPF2e,
     EffectsCanvasGroupPF2e,
@@ -54,6 +60,7 @@ export const Init = {
 
             // Assign the PF2e Sidebar subclasses
             CONFIG.ui.actors = ActorDirectoryPF2e;
+            CONFIG.ui.items = ItemDirectoryPF2e;
             CONFIG.ui.combat = EncounterTrackerPF2e;
             CONFIG.ui.chat = ChatLogPF2e;
             CONFIG.ui.compendium = CompendiumDirectoryPF2e;

--- a/src/styles/ui/sidebar/_index.scss
+++ b/src/styles/ui/sidebar/_index.scss
@@ -1,3 +1,4 @@
 @import "actor-directory";
+@import "item-directory";
 @import "chat";
 @import "compendium-directory";

--- a/src/styles/ui/sidebar/_item-directory.scss
+++ b/src/styles/ui/sidebar/_item-directory.scss
@@ -1,0 +1,13 @@
+.directory-item.item {
+    h4 {
+        line-height: normal;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+    }
+
+    .item-level {
+        font-size: x-small;
+        color: var(--color-text-light-primary);
+    }
+}

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2183,7 +2183,8 @@
                 "Info": {
                     "Added": "{item} was added to {category}."
                 },
-                "LevelLabel": "Feat"
+                "LevelLabel": "Feat",
+                "LevelN": "Feat {level}"
             },
             "Heritage": {
                 "AncestryNotFound": "The referenced ancestry item was not found.",
@@ -2245,6 +2246,7 @@
             "RemovalPrevented": "Removal of {item} is prevented by {preventer}.",
             "SidebarSummary": "{type} Summary",
             "Spell": {
+                "LevelN": "Spell {level}",
                 "PlaceMeasuredTemplate": "Place {size}-{unit} {shape}",
                 "Variants": {
                     "DeleteDialogTitle": "Delete Spell Variant",
@@ -5459,6 +5461,7 @@
             "VehicleString": "Vehicle",
             "NamePlaceholder": "Vehicle",
             "VehicleLevelLabel": "Vehicle",
+            "LevelN": "Vehicle {level}",
             "DescriptionHeading": "Description",
             "PilotingCheckLabel": "Piloting Check",
             "CrewLabel": "Crew",

--- a/static/templates/sidebar/actor-document-partial.hbs
+++ b/static/templates/sidebar/actor-document-partial.hbs
@@ -1,9 +1,17 @@
 <li class="directory-item document {{@root.documentCls}} flexrow" data-document-id="{{this.id}}">
-  {{#if this.thumbnail}}
-      <img class="thumbnail" title="{{this.name}}" data-src="{{this.thumbnail}}"/>
-  {{/if}}
-  <h4 class="document-name">
-      <a>{{this.name}}</a>
-      {{#if (ne this.type "loot")}}<span class="actor-level">{{localize "PF2E.LevelN" level=this.level}}</span>{{/if}}
+    {{#if this.thumbnail}}
+        <img class="thumbnail" title="{{this.name}}" data-src="{{this.thumbnail}}"/>
+    {{/if}}
+    <h4 class="document-name">
+        <a>{{this.name}}</a>
+        {{#if (ne this.type "loot")}}
+            {{#if (eq this.type "hazard")}}
+                <span class="actor-level">{{localize "PF2E.Actor.Hazard.Level" level=this.level}}</span>
+            {{else if (eq this.type "vehicle")}}
+                <span class="actor-level">{{localize "PF2E.vehicle.LevelN" level=this.level}}</span>
+            {{else}}
+                <span class="actor-level">{{localize "PF2E.LevelN" level=this.level}}</span>
+            {{/if}}
+        {{/if}}
   </h4>
 </li>

--- a/static/templates/sidebar/item-document-partial.hbs
+++ b/static/templates/sidebar/item-document-partial.hbs
@@ -1,0 +1,11 @@
+<li class="directory-item document {{@root.documentCls}} flexrow" data-document-id="{{this.id}}">
+  {{#if this.thumbnail}}
+      <img class="thumbnail" title="{{this.name}}" data-src="{{this.thumbnail}}"/>
+  {{/if}}
+  <h4 class="document-name">
+      <a>{{this.name}}</a>
+      {{#if (gte this.level 0)}}
+      <span class="item-level">{{localize "PF2E.LevelN" level=this.level}}</span>
+      {{/if}}
+  </h4>
+</li>

--- a/static/templates/sidebar/item-document-partial.hbs
+++ b/static/templates/sidebar/item-document-partial.hbs
@@ -1,11 +1,19 @@
 <li class="directory-item document {{@root.documentCls}} flexrow" data-document-id="{{this.id}}">
-  {{#if this.thumbnail}}
-      <img class="thumbnail" title="{{this.name}}" data-src="{{this.thumbnail}}"/>
-  {{/if}}
-  <h4 class="document-name">
-      <a>{{this.name}}</a>
-      {{#if (gte this.level 0)}}
-      <span class="item-level">{{localize "PF2E.LevelN" level=this.level}}</span>
-      {{/if}}
-  </h4>
+    {{#if this.thumbnail}}
+        <img class="thumbnail" title="{{this.name}}" data-src="{{this.thumbnail}}"/>
+    {{/if}}
+    <h4 class="document-name">
+        <a>{{this.name}}</a>
+        {{#if (gte this.level 0)}}
+            {{#if (eq this.type "feat")}}
+                <span class="item-level">{{localize "PF2E.Item.Feat.LevelN" level=this.level}}</span>
+            {{else if (eq this.type "spell")}}
+                <span class="item-level">{{localize "PF2E.Item.Spell.LevelN" level=this.level}}</span>
+            {{else if (eq this.type "effect")}}
+                <span class="item-level">{{localize "PF2E.LevelN" level=this.level}}</span>
+            {{else}}
+                <span class="item-level">{{localize "PF2E.Item.Physical.LevelLabel" level=this.level}}</span>
+            {{/if}}
+        {{/if}}
+    </h4>
 </li>


### PR DESCRIPTION
To bring the item sidebar in line with the actor one, and to improve UX to see item levels at a glance, particularly for creating homebrew.
![image](https://user-images.githubusercontent.com/77904738/214931084-8e73b8d1-2db6-4eca-abff-2fae8ed12bcf.png)
