### PR TITLE
Only retrieve origin actor from dragged effects

### DIFF
--- a/src/module/item/abstract-effect/document.ts
+++ b/src/module/item/abstract-effect/document.ts
@@ -14,26 +14,17 @@ export abstract class AbstractEffectPF2e extends ItemPF2e {
     abstract increase(): Promise<void>;
     abstract decrease(): Promise<void>;
 
-    /** Get the actor that created this effect */
-    get origin(): { actor: ActorPF2e | null; item: Embedded<ItemPF2e> | null } {
-        const [actorOrToken, item] = this.isOfType("affliction", "effect")
-            ? [
-                  fromUuidSync(this.system.context?.origin.actor ?? ""),
-                  fromUuidSync(this.system.context?.origin.item ?? ""),
-              ]
-            : [null, null];
+    /** Get the actor from which this effect originated */
+    get origin(): ActorPF2e | null {
+        const actorOrToken = this.isOfType("affliction", "effect")
+            ? fromUuidSync(this.system.context?.origin.actor ?? "")
+            : null;
 
-        const actor =
-            actorOrToken instanceof ActorPF2e
-                ? actorOrToken
-                : actorOrToken instanceof TokenDocumentPF2e
-                ? actorOrToken.actor
-                : null;
-
-        return {
-            actor,
-            item: item instanceof ItemPF2e ? (item as Embedded<ItemPF2e>) : null,
-        };
+        return actorOrToken instanceof ActorPF2e
+            ? actorOrToken
+            : actorOrToken instanceof TokenDocumentPF2e
+            ? actorOrToken.actor
+            : null;
     }
 
     /** If true, the AbstractEffect should be hidden from the user unless they are a GM */

--- a/src/module/item/condition/document.ts
+++ b/src/module/item/condition/document.ts
@@ -22,9 +22,9 @@ class ConditionPF2e extends AbstractEffectPF2e {
     }
 
     /** Retrieve this condition's origin from its granting effect, if any */
-    override get origin(): { actor: ActorPF2e | null; item: Embedded<ItemPF2e> | null } {
+    override get origin(): ActorPF2e | null {
         const grantingItem = this.actor?.items.get(this.flags.pf2e.grantedBy?.id ?? "");
-        return grantingItem?.isOfType("affliction", "effect") ? grantingItem.origin : { actor: null, item: null };
+        return grantingItem?.isOfType("affliction", "effect") ? grantingItem.origin : null;
     }
 
     /** A key that can be used in place of slug for condition types that are split up (persistent damage) */


### PR DESCRIPTION
Reconsidering the design of this: making an origin item (e.g., heightening a spell) useful is non-trivial, and it's already expensive enough to retrieve the actor via `fromUuidSync`.