### PR TITLE
Add support for enemy- and all-affecting auras

### DIFF
--- a/src/module/actor/types.ts
+++ b/src/module/actor/types.ts
@@ -1,6 +1,6 @@
 import { ActorPF2e } from "@actor";
 import { MeleePF2e, SpellPF2e, WeaponPF2e } from "@item";
-import { ItemTrait } from "@item/data/base";
+import { EffectTrait } from "@item/abstract-effect";
 import { TokenDocumentPF2e } from "@scene";
 import { immunityTypes, resistanceTypes, weaknessTypes } from "@scripts/config/iwr";
 import { DamageRoll } from "@system/damage/roll";
@@ -31,7 +31,7 @@ interface AuraData {
     radius: number;
     effects: AuraEffectData[];
     colors: AuraColors | null;
-    traits: ItemTrait[];
+    traits: EffectTrait[];
 }
 
 interface AuraEffectData {

--- a/src/module/data.ts
+++ b/src/module/data.ts
@@ -35,8 +35,10 @@ interface TypeAndValue<TType extends string> {
     value: number;
 }
 
-interface TraitsWithRarity<T extends string> extends ValuesList<T> {
+interface TraitsWithRarity<T extends string> {
+    value: T[];
     rarity: Rarity;
+    custom?: string;
 }
 
 /** Literal numeric types */

--- a/src/module/item/abstract-effect/data.ts
+++ b/src/module/item/abstract-effect/data.ts
@@ -1,9 +1,20 @@
+import { ActionTrait } from "@item/action";
+import { SpellTrait } from "@item/spell";
+
 interface EffectBadgeCounter {
     type: "counter";
     value: number;
     label?: string;
     labels?: string[];
 }
+
+interface EffectTraits {
+    value: EffectTrait[];
+    rarity?: never;
+    custom?: never;
+}
+
+type EffectTrait = ActionTrait | SpellTrait;
 
 // currently unused until specifices can be figured out
 interface EffectBadgeValue {
@@ -17,8 +28,14 @@ interface EffectBadgeFormula {
     evaluate?: boolean;
 }
 
+interface EffectAuraData {
+    slug: string;
+    origin: ActorUUID | TokenDocumentUUID;
+    removeOnExit: boolean;
+}
+
 type EffectBadge = EffectBadgeCounter | EffectBadgeValue | EffectBadgeFormula;
 
 type TimeUnit = "rounds" | "minutes" | "hours" | "days";
 
-export { TimeUnit, EffectBadge };
+export { EffectAuraData, EffectBadge, EffectTrait, EffectTraits, TimeUnit };

--- a/src/module/item/abstract-effect/index.ts
+++ b/src/module/item/abstract-effect/index.ts
@@ -1,2 +1,2 @@
 export { AbstractEffectPF2e } from "./document";
-export { EffectBadge } from "./data";
+export * from "./data";

--- a/src/module/item/action/data.ts
+++ b/src/module/item/action/data.ts
@@ -17,7 +17,9 @@ type ActionItemData = Omit<ActionItemSource, "system" | "effects" | "flags"> &
     BaseItemDataPF2e<ActionItemPF2e, "action", ActionSystemData, ActionItemSource>;
 
 type ActionTrait = keyof ConfigPF2e["PF2E"]["actionTraits"];
-type ActionTraits = ItemTraits<ActionTrait>;
+interface ActionTraits extends ItemTraits<ActionTrait> {
+    rarity?: never;
+}
 
 interface ActionSystemSource extends ItemSystemSource {
     traits: ActionTraits;

--- a/src/module/item/action/index.ts
+++ b/src/module/item/action/index.ts
@@ -1,2 +1,3 @@
 export { ActionItemPF2e } from "./document";
 export { ActionSheetPF2e } from "./sheet";
+export * from "./data";

--- a/src/module/item/affliction/data.ts
+++ b/src/module/item/affliction/data.ts
@@ -1,19 +1,34 @@
 import { SaveType } from "@actor/types";
-import { ABCSystemData } from "@item/abc/data";
-import { TimeUnit } from "@item/abstract-effect/data";
-import { ActionTraits } from "@item/action/data";
+import { EffectAuraData, EffectTraits, TimeUnit } from "@item/abstract-effect/data";
 import { ConditionSlug } from "@item/condition";
-import { BaseItemDataPF2e, BaseItemSourcePF2e, ItemLevelData, ItemSystemData, ItemSystemSource } from "@item/data/base";
+import {
+    BaseItemDataPF2e,
+    BaseItemSourcePF2e,
+    ItemFlagsPF2e,
+    ItemLevelData,
+    ItemSystemData,
+    ItemSystemSource,
+} from "@item/data/base";
 import { DamageCategoryUnique, DamageType } from "@system/damage";
 import { AfflictionPF2e } from "./document";
 
-type AfflictionSource = BaseItemSourcePF2e<"affliction", AfflictionSystemSource>;
+type AfflictionSource = BaseItemSourcePF2e<"affliction", AfflictionSystemSource> & {
+    flags: DeepPartial<AfflictionFlags>;
+};
 
 type AfflictionData = Omit<AfflictionSource, "system" | "effects" | "flags"> &
-    BaseItemDataPF2e<AfflictionPF2e, "affliction", AfflictionSystemData, AfflictionSource>;
+    BaseItemDataPF2e<AfflictionPF2e, "affliction", AfflictionSystemData, AfflictionSource> & {
+        flags: AfflictionFlags;
+    };
+
+type AfflictionFlags = ItemFlagsPF2e & {
+    pf2e: {
+        aura?: EffectAuraData;
+    };
+};
 
 interface AfflictionSystemSource extends ItemSystemSource, ItemLevelData {
-    traits: ActionTraits;
+    traits: EffectTraits;
     save: {
         type: SaveType;
         value: number;
@@ -24,6 +39,7 @@ interface AfflictionSystemSource extends ItemSystemSource, ItemLevelData {
     duration: {
         value: number;
         unit: TimeUnit | "unlimited";
+        expiry?: null;
     };
 }
 
@@ -53,7 +69,7 @@ interface AfflictionConditionData {
     value?: number;
 }
 
-interface AfflictionSystemData extends Omit<AfflictionSystemSource, "items">, Omit<ABCSystemData, "traits"> {}
+interface AfflictionSystemData extends Omit<AfflictionSystemSource, "items">, Omit<ItemSystemData, "traits"> {}
 
 export {
     AfflictionConditionData,

--- a/src/module/item/ancestry/data.ts
+++ b/src/module/item/ancestry/data.ts
@@ -1,8 +1,8 @@
 import { CreatureTrait, Language } from "@actor/creature/data";
 import { AbilityString } from "@actor/types";
 import { ABCSystemData, ABCSystemSource } from "@item/abc/data";
-import { BaseItemDataPF2e, BaseItemSourcePF2e, ItemTraits } from "@item/data/base";
-import { Size, ValuesList } from "@module/data";
+import { BaseItemDataPF2e, BaseItemSourcePF2e } from "@item/data/base";
+import { Size, TraitsWithRarity, ValuesList } from "@module/data";
 import type { AncestryPF2e } from ".";
 
 type AncestrySource = BaseItemSourcePF2e<"ancestry", AncestrySystemSource>;
@@ -10,7 +10,7 @@ type AncestrySource = BaseItemSourcePF2e<"ancestry", AncestrySystemSource>;
 type AncestryData = Omit<AncestrySource, "system" | "effects" | "flags"> &
     BaseItemDataPF2e<AncestryPF2e, "ancestry", AncestrySystemData, AncestrySource>;
 
-export type CreatureTraits = ItemTraits<CreatureTrait>;
+export type CreatureTraits = TraitsWithRarity<CreatureTrait>;
 
 interface AncestrySystemSource extends ABCSystemSource {
     traits: CreatureTraits;

--- a/src/module/item/data/base.ts
+++ b/src/module/item/data/base.ts
@@ -2,7 +2,7 @@ import { CreatureTrait } from "@actor/creature/data";
 import type { ItemPF2e } from "@item/base";
 import type { ActiveEffectPF2e } from "@module/active-effect";
 import { RuleElementSource } from "@module/rules";
-import { DocumentSchemaRecord, OneToThree, TraitsWithRarity } from "@module/data";
+import { DocumentSchemaRecord, OneToThree, Rarity } from "@module/data";
 import { ItemType } from ".";
 import { PhysicalItemTrait } from "../physical/data";
 import { NPCAttackTrait } from "@item/melee/data";
@@ -38,7 +38,11 @@ interface ActionCost {
     value: OneToThree | null;
 }
 
-type ItemTraits<T extends ItemTrait = ItemTrait> = TraitsWithRarity<T>;
+interface ItemTraits<T extends ItemTrait = ItemTrait> {
+    value: T[];
+    rarity?: Rarity;
+    custom?: string;
+}
 
 interface ItemFlagsPF2e extends foundry.data.ItemFlags {
     pf2e: {

--- a/src/module/item/effect/data.ts
+++ b/src/module/item/effect/data.ts
@@ -1,5 +1,5 @@
 import { EffectBadge } from "@item/abstract-effect";
-import { TimeUnit } from "@item/abstract-effect/data";
+import { EffectAuraData, EffectTraits, TimeUnit } from "@item/abstract-effect/data";
 import {
     BaseItemDataPF2e,
     BaseItemSourcePF2e,
@@ -26,7 +26,8 @@ type EffectFlags = ItemFlagsPF2e & {
     };
 };
 
-interface EffectSystemSource extends ItemSystemSource, ItemLevelData {
+interface EffectSystemSource extends Omit<ItemSystemSource, "traits">, ItemLevelData {
+    traits: EffectTraits;
     start: {
         value: number;
         initiative: number | null;
@@ -49,18 +50,12 @@ interface EffectSystemSource extends ItemSystemSource, ItemLevelData {
     context: EffectContextData | null;
 }
 
-interface EffectSystemData extends EffectSystemSource, ItemSystemData {
+interface EffectSystemData extends EffectSystemSource, Omit<ItemSystemData, "traits"> {
     expired: boolean;
     remaining: string;
 }
 
 type EffectExpiryType = "turn-start" | "turn-end";
-
-interface EffectAuraData {
-    slug: string;
-    origin: ActorUUID | TokenDocumentUUID;
-    removeOnExit: boolean;
-}
 
 interface EffectContextData {
     origin: {

--- a/src/module/item/feat/data.ts
+++ b/src/module/item/feat/data.ts
@@ -6,9 +6,8 @@ import {
     FrequencySource,
     ItemLevelData,
     ItemSystemSource,
-    ItemTraits,
 } from "@item/data/base";
-import { OneToThree } from "@module/data";
+import { OneToThree, TraitsWithRarity } from "@module/data";
 import { FeatPF2e } from ".";
 import { FEAT_TYPES } from "./values";
 
@@ -18,7 +17,7 @@ type FeatData = Omit<FeatSource, "system" | "effects" | "flags"> &
     BaseItemDataPF2e<FeatPF2e, "feat", FeatSystemData, FeatSource>;
 
 export type FeatTrait = keyof ConfigPF2e["PF2E"]["featTraits"];
-export type FeatTraits = ItemTraits<FeatTrait>;
+export type FeatTraits = TraitsWithRarity<FeatTrait>;
 export type FeatType = SetElement<typeof FEAT_TYPES>;
 
 export interface PrerequisiteTagData {

--- a/src/module/item/physical/data.ts
+++ b/src/module/item/physical/data.ts
@@ -4,7 +4,7 @@ import { ConsumableTrait } from "@item/consumable/data";
 import { EquipmentTrait } from "@item/equipment/data";
 import type { PhysicalItemPF2e } from "@item/physical";
 import { WeaponTrait } from "@item/weapon/types";
-import { Size, ValuesList } from "@module/data";
+import { Size, TraitsWithRarity, ValuesList } from "@module/data";
 import {
     ActionCost,
     BaseItemDataPF2e,
@@ -13,7 +13,6 @@ import {
     ItemLevelData,
     ItemSystemData,
     ItemSystemSource,
-    ItemTraits,
 } from "../data/base";
 import type { ITEM_CARRY_TYPES } from "../data/values";
 import { CoinsPF2e } from "./helpers";
@@ -131,7 +130,7 @@ type EquippedData = {
 };
 
 type PhysicalItemTrait = ArmorTrait | ConsumableTrait | EquipmentTrait | WeaponTrait;
-interface PhysicalItemTraits<T extends PhysicalItemTrait = PhysicalItemTrait> extends ItemTraits<T> {
+interface PhysicalItemTraits<T extends PhysicalItemTrait = PhysicalItemTrait> extends TraitsWithRarity<T> {
     otherTags: string[];
 }
 

--- a/src/module/item/spell/data.ts
+++ b/src/module/item/spell/data.ts
@@ -1,13 +1,6 @@
 import { AbilityString, SaveType } from "@actor/types";
-import {
-    BaseItemDataPF2e,
-    BaseItemSourcePF2e,
-    ItemLevelData,
-    ItemSystemData,
-    ItemSystemSource,
-    ItemTraits,
-} from "@item/data/base";
-import { OneToTen, ValueAndMax, ValuesList } from "@module/data";
+import { BaseItemDataPF2e, BaseItemSourcePF2e, ItemLevelData, ItemSystemData, ItemSystemSource } from "@item/data/base";
+import { OneToTen, TraitsWithRarity, ValueAndMax, ValuesList } from "@module/data";
 import { MaterialDamageEffect, DamageCategoryUnique, DamageType } from "@system/damage";
 import type { SpellPF2e } from "./document";
 import { EffectAreaSize, EffectAreaType, MagicSchool, MagicTradition, SpellComponent, SpellTrait } from "./types";
@@ -17,7 +10,7 @@ type SpellSource = BaseItemSourcePF2e<"spell", SpellSystemSource>;
 type SpellData = Omit<SpellSource, "system" | "effects" | "flags"> &
     BaseItemDataPF2e<SpellPF2e, "spell", SpellSystemData, SpellSource>;
 
-export type SpellTraits = ItemTraits<SpellTrait>;
+export type SpellTraits = TraitsWithRarity<SpellTrait>;
 
 export interface SpellDamageType {
     value: DamageType;


### PR DESCRIPTION
Before any eager beavers or weasels go to town with this, it should not be used when the aura requires a saving throw or isn't automatically applied to those merely present in the aura (so no start-of-turn or end-of-turn triggering)