### PR TITLE
Allow injected property values in 'option' property

### DIFF
--- a/src/module/rules/rule-element/roll-option.ts
+++ b/src/module/rules/rule-element/roll-option.ts
@@ -196,14 +196,26 @@ class RollOptionRuleElement extends RuleElementPF2e {
         // Directly update the rule element on the item
         const item = actor.items.get(itemId, { strict: true });
         const rules = item.toObject().system.rules;
-        const rule = rules.find(
+
+        const possibleRuleMatches = rules.filter(
             (r: RollOptionSource) =>
                 r.key === "RollOption" &&
                 tupleHasValue([true, "totm"], r.toggleable) &&
                 r.domain === domain &&
-                this.resolveInjectedProperties(r.option) === option &&
                 r.value !== value
         );
+
+        let rule;
+
+        for (const possibleRuleMatch of possibleRuleMatches) {
+            const rollOptionRuleElement = new RollOptionRuleElement(possibleRuleMatch, item);
+
+            if (rollOptionRuleElement.resolveInjectedProperties(rollOptionRuleElement.option) === option) {
+                rule = possibleRuleMatch;
+                break;
+            }
+        }
+
         if (rule) {
             rule.value = value;
             const result = await actor.updateEmbeddedDocuments("Item", [{ _id: item.id, "system.rules": rules }]);

--- a/src/module/rules/rule-element/roll-option.ts
+++ b/src/module/rules/rule-element/roll-option.ts
@@ -201,7 +201,7 @@ class RollOptionRuleElement extends RuleElementPF2e {
                 r.key === "RollOption" &&
                 tupleHasValue([true, "totm"], r.toggleable) &&
                 r.domain === domain &&
-                r.option === option &&
+                this.resolveInjectedProperties(r.option) === option &&
                 r.value !== value
         );
         if (rule) {


### PR DESCRIPTION
Currently the RollOption RuleElement does not function correctly as a toggleable if the "option" property has been interpolated with an injected property. 

This is because when the `toggleOption` method is called, it iterates the RuleElements to find the matching RuleElement that this toggle was created from. When doing this comparison, the toggle object uses the already-injected version of "option", but it compares to the unmodified version of the RuleElement, meaning that it will never find the correct RuleElement.

To fix this, we can call "resolveInjectedProperties" on the RuleElements' option properties as we iterate and compare, so that the Toggle `option` will indeed be a match for the interpolated RuleElement `option`.