### PR TITLE
Refine action macro degree of success roll notes

### DIFF
--- a/src/module/system/action-macros/acrobatics/maneuver-in-flight.ts
+++ b/src/module/system/action-macros/acrobatics/maneuver-in-flight.ts
@@ -1,12 +1,14 @@
 import { ActionMacroHelpers, SkillActionOptions } from "..";
 
+const PREFIX = "PF2E.Actions.ManeuverInFlight";
+
 export function maneuverInFlight(options: SkillActionOptions) {
     const { checkType, property, stat, subtitle } = ActionMacroHelpers.resolveStat(options?.skill ?? "acrobatics");
-    ActionMacroHelpers.simpleRollActionCheck({
+    return ActionMacroHelpers.simpleRollActionCheck({
         actors: options.actors,
         statName: property,
         actionGlyph: options.glyph ?? "A",
-        title: "PF2E.Actions.ManeuverInFlight.Title",
+        title: `${PREFIX}.Title`,
         subtitle,
         modifiers: options.modifiers,
         rollOptions: ["all", checkType, stat, "action:maneuver-in-flight"],
@@ -17,10 +19,9 @@ export function maneuverInFlight(options: SkillActionOptions) {
         callback: options.callback,
         difficultyClass: options.difficultyClass,
         extraNotes: (selector: string) => [
-            ActionMacroHelpers.note(selector, "PF2E.Actions.ManeuverInFlight", "criticalSuccess"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.ManeuverInFlight", "success"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.ManeuverInFlight", "failure"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.ManeuverInFlight", "criticalFailure"),
+            ActionMacroHelpers.outcomesNote(selector, `${PREFIX}.Notes.success`, ["success", "criticalSuccess"]),
+            ActionMacroHelpers.note(selector, PREFIX, "failure"),
+            ActionMacroHelpers.note(selector, PREFIX, "criticalFailure"),
         ],
     });
 }

--- a/src/module/system/action-macros/acrobatics/tumble-through.ts
+++ b/src/module/system/action-macros/acrobatics/tumble-through.ts
@@ -1,12 +1,14 @@
 import { ActionMacroHelpers, SkillActionOptions } from "..";
 
+const PREFIX = "PF2E.Actions.TumbleThrough.Notes";
+
 export function tumbleThrough(options: SkillActionOptions) {
     const { checkType, property, stat, subtitle } = ActionMacroHelpers.resolveStat(options?.skill ?? "acrobatics");
     ActionMacroHelpers.simpleRollActionCheck({
         actors: options.actors,
         statName: property,
         actionGlyph: options.glyph ?? "A",
-        title: "PF2E.Actions.TumbleThrough.Title",
+        title: `${PREFIX}.Title`,
         subtitle,
         modifiers: options.modifiers,
         rollOptions: ["all", checkType, stat, "action:tumble-through"],
@@ -18,10 +20,8 @@ export function tumbleThrough(options: SkillActionOptions) {
         difficultyClass: options.difficultyClass,
         difficultyClassStatistic: (target) => target.saves.reflex,
         extraNotes: (selector: string) => [
-            ActionMacroHelpers.note(selector, "PF2E.Actions.TumbleThrough", "criticalSuccess"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.TumbleThrough", "success"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.TumbleThrough", "failure"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.TumbleThrough", "criticalFailure"),
+            ActionMacroHelpers.outcomesNote(selector, `${PREFIX}.success`, ["success", "criticalSuccess"]),
+            ActionMacroHelpers.outcomesNote(selector, `${PREFIX}.failure`, ["failure", "criticalFailure"]),
         ],
     });
 }

--- a/src/module/system/action-macros/athletics/long-jump.ts
+++ b/src/module/system/action-macros/athletics/long-jump.ts
@@ -1,12 +1,14 @@
 import { ActionMacroHelpers, SkillActionOptions } from "..";
 
+const PREFIX = "PF2E.Actions.LongJump";
+
 export function longJump(options: SkillActionOptions) {
     const { checkType, property, stat, subtitle } = ActionMacroHelpers.resolveStat(options?.skill ?? "athletics");
     ActionMacroHelpers.simpleRollActionCheck({
         actors: options.actors,
         statName: property,
         actionGlyph: options.glyph ?? "D",
-        title: "PF2E.Actions.LongJump.Title",
+        title: `${PREFIX}.Title`,
         subtitle,
         modifiers: options.modifiers,
         rollOptions: ["all", checkType, stat, "action:stride", "action:leap", "action:long-jump"],
@@ -17,10 +19,9 @@ export function longJump(options: SkillActionOptions) {
         callback: options.callback,
         difficultyClass: options.difficultyClass,
         extraNotes: (selector: string) => [
-            ActionMacroHelpers.note(selector, "PF2E.Actions.LongJump", "criticalSuccess"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.LongJump", "success"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.LongJump", "failure"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.LongJump", "criticalFailure"),
+            ActionMacroHelpers.outcomesNote(selector, `${PREFIX}.Notes.success`, ["success", "criticalSuccess"]),
+            ActionMacroHelpers.note(selector, PREFIX, "failure"),
+            ActionMacroHelpers.note(selector, PREFIX, "criticalFailure"),
         ],
     });
 }

--- a/src/module/system/action-macros/deception/create-a-diversion.ts
+++ b/src/module/system/action-macros/deception/create-a-diversion.ts
@@ -1,10 +1,11 @@
 import { ActionMacroHelpers, SkillActionOptions } from "..";
 
+const PREFIX = "PF2E.Actions.CreateADiversion";
 type CreateADiversionVariant = "distracting-words" | "gesture" | "trick";
 
 export function createADiversion(options: { variant: CreateADiversionVariant } & SkillActionOptions) {
     const { checkType, property, stat, subtitle } = ActionMacroHelpers.resolveStat(options?.skill ?? "deception");
-    let title = "PF2E.Actions.CreateADiversion.";
+    let title = `${PREFIX}.`;
     const traits = ["mental"];
     switch (options.variant) {
         case "distracting-words":
@@ -41,10 +42,8 @@ export function createADiversion(options: { variant: CreateADiversionVariant } &
         difficultyClass: options.difficultyClass,
         difficultyClassStatistic: (target) => target.perception,
         extraNotes: (selector: string) => [
-            ActionMacroHelpers.note(selector, "PF2E.Actions.CreateADiversion", "criticalSuccess"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.CreateADiversion", "success"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.CreateADiversion", "failure"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.CreateADiversion", "criticalFailure"),
+            ActionMacroHelpers.outcomesNote(selector, `${PREFIX}.Notes.success`, ["success", "criticalSuccess"]),
+            ActionMacroHelpers.outcomesNote(selector, `${PREFIX}.Notes.failure`, ["failure", "criticalFailure"]),
         ],
     });
 }

--- a/src/module/system/action-macros/deception/impersonate.ts
+++ b/src/module/system/action-macros/deception/impersonate.ts
@@ -1,12 +1,14 @@
 import { ActionMacroHelpers, SkillActionOptions } from "..";
 
+const PREFIX = "PF2E.Actions.Impersonate";
+
 export function impersonate(options: SkillActionOptions) {
     const { checkType, property, stat, subtitle } = ActionMacroHelpers.resolveStat(options?.skill ?? "deception");
     ActionMacroHelpers.simpleRollActionCheck({
         actors: options.actors,
         statName: property,
         actionGlyph: options.glyph,
-        title: "PF2E.Actions.Impersonate.Title",
+        title: `${PREFIX}.Title`,
         subtitle,
         modifiers: options.modifiers,
         rollOptions: ["all", checkType, stat, "action:impersonate"],
@@ -18,10 +20,9 @@ export function impersonate(options: SkillActionOptions) {
         difficultyClass: options.difficultyClass,
         difficultyClassStatistic: (target) => target.perception,
         extraNotes: (selector: string) => [
-            ActionMacroHelpers.note(selector, "PF2E.Actions.Impersonate", "criticalSuccess"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.Impersonate", "success"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.Impersonate", "failure"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.Impersonate", "criticalFailure"),
+            ActionMacroHelpers.outcomesNote(selector, `${PREFIX}.Notes.success`, ["success", "criticalSuccess"]),
+            ActionMacroHelpers.note(selector, PREFIX, "failure"),
+            ActionMacroHelpers.note(selector, PREFIX, "criticalFailure"),
         ],
     });
 }

--- a/src/module/system/action-macros/deception/lie.ts
+++ b/src/module/system/action-macros/deception/lie.ts
@@ -1,12 +1,14 @@
 import { ActionMacroHelpers, SkillActionOptions } from "..";
 
+const PREFIX = "PF2E.Actions.Lie";
+
 export function lie(options: SkillActionOptions) {
     const { checkType, property, stat, subtitle } = ActionMacroHelpers.resolveStat(options?.skill ?? "deception");
     ActionMacroHelpers.simpleRollActionCheck({
         actors: options.actors,
         statName: property,
         actionGlyph: options.glyph,
-        title: "PF2E.Actions.Lie.Title",
+        title: `${PREFIX}.Title`,
         subtitle,
         modifiers: options.modifiers,
         rollOptions: ["all", checkType, stat, "action:lie"],
@@ -18,10 +20,8 @@ export function lie(options: SkillActionOptions) {
         difficultyClass: options.difficultyClass,
         difficultyClassStatistic: (target) => target.perception,
         extraNotes: (selector: string) => [
-            ActionMacroHelpers.note(selector, "PF2E.Actions.Lie", "criticalSuccess"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.Lie", "success"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.Lie", "failure"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.Lie", "criticalFailure"),
+            ActionMacroHelpers.outcomesNote(selector, `${PREFIX}.Notes.success`, ["success", "criticalSuccess"]),
+            ActionMacroHelpers.outcomesNote(selector, `${PREFIX}.Notes.failure`, ["failure", "criticalFailure"]),
         ],
     });
 }

--- a/src/module/system/action-macros/diplomacy/gather-information.ts
+++ b/src/module/system/action-macros/diplomacy/gather-information.ts
@@ -1,12 +1,14 @@
 import { ActionMacroHelpers, SkillActionOptions } from "..";
 
+const PREFIX = "PF2E.Actions.GatherInformation";
+
 export function gatherInformation(options: SkillActionOptions) {
     const { checkType, property, stat, subtitle } = ActionMacroHelpers.resolveStat(options?.skill ?? "diplomacy");
     ActionMacroHelpers.simpleRollActionCheck({
         actors: options.actors,
         statName: property,
         actionGlyph: options.glyph,
-        title: "PF2E.Actions.GatherInformation.Title",
+        title: `${PREFIX}.Title`,
         subtitle,
         modifiers: options.modifiers,
         rollOptions: ["all", checkType, stat, "action:gather-information"],
@@ -17,9 +19,8 @@ export function gatherInformation(options: SkillActionOptions) {
         callback: options.callback,
         difficultyClass: options.difficultyClass,
         extraNotes: (selector: string) => [
-            ActionMacroHelpers.note(selector, "PF2E.Actions.GatherInformation", "criticalSuccess"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.GatherInformation", "success"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.GatherInformation", "criticalFailure"),
+            ActionMacroHelpers.outcomesNote(selector, `${PREFIX}.Notes.success`, ["success", "criticalSuccess"]),
+            ActionMacroHelpers.note(selector, PREFIX, "criticalFailure"),
         ],
     });
 }

--- a/src/module/system/action-macros/helpers.ts
+++ b/src/module/system/action-macros/helpers.ts
@@ -68,6 +68,16 @@ export class ActionMacroHelpers {
         });
     }
 
+    static outcomesNote(selector: string, translationKey: string, outcomes: DegreeOfSuccessString[]): RollNotePF2e {
+        const visible = game.settings.get("pf2e", "metagame_showResults");
+        const visibleOutcomes = visible ? outcomes : [];
+        return new RollNotePF2e({
+            selector: selector,
+            text: game.i18n.localize(translationKey),
+            outcome: visibleOutcomes,
+        });
+    }
+
     static async simpleRollActionCheck(options: SimpleRollActionCheckOptions): Promise<void> {
         // figure out actors to roll for
         const rollers: ActorPF2e[] = [];

--- a/src/module/system/action-macros/nature/command-an-animal.ts
+++ b/src/module/system/action-macros/nature/command-an-animal.ts
@@ -1,12 +1,14 @@
 import { ActionMacroHelpers, SkillActionOptions } from "..";
 
+const PREFIX = "PF2E.Actions.CommandAnAnimal";
+
 export function commandAnAnimal(options: SkillActionOptions) {
     const { checkType, property, stat, subtitle } = ActionMacroHelpers.resolveStat(options?.skill ?? "nature");
     ActionMacroHelpers.simpleRollActionCheck({
         actors: options.actors,
         statName: property,
         actionGlyph: options.glyph ?? "A",
-        title: "PF2E.Actions.CommandAnAnimal.Title",
+        title: `${PREFIX}.Title`,
         subtitle,
         modifiers: options.modifiers,
         rollOptions: ["all", checkType, stat, "action:command-an-animal"],
@@ -18,8 +20,7 @@ export function commandAnAnimal(options: SkillActionOptions) {
         difficultyClass: options.difficultyClass,
         difficultyClassStatistic: (target) => target.saves.will,
         extraNotes: (selector: string) => [
-            ActionMacroHelpers.note(selector, "PF2E.Actions.CommandAnAnimal", "criticalSuccess"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.CommandAnAnimal", "success"),
+            ActionMacroHelpers.outcomesNote(selector, `${PREFIX}.Notes.success`, ["success", "criticalSuccess"]),
             ActionMacroHelpers.note(selector, "PF2E.Actions.CommandAnAnimal", "failure"),
             ActionMacroHelpers.note(selector, "PF2E.Actions.CommandAnAnimal", "criticalFailure"),
         ],

--- a/src/module/system/action-macros/stealth/conceal-an-object.ts
+++ b/src/module/system/action-macros/stealth/conceal-an-object.ts
@@ -1,12 +1,14 @@
 import { ActionMacroHelpers, SkillActionOptions } from "..";
 
+const PREFIX = "PF2E.Actions.ConcealAnObject";
+
 export function concealAnObject(options: SkillActionOptions) {
     const { checkType, property, stat, subtitle } = ActionMacroHelpers.resolveStat(options?.skill ?? "stealth");
     return ActionMacroHelpers.simpleRollActionCheck({
         actors: options.actors,
         statName: property,
         actionGlyph: options.glyph ?? "A",
-        title: "PF2E.Actions.ConcealAnObject.Title",
+        title: `${PREFIX}.Title`,
         subtitle,
         modifiers: options.modifiers,
         rollOptions: ["all", checkType, stat, "action:conceal-an-object"],
@@ -18,10 +20,8 @@ export function concealAnObject(options: SkillActionOptions) {
         difficultyClass: options.difficultyClass,
         difficultyClassStatistic: (target) => target.perception,
         extraNotes: (selector: string) => [
-            ActionMacroHelpers.note(selector, "PF2E.Actions.ConcealAnObject", "criticalSuccess"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.ConcealAnObject", "success"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.ConcealAnObject", "failure"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.ConcealAnObject", "criticalFailure"),
+            ActionMacroHelpers.outcomesNote(selector, `${PREFIX}.Notes.success`, ["success", "criticalSuccess"]),
+            ActionMacroHelpers.outcomesNote(selector, `${PREFIX}.Notes.failure`, ["failure", "criticalFailure"]),
         ],
     });
 }

--- a/src/module/system/action-macros/stealth/hide.ts
+++ b/src/module/system/action-macros/stealth/hide.ts
@@ -1,12 +1,14 @@
 import { ActionMacroHelpers, SkillActionOptions } from "..";
 
+const PREFIX = "PF2E.Actions.Hide";
+
 export function hide(options: SkillActionOptions) {
     const { checkType, property, stat, subtitle } = ActionMacroHelpers.resolveStat(options?.skill ?? "stealth");
     ActionMacroHelpers.simpleRollActionCheck({
         actors: options.actors,
         statName: property,
         actionGlyph: options.glyph ?? "A",
-        title: "PF2E.Actions.Hide.Title",
+        title: `${PREFIX}.Title`,
         subtitle,
         modifiers: options.modifiers,
         rollOptions: ["all", checkType, stat, "action:hide"],
@@ -18,8 +20,7 @@ export function hide(options: SkillActionOptions) {
         difficultyClass: options.difficultyClass,
         difficultyClassStatistic: (target) => target.perception,
         extraNotes: (selector: string) => [
-            ActionMacroHelpers.note(selector, "PF2E.Actions.Hide", "criticalSuccess"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.Hide", "success"),
+            ActionMacroHelpers.outcomesNote(selector, `${PREFIX}.Notes.success`, ["success", "criticalSuccess"]),
         ],
     });
 }

--- a/src/module/system/action-macros/stealth/sneak.ts
+++ b/src/module/system/action-macros/stealth/sneak.ts
@@ -1,12 +1,14 @@
 import { ActionMacroHelpers, SkillActionOptions } from "..";
 
+const PREFIX = "PF2E.Actions.Sneak";
+
 export function sneak(options: SkillActionOptions) {
     const { checkType, property, stat, subtitle } = ActionMacroHelpers.resolveStat(options?.skill ?? "stealth");
     ActionMacroHelpers.simpleRollActionCheck({
         actors: options.actors,
         statName: property,
         actionGlyph: options.glyph ?? "A",
-        title: "PF2E.Actions.Sneak.Title",
+        title: `${PREFIX}.Title`,
         subtitle,
         modifiers: options.modifiers,
         rollOptions: ["all", checkType, stat, "action:sneak"],
@@ -18,10 +20,9 @@ export function sneak(options: SkillActionOptions) {
         difficultyClass: options.difficultyClass,
         difficultyClassStatistic: (target) => target.perception,
         extraNotes: (selector: string) => [
-            ActionMacroHelpers.note(selector, "PF2E.Actions.Sneak", "criticalSuccess"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.Sneak", "success"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.Sneak", "failure"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.Sneak", "criticalFailure"),
+            ActionMacroHelpers.outcomesNote(selector, `${PREFIX}.Notes.success`, ["success", "criticalSuccess"]),
+            ActionMacroHelpers.note(selector, PREFIX, "failure"),
+            ActionMacroHelpers.note(selector, PREFIX, "criticalFailure"),
         ],
     });
 }

--- a/src/module/system/action-macros/thievery/palm-an-object.ts
+++ b/src/module/system/action-macros/thievery/palm-an-object.ts
@@ -1,12 +1,14 @@
 import { ActionMacroHelpers, SkillActionOptions } from "..";
 
+const PREFIX = "PF2E.Actions.PalmAnObject";
+
 export function palmAnObject(options: SkillActionOptions) {
     const { checkType, property, stat, subtitle } = ActionMacroHelpers.resolveStat(options?.skill ?? "thievery");
     ActionMacroHelpers.simpleRollActionCheck({
         actors: options.actors,
         statName: property,
         actionGlyph: options.glyph ?? "A",
-        title: "PF2E.Actions.PalmAnObject.Title",
+        title: `${PREFIX}.Title`,
         subtitle,
         modifiers: options.modifiers,
         rollOptions: ["all", checkType, stat, "action:palm-an-object"],
@@ -18,10 +20,8 @@ export function palmAnObject(options: SkillActionOptions) {
         difficultyClass: options.difficultyClass,
         difficultyClassStatistic: (target) => target.perception,
         extraNotes: (selector: string) => [
-            ActionMacroHelpers.note(selector, "PF2E.Actions.PalmAnObject", "criticalSuccess"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.PalmAnObject", "success"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.PalmAnObject", "failure"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.PalmAnObject", "criticalFailure"),
+            ActionMacroHelpers.outcomesNote(selector, `${PREFIX}.Notes.success`, ["success", "criticalSuccess"]),
+            ActionMacroHelpers.outcomesNote(selector, `${PREFIX}.Notes.failure`, ["failure", "criticalFailure"]),
         ],
     });
 }

--- a/src/module/system/action-macros/thievery/steal.ts
+++ b/src/module/system/action-macros/thievery/steal.ts
@@ -1,6 +1,8 @@
 import { ActionMacroHelpers, SkillActionOptions } from "..";
 import { ModifierPF2e } from "@actor/modifiers";
 
+const PREFIX = "PF2E.Actions.Steal";
+
 export function steal(options: SkillActionOptions) {
     const { checkType, property, stat, subtitle } = ActionMacroHelpers.resolveStat(options?.skill ?? "thievery");
     const modifiers = [
@@ -14,7 +16,7 @@ export function steal(options: SkillActionOptions) {
         actors: options.actors,
         statName: property,
         actionGlyph: options.glyph ?? "A",
-        title: "PF2E.Actions.Steal.Title",
+        title: `${PREFIX}.Title`,
         subtitle,
         modifiers: modifiers.concat(options.modifiers ?? []),
         rollOptions: ["all", checkType, stat, "action:steal"],
@@ -26,10 +28,8 @@ export function steal(options: SkillActionOptions) {
         difficultyClass: options.difficultyClass,
         difficultyClassStatistic: (target) => target.perception,
         extraNotes: (selector: string) => [
-            ActionMacroHelpers.note(selector, "PF2E.Actions.Steal", "criticalSuccess"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.Steal", "success"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.Steal", "failure"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.Steal", "criticalFailure"),
+            ActionMacroHelpers.outcomesNote(selector, `${PREFIX}.Notes.success`, ["success", "criticalSuccess"]),
+            ActionMacroHelpers.outcomesNote(selector, `${PREFIX}.Notes.failure`, ["failure", "criticalFailure"]),
         ],
     });
 }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -248,7 +248,6 @@
             },
             "CommandAnAnimal": {
                 "Notes": {
-                    "criticalSuccess": "<strong>Critical Success</strong> The animal does as you command on its next turn.",
                     "success": "<strong>Success</strong> The animal does as you command on its next turn.",
                     "failure": "<strong>Failure</strong> The animal is hesitant or resistant, and it does nothing.",
                     "criticalFailure": "<strong>Critical Failure</strong> The animal misbehaves or misunderstands, and it takes some other action determined by the GM."
@@ -257,10 +256,8 @@
             },
             "ConcealAnObject": {
                 "Notes": {
-                    "criticalSuccess": "<strong>Success</strong> The object remains undetected.",
                     "success": "<strong>Success</strong> The object remains undetected.",
-                    "failure": "<strong>Failure</strong> The searcher finds the object.",
-                    "criticalFailure": "<strong>Failure</strong> The searcher finds the object."
+                    "failure": "<strong>Failure</strong> The searcher finds the object."
                 },
                 "Title": "Conceal an Object"
             },
@@ -268,10 +265,8 @@
                 "DistractingWords": "Create a Diversion - Distracting Words",
                 "Gesture": "Create a Diversion - Gesture",
                 "Notes": {
-                    "criticalSuccess": "<strong>Critical Success</strong> You become @UUID[Compendium.pf2e.conditionitems.iU0fEDdBp3rXpTMC]{Hidden} to each creature whose Perception DC is less than or equal to your result. (The hidden condition allows you to @UUID[Compendium.pf2e.actionspf2e.VMozDqMMuK5kpoX4]{Sneak} away.) This lasts until the end of your turn or until you do anything except Step or use the @UUID[Compendium.pf2e.actionspf2e.XMcnh4cSI32tljXa]{Hide} or the @UUID[Compendium.pf2e.actionspf2e.VMozDqMMuK5kpoX4]{Sneak} action of the Stealth skill. If you Strike a creature, the creature remains @UUID[Compendium.pf2e.conditionitems.AJh5ex99aV6VTggg]{Flat-Footed} against that attack, and you then become @UUID[Compendium.pf2e.conditionitems.1wQY3JYyhMYeeV2G]{Observed}. If you do anything else, you become @UUID[Compendium.pf2e.conditionitems.1wQY3JYyhMYeeV2G]{Observed} just before you act unless the GM determines otherwise.",
                     "success": "<strong>Success</strong> You become @UUID[Compendium.pf2e.conditionitems.iU0fEDdBp3rXpTMC]{Hidden} to each creature whose Perception DC is less than or equal to your result. (The hidden condition allows you to @UUID[Compendium.pf2e.actionspf2e.VMozDqMMuK5kpoX4]{Sneak} away.) This lasts until the end of your turn or until you do anything except Step or use the @UUID[Compendium.pf2e.actionspf2e.XMcnh4cSI32tljXa]{Hide} or the @UUID[Compendium.pf2e.actionspf2e.VMozDqMMuK5kpoX4]{Sneak} action of the Stealth skill. If you Strike a creature, the creature remains @UUID[Compendium.pf2e.conditionitems.AJh5ex99aV6VTggg]{Flat-Footed} against that attack, and you then become @UUID[Compendium.pf2e.conditionitems.1wQY3JYyhMYeeV2G]{Observed}. If you do anything else, you become @UUID[Compendium.pf2e.conditionitems.1wQY3JYyhMYeeV2G]{Observed} just before you act unless the GM determines otherwise.",
-                    "failure": "<strong>Failure</strong> You don't divert the attention of any creatures whose Perception DC exceeds your result, and those creatures are aware you were trying to trick them.",
-                    "criticalFailure": "<strong>Critical Failure</strong> You don't divert the attention of any creatures whose Perception DC exceeds your result, and those creatures are aware you were trying to trick them."
+                    "failure": "<strong>Failure</strong> You don't divert the attention of any creatures whose Perception DC exceeds your result, and those creatures are aware you were trying to trick them."
                 },
                 "Trick": "Create a Diversion - Trick"
             },
@@ -350,7 +345,6 @@
             },
             "GatherInformation": {
                 "Notes": {
-                    "criticalSuccess": "<strong>Critical Success</strong> You collect information about the individual or topic. The GM determines the specifics.",
                     "success": "<strong>Success</strong> You collect information about the individual or topic. The GM determines the specifics.",
                     "criticalFailure": "<strong>Critical Failure</strong> You collect incorrect information about the individual or topic."
                 },
@@ -367,7 +361,6 @@
             },
             "Hide": {
                 "Notes": {
-                    "criticalSuccess": "<strong>Critical Success</strong> If the creature could see you, you're now @UUID[Compendium.pf2e.conditionitems.iU0fEDdBp3rXpTMC]{Hidden} from it instead of observed. If you were @UUID[Compendium.pf2e.conditionitems.iU0fEDdBp3rXpTMC]{Hidden} from or @UUID[Compendium.pf2e.conditionitems.VRSef5y1LmL2Hkjf]{Undetected} by the creature, you retain that condition.",
                     "success": "<strong>Success</strong> If the creature could see you, you're now @UUID[Compendium.pf2e.conditionitems.iU0fEDdBp3rXpTMC]{Hidden} from it instead of observed. If you were @UUID[Compendium.pf2e.conditionitems.iU0fEDdBp3rXpTMC]{Hidden} from or @UUID[Compendium.pf2e.conditionitems.VRSef5y1LmL2Hkjf]{Undetected} by the creature, you retain that condition."
                 },
                 "Title": "Hide"
@@ -419,7 +412,6 @@
             },
             "Impersonate": {
                 "Notes": {
-                    "criticalSuccess": "<strong>Critical Success</strong> You trick the creature into thinking you're the person you're disguised as. You might have to attempt a new check if your behavior changes.",
                     "success": "<strong>Success</strong> You trick the creature into thinking you're the person you're disguised as. You might have to attempt a new check if your behavior changes.",
                     "failure": "<strong>Failure</strong> The creature can tell you're not who you claim to be.",
                     "criticalFailure": "<strong>Critical Failure</strong> The creature can tell you're not who you claim to be, and it recognizes you if it would know you without a disguise."
@@ -428,16 +420,13 @@
             },
             "Lie": {
                 "Notes": {
-                    "criticalSuccess": "<strong>Critical Success</strong> The target believes your lie.",
                     "success": "<strong>Success</strong> The target believes your lie.",
-                    "failure": "<strong>Failure</strong> The target doesn't believe your lie and gains a +4 circumstance bonus against your attempts to Lie for the duration of your conversation. The target is also more likely to be suspicious of you in the future.",
-                    "criticalFailure": "<strong>Critical Failure</strong> The target doesn't believe your lie and gains a +4 circumstance bonus against your attempts to Lie for the duration of your conversation. The target is also more likely to be suspicious of you in the future."
+                    "failure": "<strong>Failure</strong> The target doesn't believe your lie and gains a +4 circumstance bonus against your attempts to Lie for the duration of your conversation. The target is also more likely to be suspicious of you in the future."
                 },
                 "Title": "Lie"
             },
             "LongJump": {
                 "Notes": {
-                    "criticalSuccess": "<strong>Critical Success</strong> Increase the maximum horizontal distance you @UUID[Compendium.pf2e.actionspf2e.d5I6018Mci2SWokk]{Leap} to the desired distance.",
                     "success": "<strong>Success</strong> Increase the maximum horizontal distance you @UUID[Compendium.pf2e.actionspf2e.d5I6018Mci2SWokk]{Leap} to the desired distance.",
                     "failure": "<strong>Failure</strong> You @UUID[Compendium.pf2e.actionspf2e.d5I6018Mci2SWokk]{Leap} normally.",
                     "criticalFailure": "<strong>Critical Failure</strong> You @UUID[Compendium.pf2e.actionspf2e.d5I6018Mci2SWokk]{Leap} normally, but then fall and land @UUID[Compendium.pf2e.conditionitems.j91X7x0XSomq8d60]{Prone}."
@@ -454,7 +443,6 @@
             },
             "ManeuverInFlight": {
                 "Notes": {
-                    "criticalSuccess": "<strong>Critical Success</strong> You succeed at the maneuver.",
                     "success": "<strong>Success</strong> You succeed at the maneuver.",
                     "failure": "<strong>Failure</strong> Your maneuver fails. The GM chooses if you simply can't move or if some other detrimental effect happens. The outcome should be appropriate for the maneuver you attempted (for instance, being blown off course if you were trying to fly against a strong wind).",
                     "criticalFailure": "<strong>Critical Failure</strong> As failure, but the consequence is more dire."
@@ -463,10 +451,8 @@
             },
             "PalmAnObject": {
                 "Notes": {
-                    "criticalSuccess": "<strong>Success</strong> The creature does not notice you Palming the Object.",
                     "success": "<strong>Success</strong> The creature does not notice you Palming the Object.",
-                    "failure": "<strong>Failure</strong> The creature notices you Palming the Object, and the GM determines the creature's response.",
-                    "criticalFailure": "<strong>Failure</strong> The creature notices you Palming the Object, and the GM determines the creature's response."
+                    "failure": "<strong>Failure</strong> The creature notices you Palming the Object, and the GM determines the creature's response."
                 },
                 "Title": "Palm an Object"
             },
@@ -600,7 +586,6 @@
             },
             "Sneak": {
                 "Notes": {
-                    "criticalSuccess": "<strong>Critical Success</strong> You're undetected by the creature during your movement and remain undetected by the creature at the end of it.",
                     "success": "<strong>Success</strong> You're undetected by the creature during your movement and remain undetected by the creature at the end of it.",
                     "failure": "<strong>Failure</strong> A telltale sound or other sign gives your position away, though you still remain unseen. You're hidden from the creature throughout your movement and remain so",
                     "criticalFailure": "<strong>Critical Failure</strong> You're spotted! You're observed by the creature throughout your movement and remain so. If you're invisible and were hidden from the creature, instead of being observed you're hidden throughout your movement and remain so."
@@ -617,10 +602,8 @@
             },
             "Steal": {
                 "Notes": {
-                    "criticalSuccess": "<strong>Success</strong> You steal the item without the bearer noticing, or an observer doesn't see you take or attempt to take the item.",
                     "success": "<strong>Success</strong> You steal the item without the bearer noticing, or an observer doesn't see you take or attempt to take the item.",
-                    "failure": "<strong>Failure</strong> The item's bearer notices your attempt before you can take the object, or an observer sees you take or attempt to take the item. The GM determines the response of any creature that notices your theft.",
-                    "criticalFailure": "<strong>Failure</strong> The item's bearer notices your attempt before you can take the object, or an observer sees you take or attempt to take the item. The GM determines the response of any creature that notices your theft."
+                    "failure": "<strong>Failure</strong> The item's bearer notices your attempt before you can take the object, or an observer sees you take or attempt to take the item. The GM determines the response of any creature that notices your theft."
                 },
                 "Pocketed": "Object pocketed or protected",
                 "Title": "Steal"
@@ -719,10 +702,8 @@
             },
             "TumbleThrough": {
                 "Notes": {
-                    "criticalSuccess": "<strong>Critical Success</strong> You move through the enemy's space, treating the squares in its space as difficult terrain (every 5 feet costs 10 feet of movement). If you don't have enough Speed to move all the way through its space, you get the same effect as a failure.",
                     "success": "<strong>Success</strong> You move through the enemy's space, treating the squares in its space as difficult terrain (every 5 feet costs 10 feet of movement). If you don't have enough Speed to move all the way through its space, you get the same effect as a failure.",
-                    "failure": "<strong>Failure</strong> Your movement ends, and you trigger reactions as if you had moved out of the square you started in.",
-                    "criticalFailure": "<strong>Critical Failure</strong> Your movement ends, and you trigger reactions as if you had moved out of the square you started in."
+                    "failure": "<strong>Failure</strong> Your movement ends, and you trigger reactions as if you had moved out of the square you started in."
                 },
                 "Title": "Tumble Through"
             },


### PR DESCRIPTION
De-duplicate roll notes for action macros with similar result on both success and critical success or on both failure and critical failure.