### PR TITLE
Optimize instances of processing an entire array only to use pop() to get the last element

### DIFF
--- a/src/module/actor/creature/document.ts
+++ b/src/module/actor/creature/document.ts
@@ -726,8 +726,8 @@ abstract class CreaturePF2e extends ActorPF2e {
             const landSpeed = systemData.attributes.speed;
             landSpeed.value = Number(landSpeed.value) || 0;
 
-            const fromSynthetics = (this.synthetics.movementTypes[movementType] ?? []).map((d) => d() ?? []).flat();
-            landSpeed.value = [landSpeed.value, ...fromSynthetics.map((s) => s.value)].sort().pop()!;
+            const fromSynthetics = (this.synthetics.movementTypes[movementType] ?? []).flatMap((d) => d() ?? []);
+            landSpeed.value = Math.max(landSpeed.value, ...fromSynthetics.map((s) => s.value));
 
             const base = landSpeed.value;
             const modifiers = extractModifiers(this.synthetics, domains);

--- a/src/module/system/damage/weapon.ts
+++ b/src/module/system/damage/weapon.ts
@@ -315,14 +315,14 @@ class WeaponDamagePF2e {
             // If an alternate critical specialization effect is available, apply it only if there is also a
             // qualifying non-alternate
             const critSpecs = actor.synthetics.criticalSpecalizations;
-            const standard = critSpecs.standard
-                .map((cs) => cs(weapon, options))
-                .filter((ce): ce is CritSpecEffect => !!ce)
-                .pop();
-            const alternate = critSpecs.alternate
-                .map((cs) => cs(weapon, options))
-                .filter((ce): ce is CritSpecEffect => !!ce)
-                .pop();
+            const standard = critSpecs.standard.reduceRight(
+                (result: CritSpecEffect | null, cs) => result ?? cs?.(weapon, options),
+                null
+            );
+            const alternate = critSpecs.alternate.reduceRight(
+                (result: CritSpecEffect | null, cs) => result ?? cs?.(weapon, options),
+                null
+            );
 
             return standard ? alternate ?? standard : [];
         })();


### PR DESCRIPTION
Looking for the pattern of processing an entire list, then pop() to only use last element.