### PR TITLE
Wrap precision/splash damage in parentheses if necessary

### DIFF
--- a/src/module/system/damage/formula.ts
+++ b/src/module/system/damage/formula.ts
@@ -213,10 +213,16 @@ function createPartialFormulas(
             }, [])
             .join(" + ");
 
-        const term = [combinedDice, Math.abs(constant)]
-            .filter((e) => !!e)
-            .map((e) => (typeof e === "number" && doubleDice ? `2 * ${e}` : e))
-            .join(constant > 0 ? " + " : " - ");
+        const term = ((): string => {
+            const expression = [combinedDice, Math.abs(constant)]
+                .filter((e) => !!e)
+                .map((e) => (typeof e === "number" && doubleDice ? `2 * ${e}` : e))
+                .join(constant > 0 ? " + " : " - ");
+            return ["precision", "splash"].includes(category ?? "") && hasOperators(expression)
+                ? `(${expression})`
+                : expression;
+        })();
+
         const flavored = term && category && category !== "persistent" ? `${term}[${category}]` : term;
 
         return flavored || [];


### PR DESCRIPTION
Before/After
![image](https://user-images.githubusercontent.com/106829671/218377913-1ac55542-e2b6-474f-900c-47a4cd3457d9.png)
