### PR TITLE
Don't set defaults to `ActorPF2e` and `ItemPF2e` properties

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -75,7 +75,7 @@ class ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
     spellcasting!: ActorSpellcasting;
 
     /** Rule elements drawn from owned items */
-    rules: RuleElementPF2e[] = [];
+    rules!: RuleElementPF2e[];
 
     synthetics!: RuleElementSynthetics;
 

--- a/src/module/item/base.ts
+++ b/src/module/item/base.ts
@@ -31,7 +31,7 @@ class ItemPF2e extends Item<ActorPF2e> {
     protected initialized?: true;
 
     /** Prepared rule elements from this item */
-    rules: RuleElementPF2e[] = [];
+    rules!: RuleElementPF2e[];
 
     /** The sluggified name of the item **/
     get slug(): string | null {

--- a/src/module/rules/rule-element/battle-form/rule-element.ts
+++ b/src/module/rules/rule-element/battle-form/rule-element.ts
@@ -458,6 +458,7 @@ export class BattleFormRuleElement extends RuleElementPF2e {
         }
     }
 
+    /** Disable ineligible damage adjustments (modifiers, bonuses, additional damage) */
     override applyDamageExclusion(weapon: WeaponPF2e, modifiers: (DiceModifierPF2e | ModifierPF2e)[]): void {
         if (this.ownUnarmed) return;
 


### PR DESCRIPTION
The defaults are set after the constructor completes, clobbering what gets set during data preparation.