### PR TITLE
Tagify remaining Compendium Browser trait filters

### DIFF
--- a/src/module/apps/compendium-browser/tabs/action.ts
+++ b/src/module/apps/compendium-browser/tabs/action.ts
@@ -65,18 +65,19 @@ export class CompendiumBrowserActionTab extends CompendiumBrowserTab {
         this.indexData = actions;
 
         // Set Filters
-        this.filterData.checkboxes.traits.options = this.generateCheckboxOptions(CONFIG.PF2E.actionTraits);
+        this.filterData.multiselects.traits.options = this.generateMultiselectOptions(CONFIG.PF2E.actionTraits);
         this.filterData.checkboxes.source.options = this.generateSourceCheckboxOptions(sources);
 
         console.debug("PF2e System | Compendium Browser | Finished loading actions");
     }
 
     protected override filterIndexData(entry: CompendiumBrowserIndexData): boolean {
-        const { checkboxes } = this.filterData;
+        const { checkboxes, multiselects } = this.filterData;
 
         // Traits
-        if (checkboxes.traits.selected.length) {
-            if (!this.arrayIncludes(checkboxes.traits.selected, entry.traits)) return false;
+        const selectedTraits = multiselects.traits.selected.map((s) => s.value);
+        if (selectedTraits.length > 0 && !selectedTraits.every((t) => entry.traits.includes(t))) {
+            return false;
         }
         // Source
         if (checkboxes.source.selected.length) {
@@ -88,16 +89,17 @@ export class CompendiumBrowserActionTab extends CompendiumBrowserTab {
     protected override prepareFilterData(): void {
         this.filterData = {
             checkboxes: {
-                traits: {
-                    isExpanded: false,
-                    label: "PF2E.BrowserFilterTraits",
-                    options: {},
-                    selected: [],
-                },
                 source: {
                     isExpanded: false,
                     label: "PF2E.BrowserFilterSource",
                     options: {},
+                    selected: [],
+                },
+            },
+            multiselects: {
+                traits: {
+                    label: "PF2E.BrowserFilterTraits",
+                    options: [],
                     selected: [],
                 },
             },

--- a/src/module/apps/compendium-browser/tabs/bestiary.ts
+++ b/src/module/apps/compendium-browser/tabs/bestiary.ts
@@ -87,7 +87,7 @@ export class CompendiumBrowserBestiaryTab extends CompendiumBrowserTab {
         // Filters
         this.filterData.checkboxes.sizes.options = this.generateCheckboxOptions(CONFIG.PF2E.actorSizes);
         this.filterData.checkboxes.alignments.options = this.generateCheckboxOptions(CONFIG.PF2E.alignments, false);
-        this.filterData.checkboxes.traits.options = this.generateCheckboxOptions(CONFIG.PF2E.monsterTraits);
+        this.filterData.multiselects.traits.options = this.generateMultiselectOptions(CONFIG.PF2E.monsterTraits);
         this.filterData.checkboxes.rarity.options = this.generateCheckboxOptions(CONFIG.PF2E.rarityTraits, false);
         this.filterData.checkboxes.source.options = this.generateSourceCheckboxOptions(sources);
 
@@ -95,7 +95,7 @@ export class CompendiumBrowserBestiaryTab extends CompendiumBrowserTab {
     }
 
     protected override filterIndexData(entry: CompendiumBrowserIndexData): boolean {
-        const { checkboxes, sliders } = this.filterData;
+        const { checkboxes, multiselects, sliders } = this.filterData;
 
         // Level
         if (!(entry.level >= sliders.level.values.min && entry.level <= sliders.level.values.max)) return false;
@@ -108,8 +108,9 @@ export class CompendiumBrowserBestiaryTab extends CompendiumBrowserTab {
             if (!checkboxes.alignments.selected.includes(entry.alignment)) return false;
         }
         // Traits
-        if (checkboxes.traits.selected.length) {
-            if (!this.arrayIncludes(checkboxes.traits.selected, entry.traits)) return false;
+        const selectedTraits = multiselects.traits.selected.map((s) => s.value);
+        if (selectedTraits.length > 0 && !selectedTraits.every((t) => entry.traits.includes(t))) {
+            return false;
         }
         // Source
         if (checkboxes.source.selected.length) {
@@ -137,12 +138,6 @@ export class CompendiumBrowserBestiaryTab extends CompendiumBrowserTab {
                     options: {},
                     selected: [],
                 },
-                traits: {
-                    isExpanded: false,
-                    label: "PF2E.BrowserFilterTraits",
-                    options: {},
-                    selected: [],
-                },
                 rarity: {
                     isExpanded: false,
                     label: "PF2E.BrowserFilterRarities",
@@ -153,6 +148,13 @@ export class CompendiumBrowserBestiaryTab extends CompendiumBrowserTab {
                     isExpanded: false,
                     label: "PF2E.BrowserFilterSource",
                     options: {},
+                    selected: [],
+                },
+            },
+            multiselects: {
+                traits: {
+                    label: "PF2E.BrowserFilterTraits",
+                    options: [],
                     selected: [],
                 },
             },

--- a/src/module/apps/compendium-browser/tabs/data.ts
+++ b/src/module/apps/compendium-browser/tabs/data.ts
@@ -2,6 +2,9 @@ import { FeatTrait } from "@item/feat/data";
 import { PhysicalItemTrait } from "@item/physical/data";
 import { CommonSortByOption, SortByOption, SortDirection } from "../data";
 import type { SearchResult } from "minisearch";
+import { CreatureTrait } from "@actor/creature/data";
+import { ActionTrait } from "@item";
+import { HazardTrait } from "@actor/hazard/types";
 
 type CheckboxOptions = Record<string, { label: string; selected: boolean }>;
 interface CheckboxData {
@@ -67,11 +70,13 @@ interface BaseFilterData {
 }
 
 interface ActionFilters extends BaseFilterData {
-    checkboxes: Record<"traits" | "source", CheckboxData>;
+    checkboxes: Record<"source", CheckboxData>;
+    multiselects: Record<"traits", MultiselectData<ActionTrait>>;
 }
 
 interface BestiaryFilters extends BaseFilterData {
-    checkboxes: Record<"alignments" | "rarity" | "sizes" | "source" | "traits", CheckboxData>;
+    checkboxes: Record<"alignments" | "rarity" | "sizes" | "source", CheckboxData>;
+    multiselects: Record<"traits", MultiselectData<CreatureTrait>>;
     sliders: Record<"level", SliderData>;
 }
 
@@ -89,15 +94,14 @@ interface FeatFilters extends BaseFilterData {
 }
 
 interface HazardFilters extends BaseFilterData {
-    checkboxes: Record<"complexity" | "rarity" | "source" | "traits", CheckboxData>;
+    checkboxes: Record<"complexity" | "rarity" | "source", CheckboxData>;
+    multiselects: Record<"traits", MultiselectData<HazardTrait>>;
     sliders: Record<"level", SliderData>;
 }
 
 interface SpellFilters extends BaseFilterData {
-    checkboxes: Record<
-        "category" | "classes" | "level" | "rarity" | "school" | "source" | "traditions" | "traits",
-        CheckboxData
-    >;
+    checkboxes: Record<"category" | "level" | "rarity" | "school" | "source" | "traditions", CheckboxData>;
+    multiselects: Record<"traits", MultiselectData<string>>;
     selects: Record<"timefilter", SelectData>;
 }
 

--- a/src/module/apps/compendium-browser/tabs/equipment.ts
+++ b/src/module/apps/compendium-browser/tabs/equipment.ts
@@ -178,7 +178,7 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
 
         // Traits
         const selectedTraits = multiselects.traits.selected.map((s) => s.value);
-        if (selectedTraits.length > 0 && !selectedTraits.some((t) => entry.traits.includes(t))) {
+        if (selectedTraits.length > 0 && !selectedTraits.every((t) => entry.traits.includes(t))) {
             return false;
         }
 

--- a/src/module/apps/compendium-browser/tabs/feat.ts
+++ b/src/module/apps/compendium-browser/tabs/feat.ts
@@ -128,7 +128,7 @@ export class CompendiumBrowserFeatTab extends CompendiumBrowserTab {
         }
         // Traits
         const selectedTraits = multiselects.traits.selected.map((s) => s.value);
-        if (selectedTraits.length > 0 && !selectedTraits.some((t) => entry.traits.includes(t))) {
+        if (selectedTraits.length > 0 && !selectedTraits.every((t) => entry.traits.includes(t))) {
             return false;
         }
 

--- a/src/module/apps/compendium-browser/tabs/hazard.ts
+++ b/src/module/apps/compendium-browser/tabs/hazard.ts
@@ -76,7 +76,7 @@ export class CompendiumBrowserHazardTab extends CompendiumBrowserTab {
             },
             false
         );
-        this.filterData.checkboxes.traits.options = this.generateCheckboxOptions(CONFIG.PF2E.hazardTraits);
+        this.filterData.multiselects.traits.options = this.generateMultiselectOptions(CONFIG.PF2E.hazardTraits);
         this.filterData.checkboxes.rarity.options = this.generateCheckboxOptions(CONFIG.PF2E.rarityTraits, false);
         this.filterData.checkboxes.source.options = this.generateSourceCheckboxOptions(sources);
 
@@ -84,7 +84,7 @@ export class CompendiumBrowserHazardTab extends CompendiumBrowserTab {
     }
 
     protected override filterIndexData(entry: CompendiumBrowserIndexData): boolean {
-        const { checkboxes, sliders } = this.filterData;
+        const { checkboxes, multiselects, sliders } = this.filterData;
 
         // Level
         if (!(entry.level >= sliders.level.values.min && entry.level <= sliders.level.values.max)) return false;
@@ -93,8 +93,9 @@ export class CompendiumBrowserHazardTab extends CompendiumBrowserTab {
             if (!checkboxes.complexity.selected.includes(entry.complexity)) return false;
         }
         // Traits
-        if (checkboxes.traits.selected.length) {
-            if (!this.arrayIncludes(checkboxes.traits.selected, entry.traits)) return false;
+        const selectedTraits = multiselects.traits.selected.map((s) => s.value);
+        if (selectedTraits.length > 0 && !selectedTraits.every((t) => entry.traits.includes(t))) {
+            return false;
         }
         // Source
         if (checkboxes.source.selected.length) {
@@ -116,12 +117,6 @@ export class CompendiumBrowserHazardTab extends CompendiumBrowserTab {
                     options: {},
                     selected: [],
                 },
-                traits: {
-                    isExpanded: false,
-                    label: "PF2E.BrowserFilterTraits",
-                    options: {},
-                    selected: [],
-                },
                 rarity: {
                     isExpanded: false,
                     label: "PF2E.BrowserFilterRarities",
@@ -132,6 +127,13 @@ export class CompendiumBrowserHazardTab extends CompendiumBrowserTab {
                     isExpanded: false,
                     label: "PF2E.BrowserFilterSource",
                     options: {},
+                    selected: [],
+                },
+            },
+            multiselects: {
+                traits: {
+                    label: "PF2E.BrowserFilterTraits",
+                    options: [],
                     selected: [],
                 },
             },

--- a/src/module/apps/compendium-browser/tabs/spell.ts
+++ b/src/module/apps/compendium-browser/tabs/spell.ts
@@ -127,10 +127,9 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
                 selected: false,
             };
         }
-        this.filterData.checkboxes.classes.options = this.generateCheckboxOptions(CONFIG.PF2E.classTraits);
         this.filterData.checkboxes.school.options = this.generateCheckboxOptions(CONFIG.PF2E.magicSchools);
         this.filterData.checkboxes.rarity.options = this.generateCheckboxOptions(CONFIG.PF2E.rarityTraits, false);
-        this.filterData.checkboxes.traits.options = this.generateCheckboxOptions(CONFIG.PF2E.spellTraits);
+        this.filterData.multiselects.traits.options = this.generateMultiselectOptions(CONFIG.PF2E.spellTraits);
         this.filterData.checkboxes.source.options = this.generateSourceCheckboxOptions(sources);
 
         this.filterData.selects.timefilter.options = [...times].sort().reduce(
@@ -145,7 +144,7 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
     }
 
     protected override filterIndexData(entry: CompendiumBrowserIndexData): boolean {
-        const { checkboxes, selects } = this.filterData;
+        const { checkboxes, multiselects, selects } = this.filterData;
 
         // Level
         if (checkboxes.level.selected.length) {
@@ -164,10 +163,10 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
         if (checkboxes.traditions.selected.length) {
             if (!this.arrayIncludes(checkboxes.traditions.selected, entry.traditions)) return false;
         }
-        // Traits and Class
-        if (checkboxes.classes.selected.length || checkboxes.traits.selected.length) {
-            const combined = [...checkboxes.classes.selected, ...checkboxes.traits.selected];
-            if (!this.arrayIncludes(combined, entry.traits)) return false;
+        // Traits
+        const selectedTraits = multiselects.traits.selected.map((s) => s.value);
+        if (selectedTraits.length > 0 && !selectedTraits.every((t) => entry.traits.includes(t))) {
+            return false;
         }
         // School
         if (checkboxes.school.selected.length) {
@@ -205,12 +204,6 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
                     options: {},
                     selected: [],
                 },
-                classes: {
-                    isExpanded: false,
-                    label: "PF2E.BrowserFilterClass",
-                    options: {},
-                    selected: [],
-                },
                 school: {
                     isExpanded: false,
                     label: "PF2E.BrowserFilterSchools",
@@ -223,16 +216,17 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
                     options: {},
                     selected: [],
                 },
-                traits: {
-                    isExpanded: false,
-                    label: "PF2E.BrowserFilterTraits",
-                    options: {},
-                    selected: [],
-                },
                 source: {
                     isExpanded: false,
                     label: "PF2E.BrowserFilterSource",
                     options: {},
+                    selected: [],
+                },
+            },
+            multiselects: {
+                traits: {
+                    label: "PF2E.BrowserFilterTraits",
+                    options: [],
                     selected: [],
                 },
             },

--- a/static/templates/compendium-browser/filters.hbs
+++ b/static/templates/compendium-browser/filters.hbs
@@ -44,14 +44,6 @@
     </div>
     <button type="button" class="clear-filters">{{localize "PF2E.BrowserClearFilters"}}</button>
     {{#each filterData.checkboxes as |checkbox name|}}
-        {{#if (eq @index 1)}}
-            {{#each ../filterData.multiselects as |selectData type|}}
-                <div class="filtercontainer" data-filter-type="multiselects" data-filter-name="{{type}}">
-                    <h3>{{localize selectData.label}}</h3>
-                    <input class="tags paizo-style" name="{{type}}" data-tagify-select="true" spellcheck="false" value="{{json selectData.selected}}" />
-                </div>
-            {{/each}}
-        {{/if}}
         <div class="filtercontainer" data-filter-type="checkboxes" data-filter-name="{{name}}">
             <div class="title">
                 <h3>{{localize checkbox.label}}</h3>
@@ -68,6 +60,14 @@
                 {{/each}}
             </dl>
         </div>
+        {{#if @first}}
+            {{#each ../filterData.multiselects as |selectData type|}}
+                <div class="filtercontainer" data-filter-type="multiselects" data-filter-name="{{type}}">
+                    <h3>{{localize selectData.label}}</h3>
+                    <input class="tags paizo-style" name="{{type}}" data-tagify-select="true" spellcheck="false" value="{{json selectData.selected}}" />
+                </div>
+            {{/each}}
+        {{/if}}
     {{/each}}
     {{#each filterData.ranges as |range name|}}
         <div class="filtercontainer rangecontainer" data-filter-type="ranges" data-filter-name="{{name}}">


### PR DESCRIPTION
Also changes the trait filter from `some` to `every` to work as expected when multiple traits are selected.