### PR TITLE
Add support for effect counter labels and formula badges

### DIFF
--- a/src/module/apps/effects-panel.ts
+++ b/src/module/apps/effects-panel.ts
@@ -3,7 +3,7 @@ import { AbstractEffectPF2e, EffectPF2e } from "@item";
 import { AfflictionPF2e } from "@item/affliction";
 import { PersistentDialog } from "@item/condition/persistent-damage-dialog";
 import { EffectExpiryType } from "@item/effect/data";
-import { htmlQueryAll } from "@util";
+import { htmlQuery, htmlQueryAll } from "@util";
 import { FlattenedCondition } from "../system/conditions";
 
 export class EffectsPanel extends Application {
@@ -107,6 +107,29 @@ export class EffectsPanel extends Application {
                     item.rollRecovery();
                 }
             });
+
+            // Uses a scale transform to fit the text within the box
+            // Note that the value container cannot have padding or measuring will fail.
+            // They cannot be inline elements pre-computation, but most be post-computation (for ellipses)
+            const valueContainer = htmlQuery(iconElem, ".value");
+            const textElement = htmlQuery(valueContainer, "strong");
+            if (valueContainer && textElement) {
+                const minScale = 0.75;
+                const parentWidth = valueContainer.clientWidth;
+                const scale = textElement.clientWidth
+                    ? Math.clamped(parentWidth / textElement.clientWidth, minScale, 1)
+                    : 1;
+                if (scale < 1) {
+                    valueContainer.style.transformOrigin = "left";
+                    valueContainer.style.transform = `scaleX(${scale})`;
+
+                    // Unfortunately, width is pre scaling, so we need to scale it back up
+                    // +1 prevents certain scenarios where ellipses will show even above min scale.
+                    valueContainer.style.width = `${(1 / scale) * 100 + 1}%`;
+                }
+
+                textElement.style.display = "inline";
+            }
         }
     }
 

--- a/src/module/item/abstract-effect/data.ts
+++ b/src/module/item/abstract-effect/data.ts
@@ -1,6 +1,7 @@
 interface EffectBadgeCounter {
     type: "counter";
     value: number;
+    label?: string;
     labels?: string[];
 }
 
@@ -10,7 +11,13 @@ interface EffectBadgeValue {
     value: number | string;
 }
 
-type EffectBadge = EffectBadgeCounter | EffectBadgeValue;
+interface EffectBadgeFormula {
+    type: "formula";
+    value: string;
+    evaluate?: boolean;
+}
+
+type EffectBadge = EffectBadgeCounter | EffectBadgeValue | EffectBadgeFormula;
 
 type TimeUnit = "rounds" | "minutes" | "hours" | "days";
 

--- a/src/module/item/condition/document.ts
+++ b/src/module/item/condition/document.ts
@@ -14,7 +14,7 @@ import { DegreeOfSuccess } from "@system/degree-of-success";
 class ConditionPF2e extends AbstractEffectPF2e {
     override get badge(): EffectBadge | null {
         if (this.system.persistent) {
-            return { type: "value", value: this.system.persistent.formula };
+            return { type: "formula", value: this.system.persistent.formula };
         }
 
         return this.system.value.value ? { type: "counter", value: this.system.value.value } : null;

--- a/src/module/item/effect/document.ts
+++ b/src/module/item/effect/document.ts
@@ -1,5 +1,6 @@
 import { AbstractEffectPF2e } from "@item/abstract-effect";
 import { EffectBadge } from "@item/abstract-effect/data";
+import { ChatMessagePF2e } from "@module/chat-message";
 import { RuleElementOptions, RuleElementPF2e } from "@module/rules";
 import { UserPF2e } from "@module/user";
 import { isObject, objectHasKey, sluggify } from "@util";
@@ -82,6 +83,15 @@ class EffectPF2e extends AbstractEffectPF2e {
             system.duration.expiry ||= "turn-start";
         }
         system.expired = this.remainingDuration.expired;
+
+        const badge = this.system.badge;
+        if (badge?.type === "counter") {
+            const max = badge.labels?.length ?? Infinity;
+            badge.value = Math.clamped(badge.value, 1, max);
+            if (badge.labels) {
+                badge.label = badge.labels.at(badge.value - 1);
+            }
+        }
     }
 
     /** Unless this effect is temporarily constructed, ignore rule elements if it is expired */
@@ -98,8 +108,12 @@ class EffectPF2e extends AbstractEffectPF2e {
 
     /** Increases if this is a counter effect, otherwise ignored outright */
     async increase(): Promise<void> {
-        if (this.system.badge?.type === "counter" && !this.isExpired) {
-            const value = this.system.badge.value + 1;
+        const badge = this.system.badge;
+        if (badge?.type === "counter" && !this.isExpired) {
+            const max = badge.labels?.length ?? Infinity;
+            if (badge.value >= max) return;
+
+            const value = badge.value + 1;
             await this.update({ system: { badge: { value } } });
         }
     }
@@ -148,6 +162,15 @@ class EffectPF2e extends AbstractEffectPF2e {
                     initiative,
                 },
             });
+        }
+
+        // If this is an immediate evaluation formula effect, pre-roll and change the badge type on creation
+        const badge = data.system.badge;
+        if (this.actor && badge?.type === "formula" && badge.evaluate) {
+            const roll = await new Roll(badge.value, this.getRollData()).evaluate({ async: true });
+            this._source.system.badge = { type: "value", value: roll.total };
+            const speaker = ChatMessagePF2e.getSpeaker({ actor: this.actor, token: this.actor.token });
+            roll.toMessage({ flavor: this.name, speaker });
         }
 
         return super._preCreate(data, options, user);

--- a/src/module/item/effect/sheet.ts
+++ b/src/module/item/effect/sheet.ts
@@ -1,33 +1,79 @@
 import { EffectBadge } from "@item/abstract-effect";
 import { ItemSheetDataPF2e } from "@item/sheet/data-types";
-import { EffectPF2e } from ".";
+import { htmlQuery, htmlQueryAll } from "@util";
+import { EffectPF2e, EffectSource } from ".";
 import { ItemSheetPF2e } from "../sheet/base";
 
 export class EffectSheetPF2e extends ItemSheetPF2e<EffectPF2e> {
     override async getData(options?: Partial<DocumentSheetOptions>): Promise<EffectSheetData> {
+        const badge = this.item.badge;
+
         return {
             ...(await super.getData(options)),
             hasSidebar: true,
             hasDetails: false,
             itemType: game.i18n.localize("PF2E.LevelLabel"),
+            badgeType: badge ? game.i18n.localize(`PF2E.Item.Effect.BadgeType.${badge.type}`) : "",
             timeUnits: CONFIG.PF2E.timeUnits,
         };
     }
 
     override activateListeners($html: JQuery<HTMLElement>): void {
         super.activateListeners($html);
+        const html = $html[0];
 
-        $html.find("[data-action=badge-add]").on("click", () => {
-            const badge: EffectBadge = { type: "counter", value: 1 };
+        htmlQuery(html, "[data-action=badge-add]")?.addEventListener("click", () => {
+            const type = htmlQuery<HTMLSelectElement>(html, ".badge-type")?.value;
+            const badge: EffectBadge =
+                type === "formula"
+                    ? { type: "formula", value: "d20", evaluate: true }
+                    : type === "labels"
+                    ? { type: "counter", value: 1, labels: [""] }
+                    : { type: "counter", value: 1 };
             this.item.update({ system: { badge } });
         });
 
-        $html.find("[data-action=badge-delete]").on("click", () => {
+        htmlQuery(html, "[data-action=badge-delete]")?.addEventListener("click", () => {
             this.item.update({ "system.-=badge": null });
         });
+
+        htmlQuery(html, "[data-action=badge-add-label")?.addEventListener("click", () => {
+            const labels = this.item.system.badge?.type === "counter" ? this.item.system.badge.labels : null;
+            if (labels) {
+                labels.push("");
+                this.item.update({ system: { badge: { labels } } });
+            }
+        });
+
+        for (const deleteIcon of htmlQueryAll(html, "[data-action=badge-delete-label]")) {
+            const idx = Number(deleteIcon.dataset.idx);
+            deleteIcon.addEventListener("click", () => {
+                const labels = this.item.system.badge?.type === "counter" ? this.item.system.badge.labels : null;
+                if (labels) {
+                    labels.splice(idx, 1);
+                    if (labels.length === 0) {
+                        this.item.update({ "system.-=badge": null });
+                    } else {
+                        this.item.update({ system: { badge: { labels } } });
+                    }
+                }
+            });
+        }
+    }
+
+    protected override async _updateObject(event: Event, formData: Record<string, unknown>): Promise<void> {
+        // Ensure badge labels remain an array
+        const expanded = expandObject(formData) as DeepPartial<EffectSource>;
+        const badge = expanded.system?.badge;
+        if (badge && "labels" in badge && typeof badge.labels === "object") {
+            badge.labels = Object.values(badge.labels);
+        }
+
+        super._updateObject(event, flattenObject(expanded));
     }
 }
 
 interface EffectSheetData extends ItemSheetDataPF2e<EffectPF2e> {
+    badgeType: string;
     timeUnits: ConfigPF2e["PF2E"]["timeUnits"];
 }

--- a/src/styles/item/_sidebar.scss
+++ b/src/styles/item/_sidebar.scss
@@ -91,9 +91,47 @@
         height: 18px;
     }
 
-    .form-fields button {
+    button {
         padding-top: 0;
         padding-bottom: 0;
         white-space: nowrap;
+    }
+
+    .badge-label-row {
+        width: 100%;
+        label {
+            cursor: pointer;
+            max-width: unset;
+        }
+
+        input[type=radio] {
+            margin: 0;
+            top: 0;
+        }
+
+        .badge-value {
+            margin-right: 0.1rem;
+            width: 3ch;
+            font-weight: bold;
+            text-align: end;
+        }
+
+        input[type=text] {
+            flex: 1;
+            text-align: end;
+        }
+    }
+
+    .add-badge {
+        display: flex;
+        align-items: center;
+        select {
+            flex: 1;
+            max-width: unset;
+        }
+        button {
+            flex: 0;
+            line-height: 1.2em;
+        }
     }
 }

--- a/src/styles/system/_effects-panel.scss
+++ b/src/styles/system/_effects-panel.scss
@@ -11,7 +11,7 @@
     .effect-item {
         display: flex;
         justify-content: flex-end;
-        height: 46px;
+        height: 52px;
 
         &:hover {
             .effect-info {
@@ -71,8 +71,8 @@
             justify-content: center;
             position: relative;
             margin: 2px 0;
-            height: 42px;
-            width: 42px;
+            height: 48px;
+            width: 48px;
 
             .expired {
                 position: absolute;
@@ -93,13 +93,12 @@
                 color: white;
                 background-color: rgba(0, 0, 0, 0.75);
             }
-            .value {
-                display: inline-block;
+            .value-wrapper {
                 position: absolute;
                 bottom: -1px;
                 left: -1px;
+                max-width: calc(100% + 2px);
                 padding: 0px 2px;
-                max-width: 100%;
 
                 color: white;
                 background-color: rgba(0, 0, 0, 0.75);
@@ -107,7 +106,15 @@
                 letter-spacing: -0.05em;
                 white-space: nowrap;
                 overflow: hidden;
-                text-overflow: ellipsis;
+
+                .value {
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    strong {
+                        display: inline-block;
+                        padding-right: 1px; // prevent clipping
+                    }
+                }
             }
 
             &.unidentified {
@@ -118,6 +125,6 @@
 
     hr {
         margin-right: 0;
-        width: 36px;
+        width: 40px;
     }
 }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2215,9 +2215,16 @@
                 },
                 "ShowTokenIcon": "Show token icon?",
                 "Unidentified": "Unidentified?",
-                "AddBadge": "Add Counter",
+                "AddBadge": "Add",
+                "AddLabel": "Add Label",
+                "LabelPlaceholder": "Stage Label",
                 "BadgeType": {
-                    "Counter": "Counter"
+                    "counter": "Counter",
+                    "formula": "Formula",
+                    "value": "Fixed Value"
+                },
+                "ExtraSelections": {
+                    "Labels": "Counter (Labeled)"
                 }
             },
             "Feat": {

--- a/static/templates/items/effect-sidebar.hbs
+++ b/static/templates/items/effect-sidebar.hbs
@@ -37,18 +37,44 @@
     </div>
     {{/if}}
     <hr/>
-    <div class="form-group">
-        {{#if data.badge}}
-            <div class="form-fields">
-                {{localize "PF2E.Item.Effect.BadgeType.Counter"}}
-                <input type={{#if (eq data.badge.type "counter")}}"number"{{else}}"text"{{/if}} name="system.badge.value" value="{{data.badge.value}}"/>
-                <div class="item-controls">
-                    <a data-action="badge-delete"><i class="fas fa-fw fa-times"></i></a>
-                </div>
+    {{#if data.badge.labels}}
+        {{#each data.badge.labels as |label idx|}}
+            <div class="badge-label-row details-container-flex-row">
+                <label>
+                    <input type="radio" name="system.badge.value" {{checked (eq @root.data.badge.value (add idx 1))}} value="{{add idx 1}}" data-dtype="Number" tabindex="-1"/>
+                    <span class="badge-value">{{add idx 1}}</span>
+                </label>
+                <input type="text" name="system.badge.labels.{{idx}}" value="{{label}}" placeholder="{{localize "PF2E.Item.Effect.LabelPlaceholder"}}"/>
+                {{#if @root.options.editable}}
+                    <div class="item-controls">
+                        <a data-action="badge-delete-label" data-idx="{{idx}}"><i class="fas fa-fw fa-times"></i></a>
+                    </div>
+                {{/if}}
             </div>
-        {{else}}
-            <button type="button" data-action="badge-add">{{localize "PF2E.Item.Effect.AddBadge"}}</button>
-        {{/if}}
-    </div>
-
+        {{/each}}
+        <div class="form-fields">
+            <button type="button" data-action="badge-add-label"><i class="fas fa-plus"></i> {{localize "PF2E.Item.Effect.AddLabel"}}</button>
+        </div>
+    {{else if data.badge}}
+        <div class="form-group">
+            <label>{{badgeType}}</label>
+            <div class="form-fields">
+                <input type={{#if (eq data.badge.type "counter")}}"number"{{else}}"text"{{/if}} name="system.badge.value" value="{{data.badge.value}}"/>
+                {{#if @root.options.editable}}
+                    <div class="item-controls">
+                        <a data-action="badge-delete"><i class="fas fa-fw fa-times"></i></a>
+                    </div>
+                {{/if}}
+            </div>
+        </div>
+    {{else}}
+        <div class="add-badge">
+            <select class="badge-type">
+                <option value="counter">{{localize "PF2E.Item.Effect.BadgeType.counter"}}</option>
+                <option value="labels">{{localize "PF2E.Item.Effect.ExtraSelections.Labels"}}</option>
+                <option value="formula">{{localize "PF2E.Item.Effect.BadgeType.formula"}}</option>
+            </select>
+            <button type="button" data-action="badge-add"><i class="fas fa-plus"></i> {{localize "PF2E.Item.Effect.AddBadge"}}</button>
+        </div>
+    {{/if}}
 </div>

--- a/static/templates/system/effects-panel.hbs
+++ b/static/templates/system/effects-panel.hbs
@@ -60,7 +60,10 @@
         {{#if effect.system.expired}}
             <span class="expired">{{localize "PF2E.EffectPanel.Expired"}}</span>
         {{else if effect.badge}}
-            <div class="value"><strong>{{effect.badge.value}}</strong></div>
+            <div class="value-wrapper">
+                <div class="value"><strong>{{coalesce effect.badge.label effect.badge.value}}</strong></div>
+            </div>
+
         {{/if}}
     </div>
 </div>


### PR DESCRIPTION
Labels exist in data yet but they're not shown. We can probably add it to the tooltip under the name?

![image](https://user-images.githubusercontent.com/1286721/215319188-7f4308ec-212e-4c4a-9a78-9e15714fad01.png)

![image](https://user-images.githubusercontent.com/1286721/215319242-b6e9458e-17b8-4ed7-bff1-9ecdf96fe23e.png)

![image](https://user-images.githubusercontent.com/1286721/215319267-b0aa3b6f-dab2-4712-bf22-b62df7085382.png)