### PR TITLE
Automate Dread Striker

### DIFF
--- a/packs/data/feats.db/dread-striker.json
+++ b/packs/data/feats.db/dread-striker.json
@@ -21,7 +21,16 @@
         "prerequisites": {
             "value": []
         },
-        "rules": [],
+        "rules": [
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "option": "self:override-target-flat-footed",
+                "predicate": [
+                    "target:condition:frightened"
+                ]
+            }
+        ],
         "source": {
             "value": "Pathfinder Core Rulebook"
         },

--- a/src/module/actor/creature/document.ts
+++ b/src/module/actor/creature/document.ts
@@ -266,6 +266,11 @@ abstract class CreaturePF2e extends ActorPF2e {
             return flanking.flatFootable && PredicatePF2e.test(["origin:flanking"], rollOptions);
         }
 
+        if (dueTo === "ability") {
+            const rollOptions = this.getRollOptions();
+            return PredicatePF2e.test(["origin:override-target-flat-footed"], rollOptions);
+        }
+
         return false;
     }
 
@@ -386,6 +391,19 @@ abstract class CreaturePF2e extends ActorPF2e {
         // Add modifiers from being flanked
         if (this.isFlatFooted({ dueTo: "flanking" })) {
             const name = game.i18n.localize("PF2E.Item.Condition.Flanked");
+            const condition = game.pf2e.ConditionManager.getCondition("flat-footed", { name });
+            const flatFooted = new ConditionPF2e(condition.toObject(), { parent: this }) as Embedded<ConditionPF2e>;
+
+            const rule = flatFooted.prepareRuleElements().shift();
+            if (!rule) throw ErrorPF2e("Unexpected error retrieving condition");
+            rule.beforePrepareData?.();
+
+            this.rollOptions.all["self:condition:flat-footed"] = true;
+        }
+
+        // Add modifiers from being flat-footed due to surprise attack
+        if (this.isFlatFooted({ dueTo: "ability" })) {
+            const name = game.i18n.localize("PF2E.Item.Condition.FlatFootedAbility");
             const condition = game.pf2e.ConditionManager.getCondition("flat-footed", { name });
             const flatFooted = new ConditionPF2e(condition.toObject(), { parent: this }) as Embedded<ConditionPF2e>;
 

--- a/src/module/actor/creature/types.ts
+++ b/src/module/actor/creature/types.ts
@@ -23,7 +23,7 @@ interface GetReachParameters {
 
 interface IsFlatFootedParams {
     /** The circumstance potentially imposing the flat-footed condition */
-    dueTo: "flanking" | "surprise" | "hidden" | "undetected";
+    dueTo: "flanking" | "ability" | "hidden" | "undetected";
 }
 
 interface CreatureUpdateContext<T extends CreaturePF2e> extends ActorUpdateContext<T> {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1905,6 +1905,8 @@
             },
             "CannotAddType": "{type} items cannot be added to this actor.",
             "Condition": {
+                "Flanked": "Flat-Footed (Flanked)",
+                "FlatFootedAbility": "Flat-Footed (From Ability)",
                 "PersistentDamage": {
                     "Name": "Persistent Damage ({formula} {damageType})",
                     "NameWithDC": "Persistent Damage ({formula} DC{dc})",
@@ -1921,8 +1923,7 @@
                         "DoesNotExist": "No persistent {damageType} damage exists on the actor"
                     },
                     "RollDamage": "Roll Damage"
-                },
-                "Flanked": "Flat-Footed (Flanked)"
+                }
             },
             "CreationDialog": {
                 "Categories": {


### PR DESCRIPTION
I don't like the roll option name, but that's easily changed. If we had roll options for initiative value and skill rolled this same method could be used for Surprise Attack.

I'll need to write a migration, which won't be hard just need a finalized version of this.

Also need to check if the target is blanket immune to being flat footed, though not sure how to go about that one immediately.