### PR TITLE
Replace explicit NPC crit spec text with PF2E.Item.Weapon.CriticalSpecialization.*

### DIFF
--- a/packs/data/agents-of-edgewatch-bestiary.db/graveknight-of-kharnas.json
+++ b/packs/data/agents-of-edgewatch-bestiary.db/graveknight-of-kharnas.json
@@ -367,7 +367,7 @@
                             "criticalSuccess"
                         ],
                         "selector": "{item|_id}-damage",
-                        "text": "Choose one creature adjacent to the initial target and within reach. If its AC is lower than your attack roll result for the critical hit, you deal damage to that creature equal to the result of the weapon damage die you rolled (including extra dice for its potency rune, if any). This amount isn't doubled, and no bonuses or other additional dice apply to this damage.",
+                        "text": "PF2E.Item.Weapon.CriticalSpecialization.axe",
                         "title": "PF2E.Actor.Creature.CriticalSpecialization"
                     }
                 ],
@@ -425,7 +425,7 @@
                             "criticalSuccess"
                         ],
                         "selector": "{item|_id}-damage",
-                        "text": "The target takes @Localize[PF2E.PersistentDamage.Bleed1d6.success]. You gain an item bonus to this bleed damage equal to the weapon's item bonus to attack rolls.",
+                        "text": "PF2E.Item.Weapon.CriticalSpecialization.dart",
                         "title": "PF2E.Actor.Creature.CriticalSpecialization"
                     }
                 ],

--- a/packs/data/feats.db/garudas-squall.json
+++ b/packs/data/feats.db/garudas-squall.json
@@ -28,13 +28,10 @@
         },
         "rules": [
             {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "bow-weapon-group-damage",
-                "text": "If the target of the critical hit is adjacent to a surface, it gets stuck to that surface by the missile. The target is @UUID[Compendium.pf2e.conditionitems.Immobilized]{Immobilized} and must spend an Interact action to attempt a @Check[type:athletics|dc:10] check to pull the missile free; it can't move from its space until it succeeds. The creature doesn't become stuck if it is incorporeal, is liquid (like a water elemental or some oozes), or could otherwise escape without effort.",
-                "title": "PF2E.Actor.Creature.CriticalSpecialization"
+                "key": "CriticalSpecialization",
+                "predicate": [
+                    "item:group:bow"
+                ]
             }
         ],
         "source": {

--- a/packs/data/kingmaker-bestiary.db/ntavi.json
+++ b/packs/data/kingmaker-bestiary.db/ntavi.json
@@ -801,7 +801,8 @@
                             "criticalSuccess"
                         ],
                         "selector": "maul-attack",
-                        "text": "<p><b>Critical Specialization</b> The target is knocked @UUID[Compendium.pf2e.conditionitems.Prone]{Prone}.</p>\n"
+                        "text": "PF2E.Item.Weapon.CriticalSpecialization.hammer",
+                        "title": "PF2E.Actor.Creature.CriticalSpecialization"
                     }
                 ],
                 "slug": null,

--- a/packs/data/npc-gallery.db/pathfinder-venture-captain.json
+++ b/packs/data/npc-gallery.db/pathfinder-venture-captain.json
@@ -1482,7 +1482,7 @@
                             "criticalSuccess"
                         ],
                         "selector": "warhammer-damage",
-                        "text": "The target is knocked @UUID[Compendium.pf2e.conditionitems.Prone]{Prone}.",
+                        "text": "PF2E.Item.Weapon.CriticalSpecialization.hammer",
                         "title": "PF2E.Actor.Creature.CriticalSpecialization"
                     }
                 ],

--- a/packs/data/npc-gallery.db/veteran-reclaimer.json
+++ b/packs/data/npc-gallery.db/veteran-reclaimer.json
@@ -1090,7 +1090,7 @@
                             "criticalSuccess"
                         ],
                         "selector": "composite-longbow-damage",
-                        "text": "If the target of the critical hit is adjacent to a surface, it gets stuck to that surface by the missile. The target is @UUID[Compendium.pf2e.conditionitems.Immobilized]{Immobilized} and must spend an Interact action to attempt a @Check[type:athletics|dc:10] check to pull the missile free; it can't move from its space until it succeeds. The creature doesn't become stuck if it is incorporeal, is liquid (like a water elemental or some oozes), or could otherwise escape without effort.",
+                        "text": "PF2E.Item.Weapon.CriticalSpecialization.bow",
                         "title": "PF2E.Actor.Creature.CriticalSpecialization"
                     },
                     {
@@ -1099,7 +1099,7 @@
                             "criticalSuccess"
                         ],
                         "selector": "dagger-damage",
-                        "text": "The target takes @Localize[PF2E.PersistentDamage.Bleed1d6.success]. You gain an item bonus to this bleed damage equal to the weapon's item bonus to attack rolls.",
+                        "text": "PF2E.Item.Weapon.CriticalSpecialization.knife",
                         "title": "PF2E.Actor.Creature.CriticalSpecialization"
                     },
                     {
@@ -1108,7 +1108,7 @@
                             "criticalSuccess"
                         ],
                         "selector": "bastard-sword-damage",
-                        "text": "The target is made off-balance by your attack, becoming @UUID[Compendium.pf2e.conditionitems.Flat-Footed]{Flat-Footed} until the start of your next turn.",
+                        "text": "PF2E.Item.Weapon.CriticalSpecialization.sword",
                         "title": "PF2E.Actor.Creature.CriticalSpecialization"
                     },
                     {
@@ -1117,7 +1117,7 @@
                             "criticalSuccess"
                         ],
                         "selector": "bastard-sword-two-handed-damage",
-                        "text": "The target is made off-balance by your attack, becoming @UUID[Compendium.pf2e.conditionitems.Flat-Footed]{Flat-Footed} until the start of your next turn.",
+                        "text": "PF2E.Item.Weapon.CriticalSpecialization.sword",
                         "title": "PF2E.Actor.Creature.CriticalSpecialization"
                     }
                 ],

--- a/packs/data/strength-of-thousands-bestiary.db/bharlen-sajor.json
+++ b/packs/data/strength-of-thousands-bestiary.db/bharlen-sajor.json
@@ -534,7 +534,7 @@
                             "criticalSuccess"
                         ],
                         "selector": "{item|_id}-damage",
-                        "text": "The target is @UUID[Compendium.pf2e.conditionitems.Clumsy]{Clumsy 1} until the start of Bharlen Sajor's next turn",
+                        "text": "PF2E.Item.Weapon.CriticalSpecialization.spear",
                         "title": "PF2E.Actor.Creature.CriticalSpecialization"
                     }
                 ],
@@ -654,7 +654,7 @@
                             "criticalSuccess"
                         ],
                         "selector": "{item|_id}-damage",
-                        "text": "If the target of the critical hit is adjacent to a surface, it gets stuck to that surface by the missile. The target is @UUID[Compendium.pf2e.conditionitems.Immobilized]{Immobilized} and must spend an Interact action to attempt a @Check[type:athletics|dc:10|name:Bow Critical Specialization] check to pull the missile free; it can't move from its space until it succeeds. The creature doesn't become stuck if it is incorporeal, is liquid (like a water elemental or some oozes), or could otherwise escape without effort.",
+                        "text": "PF2E.Item.Weapon.CriticalSpecialization.bow",
                         "title": "PF2E.Actor.Creature.CriticalSpecialization"
                     }
                 ],
@@ -714,7 +714,7 @@
                             "criticalSuccess"
                         ],
                         "selector": "{item|_id}-damage",
-                        "text": "The target is @UUID[Compendium.pf2e.conditionitems.Clumsy]{Clumsy 1} until the start of Bharlen Sajor's next turn",
+                        "text": "PF2E.Item.Weapon.CriticalSpecialization.spear",
                         "title": "PF2E.Actor.Creature.CriticalSpecialization"
                     }
                 ],

--- a/packs/data/strength-of-thousands-bestiary.db/graveknight-captain.json
+++ b/packs/data/strength-of-thousands-bestiary.db/graveknight-captain.json
@@ -363,7 +363,7 @@
                             "criticalSuccess"
                         ],
                         "selector": "{item|_id}-damage",
-                        "text": "The target is knocked @UUID[Compendium.pf2e.conditionitems.Prone]{Prone}.",
+                        "text": "PF2E.Item.Weapon.CriticalSpecialization.hammer",
                         "title": "PF2E.Actor.Creature.CriticalSpecialization"
                     }
                 ],

--- a/packs/data/strength-of-thousands-bestiary.db/graveknight-champion.json
+++ b/packs/data/strength-of-thousands-bestiary.db/graveknight-champion.json
@@ -1968,7 +1968,7 @@
                             "criticalSuccess"
                         ],
                         "selector": "{item|_id}-damage",
-                        "text": "If the target of the critical hit is adjacent to a surface, it gets stuck to that surface by the missile. The target is @UUID[Compendium.pf2e.conditionitems.Immobilized]{Immobilized} and must spend an Interact action to attempt a @Check[type:athletics|dc:10|name:Bow Critical Specialization] check to pull the missile free; it can't move from its space until it succeeds. The creature doesn't become stuck if it is incorporeal, is liquid (like a water elemental or some oozes), or could otherwise escape without effort.",
+                        "text": "PF2E.Item.Weapon.CriticalSpecialization.bow",
                         "title": "PF2E.Actor.Creature.CriticalSpecialization"
                     }
                 ],


### PR DESCRIPTION
Doesn't change note REs into damage REs, e.g. for pick.
Doesn't change the brawling notes, as the class DC based inline save doesn't work for NPCs.