### PR TITLE
Adding slug to Incredible Movement RE

### DIFF
--- a/packs/data/classfeatures.db/incredible-movement.json
+++ b/packs/data/classfeatures.db/incredible-movement.json
@@ -30,6 +30,7 @@
                     }
                 ],
                 "selector": "land-speed",
+                "slug": "incredible-movement",
                 "type": "status",
                 "value": {
                     "brackets": [


### PR DESCRIPTION
So other feats targeting it (like https://github.com/foundryvtt/pf2e/blob/master/packs/data/feat-effects.db/stance-stoked-flame-stance.json) continue to work even if localized