### PR TITLE
Update age of ashes spell exceptions

### DIFF
--- a/packs/data/age-of-ashes-bestiary.db/barushak-il-varashma.json
+++ b/packs/data/age-of-ashes-bestiary.db/barushak-il-varashma.json
@@ -100,9 +100,11 @@
                                 "id": "YwaWdEIFesY4tROV"
                             },
                             "2": {
+                                "expended": false,
                                 "id": "OuGn9uqYP90nZvNX"
                             },
                             "3": {
+                                "expended": false,
                                 "id": "OuGn9uqYP90nZvNX"
                             }
                         },
@@ -139,6 +141,7 @@
                                 "id": "yj70K4rBplV9mK1D"
                             },
                             "3": {
+                                "expended": false,
                                 "id": "tSQ2I9ViRu4ocrSQ"
                             }
                         },
@@ -4903,7 +4906,7 @@
         },
         "resources": {
             "focus": {
-                "max": "2",
+                "max": 2,
                 "value": 2
             }
         },

--- a/packs/data/age-of-ashes-bestiary.db/immortal-ichor.json
+++ b/packs/data/age-of-ashes-bestiary.db/immortal-ichor.json
@@ -23,7 +23,7 @@
                 },
                 "rules": [],
                 "showSlotlessLevels": {
-                    "value": true
+                    "value": false
                 },
                 "showUnpreparedSpells": {
                     "value": true
@@ -219,231 +219,6 @@
             "type": "spellcastingEntry"
         },
         {
-            "_id": "WsUUFmkLVmnzqXxq",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.vLA0q0WOK2YPuJs6"
-                }
-            },
-            "img": "systems/pf2e/icons/spells/charm.webp",
-            "name": "Charm",
-            "sort": 300000,
-            "system": {
-                "ability": {
-                    "value": ""
-                },
-                "area": null,
-                "category": {
-                    "value": "spell"
-                },
-                "components": {
-                    "focus": false,
-                    "material": false,
-                    "somatic": true,
-                    "verbal": true
-                },
-                "cost": {
-                    "value": ""
-                },
-                "damage": {
-                    "value": {}
-                },
-                "description": {
-                    "value": "<p>To the target, your words are honey and your visage seems bathed in a dreamy haze. It must attempt a Will save, with a +4 circumstance bonus if you or your allies recently threatened it or used hostile actions against it.</p>\n<p>You can Dismiss the spell. If you use hostile actions against the target, the spell ends. When the spell ends, the target doesn't necessarily realize it was charmed unless its friendship with you or the actions you convinced it to take clash with its expectations, meaning you could potentially convince the target to continue being your friend via mundane means.</p>\n<hr />\n<p><strong>Critical Success</strong> The target is unaffected and aware you tried to charm it.</p>\n<p><strong>Success</strong> The target is unaffected but thinks your spell was something harmless instead of charm, unless it identifies the spell.</p>\n<p><strong>Failure</strong> The target's attitude becomes @UUID[Compendium.pf2e.conditionitems.Friendly]{Friendly} toward you. If it was Friendly, it becomes @UUID[Compendium.pf2e.conditionitems.Helpful]{Helpful}. It can't use hostile actions against you.</p>\n<p><strong>Critical Failure</strong> The target's attitude becomes Helpful toward you, and it can't use hostile actions against you.</p>\n<hr />\n<p><strong>Heightened (4th)</strong> The duration lasts until the next time you make your daily preparations.</p>\n<p><strong>Heightened (8th)</strong> The duration lasts until the next time you make your daily preparations, and you can target up to 10 creatures.</p>"
-                },
-                "duration": {
-                    "value": "1 hour"
-                },
-                "hasCounteractCheck": {
-                    "value": false
-                },
-                "heightening": {
-                    "levels": {
-                        "8": {
-                            "target": {
-                                "value": "10 creatures"
-                            }
-                        }
-                    },
-                    "type": "fixed"
-                },
-                "level": {
-                    "value": 7
-                },
-                "location": {
-                    "uses": {
-                        "max": 3,
-                        "value": 3
-                    },
-                    "value": "DCLGBKaqRvqYPFZZ"
-                },
-                "materials": {
-                    "value": ""
-                },
-                "prepared": {
-                    "value": ""
-                },
-                "primarycheck": {
-                    "value": ""
-                },
-                "range": {
-                    "value": "30 feet"
-                },
-                "rules": [],
-                "save": {
-                    "basic": "",
-                    "value": "will"
-                },
-                "school": {
-                    "value": "enchantment"
-                },
-                "secondarycasters": {
-                    "value": ""
-                },
-                "secondarycheck": {
-                    "value": ""
-                },
-                "slug": "charm",
-                "source": {
-                    "value": "Pathfinder Core Rulebook"
-                },
-                "spellType": {
-                    "value": "save"
-                },
-                "sustained": {
-                    "value": false
-                },
-                "target": {
-                    "value": "1 creature"
-                },
-                "time": {
-                    "value": "2"
-                },
-                "traditions": {
-                    "value": [
-                        "arcane",
-                        "occult",
-                        "primal"
-                    ]
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": [
-                        "emotion",
-                        "incapacitation",
-                        "mental"
-                    ]
-                }
-            },
-            "type": "spell"
-        },
-        {
-            "_id": "fsXzYvSSpK2yBqBH",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.5BbU1V6wGSGbrmRD"
-                }
-            },
-            "img": "systems/pf2e/icons/spells/feeblemind.webp",
-            "name": "Feeblemind",
-            "sort": 400000,
-            "system": {
-                "ability": {
-                    "value": ""
-                },
-                "area": null,
-                "category": {
-                    "value": "spell"
-                },
-                "components": {
-                    "focus": false,
-                    "material": false,
-                    "somatic": true,
-                    "verbal": true
-                },
-                "cost": {
-                    "value": ""
-                },
-                "damage": {
-                    "value": {}
-                },
-                "description": {
-                    "value": "<p>You drastically reduce the target's mental faculties. The target must attempt a Will save. The effects of this curse can be removed only through remove curse or another effect that targets curses.</p>\n<hr />\n<p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target is @UUID[Compendium.pf2e.conditionitems.Stupefied]{Stupefied 2} for 1 round.</p>\n<p><strong>Failure</strong> The target is @UUID[Compendium.pf2e.conditionitems.Stupefied]{Stupefied 4} with an unlimited duration.</p>\n<p><strong>Critical Failure</strong> The target's intellect is permanently reduced below that of an animal, and it treats its Charisma, Intelligence, and Wisdom modifiers as -5. It loses all class abilities that require mental faculties, including all spellcasting. If the target is a PC, they become an NPC under the GM's control.</p>"
-                },
-                "duration": {
-                    "value": "varies"
-                },
-                "hasCounteractCheck": {
-                    "value": false
-                },
-                "level": {
-                    "value": 7
-                },
-                "location": {
-                    "value": "DCLGBKaqRvqYPFZZ"
-                },
-                "materials": {
-                    "value": ""
-                },
-                "prepared": {
-                    "value": ""
-                },
-                "primarycheck": {
-                    "value": ""
-                },
-                "range": {
-                    "value": "30 feet"
-                },
-                "rules": [],
-                "save": {
-                    "basic": "",
-                    "value": "will"
-                },
-                "school": {
-                    "value": "enchantment"
-                },
-                "secondarycasters": {
-                    "value": ""
-                },
-                "secondarycheck": {
-                    "value": ""
-                },
-                "slug": "feeblemind",
-                "source": {
-                    "value": "Pathfinder Core Rulebook"
-                },
-                "spellType": {
-                    "value": "save"
-                },
-                "sustained": {
-                    "value": false
-                },
-                "target": {
-                    "value": "1 creature"
-                },
-                "time": {
-                    "value": "2"
-                },
-                "traditions": {
-                    "value": [
-                        "arcane",
-                        "occult"
-                    ]
-                },
-                "traits": {
-                    "custom": "",
-                    "rarity": "common",
-                    "value": [
-                        "curse",
-                        "incapacitation",
-                        "mental"
-                    ]
-                }
-            },
-            "type": "spell"
-        },
-        {
             "_id": "QUpxwlYg33RhtARx",
             "flags": {
                 "core": {
@@ -452,7 +227,7 @@
             },
             "img": "systems/pf2e/icons/spells/possession.webp",
             "name": "Possession",
-            "sort": 500000,
+            "sort": 300000,
             "system": {
                 "ability": {
                     "value": ""
@@ -548,15 +323,15 @@
             "type": "spell"
         },
         {
-            "_id": "ktSaorw4uArSFt1G",
+            "_id": "fsXzYvSSpK2yBqBH",
             "flags": {
                 "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.qwlh6aDgi86U3Q7H"
+                    "sourceId": "Compendium.pf2e.spells-srd.5BbU1V6wGSGbrmRD"
                 }
             },
-            "img": "systems/pf2e/icons/spells/suggestion.webp",
-            "name": "Suggestion",
-            "sort": 600000,
+            "img": "systems/pf2e/icons/spells/feeblemind.webp",
+            "name": "Feeblemind",
+            "sort": 400000,
             "system": {
                 "ability": {
                     "value": ""
@@ -578,7 +353,7 @@
                     "value": {}
                 },
                 "description": {
-                    "value": "<p>Your honeyed words are difficult for creatures to resist. You suggest a course of action to the target, which must be phrased in such a way as to seem like a logical course of action to the target and can't be self-destructive or obviously against the target's self-interest. The target must attempt a Will save.</p>\n<hr /><strong>Critical Success</strong> The target is unaffected and knows you tried to control it.\n<p><strong>Success</strong> The target is unaffected and thinks you were talking to them normally, not casting a spell on them.</p>\n<p><strong>Failure</strong> The target immediately follows your suggestion. The spell has a duration of 1 minute, or until the target has completed a finite suggestion or the suggestion becomes self-destructive or has other obvious negative effects.</p>\n<p><strong>Critical Failure</strong> As failure, but the base duration is 1 hour.</p>\n<hr /><strong>Heightened (8th)</strong> You can target up to 10 creatures."
+                    "value": "<p>You drastically reduce the target's mental faculties. The target must attempt a Will save. The effects of this curse can be removed only through remove curse or another effect that targets curses.</p>\n<hr />\n<p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target is @UUID[Compendium.pf2e.conditionitems.Stupefied]{Stupefied 2} for 1 round.</p>\n<p><strong>Failure</strong> The target is @UUID[Compendium.pf2e.conditionitems.Stupefied]{Stupefied 4} with an unlimited duration.</p>\n<p><strong>Critical Failure</strong> The target's intellect is permanently reduced below that of an animal, and it treats its Charisma, Intelligence, and Wisdom modifiers as -5. It loses all class abilities that require mental faculties, including all spellcasting. If the target is a PC, they become an NPC under the GM's control.</p>"
                 },
                 "duration": {
                     "value": "varies"
@@ -586,20 +361,11 @@
                 "hasCounteractCheck": {
                     "value": false
                 },
-                "heightening": {
-                    "levels": {
-                        "8": {
-                            "target": {
-                                "value": "10 creatures"
-                            }
-                        }
-                    },
-                    "type": "fixed"
-                },
                 "level": {
-                    "value": 7
+                    "value": 6
                 },
                 "location": {
+                    "heightenedLevel": 7,
                     "value": "DCLGBKaqRvqYPFZZ"
                 },
                 "materials": {
@@ -628,7 +394,7 @@
                 "secondarycheck": {
                     "value": ""
                 },
-                "slug": "suggestion",
+                "slug": "feeblemind",
                 "source": {
                     "value": "Pathfinder Core Rulebook"
                 },
@@ -654,8 +420,8 @@
                     "custom": "",
                     "rarity": "common",
                     "value": [
+                        "curse",
                         "incapacitation",
-                        "linguistic",
                         "mental"
                     ]
                 }
@@ -671,7 +437,7 @@
             },
             "img": "systems/pf2e/icons/spells/telekinetic-haul.webp",
             "name": "Telekinetic Haul (At Will)",
-            "sort": 700000,
+            "sort": 500000,
             "system": {
                 "ability": {
                     "value": ""
@@ -702,9 +468,10 @@
                     "value": false
                 },
                 "level": {
-                    "value": 6
+                    "value": 5
                 },
                 "location": {
+                    "heightenedLevel": 6,
                     "value": "DCLGBKaqRvqYPFZZ"
                 },
                 "materials": {
@@ -772,7 +539,7 @@
             },
             "img": "systems/pf2e/icons/spells/destructive-aura.webp",
             "name": "Destructive Aura",
-            "sort": 800000,
+            "sort": 600000,
             "system": {
                 "ability": {
                     "value": ""
@@ -868,6 +635,122 @@
             "type": "spell"
         },
         {
+            "_id": "ktSaorw4uArSFt1G",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.qwlh6aDgi86U3Q7H"
+                }
+            },
+            "img": "systems/pf2e/icons/spells/suggestion.webp",
+            "name": "Suggestion",
+            "sort": 700000,
+            "system": {
+                "ability": {
+                    "value": ""
+                },
+                "area": null,
+                "category": {
+                    "value": "spell"
+                },
+                "components": {
+                    "focus": false,
+                    "material": false,
+                    "somatic": true,
+                    "verbal": true
+                },
+                "cost": {
+                    "value": ""
+                },
+                "damage": {
+                    "value": {}
+                },
+                "description": {
+                    "value": "<p>Your honeyed words are difficult for creatures to resist. You suggest a course of action to the target, which must be phrased in such a way as to seem like a logical course of action to the target and can't be self-destructive or obviously against the target's self-interest. The target must attempt a Will save.</p>\n<hr /><strong>Critical Success</strong> The target is unaffected and knows you tried to control it.\n<p><strong>Success</strong> The target is unaffected and thinks you were talking to them normally, not casting a spell on them.</p>\n<p><strong>Failure</strong> The target immediately follows your suggestion. The spell has a duration of 1 minute, or until the target has completed a finite suggestion or the suggestion becomes self-destructive or has other obvious negative effects.</p>\n<p><strong>Critical Failure</strong> As failure, but the base duration is 1 hour.</p>\n<hr /><strong>Heightened (8th)</strong> You can target up to 10 creatures."
+                },
+                "duration": {
+                    "value": "varies"
+                },
+                "hasCounteractCheck": {
+                    "value": false
+                },
+                "heightening": {
+                    "levels": {
+                        "8": {
+                            "target": {
+                                "value": "10 creatures"
+                            }
+                        }
+                    },
+                    "type": "fixed"
+                },
+                "level": {
+                    "value": 4
+                },
+                "location": {
+                    "heightenedLevel": 7,
+                    "value": "DCLGBKaqRvqYPFZZ"
+                },
+                "materials": {
+                    "value": ""
+                },
+                "prepared": {
+                    "value": ""
+                },
+                "primarycheck": {
+                    "value": ""
+                },
+                "range": {
+                    "value": "30 feet"
+                },
+                "rules": [],
+                "save": {
+                    "basic": "",
+                    "value": "will"
+                },
+                "school": {
+                    "value": "enchantment"
+                },
+                "secondarycasters": {
+                    "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "suggestion",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "spellType": {
+                    "value": "save"
+                },
+                "sustained": {
+                    "value": false
+                },
+                "target": {
+                    "value": "1 creature"
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traditions": {
+                    "value": [
+                        "arcane",
+                        "occult"
+                    ]
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "incapacitation",
+                        "linguistic",
+                        "mental"
+                    ]
+                }
+            },
+            "type": "spell"
+        },
+        {
             "_id": "IhxqNC6zrrbwCwYt",
             "flags": {
                 "core": {
@@ -876,7 +759,7 @@
             },
             "img": "systems/pf2e/icons/spells/crisis-of-faith.webp",
             "name": "Crisis of Faith",
-            "sort": 900000,
+            "sort": 800000,
             "system": {
                 "ability": {
                     "value": ""
@@ -897,10 +780,8 @@
                 "damage": {
                     "value": {
                         "0": {
-                            "applyMod": false,
                             "type": {
                                 "categories": [],
-                                "subtype": "",
                                 "value": "mental"
                             },
                             "value": "6d6"
@@ -996,7 +877,7 @@
             },
             "img": "systems/pf2e/icons/spells/mind-reading.webp",
             "name": "Mind Reading (At Will)",
-            "sort": 1000000,
+            "sort": 900000,
             "system": {
                 "ability": {
                     "value": ""
@@ -1100,7 +981,7 @@
             },
             "img": "systems/pf2e/icons/spells/telekinetic-maneuver.webp",
             "name": "Telekinetic Maneuver (At Will)",
-            "sort": 1100000,
+            "sort": 1000000,
             "system": {
                 "ability": {
                     "value": ""
@@ -1190,6 +1071,127 @@
                     "value": [
                         "attack",
                         "force"
+                    ]
+                }
+            },
+            "type": "spell"
+        },
+        {
+            "_id": "WsUUFmkLVmnzqXxq",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.vLA0q0WOK2YPuJs6"
+                }
+            },
+            "img": "systems/pf2e/icons/spells/charm.webp",
+            "name": "Charm",
+            "sort": 1100000,
+            "system": {
+                "ability": {
+                    "value": ""
+                },
+                "area": null,
+                "category": {
+                    "value": "spell"
+                },
+                "components": {
+                    "focus": false,
+                    "material": false,
+                    "somatic": true,
+                    "verbal": true
+                },
+                "cost": {
+                    "value": ""
+                },
+                "damage": {
+                    "value": {}
+                },
+                "description": {
+                    "value": "<p>To the target, your words are honey and your visage seems bathed in a dreamy haze. It must attempt a Will save, with a +4 circumstance bonus if you or your allies recently threatened it or used hostile actions against it.</p>\n<p>You can Dismiss the spell. If you use hostile actions against the target, the spell ends. When the spell ends, the target doesn't necessarily realize it was charmed unless its friendship with you or the actions you convinced it to take clash with its expectations, meaning you could potentially convince the target to continue being your friend via mundane means.</p>\n<hr />\n<p><strong>Critical Success</strong> The target is unaffected and aware you tried to charm it.</p>\n<p><strong>Success</strong> The target is unaffected but thinks your spell was something harmless instead of charm, unless it identifies the spell.</p>\n<p><strong>Failure</strong> The target's attitude becomes @UUID[Compendium.pf2e.conditionitems.Friendly]{Friendly} toward you. If it was Friendly, it becomes @UUID[Compendium.pf2e.conditionitems.Helpful]{Helpful}. It can't use hostile actions against you.</p>\n<p><strong>Critical Failure</strong> The target's attitude becomes Helpful toward you, and it can't use hostile actions against you.</p>\n<hr />\n<p><strong>Heightened (4th)</strong> The duration lasts until the next time you make your daily preparations.</p>\n<p><strong>Heightened (8th)</strong> The duration lasts until the next time you make your daily preparations, and you can target up to 10 creatures.</p>"
+                },
+                "duration": {
+                    "value": "1 hour"
+                },
+                "hasCounteractCheck": {
+                    "value": false
+                },
+                "heightening": {
+                    "levels": {
+                        "8": {
+                            "target": {
+                                "value": "10 creatures"
+                            }
+                        }
+                    },
+                    "type": "fixed"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": {
+                    "heightenedLevel": 7,
+                    "uses": {
+                        "max": 3,
+                        "value": 3
+                    },
+                    "value": "DCLGBKaqRvqYPFZZ"
+                },
+                "materials": {
+                    "value": ""
+                },
+                "prepared": {
+                    "value": ""
+                },
+                "primarycheck": {
+                    "value": ""
+                },
+                "range": {
+                    "value": "30 feet"
+                },
+                "rules": [],
+                "save": {
+                    "basic": "",
+                    "value": "will"
+                },
+                "school": {
+                    "value": "enchantment"
+                },
+                "secondarycasters": {
+                    "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "charm",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "spellType": {
+                    "value": "save"
+                },
+                "sustained": {
+                    "value": false
+                },
+                "target": {
+                    "value": "1 creature"
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traditions": {
+                    "value": [
+                        "arcane",
+                        "occult",
+                        "primal"
+                    ]
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "emotion",
+                        "incapacitation",
+                        "mental"
                     ]
                 }
             },
@@ -1547,10 +1549,184 @@
             "type": "spell"
         },
         {
+            "_id": "IbL40eKZRnQNwNuN",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.60sgbuMWN0268dB7"
+                }
+            },
+            "img": "systems/pf2e/icons/spells/telekinetic-projectile.webp",
+            "name": "Telekinetic Projectile",
+            "sort": 1500000,
+            "system": {
+                "ability": {
+                    "value": ""
+                },
+                "area": null,
+                "category": {
+                    "value": "spell"
+                },
+                "components": {
+                    "focus": false,
+                    "material": false,
+                    "somatic": true,
+                    "verbal": true
+                },
+                "cost": {
+                    "value": ""
+                },
+                "damage": {
+                    "value": {
+                        "0": {
+                            "applyMod": true,
+                            "type": {
+                                "categories": [],
+                                "subtype": "",
+                                "value": "untyped"
+                            },
+                            "value": "1d6"
+                        }
+                    }
+                },
+                "description": {
+                    "value": "<p>You hurl a loose, unattended object that is within range and that has 1 Bulk or less at the target. Make a spell attack roll against the target. If you hit, you deal bludgeoning, piercing, or slashing damage-as appropriate for the object you hurled-equal to 1d6 plus your spellcasting ability modifier. No specific traits or magic properties of the hurled item affect the attack or the damage.</p>\n<hr />\n<p><strong>Critical Success</strong> You deal double damage.</p>\n<p><strong>Success</strong> You deal full damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 1d6.</p>"
+                },
+                "duration": {
+                    "value": ""
+                },
+                "hasCounteractCheck": {
+                    "value": false
+                },
+                "heightening": {
+                    "damage": {
+                        "0": "1d6"
+                    },
+                    "interval": 1,
+                    "type": "interval"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": {
+                    "value": "DCLGBKaqRvqYPFZZ"
+                },
+                "materials": {
+                    "value": ""
+                },
+                "overlays": {
+                    "2I469pfbYcmFvzOA": {
+                        "_id": "2I469pfbYcmFvzOA",
+                        "name": "Telekinetic Projectile (Bludgeoning)",
+                        "overlayType": "override",
+                        "sort": 1,
+                        "system": {
+                            "damage": {
+                                "value": {
+                                    "0": {
+                                        "type": {
+                                            "value": "bludgeoning"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "cUFX7ExSLeoa3vIF": {
+                        "_id": "cUFX7ExSLeoa3vIF",
+                        "name": "Telekinetic Projectile (Piercing)",
+                        "overlayType": "override",
+                        "sort": 2,
+                        "system": {
+                            "damage": {
+                                "value": {
+                                    "0": {
+                                        "type": {
+                                            "value": "piercing"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "zFWsMjoeCnLxqJaV": {
+                        "_id": "zFWsMjoeCnLxqJaV",
+                        "name": "Telekinetic Projectile (Slashing)",
+                        "overlayType": "override",
+                        "sort": 3,
+                        "system": {
+                            "damage": {
+                                "value": {
+                                    "0": {
+                                        "type": {
+                                            "value": "slashing"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "prepared": {
+                    "value": ""
+                },
+                "primarycheck": {
+                    "value": ""
+                },
+                "range": {
+                    "value": "30 feet"
+                },
+                "rules": [],
+                "save": {
+                    "basic": "",
+                    "value": ""
+                },
+                "school": {
+                    "value": "evocation"
+                },
+                "secondarycasters": {
+                    "value": ""
+                },
+                "secondarycheck": {
+                    "value": ""
+                },
+                "slug": "telekinetic-projectile",
+                "source": {
+                    "value": "Pathfinder Core Rulebook"
+                },
+                "spellType": {
+                    "value": "attack"
+                },
+                "sustained": {
+                    "value": false
+                },
+                "target": {
+                    "value": "1 creature"
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traditions": {
+                    "value": [
+                        "arcane",
+                        "occult"
+                    ]
+                },
+                "traits": {
+                    "custom": "",
+                    "rarity": "common",
+                    "value": [
+                        "attack",
+                        "cantrip"
+                    ]
+                }
+            },
+            "type": "spell"
+        },
+        {
             "_id": "WpLmYPgmK0qG58K8",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Pseudopod",
-            "sort": 1500000,
+            "sort": 1600000,
             "system": {
                 "attack": {
                     "value": ""
@@ -1597,7 +1773,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "At-Will Spells",
-            "sort": 1600000,
+            "sort": 1700000,
             "system": {
                 "actionCategory": {
                     "value": "interaction"
@@ -1642,7 +1818,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Regeneration 15 (Deactivated by Good)",
-            "sort": 1700000,
+            "sort": 1800000,
             "system": {
                 "actionCategory": {
                     "value": "defensive"
@@ -1682,7 +1858,7 @@
             "_id": "wDnuOjox5cjI817l",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Immortality",
-            "sort": 1800000,
+            "sort": 1900000,
             "system": {
                 "actionCategory": {
                     "value": "defensive"
@@ -1722,7 +1898,7 @@
             "_id": "Ut7DWly2y0Fghbxh",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Corrupt Ally",
-            "sort": 1900000,
+            "sort": 2000000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -1766,7 +1942,7 @@
             "_id": "9yNmVUtApEo0Ky5V",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Dead Spells",
-            "sort": 2000000,
+            "sort": 2100000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -1806,7 +1982,7 @@
             "_id": "gzeeloXOYQJ3ZCvu",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Mental Erosion",
-            "sort": 2100000,
+            "sort": 2200000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -1846,7 +2022,7 @@
             "_id": "3tkJJs6AuFOwEB2K",
             "img": "systems/pf2e/icons/actions/ThreeActions.webp",
             "name": "Resanguinate",
-            "sort": 2200000,
+            "sort": 2300000,
             "system": {
                 "actionCategory": {
                     "value": "offensive"
@@ -1890,7 +2066,7 @@
             "_id": "P8LB7aKoS0qhsbne",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Ancient History Lore",
-            "sort": 2300000,
+            "sort": 2400000,
             "system": {
                 "description": {
                     "value": ""
@@ -1918,7 +2094,7 @@
             "_id": "DInqRzwyXMnQw04B",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Arcana",
-            "sort": 2400000,
+            "sort": 2500000,
             "system": {
                 "description": {
                     "value": ""
@@ -1946,7 +2122,7 @@
             "_id": "zLfl1Odw1AR18T5A",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Religion",
-            "sort": 2500000,
+            "sort": 2600000,
             "system": {
                 "description": {
                     "value": ""

--- a/packs/data/age-of-ashes-bestiary.db/spiritbound-aluum.json
+++ b/packs/data/age-of-ashes-bestiary.db/spiritbound-aluum.json
@@ -24,7 +24,7 @@
                 },
                 "rules": [],
                 "showSlotlessLevels": {
-                    "value": true
+                    "value": false
                 },
                 "showUnpreparedSpells": {
                     "value": true
@@ -269,9 +269,10 @@
                     "type": "fixed"
                 },
                 "level": {
-                    "value": 5
+                    "value": 3
                 },
                 "location": {
+                    "heightenedLevel": 5,
                     "value": "LePEQxJOrm3uEIPP"
                 },
                 "materials": {

--- a/packs/data/age-of-ashes-bestiary.db/teyam-ishtori.json
+++ b/packs/data/age-of-ashes-bestiary.db/teyam-ishtori.json
@@ -23,7 +23,7 @@
                 },
                 "rules": [],
                 "showSlotlessLevels": {
-                    "value": true
+                    "value": false
                 },
                 "showUnpreparedSpells": {
                     "value": true
@@ -161,9 +161,10 @@
                     "value": false
                 },
                 "level": {
-                    "value": 10
+                    "value": 9
                 },
                 "location": {
+                    "heightenedLevel": 10,
                     "value": "lup461lEK9zazSYF"
                 },
                 "materials": {
@@ -269,6 +270,7 @@
                     "value": 7
                 },
                 "location": {
+                    "heightenedLevel": 8,
                     "value": "lup461lEK9zazSYF"
                 },
                 "materials": {
@@ -687,9 +689,10 @@
                     "value": false
                 },
                 "level": {
-                    "value": 4
+                    "value": 2
                 },
                 "location": {
+                    "heightenedLevel": 4,
                     "value": "lup461lEK9zazSYF"
                 },
                 "materials": {


### PR DESCRIPTION
Found some remaining oddballs in the age of ashes spells. Immortal ichor for example had the levels of his spells changed instead of them being heightened.