### PR TITLE
Added pf2e.chatMessageSave hook.

### DIFF
--- a/src/module/chat-message/listeners/cards.ts
+++ b/src/module/chat-message/listeners/cards.ts
@@ -19,7 +19,7 @@ export interface ChatMessageSaveEventArgs {
     message: ChatMessagePF2e;
     actor: ActorPF2e | null | undefined;
     token: TokenPF2e | null | undefined;
-    item: Embedded<ItemPF2e>;
+    item: Embedded<ItemPF2e> | null | undefined;
     roll: Rolled<CheckRoll>;
     outcome: DegreeOfSuccessString | null | undefined;
     rollMessage: ChatMessagePF2e;

--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -9,7 +9,6 @@ import { htmlClosest, htmlQueryAll, objectHasKey, sluggify } from "@util";
 import { getSelectedOrOwnActors } from "@util/token-actor-utils";
 import { MeasuredTemplateDocumentPF2e } from "@scene";
 import { ChatMessageSaveEventArgs } from "@module/chat-message/listeners/cards";
-import { ItemPF2e } from "@item";
 
 const inlineSelector = ["action", "check", "effect-area", "repost"].map((keyword) => `[data-pf2-${keyword}]`).join(",");
 
@@ -176,7 +175,7 @@ export const InlineRollLinks = {
                                         message: message,
                                         actor: message?.token?.actor,
                                         token: rollMessage.token?.object,
-                                        item: {} as Embedded<ItemPF2e>, // item,
+                                        item: message?.item,
                                         roll: roll,
                                         outcome: outcome,
                                         rollMessage: rollMessage,


### PR DESCRIPTION
So, I have been trying to create a module that makes it easier to get an overview of save results as well as to select involved tokens:
![image](https://user-images.githubusercontent.com/2363121/215291414-fcd3cf93-2685-4889-b51d-36445cdf84ed.png)

I have not been successful in doing what I wanted without adding some hooks to PF2E.
I have no idea if this is reasonable or not, or if there's some way to implement this without changing PF2E.
Do this make any sense, or am I going about this in the wrong way?
Just thought I should check before I spend more time on this.