### PR TITLE
Add range increment display to strike action item

### DIFF
--- a/static/templates/actors/character/tabs/actions.hbs
+++ b/static/templates/actors/character/tabs/actions.hbs
@@ -94,6 +94,9 @@
                                         {{#each action.weaponTraits as |trait|}}
                                             <span class="tag tag_alt {{trait.cssClass}}"{{#if trait.description}} data-description="{{trait.description}}"{{/if}}>{{trait.label}}</span>
                                         {{/each}}
+                                        {{#if action.item.system.range}}
+                                            <span class="tag tag_secondary {{trait.cssClass}}">{{localize (concat "PF2E.TraitRangeIncrement" action.item.system.range)}}</span>
+                                        {{/if}}
                                     </div>
                                 </div>
                             </li>


### PR DESCRIPTION
It's nice to see and it doesn't appear as one of the traits.
For ranged attacks added by a Strike RE, there's no other way to find it.