### PR TITLE
Fix placement of save button in compendium browser on resizing

### DIFF
--- a/src/styles/packs/_settings.scss
+++ b/src/styles/packs/_settings.scss
@@ -1,57 +1,64 @@
 .compendium-browser-settings {
-    .setting-section {
-        border: 1px solid #bbb;
-        border-radius: 5px;
-        margin-top: 5px;
-        padding:2px;
+    height: 100%;
 
-        h3 {
-            margin:0;
-            cursor:pointer;
-        }
+    form {
+      display: flex;
+      height: 100%;
+      flex-direction: column;
 
-        dt {
-            width:10%;
-        }
+      .setting-section {
+          border: 1px solid #bbb;
+          border-radius: 5px;
+          margin-top: 5px;
+          padding:2px;
 
-        /* Checkbox */
-        dt > input[type="checkbox"] {
-            transform: none;
-            flex: none;
-            height: auto;
-            margin: 3px 3px;
-        }
+          h3 {
+              margin:0;
+              cursor:pointer;
+          }
 
-        dd {
-            width:88%;
-        }
-    }
+          dt {
+              width:10%;
+          }
 
-    dl {
-        margin: 5px 0;
-    }
+          /* Checkbox */
+          dt > input[type="checkbox"] {
+              transform: none;
+              flex: none;
+              height: auto;
+              margin: 3px 3px;
+          }
 
-    dt {
-        display:inline-block;
-        width:40%;
-        padding-left:5px;
-    }
+          dd {
+              width:88%;
+          }
+      }
 
-    dd {
-        display:inline-block;
-        width:58%;
-        margin-left:0;
-    }
+      dl {
+          margin: 5px 0;
+      }
 
-    .settings-container {
-        height: 580px;
-        overflow-y: auto;
-        display: flex;
-        flex-wrap: wrap;
+      dt {
+          display:inline-block;
+          width:40%;
+          padding-left:5px;
+      }
 
-        div {
-            width: 375px;
-            margin-right: 1em;
-        }
-    }
+      dd {
+          display:inline-block;
+          width:58%;
+          margin-left:0;
+      }
+
+      .settings-container {
+          overflow-y: auto;
+          display: flex;
+          flex-wrap: wrap;
+
+          div {
+              width: 375px;
+              margin-right: 1em;
+          }
+      }
+  }
 }


### PR DESCRIPTION
Fixes foundryvtt/pf2e#5078

This pushes the save button to the bottom of the screen so that the user can expand the compendium to as large as they'd like without getting a lot of white space.

Note: This is my first contributing PR to a GitHub project that isn't mine so let me know if I need to include anything else!

![image](https://user-images.githubusercontent.com/12388731/216185260-c12236df-05af-48ce-bb5f-0d12926e0790.png)
