### PR TITLE
Add vehicles as a valid target for attack rolls

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -666,7 +666,8 @@ class ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
     /* -------------------------------------------- */
 
     getStrikeRollContext<I extends AttackItem>(params: StrikeRollContextParams<I>): StrikeRollContext<this, I> {
-        const targetToken = Array.from(game.user.targets).find((t) => t.actor?.isOfType("creature", "hazard")) ?? null;
+        const targetToken =
+            Array.from(game.user.targets).find((t) => t.actor?.isOfType("creature", "hazard", "vehicle")) ?? null;
 
         const selfToken = canvas.ready
             ? canvas.tokens.controlled.find((t) => t.actor === this) ?? this.getActiveTokens().shift() ?? null


### PR DESCRIPTION
Vehicles already have an AC, even if not prepared. This could have been working since forever, funny enough.