### PR TITLE
Rewrite order of weapon rune preparation

### DIFF
--- a/src/module/actor/character/automatic-bonus-progression.ts
+++ b/src/module/actor/character/automatic-bonus-progression.ts
@@ -128,14 +128,6 @@ class AutomaticBonusProgression {
         }
     }
 
-    static applyPropertyRunes(potency: PotencySynthetic[], weapon: Embedded<WeaponPF2e>): void {
-        if (game.settings.get("pf2e", "automaticBonusVariant") !== "ABPFundamentalPotency") return;
-        const potencyBonuses = potency.filter((p) => p.type === "potency");
-        for (const bonus of potencyBonuses) {
-            bonus.property = deepClone(weapon.system.runes.property);
-        }
-    }
-
     /**
      * Determine whether a rule element can be applied to an actor.
      * @param rule The rule element to assess

--- a/src/module/item/physical/runes.ts
+++ b/src/module/item/physical/runes.ts
@@ -4,7 +4,7 @@ import { ResistanceType } from "@actor/types";
 import { ArmorPF2e, WeaponPF2e } from "@item";
 import type { ResilientRuneType } from "@item/armor/types";
 import type { OtherWeaponTag, StrikingRuneType, WeaponPropertyRuneType, WeaponTrait } from "@item/weapon/types";
-import { OneToFour, Rarity, ZeroToFour, ZeroToThree } from "@module/data";
+import { OneToFour, OneToThree, Rarity, ZeroToFour, ZeroToThree } from "@module/data";
 import { RollNoteSource } from "@module/notes";
 import { PredicatePF2e, RawPredicate } from "@system/predication";
 import { isBlank } from "@util";
@@ -1070,20 +1070,20 @@ const POTENCY_RUNE_DATA: Record<OneToFour, RuneValuationData> = {
 };
 
 // https://2e.aonprd.com/Equipment.aspx?Category=23&Subcategory=25
-const STRIKING_RUNE_DATA: Record<StrikingRuneType, RuneValuationData> = {
-    striking: { level: 4, price: 65, rarity: "common", traits: ["evocation"] },
-    greaterStriking: { level: 12, price: 1065, rarity: "common", traits: ["evocation"] },
-    majorStriking: { level: 19, price: 31065, rarity: "common", traits: ["evocation"] },
+const STRIKING_RUNE_DATA: Record<OneToThree, RuneValuationData> = {
+    1: { level: 4, price: 65, rarity: "common", traits: ["evocation"] },
+    2: { level: 12, price: 1065, rarity: "common", traits: ["evocation"] },
+    3: { level: 19, price: 31065, rarity: "common", traits: ["evocation"] },
 };
 
 interface WeaponValuationData {
     potency: { 0: null } & Record<OneToFour, RuneValuationData>;
-    striking: { "": null } & Record<StrikingRuneType, RuneValuationData>;
+    striking: { 0: null } & Record<OneToThree, RuneValuationData>;
 }
 
 const WEAPON_VALUATION_DATA: WeaponValuationData = {
     potency: { 0: null, ...POTENCY_RUNE_DATA },
-    striking: { "": null, ...STRIKING_RUNE_DATA },
+    striking: { 0: null, ...STRIKING_RUNE_DATA },
 };
 
 export {

--- a/src/module/item/weapon/data.ts
+++ b/src/module/item/weapon/data.ts
@@ -9,7 +9,7 @@ import {
     PreciousMaterialGrade,
     UsageDetails,
 } from "@item/physical";
-import { OneToFour, ZeroToThree } from "@module/data";
+import { OneToFour, ZeroToFour, ZeroToThree } from "@module/data";
 import { DamageDieSize, DamageType } from "@system/damage";
 import { type WeaponPF2e } from "./document";
 import {
@@ -161,7 +161,7 @@ interface WeaponSystemData
         consume: boolean | null;
     };
     runes: {
-        potency: number;
+        potency: ZeroToFour;
         striking: ZeroToThree;
         property: WeaponPropertyRuneType[];
         effects: [];

--- a/src/module/system/damage/weapon.ts
+++ b/src/module/system/damage/weapon.ts
@@ -348,14 +348,12 @@ class WeaponDamagePF2e {
         damageDice.push(...critSpecEffect.filter((e): e is DamageDicePF2e => e instanceof DamageDicePF2e));
 
         // Property Runes
-        const propertyRunes = weaponPotency?.property ?? [];
+        const propertyRunes = weapon.isOfType("weapon") ? weapon.system.runes.property : [];
         damageDice.push(...getPropertyRuneDice(propertyRunes));
-
+        const propertyRuneAdjustments = getPropertyRuneAdjustments(propertyRunes);
         const ignoredResistances = propertyRunes.flatMap(
             (r) => CONFIG.PF2E.runes.weapon.property[r].damage?.ignoredResistances ?? []
         );
-
-        const propertyRuneAdjustments = getPropertyRuneAdjustments(propertyRunes);
 
         // Backstabber trait
         if (weaponTraits.some((t) => t === "backstabber") && options.has("target:condition:flat-footed")) {

--- a/src/module/system/tag-selector/index.ts
+++ b/src/module/system/tag-selector/index.ts
@@ -78,10 +78,7 @@ const SELECTABLE_TAG_FIELDS = [
     "weaponGroups",
     "weaponHands",
     "weaponMAP",
-    "weaponPotencyRunes",
-    "weaponPropertyRunes",
     "weaponReload",
-    "weaponStrikingRunes",
     "weaponTraits",
 ] as const;
 


### PR DESCRIPTION
Among other issues, adjusted weapon names were getting set before runes on weapons were finalized, and strike adjustments were getting missed. This is a refactor to consolidate sourcing of rune data during item data preparation and for damage formula construction.