### PR TITLE
Fix name of Thorns battle form translation and update Hidden/Murderous Thorn(s) feats

### DIFF
--- a/packs/data/feats.db/hidden-thorn.json
+++ b/packs/data/feats.db/hidden-thorn.json
@@ -34,9 +34,9 @@
                 "group": "knife",
                 "img": "systems/pf2e/icons/unarmed-attacks/spine.webp",
                 "key": "Strike",
-                "label": "PF2E.BattleForm.Attack.Thorn",
+                "label": "PF2E.BattleForm.Attack.Thorns",
                 "range": null,
-                "slug": "thorn",
+                "slug": "thorns",
                 "traits": [
                     "finesse",
                     "unarmed"

--- a/packs/data/feats.db/murderous-thorns.json
+++ b/packs/data/feats.db/murderous-thorns.json
@@ -28,7 +28,7 @@
         "rules": [
             {
                 "definition": [
-                    "item:slug:thorn"
+                    "item:slug:thorns"
                 ],
                 "key": "AdjustStrike",
                 "mode": "add",

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -48,7 +48,7 @@
                 "Tendril": "Tendril",
                 "Tentacle": "Tentacle",
                 "TentacleArm": "Tentacle Arm",
-                "Thorn": "Thorns",
+                "Thorns": "Thorns",
                 "Tongue": "Tongue",
                 "Trunk": "Trunk",
                 "Tusk": "Tusk",


### PR DESCRIPTION
The BattleForm RE uses "Thorns".  It's written "thorns" in the book.  But the translation entry was "Thorn".