### PR TITLE
Record ancestry slug in heritage data, add support for heritage-granting feats

### DIFF
--- a/packs/data/feats.db/elf-atavism.json
+++ b/packs/data/feats.db/elf-atavism.json
@@ -21,7 +21,25 @@
         "prerequisites": {
             "value": []
         },
-        "rules": [],
+        "rules": [
+            {
+                "allowedDrops": {
+                    "label": "PF2E.SpecificRule.ElfAtavism.AllowedDrops",
+                    "predicate": [
+                        "item:type:heritage",
+                        "item:ancestry:elf"
+                    ]
+                },
+                "choices": {
+                    "itemType": "heritage",
+                    "pack": "pf2e.heritages",
+                    "query": "{\"system.ancestry.slug\":\"elf\"}"
+                },
+                "flag": "heritage",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.ElfAtavism.Prompt"
+            }
+        ],
         "source": {
             "value": "Pathfinder Core Rulebook"
         },

--- a/packs/data/feats.db/reset-the-past.json
+++ b/packs/data/feats.db/reset-the-past.json
@@ -28,7 +28,7 @@
                     "value": "Chronoskimmer Dedication"
                 }
             ]
-        },        
+        },
         "rules": [],
         "source": {
             "value": "Pathfinder Dark Archive"

--- a/packs/data/feats.db/shared-stratagem.json
+++ b/packs/data/feats.db/shared-stratagem.json
@@ -22,30 +22,30 @@
             "value": []
         },
         "rules": [
-          {
-            "key": "Note",
-            "selector": "strike-damage",
-            "text": "The creature you hit is @UUID[Compendium.pf2e.conditionitems.Flat-Footed] to a designated ally on the next attack the ally makes against the creature before the start of your next turn.",
-            "title": "{item|name}",
-            "predicate": [
-                "devise-a-stratagem",
-                {
-                    "or": [
-                        "item:trait:agile",
-                        "item:trait:finesse",
-                        {
-                          "and": [
-                            "item:ranged",
+            {
+                "key": "Note",
+                "predicate": [
+                    "devise-a-stratagem",
+                    {
+                        "or": [
+                            "item:trait:agile",
+                            "item:trait:finesse",
                             {
-                              "not": "item:thrown-melee"
-                            }
-                          ]
-                        },
-                        "item:base:sap"
-                    ]
-                }
-            ]
-          }
+                                "and": [
+                                    "item:ranged",
+                                    {
+                                        "not": "item:thrown-melee"
+                                    }
+                                ]
+                            },
+                            "item:base:sap"
+                        ]
+                    }
+                ],
+                "selector": "strike-damage",
+                "text": "The creature you hit is @UUID[Compendium.pf2e.conditionitems.Flat-Footed] to a designated ally on the next attack the ally makes against the creature before the start of your next turn.",
+                "title": "{item|name}"
+            }
         ],
         "source": {
             "value": "Pathfinder Advanced Player's Guide"

--- a/packs/data/heritages.db/adaptive-anadi.json
+++ b/packs/data/heritages.db/adaptive-anadi.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Anadi",
+            "slug": "anadi",
             "uuid": "Compendium.pf2e.ancestries.TQEqWqc7BYiadUdY"
         },
         "description": {

--- a/packs/data/heritages.db/ancient-ash.json
+++ b/packs/data/heritages.db/ancient-ash.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Ghoran",
+            "slug": "ghoran",
             "uuid": "Compendium.pf2e.ancestries.tSurOqRcfumadTfr"
         },
         "description": {

--- a/packs/data/heritages.db/ancient-blooded-dwarf.json
+++ b/packs/data/heritages.db/ancient-blooded-dwarf.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Dwarf",
+            "slug": "dwarf",
             "uuid": "Compendium.pf2e.ancestries.BYj5ZvlXZdpaEgA6"
         },
         "description": {

--- a/packs/data/heritages.db/ancient-elf.json
+++ b/packs/data/heritages.db/ancient-elf.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Elf",
+            "slug": "elf",
             "uuid": "Compendium.pf2e.ancestries.PgKmsA2aKdbLU6O0"
         },
         "description": {

--- a/packs/data/heritages.db/ancient-scale-azarketi.json
+++ b/packs/data/heritages.db/ancient-scale-azarketi.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Azarketi",
+            "slug": "azarketi",
             "uuid": "Compendium.pf2e.ancestries.yFoojz6q3ZjvceFw"
         },
         "description": {

--- a/packs/data/heritages.db/ant-gnoll.json
+++ b/packs/data/heritages.db/ant-gnoll.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Gnoll",
+            "slug": "gnoll",
             "uuid": "Compendium.pf2e.ancestries.vxbQ1Yw4qwgjTzqo"
         },
         "description": {

--- a/packs/data/heritages.db/anvil-dwarf.json
+++ b/packs/data/heritages.db/anvil-dwarf.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Dwarf",
+            "slug": "dwarf",
             "uuid": "Compendium.pf2e.ancestries.BYj5ZvlXZdpaEgA6"
         },
         "description": {

--- a/packs/data/heritages.db/arctic-elf.json
+++ b/packs/data/heritages.db/arctic-elf.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Elf",
+            "slug": "elf",
             "uuid": "Compendium.pf2e.ancestries.PgKmsA2aKdbLU6O0"
         },
         "description": {

--- a/packs/data/heritages.db/artisan-android.json
+++ b/packs/data/heritages.db/artisan-android.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Android",
+            "slug": "android",
             "uuid": "Compendium.pf2e.ancestries.GfLwE884NoRC7cRi"
         },
         "description": {

--- a/packs/data/heritages.db/athamasi.json
+++ b/packs/data/heritages.db/athamasi.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Kashrishi",
+            "slug": "kashrishi",
             "uuid": "Compendium.pf2e.ancestries.dw2K1AJR9mQ25nDP"
         },
         "description": {

--- a/packs/data/heritages.db/badlands-orc.json
+++ b/packs/data/heritages.db/badlands-orc.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Orc",
+            "slug": "orc",
             "uuid": "Compendium.pf2e.ancestries.lSGWXjcbOa6O5fTx"
         },
         "description": {

--- a/packs/data/heritages.db/bandaagee-vanara.json
+++ b/packs/data/heritages.db/bandaagee-vanara.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Vanara",
+            "slug": "vanara",
             "uuid": "Compendium.pf2e.ancestries.cLtOGIkuSSa4UDHY"
         },
         "description": {

--- a/packs/data/heritages.db/battle-ready-orc.json
+++ b/packs/data/heritages.db/battle-ready-orc.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Orc",
+            "slug": "orc",
             "uuid": "Compendium.pf2e.ancestries.lSGWXjcbOa6O5fTx"
         },
         "description": {

--- a/packs/data/heritages.db/battle-trained-human-bb.json
+++ b/packs/data/heritages.db/battle-trained-human-bb.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Human",
+            "slug": "human",
             "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
         },
         "description": {

--- a/packs/data/heritages.db/benthic-azarketi.json
+++ b/packs/data/heritages.db/benthic-azarketi.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Azarketi",
+            "slug": "azarketi",
             "uuid": "Compendium.pf2e.ancestries.yFoojz6q3ZjvceFw"
         },
         "description": {

--- a/packs/data/heritages.db/bloodhound-shoony.json
+++ b/packs/data/heritages.db/bloodhound-shoony.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Shoony",
+            "slug": "shoony",
             "uuid": "Compendium.pf2e.ancestries.q6rsqYARyOGXZA8F"
         },
         "description": {

--- a/packs/data/heritages.db/bright-fetchling.json
+++ b/packs/data/heritages.db/bright-fetchling.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Fetchling",
+            "slug": "fetchling",
             "uuid": "Compendium.pf2e.ancestries.hIA3qiUsxvLZXrFP"
         },
         "description": {

--- a/packs/data/heritages.db/cactus-leshy.json
+++ b/packs/data/heritages.db/cactus-leshy.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Leshy",
+            "slug": "leshy",
             "uuid": "Compendium.pf2e.ancestries.cdhgByGG1WtuaK73"
         },
         "description": {

--- a/packs/data/heritages.db/cataphract-fleshwarp.json
+++ b/packs/data/heritages.db/cataphract-fleshwarp.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Fleshwarp",
+            "slug": "fleshwarp",
             "uuid": "Compendium.pf2e.ancestries.FXlXmNBFiiz9oasi"
         },
         "description": {

--- a/packs/data/heritages.db/caveclimber-kobold.json
+++ b/packs/data/heritages.db/caveclimber-kobold.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Kobold",
+            "slug": "kobold",
             "uuid": "Compendium.pf2e.ancestries.7oQxL6wgsokD3QXG"
         },
         "description": {

--- a/packs/data/heritages.db/cavern-elf.json
+++ b/packs/data/heritages.db/cavern-elf.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Elf",
+            "slug": "elf",
             "uuid": "Compendium.pf2e.ancestries.PgKmsA2aKdbLU6O0"
         },
         "description": {

--- a/packs/data/heritages.db/cavern-kobold.json
+++ b/packs/data/heritages.db/cavern-kobold.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Kobold",
+            "slug": "kobold",
             "uuid": "Compendium.pf2e.ancestries.7oQxL6wgsokD3QXG"
         },
         "description": {

--- a/packs/data/heritages.db/celestial-envoy-kitsune.json
+++ b/packs/data/heritages.db/celestial-envoy-kitsune.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Kitsune",
+            "slug": "kitsune",
             "uuid": "Compendium.pf2e.ancestries.4BL5wf1VF9feC2rY"
         },
         "description": {

--- a/packs/data/heritages.db/chameleon-gnome.json
+++ b/packs/data/heritages.db/chameleon-gnome.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Gnome",
+            "slug": "gnome",
             "uuid": "Compendium.pf2e.ancestries.CYlfsYLJcBOgqKtD"
         },
         "description": {

--- a/packs/data/heritages.db/charhide-goblin.json
+++ b/packs/data/heritages.db/charhide-goblin.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Goblin",
+            "slug": "goblin",
             "uuid": "Compendium.pf2e.ancestries.sQfjTMDaZbT9DThq"
         },
         "description": {

--- a/packs/data/heritages.db/clawed-catfolk.json
+++ b/packs/data/heritages.db/clawed-catfolk.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Catfolk",
+            "slug": "catfolk",
             "uuid": "Compendium.pf2e.ancestries.972EkpJOPv9KkQIW"
         },
         "description": {

--- a/packs/data/heritages.db/cliffscale-lizardfolk.json
+++ b/packs/data/heritages.db/cliffscale-lizardfolk.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Lizardfolk",
+            "slug": "lizardfolk",
             "uuid": "Compendium.pf2e.ancestries.HWEgF7Gmoq55VhTL"
         },
         "description": {

--- a/packs/data/heritages.db/cloudleaper-lizardfolk.json
+++ b/packs/data/heritages.db/cloudleaper-lizardfolk.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Lizardfolk",
+            "slug": "lizardfolk",
             "uuid": "Compendium.pf2e.ancestries.HWEgF7Gmoq55VhTL"
         },
         "description": {

--- a/packs/data/heritages.db/compact-skeleton.json
+++ b/packs/data/heritages.db/compact-skeleton.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Skeleton",
+            "slug": "skeleton",
             "uuid": "Compendium.pf2e.ancestries.58rL5sg2y4arW1i5"
         },
         "description": {

--- a/packs/data/heritages.db/created-fleshwarp.json
+++ b/packs/data/heritages.db/created-fleshwarp.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Fleshwarp",
+            "slug": "fleshwarp",
             "uuid": "Compendium.pf2e.ancestries.FXlXmNBFiiz9oasi"
         },
         "description": {

--- a/packs/data/heritages.db/dark-fields-kitsune.json
+++ b/packs/data/heritages.db/dark-fields-kitsune.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Kitsune",
+            "slug": "kitsune",
             "uuid": "Compendium.pf2e.ancestries.4BL5wf1VF9feC2rY"
         },
         "description": {

--- a/packs/data/heritages.db/death-warden-dwarf.json
+++ b/packs/data/heritages.db/death-warden-dwarf.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Dwarf",
+            "slug": "dwarf",
             "uuid": "Compendium.pf2e.ancestries.BYj5ZvlXZdpaEgA6"
         },
         "description": {

--- a/packs/data/heritages.db/deep-fetchling.json
+++ b/packs/data/heritages.db/deep-fetchling.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Fetchling",
+            "slug": "fetchling",
             "uuid": "Compendium.pf2e.ancestries.hIA3qiUsxvLZXrFP"
         },
         "description": {

--- a/packs/data/heritages.db/deep-orc.json
+++ b/packs/data/heritages.db/deep-orc.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Orc",
+            "slug": "orc",
             "uuid": "Compendium.pf2e.ancestries.lSGWXjcbOa6O5fTx"
         },
         "description": {

--- a/packs/data/heritages.db/deep-rat.json
+++ b/packs/data/heritages.db/deep-rat.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Ratfolk",
+            "slug": "ratfolk",
             "uuid": "Compendium.pf2e.ancestries.P6PcVnCkh4XMdefw"
         },
         "description": {

--- a/packs/data/heritages.db/desert-elf.json
+++ b/packs/data/heritages.db/desert-elf.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Elf",
+            "slug": "elf",
             "uuid": "Compendium.pf2e.ancestries.PgKmsA2aKdbLU6O0"
         },
         "description": {

--- a/packs/data/heritages.db/desert-rat.json
+++ b/packs/data/heritages.db/desert-rat.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Ratfolk",
+            "slug": "ratfolk",
             "uuid": "Compendium.pf2e.ancestries.P6PcVnCkh4XMdefw"
         },
         "description": {

--- a/packs/data/heritages.db/discarded-fleshwarp.json
+++ b/packs/data/heritages.db/discarded-fleshwarp.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Fleshwarp",
+            "slug": "fleshwarp",
             "uuid": "Compendium.pf2e.ancestries.FXlXmNBFiiz9oasi"
         },
         "description": {

--- a/packs/data/heritages.db/dogtooth-tengu.json
+++ b/packs/data/heritages.db/dogtooth-tengu.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Tengu",
+            "slug": "tengu",
             "uuid": "Compendium.pf2e.ancestries.18xDKYPDBLEv2myX"
         },
         "description": {

--- a/packs/data/heritages.db/dragonscaled-kobold.json
+++ b/packs/data/heritages.db/dragonscaled-kobold.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Kobold",
+            "slug": "kobold",
             "uuid": "Compendium.pf2e.ancestries.7oQxL6wgsokD3QXG"
         },
         "description": {

--- a/packs/data/heritages.db/draxie.json
+++ b/packs/data/heritages.db/draxie.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Sprite",
+            "slug": "sprite",
             "uuid": "Compendium.pf2e.ancestries.TRqoeYfGAFjQbviF"
         },
         "description": {

--- a/packs/data/heritages.db/earthly-wilds-kitsune.json
+++ b/packs/data/heritages.db/earthly-wilds-kitsune.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Kitsune",
+            "slug": "kitsune",
             "uuid": "Compendium.pf2e.ancestries.4BL5wf1VF9feC2rY"
         },
         "description": {

--- a/packs/data/heritages.db/elemental-heart-dwarf.json
+++ b/packs/data/heritages.db/elemental-heart-dwarf.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Dwarf",
+            "slug": "dwarf",
             "uuid": "Compendium.pf2e.ancestries.BYj5ZvlXZdpaEgA6"
         },
         "description": {

--- a/packs/data/heritages.db/elfbane-hobgoblin.json
+++ b/packs/data/heritages.db/elfbane-hobgoblin.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Hobgoblin",
+            "slug": "hobgoblin",
             "uuid": "Compendium.pf2e.ancestries.piNLXUrm9iaGqD2i"
         },
         "description": {

--- a/packs/data/heritages.db/elusive-vishkanya.json
+++ b/packs/data/heritages.db/elusive-vishkanya.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Vishkanya",
+            "slug": "vishkanya",
             "uuid": "Compendium.pf2e.ancestries.u1VJEXsVlmh3Fyx0"
         },
         "description": {

--- a/packs/data/heritages.db/empty-sky-kitsune.json
+++ b/packs/data/heritages.db/empty-sky-kitsune.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Kitsune",
+            "slug": "kitsune",
             "uuid": "Compendium.pf2e.ancestries.4BL5wf1VF9feC2rY"
         },
         "description": {

--- a/packs/data/heritages.db/enchanting-lily.json
+++ b/packs/data/heritages.db/enchanting-lily.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Ghoran",
+            "slug": "ghoran",
             "uuid": "Compendium.pf2e.ancestries.tSurOqRcfumadTfr"
         },
         "description": {

--- a/packs/data/heritages.db/farsight-goloma.json
+++ b/packs/data/heritages.db/farsight-goloma.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Goloma",
+            "slug": "goloma",
             "uuid": "Compendium.pf2e.ancestries.c4secsSNG2AO7I5i"
         },
         "description": {

--- a/packs/data/heritages.db/fey-touched-gnome.json
+++ b/packs/data/heritages.db/fey-touched-gnome.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Gnome",
+            "slug": "gnome",
             "uuid": "Compendium.pf2e.ancestries.CYlfsYLJcBOgqKtD"
         },
         "description": {

--- a/packs/data/heritages.db/fishseeker-shoony.json
+++ b/packs/data/heritages.db/fishseeker-shoony.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Shoony",
+            "slug": "shoony",
             "uuid": "Compendium.pf2e.ancestries.q6rsqYARyOGXZA8F"
         },
         "description": {

--- a/packs/data/heritages.db/flexible-catfolk.json
+++ b/packs/data/heritages.db/flexible-catfolk.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Catfolk",
+            "slug": "catfolk",
             "uuid": "Compendium.pf2e.ancestries.972EkpJOPv9KkQIW"
         },
         "description": {

--- a/packs/data/heritages.db/fodder-skeleton.json
+++ b/packs/data/heritages.db/fodder-skeleton.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Skeleton",
+            "slug": "skeleton",
             "uuid": "Compendium.pf2e.ancestries.58rL5sg2y4arW1i5"
         },
         "description": {

--- a/packs/data/heritages.db/forge-dwarf.json
+++ b/packs/data/heritages.db/forge-dwarf.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Dwarf",
+            "slug": "dwarf",
             "uuid": "Compendium.pf2e.ancestries.BYj5ZvlXZdpaEgA6"
         },
         "description": {

--- a/packs/data/heritages.db/frightful-goloma.json
+++ b/packs/data/heritages.db/frightful-goloma.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Goloma",
+            "slug": "goloma",
             "uuid": "Compendium.pf2e.ancestries.c4secsSNG2AO7I5i"
         },
         "description": {

--- a/packs/data/heritages.db/frilled-lizardfolk.json
+++ b/packs/data/heritages.db/frilled-lizardfolk.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Lizardfolk",
+            "slug": "lizardfolk",
             "uuid": "Compendium.pf2e.ancestries.HWEgF7Gmoq55VhTL"
         },
         "description": {

--- a/packs/data/heritages.db/frozen-wind-kitsune.json
+++ b/packs/data/heritages.db/frozen-wind-kitsune.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Kitsune",
+            "slug": "kitsune",
             "uuid": "Compendium.pf2e.ancestries.4BL5wf1VF9feC2rY"
         },
         "description": {

--- a/packs/data/heritages.db/fruit-leshy.json
+++ b/packs/data/heritages.db/fruit-leshy.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Leshy",
+            "slug": "leshy",
             "uuid": "Compendium.pf2e.ancestries.cdhgByGG1WtuaK73"
         },
         "description": {

--- a/packs/data/heritages.db/fungus-leshy.json
+++ b/packs/data/heritages.db/fungus-leshy.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Leshy",
+            "slug": "leshy",
             "uuid": "Compendium.pf2e.ancestries.cdhgByGG1WtuaK73"
         },
         "description": {

--- a/packs/data/heritages.db/ghost-poppet.json
+++ b/packs/data/heritages.db/ghost-poppet.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Poppet",
+            "slug": "poppet",
             "uuid": "Compendium.pf2e.ancestries.6F2fSFC1Eo1JdpY4"
         },
         "description": {

--- a/packs/data/heritages.db/gourd-leshy.json
+++ b/packs/data/heritages.db/gourd-leshy.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Leshy",
+            "slug": "leshy",
             "uuid": "Compendium.pf2e.ancestries.cdhgByGG1WtuaK73"
         },
         "description": {

--- a/packs/data/heritages.db/grave-orc.json
+++ b/packs/data/heritages.db/grave-orc.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Orc",
+            "slug": "orc",
             "uuid": "Compendium.pf2e.ancestries.lSGWXjcbOa6O5fTx"
         },
         "description": {

--- a/packs/data/heritages.db/great-gnoll.json
+++ b/packs/data/heritages.db/great-gnoll.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Gnoll",
+            "slug": "gnoll",
             "uuid": "Compendium.pf2e.ancestries.vxbQ1Yw4qwgjTzqo"
         },
         "description": {

--- a/packs/data/heritages.db/grig.json
+++ b/packs/data/heritages.db/grig.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Sprite",
+            "slug": "sprite",
             "uuid": "Compendium.pf2e.ancestries.TRqoeYfGAFjQbviF"
         },
         "description": {

--- a/packs/data/heritages.db/gutsy-halfling.json
+++ b/packs/data/heritages.db/gutsy-halfling.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Halfling",
+            "slug": "halfling",
             "uuid": "Compendium.pf2e.ancestries.GgZAHbrjnzWOZy2v"
         },
         "description": {

--- a/packs/data/heritages.db/half-elf.json
+++ b/packs/data/heritages.db/half-elf.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Human",
+            "slug": "human",
             "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
         },
         "description": {

--- a/packs/data/heritages.db/half-orc.json
+++ b/packs/data/heritages.db/half-orc.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Human",
+            "slug": "human",
             "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
         },
         "description": {

--- a/packs/data/heritages.db/hillock-halfling.json
+++ b/packs/data/heritages.db/hillock-halfling.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Halfling",
+            "slug": "halfling",
             "uuid": "Compendium.pf2e.ancestries.GgZAHbrjnzWOZy2v"
         },
         "description": {

--- a/packs/data/heritages.db/hold-scarred-orc.json
+++ b/packs/data/heritages.db/hold-scarred-orc.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Orc",
+            "slug": "orc",
             "uuid": "Compendium.pf2e.ancestries.lSGWXjcbOa6O5fTx"
         },
         "description": {

--- a/packs/data/heritages.db/hooded-nagaji.json
+++ b/packs/data/heritages.db/hooded-nagaji.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Nagaji",
+            "slug": "nagaji",
             "uuid": "Compendium.pf2e.ancestries.J7T7bDLaQGoY1sMF"
         },
         "description": {

--- a/packs/data/heritages.db/hunter-automaton.json
+++ b/packs/data/heritages.db/hunter-automaton.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Automaton",
+            "slug": "automaton",
             "uuid": "Compendium.pf2e.ancestries.kYsBAJ103T44agJF"
         },
         "description": {

--- a/packs/data/heritages.db/hunting-catfolk.json
+++ b/packs/data/heritages.db/hunting-catfolk.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Catfolk",
+            "slug": "catfolk",
             "uuid": "Compendium.pf2e.ancestries.972EkpJOPv9KkQIW"
         },
         "description": {

--- a/packs/data/heritages.db/impersonator-android.json
+++ b/packs/data/heritages.db/impersonator-android.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Android",
+            "slug": "android",
             "uuid": "Compendium.pf2e.ancestries.GfLwE884NoRC7cRi"
         },
         "description": {

--- a/packs/data/heritages.db/insightful-goloma.json
+++ b/packs/data/heritages.db/insightful-goloma.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Goloma",
+            "slug": "goloma",
             "uuid": "Compendium.pf2e.ancestries.c4secsSNG2AO7I5i"
         },
         "description": {

--- a/packs/data/heritages.db/inured-azarketi.json
+++ b/packs/data/heritages.db/inured-azarketi.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Azarketi",
+            "slug": "azarketi",
             "uuid": "Compendium.pf2e.ancestries.yFoojz6q3ZjvceFw"
         },
         "description": {

--- a/packs/data/heritages.db/irongut-goblin.json
+++ b/packs/data/heritages.db/irongut-goblin.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Goblin",
+            "slug": "goblin",
             "uuid": "Compendium.pf2e.ancestries.sQfjTMDaZbT9DThq"
         },
         "description": {

--- a/packs/data/heritages.db/jinxed-halfling.json
+++ b/packs/data/heritages.db/jinxed-halfling.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Halfling",
+            "slug": "halfling",
             "uuid": "Compendium.pf2e.ancestries.GgZAHbrjnzWOZy2v"
         },
         "description": {

--- a/packs/data/heritages.db/jinxed-tengu.json
+++ b/packs/data/heritages.db/jinxed-tengu.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Tengu",
+            "slug": "tengu",
             "uuid": "Compendium.pf2e.ancestries.18xDKYPDBLEv2myX"
         },
         "description": {

--- a/packs/data/heritages.db/jungle-catfolk.json
+++ b/packs/data/heritages.db/jungle-catfolk.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Catfolk",
+            "slug": "catfolk",
             "uuid": "Compendium.pf2e.ancestries.972EkpJOPv9KkQIW"
         },
         "description": {

--- a/packs/data/heritages.db/keen-venom-vishkanya.json
+++ b/packs/data/heritages.db/keen-venom-vishkanya.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Vishkanya",
+            "slug": "vishkanya",
             "uuid": "Compendium.pf2e.ancestries.u1VJEXsVlmh3Fyx0"
         },
         "description": {

--- a/packs/data/heritages.db/laborer-android.json
+++ b/packs/data/heritages.db/laborer-android.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Android",
+            "slug": "android",
             "uuid": "Compendium.pf2e.ancestries.GfLwE884NoRC7cRi"
         },
         "description": {

--- a/packs/data/heritages.db/lahkgyan-vanara.json
+++ b/packs/data/heritages.db/lahkgyan-vanara.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Vanara",
+            "slug": "vanara",
             "uuid": "Compendium.pf2e.ancestries.cLtOGIkuSSa4UDHY"
         },
         "description": {

--- a/packs/data/heritages.db/leaf-leshy.json
+++ b/packs/data/heritages.db/leaf-leshy.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Leshy",
+            "slug": "leshy",
             "uuid": "Compendium.pf2e.ancestries.cdhgByGG1WtuaK73"
         },
         "description": {

--- a/packs/data/heritages.db/lethoci.json
+++ b/packs/data/heritages.db/lethoci.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Kashrishi",
+            "slug": "kashrishi",
             "uuid": "Compendium.pf2e.ancestries.dw2K1AJR9mQ25nDP"
         },
         "description": {

--- a/packs/data/heritages.db/liminal-catfolk.json
+++ b/packs/data/heritages.db/liminal-catfolk.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Catfolk",
+            "slug": "catfolk",
             "uuid": "Compendium.pf2e.ancestries.972EkpJOPv9KkQIW"
         },
         "description": {

--- a/packs/data/heritages.db/liminal-fetchling.json
+++ b/packs/data/heritages.db/liminal-fetchling.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Fetchling",
+            "slug": "fetchling",
             "uuid": "Compendium.pf2e.ancestries.hIA3qiUsxvLZXrFP"
         },
         "description": {

--- a/packs/data/heritages.db/longsnout-rat.json
+++ b/packs/data/heritages.db/longsnout-rat.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Ratfolk",
+            "slug": "ratfolk",
             "uuid": "Compendium.pf2e.ancestries.P6PcVnCkh4XMdefw"
         },
         "description": {

--- a/packs/data/heritages.db/lorekeeper-shisk.json
+++ b/packs/data/heritages.db/lorekeeper-shisk.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Shisk",
+            "slug": "shisk",
             "uuid": "Compendium.pf2e.ancestries.x1YinOddgUxwOLqP"
         },
         "description": {

--- a/packs/data/heritages.db/lotus-leshy.json
+++ b/packs/data/heritages.db/lotus-leshy.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Leshy",
+            "slug": "leshy",
             "uuid": "Compendium.pf2e.ancestries.cdhgByGG1WtuaK73"
         },
         "description": {

--- a/packs/data/heritages.db/luminous-sprite.json
+++ b/packs/data/heritages.db/luminous-sprite.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Sprite",
+            "slug": "sprite",
             "uuid": "Compendium.pf2e.ancestries.TRqoeYfGAFjQbviF"
         },
         "description": {

--- a/packs/data/heritages.db/mage-automaton.json
+++ b/packs/data/heritages.db/mage-automaton.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Automaton",
+            "slug": "automaton",
             "uuid": "Compendium.pf2e.ancestries.kYsBAJ103T44agJF"
         },
         "description": {

--- a/packs/data/heritages.db/melixie.json
+++ b/packs/data/heritages.db/melixie.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Sprite",
+            "slug": "sprite",
             "uuid": "Compendium.pf2e.ancestries.TRqoeYfGAFjQbviF"
         },
         "description": {

--- a/packs/data/heritages.db/mistbreath-azarketi.json
+++ b/packs/data/heritages.db/mistbreath-azarketi.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Azarketi",
+            "slug": "azarketi",
             "uuid": "Compendium.pf2e.ancestries.yFoojz6q3ZjvceFw"
         },
         "description": {

--- a/packs/data/heritages.db/monstrous-skeleton.json
+++ b/packs/data/heritages.db/monstrous-skeleton.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Skeleton",
+            "slug": "skeleton",
             "uuid": "Compendium.pf2e.ancestries.58rL5sg2y4arW1i5"
         },
         "description": {

--- a/packs/data/heritages.db/mountainkeeper-tengu.json
+++ b/packs/data/heritages.db/mountainkeeper-tengu.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Tengu",
+            "slug": "tengu",
             "uuid": "Compendium.pf2e.ancestries.18xDKYPDBLEv2myX"
         },
         "description": {

--- a/packs/data/heritages.db/murkeyed-azarketi.json
+++ b/packs/data/heritages.db/murkeyed-azarketi.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Azarketi",
+            "slug": "azarketi",
             "uuid": "Compendium.pf2e.ancestries.yFoojz6q3ZjvceFw"
         },
         "description": {

--- a/packs/data/heritages.db/mutated-fleshwarp.json
+++ b/packs/data/heritages.db/mutated-fleshwarp.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Fleshwarp",
+            "slug": "fleshwarp",
             "uuid": "Compendium.pf2e.ancestries.FXlXmNBFiiz9oasi"
         },
         "description": {

--- a/packs/data/heritages.db/nascent.json
+++ b/packs/data/heritages.db/nascent.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Kashrishi",
+            "slug": "kashrishi",
             "uuid": "Compendium.pf2e.ancestries.dw2K1AJR9mQ25nDP"
         },
         "description": {

--- a/packs/data/heritages.db/nightglider-strix.json
+++ b/packs/data/heritages.db/nightglider-strix.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Strix",
+            "slug": "strix",
             "uuid": "Compendium.pf2e.ancestries.GXcC6oVa5quzgNHD"
         },
         "description": {

--- a/packs/data/heritages.db/nine-lives-catfolk.json
+++ b/packs/data/heritages.db/nine-lives-catfolk.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Catfolk",
+            "slug": "catfolk",
             "uuid": "Compendium.pf2e.ancestries.972EkpJOPv9KkQIW"
         },
         "description": {

--- a/packs/data/heritages.db/nomadic-halfling.json
+++ b/packs/data/heritages.db/nomadic-halfling.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Halfling",
+            "slug": "halfling",
             "uuid": "Compendium.pf2e.ancestries.GgZAHbrjnzWOZy2v"
         },
         "description": {

--- a/packs/data/heritages.db/nyktera.json
+++ b/packs/data/heritages.db/nyktera.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Sprite",
+            "slug": "sprite",
             "uuid": "Compendium.pf2e.ancestries.TRqoeYfGAFjQbviF"
         },
         "description": {

--- a/packs/data/heritages.db/oathkeeper-dwarf.json
+++ b/packs/data/heritages.db/oathkeeper-dwarf.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Dwarf",
+            "slug": "dwarf",
             "uuid": "Compendium.pf2e.ancestries.BYj5ZvlXZdpaEgA6"
         },
         "description": {

--- a/packs/data/heritages.db/observant-halfling.json
+++ b/packs/data/heritages.db/observant-halfling.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Halfling",
+            "slug": "halfling",
             "uuid": "Compendium.pf2e.ancestries.GgZAHbrjnzWOZy2v"
         },
         "description": {

--- a/packs/data/heritages.db/old-blood-vishkanya.json
+++ b/packs/data/heritages.db/old-blood-vishkanya.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Vishkanya",
+            "slug": "vishkanya",
             "uuid": "Compendium.pf2e.ancestries.u1VJEXsVlmh3Fyx0"
         },
         "description": {

--- a/packs/data/heritages.db/paddler-shoony.json
+++ b/packs/data/heritages.db/paddler-shoony.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Shoony",
+            "slug": "shoony",
             "uuid": "Compendium.pf2e.ancestries.q6rsqYARyOGXZA8F"
         },
         "description": {

--- a/packs/data/heritages.db/pine-leshy.json
+++ b/packs/data/heritages.db/pine-leshy.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Leshy",
+            "slug": "leshy",
             "uuid": "Compendium.pf2e.ancestries.cdhgByGG1WtuaK73"
         },
         "description": {

--- a/packs/data/heritages.db/pixie.json
+++ b/packs/data/heritages.db/pixie.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Sprite",
+            "slug": "sprite",
             "uuid": "Compendium.pf2e.ancestries.TRqoeYfGAFjQbviF"
         },
         "description": {

--- a/packs/data/heritages.db/poisonhide-grippli.json
+++ b/packs/data/heritages.db/poisonhide-grippli.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Grippli",
+            "slug": "grippli",
             "uuid": "Compendium.pf2e.ancestries.hXM5jXezIki1cMI2"
         },
         "description": {

--- a/packs/data/heritages.db/polychromatic-anadi.json
+++ b/packs/data/heritages.db/polychromatic-anadi.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Anadi",
+            "slug": "anadi",
             "uuid": "Compendium.pf2e.ancestries.TQEqWqc7BYiadUdY"
         },
         "description": {

--- a/packs/data/heritages.db/polyglot-android.json
+++ b/packs/data/heritages.db/polyglot-android.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Android",
+            "slug": "android",
             "uuid": "Compendium.pf2e.ancestries.GfLwE884NoRC7cRi"
         },
         "description": {

--- a/packs/data/heritages.db/predator-strix.json
+++ b/packs/data/heritages.db/predator-strix.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Strix",
+            "slug": "strix",
             "uuid": "Compendium.pf2e.ancestries.GXcC6oVa5quzgNHD"
         },
         "description": {

--- a/packs/data/heritages.db/prismatic-vishkanya.json
+++ b/packs/data/heritages.db/prismatic-vishkanya.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Vishkanya",
+            "slug": "vishkanya",
             "uuid": "Compendium.pf2e.ancestries.u1VJEXsVlmh3Fyx0"
         },
         "description": {

--- a/packs/data/heritages.db/quillcoat-shisk.json
+++ b/packs/data/heritages.db/quillcoat-shisk.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Shisk",
+            "slug": "shisk",
             "uuid": "Compendium.pf2e.ancestries.x1YinOddgUxwOLqP"
         },
         "description": {

--- a/packs/data/heritages.db/ragdyan-vanara.json
+++ b/packs/data/heritages.db/ragdyan-vanara.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Vanara",
+            "slug": "vanara",
             "uuid": "Compendium.pf2e.ancestries.cLtOGIkuSSa4UDHY"
         },
         "description": {

--- a/packs/data/heritages.db/rainfall-orc.json
+++ b/packs/data/heritages.db/rainfall-orc.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Orc",
+            "slug": "orc",
             "uuid": "Compendium.pf2e.ancestries.lSGWXjcbOa6O5fTx"
         },
         "description": {

--- a/packs/data/heritages.db/razortooth-goblin.json
+++ b/packs/data/heritages.db/razortooth-goblin.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Goblin",
+            "slug": "goblin",
             "uuid": "Compendium.pf2e.ancestries.sQfjTMDaZbT9DThq"
         },
         "description": {

--- a/packs/data/heritages.db/resolute-fetchling.json
+++ b/packs/data/heritages.db/resolute-fetchling.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Fetchling",
+            "slug": "fetchling",
             "uuid": "Compendium.pf2e.ancestries.hIA3qiUsxvLZXrFP"
         },
         "description": {

--- a/packs/data/heritages.db/rite-of-invocation.json
+++ b/packs/data/heritages.db/rite-of-invocation.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Conrasu",
+            "slug": "conrasu",
             "uuid": "Compendium.pf2e.ancestries.tZn4qIHCUA6wCdnI"
         },
         "description": {

--- a/packs/data/heritages.db/rite-of-knowing.json
+++ b/packs/data/heritages.db/rite-of-knowing.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Conrasu",
+            "slug": "conrasu",
             "uuid": "Compendium.pf2e.ancestries.tZn4qIHCUA6wCdnI"
         },
         "description": {

--- a/packs/data/heritages.db/rite-of-light.json
+++ b/packs/data/heritages.db/rite-of-light.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Conrasu",
+            "slug": "conrasu",
             "uuid": "Compendium.pf2e.ancestries.tZn4qIHCUA6wCdnI"
         },
         "description": {

--- a/packs/data/heritages.db/rite-of-passage.json
+++ b/packs/data/heritages.db/rite-of-passage.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Conrasu",
+            "slug": "conrasu",
             "uuid": "Compendium.pf2e.ancestries.tZn4qIHCUA6wCdnI"
         },
         "description": {

--- a/packs/data/heritages.db/rite-of-reinforcement.json
+++ b/packs/data/heritages.db/rite-of-reinforcement.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Conrasu",
+            "slug": "conrasu",
             "uuid": "Compendium.pf2e.ancestries.tZn4qIHCUA6wCdnI"
         },
         "description": {

--- a/packs/data/heritages.db/river-azarketi.json
+++ b/packs/data/heritages.db/river-azarketi.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Azarketi",
+            "slug": "azarketi",
             "uuid": "Compendium.pf2e.ancestries.yFoojz6q3ZjvceFw"
         },
         "description": {

--- a/packs/data/heritages.db/rock-dwarf.json
+++ b/packs/data/heritages.db/rock-dwarf.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Dwarf",
+            "slug": "dwarf",
             "uuid": "Compendium.pf2e.ancestries.BYj5ZvlXZdpaEgA6"
         },
         "description": {

--- a/packs/data/heritages.db/root-leshy.json
+++ b/packs/data/heritages.db/root-leshy.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Leshy",
+            "slug": "leshy",
             "uuid": "Compendium.pf2e.ancestries.cdhgByGG1WtuaK73"
         },
         "description": {

--- a/packs/data/heritages.db/runtboss-hobgoblin.json
+++ b/packs/data/heritages.db/runtboss-hobgoblin.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Hobgoblin",
+            "slug": "hobgoblin",
             "uuid": "Compendium.pf2e.ancestries.piNLXUrm9iaGqD2i"
         },
         "description": {

--- a/packs/data/heritages.db/sacred-nagaji.json
+++ b/packs/data/heritages.db/sacred-nagaji.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Nagaji",
+            "slug": "nagaji",
             "uuid": "Compendium.pf2e.ancestries.J7T7bDLaQGoY1sMF"
         },
         "description": {

--- a/packs/data/heritages.db/sandstrider-lizardfolk.json
+++ b/packs/data/heritages.db/sandstrider-lizardfolk.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Lizardfolk",
+            "slug": "lizardfolk",
             "uuid": "Compendium.pf2e.ancestries.HWEgF7Gmoq55VhTL"
         },
         "description": {

--- a/packs/data/heritages.db/scalekeeper-vishkanya.json
+++ b/packs/data/heritages.db/scalekeeper-vishkanya.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Vishkanya",
+            "slug": "vishkanya",
             "uuid": "Compendium.pf2e.ancestries.u1VJEXsVlmh3Fyx0"
         },
         "description": {

--- a/packs/data/heritages.db/scavenger-strix.json
+++ b/packs/data/heritages.db/scavenger-strix.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Strix",
+            "slug": "strix",
             "uuid": "Compendium.pf2e.ancestries.GXcC6oVa5quzgNHD"
         },
         "description": {

--- a/packs/data/heritages.db/seaweed-leshy.json
+++ b/packs/data/heritages.db/seaweed-leshy.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Leshy",
+            "slug": "leshy",
             "uuid": "Compendium.pf2e.ancestries.cdhgByGG1WtuaK73"
         },
         "description": {

--- a/packs/data/heritages.db/seer-elf.json
+++ b/packs/data/heritages.db/seer-elf.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Elf",
+            "slug": "elf",
             "uuid": "Compendium.pf2e.ancestries.PgKmsA2aKdbLU6O0"
         },
         "description": {

--- a/packs/data/heritages.db/sensate-gnome.json
+++ b/packs/data/heritages.db/sensate-gnome.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Gnome",
+            "slug": "gnome",
             "uuid": "Compendium.pf2e.ancestries.CYlfsYLJcBOgqKtD"
         },
         "description": {

--- a/packs/data/heritages.db/sewer-rat.json
+++ b/packs/data/heritages.db/sewer-rat.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Ratfolk",
+            "slug": "ratfolk",
             "uuid": "Compendium.pf2e.ancestries.P6PcVnCkh4XMdefw"
         },
         "description": {

--- a/packs/data/heritages.db/shadow-rat.json
+++ b/packs/data/heritages.db/shadow-rat.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Ratfolk",
+            "slug": "ratfolk",
             "uuid": "Compendium.pf2e.ancestries.P6PcVnCkh4XMdefw"
         },
         "description": {

--- a/packs/data/heritages.db/shapewrought-fleshwarp.json
+++ b/packs/data/heritages.db/shapewrought-fleshwarp.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Fleshwarp",
+            "slug": "fleshwarp",
             "uuid": "Compendium.pf2e.ancestries.FXlXmNBFiiz9oasi"
         },
         "description": {

--- a/packs/data/heritages.db/sharp-eared-catfolk.json
+++ b/packs/data/heritages.db/sharp-eared-catfolk.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Catfolk",
+            "slug": "catfolk",
             "uuid": "Compendium.pf2e.ancestries.972EkpJOPv9KkQIW"
         },
         "description": {

--- a/packs/data/heritages.db/sharpshooter-automaton.json
+++ b/packs/data/heritages.db/sharpshooter-automaton.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Automaton",
+            "slug": "automaton",
             "uuid": "Compendium.pf2e.ancestries.kYsBAJ103T44agJF"
         },
         "description": {

--- a/packs/data/heritages.db/shoreline-strix.json
+++ b/packs/data/heritages.db/shoreline-strix.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Strix",
+            "slug": "strix",
             "uuid": "Compendium.pf2e.ancestries.GXcC6oVa5quzgNHD"
         },
         "description": {

--- a/packs/data/heritages.db/shortshanks-hobgoblin.json
+++ b/packs/data/heritages.db/shortshanks-hobgoblin.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Hobgoblin",
+            "slug": "hobgoblin",
             "uuid": "Compendium.pf2e.ancestries.piNLXUrm9iaGqD2i"
         },
         "description": {

--- a/packs/data/heritages.db/skilled-heritage.json
+++ b/packs/data/heritages.db/skilled-heritage.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Human",
+            "slug": "human",
             "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
         },
         "description": {

--- a/packs/data/heritages.db/skyborn-tengu.json
+++ b/packs/data/heritages.db/skyborn-tengu.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Tengu",
+            "slug": "tengu",
             "uuid": "Compendium.pf2e.ancestries.18xDKYPDBLEv2myX"
         },
         "description": {

--- a/packs/data/heritages.db/smokeworker-hobgoblin.json
+++ b/packs/data/heritages.db/smokeworker-hobgoblin.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Hobgoblin",
+            "slug": "hobgoblin",
             "uuid": "Compendium.pf2e.ancestries.piNLXUrm9iaGqD2i"
         },
         "description": {

--- a/packs/data/heritages.db/snaptongue-grippli.json
+++ b/packs/data/heritages.db/snaptongue-grippli.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Grippli",
+            "slug": "grippli",
             "uuid": "Compendium.pf2e.ancestries.hXM5jXezIki1cMI2"
         },
         "description": {

--- a/packs/data/heritages.db/snaring-anadi.json
+++ b/packs/data/heritages.db/snaring-anadi.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Anadi",
+            "slug": "anadi",
             "uuid": "Compendium.pf2e.ancestries.TQEqWqc7BYiadUdY"
         },
         "description": {

--- a/packs/data/heritages.db/snow-goblin.json
+++ b/packs/data/heritages.db/snow-goblin.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Goblin",
+            "slug": "goblin",
             "uuid": "Compendium.pf2e.ancestries.sQfjTMDaZbT9DThq"
         },
         "description": {

--- a/packs/data/heritages.db/snow-rat.json
+++ b/packs/data/heritages.db/snow-rat.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Ratfolk",
+            "slug": "ratfolk",
             "uuid": "Compendium.pf2e.ancestries.P6PcVnCkh4XMdefw"
         },
         "description": {

--- a/packs/data/heritages.db/songbird-strix.json
+++ b/packs/data/heritages.db/songbird-strix.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Strix",
+            "slug": "strix",
             "uuid": "Compendium.pf2e.ancestries.GXcC6oVa5quzgNHD"
         },
         "description": {

--- a/packs/data/heritages.db/spellkeeper-shisk.json
+++ b/packs/data/heritages.db/spellkeeper-shisk.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Shisk",
+            "slug": "shisk",
             "uuid": "Compendium.pf2e.ancestries.x1YinOddgUxwOLqP"
         },
         "description": {

--- a/packs/data/heritages.db/spellscale-kobold.json
+++ b/packs/data/heritages.db/spellscale-kobold.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Kobold",
+            "slug": "kobold",
             "uuid": "Compendium.pf2e.ancestries.7oQxL6wgsokD3QXG"
         },
         "description": {

--- a/packs/data/heritages.db/spindly-anadi.json
+++ b/packs/data/heritages.db/spindly-anadi.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Anadi",
+            "slug": "anadi",
             "uuid": "Compendium.pf2e.ancestries.TQEqWqc7BYiadUdY"
         },
         "description": {

--- a/packs/data/heritages.db/spined-azarketi.json
+++ b/packs/data/heritages.db/spined-azarketi.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Azarketi",
+            "slug": "azarketi",
             "uuid": "Compendium.pf2e.ancestries.yFoojz6q3ZjvceFw"
         },
         "description": {

--- a/packs/data/heritages.db/steelskin-hobgoblin.json
+++ b/packs/data/heritages.db/steelskin-hobgoblin.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Hobgoblin",
+            "slug": "hobgoblin",
             "uuid": "Compendium.pf2e.ancestries.piNLXUrm9iaGqD2i"
         },
         "description": {

--- a/packs/data/heritages.db/stickytoe-grippli.json
+++ b/packs/data/heritages.db/stickytoe-grippli.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Grippli",
+            "slug": "grippli",
             "uuid": "Compendium.pf2e.ancestries.hXM5jXezIki1cMI2"
         },
         "description": {

--- a/packs/data/heritages.db/stonestep-shisk.json
+++ b/packs/data/heritages.db/stonestep-shisk.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Shisk",
+            "slug": "shisk",
             "uuid": "Compendium.pf2e.ancestries.x1YinOddgUxwOLqP"
         },
         "description": {

--- a/packs/data/heritages.db/stormtossed-tengu.json
+++ b/packs/data/heritages.db/stormtossed-tengu.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Tengu",
+            "slug": "tengu",
             "uuid": "Compendium.pf2e.ancestries.18xDKYPDBLEv2myX"
         },
         "description": {

--- a/packs/data/heritages.db/strong-blooded-dwarf.json
+++ b/packs/data/heritages.db/strong-blooded-dwarf.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Dwarf",
+            "slug": "dwarf",
             "uuid": "Compendium.pf2e.ancestries.BYj5ZvlXZdpaEgA6"
         },
         "description": {

--- a/packs/data/heritages.db/strong-oak.json
+++ b/packs/data/heritages.db/strong-oak.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Ghoran",
+            "slug": "ghoran",
             "uuid": "Compendium.pf2e.ancestries.tSurOqRcfumadTfr"
         },
         "description": {

--- a/packs/data/heritages.db/stronggut-shisk.json
+++ b/packs/data/heritages.db/stronggut-shisk.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Shisk",
+            "slug": "shisk",
             "uuid": "Compendium.pf2e.ancestries.x1YinOddgUxwOLqP"
         },
         "description": {

--- a/packs/data/heritages.db/strongjaw-kobold.json
+++ b/packs/data/heritages.db/strongjaw-kobold.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Kobold",
+            "slug": "kobold",
             "uuid": "Compendium.pf2e.ancestries.7oQxL6wgsokD3QXG"
         },
         "description": {

--- a/packs/data/heritages.db/stuffed-poppet.json
+++ b/packs/data/heritages.db/stuffed-poppet.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Poppet",
+            "slug": "poppet",
             "uuid": "Compendium.pf2e.ancestries.6F2fSFC1Eo1JdpY4"
         },
         "description": {

--- a/packs/data/heritages.db/sturdy-skeleton.json
+++ b/packs/data/heritages.db/sturdy-skeleton.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Skeleton",
+            "slug": "skeleton",
             "uuid": "Compendium.pf2e.ancestries.58rL5sg2y4arW1i5"
         },
         "description": {

--- a/packs/data/heritages.db/surgewise-fleshwarp.json
+++ b/packs/data/heritages.db/surgewise-fleshwarp.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Fleshwarp",
+            "slug": "fleshwarp",
             "uuid": "Compendium.pf2e.ancestries.FXlXmNBFiiz9oasi"
         },
         "description": {

--- a/packs/data/heritages.db/sweetbreath-gnoll.json
+++ b/packs/data/heritages.db/sweetbreath-gnoll.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Gnoll",
+            "slug": "gnoll",
             "uuid": "Compendium.pf2e.ancestries.vxbQ1Yw4qwgjTzqo"
         },
         "description": {

--- a/packs/data/heritages.db/tactile-azarketi.json
+++ b/packs/data/heritages.db/tactile-azarketi.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Azarketi",
+            "slug": "azarketi",
             "uuid": "Compendium.pf2e.ancestries.yFoojz6q3ZjvceFw"
         },
         "description": {

--- a/packs/data/heritages.db/tailed-goblin.json
+++ b/packs/data/heritages.db/tailed-goblin.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Goblin",
+            "slug": "goblin",
             "uuid": "Compendium.pf2e.ancestries.sQfjTMDaZbT9DThq"
         },
         "description": {

--- a/packs/data/heritages.db/taloned-tengu.json
+++ b/packs/data/heritages.db/taloned-tengu.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Tengu",
+            "slug": "tengu",
             "uuid": "Compendium.pf2e.ancestries.18xDKYPDBLEv2myX"
         },
         "description": {

--- a/packs/data/heritages.db/technological-fleshwarp.json
+++ b/packs/data/heritages.db/technological-fleshwarp.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Fleshwarp",
+            "slug": "fleshwarp",
             "uuid": "Compendium.pf2e.ancestries.FXlXmNBFiiz9oasi"
         },
         "description": {

--- a/packs/data/heritages.db/thalassic-azarketi.json
+++ b/packs/data/heritages.db/thalassic-azarketi.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Azarketi",
+            "slug": "azarketi",
             "uuid": "Compendium.pf2e.ancestries.yFoojz6q3ZjvceFw"
         },
         "description": {

--- a/packs/data/heritages.db/thickcoat-shoony.json
+++ b/packs/data/heritages.db/thickcoat-shoony.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Shoony",
+            "slug": "shoony",
             "uuid": "Compendium.pf2e.ancestries.q6rsqYARyOGXZA8F"
         },
         "description": {

--- a/packs/data/heritages.db/thorned-rose.json
+++ b/packs/data/heritages.db/thorned-rose.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Ghoran",
+            "slug": "ghoran",
             "uuid": "Compendium.pf2e.ancestries.tSurOqRcfumadTfr"
         },
         "description": {

--- a/packs/data/heritages.db/titan-nagaji.json
+++ b/packs/data/heritages.db/titan-nagaji.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Nagaji",
+            "slug": "nagaji",
             "uuid": "Compendium.pf2e.ancestries.J7T7bDLaQGoY1sMF"
         },
         "description": {

--- a/packs/data/heritages.db/toy-poppet.json
+++ b/packs/data/heritages.db/toy-poppet.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Poppet",
+            "slug": "poppet",
             "uuid": "Compendium.pf2e.ancestries.6F2fSFC1Eo1JdpY4"
         },
         "description": {

--- a/packs/data/heritages.db/treedweller-goblin.json
+++ b/packs/data/heritages.db/treedweller-goblin.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Goblin",
+            "slug": "goblin",
             "uuid": "Compendium.pf2e.ancestries.sQfjTMDaZbT9DThq"
         },
         "description": {

--- a/packs/data/heritages.db/trogloshi.json
+++ b/packs/data/heritages.db/trogloshi.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Kashrishi",
+            "slug": "kashrishi",
             "uuid": "Compendium.pf2e.ancestries.dw2K1AJR9mQ25nDP"
         },
         "description": {

--- a/packs/data/heritages.db/tunnel-rat.json
+++ b/packs/data/heritages.db/tunnel-rat.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Ratfolk",
+            "slug": "ratfolk",
             "uuid": "Compendium.pf2e.ancestries.P6PcVnCkh4XMdefw"
         },
         "description": {

--- a/packs/data/heritages.db/tunnelflood-kobold.json
+++ b/packs/data/heritages.db/tunnelflood-kobold.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Kobold",
+            "slug": "kobold",
             "uuid": "Compendium.pf2e.ancestries.7oQxL6wgsokD3QXG"
         },
         "description": {

--- a/packs/data/heritages.db/twilight-halfling.json
+++ b/packs/data/heritages.db/twilight-halfling.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Halfling",
+            "slug": "halfling",
             "uuid": "Compendium.pf2e.ancestries.GgZAHbrjnzWOZy2v"
         },
         "description": {

--- a/packs/data/heritages.db/umbral-gnome.json
+++ b/packs/data/heritages.db/umbral-gnome.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Gnome",
+            "slug": "gnome",
             "uuid": "Compendium.pf2e.ancestries.CYlfsYLJcBOgqKtD"
         },
         "description": {

--- a/packs/data/heritages.db/unbreakable-goblin.json
+++ b/packs/data/heritages.db/unbreakable-goblin.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Goblin",
+            "slug": "goblin",
             "uuid": "Compendium.pf2e.ancestries.sQfjTMDaZbT9DThq"
         },
         "description": {

--- a/packs/data/heritages.db/unseen-lizardfolk.json
+++ b/packs/data/heritages.db/unseen-lizardfolk.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Lizardfolk",
+            "slug": "lizardfolk",
             "uuid": "Compendium.pf2e.ancestries.HWEgF7Gmoq55VhTL"
         },
         "description": {

--- a/packs/data/heritages.db/venom-resistant-vishkanya.json
+++ b/packs/data/heritages.db/venom-resistant-vishkanya.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Vishkanya",
+            "slug": "vishkanya",
             "uuid": "Compendium.pf2e.ancestries.u1VJEXsVlmh3Fyx0"
         },
         "description": {

--- a/packs/data/heritages.db/venomous-anadi.json
+++ b/packs/data/heritages.db/venomous-anadi.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Anadi",
+            "slug": "anadi",
             "uuid": "Compendium.pf2e.ancestries.TQEqWqc7BYiadUdY"
         },
         "description": {

--- a/packs/data/heritages.db/venomshield-nagaji.json
+++ b/packs/data/heritages.db/venomshield-nagaji.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Nagaji",
+            "slug": "nagaji",
             "uuid": "Compendium.pf2e.ancestries.J7T7bDLaQGoY1sMF"
         },
         "description": {

--- a/packs/data/heritages.db/venomtail-kobold.json
+++ b/packs/data/heritages.db/venomtail-kobold.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Kobold",
+            "slug": "kobold",
             "uuid": "Compendium.pf2e.ancestries.7oQxL6wgsokD3QXG"
         },
         "description": {

--- a/packs/data/heritages.db/versatile-heritage.json
+++ b/packs/data/heritages.db/versatile-heritage.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Human",
+            "slug": "human",
             "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
         },
         "description": {

--- a/packs/data/heritages.db/vicious-goloma.json
+++ b/packs/data/heritages.db/vicious-goloma.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Goloma",
+            "slug": "goloma",
             "uuid": "Compendium.pf2e.ancestries.c4secsSNG2AO7I5i"
         },
         "description": {

--- a/packs/data/heritages.db/vigilant-goloma.json
+++ b/packs/data/heritages.db/vigilant-goloma.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Goloma",
+            "slug": "goloma",
             "uuid": "Compendium.pf2e.ancestries.c4secsSNG2AO7I5i"
         },
         "description": {

--- a/packs/data/heritages.db/vine-leshy.json
+++ b/packs/data/heritages.db/vine-leshy.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Leshy",
+            "slug": "leshy",
             "uuid": "Compendium.pf2e.ancestries.cdhgByGG1WtuaK73"
         },
         "description": {

--- a/packs/data/heritages.db/vivacious-gnome.json
+++ b/packs/data/heritages.db/vivacious-gnome.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Gnome",
+            "slug": "gnome",
             "uuid": "Compendium.pf2e.ancestries.CYlfsYLJcBOgqKtD"
         },
         "description": {

--- a/packs/data/heritages.db/wajaghand-vanara.json
+++ b/packs/data/heritages.db/wajaghand-vanara.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Vanara",
+            "slug": "vanara",
             "uuid": "Compendium.pf2e.ancestries.cLtOGIkuSSa4UDHY"
         },
         "description": {

--- a/packs/data/heritages.db/warden-human-bb.json
+++ b/packs/data/heritages.db/warden-human-bb.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Human",
+            "slug": "human",
             "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
         },
         "description": {

--- a/packs/data/heritages.db/warmarch-hobgoblin.json
+++ b/packs/data/heritages.db/warmarch-hobgoblin.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Hobgoblin",
+            "slug": "hobgoblin",
             "uuid": "Compendium.pf2e.ancestries.piNLXUrm9iaGqD2i"
         },
         "description": {

--- a/packs/data/heritages.db/warrenbred-hobgoblin.json
+++ b/packs/data/heritages.db/warrenbred-hobgoblin.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Hobgoblin",
+            "slug": "hobgoblin",
             "uuid": "Compendium.pf2e.ancestries.piNLXUrm9iaGqD2i"
         },
         "description": {

--- a/packs/data/heritages.db/warrior-android.json
+++ b/packs/data/heritages.db/warrior-android.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Android",
+            "slug": "android",
             "uuid": "Compendium.pf2e.ancestries.GfLwE884NoRC7cRi"
         },
         "description": {

--- a/packs/data/heritages.db/warrior-automaton.json
+++ b/packs/data/heritages.db/warrior-automaton.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Automaton",
+            "slug": "automaton",
             "uuid": "Compendium.pf2e.ancestries.kYsBAJ103T44agJF"
         },
         "description": {

--- a/packs/data/heritages.db/wavediver-tengu.json
+++ b/packs/data/heritages.db/wavediver-tengu.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Tengu",
+            "slug": "tengu",
             "uuid": "Compendium.pf2e.ancestries.18xDKYPDBLEv2myX"
         },
         "description": {

--- a/packs/data/heritages.db/wellspring-gnome.json
+++ b/packs/data/heritages.db/wellspring-gnome.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Gnome",
+            "slug": "gnome",
             "uuid": "Compendium.pf2e.ancestries.CYlfsYLJcBOgqKtD"
         },
         "description": {

--- a/packs/data/heritages.db/wetlander-lizardfolk.json
+++ b/packs/data/heritages.db/wetlander-lizardfolk.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Lizardfolk",
+            "slug": "lizardfolk",
             "uuid": "Compendium.pf2e.ancestries.HWEgF7Gmoq55VhTL"
         },
         "description": {

--- a/packs/data/heritages.db/whipfang-nagaji.json
+++ b/packs/data/heritages.db/whipfang-nagaji.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Nagaji",
+            "slug": "nagaji",
             "uuid": "Compendium.pf2e.ancestries.J7T7bDLaQGoY1sMF"
         },
         "description": {

--- a/packs/data/heritages.db/whisper-elf.json
+++ b/packs/data/heritages.db/whisper-elf.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Elf",
+            "slug": "elf",
             "uuid": "Compendium.pf2e.ancestries.PgKmsA2aKdbLU6O0"
         },
         "description": {

--- a/packs/data/heritages.db/wildwood-halfling.json
+++ b/packs/data/heritages.db/wildwood-halfling.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Halfling",
+            "slug": "halfling",
             "uuid": "Compendium.pf2e.ancestries.GgZAHbrjnzWOZy2v"
         },
         "description": {

--- a/packs/data/heritages.db/windup-poppet.json
+++ b/packs/data/heritages.db/windup-poppet.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Poppet",
+            "slug": "poppet",
             "uuid": "Compendium.pf2e.ancestries.6F2fSFC1Eo1JdpY4"
         },
         "description": {

--- a/packs/data/heritages.db/windweb-grippli.json
+++ b/packs/data/heritages.db/windweb-grippli.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Grippli",
+            "slug": "grippli",
             "uuid": "Compendium.pf2e.ancestries.hXM5jXezIki1cMI2"
         },
         "description": {

--- a/packs/data/heritages.db/winter-catfolk.json
+++ b/packs/data/heritages.db/winter-catfolk.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Catfolk",
+            "slug": "catfolk",
             "uuid": "Compendium.pf2e.ancestries.972EkpJOPv9KkQIW"
         },
         "description": {

--- a/packs/data/heritages.db/winter-orc.json
+++ b/packs/data/heritages.db/winter-orc.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Orc",
+            "slug": "orc",
             "uuid": "Compendium.pf2e.ancestries.lSGWXjcbOa6O5fTx"
         },
         "description": {

--- a/packs/data/heritages.db/wintertouched-human.json
+++ b/packs/data/heritages.db/wintertouched-human.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Human",
+            "slug": "human",
             "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
         },
         "description": {

--- a/packs/data/heritages.db/wishborn-poppet.json
+++ b/packs/data/heritages.db/wishborn-poppet.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Poppet",
+            "slug": "poppet",
             "uuid": "Compendium.pf2e.ancestries.6F2fSFC1Eo1JdpY4"
         },
         "description": {

--- a/packs/data/heritages.db/wisp-fetchling.json
+++ b/packs/data/heritages.db/wisp-fetchling.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Fetchling",
+            "slug": "fetchling",
             "uuid": "Compendium.pf2e.ancestries.hIA3qiUsxvLZXrFP"
         },
         "description": {

--- a/packs/data/heritages.db/witch-gnoll.json
+++ b/packs/data/heritages.db/witch-gnoll.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Gnoll",
+            "slug": "gnoll",
             "uuid": "Compendium.pf2e.ancestries.vxbQ1Yw4qwgjTzqo"
         },
         "description": {

--- a/packs/data/heritages.db/woodland-elf.json
+++ b/packs/data/heritages.db/woodland-elf.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Elf",
+            "slug": "elf",
             "uuid": "Compendium.pf2e.ancestries.PgKmsA2aKdbLU6O0"
         },
         "description": {

--- a/packs/data/heritages.db/woodstalker-lizardfolk.json
+++ b/packs/data/heritages.db/woodstalker-lizardfolk.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Lizardfolk",
+            "slug": "lizardfolk",
             "uuid": "Compendium.pf2e.ancestries.HWEgF7Gmoq55VhTL"
         },
         "description": {

--- a/packs/data/heritages.db/xyloshi.json
+++ b/packs/data/heritages.db/xyloshi.json
@@ -5,6 +5,7 @@
     "system": {
         "ancestry": {
             "name": "Kashrishi",
+            "slug": "kashrishi",
             "uuid": "Compendium.pf2e.ancestries.dw2K1AJR9mQ25nDP"
         },
         "description": {

--- a/packs/data/iconics.db/amiri-level-1.json
+++ b/packs/data/iconics.db/amiri-level-1.json
@@ -128,6 +128,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/iconics.db/amiri-level-3.json
+++ b/packs/data/iconics.db/amiri-level-3.json
@@ -128,6 +128,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/iconics.db/amiri-level-5.json
+++ b/packs/data/iconics.db/amiri-level-5.json
@@ -128,6 +128,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/iconics.db/ezren-level-1.json
+++ b/packs/data/iconics.db/ezren-level-1.json
@@ -120,6 +120,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/iconics.db/ezren-level-3.json
+++ b/packs/data/iconics.db/ezren-level-3.json
@@ -120,6 +120,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/iconics.db/ezren-level-5.json
+++ b/packs/data/iconics.db/ezren-level-5.json
@@ -120,6 +120,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/iconics.db/feiya-level-1.json
+++ b/packs/data/iconics.db/feiya-level-1.json
@@ -22,6 +22,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/iconics.db/feiya-level-5.json
+++ b/packs/data/iconics.db/feiya-level-5.json
@@ -22,6 +22,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/iconics.db/fumbus-level-1.json
+++ b/packs/data/iconics.db/fumbus-level-1.json
@@ -2668,6 +2668,7 @@
             "system": {
                 "ancestry": {
                     "name": "Goblin",
+                    "slug": "goblin",
                     "uuid": "Compendium.pf2e.ancestries.sQfjTMDaZbT9DThq"
                 },
                 "description": {

--- a/packs/data/iconics.db/fumbus-level-3.json
+++ b/packs/data/iconics.db/fumbus-level-3.json
@@ -2910,6 +2910,7 @@
             "system": {
                 "ancestry": {
                     "name": "Goblin",
+                    "slug": "goblin",
                     "uuid": "Compendium.pf2e.ancestries.sQfjTMDaZbT9DThq"
                 },
                 "description": {

--- a/packs/data/iconics.db/fumbus-level-5.json
+++ b/packs/data/iconics.db/fumbus-level-5.json
@@ -3816,6 +3816,7 @@
             "system": {
                 "ancestry": {
                     "name": "Goblin",
+                    "slug": "goblin",
                     "uuid": "Compendium.pf2e.ancestries.sQfjTMDaZbT9DThq"
                 },
                 "description": {

--- a/packs/data/iconics.db/harsk-level-1.json
+++ b/packs/data/iconics.db/harsk-level-1.json
@@ -351,6 +351,7 @@
             "system": {
                 "ancestry": {
                     "name": "Dwarf",
+                    "slug": "dwarf",
                     "uuid": "Compendium.pf2e.ancestries.BYj5ZvlXZdpaEgA6"
                 },
                 "description": {

--- a/packs/data/iconics.db/harsk-level-5.json
+++ b/packs/data/iconics.db/harsk-level-5.json
@@ -351,6 +351,7 @@
             "system": {
                 "ancestry": {
                     "name": "Dwarf",
+                    "slug": "dwarf",
                     "uuid": "Compendium.pf2e.ancestries.BYj5ZvlXZdpaEgA6"
                 },
                 "description": {

--- a/packs/data/iconics.db/jirelle-level-1.json
+++ b/packs/data/iconics.db/jirelle-level-1.json
@@ -15,6 +15,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/iconics.db/jirelle-level-5.json
+++ b/packs/data/iconics.db/jirelle-level-5.json
@@ -15,6 +15,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/iconics.db/korakai-level-1.json
+++ b/packs/data/iconics.db/korakai-level-1.json
@@ -15,6 +15,7 @@
             "system": {
                 "ancestry": {
                     "name": "Tengu",
+                    "slug": "tengu",
                     "uuid": "Compendium.pf2e.ancestries.18xDKYPDBLEv2myX"
                 },
                 "description": {

--- a/packs/data/iconics.db/korakai-level-5.json
+++ b/packs/data/iconics.db/korakai-level-5.json
@@ -15,6 +15,7 @@
             "system": {
                 "ancestry": {
                     "name": "Tengu",
+                    "slug": "tengu",
                     "uuid": "Compendium.pf2e.ancestries.18xDKYPDBLEv2myX"
                 },
                 "description": {

--- a/packs/data/iconics.db/kyra-level-1.json
+++ b/packs/data/iconics.db/kyra-level-1.json
@@ -2475,6 +2475,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/iconics.db/kyra-level-3.json
+++ b/packs/data/iconics.db/kyra-level-3.json
@@ -2914,6 +2914,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/iconics.db/kyra-level-5.json
+++ b/packs/data/iconics.db/kyra-level-5.json
@@ -3393,6 +3393,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/iconics.db/lem-level-1.json
+++ b/packs/data/iconics.db/lem-level-1.json
@@ -15,6 +15,7 @@
             "system": {
                 "ancestry": {
                     "name": "Halfling",
+                    "slug": "halfling",
                     "uuid": "Compendium.pf2e.ancestries.GgZAHbrjnzWOZy2v"
                 },
                 "description": {

--- a/packs/data/iconics.db/lem-level-5.json
+++ b/packs/data/iconics.db/lem-level-5.json
@@ -15,6 +15,7 @@
             "system": {
                 "ancestry": {
                     "name": "Halfling",
+                    "slug": "halfling",
                     "uuid": "Compendium.pf2e.ancestries.GgZAHbrjnzWOZy2v"
                 },
                 "description": {

--- a/packs/data/iconics.db/lini-level-1.json
+++ b/packs/data/iconics.db/lini-level-1.json
@@ -15,6 +15,7 @@
             "system": {
                 "ancestry": {
                     "name": "Gnome",
+                    "slug": "gnome",
                     "uuid": "Compendium.pf2e.ancestries.CYlfsYLJcBOgqKtD"
                 },
                 "description": {

--- a/packs/data/iconics.db/lini-level-5.json
+++ b/packs/data/iconics.db/lini-level-5.json
@@ -15,6 +15,7 @@
             "system": {
                 "ancestry": {
                     "name": "Gnome",
+                    "slug": "gnome",
                     "uuid": "Compendium.pf2e.ancestries.CYlfsYLJcBOgqKtD"
                 },
                 "description": {

--- a/packs/data/iconics.db/merisiel-level-1.json
+++ b/packs/data/iconics.db/merisiel-level-1.json
@@ -127,6 +127,7 @@
             "system": {
                 "ancestry": {
                     "name": "Elf",
+                    "slug": "elf",
                     "uuid": "Compendium.pf2e.ancestries.PgKmsA2aKdbLU6O0"
                 },
                 "description": {

--- a/packs/data/iconics.db/merisiel-level-3.json
+++ b/packs/data/iconics.db/merisiel-level-3.json
@@ -127,6 +127,7 @@
             "system": {
                 "ancestry": {
                     "name": "Elf",
+                    "slug": "elf",
                     "uuid": "Compendium.pf2e.ancestries.PgKmsA2aKdbLU6O0"
                 },
                 "description": {

--- a/packs/data/iconics.db/merisiel-level-5.json
+++ b/packs/data/iconics.db/merisiel-level-5.json
@@ -127,6 +127,7 @@
             "system": {
                 "ancestry": {
                     "name": "Elf",
+                    "slug": "elf",
                     "uuid": "Compendium.pf2e.ancestries.PgKmsA2aKdbLU6O0"
                 },
                 "description": {

--- a/packs/data/iconics.db/quinn-level-1.json
+++ b/packs/data/iconics.db/quinn-level-1.json
@@ -15,6 +15,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/iconics.db/quinn-level-5.json
+++ b/packs/data/iconics.db/quinn-level-5.json
@@ -15,6 +15,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/iconics.db/sajan-level-1.json
+++ b/packs/data/iconics.db/sajan-level-1.json
@@ -18,6 +18,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/iconics.db/sajan-level-5.json
+++ b/packs/data/iconics.db/sajan-level-5.json
@@ -18,6 +18,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/iconics.db/seelah-level-1.json
+++ b/packs/data/iconics.db/seelah-level-1.json
@@ -1916,6 +1916,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/iconics.db/seelah-level-5.json
+++ b/packs/data/iconics.db/seelah-level-5.json
@@ -2029,6 +2029,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/iconics.db/seoni-level-1.json
+++ b/packs/data/iconics.db/seoni-level-1.json
@@ -3083,6 +3083,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/iconics.db/seoni-level-5.json
+++ b/packs/data/iconics.db/seoni-level-5.json
@@ -3428,6 +3428,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/iconics.db/valeros-level-1.json
+++ b/packs/data/iconics.db/valeros-level-1.json
@@ -15,6 +15,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/iconics.db/valeros-level-3.json
+++ b/packs/data/iconics.db/valeros-level-3.json
@@ -15,6 +15,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/iconics.db/valeros-level-5.json
+++ b/packs/data/iconics.db/valeros-level-5.json
@@ -15,6 +15,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/kingmaker-bestiary.db/amiri-level-1-kingmaker.json
+++ b/packs/data/kingmaker-bestiary.db/amiri-level-1-kingmaker.json
@@ -818,6 +818,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/kingmaker-bestiary.db/amiri-level-11-kingmaker.json
+++ b/packs/data/kingmaker-bestiary.db/amiri-level-11-kingmaker.json
@@ -818,6 +818,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/kingmaker-bestiary.db/ekundayo-level-1.json
+++ b/packs/data/kingmaker-bestiary.db/ekundayo-level-1.json
@@ -859,6 +859,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/kingmaker-bestiary.db/ekundayo-level-6.json
+++ b/packs/data/kingmaker-bestiary.db/ekundayo-level-6.json
@@ -859,6 +859,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/kingmaker-bestiary.db/jubilost-level-1.json
+++ b/packs/data/kingmaker-bestiary.db/jubilost-level-1.json
@@ -1296,6 +1296,7 @@
             "system": {
                 "ancestry": {
                     "name": "Gnome",
+                    "slug": "gnome",
                     "uuid": "Compendium.pf2e.ancestries.CYlfsYLJcBOgqKtD"
                 },
                 "description": {

--- a/packs/data/kingmaker-bestiary.db/jubilost-level-8.json
+++ b/packs/data/kingmaker-bestiary.db/jubilost-level-8.json
@@ -1300,6 +1300,7 @@
             "system": {
                 "ancestry": {
                     "name": "Gnome",
+                    "slug": "gnome",
                     "uuid": "Compendium.pf2e.ancestries.CYlfsYLJcBOgqKtD"
                 },
                 "description": {

--- a/packs/data/kingmaker-bestiary.db/linzi-level-1.json
+++ b/packs/data/kingmaker-bestiary.db/linzi-level-1.json
@@ -168,6 +168,7 @@
             "system": {
                 "ancestry": {
                     "name": "Halfling",
+                    "slug": "halfling",
                     "uuid": "Compendium.pf2e.ancestries.GgZAHbrjnzWOZy2v"
                 },
                 "description": {

--- a/packs/data/kingmaker-bestiary.db/linzi-level-7.json
+++ b/packs/data/kingmaker-bestiary.db/linzi-level-7.json
@@ -168,6 +168,7 @@
             "system": {
                 "ancestry": {
                     "name": "Halfling",
+                    "slug": "halfling",
                     "uuid": "Compendium.pf2e.ancestries.GgZAHbrjnzWOZy2v"
                 },
                 "description": {

--- a/packs/data/kingmaker-bestiary.db/nok-nok-level-1.json
+++ b/packs/data/kingmaker-bestiary.db/nok-nok-level-1.json
@@ -99,6 +99,7 @@
             "system": {
                 "ancestry": {
                     "name": "Goblin",
+                    "slug": "goblin",
                     "uuid": "Compendium.pf2e.ancestries.sQfjTMDaZbT9DThq"
                 },
                 "description": {

--- a/packs/data/kingmaker-bestiary.db/nok-nok-level-5.json
+++ b/packs/data/kingmaker-bestiary.db/nok-nok-level-5.json
@@ -99,6 +99,7 @@
             "system": {
                 "ancestry": {
                     "name": "Goblin",
+                    "slug": "goblin",
                     "uuid": "Compendium.pf2e.ancestries.sQfjTMDaZbT9DThq"
                 },
                 "description": {

--- a/packs/data/kingmaker-bestiary.db/valerie-level-1.json
+++ b/packs/data/kingmaker-bestiary.db/valerie-level-1.json
@@ -101,6 +101,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/kingmaker-bestiary.db/valerie-level-9.json
+++ b/packs/data/kingmaker-bestiary.db/valerie-level-9.json
@@ -101,6 +101,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/paizo-pregens.db/booker-kaar.json
+++ b/packs/data/paizo-pregens.db/booker-kaar.json
@@ -128,6 +128,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/paizo-pregens.db/bottlespeaker.json
+++ b/packs/data/paizo-pregens.db/bottlespeaker.json
@@ -15,6 +15,7 @@
             "system": {
                 "ancestry": {
                     "name": "Leshy",
+                    "slug": "leshy",
                     "uuid": "Compendium.pf2e.ancestries.cdhgByGG1WtuaK73"
                 },
                 "description": {

--- a/packs/data/paizo-pregens.db/doc-featherton.json
+++ b/packs/data/paizo-pregens.db/doc-featherton.json
@@ -128,6 +128,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/paizo-pregens.db/ekene.json
+++ b/packs/data/paizo-pregens.db/ekene.json
@@ -127,6 +127,7 @@
             "system": {
                 "ancestry": {
                     "name": "Elf",
+                    "slug": "elf",
                     "uuid": "Compendium.pf2e.ancestries.PgKmsA2aKdbLU6O0"
                 },
                 "description": {

--- a/packs/data/paizo-pregens.db/eteleon.json
+++ b/packs/data/paizo-pregens.db/eteleon.json
@@ -127,6 +127,7 @@
             "system": {
                 "ancestry": {
                     "name": "Elf",
+                    "slug": "elf",
                     "uuid": "Compendium.pf2e.ancestries.PgKmsA2aKdbLU6O0"
                 },
                 "description": {

--- a/packs/data/paizo-pregens.db/ezren-beginner-box.json
+++ b/packs/data/paizo-pregens.db/ezren-beginner-box.json
@@ -120,6 +120,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/paizo-pregens.db/fluff-fang.json
+++ b/packs/data/paizo-pregens.db/fluff-fang.json
@@ -204,6 +204,7 @@
             "system": {
                 "ancestry": {
                     "name": "Leshy",
+                    "slug": "leshy",
                     "uuid": "Compendium.pf2e.ancestries.cdhgByGG1WtuaK73"
                 },
                 "description": {

--- a/packs/data/paizo-pregens.db/grimmnir.json
+++ b/packs/data/paizo-pregens.db/grimmnir.json
@@ -228,6 +228,7 @@
             "system": {
                 "ancestry": {
                     "name": "Kobold",
+                    "slug": "kobold",
                     "uuid": "Compendium.pf2e.ancestries.7oQxL6wgsokD3QXG"
                 },
                 "description": {

--- a/packs/data/paizo-pregens.db/izni.json
+++ b/packs/data/paizo-pregens.db/izni.json
@@ -3897,6 +3897,7 @@
             "system": {
                 "ancestry": {
                     "name": "Kobold",
+                    "slug": "kobold",
                     "uuid": "Compendium.pf2e.ancestries.7oQxL6wgsokD3QXG"
                 },
                 "description": {

--- a/packs/data/paizo-pregens.db/jaithe.json
+++ b/packs/data/paizo-pregens.db/jaithe.json
@@ -215,6 +215,7 @@
             "system": {
                 "ancestry": {
                     "name": "Fleshwarp",
+                    "slug": "fleshwarp",
                     "uuid": "Compendium.pf2e.ancestries.FXlXmNBFiiz9oasi"
                 },
                 "description": {

--- a/packs/data/paizo-pregens.db/kaako-ashfeather.json
+++ b/packs/data/paizo-pregens.db/kaako-ashfeather.json
@@ -1071,6 +1071,7 @@
             "system": {
                 "ancestry": {
                     "name": "Tengu",
+                    "slug": "tengu",
                     "uuid": "Compendium.pf2e.ancestries.18xDKYPDBLEv2myX"
                 },
                 "description": {

--- a/packs/data/paizo-pregens.db/kalaggi-nakutu.json
+++ b/packs/data/paizo-pregens.db/kalaggi-nakutu.json
@@ -128,6 +128,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/paizo-pregens.db/kangir.json
+++ b/packs/data/paizo-pregens.db/kangir.json
@@ -378,6 +378,7 @@
             "system": {
                 "ancestry": {
                     "name": "Dwarf",
+                    "slug": "dwarf",
                     "uuid": "Compendium.pf2e.ancestries.BYj5ZvlXZdpaEgA6"
                 },
                 "description": {

--- a/packs/data/paizo-pregens.db/kyra-beginner-box.json
+++ b/packs/data/paizo-pregens.db/kyra-beginner-box.json
@@ -37,6 +37,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/paizo-pregens.db/merisiel-beginner-box.json
+++ b/packs/data/paizo-pregens.db/merisiel-beginner-box.json
@@ -127,6 +127,7 @@
             "system": {
                 "ancestry": {
                     "name": "Elf",
+                    "slug": "elf",
                     "uuid": "Compendium.pf2e.ancestries.PgKmsA2aKdbLU6O0"
                 },
                 "description": {

--- a/packs/data/paizo-pregens.db/muruwa.json
+++ b/packs/data/paizo-pregens.db/muruwa.json
@@ -154,6 +154,7 @@
             "system": {
                 "ancestry": {
                     "name": "Grippli",
+                    "slug": "grippli",
                     "uuid": "Compendium.pf2e.ancestries.hXM5jXezIki1cMI2"
                 },
                 "description": {

--- a/packs/data/paizo-pregens.db/oraka.json
+++ b/packs/data/paizo-pregens.db/oraka.json
@@ -120,6 +120,7 @@
             "system": {
                 "ancestry": {
                     "name": "Orc",
+                    "slug": "orc",
                     "uuid": "Compendium.pf2e.ancestries.lSGWXjcbOa6O5fTx"
                 },
                 "description": {

--- a/packs/data/paizo-pregens.db/popcorn.json
+++ b/packs/data/paizo-pregens.db/popcorn.json
@@ -15,6 +15,7 @@
             "system": {
                 "ancestry": {
                     "name": "Leshy",
+                    "slug": "leshy",
                     "uuid": "Compendium.pf2e.ancestries.cdhgByGG1WtuaK73"
                 },
                 "description": {

--- a/packs/data/paizo-pregens.db/quizrel.json
+++ b/packs/data/paizo-pregens.db/quizrel.json
@@ -69,6 +69,7 @@
             "system": {
                 "ancestry": {
                     "name": "Kobold",
+                    "slug": "kobold",
                     "uuid": "Compendium.pf2e.ancestries.7oQxL6wgsokD3QXG"
                 },
                 "description": {

--- a/packs/data/paizo-pregens.db/reaching-rings.json
+++ b/packs/data/paizo-pregens.db/reaching-rings.json
@@ -177,6 +177,7 @@
             "system": {
                 "ancestry": {
                     "name": "Leshy",
+                    "slug": "leshy",
                     "uuid": "Compendium.pf2e.ancestries.cdhgByGG1WtuaK73"
                 },
                 "description": {

--- a/packs/data/paizo-pregens.db/rhin.json
+++ b/packs/data/paizo-pregens.db/rhin.json
@@ -282,6 +282,7 @@
             "system": {
                 "ancestry": {
                     "name": "Kobold",
+                    "slug": "kobold",
                     "uuid": "Compendium.pf2e.ancestries.7oQxL6wgsokD3QXG"
                 },
                 "description": {

--- a/packs/data/paizo-pregens.db/savshin-starwatcher.json
+++ b/packs/data/paizo-pregens.db/savshin-starwatcher.json
@@ -339,6 +339,7 @@
             "system": {
                 "ancestry": {
                     "name": "Lizardfolk",
+                    "slug": "lizardfolk",
                     "uuid": "Compendium.pf2e.ancestries.HWEgF7Gmoq55VhTL"
                 },
                 "description": {

--- a/packs/data/paizo-pregens.db/simeek.json
+++ b/packs/data/paizo-pregens.db/simeek.json
@@ -232,6 +232,7 @@
             "system": {
                 "ancestry": {
                     "name": "Kobold",
+                    "slug": "kobold",
                     "uuid": "Compendium.pf2e.ancestries.7oQxL6wgsokD3QXG"
                 },
                 "description": {

--- a/packs/data/paizo-pregens.db/takemiru.json
+++ b/packs/data/paizo-pregens.db/takemiru.json
@@ -269,6 +269,7 @@
             "system": {
                 "ancestry": {
                     "name": "Kitsune",
+                    "slug": "kitsune",
                     "uuid": "Compendium.pf2e.ancestries.4BL5wf1VF9feC2rY"
                 },
                 "description": {

--- a/packs/data/paizo-pregens.db/ufi.json
+++ b/packs/data/paizo-pregens.db/ufi.json
@@ -128,6 +128,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/paizo-pregens.db/valeros-beginner-box.json
+++ b/packs/data/paizo-pregens.db/valeros-beginner-box.json
@@ -37,6 +37,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/paizo-pregens.db/yacob.json
+++ b/packs/data/paizo-pregens.db/yacob.json
@@ -155,6 +155,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/paizo-pregens.db/zakzak.json
+++ b/packs/data/paizo-pregens.db/zakzak.json
@@ -236,6 +236,7 @@
             "system": {
                 "ancestry": {
                     "name": "Goblin",
+                    "slug": "goblin",
                     "uuid": "Compendium.pf2e.ancestries.sQfjTMDaZbT9DThq"
                 },
                 "description": {

--- a/packs/data/paizo-pregens.db/zane-ikundi.json
+++ b/packs/data/paizo-pregens.db/zane-ikundi.json
@@ -93,6 +93,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/paizo-pregens.db/zathri.json
+++ b/packs/data/paizo-pregens.db/zathri.json
@@ -182,6 +182,7 @@
             "system": {
                 "ancestry": {
                     "name": "Catfolk",
+                    "slug": "catfolk",
                     "uuid": "Compendium.pf2e.ancestries.972EkpJOPv9KkQIW"
                 },
                 "description": {

--- a/packs/data/paizo-pregens.db/zeah.json
+++ b/packs/data/paizo-pregens.db/zeah.json
@@ -155,6 +155,7 @@
             "system": {
                 "ancestry": {
                     "name": "Human",
+                    "slug": "human",
                     "uuid": "Compendium.pf2e.ancestries.IiG7DgeLWYrSNXuX"
                 },
                 "description": {

--- a/packs/data/paizo-pregens.db/zerryd.json
+++ b/packs/data/paizo-pregens.db/zerryd.json
@@ -198,6 +198,7 @@
             "system": {
                 "ancestry": {
                     "name": "Strix",
+                    "slug": "strix",
                     "uuid": "Compendium.pf2e.ancestries.GXcC6oVa5quzgNHD"
                 },
                 "description": {

--- a/packs/data/paizo-pregens.db/zindarel.json
+++ b/packs/data/paizo-pregens.db/zindarel.json
@@ -127,6 +127,7 @@
             "system": {
                 "ancestry": {
                     "name": "Elf",
+                    "slug": "elf",
                     "uuid": "Compendium.pf2e.ancestries.PgKmsA2aKdbLU6O0"
                 },
                 "description": {

--- a/src/module/actor/character/data/types.ts
+++ b/src/module/actor/character/data/types.ts
@@ -26,7 +26,7 @@ import {
 } from "@actor/data/base";
 import { StatisticModifier } from "@actor/modifiers";
 import { AbilityString, SaveType } from "@actor/types";
-import { FeatPF2e, WeaponPF2e } from "@item";
+import { FeatPF2e, HeritagePF2e, WeaponPF2e } from "@item";
 import { ArmorCategory } from "@item/armor/types";
 import { ProficiencyRank } from "@item/data";
 import { DeitySystemData } from "@item/deity/data";
@@ -434,7 +434,7 @@ interface CharacterTraitsData extends CreatureTraitsData {
 }
 
 interface GrantedFeat {
-    feat: FeatPF2e;
+    feat: FeatPF2e | HeritagePF2e;
     grants: GrantedFeat[];
 }
 

--- a/src/module/actor/character/feats.ts
+++ b/src/module/actor/character/feats.ts
@@ -114,11 +114,12 @@ class CharacterFeats extends Collection<FeatCategory> {
         this.set(options.id, new FeatCategory(this.actor, options));
     }
 
-    private combineGrants(feat: FeatPF2e): { feat: FeatPF2e; grants: GrantedFeat[] } {
+    #combineGrants(feat: FeatPF2e): { feat: FeatPF2e; grants: GrantedFeat[] } {
         const getGrantedItems = (grants: Record<string, ItemGrantData>): GrantedFeat[] => {
             return Object.values(grants).flatMap((grant) => {
                 const item = this.actor.items.get(grant.id);
-                return item?.isOfType("feat") && !item.system.location
+                // Allow heritages to be included as granted "feats" (see Elf Atavism, Chosen of Lamashtu)
+                return (item?.isOfType("feat") && !item.system.location) || item?.isOfType("heritage")
                     ? { feat: item, grants: getGrantedItems(item.flags.pf2e.itemGrants) }
                     : [];
             });
@@ -227,7 +228,7 @@ class CharacterFeats extends Collection<FeatCategory> {
                 continue;
             }
 
-            const base = this.combineGrants(feat);
+            const base = this.#combineGrants(feat);
 
             const location = feat.system.location;
             const categoryForSlot = categoryBySlot[location ?? ""];

--- a/src/module/item/base.ts
+++ b/src/module/item/base.ts
@@ -53,9 +53,14 @@ class ItemPF2e extends Item<ActorPF2e> {
         return this.system.description.value.trim();
     }
 
+    /** The item that granted this item, if any */
+    get grantedBy(): Embedded<ItemPF2e> | null {
+        return this.actor?.items.get(this.flags.pf2e.grantedBy?.id ?? "") ?? null;
+    }
+
     /** Check this item's type (or whether it's one among multiple types) without a call to `instanceof` */
-    isOfType(type: "physical"): this is PhysicalItemPF2e;
     isOfType<T extends ItemType>(...types: T[]): this is InstanceType<ConfigPF2e["PF2E"]["Item"]["documentClasses"][T]>;
+    isOfType(type: "physical"): this is PhysicalItemPF2e;
     isOfType<T extends "physical" | ItemType>(
         ...types: T[]
     ): this is PhysicalItemPF2e | InstanceType<ConfigPF2e["PF2E"]["Item"]["documentClasses"][Exclude<T, "physical">]>;

--- a/src/module/item/heritage/data.ts
+++ b/src/module/item/heritage/data.ts
@@ -10,6 +10,7 @@ type HeritageData = Omit<HeritageSource, "system" | "effects" | "flags"> &
 interface HeritageSystemSource extends ItemSystemData {
     ancestry: {
         name: string;
+        slug: string;
         uuid: ItemUUID;
     } | null;
     traits: CreatureTraits;

--- a/src/module/item/heritage/document.ts
+++ b/src/module/item/heritage/document.ts
@@ -16,7 +16,11 @@ class HeritagePF2e extends ItemPF2e {
 
     /** Prepare a character's data derived from their heritage */
     override prepareActorData(this: Embedded<HeritagePF2e>): void {
-        this.actor.heritage = this;
+        // Some abilities allow for a second heritage. If the PC has more than one, set this heritage as the actor's
+        // main one only if it wasn't granted by another item.
+        if (this.actor.itemTypes.heritage.length === 1 || !this.grantedBy) {
+            this.actor.heritage = this;
+        }
 
         // Add and remove traits as specified
         this.actor.system.traits.value.push(...this.traits);
@@ -31,6 +35,12 @@ class HeritagePF2e extends ItemPF2e {
         this.actor.rollOptions.all[`heritage:${slug}`] = true;
         // Backward compatibility until migration
         this.actor.rollOptions.all[`self:heritage:${slug}`] = true;
+    }
+
+    override getRollOptions(prefix = this.type): string[] {
+        const ancestryOrVersatile = this.system.ancestry ? `ancestry:${this.system.ancestry.slug}` : "versatile";
+
+        return [...super.getRollOptions(prefix), `${prefix}:${ancestryOrVersatile}`];
     }
 }
 

--- a/src/module/item/heritage/sheet.ts
+++ b/src/module/item/heritage/sheet.ts
@@ -1,7 +1,7 @@
 import { AncestryPF2e, HeritagePF2e, ItemPF2e } from "@item";
 import { ItemSheetPF2e } from "@item/sheet/base";
 import { HeritageSheetData } from "@item/sheet/data-types";
-import { ErrorPF2e } from "@util";
+import { ErrorPF2e, sluggify } from "@util";
 import { UUIDUtils } from "@util/uuid-utils";
 
 export class HeritageSheetPF2e extends ItemSheetPF2e<HeritagePF2e> {
@@ -51,7 +51,13 @@ export class HeritageSheetPF2e extends ItemSheetPF2e<HeritagePF2e> {
         if (!(item instanceof AncestryPF2e)) {
             throw ErrorPF2e("Invalid item drop on heritage sheet");
         }
-        const ancestryReference = { name: item.name, uuid: item.uuid };
+
+        const ancestryReference = {
+            name: item.name,
+            slug: item.slug ?? sluggify(item.name),
+            uuid: item.uuid,
+        };
+
         await this.item.update({ "system.ancestry": ancestryReference });
     }
 }

--- a/src/module/migration/migrations/711-heritage-items.ts
+++ b/src/module/migration/migrations/711-heritage-items.ts
@@ -166,7 +166,7 @@ export class Migration711HeritageItems extends MigrationBase {
 
     private ancestrySlugs = Object.keys(this.officialAncestries);
 
-    private heritageFromFeat(feature: FeatSource): HeritageSource {
+    private heritageFromFeat(feature: FeatSource): HeritageSourceWithNoAncestrySlug {
         const featureSlug = feature.system.slug ?? "";
         const ancestrySlug =
             this.heritagesWithoutAncestryInName[featureSlug] ?? this.ancestrySlugs.find((s) => featureSlug.includes(s));
@@ -235,7 +235,8 @@ export class Migration711HeritageItems extends MigrationBase {
         if (itemSource.img === "systems/pf2e/icons/default-icons/feat.svg") {
             itemSource.img = "systems/pf2e/icons/default-icons/heritage.svg";
         }
-        const newSystemData: HeritageSystemSource & FeatPropertyDeletions = this.heritageFromFeat(itemSource).system;
+        type WithPropertyDeletions = HeritageSystemSourceWithNoAncestrySlug & FeatPropertyDeletions;
+        const newSystemData: WithPropertyDeletions = this.heritageFromFeat(itemSource).system;
         const deletionProperties = toDelete.map((k) => `-=${k}` as const);
         for (const property of deletionProperties) {
             newSystemData[property] = null;
@@ -262,5 +263,13 @@ type MaybeWithHeritageFeatType = ItemSourcePF2e & {
         };
     };
 };
+
+interface HeritageSourceWithNoAncestrySlug extends Omit<HeritageSource, "system"> {
+    system: HeritageSystemSourceWithNoAncestrySlug;
+}
+
+interface HeritageSystemSourceWithNoAncestrySlug extends Omit<HeritageSystemSource, "ancestry"> {
+    ancestry: { uuid: ItemUUID; name: string } | null;
+}
 
 type MaybeWithStoredHeritage = Omit<CharacterDetails, "heritage"> & { heritage?: unknown; "-=heritage"?: null };

--- a/src/module/migration/migrations/823-heritage-ancestry-slug.ts
+++ b/src/module/migration/migrations/823-heritage-ancestry-slug.ts
@@ -1,0 +1,22 @@
+import { AncestryPF2e } from "@item";
+import { ItemSourcePF2e } from "@item/data";
+import { sluggify } from "@util";
+import { UUIDUtils } from "@util/uuid-utils";
+import { MigrationBase } from "../base";
+
+/** Set a slug in heritages' ancestry data */
+export class Migration823HeritageAncestrySlug extends MigrationBase {
+    static override version = 0.823;
+
+    override async updateItem(source: ItemSourcePF2e): Promise<void> {
+        if (source.type !== "heritage" || !source.system.ancestry || source.system.ancestry.slug) {
+            return;
+        }
+
+        const ancestry = await UUIDUtils.fromUuid(source.system.ancestry.uuid);
+        source.system.ancestry.slug =
+            ancestry instanceof AncestryPF2e
+                ? ancestry.slug ?? sluggify(ancestry.name)
+                : sluggify(source.system.ancestry.name);
+    }
+}

--- a/src/module/migration/migrations/index.ts
+++ b/src/module/migration/migrations/index.ts
@@ -220,3 +220,4 @@ export { Migration819SpinTaleAdventureSpecific } from "./819-spin-tale-adventure
 export { Migration820RemoveUnusedTraitsData } from "./820-remove-unused-traits-data";
 export { Migration821InlineDamageRolls } from "./821-inline-damage-rolls";
 export { Migration822BladeAllyConsolidation } from "./822-blade-ally-consolidation";
+export { Migration823HeritageAncestrySlug } from "./823-heritage-ancestry-slug";

--- a/src/module/migration/runner/base.ts
+++ b/src/module/migration/runner/base.ts
@@ -14,7 +14,7 @@ interface CollectionDiff<T extends foundry.data.ActiveEffectSource | ItemSourceP
 export class MigrationRunnerBase {
     migrations: MigrationBase[];
 
-    static LATEST_SCHEMA_VERSION = 0.822;
+    static LATEST_SCHEMA_VERSION = 0.823;
 
     static MINIMUM_SAFE_VERSION = 0.618;
 

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -1407,6 +1407,10 @@
                 }
             },
             "Elf": {
+                "Atavism": {
+                    "AllowedDrops": "elf heritage",
+                    "Prompt": "Self an elf heritage."
+                },
                 "BrightnessSeeker": {
                     "Label": "Call Upon the Brightness",
                     "Prompt": "Select the outcome of your Augury.",

--- a/static/templates/items/rules/grant-item.hbs
+++ b/static/templates/items/rules/grant-item.hbs
@@ -13,7 +13,7 @@
     </label>
 </div>
 <div class="form-group">
-    <label class="short">{{localize "PF2E.ItemUUIDLabel"}}</label>
+    <label class="short">{{localize "PF2E.UUID.Label"}}</label>
     <div class="details-container-flex-row">
         <input type="text" name="system.rules.{{index}}.uuid" value="{{rule.uuid}}" />
         {{#if granted}}


### PR DESCRIPTION
Compendium data migrated separately due to Foundry API usage in migration