### PR TITLE
🐵 🩹 ` _parseUuid` and `fromUuid` to return cached compendium documents

### DIFF
--- a/src/scripts/🐵🩹.ts
+++ b/src/scripts/🐵🩹.ts
@@ -1,7 +1,35 @@
 import { TextEditorPF2e } from "@system/text-editor";
 
+const superParseUuid = _parseUuid;
+
+/** In foundry v10.291 _parseUuid does not return any cached compendium documents */
+function parseUuidCached(uuid: string, relative?: ClientDocument): ResolvedUUID {
+    const resolved = superParseUuid(uuid, relative);
+    if (resolved.collection) {
+        resolved.doc = resolved.collection.get(resolved.documentId) ?? null;
+    }
+    return resolved;
+}
+
+/** In foundry v10.291 fromUuid does not return any cached compendium documents */
+async function fromUuidCached(uuid: string, relative?: ClientDocument): Promise<ClientDocument | null> {
+    const { collection, documentId, embedded, doc } = parseUuidCached(uuid, relative);
+    const document = await (async (): Promise<ClientDocument | null> => {
+        if (doc) return doc;
+        return collection instanceof CompendiumCollection
+            ? ((await collection.getDocument(documentId)) as ClientDocument)
+            : collection?.get(documentId) ?? null;
+    })();
+    if (embedded.length && document) {
+        return _resolveEmbedded(document, embedded) ?? null;
+    }
+    return document;
+}
+
 export function monkeyPatchFoundry(): void {
     TextEditor.enrichHTML = TextEditorPF2e.enrichHTML;
     TextEditor._createInlineRoll = TextEditorPF2e._createInlineRoll;
     TextEditor._onClickInlineRoll = TextEditorPF2e._onClickInlineRoll;
+    globalThis._parseUuid = parseUuidCached;
+    globalThis.fromUuid = fromUuidCached;
 }

--- a/src/util/from-uuids.ts
+++ b/src/util/from-uuids.ts
@@ -10,9 +10,7 @@ async function fromUUIDs(uuids: string[]): Promise<ClientDocument[]> {
     const actors: ActorPF2e[] = [];
     const items: ItemPF2e[] = [];
 
-    const documents = uuids.map((u): [string, ReturnType<typeof fromUuidSync>] =>
-        u.startsWith("Compendium") ? [u, fromCompendiumUuidSync(u)] : [u, fromUuidSync(u)]
-    );
+    const documents = uuids.map((u): [string, ReturnType<typeof fromUuidSync>] => [u, fromUuidSync(u)]);
     for (const [uuid, doc] of documents) {
         if (doc instanceof ActorPF2e) {
             actors.push(doc);
@@ -30,14 +28,6 @@ async function fromUUIDs(uuids: string[]): Promise<ClientDocument[]> {
     }
 
     return actors.length > 0 ? actors : items;
-}
-
-function fromCompendiumUuidSync(uuid: Exclude<ActorUUID | TokenDocumentUUID, CompendiumUUID>): ActorPF2e | null;
-function fromCompendiumUuidSync(uuid: Exclude<ItemUUID, CompendiumUUID>): ItemPF2e | null;
-function fromCompendiumUuidSync(uuid: string): ClientDocument | null;
-function fromCompendiumUuidSync(uuid: string): ClientDocument | null {
-    const [_type, scope, packId, id]: (string | undefined)[] = uuid.split(".");
-    return game.packs.get(`${scope}.${packId}`)?.get(id) ?? null;
 }
 
 function isItemUUID(uuid: unknown): uuid is ItemUUID {

--- a/types/foundry/client/collections/compendium-collection.d.ts
+++ b/types/foundry/client/collections/compendium-collection.d.ts
@@ -170,8 +170,14 @@ declare global {
     type CompendiumUUID = `Compendium.${string}.${string}`;
     type DocumentUUID = WorldDocumentUUID | CompendiumUUID | TokenDocumentUUID;
 
-    function fromUuid<T extends CompendiumDocument = CompendiumDocument>(uuid: CompendiumUUID): Promise<T | null>;
-    function fromUuid<T extends ClientDocument = ClientDocument>(uuid: string): Promise<T | null>;
+    function fromUuid<T extends CompendiumDocument = CompendiumDocument>(
+        uuid: CompendiumUUID,
+        relative?: CompendiumDocument
+    ): Promise<T | null>;
+    function fromUuid<T extends ClientDocument = ClientDocument>(
+        uuid: string,
+        relative?: CompendiumDocument
+    ): Promise<T | null>;
 
     /**
      * Retrieve a Document by its Universally Unique Identifier (uuid) synchronously. If the uuid resolves to a compendium
@@ -189,6 +195,34 @@ declare global {
         uuid: string,
         relative?: ClientDocument | CompendiumIndexData | null
     ): ClientDocument | CompendiumIndexData | null;
+
+    /**
+     * Parse a UUID into its constituent parts.
+     * @param uuid The UUID to parse.
+     * @param relative A document to resolve relative UUIDs against.
+     * @returns The Collection and the Document ID to resolve the parent document, as
+     *          well as the remaining Embedded Document parts, if any.
+     */
+    function _parseUuid(uuid: string, relative?: ClientDocument): ResolvedUUID;
+
+    interface ResolvedUUID {
+        /** The parent collection. */
+        collection?: DocumentCollection<ClientDocument>;
+        /** The parent document. */
+        documentId: string;
+        /** An already-resolved document. */
+        doc: ClientDocument | null;
+        /** Any remaining Embedded Document parts. */
+        embedded: string[];
+    }
+
+    /**
+     * Resolve a series of embedded document UUID parts against a parent Document.
+     * @param parent The parent Document.
+     * @param parts A series of Embedded Document UUID parts.
+     * @returns The resolved Embedded Document.
+     */
+    function _resolveEmbedded(parent: ClientDocument, parts: string[]): ClientDocument | undefined;
 
     interface CompendiumMetadata<T extends CompendiumDocument = CompendiumDocument> {
         readonly type: T["documentName"];


### PR DESCRIPTION
Turns out the same bug that affects `fromUuidSync` prevents `fromUuid` from returning cached documents too.
`fromUuid` needs patching because it doesn't check if a `Document` was returned before fetching from the server.

Still works as expected:
![image](https://user-images.githubusercontent.com/41452412/218311534-d4b73d24-f3bf-4915-9276-b155f6bd3e5e.png)

Original functions for reference:
```js
async function fromUuid(uuid, relative) {
  let {collection, documentId, embedded, doc} = _parseUuid(uuid, relative);
  if ( collection instanceof CompendiumCollection ) doc = await collection.getDocument(documentId);
  else doc = doc ?? collection?.get(documentId);
  if ( embedded.length ) doc = _resolveEmbedded(doc, embedded);
  return doc || null;
}

/* -------------------------------------------- */

function _parseUuid(uuid, relative) {
  if ( uuid.startsWith(".") && relative ) return _resolveRelativeUuid(uuid, relative);
  let parts = uuid.split(".");
  let collection;
  let documentId;

  // Compendium Documents
  if ( parts[0] === "Compendium" ) {
    parts.shift();
    const [scope, packName, id] = parts.splice(0, 3);
    collection = game.packs.get(`${scope}.${packName}`);
    documentId = id;
  }

  // World Documents
  else {
    const [documentName, id] = parts.splice(0, 2);
    collection = CONFIG[documentName]?.collection.instance;
    documentId = id;
  }

  return {collection, documentId, embedded: parts};
}
```