### PR TITLE
Remove warning from extract

### DIFF
--- a/packs/scripts/extract.ts
+++ b/packs/scripts/extract.ts
@@ -397,15 +397,6 @@ function convertLinks(docSource: PackEntry, packName: string): PackEntry {
         return partiallyConverted.replace(replacePattern, docName);
     }, docJSON);
 
-    // In case some new items with links to other new items weren't found
-    if (notFound.length > 0) {
-        const idsNotFound = notFound.join(", ");
-        console.debug(
-            `Warning: Unable to find names for the following links in ${docSource.name} ` +
-                `(${packName}): ${idsNotFound}`
-        );
-    }
-
     return JSON.parse(convertedJson) as PackEntry;
 }
 


### PR DESCRIPTION
This warning clutters our extracts on data entry. If the warning is valid it will fail the pipeline, but 99% of the time on large data entry projects it just spams terminal and hides warnings we care about like missing action categories. The reason it comes up so often is because the script enters condition and action links with the name rather than the UUID, which makes several things easier for us.