### PR TITLE
Simplify slug recording for `ChoiceSet#rollOption`

### DIFF
--- a/packs/data/classfeatures.db/armor-innovation.json
+++ b/packs/data/classfeatures.db/armor-innovation.json
@@ -49,7 +49,6 @@
                 "flag": "armorInnovation",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Inventor.Innovation.Armor.Prompt",
-                "recordSlug": true,
                 "rollOption": "armor-innovation"
             },
             {


### PR DESCRIPTION
If a roll option is declared for a Choice Set, it obviously never wants a UUID. Given that, a `recordSlug` property isn't actually necessary.