### PR TITLE
Fix target of levitate spell in carbuncle to Self only

### DIFF
--- a/packs/data/pathfinder-bestiary-2.db/carbuncle.json
+++ b/packs/data/pathfinder-bestiary-2.db/carbuncle.json
@@ -188,7 +188,7 @@
                     "value": false
                 },
                 "target": {
-                    "value": "1 unatteded object or willing creature"
+                    "value": "Self only"
                 },
                 "time": {
                     "value": "2"


### PR DESCRIPTION
Fix carbuncle (of bestiary 2): Levitate target has to be "Self only"