### PR TITLE
Fixed stealth for Breath of Depair

### DIFF
--- a/packs/data/kingmaker-bestiary.db/breath-of-despair.json
+++ b/packs/data/kingmaker-bestiary.db/breath-of-despair.json
@@ -121,7 +121,7 @@
             ],
             "stealth": {
                 "details": "<p>(trained)</p>",
-                "value": 3
+                "value": 13
             }
         },
         "creatureType": "",


### PR DESCRIPTION
Breath of Despair has Stealth +13 in the books (page 133) but in the module is +3