### PR TITLE
Source sneak attack damage from a common actor flag

### DIFF
--- a/packs/data/classfeatures.db/ruffian.json
+++ b/packs/data/classfeatures.db/ruffian.json
@@ -24,7 +24,8 @@
         "rules": [
             {
                 "category": "precision",
-                "dieSize": "d6",
+                "diceNumber": "@actor.flags.pf2e.sneakAttackDamage.number",
+                "dieSize": "d{actor|flags.pf2e.sneakAttackDamage.faces}",
                 "key": "DamageDice",
                 "label": "PF2E.SpecificRule.SneakAttack",
                 "predicate": [
@@ -45,37 +46,7 @@
                         ]
                     }
                 ],
-                "selector": "strike-damage",
-                "value": {
-                    "brackets": [
-                        {
-                            "end": 4,
-                            "value": {
-                                "diceNumber": 1
-                            }
-                        },
-                        {
-                            "end": 10,
-                            "start": 5,
-                            "value": {
-                                "diceNumber": 2
-                            }
-                        },
-                        {
-                            "end": 16,
-                            "start": 11,
-                            "value": {
-                                "diceNumber": 3
-                            }
-                        },
-                        {
-                            "start": 17,
-                            "value": {
-                                "diceNumber": 4
-                            }
-                        }
-                    ]
-                }
+                "selector": "strike-damage"
             },
             {
                 "key": "ActiveEffectLike",

--- a/packs/data/classfeatures.db/sneak-attack.json
+++ b/packs/data/classfeatures.db/sneak-attack.json
@@ -23,11 +23,29 @@
         },
         "rules": [
             {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.sneakAttackDamage.number",
+                "predicate": [
+                    "class:rogue"
+                ],
+                "value": "ternary(lt(@actor.level, 5), 1, ternary(lt(@actor.level, 11), 2, ternary(lt(@actor.level, 17), 3, 4)))"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.sneakAttackDamage.faces",
+                "predicate": [
+                    "class:rogue"
+                ],
+                "value": 6
+            },
+            {
                 "category": "precision",
-                "dieSize": "d6",
+                "diceNumber": "@actor.flags.pf2e.sneakAttackDamage.number",
+                "dieSize": "d{actor|flags.pf2e.sneakAttackDamage.faces}",
                 "key": "DamageDice",
                 "predicate": [
-                    "class:rogue",
                     "target:condition:flat-footed",
                     {
                         "or": [
@@ -44,37 +62,7 @@
                         ]
                     }
                 ],
-                "selector": "strike-damage",
-                "value": {
-                    "brackets": [
-                        {
-                            "end": 4,
-                            "value": {
-                                "diceNumber": 1
-                            }
-                        },
-                        {
-                            "end": 10,
-                            "start": 5,
-                            "value": {
-                                "diceNumber": 2
-                            }
-                        },
-                        {
-                            "end": 16,
-                            "start": 11,
-                            "value": {
-                                "diceNumber": 3
-                            }
-                        },
-                        {
-                            "start": 17,
-                            "value": {
-                                "diceNumber": 4
-                            }
-                        }
-                    ]
-                }
+                "selector": "strike-damage"
             },
             {
                 "domain": "all",

--- a/packs/data/feats.db/butterflys-sting.json
+++ b/packs/data/feats.db/butterflys-sting.json
@@ -27,21 +27,16 @@
         },
         "rules": [
             {
-                "category": "precision",
-                "diceNumber": 1,
-                "dieSize": "d6",
-                "key": "DamageDice",
-                "predicate": [
-                    "target:condition:flat-footed",
-                    {
-                        "or": [
-                            "finesse",
-                            "agile",
-                            "ranged"
-                        ]
-                    }
-                ],
-                "selector": "strike-damage"
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.sneakAttackDamage.number",
+                "value": 1
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.sneakAttackDamage.faces",
+                "value": 6
             },
             {
                 "key": "GrantItem",

--- a/packs/data/feats.db/magical-trickster.json
+++ b/packs/data/feats.db/magical-trickster.json
@@ -21,7 +21,19 @@
         "prerequisites": {
             "value": []
         },
-        "rules": [],
+        "rules": [
+            {
+                "category": "precision",
+                "diceNumber": "@actor.flags.pf2e.sneakAttackDamage.number",
+                "dieSize": "d{actor|flags.pf2e.sneakAttackDamage.faces}",
+                "key": "DamageDice",
+                "predicate": [
+                    "item:trait:attack",
+                    "target:condition:flat-footed"
+                ],
+                "selector": "spell-damage"
+            }
+        ],
         "source": {
             "value": "Pathfinder Core Rulebook"
         },

--- a/packs/data/feats.db/sneak-attacker.json
+++ b/packs/data/feats.db/sneak-attacker.json
@@ -27,44 +27,16 @@
         },
         "rules": [
             {
-                "category": "precision",
-                "diceNumber": 1,
-                "key": "DamageDice",
-                "label": "PF2E.SpecificRule.SneakAttack",
-                "predicate": [
-                    "target:condition:flat-footed",
-                    {
-                        "or": [
-                            "item:trait:agile",
-                            "item:trait:finesse",
-                            {
-                                "and": [
-                                    "item:ranged",
-                                    {
-                                        "not": "item:thrown-melee"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                ],
-                "selector": "strike-damage",
-                "value": {
-                    "brackets": [
-                        {
-                            "end": 5,
-                            "value": {
-                                "dieSize": "d4"
-                            }
-                        },
-                        {
-                            "start": 6,
-                            "value": {
-                                "dieSize": "d6"
-                            }
-                        }
-                    ]
-                }
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.sneakAttackDamage.number",
+                "value": 1
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.sneakAttackDamage.faces",
+                "value": "ternary(lt(@actor.level, 6), 4, 6)"
             },
             {
                 "key": "GrantItem",

--- a/packs/data/iconics.db/merisiel-level-1.json
+++ b/packs/data/iconics.db/merisiel-level-1.json
@@ -681,11 +681,29 @@
                 },
                 "rules": [
                     {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "flags.pf2e.sneakAttackDamage.number",
+                        "predicate": [
+                            "class:rogue"
+                        ],
+                        "value": "ternary(lt(@actor.level, 5), 1, ternary(lt(@actor.level, 11), 2, ternary(lt(@actor.level, 17), 3, 4)))"
+                    },
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "flags.pf2e.sneakAttackDamage.faces",
+                        "predicate": [
+                            "class:rogue"
+                        ],
+                        "value": 6
+                    },
+                    {
                         "category": "precision",
-                        "dieSize": "d6",
+                        "diceNumber": "@actor.flags.pf2e.sneakAttackDamage.number",
+                        "dieSize": "d{actor|flags.pf2e.sneakAttackDamage.faces}",
                         "key": "DamageDice",
                         "predicate": [
-                            "class:rogue",
                             "target:condition:flat-footed",
                             {
                                 "or": [
@@ -702,37 +720,7 @@
                                 ]
                             }
                         ],
-                        "selector": "strike-damage",
-                        "value": {
-                            "brackets": [
-                                {
-                                    "end": 4,
-                                    "value": {
-                                        "diceNumber": 1
-                                    }
-                                },
-                                {
-                                    "end": 10,
-                                    "start": 5,
-                                    "value": {
-                                        "diceNumber": 2
-                                    }
-                                },
-                                {
-                                    "end": 16,
-                                    "start": 11,
-                                    "value": {
-                                        "diceNumber": 3
-                                    }
-                                },
-                                {
-                                    "start": 17,
-                                    "value": {
-                                        "diceNumber": 4
-                                    }
-                                }
-                            ]
-                        }
+                        "selector": "strike-damage"
                     },
                     {
                         "domain": "all",

--- a/packs/data/iconics.db/merisiel-level-3.json
+++ b/packs/data/iconics.db/merisiel-level-3.json
@@ -681,11 +681,29 @@
                 },
                 "rules": [
                     {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "flags.pf2e.sneakAttackDamage.number",
+                        "predicate": [
+                            "class:rogue"
+                        ],
+                        "value": "ternary(lt(@actor.level, 5), 1, ternary(lt(@actor.level, 11), 2, ternary(lt(@actor.level, 17), 3, 4)))"
+                    },
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "flags.pf2e.sneakAttackDamage.faces",
+                        "predicate": [
+                            "class:rogue"
+                        ],
+                        "value": 6
+                    },
+                    {
                         "category": "precision",
-                        "dieSize": "d6",
+                        "diceNumber": "@actor.flags.pf2e.sneakAttackDamage.number",
+                        "dieSize": "d{actor|flags.pf2e.sneakAttackDamage.faces}",
                         "key": "DamageDice",
                         "predicate": [
-                            "class:rogue",
                             "target:condition:flat-footed",
                             {
                                 "or": [
@@ -702,37 +720,7 @@
                                 ]
                             }
                         ],
-                        "selector": "strike-damage",
-                        "value": {
-                            "brackets": [
-                                {
-                                    "end": 4,
-                                    "value": {
-                                        "diceNumber": 1
-                                    }
-                                },
-                                {
-                                    "end": 10,
-                                    "start": 5,
-                                    "value": {
-                                        "diceNumber": 2
-                                    }
-                                },
-                                {
-                                    "end": 16,
-                                    "start": 11,
-                                    "value": {
-                                        "diceNumber": 3
-                                    }
-                                },
-                                {
-                                    "start": 17,
-                                    "value": {
-                                        "diceNumber": 4
-                                    }
-                                }
-                            ]
-                        }
+                        "selector": "strike-damage"
                     },
                     {
                         "domain": "all",

--- a/packs/data/iconics.db/merisiel-level-5.json
+++ b/packs/data/iconics.db/merisiel-level-5.json
@@ -681,11 +681,29 @@
                 },
                 "rules": [
                     {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "flags.pf2e.sneakAttackDamage.number",
+                        "predicate": [
+                            "class:rogue"
+                        ],
+                        "value": "ternary(lt(@actor.level, 5), 1, ternary(lt(@actor.level, 11), 2, ternary(lt(@actor.level, 17), 3, 4)))"
+                    },
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "flags.pf2e.sneakAttackDamage.faces",
+                        "predicate": [
+                            "class:rogue"
+                        ],
+                        "value": 6
+                    },
+                    {
                         "category": "precision",
-                        "dieSize": "d6",
+                        "diceNumber": "@actor.flags.pf2e.sneakAttackDamage.number",
+                        "dieSize": "d{actor|flags.pf2e.sneakAttackDamage.faces}",
                         "key": "DamageDice",
                         "predicate": [
-                            "class:rogue",
                             "target:condition:flat-footed",
                             {
                                 "or": [
@@ -702,37 +720,7 @@
                                 ]
                             }
                         ],
-                        "selector": "strike-damage",
-                        "value": {
-                            "brackets": [
-                                {
-                                    "end": 4,
-                                    "value": {
-                                        "diceNumber": 1
-                                    }
-                                },
-                                {
-                                    "end": 10,
-                                    "start": 5,
-                                    "value": {
-                                        "diceNumber": 2
-                                    }
-                                },
-                                {
-                                    "end": 16,
-                                    "start": 11,
-                                    "value": {
-                                        "diceNumber": 3
-                                    }
-                                },
-                                {
-                                    "start": 17,
-                                    "value": {
-                                        "diceNumber": 4
-                                    }
-                                }
-                            ]
-                        }
+                        "selector": "strike-damage"
                     },
                     {
                         "domain": "all",

--- a/packs/data/kingmaker-bestiary.db/nok-nok-level-1.json
+++ b/packs/data/kingmaker-bestiary.db/nok-nok-level-1.json
@@ -271,11 +271,29 @@
                 },
                 "rules": [
                     {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "flags.pf2e.sneakAttackDamage.number",
+                        "predicate": [
+                            "class:rogue"
+                        ],
+                        "value": "ternary(lt(@actor.level, 5), 1, ternary(lt(@actor.level, 11), 2, ternary(lt(@actor.level, 17), 3, 4)))"
+                    },
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "flags.pf2e.sneakAttackDamage.faces",
+                        "predicate": [
+                            "class:rogue"
+                        ],
+                        "value": 6
+                    },
+                    {
                         "category": "precision",
-                        "dieSize": "d6",
+                        "diceNumber": "@actor.flags.pf2e.sneakAttackDamage.number",
+                        "dieSize": "d{actor|flags.pf2e.sneakAttackDamage.faces}",
                         "key": "DamageDice",
                         "predicate": [
-                            "class:rogue",
                             "target:condition:flat-footed",
                             {
                                 "or": [
@@ -292,37 +310,7 @@
                                 ]
                             }
                         ],
-                        "selector": "strike-damage",
-                        "value": {
-                            "brackets": [
-                                {
-                                    "end": 4,
-                                    "value": {
-                                        "diceNumber": 1
-                                    }
-                                },
-                                {
-                                    "end": 10,
-                                    "start": 5,
-                                    "value": {
-                                        "diceNumber": 2
-                                    }
-                                },
-                                {
-                                    "end": 16,
-                                    "start": 11,
-                                    "value": {
-                                        "diceNumber": 3
-                                    }
-                                },
-                                {
-                                    "start": 17,
-                                    "value": {
-                                        "diceNumber": 4
-                                    }
-                                }
-                            ]
-                        }
+                        "selector": "strike-damage"
                     },
                     {
                         "domain": "all",

--- a/packs/data/kingmaker-bestiary.db/nok-nok-level-5.json
+++ b/packs/data/kingmaker-bestiary.db/nok-nok-level-5.json
@@ -271,11 +271,29 @@
                 },
                 "rules": [
                     {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "flags.pf2e.sneakAttackDamage.number",
+                        "predicate": [
+                            "class:rogue"
+                        ],
+                        "value": "ternary(lt(@actor.level, 5), 1, ternary(lt(@actor.level, 11), 2, ternary(lt(@actor.level, 17), 3, 4)))"
+                    },
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "flags.pf2e.sneakAttackDamage.faces",
+                        "predicate": [
+                            "class:rogue"
+                        ],
+                        "value": 6
+                    },
+                    {
                         "category": "precision",
-                        "dieSize": "d6",
+                        "diceNumber": "@actor.flags.pf2e.sneakAttackDamage.number",
+                        "dieSize": "d{actor|flags.pf2e.sneakAttackDamage.faces}",
                         "key": "DamageDice",
                         "predicate": [
-                            "class:rogue",
                             "target:condition:flat-footed",
                             {
                                 "or": [
@@ -292,37 +310,7 @@
                                 ]
                             }
                         ],
-                        "selector": "strike-damage",
-                        "value": {
-                            "brackets": [
-                                {
-                                    "end": 4,
-                                    "value": {
-                                        "diceNumber": 1
-                                    }
-                                },
-                                {
-                                    "end": 10,
-                                    "start": 5,
-                                    "value": {
-                                        "diceNumber": 2
-                                    }
-                                },
-                                {
-                                    "end": 16,
-                                    "start": 11,
-                                    "value": {
-                                        "diceNumber": 3
-                                    }
-                                },
-                                {
-                                    "start": 17,
-                                    "value": {
-                                        "diceNumber": 4
-                                    }
-                                }
-                            ]
-                        }
+                        "selector": "strike-damage"
                     },
                     {
                         "domain": "all",

--- a/packs/data/paizo-pregens.db/kaako-ashfeather.json
+++ b/packs/data/paizo-pregens.db/kaako-ashfeather.json
@@ -707,11 +707,29 @@
                 },
                 "rules": [
                     {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "flags.pf2e.sneakAttackDamage.number",
+                        "predicate": [
+                            "class:rogue"
+                        ],
+                        "value": "ternary(lt(@actor.level, 5), 1, ternary(lt(@actor.level, 11), 2, ternary(lt(@actor.level, 17), 3, 4)))"
+                    },
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "flags.pf2e.sneakAttackDamage.faces",
+                        "predicate": [
+                            "class:rogue"
+                        ],
+                        "value": 6
+                    },
+                    {
                         "category": "precision",
-                        "dieSize": "d6",
+                        "diceNumber": "@actor.flags.pf2e.sneakAttackDamage.number",
+                        "dieSize": "d{actor|flags.pf2e.sneakAttackDamage.faces}",
                         "key": "DamageDice",
                         "predicate": [
-                            "class:rogue",
                             "target:condition:flat-footed",
                             {
                                 "or": [
@@ -728,37 +746,7 @@
                                 ]
                             }
                         ],
-                        "selector": "strike-damage",
-                        "value": {
-                            "brackets": [
-                                {
-                                    "end": 4,
-                                    "value": {
-                                        "diceNumber": 1
-                                    }
-                                },
-                                {
-                                    "end": 10,
-                                    "start": 5,
-                                    "value": {
-                                        "diceNumber": 2
-                                    }
-                                },
-                                {
-                                    "end": 16,
-                                    "start": 11,
-                                    "value": {
-                                        "diceNumber": 3
-                                    }
-                                },
-                                {
-                                    "start": 17,
-                                    "value": {
-                                        "diceNumber": 4
-                                    }
-                                }
-                            ]
-                        }
+                        "selector": "strike-damage"
                     },
                     {
                         "domain": "all",

--- a/packs/data/paizo-pregens.db/merisiel-beginner-box.json
+++ b/packs/data/paizo-pregens.db/merisiel-beginner-box.json
@@ -681,11 +681,29 @@
                 },
                 "rules": [
                     {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "flags.pf2e.sneakAttackDamage.number",
+                        "predicate": [
+                            "class:rogue"
+                        ],
+                        "value": "ternary(lt(@actor.level, 5), 1, ternary(lt(@actor.level, 11), 2, ternary(lt(@actor.level, 17), 3, 4)))"
+                    },
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "flags.pf2e.sneakAttackDamage.faces",
+                        "predicate": [
+                            "class:rogue"
+                        ],
+                        "value": 6
+                    },
+                    {
                         "category": "precision",
-                        "dieSize": "d6",
+                        "diceNumber": "@actor.flags.pf2e.sneakAttackDamage.number",
+                        "dieSize": "d{actor|flags.pf2e.sneakAttackDamage.faces}",
                         "key": "DamageDice",
                         "predicate": [
-                            "class:rogue",
                             "target:condition:flat-footed",
                             {
                                 "or": [
@@ -702,37 +720,7 @@
                                 ]
                             }
                         ],
-                        "selector": "strike-damage",
-                        "value": {
-                            "brackets": [
-                                {
-                                    "end": 4,
-                                    "value": {
-                                        "diceNumber": 1
-                                    }
-                                },
-                                {
-                                    "end": 10,
-                                    "start": 5,
-                                    "value": {
-                                        "diceNumber": 2
-                                    }
-                                },
-                                {
-                                    "end": 16,
-                                    "start": 11,
-                                    "value": {
-                                        "diceNumber": 3
-                                    }
-                                },
-                                {
-                                    "start": 17,
-                                    "value": {
-                                        "diceNumber": 4
-                                    }
-                                }
-                            ]
-                        }
+                        "selector": "strike-damage"
                     },
                     {
                         "domain": "all",

--- a/packs/data/paizo-pregens.db/muruwa.json
+++ b/packs/data/paizo-pregens.db/muruwa.json
@@ -705,11 +705,29 @@
                 },
                 "rules": [
                     {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "flags.pf2e.sneakAttackDamage.number",
+                        "predicate": [
+                            "class:rogue"
+                        ],
+                        "value": "ternary(lt(@actor.level, 5), 1, ternary(lt(@actor.level, 11), 2, ternary(lt(@actor.level, 17), 3, 4)))"
+                    },
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "flags.pf2e.sneakAttackDamage.faces",
+                        "predicate": [
+                            "class:rogue"
+                        ],
+                        "value": 6
+                    },
+                    {
                         "category": "precision",
-                        "dieSize": "d6",
+                        "diceNumber": "@actor.flags.pf2e.sneakAttackDamage.number",
+                        "dieSize": "d{actor|flags.pf2e.sneakAttackDamage.faces}",
                         "key": "DamageDice",
                         "predicate": [
-                            "class:rogue",
                             "target:condition:flat-footed",
                             {
                                 "or": [
@@ -726,37 +744,7 @@
                                 ]
                             }
                         ],
-                        "selector": "strike-damage",
-                        "value": {
-                            "brackets": [
-                                {
-                                    "end": 4,
-                                    "value": {
-                                        "diceNumber": 1
-                                    }
-                                },
-                                {
-                                    "end": 10,
-                                    "start": 5,
-                                    "value": {
-                                        "diceNumber": 2
-                                    }
-                                },
-                                {
-                                    "end": 16,
-                                    "start": 11,
-                                    "value": {
-                                        "diceNumber": 3
-                                    }
-                                },
-                                {
-                                    "start": 17,
-                                    "value": {
-                                        "diceNumber": 4
-                                    }
-                                }
-                            ]
-                        }
+                        "selector": "strike-damage"
                     },
                     {
                         "domain": "all",
@@ -862,7 +850,8 @@
                 "rules": [
                     {
                         "category": "precision",
-                        "dieSize": "d6",
+                        "diceNumber": "@actor.flags.pf2e.sneakAttackDamage.number",
+                        "dieSize": "d{actor|flags.pf2e.sneakAttackDamage.faces}",
                         "key": "DamageDice",
                         "label": "PF2E.SpecificRule.SneakAttack",
                         "predicate": [
@@ -883,37 +872,7 @@
                                 ]
                             }
                         ],
-                        "selector": "strike-damage",
-                        "value": {
-                            "brackets": [
-                                {
-                                    "end": 4,
-                                    "value": {
-                                        "diceNumber": 1
-                                    }
-                                },
-                                {
-                                    "end": 10,
-                                    "start": 5,
-                                    "value": {
-                                        "diceNumber": 2
-                                    }
-                                },
-                                {
-                                    "end": 16,
-                                    "start": 11,
-                                    "value": {
-                                        "diceNumber": 3
-                                    }
-                                },
-                                {
-                                    "start": 17,
-                                    "value": {
-                                        "diceNumber": 4
-                                    }
-                                }
-                            ]
-                        }
+                        "selector": "strike-damage"
                     },
                     {
                         "key": "ActiveEffectLike",

--- a/packs/data/paizo-pregens.db/quizrel.json
+++ b/packs/data/paizo-pregens.db/quizrel.json
@@ -796,11 +796,29 @@
                 },
                 "rules": [
                     {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "flags.pf2e.sneakAttackDamage.number",
+                        "predicate": [
+                            "class:rogue"
+                        ],
+                        "value": "ternary(lt(@actor.level, 5), 1, ternary(lt(@actor.level, 11), 2, ternary(lt(@actor.level, 17), 3, 4)))"
+                    },
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "flags.pf2e.sneakAttackDamage.faces",
+                        "predicate": [
+                            "class:rogue"
+                        ],
+                        "value": 6
+                    },
+                    {
                         "category": "precision",
-                        "dieSize": "d6",
+                        "diceNumber": "@actor.flags.pf2e.sneakAttackDamage.number",
+                        "dieSize": "d{actor|flags.pf2e.sneakAttackDamage.faces}",
                         "key": "DamageDice",
                         "predicate": [
-                            "class:rogue",
                             "target:condition:flat-footed",
                             {
                                 "or": [
@@ -817,37 +835,7 @@
                                 ]
                             }
                         ],
-                        "selector": "strike-damage",
-                        "value": {
-                            "brackets": [
-                                {
-                                    "end": 4,
-                                    "value": {
-                                        "diceNumber": 1
-                                    }
-                                },
-                                {
-                                    "end": 10,
-                                    "start": 5,
-                                    "value": {
-                                        "diceNumber": 2
-                                    }
-                                },
-                                {
-                                    "end": 16,
-                                    "start": 11,
-                                    "value": {
-                                        "diceNumber": 3
-                                    }
-                                },
-                                {
-                                    "start": 17,
-                                    "value": {
-                                        "diceNumber": 4
-                                    }
-                                }
-                            ]
-                        }
+                        "selector": "strike-damage"
                     },
                     {
                         "domain": "all",

--- a/packs/data/paizo-pregens.db/reaching-rings.json
+++ b/packs/data/paizo-pregens.db/reaching-rings.json
@@ -765,11 +765,29 @@
                 },
                 "rules": [
                     {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "flags.pf2e.sneakAttackDamage.number",
+                        "predicate": [
+                            "class:rogue"
+                        ],
+                        "value": "ternary(lt(@actor.level, 5), 1, ternary(lt(@actor.level, 11), 2, ternary(lt(@actor.level, 17), 3, 4)))"
+                    },
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "flags.pf2e.sneakAttackDamage.faces",
+                        "predicate": [
+                            "class:rogue"
+                        ],
+                        "value": 6
+                    },
+                    {
                         "category": "precision",
-                        "dieSize": "d6",
+                        "diceNumber": "@actor.flags.pf2e.sneakAttackDamage.number",
+                        "dieSize": "d{actor|flags.pf2e.sneakAttackDamage.faces}",
                         "key": "DamageDice",
                         "predicate": [
-                            "class:rogue",
                             "target:condition:flat-footed",
                             {
                                 "or": [
@@ -786,37 +804,7 @@
                                 ]
                             }
                         ],
-                        "selector": "strike-damage",
-                        "value": {
-                            "brackets": [
-                                {
-                                    "end": 4,
-                                    "value": {
-                                        "diceNumber": 1
-                                    }
-                                },
-                                {
-                                    "end": 10,
-                                    "start": 5,
-                                    "value": {
-                                        "diceNumber": 2
-                                    }
-                                },
-                                {
-                                    "end": 16,
-                                    "start": 11,
-                                    "value": {
-                                        "diceNumber": 3
-                                    }
-                                },
-                                {
-                                    "start": 17,
-                                    "value": {
-                                        "diceNumber": 4
-                                    }
-                                }
-                            ]
-                        }
+                        "selector": "strike-damage"
                     },
                     {
                         "domain": "all",

--- a/packs/data/paizo-pregens.db/zeah.json
+++ b/packs/data/paizo-pregens.db/zeah.json
@@ -776,11 +776,29 @@
                 },
                 "rules": [
                     {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "flags.pf2e.sneakAttackDamage.number",
+                        "predicate": [
+                            "class:rogue"
+                        ],
+                        "value": "ternary(lt(@actor.level, 5), 1, ternary(lt(@actor.level, 11), 2, ternary(lt(@actor.level, 17), 3, 4)))"
+                    },
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "flags.pf2e.sneakAttackDamage.faces",
+                        "predicate": [
+                            "class:rogue"
+                        ],
+                        "value": 6
+                    },
+                    {
                         "category": "precision",
-                        "dieSize": "d6",
+                        "diceNumber": "@actor.flags.pf2e.sneakAttackDamage.number",
+                        "dieSize": "d{actor|flags.pf2e.sneakAttackDamage.faces}",
                         "key": "DamageDice",
                         "predicate": [
-                            "class:rogue",
                             "target:condition:flat-footed",
                             {
                                 "or": [
@@ -797,37 +815,7 @@
                                 ]
                             }
                         ],
-                        "selector": "strike-damage",
-                        "value": {
-                            "brackets": [
-                                {
-                                    "end": 4,
-                                    "value": {
-                                        "diceNumber": 1
-                                    }
-                                },
-                                {
-                                    "end": 10,
-                                    "start": 5,
-                                    "value": {
-                                        "diceNumber": 2
-                                    }
-                                },
-                                {
-                                    "end": 16,
-                                    "start": 11,
-                                    "value": {
-                                        "diceNumber": 3
-                                    }
-                                },
-                                {
-                                    "start": 17,
-                                    "value": {
-                                        "diceNumber": 4
-                                    }
-                                }
-                            ]
-                        }
+                        "selector": "strike-damage"
                     },
                     {
                         "domain": "all",

--- a/packs/data/paizo-pregens.db/zerryd.json
+++ b/packs/data/paizo-pregens.db/zerryd.json
@@ -745,11 +745,29 @@
                 },
                 "rules": [
                     {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "flags.pf2e.sneakAttackDamage.number",
+                        "predicate": [
+                            "class:rogue"
+                        ],
+                        "value": "ternary(lt(@actor.level, 5), 1, ternary(lt(@actor.level, 11), 2, ternary(lt(@actor.level, 17), 3, 4)))"
+                    },
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "flags.pf2e.sneakAttackDamage.faces",
+                        "predicate": [
+                            "class:rogue"
+                        ],
+                        "value": 6
+                    },
+                    {
                         "category": "precision",
-                        "dieSize": "d6",
+                        "diceNumber": "@actor.flags.pf2e.sneakAttackDamage.number",
+                        "dieSize": "d{actor|flags.pf2e.sneakAttackDamage.faces}",
                         "key": "DamageDice",
                         "predicate": [
-                            "class:rogue",
                             "target:condition:flat-footed",
                             {
                                 "or": [
@@ -766,37 +784,7 @@
                                 ]
                             }
                         ],
-                        "selector": "strike-damage",
-                        "value": {
-                            "brackets": [
-                                {
-                                    "end": 4,
-                                    "value": {
-                                        "diceNumber": 1
-                                    }
-                                },
-                                {
-                                    "end": 10,
-                                    "start": 5,
-                                    "value": {
-                                        "diceNumber": 2
-                                    }
-                                },
-                                {
-                                    "end": 16,
-                                    "start": 11,
-                                    "value": {
-                                        "diceNumber": 3
-                                    }
-                                },
-                                {
-                                    "start": 17,
-                                    "value": {
-                                        "diceNumber": 4
-                                    }
-                                }
-                            ]
-                        }
+                        "selector": "strike-damage"
                     },
                     {
                         "domain": "all",

--- a/packs/scripts/run-migration.ts
+++ b/packs/scripts/run-migration.ts
@@ -7,21 +7,6 @@ import { JSDOM } from "jsdom";
 import { sluggify } from "@util";
 import { MigrationBase } from "@module/migration/base";
 import { MigrationRunnerBase } from "@module/migration/runner/base";
-import { Migration787ResolvablesToSystem } from "@module/migration/migrations/787-resolvables-to-system";
-import { Migration788UpdateTanglefootBags } from "@module/migration/migrations/788-update-tanglefoot-bags";
-import { Migration789UpdatePreciseStrike } from "@module/migration/migrations/789-update-precise-strike";
-import { Migration790MultipleClassDCs } from "@module/migration/migrations/790-multiple-class-dcs";
-import { Migration791RuffianHands } from "@module/migration/migrations/791-ruffian-hands";
-import { Migration793MakePredicatesArrays } from "@module/migration/migrations/793-make-predicates-arrays";
-import { Migration795CleanupFlatFootedToggle } from "@module/migration/migrations/795-cleanup-flat-footed-toggle";
-import { Migration796ItemGrantsToObjects } from "@module/migration/migrations/796-item-grants-to-objects";
-import { Migration798WeaponToItemStatements } from "@module/migration/migrations/798-weapon-to-item-statements";
-import { Migration799RMRecallKnowledgeDuplicates } from "@module/migration/migrations/799-rm-recall-knowledge-duplicates";
-import { Migration800SelfEffectPanacheRage } from "@module/migration/migrations/800-self-effect-panache-rage";
-import { Migration801ColorDarkvision } from "@module/migration/migrations/801-color-darkvision";
-import { Migration802StripFeatActionCategory } from "@module/migration/migrations/802-strip-feat-action-category";
-import { Migration803NormalizeSpellArea } from "@module/migration/migrations/803-normalize-spell-area";
-import { Migration804RemoveConsumableProperties } from "@module/migration/migrations/804-remove-consumable-properties";
 import { Migration805InlineDamageRolls } from "@module/migration/migrations/805-inline-damage-formulas";
 import { Migration806TorchImprovisedOtherTags } from "@module/migration/migrations/806-torch-improvised-othertags";
 import { Migration807RMActivatedEffectFields } from "@module/migration/migrations/807-rm-activated-effect-fields";
@@ -38,6 +23,7 @@ import { Migration819SpinTaleAdventureSpecific } from "@module/migration/migrati
 import { Migration820RemoveUnusedTraitsData } from "@module/migration/migrations/820-remove-unused-traits-data";
 import { Migration821InlineDamageRolls } from "@module/migration/migrations/821-inline-damage-rolls";
 import { Migration822BladeAllyConsolidation } from "@module/migration/migrations/822-blade-ally-consolidation";
+import { Migration824SneakAttackDamageSource } from "@module/migration/migrations/824-sneak-attack-damage-source";
 
 // ^^^ don't let your IDE use the index in these imports. you need to specify the full path ^^^
 
@@ -48,21 +34,6 @@ globalThis.HTMLParagraphElement = window.HTMLParagraphElement;
 globalThis.Text = window.Text;
 
 const migrations: MigrationBase[] = [
-    new Migration787ResolvablesToSystem(),
-    new Migration788UpdateTanglefootBags(),
-    new Migration789UpdatePreciseStrike(),
-    new Migration790MultipleClassDCs(),
-    new Migration791RuffianHands(),
-    new Migration793MakePredicatesArrays(),
-    new Migration795CleanupFlatFootedToggle(),
-    new Migration796ItemGrantsToObjects(),
-    new Migration798WeaponToItemStatements(),
-    new Migration799RMRecallKnowledgeDuplicates(),
-    new Migration800SelfEffectPanacheRage(),
-    new Migration801ColorDarkvision(),
-    new Migration802StripFeatActionCategory(),
-    new Migration803NormalizeSpellArea(),
-    new Migration804RemoveConsumableProperties(),
     new Migration805InlineDamageRolls(),
     new Migration806TorchImprovisedOtherTags(),
     new Migration807RMActivatedEffectFields(),
@@ -79,6 +50,7 @@ const migrations: MigrationBase[] = [
     new Migration820RemoveUnusedTraitsData(),
     new Migration821InlineDamageRolls(),
     new Migration822BladeAllyConsolidation(),
+    new Migration824SneakAttackDamageSource(),
 ];
 
 global.deepClone = <T>(original: T): T => {

--- a/src/module/migration/migrations/824-sneak-attack-damage-source.ts
+++ b/src/module/migration/migrations/824-sneak-attack-damage-source.ts
@@ -144,6 +144,20 @@ export class Migration824SneakAttackDamageSource extends MigrationBase {
                 source.system.rules = rules;
                 return;
             }
+            case "magical-trickster": {
+                const rules = [
+                    {
+                        category: "precision",
+                        diceNumber: "@actor.flags.pf2e.sneakAttackDamage.number",
+                        dieSize: "d{actor|flags.pf2e.sneakAttackDamage.faces}",
+                        key: "DamageDice",
+                        predicate: ["item:trait:attack", "target:condition:flat-footed"],
+                        selector: "spell-damage",
+                    },
+                ];
+                source.system.rules = rules;
+                return;
+            }
         }
     }
 }

--- a/src/module/migration/migrations/824-sneak-attack-damage-source.ts
+++ b/src/module/migration/migrations/824-sneak-attack-damage-source.ts
@@ -1,0 +1,149 @@
+import { ItemSourcePF2e } from "@item/data";
+import { MigrationBase } from "../base";
+
+/** Record PC sneak attack damage in an actor flag for reuse by related abilities */
+export class Migration824SneakAttackDamageSource extends MigrationBase {
+    static override version = 0.824;
+
+    override async updateItem(source: ItemSourcePF2e): Promise<void> {
+        if (source.type !== "feat") return;
+
+        switch (source.system.slug) {
+            case "sneak-attack": {
+                const rules = [
+                    {
+                        key: "ActiveEffectLike",
+                        mode: "override",
+                        path: "flags.pf2e.sneakAttackDamage.number",
+                        predicate: ["class:rogue"],
+                        value: "ternary(lt(@actor.level, 5), 1, ternary(lt(@actor.level, 11), 2, ternary(lt(@actor.level, 17), 3, 4)))",
+                    },
+                    {
+                        key: "ActiveEffectLike",
+                        mode: "override",
+                        path: "flags.pf2e.sneakAttackDamage.faces",
+                        predicate: ["class:rogue"],
+                        value: 6,
+                    },
+                    {
+                        category: "precision",
+                        diceNumber: "@actor.flags.pf2e.sneakAttackDamage.number",
+                        dieSize: "d{actor|flags.pf2e.sneakAttackDamage.faces}",
+                        key: "DamageDice",
+                        predicate: [
+                            "target:condition:flat-footed",
+                            {
+                                or: [
+                                    "item:trait:agile",
+                                    "item:trait:finesse",
+                                    { and: ["item:ranged", { not: "item:thrown-melee" }] },
+                                ],
+                            },
+                        ],
+                        selector: "strike-damage",
+                    },
+                    {
+                        domain: "all",
+                        key: "RollOption",
+                        label: "PF2E.SpecificRule.TOTMToggle.FlatFooted",
+                        option: "target:condition:flat-footed",
+                        toggleable: "totm",
+                    },
+                ];
+
+                source.system.rules = rules;
+                return;
+            }
+            case "ruffian": {
+                const rules = [
+                    {
+                        category: "precision",
+                        diceNumber: "@actor.flags.pf2e.sneakAttackDamage.number",
+                        dieSize: "d{actor|flags.pf2e.sneakAttackDamage.faces}",
+                        key: "DamageDice",
+                        label: "PF2E.SpecificRule.SneakAttack",
+                        predicate: [
+                            "target:condition:flat-footed",
+                            "item:category:simple",
+                            {
+                                nor: [
+                                    { and: ["item:ranged", { not: "item:thrown-melee" }] },
+                                    "item:trait:agile",
+                                    "item:trait:finesse",
+                                ],
+                            },
+                        ],
+                        selector: "strike-damage",
+                    },
+                    {
+                        key: "ActiveEffectLike",
+                        mode: "upgrade",
+                        path: "system.martial.medium.rank",
+                        value: 1,
+                    },
+                    {
+                        key: "ActiveEffectLike",
+                        mode: "upgrade",
+                        path: "system.skills.itm.rank",
+                        value: 1,
+                    },
+                    {
+                        key: "CriticalSpecialization",
+                        predicate: [
+                            "target:condition:flat-footed",
+                            "item:category:simple",
+                            { lte: ["item:damage:die:faces", 8] },
+                        ],
+                    },
+                ];
+                source.system.rules = rules;
+                return;
+            }
+            case "sneak-attacker": {
+                const rules = [
+                    {
+                        key: "ActiveEffectLike",
+                        mode: "override",
+                        path: "flags.pf2e.sneakAttackDamage.number",
+                        value: 1,
+                    },
+                    {
+                        key: "ActiveEffectLike",
+                        mode: "override",
+                        path: "flags.pf2e.sneakAttackDamage.faces",
+                        value: "ternary(lt(@actor.level, 6), 4, 6)",
+                    },
+                    { key: "GrantItem", uuid: "Compendium.pf2e.classfeatures.Sneak Attack" },
+                ];
+                source.system.rules = rules;
+                return;
+            }
+            case "butterflys-sting": {
+                const rules = [
+                    {
+                        key: "ActiveEffectLike",
+                        mode: "override",
+                        path: "flags.pf2e.sneakAttackDamage.number",
+                        value: 1,
+                    },
+                    {
+                        key: "ActiveEffectLike",
+                        mode: "override",
+                        path: "flags.pf2e.sneakAttackDamage.faces",
+                        value: 6,
+                    },
+                    { key: "GrantItem", uuid: "Compendium.pf2e.classfeatures.Sneak Attack" },
+                    {
+                        domain: "all",
+                        key: "RollOption",
+                        label: "PF2E.SpecificRule.TOTMToggle.FlatFooted",
+                        option: "target:condition:flat-footed",
+                        toggleable: "totm",
+                    },
+                ];
+                source.system.rules = rules;
+                return;
+            }
+        }
+    }
+}

--- a/src/module/migration/migrations/index.ts
+++ b/src/module/migration/migrations/index.ts
@@ -221,3 +221,4 @@ export { Migration820RemoveUnusedTraitsData } from "./820-remove-unused-traits-d
 export { Migration821InlineDamageRolls } from "./821-inline-damage-rolls";
 export { Migration822BladeAllyConsolidation } from "./822-blade-ally-consolidation";
 export { Migration823HeritageAncestrySlug } from "./823-heritage-ancestry-slug";
+export { Migration824SneakAttackDamageSource } from "./824-sneak-attack-damage-source";

--- a/src/module/migration/runner/base.ts
+++ b/src/module/migration/runner/base.ts
@@ -14,7 +14,7 @@ interface CollectionDiff<T extends foundry.data.ActiveEffectSource | ItemSourceP
 export class MigrationRunnerBase {
     migrations: MigrationBase[];
 
-    static LATEST_SCHEMA_VERSION = 0.823;
+    static LATEST_SCHEMA_VERSION = 0.824;
 
     static MINIMUM_SAFE_VERSION = 0.618;
 

--- a/src/module/rules/rule-element/damage-dice.ts
+++ b/src/module/rules/rule-element/damage-dice.ts
@@ -14,7 +14,7 @@ class DamageDiceRuleElement extends RuleElementPF2e {
 
     diceNumber: number | string = 0;
 
-    dieSize: DamageDieSize | null = null;
+    dieSize: string | null = null;
 
     damageType: string | null = null;
 
@@ -38,7 +38,7 @@ class DamageDiceRuleElement extends RuleElementPF2e {
 
         this.slug = sluggify(typeof data.slug === "string" && data.slug.length > 0 ? data.slug : this.item.name);
 
-        // Number of dice
+        // Dice number
         if (typeof data.diceNumber === "string" || typeof data.diceNumber === "number") {
             this.diceNumber = data.diceNumber;
         } else if ("diceNumber" in data) {
@@ -46,10 +46,10 @@ class DamageDiceRuleElement extends RuleElementPF2e {
         }
 
         // Die faces
-        if (setHasElement(DAMAGE_DIE_FACES, data.dieSize)) {
+        if (typeof data.dieSize === "string" || data.dieSize === null) {
             this.dieSize = data.dieSize;
         } else if ("dieSize" in data) {
-            this.failValidation("dieSize must be a string or omitted");
+            this.failValidation("dieSize must be a string, null, or omitted");
         }
 
         // Damage type
@@ -124,6 +124,12 @@ class DamageDiceRuleElement extends RuleElementPF2e {
                 }
             }
 
+            const dieSize = this.resolveInjectedProperties(this.dieSize);
+            if (dieSize !== null && !setHasElement(DAMAGE_DIE_FACES, dieSize)) {
+                this.failValidation(`Die size must be a recognized damage die size, null, or omitted`);
+                return null;
+            }
+
             // If this failed validation partway through (such as in resolveInjectedProperties), return null
             if (this.ignored) return null;
 
@@ -131,8 +137,8 @@ class DamageDiceRuleElement extends RuleElementPF2e {
                 selector,
                 slug: this.slug,
                 label,
-                dieSize: this.dieSize,
                 diceNumber,
+                dieSize,
                 critical: this.critical,
                 category: this.category,
                 damageType,


### PR DESCRIPTION
This sets PC sneak attack damage dice number and die size at `actor.flags.pf2e.sneakAttackDamage`, allowing Sneak Attack's DamageDice RE (and other abilities like Magical Trickster) to pull the correct damage regardless of the PC's class or other feats.