### PR TITLE
Support building action subtitle from actor and target

### DIFF
--- a/src/module/system/action-macros/types.ts
+++ b/src/module/system/action-macros/types.ts
@@ -28,7 +28,7 @@ interface SimpleRollActionCheckOptions<ItemType extends Embedded<ItemPF2e>> {
     statName: string;
     actionGlyph: ActionGlyph | undefined;
     title: string;
-    subtitle: string;
+    subtitle: string | ((args: { actor: ActorPF2e; target?: ActorPF2e | null }) => Promise<string> | string);
     content?: (title: string) => Promise<string | null | undefined | void> | string | null | undefined | void;
     item?: (actor: ActorPF2e) => ItemType | undefined;
     modifiers: ((args: CheckModifierContext<ItemType>) => ModifierPF2e[] | undefined) | ModifierPF2e[] | undefined;

--- a/src/scripts/register-templates.ts
+++ b/src/scripts/register-templates.ts
@@ -139,6 +139,7 @@ export function registerTemplates(): void {
         "systems/pf2e/templates/compendium-browser/filters.hbs",
 
         // Action Partial
+        "systems/pf2e/templates/chat/action/header.hbs",
         "systems/pf2e/templates/system/actions/repair/chat-button-partial.hbs",
         "systems/pf2e/templates/system/actions/repair/repair-result-partial.hbs",
         "systems/pf2e/templates/system/actions/repair/item-heading-partial.hbs",

--- a/static/templates/chat/action/flavor.hbs
+++ b/static/templates/chat/action/flavor.hbs
@@ -1,7 +1,4 @@
-<strong>
-    <span class="pf2-icon larger">{{action.typeNumber}}</span>
-    {{localize action.title}}{{#if action.subtitle}}: {{localize action.subtitle}}{{/if}}
-</strong>
+{{> systems/pf2e/templates/chat/action/header.hbs glyph=action.typeNumber subtitle=action.subtitle title=action.title}}
 {{#if traits}}
     <div class="tags">
         {{#each traits as |trait|}}

--- a/static/templates/chat/action/header.hbs
+++ b/static/templates/chat/action/header.hbs
@@ -1,0 +1,9 @@
+<h4 class="action">
+    {{#if glyph}}
+        <span class="pf2-icon larger">{{glyph}}</span>
+    {{/if}}
+    <strong>{{localize title}}</strong>
+    {{#if subtitle}}
+        <p class="compact-text">({{localize subtitle}})</p>
+    {{/if}}
+</h4>


### PR DESCRIPTION
Allow an action to dynamically build the subtitle of the action chat card - which will usually be the check type, like "Mercantile Lore Check" - from the actor performing the action and the target of the action. This will be helpful for the Discover and Influence actions that might often rely on lore skills where we need the convert the slug to the translated name from either of those actors.