### PR TITLE
Use `object-fit: contain` for item icons on sheets and sidebar

### DIFF
--- a/src/styles/item/_header.scss
+++ b/src/styles/item/_header.scss
@@ -8,6 +8,7 @@
 
     img {
         border: none;
+        object-fit: contain;
         flex: 0 0 64px;
         margin-right: 6px;
     }

--- a/src/styles/ui/sidebar/_item-directory.scss
+++ b/src/styles/ui/sidebar/_item-directory.scss
@@ -1,4 +1,8 @@
 .directory-item.item {
+    img.thumbnail {
+        object-fit: contain;
+    }
+
     h4 {
         line-height: normal;
         display: flex;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/106829671/217652039-76a5fcd7-b573-4bb5-b068-900a71bb2925.png)

After:
![image](https://user-images.githubusercontent.com/106829671/217651943-6e9faf31-61ca-4619-a458-12fb4801c1f0.png)
