### PR TITLE
Add effect for Utter Despair

### DIFF
--- a/packs/data/bestiary-effects.db/effect-utter-despair.json
+++ b/packs/data/bestiary-effects.db/effect-utter-despair.json
@@ -1,11 +1,11 @@
 {
-    "_id": "1bOSJ2LbEC28aI9f",
+    "_id": "ob00D61F0c4PIvj1",
     "img": "systems/pf2e/icons/spells/canticle-of-everlasting-grief.webp",
-    "name": "Effect: Despair",
+    "name": "Effect: Utter Despair",
     "system": {
         "badge": null,
         "description": {
-            "value": "<p>Living creatures are frightened 1 while in a despair aura. They can't naturally recover from this fear while in the area but recover instantly once they leave the area.</p>"
+            "value": "<p>Living creatures are frightened 2 while in an utter despair aura. They can't naturally recover from this fear while in the area but lose the frightened condition immediately upon leaving the area.</p>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -18,6 +18,13 @@
         },
         "rules": [
             {
+                "alterations": [
+                    {
+                        "mode": "override",
+                        "property": "badge-value",
+                        "value": 2
+                    }
+                ],
                 "key": "GrantItem",
                 "onDeleteActions": {
                     "grantee": "restrict"
@@ -29,7 +36,7 @@
             }
         ],
         "source": {
-            "value": "Pathfinder Bestiary"
+            "value": "Pathfinder #155: Lord of the Black Sands"
         },
         "start": {
             "initiative": null,

--- a/packs/data/extinction-curse-bestiary.db/dyzallin-shraen.json
+++ b/packs/data/extinction-curse-bestiary.db/dyzallin-shraen.json
@@ -7002,17 +7002,28 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>@Template[type:emanation|distance:30]{30 feet} @UUID[Compendium.pf2e.bestiary-ability-glossary-srd.Aura]{Aura}</p>\n<hr />\n<p>Living creatures are @UUID[Compendium.pf2e.conditionitems.Frightened]{Frightened 2} while in Dyzallin's utter despair aura. They can't naturally recover from this fear while in the area but lose the frightened condition immediately upon leaving the area.</p>\n<p>When a creature first enters the aura, it must succeed at a @Check[type:will|dc:39|traits:incapcitation] save (after taking the penalty from being frightened) or be @UUID[Compendium.pf2e.conditionitems.Paralyzed]{Paralyzed} for [[/br 1d4 #rounds]]{1d4 rounds}.</p>\n<p>The creature is then temporarily immune to the paralysis caused by the utter despair aura for 24 hours.</p>"
+                    "value": "<p>@Template[type:emanation|distance:30]{30 feet} @UUID[Compendium.pf2e.bestiary-ability-glossary-srd.Aura]{Aura}</p>\n<hr />\n<p>Living creatures are @UUID[Compendium.pf2e.conditionitems.Frightened]{Frightened 2} while in Dyzallin's utter despair aura. They can't naturally recover from this fear while in the area but lose the frightened condition immediately upon leaving the area.</p>\n<p>When a creature first enters the aura, it must succeed at a @Check[type:will|dc:39|traits:incapcitation] save (after taking the penalty from being frightened) or be @UUID[Compendium.pf2e.conditionitems.Paralyzed]{Paralyzed} for [[/br 1d4 #rounds]]{1d4 rounds}.</p>\n<p>The creature is then temporarily immune to the paralysis caused by the utter despair aura for 24 hours.</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Effect: Utter Despair]{Effect: Utter Despair}</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
                 "rules": [
                     {
+                        "effects": [
+                            {
+                                "affects": "all",
+                                "events": [
+                                    "enter"
+                                ],
+                                "includesSelf": false,
+                                "uuid": "Compendium.pf2e.bestiary-effects.ob00D61F0c4PIvj1"
+                            }
+                        ],
                         "key": "Aura",
                         "radius": 30,
                         "slug": "utter-despair",
                         "traits": [
+                            "aura",
                             "divine",
                             "emotion",
                             "enchantment",


### PR DESCRIPTION
Note that right-clicking on the Frightened 2 can reduce it to 1, but it can't be removed.