### PR TITLE
Improve accuracy of generated `DataModel` fields

### DIFF
--- a/src/module/rules/rule-element/adjust-modifier.ts
+++ b/src/module/rules/rule-element/adjust-modifier.ts
@@ -18,16 +18,12 @@ class AdjustModifierRuleElement extends AELikeRuleElement<AdjustModifierSchema> 
         return {
             ...super.defineSchema(),
             // `path` isn't used for AdjustModifier REs
-            path: new fields.StringField({ required: false, blank: true, initial: undefined }),
+            path: new fields.StringField({ blank: true }),
             selector: new fields.StringField({ required: false, blank: false, initial: undefined }),
-            selectors: new fields.ArrayField(new fields.StringField({ required: true, blank: false }), {
-                required: false,
-                nullable: false,
-                initial: [],
-            }),
+            selectors: new fields.ArrayField(new fields.StringField({ required: true, blank: false })),
             relabel: new fields.StringField({ required: false, blank: false, initial: undefined }),
             damageType: new fields.StringField({ required: false, blank: false, initial: undefined }),
-            suppress: new fields.BooleanField({ required: true, initial: false }),
+            suppress: new fields.BooleanField({ required: false, initial: undefined }),
         };
     }
 
@@ -107,15 +103,17 @@ interface AdjustModifierRuleElement
     extends AELikeRuleElement<AdjustModifierSchema>,
         ModelPropsFromSchema<AdjustModifierSchema> {
     data: AELikeData;
+
+    suppress: boolean;
 }
 
 type AdjustModifierSchema = AELikeSchema & {
     /** An optional relabeling of the adjusted modifier */
-    relabel: StringField;
-    selector: StringField;
-    selectors: ArrayField<StringField>;
-    damageType: StringField;
-    suppress: BooleanField;
+    relabel: StringField<string, string, false, true>;
+    selector: StringField<string, string, false, false, false>;
+    selectors: ArrayField<StringField<string, string, true>>;
+    damageType: StringField<string, string, false, false, false>;
+    suppress: BooleanField<boolean, boolean, false, false, false>;
 };
 
 interface AdjustModifierSource extends Exclude<AELikeSource, "path"> {

--- a/src/module/rules/rule-element/adjust-strike.ts
+++ b/src/module/rules/rule-element/adjust-strike.ts
@@ -15,7 +15,11 @@ const { fields } = foundry.data;
 class AdjustStrikeRuleElement extends AELikeRuleElement<AdjustStrikeSchema> {
     protected static override validActorTypes: ActorType[] = ["character", "familiar", "npc"];
 
-    private static VALID_PROPERTIES = new Set([
+    constructor(data: AdjustStrikeSource, item: Embedded<ItemPF2e>, options?: RuleElementOptions) {
+        super({ ...data, path: "ignore", phase: "beforeDerived", priority: 110 }, item, options);
+    }
+
+    static VALID_PROPERTIES = new Set([
         "materials",
         "property-runes",
         "range-increment",
@@ -27,17 +31,14 @@ class AdjustStrikeRuleElement extends AELikeRuleElement<AdjustStrikeSchema> {
         return {
             ...super.defineSchema(),
             // `path` isn't used for AdjustAdjustStrike REs
-            path: new fields.StringField({ required: false, blank: false, initial: undefined }),
-            property: new fields.StringField<AdjustStrikeProperty>({
+            path: new fields.StringField({ blank: true }),
+            property: new fields.StringField({
                 required: true,
                 choices: Array.from(this.VALID_PROPERTIES),
+                initial: undefined,
             }),
             definition: new PredicateField(),
         };
-    }
-
-    constructor(data: AdjustStrikeSource, item: Embedded<ItemPF2e>, options?: RuleElementOptions) {
-        super({ ...data, path: "ignore", phase: "beforeDerived", priority: 110 }, item, options);
     }
 
     protected override validateData(): void {
@@ -227,7 +228,7 @@ interface AdjustStrikeRuleElement
 
 type AdjustStrikeSchema = AELikeSchema & {
     /** The property of the strike to adjust */
-    property: StringField<AdjustStrikeProperty>;
+    property: StringField<AdjustStrikeProperty, AdjustStrikeProperty, true, false, false>;
     /** The definition of the strike in terms of its item (weapon) roll options */
     definition: PredicateField;
 };

--- a/src/module/rules/rule-element/crit-spec.ts
+++ b/src/module/rules/rule-element/crit-spec.ts
@@ -17,7 +17,7 @@ class CritSpecRuleElement extends RuleElementPF2e<CritSpecRuleSchema> {
         return {
             ...super.defineSchema(),
             alternate: new fields.BooleanField(),
-            text: new fields.StringField({ required: true, blank: false, nullable: true, initial: null }),
+            text: new fields.StringField({ blank: false, nullable: false, initial: undefined }),
         };
     }
 
@@ -107,7 +107,7 @@ type CritSpecRuleSchema = RuleElementSchema & {
     /** Whether this critical specialization note substitutes for the standard one of a given weapon group */
     alternate: BooleanField;
     /** Alternative note text: if not provided, the standard one for a given weapon group is used */
-    text: StringField<string, string, true>;
+    text: StringField<string, string, false, false, false>;
 };
 
 export { CritSpecRuleElement };

--- a/src/module/rules/rule-element/data.ts
+++ b/src/module/rules/rule-element/data.ts
@@ -42,21 +42,21 @@ interface BracketedValue<T extends object | number | string = object | number | 
 }
 
 type RuleElementSchema = {
-    key: StringField;
+    key: StringField<string, string, true>;
     /** An identifying slug for the rule element: its significance and restrictions are determined per RE type */
     slug: SlugField;
     /** A label for use by any rule element for display in an interface */
     label: StringField;
     /** The place in order of application (ascending), among an actor's list of rule elements */
-    priority: NumberField<number, number, false>;
+    priority: NumberField<number, number, false, false, true>;
     /** A test of whether the rules element is to be applied */
     predicate: PredicateField;
     /** Whether the rule element is ignored and deactivated */
     ignored: BooleanField;
     /** Whether the rule element requires that the parent item (if physical) be equipped */
-    requiresEquipped: BooleanField<boolean, boolean, true>;
+    requiresEquipped: BooleanField<boolean, boolean, false, true, false>;
     /** Whether the rule element requires that the parent item (if physical) be invested */
-    requiresInvestment: BooleanField<boolean, boolean, true>;
+    requiresInvestment: BooleanField<boolean, boolean, false, true, false>;
 };
 
 export { Bracket, BracketedValue, RuleElementData, RuleElementSchema, RuleElementSource, RuleValue };

--- a/src/module/rules/rule-element/flat-modifier.ts
+++ b/src/module/rules/rule-element/flat-modifier.ts
@@ -23,43 +23,6 @@ const { fields } = foundry.data;
 class FlatModifierRuleElement extends RuleElementPF2e<FlatModifierSchema> {
     protected static override validActorTypes: ActorType[] = ["character", "familiar", "npc"];
 
-    static override defineSchema(): FlatModifierSchema {
-        return {
-            ...super.defineSchema(),
-            selector: new fields.ArrayField(new fields.StringField({ required: true, blank: false }), {
-                required: true,
-                nullable: false,
-            }),
-            type: new fields.StringField({
-                required: true,
-                choices: Array.from(MODIFIER_TYPES),
-                initial: "untyped",
-            }),
-            ability: new fields.StringField({
-                required: false,
-                choices: Array.from(ABILITY_ABBREVIATIONS),
-                initial: undefined,
-            }),
-            min: new fields.NumberField({ required: false, nullable: false, initial: undefined }),
-            max: new fields.NumberField({ required: false, nullable: false, initial: undefined }),
-            force: new fields.BooleanField(),
-            hideIfDisabled: new fields.BooleanField(),
-            fromEquipment: new fields.BooleanField({ initial: true }),
-            damageType: new fields.StringField({ required: false, blank: false, initial: undefined }),
-            damageCategory: new fields.StringField({
-                required: false,
-                blank: false,
-                choices: Array.from(DAMAGE_CATEGORIES_UNIQUE),
-                initial: undefined,
-            }),
-            critical: new fields.BooleanField({ required: false, nullable: true, initial: undefined }),
-        };
-    }
-
-    get selectors(): string[] {
-        return this.selector;
-    }
-
     constructor(source: FlatModifierSource, item: Embedded<ItemPF2e>, options?: RuleElementOptions) {
         if (typeof source.selector === "string") {
             source.selector = [source.selector];
@@ -90,6 +53,42 @@ class FlatModifierRuleElement extends RuleElementPF2e<FlatModifierSchema> {
         if (this.force && this.type === "untyped") {
             this.failValidation("A forced bonus or penalty must have a type");
         }
+    }
+
+    static override defineSchema(): FlatModifierSchema {
+        return {
+            ...super.defineSchema(),
+            selector: new fields.ArrayField(
+                new fields.StringField({ required: true, blank: false, initial: undefined })
+            ),
+            type: new fields.StringField({
+                required: true,
+                choices: Array.from(MODIFIER_TYPES),
+                initial: "untyped",
+            }),
+            ability: new fields.StringField({
+                required: false,
+                choices: Array.from(ABILITY_ABBREVIATIONS),
+                initial: undefined,
+            }),
+            min: new fields.NumberField({ required: false, nullable: false, initial: undefined }),
+            max: new fields.NumberField({ required: false, nullable: false, initial: undefined }),
+            force: new fields.BooleanField(),
+            hideIfDisabled: new fields.BooleanField(),
+            fromEquipment: new fields.BooleanField({ initial: true }),
+            damageType: new fields.StringField({ required: false, blank: false, initial: undefined }),
+            damageCategory: new fields.StringField({
+                required: false,
+                blank: false,
+                choices: Array.from(DAMAGE_CATEGORIES_UNIQUE),
+                initial: undefined,
+            }),
+            critical: new fields.BooleanField({ required: false, nullable: true, initial: undefined }),
+        };
+    }
+
+    get selectors(): string[] {
+        return this.selector;
     }
 
     override beforePrepareData(): void {
@@ -155,14 +154,14 @@ interface FlatModifierRuleElement
 
 type FlatModifierSchema = RuleElementSchema & {
     /** All domains to add a modifier to */
-    selector: ArrayField<StringField>;
+    selector: ArrayField<StringField<string, string, true, false, false>>;
     /** The modifier (or bonus/penalty) type */
-    type: StringField<ModifierType>;
+    type: StringField<ModifierType, ModifierType, true, false, true>;
     /** If this is an ability modifier, the ability score it modifies */
     ability: StringField<AbilityString>;
     /** Hide this modifier from breakdown tooltips if it is disabled */
-    min: NumberField<number, number, false>;
-    max: NumberField<number, number, false>;
+    min: NumberField<number, number, false, false, false>;
+    max: NumberField<number, number, false, false, false>;
     hideIfDisabled: BooleanField;
     /** Whether to use this bonus/penalty/modifier even if it isn't the greatest magnitude */
     force: BooleanField;
@@ -173,7 +172,7 @@ type FlatModifierSchema = RuleElementSchema & {
     /** If a damage modifier, a special category */
     damageCategory: StringField<DamageCategoryUnique>;
     /** If a damage modifier, whether it applies given the presence or absence of a critically successful attack roll */
-    critical: BooleanField<boolean, boolean, true>;
+    critical: BooleanField<boolean, boolean, false, true, false>;
 };
 
 interface FlatModifierSource extends RuleElementSource {

--- a/src/module/rules/rule-element/iwr/base.ts
+++ b/src/module/rules/rule-element/iwr/base.ts
@@ -22,14 +22,10 @@ abstract class IWRRuleElement<TSchema extends IWRRuleSchema> extends RuleElement
     static override defineSchema(): IWRRuleSchema {
         return {
             ...super.defineSchema(),
-            type: new fields.ArrayField(new fields.StringField({ required: true, blank: false }), {
-                required: true,
-                nullable: false,
-            }),
-            exceptions: new fields.ArrayField(new fields.StringField({ required: true, blank: false }), {
-                required: true,
-                nullable: false,
-            }),
+            type: new fields.ArrayField(new fields.StringField({ required: true, blank: false, initial: undefined })),
+            exceptions: new fields.ArrayField(
+                new fields.StringField({ required: true, blank: false, initial: undefined })
+            ),
             override: new fields.BooleanField(),
         };
     }
@@ -87,8 +83,8 @@ interface IWRRuleElement<TSchema extends IWRRuleSchema>
 }
 
 type IWRRuleSchema = RuleElementSchema & {
-    type: ArrayField<StringField>;
-    exceptions: ArrayField<StringField>;
+    type: ArrayField<StringField<string, string, true, false, false>>;
+    exceptions: ArrayField<StringField<string, string, true, false, false>>;
     override: BooleanField;
 };
 

--- a/src/module/rules/rule-element/iwr/immunity.ts
+++ b/src/module/rules/rule-element/iwr/immunity.ts
@@ -11,8 +11,7 @@ class ImmunityRuleElement extends IWRRuleElement<ImmunityRuleSchema> {
         return {
             ...super.defineSchema(),
             exceptions: new fields.ArrayField(
-                new fields.StringField({ required: true, blank: false, choices: this.dictionary }),
-                { nullable: false }
+                new fields.StringField({ required: true, blank: false, choices: this.dictionary, initial: undefined })
             ),
         };
     }
@@ -54,7 +53,7 @@ interface ImmunityRuleElement extends IWRRuleElement<ImmunityRuleSchema>, ModelP
 }
 
 type ImmunityRuleSchema = Omit<IWRRuleSchema, "exceptions"> & {
-    exceptions: ArrayField<StringField<ImmunityType>>;
+    exceptions: ArrayField<StringField<ImmunityType, ImmunityType, true, false, false>>;
 };
 
 export { ImmunityRuleElement };

--- a/src/module/rules/rule-element/iwr/resistance.ts
+++ b/src/module/rules/rule-element/iwr/resistance.ts
@@ -8,10 +8,14 @@ const { fields } = foundry.data;
 /** @category RuleElement */
 class ResistanceRuleElement extends IWRRuleElement<ResistanceRuleSchema> {
     static override defineSchema(): ResistanceRuleSchema {
-        const exceptionsOrDoubleVs = () =>
+        const exceptionsOrDoubleVs = (): ArrayField<StringField<ResistanceType, ResistanceType, true, false, false>> =>
             new fields.ArrayField(
-                new fields.StringField({ required: true, blank: false, choices: CONFIG.PF2E.resistanceTypes }),
-                { nullable: false }
+                new fields.StringField({
+                    required: true as const,
+                    blank: false,
+                    choices: this.dictionary,
+                    initial: undefined,
+                })
             );
 
         return {
@@ -70,8 +74,8 @@ interface ResistanceRuleElement
 }
 
 type ResistanceRuleSchema = Omit<IWRRuleSchema, "exceptions"> & {
-    exceptions: ArrayField<StringField<ResistanceType>>;
-    doubleVs: ArrayField<StringField<ResistanceType>>;
+    exceptions: ArrayField<StringField<ResistanceType, ResistanceType, true, false, false>>;
+    doubleVs: ArrayField<StringField<ResistanceType, ResistanceType, true, false, false>>;
 };
 
 export { ResistanceRuleElement };

--- a/src/module/rules/rule-element/iwr/weakness.ts
+++ b/src/module/rules/rule-element/iwr/weakness.ts
@@ -11,8 +11,7 @@ class WeaknessRuleElement extends IWRRuleElement<WeaknessRuleSchema> {
         return {
             ...super.defineSchema(),
             exceptions: new fields.ArrayField(
-                new fields.StringField({ required: true, blank: false, choices: this.dictionary }),
-                { nullable: false }
+                new fields.StringField({ required: true, blank: false, choices: this.dictionary, initial: undefined })
             ),
         };
     }
@@ -64,7 +63,7 @@ interface WeaknessRuleElement extends IWRRuleElement<WeaknessRuleSchema>, ModelP
 }
 
 type WeaknessRuleSchema = Omit<IWRRuleSchema, "exceptions"> & {
-    exceptions: ArrayField<StringField<WeaknessType>>;
+    exceptions: ArrayField<StringField<WeaknessType, WeaknessType, true, false, false>>;
 };
 
 export { WeaknessRuleElement };

--- a/src/module/rules/rule-element/roll-note.ts
+++ b/src/module/rules/rule-element/roll-note.ts
@@ -12,7 +12,7 @@ class RollNoteRuleElement extends RuleElementPF2e<RollNoteSchema> {
     static override defineSchema(): RollNoteSchema {
         return {
             ...super.defineSchema(),
-            selector: new fields.StringField({ required: true, blank: false }),
+            selector: new fields.StringField({ required: true, blank: false, initial: undefined }),
             title: new fields.StringField({ required: true, nullable: true, initial: null }),
             visibility: new fields.StringField({
                 required: true,
@@ -81,13 +81,13 @@ interface RollNoteRuleElement extends RuleElementPF2e<RollNoteSchema>, ModelProp
 
 type RollNoteSchema = RuleElementSchema & {
     /** The statistic(s) slugs of the rolls for which this note will be appended */
-    selector: StringField;
+    selector: StringField<string, string, true, false, false>;
     /** An optional title prepended to the note */
-    title: StringField<string, string, true>;
+    title: StringField<string, string, true, true, true>;
     /** An optional limitation of the notes visibility to GMs */
-    visibility: StringField<UserVisibility, UserVisibility, true>;
+    visibility: StringField<UserVisibility, UserVisibility, true, true, true>;
     /** Applicable degree-of-success outcomes for the note */
-    outcome: ArrayField<StringField<DegreeOfSuccessString>>;
+    outcome: ArrayField<StringField<DegreeOfSuccessString, DegreeOfSuccessString, true, false, false>>;
 };
 
 interface RollNoteSource extends RuleElementSource {

--- a/types/foundry/common/abstract/data.d.mts
+++ b/types/foundry/common/abstract/data.d.mts
@@ -42,7 +42,7 @@ export abstract class DataModel<
     static defineSchema(): fields.DataSchema;
 
     /** Define the data schema for documents of this type. */
-    static get schema(): fields.SchemaField;
+    static get schema(): fields.SchemaField<ReturnType<typeof this["defineSchema"]>>;
 
     /** Define the data schema for this document instance. */
     // PROJECT NOTE: this must be overloaded in an interface merge declaration


### PR DESCRIPTION
When `DataField#required` is `false` and `DataField#initial` is `undefined`, the generated property on the parent `DataModel` may also be `undefined`. Minimal runtime updates.