### PR TITLE
Improve character sheet crafting tab

### DIFF
--- a/src/module/actor/character/crafting/formula.ts
+++ b/src/module/actor/character/crafting/formula.ts
@@ -82,6 +82,7 @@ export class CraftingFormula implements CraftingFormulaData {
 
 export interface CraftingFormulaData {
     uuid: ItemUUID;
+    sort?: number;
     dc?: number;
     batchSize?: number;
     deletable?: boolean;

--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -175,6 +175,7 @@ class CharacterPF2e extends CreaturePF2e {
 
     async getCraftingFormulas(): Promise<CraftingFormula[]> {
         const { formulas } = this.system.crafting;
+        formulas.sort((a, b) => (a.sort ?? 0) - (b.sort ?? 0));
         const formulaMap = new Map(formulas.map((data) => [data.uuid, data]));
         const items: unknown[] = await UUIDUtils.fromUUIDs(formulas.map((data) => data.uuid));
         if (!items.every((i): i is ItemPF2e => i instanceof ItemPF2e)) return [];

--- a/src/module/item/consumable/document.ts
+++ b/src/module/item/consumable/document.ts
@@ -78,7 +78,8 @@ class ConsumablePF2e extends PhysicalItemPF2e {
 
     override async getChatData(
         this: Embedded<ConsumablePF2e>,
-        htmlOptions: EnrichHTMLOptions = {}
+        htmlOptions: EnrichHTMLOptions = {},
+        rollOptions: Record<string, unknown> = {}
     ): Promise<ItemSummaryData> {
         const systemData = this.system;
         const traits = this.traitChatData(CONFIG.PF2E.consumableTraits);
@@ -90,6 +91,7 @@ class ConsumablePF2e extends PhysicalItemPF2e {
               ];
 
         const usesLabel = game.i18n.localize("PF2E.ConsumableChargesLabel");
+        const fromFormula = !!rollOptions.fromFormula;
 
         return this.processChatData(htmlOptions, {
             ...systemData,
@@ -101,7 +103,7 @@ class ConsumablePF2e extends PhysicalItemPF2e {
             usesCharges: this.uses.max > 0,
             hasCharges: this.uses.max > 0 && this.uses.value > 0,
             consumableType,
-            isUsable,
+            isUsable: fromFormula ? false : isUsable,
         });
     }
 

--- a/src/styles/actor/character/_crafting.scss
+++ b/src/styles/actor/character/_crafting.scss
@@ -90,11 +90,11 @@
             }
 
             .formula-level-header, .formula-item {
-                display: flex;
+                display: grid;
+                grid: "name dc price quantity controls" 1fr
+                      / 4fr 0.7fr 1fr 1fr 1fr;
                 align-items: center;
                 justify-items: center;
-                justify-content: space-between;
-                flex-wrap: wrap;
 
                 @include p-reset;
                 background: none;
@@ -231,7 +231,7 @@
                 }
 
                 .item-summary {
-                    flex-basis: 100%;
+                    grid-column: 1 / 6;
                     padding: 8px;
                     border-bottom: 1px solid var(--sub);
                     border-top: 1px solid lighten($sub-color, 30);

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1435,9 +1435,13 @@
             "ExpendFormula": "Expend Formula",
             "NoEligibleEntry": "No eligible crafting entry was found.",
             "QuickAddTitle": "Add this formula to one or more crafting entries",
+            "RemoveFormulaDialogQuestion": "Are you sure you want to remove the formula for {name}?",
+            "RemoveFormulaDialogTitle": "Remove Formula",
             "ToggleFreeCrafting": "Toggle Free Crafting",
             "ToggleQuickAlchemy": "Quick Alchemy",
-            "UndeletableTooltip": "This crafting formula is part of another item and cannot be individually deleted."
+            "UndeletableTooltip": "This crafting formula is part of another item and cannot be individually deleted.",
+            "UnprepareFormulaDialogQuestion": "Are you sure you want to unprepare the formula for {name}?",
+            "UnprepareFormulaDialogTitle": "Unprepare Formula"
         },
         "CreateActionTitle": "Create Action",
         "CreateAttackTitle": "Create Attack",

--- a/static/templates/actors/character/tabs/crafting.hbs
+++ b/static/templates/actors/character/tabs/crafting.hbs
@@ -37,8 +37,7 @@
 
                         {{#if @root.options.editable}}
                             <div class="item-controls">
-                                <a class="item-control inventory-browse" title="{{localize "PF2E.OpenInventoryBrowser"}}"
-                                    data-type="equipment" data-level="{{lvl}}" data-location="{{entry._id}}"><i class="fa-solid fa-fw fa-search"></i></a>
+                                <a class="item-control inventory-browse" title="{{localize "PF2E.OpenInventoryBrowser"}}" data-level="{{lvl}}"><i class="fa-solid fa-fw fa-search"></i></a>
                             </div>
                         {{/if}}
                     </li>
@@ -79,8 +78,7 @@
                     {{#if @root.options.editable}}
                         <li class="formula-header empty">
                             <h4>{{localize "PF2E.FormulaListEmpty"}}</h4>
-                            <a class="item-control inventory-browse" title="{{localize "PF2E.OpenInventoryBrowser"}}"
-                                data-type="equipment" data-location="{{entry._id}}">
+                            <a class="item-control inventory-browse" title="{{localize "PF2E.OpenInventoryBrowser"}}" data-level="{{lvl}}">
                                 <i class="fas fa-fw fa-search"></i>{{localize "PF2E.OpenInventoryBrowser"}}
                             </a>
                         </li>

--- a/static/templates/actors/crafting-entry-alchemical.hbs
+++ b/static/templates/actors/crafting-entry-alchemical.hbs
@@ -44,7 +44,7 @@
                     </li>
 
                     {{#each entry.formulas}}
-                        <li class="item formula-item" data-item-id="{{this.uuid}}" data-item-type="formula" data-item-index={{@key}}>
+                        <li class="item formula-item" data-item-id="{{this.uuid}}" data-item-type="formula" data-item-index={{@key}} data-entry-selector="{{entry.selector}}" data-is-formula="true">
                             <div class="item-name rollable">
                                 <div class="item-image">
                                     <img class="item-icon" src="{{this.img}}" alt="{{this.name}}">

--- a/static/templates/actors/crafting-entry-list.hbs
+++ b/static/templates/actors/crafting-entry-list.hbs
@@ -8,7 +8,7 @@
         </div>
         <ol class="directory-list item-list formula-list">
             {{#each entry.formulas}}
-                <li class="item formula-item" data-item-id="{{this.uuid}}" data-item-type="formula" data-expended-state="{{this.expended}}" data-item-index={{@key}}>
+                <li class="item formula-item" data-item-id="{{this.uuid}}" data-is-formula="true" data-item-type="formula" data-expended-state="{{this.expended}}" data-item-index={{@key}} data-entry-selector="{{entry.selector}}">
                     <div class="item-name rollable">
                         {{#if this}}
                             <div class="item-image">


### PR DESCRIPTION
- Some CSS improvements for better header alignment.
- Removed a big chunk of `jQuery` from the tabs listeners.
- All Formulas are now sortable.
- All Formula items can now be sent to chat by clicking on the item image.
- All Formulas now support expanding their item summary.
- Deleting or unpreparing a formula now opens a confirmation dialog before deletion.
- The Compendium Browser buttons now open with the maximum level of the header they were clicked in.

Before:
![Before](https://user-images.githubusercontent.com/41452412/218324073-a6bd9f59-8a12-475b-b7d9-296330f4919d.png)

After:
![Recording 2023-03-05 at 17 12 44](https://user-images.githubusercontent.com/41452412/222972277-9f5ced93-80cc-4860-a6f6-b42aaad67060.gif)



Closes #6086, #1776