### PR TITLE
Show condition summary and render item summary in template

### DIFF
--- a/src/module/item/base.ts
+++ b/src/module/item/base.ts
@@ -310,9 +310,6 @@ class ItemPF2e extends Item<ActorPF2e> {
     }
 
     protected traitChatData(dictionary: Record<string, string | undefined> = {}): TraitChatData[] {
-        if (this.isOfType("affliction")) {
-            this.system.traits;
-        }
         const traits: string[] = [...(this.system.traits?.value ?? [])].sort();
 
         const traitChatLabels = traits.map((trait) => {

--- a/src/module/item/weapon/document.ts
+++ b/src/module/item/weapon/document.ts
@@ -417,7 +417,7 @@ class WeaponPF2e extends PhysicalItemPF2e {
             properties: [
                 CONFIG.PF2E.weaponCategories[this.category],
                 this.rangeIncrement ? `PF2E.TraitRangeIncrement${this.rangeIncrement}` : null,
-            ],
+            ].filter((p) => !!p),
         });
     }
 

--- a/src/styles/actor/_spell-list.scss
+++ b/src/styles/actor/_spell-list.scss
@@ -266,9 +266,6 @@ ol.spell-list {
             border-top: 1px solid lighten($sub-color, 30);
             background-color: var(--bg);
 
-            p {
-                margin-top: 0;
-            }
             .item-buttons {
                 button {
                     @include p-reset;

--- a/static/templates/actors/partials/conditions.hbs
+++ b/static/templates/actors/partials/conditions.hbs
@@ -33,39 +33,6 @@
                                                                                                       class="fas fa-trash"></i></a>
                 </div>
             {{/if}}
-
-            {{#if (eq item.type "condition")}}
-                <div class="item-summary">
-                    <div class="item-description">
-                        <p>{{{item.enrichedDescription}}}</p>
-                    </div>
-                    {{#if item.references}}
-                        <div class="condition-references">
-                            {{#if item.parents.length}}
-                                <div class="condition-parents">
-                                    <p>Applied From:{{#each item.parents as |parent|}} <span
-                                                                                           data-item-id="{{parent.id}}">{{{parent.enrichedText}}}</span>{{/each}}</p>
-                                </div>
-                            {{/if}}
-                            {{#if item.children.length}}
-                                <div class="condition-children">
-                                    <p>Also Applied:{{#each item.children as |child|}} {{{child.enrichedText}}}{{/each}}</p>
-                                </div>
-                            {{/if}}
-                            {{#if item.overrides.length}}
-                                <div class="condition-overriding">
-                                    <p>Overriding:{{#each item.overrides as |o|}} {{{o.enrichedText}}}{{/each}}</p>
-                                </div>
-                            {{/if}}
-                            {{#if item.overriddenBy.length}}
-                                <div class="condition-overridden">
-                                    <p>Overridden by:{{#each item.overriddenBy as |o|}} {{{o.enrichedText}}}{{/each}}</p>
-                                </div>
-                            {{/if}}
-                        </div>
-                    {{/if}}
-                </div>
-            {{/if}}
         </li>
     {{/if}}
 {{/each}}

--- a/static/templates/actors/partials/item-summary.hbs
+++ b/static/templates/actors/partials/item-summary.hbs
@@ -1,0 +1,54 @@
+{{#if (or item.system.traits item.isIdentified)}}
+    <div class="tags item-properties">
+        {{#if rarityLabel}}
+            <span class="tag {{item.system.traits.rarity}}">{{localize rarityLabel}}</span>
+        {{/if}}
+        {{#each chatData.traits as |trait|}}
+            <span class="tag" data-tooltip="{{trait.description}}">{{localize trait.label}}</span>
+        {{/each}}
+        {{#each chatData.properties as |property|}}
+            <span class="tag tag_secondary">{{localize property}}</span>
+        {{/each}}
+    </div>
+{{/if}}
+
+{{#if item.price}}
+<section>
+    <div>{{localize "PF2E.LevelN" level=item.level}}</div>
+    <div>{{localize "PF2E.Item.Physical.PriceLabel" price=item.price.value}}</div>
+</section>
+{{/if}}
+
+<div class="item-description">
+    {{{description}}}
+</div>
+
+{{#if (and (eq item.type "condition") item.references)}}
+    <div class="condition-references">
+        {{#if item.parents.length}}
+            <div class="condition-parents">
+                <p>
+                    Applied From:
+                    {{#each item.parents as |parent|}}
+                        <span data-item-id="{{parent.id}}">{{{parent.enrichedText}}}</span>
+                    {{/each}}
+                </p>
+            </div>
+        {{/if}}
+        {{#if item.children.length}}
+            <div class="condition-children">
+                <p>Also Applied:{{#each item.children as |child|}} {{{child.enrichedText}}}{{/each}}</p>
+            </div>
+        {{/if}}
+        {{#if item.overrides.length}}
+            <div class="condition-overriding">
+                <p>Overriding:{{#each item.overrides as |o|}} {{{o.enrichedText}}}{{/each}}</p>
+            </div>
+        {{/if}}
+        {{#if item.overriddenBy.length}}
+            <div class="condition-overridden">
+                <p>Overridden by:{{#each item.overriddenBy as |o|}} {{{o.enrichedText}}}{{/each}}</p>
+            </div>
+        {{/if}}
+    </div>
+{{/if}}


### PR DESCRIPTION
I'll look into toggle behavior smoothness and verifying the affected by stuff at a later date. The affected by likely doesn't work because it wants a flattened condition object, but its less broken than it was before (at least the condition summary renders).