### PR TITLE
Add rule elements for wing deflection reaction

### DIFF
--- a/packs/data/blog-bestiary.db/firebrand-ancient-brass-dragon.json
+++ b/packs/data/blog-bestiary.db/firebrand-ancient-brass-dragon.json
@@ -493,7 +493,23 @@
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "domain": "ac",
+                        "key": "RollOption",
+                        "option": "wing-deflection",
+                        "toggleable": true
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "predicate": [
+                            "wing-deflection"
+                        ],
+                        "selector": "ac",
+                        "type": "circumstance",
+                        "value": 2
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""

--- a/packs/data/pathfinder-bestiary-2.db/adult-magma-dragon-spellcaster.json
+++ b/packs/data/pathfinder-bestiary-2.db/adult-magma-dragon-spellcaster.json
@@ -3471,7 +3471,23 @@
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "domain": "ac",
+                        "key": "RollOption",
+                        "option": "wing-deflection",
+                        "toggleable": true
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "predicate": [
+                            "wing-deflection"
+                        ],
+                        "selector": "ac",
+                        "type": "circumstance",
+                        "value": 2
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""

--- a/packs/data/pathfinder-bestiary-2.db/adult-magma-dragon.json
+++ b/packs/data/pathfinder-bestiary-2.db/adult-magma-dragon.json
@@ -942,7 +942,23 @@
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "domain": "ac",
+                        "key": "RollOption",
+                        "option": "wing-deflection",
+                        "toggleable": true
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "predicate": [
+                            "wing-deflection"
+                        ],
+                        "selector": "ac",
+                        "type": "circumstance",
+                        "value": 2
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""

--- a/packs/data/pathfinder-bestiary-2.db/ancient-magma-dragon-spellcaster.json
+++ b/packs/data/pathfinder-bestiary-2.db/ancient-magma-dragon-spellcaster.json
@@ -4509,7 +4509,23 @@
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "domain": "ac",
+                        "key": "RollOption",
+                        "option": "wing-deflection",
+                        "toggleable": true
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "predicate": [
+                            "wing-deflection"
+                        ],
+                        "selector": "ac",
+                        "type": "circumstance",
+                        "value": 2
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""

--- a/packs/data/pathfinder-bestiary-2.db/ancient-magma-dragon.json
+++ b/packs/data/pathfinder-bestiary-2.db/ancient-magma-dragon.json
@@ -1190,7 +1190,23 @@
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "domain": "ac",
+                        "key": "RollOption",
+                        "option": "wing-deflection",
+                        "toggleable": true
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "predicate": [
+                            "wing-deflection"
+                        ],
+                        "selector": "ac",
+                        "type": "circumstance",
+                        "value": 2
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""

--- a/packs/data/pathfinder-bestiary-2.db/young-magma-dragon-spellcaster.json
+++ b/packs/data/pathfinder-bestiary-2.db/young-magma-dragon-spellcaster.json
@@ -2579,7 +2579,23 @@
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "domain": "ac",
+                        "key": "RollOption",
+                        "option": "wing-deflection",
+                        "toggleable": true
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "predicate": [
+                            "wing-deflection"
+                        ],
+                        "selector": "ac",
+                        "type": "circumstance",
+                        "value": 2
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""

--- a/packs/data/pathfinder-bestiary-2.db/young-magma-dragon.json
+++ b/packs/data/pathfinder-bestiary-2.db/young-magma-dragon.json
@@ -731,7 +731,23 @@
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "domain": "ac",
+                        "key": "RollOption",
+                        "option": "wing-deflection",
+                        "toggleable": true
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "predicate": [
+                            "wing-deflection"
+                        ],
+                        "selector": "ac",
+                        "type": "circumstance",
+                        "value": 2
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""


### PR DESCRIPTION
wing deflection is missing rule elements that can be found in other creatures like `packs/data/pathfinder-bestiary.db/adult-brass-dragon.json`