### PR TITLE
Prepare vehicle hp, run ae-likes, and enable usage of certain REs in vehicles/hazards

### DIFF
--- a/src/module/actor/creature/document.ts
+++ b/src/module/actor/creature/document.ts
@@ -318,7 +318,6 @@ abstract class CreaturePF2e extends ActorPF2e {
         setTraitIWR(this);
     }
 
-    /** Apply ActiveEffect-Like rule elements immediately after application of actual `ActiveEffect`s */
     override prepareEmbeddedDocuments(): void {
         super.prepareEmbeddedDocuments();
 

--- a/src/module/rules/rule-element/adjust-modifier.ts
+++ b/src/module/rules/rule-element/adjust-modifier.ts
@@ -1,4 +1,3 @@
-import { ActorType } from "@actor/data";
 import { ModifierAdjustment } from "@actor/modifiers";
 import { ItemPF2e } from "@item";
 import { DamageType } from "@system/damage/types";
@@ -12,8 +11,6 @@ const { fields } = foundry.data;
 
 /** Adjust the value of a modifier, change its damage type (in case of damage modifiers) or suppress it entirely */
 class AdjustModifierRuleElement extends AELikeRuleElement<AdjustModifierSchema> {
-    protected static override validActorTypes: ActorType[] = ["character", "familiar", "npc"];
-
     static override defineSchema(): AdjustModifierSchema {
         return {
             ...super.defineSchema(),

--- a/src/module/rules/rule-element/flat-modifier.ts
+++ b/src/module/rules/rule-element/flat-modifier.ts
@@ -1,4 +1,3 @@
-import { ActorType } from "@actor/data";
 import { DeferredValueParams, ModifierPF2e, ModifierType, MODIFIER_TYPES } from "@actor/modifiers";
 import { AbilityString } from "@actor/types";
 import { ABILITY_ABBREVIATIONS } from "@actor/values";
@@ -21,13 +20,7 @@ const { fields } = foundry.data;
  * @category RuleElement
  */
 class FlatModifierRuleElement extends RuleElementPF2e<FlatModifierSchema> {
-    protected static override validActorTypes: ActorType[] = ["character", "familiar", "npc"];
-
     constructor(source: FlatModifierSource, item: Embedded<ItemPF2e>, options?: RuleElementOptions) {
-        if (typeof source.selector === "string") {
-            source.selector = [source.selector];
-        }
-
         if (!item.isOfType("physical") && source.type !== "item") {
             source.fromEquipment = false;
         }

--- a/static/templates/actors/vehicle/sidebar/vehicle-armorclass.hbs
+++ b/static/templates/actors/vehicle/sidebar/vehicle-armorclass.hbs
@@ -15,7 +15,7 @@
                 type="number"
                 data-dtype="Number"
                 placeholder="0"
-                name="system.attributes.hardness"
+                data-property="system.attributes.hardness"
                 value="{{data.attributes.hardness}}"
             />
         </div>

--- a/static/templates/actors/vehicle/sidebar/vehicle-health.hbs
+++ b/static/templates/actors/vehicle/sidebar/vehicle-health.hbs
@@ -20,7 +20,7 @@
     <div class="container max-hp" title="{{localize "PF2E.vehicle.MaxHPTitle"}}">
       <label for="{{options.id}}-vehicle-hp-max" class="sidebar_label">{{localize "PF2E.MaxHitPointsShortLabel"}}</label>
       <div class="data-value">
-        <input id="{{options.id}}-vehicle-hp-max" data-property="system.attributes.hp.max" type="number" value="{{data.attributes.hp.max}}" placeholder="0" size="1"/>
+        <input id="{{options.id}}-vehicle-hp-max" data-property="system.attributes.hp.max" type="number" value="{{data.attributes.hp.max}}" placeholder="0" size="1" />
       </div>
     </div>
   </div>

--- a/static/templates/actors/vehicle/sidebar/vehicle-health.hbs
+++ b/static/templates/actors/vehicle/sidebar/vehicle-health.hbs
@@ -20,7 +20,7 @@
     <div class="container max-hp" title="{{localize "PF2E.vehicle.MaxHPTitle"}}">
       <label for="{{options.id}}-vehicle-hp-max" class="sidebar_label">{{localize "PF2E.MaxHitPointsShortLabel"}}</label>
       <div class="data-value">
-        <input id="{{options.id}}-vehicle-hp-max" data-property="system.attributes.hp.max" type="number" value="{{data.attributes.hp.max}}" data-dtype="Number" placeholder="0" size="1"/>
+        <input id="{{options.id}}-vehicle-hp-max" data-property="system.attributes.hp.max" type="number" value="{{data.attributes.hp.max}}" placeholder="0" size="1"/>
       </div>
     </div>
   </div>

--- a/static/templates/actors/vehicle/sidebar/vehicle-health.hbs
+++ b/static/templates/actors/vehicle/sidebar/vehicle-health.hbs
@@ -20,7 +20,7 @@
     <div class="container max-hp" title="{{localize "PF2E.vehicle.MaxHPTitle"}}">
       <label for="{{options.id}}-vehicle-hp-max" class="sidebar_label">{{localize "PF2E.MaxHitPointsShortLabel"}}</label>
       <div class="data-value">
-        <input id="{{options.id}}-vehicle-hp-max" name="system.attributes.hp.max" type="number" value="{{data.attributes.hp.max}}" data-dtype="Number" placeholder="0" size="1"/>
+        <input id="{{options.id}}-vehicle-hp-max" data-property="system.attributes.hp.max" type="number" value="{{data.attributes.hp.max}}" data-dtype="Number" placeholder="0" size="1"/>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Hardness uses data-property in case ae-likes touch it, but otherwise doesn't receive modifiers until we find something in the game that tweaks it. This doesn't make clumsy/enfeebled work for hazard strikes, since hazard strikes don't add {ability}-based selectors.

After this we can probably make rework speed, but anything more will require the ability to retrieve an abilities/effect's source actor (making collision dc match class dc, for example).