### PR TITLE
Add palm an object action macro

### DIFF
--- a/packs/data/action-macros.db/palm-an-object-thievery.json
+++ b/packs/data/action-macros.db/palm-an-object-thievery.json
@@ -1,0 +1,12 @@
+{
+    "_id": "Gj68YCVlDjc75iCP",
+    "author": "qZdAigNsA8Xx4gAx",
+    "command": "game.pf2e.actions.palmAnObject({ event: event });",
+    "img": "icons/svg/dice-target.svg",
+    "name": "Palm an Object: Thievery",
+    "ownership": {
+        "default": 1
+    },
+    "scope": "global",
+    "type": "script"
+}

--- a/packs/data/actions.db/palm-an-object.json
+++ b/packs/data/actions.db/palm-an-object.json
@@ -13,7 +13,7 @@
             "value": 1
         },
         "description": {
-            "value": "<p>Palming a small, unattended object without being noticed requires you to roll a single Thievery check against the Perception DCs of all creatures who are currently observing you. You take the object whether or not you successfully conceal that you did so. You can typically only Palm Objects of negligible Bulk, though the GM might determine otherwise depending on the situation.</p>\n<hr />\n<p><strong>Success</strong> The creature does not notice you Palming the Object.</p>\n<p><strong>Failure</strong> The creature notices you Palming the Object, and the GM determines the creature's response.</p>"
+            "value": "<p>Palming a small, unattended object without being noticed requires you to roll a single <span data-pf2-action=\"palmAnObject\" data-pf2-glyph=\"A\">Thievery</span> check against the Perception DCs of all creatures who are currently observing you. You take the object whether or not you successfully conceal that you did so. You can typically only Palm Objects of negligible Bulk, though the GM might determine otherwise depending on the situation.</p>\n<hr />\n<p><strong>Success</strong> The creature does not notice you Palming the Object.</p>\n<p><strong>Failure</strong> The creature notices you Palming the Object, and the GM determines the creature's response.</p>"
         },
         "requirements": {
             "value": ""

--- a/src/module/system/action-macros/index.ts
+++ b/src/module/system/action-macros/index.ts
@@ -38,6 +38,7 @@ import { commandAnAnimal } from "./nature/command-an-animal";
 import { perform } from "./performance/perform";
 import { hide } from "./stealth/hide";
 import { sneak } from "./stealth/sneak";
+import { palmAnObject } from "./thievery/palm-an-object";
 import { disableDevice } from "./thievery/disable-device";
 import { pickALock } from "./thievery/pick-a-lock";
 export { ActionMacroHelpers } from "./helpers";
@@ -116,6 +117,7 @@ export const ActionMacros = {
     sneak,
 
     // Thievery
+    palmAnObject,
     disableDevice,
     pickALock,
 };

--- a/src/module/system/action-macros/thievery/palm-an-object.ts
+++ b/src/module/system/action-macros/thievery/palm-an-object.ts
@@ -1,0 +1,27 @@
+import { ActionMacroHelpers, SkillActionOptions } from "..";
+
+export function palmAnObject(options: SkillActionOptions) {
+    const { checkType, property, stat, subtitle } = ActionMacroHelpers.resolveStat(options?.skill ?? "thievery");
+    ActionMacroHelpers.simpleRollActionCheck({
+        actors: options.actors,
+        statName: property,
+        actionGlyph: options.glyph ?? "A",
+        title: "PF2E.Actions.PalmAnObject.Title",
+        subtitle,
+        modifiers: options.modifiers,
+        rollOptions: ["all", checkType, stat, "action:palm-an-object"],
+        extraOptions: ["action:palm-an-object"],
+        traits: ["manipulate"],
+        checkType,
+        event: options.event,
+        callback: options.callback,
+        difficultyClass: options.difficultyClass,
+        difficultyClassStatistic: (target) => target.perception,
+        extraNotes: (selector: string) => [
+            ActionMacroHelpers.note(selector, "PF2E.Actions.PalmAnObject", "criticalSuccess"),
+            ActionMacroHelpers.note(selector, "PF2E.Actions.PalmAnObject", "success"),
+            ActionMacroHelpers.note(selector, "PF2E.Actions.PalmAnObject", "failure"),
+            ActionMacroHelpers.note(selector, "PF2E.Actions.PalmAnObject", "criticalFailure"),
+        ],
+    });
+}

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -452,6 +452,15 @@
                 },
                 "Title": "Maneuver in Flight"
             },
+            "PalmAnObject": {
+                "Notes": {
+                    "criticalSuccess": "<strong>Success</strong> The creature does not notice you Palming the Object.",
+                    "success": "<strong>Success</strong> The creature does not notice you Palming the Object.",
+                    "failure": "<strong>Failure</strong> The creature notices you Palming the Object, and the GM determines the creature's response.",
+                    "criticalFailure": "<strong>Failure</strong> The creature notices you Palming the Object, and the GM determines the creature's response."
+                },
+                "Title": "Palm an Object"
+            },
             "Perform": {
                 "Notes": {
                     "criticalSuccess": "<strong>Critical Success</strong> Your performance impresses the observers, and they're likely to share stories of your ability.",


### PR DESCRIPTION
For the Palm an Object skill action, add action implementation to the system and expose it on the pf2e namespace of the game object, add an action macro to call that system implementation, and also add a link to execute the action implementation from the action item description.