### PR TITLE
Move action-specific bonuses from traits to the individual actions

### DIFF
--- a/src/module/system/action-macros/ancestry/automaton/arcane-slam.ts
+++ b/src/module/system/action-macros/ancestry/automaton/arcane-slam.ts
@@ -1,13 +1,13 @@
 import { ActionMacroHelpers, SkillActionOptions } from "../..";
 import { RollNotePF2e } from "@module/notes";
 import { PredicatePF2e } from "@system/predication";
-import { ActorPF2e, CreaturePF2e } from "@actor";
+import { CreaturePF2e } from "@actor";
 import { MODIFIER_TYPE, ModifierPF2e } from "@actor/modifiers";
 
 export function arcaneSlam(options: SkillActionOptions) {
     const { checkType, property, stat, subtitle } = ActionMacroHelpers.resolveStat(options?.skill ?? "athletics");
 
-    const { actor, token } = ActionMacroHelpers.target();
+    const { actor: target, token } = ActionMacroHelpers.target();
 
     ActionMacroHelpers.simpleRollActionCheck({
         actors: options.actors,
@@ -15,11 +15,11 @@ export function arcaneSlam(options: SkillActionOptions) {
         actionGlyph: options.glyph ?? "D",
         title: "PF2E.Actions.ArcaneSlam.Title",
         subtitle,
-        modifiers: (roller: ActorPF2e) => {
+        modifiers: (args) => {
             const modifiers = options.modifiers?.length ? [...options.modifiers] : [];
-            if (roller instanceof CreaturePF2e && actor instanceof CreaturePF2e) {
-                const attackerSize = roller.system.traits.size;
-                const targetSize = actor.system.traits.size;
+            if (args.actor instanceof CreaturePF2e && target instanceof CreaturePF2e) {
+                const attackerSize = args.actor.system.traits.size;
+                const targetSize = target.system.traits.size;
                 const sizeDifference = attackerSize.difference(targetSize);
                 const sizeModifier = new ModifierPF2e(
                     "PF2E.Actions.ArcaneSlam.Modifier.SizeDifference",
@@ -47,7 +47,7 @@ export function arcaneSlam(options: SkillActionOptions) {
                 ActionMacroHelpers.note(selector, "PF2E.Actions.ArcaneSlam", "failure"),
                 ActionMacroHelpers.note(selector, "PF2E.Actions.ArcaneSlam", "criticalFailure"),
             ];
-            if (!actor) {
+            if (!target) {
                 const translated = game.i18n.localize("PF2E.Actions.ArcaneSlam.Notes.NoTarget");
                 notes.unshift(
                     new RollNotePF2e({
@@ -60,6 +60,6 @@ export function arcaneSlam(options: SkillActionOptions) {
             }
             return notes;
         },
-        target: () => (actor && token ? { actor, token } : null),
+        target: () => (target && token ? { actor: target, token } : null),
     });
 }

--- a/src/module/system/action-macros/athletics/disarm.ts
+++ b/src/module/system/action-macros/athletics/disarm.ts
@@ -1,14 +1,26 @@
 import { ActionMacroHelpers, SkillActionOptions } from "..";
+import { WeaponPF2e } from "@item";
+import { ModifierPF2e } from "@actor/modifiers";
 
 export function disarm(options: SkillActionOptions) {
     const { checkType, property, stat, subtitle } = ActionMacroHelpers.resolveStat(options?.skill ?? "athletics");
-    ActionMacroHelpers.simpleRollActionCheck({
+    ActionMacroHelpers.simpleRollActionCheck<Embedded<WeaponPF2e>>({
         actors: options.actors,
         statName: property,
         actionGlyph: options.glyph ?? "A",
         title: "PF2E.Actions.Disarm.Title",
         subtitle,
-        modifiers: options.modifiers,
+        item: (actor) => (ActionMacroHelpers.getApplicableEquippedWeapons(actor, "disarm") ?? []).shift(),
+        modifiers: (args) => {
+            const modifiers: ModifierPF2e[] = [];
+            if (args.item && args.item.slug !== "basic-unarmed") {
+                const modifier = ActionMacroHelpers.getWeaponPotencyModifier(args.item, stat);
+                if (modifier) {
+                    modifiers.push(modifier);
+                }
+            }
+            return modifiers.concat(options.modifiers ?? []);
+        },
         rollOptions: ["all", checkType, stat, "action:disarm"],
         extraOptions: ["action:disarm"],
         traits: ["attack"],
@@ -22,6 +34,5 @@ export function disarm(options: SkillActionOptions) {
             ActionMacroHelpers.note(selector, "PF2E.Actions.Disarm", "success"),
             ActionMacroHelpers.note(selector, "PF2E.Actions.Disarm", "criticalFailure"),
         ],
-        weaponTrait: "disarm",
     });
 }

--- a/src/module/system/action-macros/athletics/grapple.ts
+++ b/src/module/system/action-macros/athletics/grapple.ts
@@ -1,14 +1,26 @@
 import { ActionMacroHelpers, SkillActionOptions } from "..";
+import { ModifierPF2e } from "@actor/modifiers";
+import { WeaponPF2e } from "@item";
 
 export function grapple(options: SkillActionOptions) {
     const { checkType, property, stat, subtitle } = ActionMacroHelpers.resolveStat(options?.skill ?? "athletics");
-    ActionMacroHelpers.simpleRollActionCheck({
+    ActionMacroHelpers.simpleRollActionCheck<Embedded<WeaponPF2e>>({
         actors: options.actors,
         statName: property,
         actionGlyph: options.glyph ?? "A",
         title: "PF2E.Actions.Grapple.Title",
         subtitle,
-        modifiers: options.modifiers,
+        item: (actor) => (ActionMacroHelpers.getApplicableEquippedWeapons(actor, "grapple") ?? []).shift(),
+        modifiers: (args) => {
+            const modifiers: ModifierPF2e[] = [];
+            if (args.item && args.item.traits.has("grapple")) {
+                const modifier = ActionMacroHelpers.getWeaponPotencyModifier(args.item, stat);
+                if (modifier) {
+                    modifiers.push(modifier);
+                }
+            }
+            return modifiers.concat(options.modifiers ?? []);
+        },
         rollOptions: ["all", checkType, stat, "action:grapple"],
         extraOptions: ["action:grapple"],
         traits: ["attack"],
@@ -23,6 +35,5 @@ export function grapple(options: SkillActionOptions) {
             ActionMacroHelpers.note(selector, "PF2E.Actions.Grapple", "failure"),
             ActionMacroHelpers.note(selector, "PF2E.Actions.Grapple", "criticalFailure"),
         ],
-        weaponTrait: "grapple",
     });
 }

--- a/src/module/system/action-macros/athletics/shove.ts
+++ b/src/module/system/action-macros/athletics/shove.ts
@@ -1,14 +1,26 @@
 import { ActionMacroHelpers, SkillActionOptions } from "..";
+import { ModifierPF2e } from "@actor/modifiers";
+import { WeaponPF2e } from "@item";
 
 export function shove(options: SkillActionOptions) {
     const { checkType, property, stat, subtitle } = ActionMacroHelpers.resolveStat(options?.skill ?? "athletics");
-    ActionMacroHelpers.simpleRollActionCheck({
+    ActionMacroHelpers.simpleRollActionCheck<Embedded<WeaponPF2e>>({
         actors: options.actors,
         statName: property,
         actionGlyph: options.glyph ?? "A",
         title: "PF2E.Actions.Shove.Title",
         subtitle,
-        modifiers: options.modifiers,
+        item: (actor) => (ActionMacroHelpers.getApplicableEquippedWeapons(actor, "shove") ?? []).shift(),
+        modifiers: (args) => {
+            const modifiers: ModifierPF2e[] = [];
+            if (args.item && args.item.traits.has("shove")) {
+                const modifier = ActionMacroHelpers.getWeaponPotencyModifier(args.item, stat);
+                if (modifier) {
+                    modifiers.push(modifier);
+                }
+            }
+            return modifiers.concat(options.modifiers ?? []);
+        },
         rollOptions: ["all", checkType, stat, "action:shove"],
         extraOptions: ["action:shove"],
         traits: ["attack"],
@@ -22,6 +34,5 @@ export function shove(options: SkillActionOptions) {
             ActionMacroHelpers.note(selector, "PF2E.Actions.Shove", "success"),
             ActionMacroHelpers.note(selector, "PF2E.Actions.Shove", "criticalFailure"),
         ],
-        weaponTrait: "shove",
     });
 }

--- a/src/module/system/action-macros/athletics/trip.ts
+++ b/src/module/system/action-macros/athletics/trip.ts
@@ -1,14 +1,49 @@
 import { ActionMacroHelpers, SkillActionOptions } from "..";
+import { MODIFIER_TYPE, ModifierPF2e } from "@actor/modifiers";
+import { extractModifierAdjustments } from "@module/rules/helpers";
+import { WeaponPF2e } from "@item";
 
 export function trip(options: SkillActionOptions) {
     const { checkType, property, stat, subtitle } = ActionMacroHelpers.resolveStat(options?.skill ?? "athletics");
-    ActionMacroHelpers.simpleRollActionCheck({
+    ActionMacroHelpers.simpleRollActionCheck<Embedded<WeaponPF2e>>({
         actors: options.actors,
         statName: property,
         actionGlyph: options.glyph ?? "A",
         title: "PF2E.Actions.Trip.Title",
         subtitle,
-        modifiers: options.modifiers,
+        item: (actor) => {
+            return [
+                ...(ActionMacroHelpers.getApplicableEquippedWeapons(actor, "trip") ?? []),
+                ...(ActionMacroHelpers.getApplicableEquippedWeapons(actor, "ranged-trip") ?? []),
+            ].shift();
+        },
+        modifiers: (args) => {
+            const modifiers: ModifierPF2e[] = [];
+            if (args.item) {
+                if (args.item.traits.has("trip") || args.item.traits.has("ranged-trip")) {
+                    const modifier = ActionMacroHelpers.getWeaponPotencyModifier(args.item, stat);
+                    if (modifier) {
+                        modifiers.push(modifier);
+                    }
+                }
+                if (args.item.traits.has("ranged-trip")) {
+                    modifiers.push(
+                        new ModifierPF2e({
+                            slug: "ranged-trip",
+                            adjustments: extractModifierAdjustments(
+                                args.actor.synthetics.modifierAdjustments,
+                                args.rollOptions,
+                                "ranged-trip"
+                            ),
+                            type: MODIFIER_TYPE.CIRCUMSTANCE,
+                            label: CONFIG.PF2E.weaponTraits["ranged-trip"],
+                            modifier: -2,
+                        })
+                    );
+                }
+            }
+            return modifiers.concat(options.modifiers ?? []);
+        },
         rollOptions: ["all", checkType, stat, "action:trip"],
         extraOptions: ["action:trip"],
         traits: ["attack"],
@@ -22,7 +57,5 @@ export function trip(options: SkillActionOptions) {
             ActionMacroHelpers.note(selector, "PF2E.Actions.Trip", "success"),
             ActionMacroHelpers.note(selector, "PF2E.Actions.Trip", "criticalFailure"),
         ],
-        weaponTrait: "trip",
-        weaponTraitWithPenalty: "ranged-trip",
     });
 }

--- a/src/module/system/action-macros/helpers.ts
+++ b/src/module/system/action-macros/helpers.ts
@@ -7,7 +7,7 @@ import {
     MODIFIER_TYPE,
     StatisticModifier,
 } from "@actor/modifiers";
-import { WeaponPF2e } from "@item";
+import { ItemPF2e, WeaponPF2e } from "@item";
 import { WeaponTrait } from "@item/weapon/types";
 import { RollNotePF2e } from "@module/notes";
 import {
@@ -78,7 +78,9 @@ export class ActionMacroHelpers {
         });
     }
 
-    static async simpleRollActionCheck(options: SimpleRollActionCheckOptions): Promise<void> {
+    static async simpleRollActionCheck<ItemType extends Embedded<ItemPF2e>>(
+        options: SimpleRollActionCheckOptions<ItemType>
+    ): Promise<void> {
         // figure out actors to roll for
         const rollers: ActorPF2e[] = [];
         if (Array.isArray(options.actors)) {
@@ -118,49 +120,16 @@ export class ActionMacroHelpers {
             ].flat();
             const selfActor = actor.getContextualClone(combinedOptions.filter((o) => o.startsWith("self:")));
 
-            // Modifier from roller's equipped weapon
-            const weapon = ((): Embedded<WeaponPF2e> | null => {
-                if (!options.traits.includes("attack")) return null;
-                return (
-                    [
-                        ...(options.weaponTrait
-                            ? this.getApplicableEquippedWeapons(selfActor, options.weaponTrait)
-                            : []),
-                        ...(options.weaponTraitWithPenalty
-                            ? this.getApplicableEquippedWeapons(selfActor, options.weaponTraitWithPenalty)
-                            : []),
-                    ].shift() ?? null
-                );
-            })();
+            const weapon = options.item?.(selfActor);
             combinedOptions.push(...(weapon?.getRollOptions("item") ?? []));
 
             const stat = getProperty(selfActor, options.statName) as StatisticModifier & { rank?: number };
-            const itemBonus =
-                weapon && weapon.slug !== "basic-unarmed" ? this.getWeaponPotencyModifier(weapon, stat.slug) : null;
 
             const modifiers =
-                (typeof options.modifiers === "function" ? options.modifiers(selfActor) : options.modifiers) ?? [];
-            if (itemBonus) modifiers.push(itemBonus);
+                (typeof options.modifiers === "function"
+                    ? options.modifiers({ actor: selfActor, item: weapon, rollOptions: options.rollOptions })
+                    : options.modifiers) ?? [];
             const check = new CheckModifier(content, stat, modifiers);
-            const domains = options.rollOptions;
-
-            const weaponTraits = weapon?.traits;
-
-            // Modifier from roller's equipped weapon with -2 ranged penalty
-            if (options.weaponTraitWithPenalty === "ranged-trip" && weaponTraits?.has("ranged-trip")) {
-                const slug = "ranged-trip";
-
-                const syntheticAdjustments = selfActor.synthetics.modifierAdjustments;
-                check.push(
-                    new ModifierPF2e({
-                        slug,
-                        adjustments: extractModifierAdjustments(syntheticAdjustments, domains, slug),
-                        type: MODIFIER_TYPE.CIRCUMSTANCE,
-                        label: CONFIG.PF2E.weaponTraits["ranged-trip"],
-                        modifier: -2,
-                    })
-                );
-            }
 
             const dc = ((): CheckDC | null => {
                 if (options.difficultyClass) {
@@ -194,12 +163,15 @@ export class ActionMacroHelpers {
 
             const distance = ((): number | null => {
                 const reach =
-                    selfActor instanceof CreaturePF2e ? selfActor.getReach({ action: "attack", weapon }) ?? null : null;
+                    selfActor instanceof CreaturePF2e && weapon?.isOfType("weapon")
+                        ? selfActor.getReach({ action: "attack", weapon }) ?? null
+                        : null;
                 return selfToken?.object && target?.object
                     ? selfToken.object.distanceTo(target.object, { reach })
                     : null;
             })();
-            const rangeIncrement = weapon && typeof distance === "number" ? getRangeIncrement(weapon, distance) : null;
+            const rangeIncrement =
+                weapon?.isOfType("weapon") && typeof distance === "number" ? getRangeIncrement(weapon, distance) : null;
 
             const targetInfo =
                 target && targetActor && typeof distance === "number"
@@ -249,23 +221,22 @@ export class ActionMacroHelpers {
         };
     }
 
-    private static getWeaponPotencyModifier(item: Embedded<WeaponPF2e>, selector: string): ModifierPF2e | null {
-        const itemBonus = item.system.runes.potency;
+    static getWeaponPotencyModifier(item: Embedded<WeaponPF2e>, selector: string): ModifierPF2e | null {
         const slug = "potency";
         if (AutomaticBonusProgression.isEnabled(item.actor)) {
             return new ModifierPF2e({
                 slug,
                 type: MODIFIER_TYPE.POTENCY,
-                label: item.name,
+                label: "PF2E.AutomaticBonusProgression.attackPotency",
                 modifier: item.actor.synthetics.weaponPotency["mundane-attack"]?.[0]?.bonus ?? 0,
                 adjustments: extractModifierAdjustments(item.actor.synthetics.modifierAdjustments, [selector], slug),
             });
-        } else if (itemBonus > 0) {
+        } else if (item.system.runes.potency > 0) {
             return new ModifierPF2e({
                 slug,
                 type: MODIFIER_TYPE.ITEM,
-                label: item.name,
-                modifier: itemBonus,
+                label: "PF2E.PotencyRuneLabel",
+                modifier: item.system.runes.potency,
                 adjustments: extractModifierAdjustments(item.actor.synthetics.modifierAdjustments, [selector], slug),
             });
         } else {
@@ -273,7 +244,7 @@ export class ActionMacroHelpers {
         }
     }
 
-    private static getApplicableEquippedWeapons(actor: ActorPF2e, trait: WeaponTrait): Embedded<WeaponPF2e>[] {
+    static getApplicableEquippedWeapons(actor: ActorPF2e, trait: WeaponTrait): Embedded<WeaponPF2e>[] {
         if (actor.isOfType("character")) {
             return actor.system.actions.flatMap((s) => (s.ready && s.item.traits.has(trait) ? s.item : []));
         } else {

--- a/src/module/system/action-macros/types.ts
+++ b/src/module/system/action-macros/types.ts
@@ -6,8 +6,15 @@ import { TokenDocumentPF2e } from "@scene";
 import { CheckRoll, CheckType } from "@system/check";
 import { CheckDC, DegreeOfSuccessString } from "@system/degree-of-success";
 import { Statistic } from "@system/statistic";
+import { ItemPF2e } from "@item";
 
 type ActionGlyph = "A" | "D" | "T" | "R" | "F" | "a" | "d" | "t" | "r" | "f" | 1 | 2 | 3 | "1" | "2" | "3";
+
+interface CheckModifierContext<ItemType extends Embedded<ItemPF2e>> {
+    actor: ActorPF2e;
+    item?: ItemType;
+    rollOptions: string[];
+}
 
 interface CheckResultCallback {
     actor: ActorPF2e;
@@ -16,14 +23,15 @@ interface CheckResultCallback {
     roll: Rolled<CheckRoll>;
 }
 
-interface SimpleRollActionCheckOptions {
+interface SimpleRollActionCheckOptions<ItemType extends Embedded<ItemPF2e>> {
     actors: ActorPF2e | ActorPF2e[] | undefined;
     statName: string;
     actionGlyph: ActionGlyph | undefined;
     title: string;
     subtitle: string;
     content?: (title: string) => Promise<string | null | undefined | void> | string | null | undefined | void;
-    modifiers: ((roller: ActorPF2e) => ModifierPF2e[] | undefined) | ModifierPF2e[] | undefined;
+    item?: (actor: ActorPF2e) => ItemType | undefined;
+    modifiers: ((args: CheckModifierContext<ItemType>) => ModifierPF2e[] | undefined) | ModifierPF2e[] | undefined;
     rollOptions: string[];
     extraOptions: string[];
     traits: string[];


### PR DESCRIPTION
Refactor action check roll code to have item bonus logic from traits in the action code itself. This is mostly affecting the various combat maneuver actions with the attack trait at this point. The refactoring should cut down a bit on the shared action code while still making it more flexible for future actions.