### PR TITLE
Have Diverse Weapon Expert upgrade advanced weapon proficiency to trained

### DIFF
--- a/packs/data/feats.db/diverse-weapon-expert.json
+++ b/packs/data/feats.db/diverse-weapon-expert.json
@@ -46,6 +46,12 @@
                 "mode": "upgrade",
                 "path": "system.martial.martial.rank",
                 "value": 2
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "system.martial.advanced.rank",
+                "value": 1
             }
         ],
         "source": {


### PR DESCRIPTION
The Diverse Weapon Expert feat already used rule elements to set up the new proficiency for simple and martial weapons, but was missing the proficiency for advanced weapons.