### PR TITLE
Prevent creation of NPC splash/precision damage without matching partial

### DIFF
--- a/src/module/item/melee/document.ts
+++ b/src/module/item/melee/document.ts
@@ -102,7 +102,7 @@ class MeleePF2e extends ItemPF2e {
         this.system.material = { precious: null };
 
         for (const attackDamage of Object.values(this.system.damageRolls)) {
-            attackDamage.category ??= null;
+            attackDamage.category ||= null;
             if (attackDamage.damageType === "bleed") {
                 attackDamage.category = "persistent";
             }

--- a/src/module/item/melee/sheet.ts
+++ b/src/module/item/melee/sheet.ts
@@ -48,7 +48,26 @@ export class MeleeSheetPF2e extends ItemSheetPF2e<MeleePF2e> {
             formData[key] ||= null;
         }
 
-        return super._updateObject(event, formData);
+        if (this.#categoriesAreValid(formData)) {
+            return super._updateObject(event, formData);
+        } else {
+            ui.notifications.warn("PF2E.Item.NPCAttack.CantSetCategory", { localize: true });
+            this.render();
+        }
+    }
+
+    /** Check whether, for each precision or splash partial, another uncategorized partial is also present */
+    #categoriesAreValid(formData: Record<string, unknown>): boolean {
+        const withUpdate = this.item.clone(formData);
+        const updatedDamage = Object.values(withUpdate.system.damageRolls);
+
+        for (const partial of updatedDamage.filter((p) => ["precision", "splash"].includes(p.category ?? ""))) {
+            if (!updatedDamage.some((p) => p.damageType === partial.damageType && p.category === null)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }
 

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2303,6 +2303,9 @@
             },
             "IconLabel": "Icon",
             "NameLabel": "Name",
+            "NPCAttack": {
+                "CantSetCategory": "Cannot set category without a matching uncategorized partial of the same damage type."
+            },
             "Physical": {
                 "Broken": "Broken",
                 "Destroyed": "Destroyed",


### PR DESCRIPTION
Temporary measure until NPC damage refactor