### PR TITLE
Brighten darker scene default colors for basic usability

### DIFF
--- a/src/scripts/config/index.ts
+++ b/src/scripts/config/index.ts
@@ -1729,7 +1729,7 @@ export const PF2ECONFIG = {
     Canvas: {
         darkness: {
             default: CONFIG.Canvas.darknessColor,
-            gmVision: 0x76739e,
+            gmVision: 0x908cb9,
         },
     },
 };

--- a/src/scripts/hooks/load.ts
+++ b/src/scripts/hooks/load.ts
@@ -40,6 +40,9 @@ export const Load = {
         CONFIG.Token.prototypeSheetClass = TokenConfigPF2e;
         CONFIG.User.documentClass = UserPF2e;
 
+        CONFIG.Canvas.darknessColor = 0x2d2d52; // Lightness increased by ~0.4/10 (Munsell value)
+        CONFIG.Canvas.exploredColor = 0x262626; // Increased from 0 (black)
+
         CONFIG.Dice.rolls.push(CheckRoll, StrikeAttackRoll, DamageRoll, DamageInstance);
         for (const TermCls of [ArithmeticExpression, Grouping, InstancePool, IntermediateDie]) {
             CONFIG.Dice.termTypes[TermCls.name] = TermCls;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/106829671/215230107-c60c86cd-90e5-423f-a8fe-01ef27b2f20a.png)

After:
![image](https://user-images.githubusercontent.com/106829671/215230217-3282b162-d591-4e77-b7a6-097c176c4c15.png)
