### PR TITLE
Add EphemeralEffect rule element

### DIFF
--- a/packs/data/feats.db/dread-striker.json
+++ b/packs/data/feats.db/dread-striker.json
@@ -21,7 +21,21 @@
         "prerequisites": {
             "value": []
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "EphemeralEffect",
+                "predicate": [
+                    "target:condition:frightened"
+                ],
+                "selectors": [
+                    "strike-attack-roll",
+                    "spell-attack-roll",
+                    "strike-damage",
+                    "attack-spell-damage"
+                ],
+                "uuid": "Compendium.pf2e.conditionitems.AJh5ex99aV6VTggg"
+            }
+        ],
         "source": {
             "value": "Pathfinder Core Rulebook"
         },

--- a/src/module/actor/data/base.ts
+++ b/src/module/actor/data/base.ts
@@ -246,8 +246,6 @@ interface StrikeData extends StatisticModifier {
         } | null;
     };
 
-    /** The item that generated this strike */
-    origin?: Embedded<ItemPF2e> | null;
     /** The weapon or melee item--possibly ephemeral--being used for the strike */
     item: WeaponPF2e | MeleePF2e;
 }

--- a/src/module/actor/helpers.ts
+++ b/src/module/actor/helpers.ts
@@ -267,7 +267,7 @@ function strikeFromMeleeItem(item: Embedded<MeleePF2e>): NPCStrike {
 
                 params.options ??= [];
                 // Always add all weapon traits as options
-                const context = actor.getAttackRollContext({
+                const context = await actor.getAttackRollContext({
                     item,
                     viewOnly: false,
                     domains,
@@ -327,8 +327,8 @@ function strikeFromMeleeItem(item: Embedded<MeleePF2e>): NPCStrike {
     const damageRoll =
         (outcome: "success" | "criticalSuccess"): DamageRollFunction =>
         async (params: DamageRollParams = {}): Promise<Rolled<DamageRoll> | string | null> => {
-            const domains = ["all", "strike-damage", "damage-roll"];
-            const context = actor.getStrikeRollContext({
+            const domains = ["all", `{item.id}-damage`, "strike-damage", "damage-roll"];
+            const context = await actor.getStrikeRollContext({
                 item,
                 viewOnly: false,
                 domains,

--- a/src/module/actor/modifiers.ts
+++ b/src/module/actor/modifiers.ts
@@ -111,6 +111,7 @@ interface DeferredValueParams {
     test?: string[] | Set<string>;
 }
 type DeferredValue<T> = (options?: DeferredValueParams) => T | null;
+type DeferredPromise<T> = (options?: DeferredValueParams) => Promise<T | null>;
 
 /** Represents a discrete modifier, bonus, or penalty, to a statistic or check. */
 class ModifierPF2e implements RawModifier {
@@ -696,6 +697,7 @@ export {
     DamageDiceOverride,
     DamageDicePF2e,
     DamageDiceParameters,
+    DeferredPromise,
     DeferredValue,
     DeferredValueParams,
     DiceModifierPF2e,

--- a/src/module/actor/types.ts
+++ b/src/module/actor/types.ts
@@ -93,6 +93,7 @@ interface StrikeRollContext<A extends ActorPF2e, I extends AttackItem> {
 }
 
 interface StrikeRollContextParams<T extends AttackItem> {
+    /** The item being used in the attack or damage roll */
     item: T;
     /** Domains from which to draw roll options */
     domains: string[];

--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -263,7 +263,13 @@ class SpellPF2e extends ItemPF2e {
         }
 
         const { actor, ability } = this;
-        const domains = ["damage", "spell-damage", `${this.id}-damage`];
+        const domains = [
+            "damage",
+            "spell-damage",
+            `${this.id}-damage`,
+            this.traits.has("attack") ? "attack-spell-damage" : [],
+        ].flat();
+
         const options = new Set([
             ...(actor?.getRollOptions(domains) ?? []),
             ...(damageOptions.target?.getSelfRollOptions("target") ?? []),

--- a/src/module/rules/index.ts
+++ b/src/module/rules/index.ts
@@ -33,6 +33,7 @@ import { LoseHitPointsRuleElement } from "./rule-element/lose-hit-points";
 import { MarkTokenRuleElement } from "./rule-element/mark-token/rule-element";
 import { MartialProficiencyRuleElement } from "./rule-element/martial-proficiency";
 import { MultipleAttackPenaltyRuleElement } from "./rule-element/multiple-attack-penalty";
+import { EphemeralEffectRuleElement } from "./rule-element/ephemeral-effect";
 import { RollNoteRuleElement } from "./rule-element/roll-note";
 import { RollOptionRuleElement } from "./rule-element/roll-option";
 import { RollTwiceRuleElement } from "./rule-element/roll-twice";
@@ -68,6 +69,7 @@ class RuleElements {
         CriticalSpecialization: CritSpecRuleElement,
         DamageDice: DamageDiceRuleElement,
         DexterityModifierCap: DexterityModifierCapRuleElement,
+        EphemeralEffect: EphemeralEffectRuleElement,
         FastHealing: FastHealingRuleElement,
         FixedProficiency: FixedProficiencyRuleElement,
         FlatModifier: FlatModifierRuleElement,

--- a/src/module/rules/rule-element/ephemeral-effect.ts
+++ b/src/module/rules/rule-element/ephemeral-effect.ts
@@ -1,0 +1,122 @@
+import { DeferredValueParams } from "@actor/modifiers";
+import { ItemPF2e } from "@item";
+import { ConditionSource, EffectSource } from "@item/data";
+import { UUIDUtils } from "@util/uuid-utils";
+import {
+    ArrayField,
+    BooleanField,
+    ModelPropsFromSchema,
+    SchemaField,
+    StringField,
+} from "types/foundry/common/data/fields.mjs";
+import { AELikeChangeMode } from "./ae-like";
+import { RuleElementPF2e } from "./base";
+import { RuleElementSchema } from "./data";
+import { WithItemAlterations } from "./mixins";
+
+const { fields } = foundry.data;
+
+/** An effect that applies ephemerally during a single action, such as a strike */
+class EphemeralEffectRuleElement extends RuleElementPF2e<EphemeralEffectSchema> {
+    static override defineSchema(): EphemeralEffectSchema {
+        return {
+            ...super.defineSchema(),
+            affects: new fields.StringField({ required: true, choices: ["target", "origin"], initial: "target" }),
+            selectors: new fields.ArrayField(
+                new fields.StringField({ required: true, blank: false, nullable: false, initial: undefined })
+            ),
+            uuid: new fields.StringField({ required: true, blank: false, nullable: false, initial: undefined }),
+            adjustName: new fields.BooleanField({ required: true, nullable: false, initial: true }),
+            alterations: new fields.ArrayField(new fields.SchemaField({})),
+        };
+    }
+
+    protected override _validateModel(data: SourceFromSchema<EphemeralEffectSchema>): void {
+        if (data.selectors.length === 0) {
+            throw Error("must have at least one selector");
+        }
+    }
+
+    override afterPrepareData(): void {
+        for (const selector of this.resolveInjectedProperties(this.selectors)) {
+            const deferredEffect = this.#createDeferredEffect();
+            const synthetics = (this.actor.synthetics.ephemeralEffects[selector] ??= { target: [], origin: [] });
+            synthetics[this.affects].push(deferredEffect);
+        }
+    }
+
+    #createDeferredEffect(): (params?: DeferredValueParams) => Promise<EffectSource | ConditionSource | null> {
+        return async (params: DeferredValueParams = {}): Promise<EffectSource | ConditionSource | null> => {
+            if (!this.test(params.test ?? this.actor.getRollOptions())) {
+                return null;
+            }
+
+            const uuid = this.resolveInjectedProperties(this.uuid);
+            if (!UUIDUtils.isItemUUID(uuid)) {
+                this.failValidation(`"${uuid}" does not look like a UUID`);
+                return null;
+            }
+            const effect = game.pf2e.ConditionManager.conditions.get(uuid) ?? (await UUIDUtils.fromUuid(uuid));
+            if (!(effect instanceof ItemPF2e && effect.isOfType("condition", "effect"))) {
+                this.failValidation(`unable to find effect or condition item with uuid "${uuid}"`);
+                return null;
+            }
+
+            const source = effect.toObject();
+
+            // An ephemeral effect will be added to a contextual clone's item source array and cannot include any
+            // asynchronous rule elements
+            const hasForbiddenREs = source.system.rules.some(
+                (r) => typeof r.key === "string" && ["ChoiceSet", "GrantItem"].includes(r.key)
+            );
+            if (hasForbiddenREs) {
+                this.failValidation("an ephemeral effect may not include a choice set or grant");
+            }
+
+            if (this.adjustName) {
+                const label = this.data.label.includes(":")
+                    ? this.label.replace(/^[^:]+:\s*|\s*\([^)]+\)$/g, "")
+                    : this.label;
+                source.name = `${source.name} (${label})`;
+            }
+
+            const resolvables = params.resolvables ?? {};
+            for (const alteration of this.alterations) {
+                const value = this.resolveValue(alteration.value, { resolvables });
+                if (!this.itemCanBeAltered(source, value)) {
+                    return null;
+                }
+                this.applyAlterations(source);
+            }
+
+            return source;
+        };
+    }
+}
+
+interface EphemeralEffectRuleElement
+    extends RuleElementPF2e<EphemeralEffectSchema>,
+        ModelPropsFromSchema<EphemeralEffectSchema>,
+        WithItemAlterations<EphemeralEffectSchema> {
+    alterations: SourceFromSchema<ItemAlterationData>[];
+}
+
+// Apply mixin
+WithItemAlterations.apply(EphemeralEffectRuleElement);
+
+type EphemeralEffectSchema = RuleElementSchema & {
+    affects: StringField<"target" | "origin", "target" | "origin", true, false, true>;
+    selectors: ArrayField<StringField<string, string, true, false, false>>;
+    uuid: StringField<string, string, true, false, false>;
+    adjustName: BooleanField<boolean, boolean, true, false, true>;
+    alterations: ArrayField<SchemaField<ItemAlterationData>>;
+};
+
+type AddOverrideUpgrade = Extract<AELikeChangeMode, "add" | "override" | "upgrade">;
+type ItemAlterationData = {
+    mode: StringField<AddOverrideUpgrade, AddOverrideUpgrade, true, false, false>;
+    property: StringField<"badge-value", "badge-value", true, false, false>;
+    value: StringField<string, string, true, true, false>;
+};
+
+export { EphemeralEffectRuleElement };

--- a/src/module/rules/rule-element/mixins.ts
+++ b/src/module/rules/rule-element/mixins.ts
@@ -1,0 +1,89 @@
+import { ItemSourcePF2e } from "@item/data";
+import { AELikeChangeMode } from "./ae-like";
+import { RuleElementPF2e } from "./base";
+import { RuleElementSchema } from "./data";
+
+/** A mixin for rule elements that allow item alterations */
+abstract class WithItemAlterations<TSchema extends RuleElementSchema> {
+    static apply<TSchema extends RuleElementSchema>(Class: typeof RuleElementPF2e<TSchema>): void {
+        for (const methodName of ["itemCanBeAltered", "isValidItemAlteration", "applyAlterations"] as const) {
+            Object.defineProperty(Class.prototype, methodName, {
+                enumerable: false,
+                writable: false,
+                value: WithItemAlterations.prototype[methodName],
+            });
+        }
+    }
+
+    /** Is the item-alteration data structurally sound? Currently only overrides are supported. */
+    isValidItemAlteration(data: {}): data is ItemAlterationData[] {
+        return (
+            Array.isArray(data) &&
+            data.every(
+                (d: unknown) =>
+                    d instanceof Object &&
+                    "mode" in d &&
+                    d.mode === "override" &&
+                    "property" in d &&
+                    d.property === "badge-value" &&
+                    "value" in d &&
+                    (["string", "number"].includes(typeof d.value) || d.value === null)
+            )
+        );
+    }
+
+    /** Is the item alteration valid for the item type? */
+    itemCanBeAltered(this: RuleElementPF2e, source: ItemSourcePF2e, value: unknown): boolean | null {
+        const sourceId = source.flags.core?.sourceId ? ` (${source.flags.core.sourceId})` : "";
+        if (source.type !== "condition" && source.type !== "effect") {
+            this.failValidation(`unable to alter "${source.name}"${sourceId}: must be condition or effect`);
+            return false;
+        }
+
+        const hasBadge =
+            source.type === "condition"
+                ? typeof source.system.value.value === "number"
+                : source.type === "effect"
+                ? source.system.badge?.type === "counter"
+                : false;
+        if (!hasBadge) {
+            this.failValidation(`unable to alter "${source.name}"${sourceId}: effect lacks a badge`);
+        }
+
+        const positiveInteger = typeof value === "number" && Number.isInteger(value) && value > 0;
+        // Hard-coded until condition data can indicate that it can operate valueless
+        const nullValuedStun = value === null && source.system.slug === "stunned";
+        if (!(positiveInteger || nullValuedStun)) {
+            this.failValidation("badge-value alteration not applicable to item");
+            return false;
+        }
+
+        return hasBadge;
+    }
+
+    /** Set the badge value of a condition or effect */
+    applyAlterations(this: WithItemAlterations<TSchema>, itemSource: ItemSourcePF2e): void {
+        for (const alteration of this.alterations) {
+            const value: unknown = this.resolveValue(alteration.value);
+            if (!this.itemCanBeAltered(itemSource, value)) continue;
+
+            if (itemSource.type === "condition" && (typeof value === "number" || value === null)) {
+                itemSource.system.value.value = value;
+            } else if (itemSource.type === "effect" && typeof value === "number") {
+                itemSource.system.badge!.value = value;
+            }
+        }
+    }
+}
+
+interface WithItemAlterations<TSchema extends RuleElementSchema> extends RuleElementPF2e<TSchema> {
+    alterations: ItemAlterationData[];
+}
+
+interface ItemAlterationData {
+    mode: AELikeChangeMode;
+    property: string;
+    value: string | number | null;
+}
+
+export { ItemAlterationData, WithItemAlterations };

--- a/src/module/rules/synthetics.ts
+++ b/src/module/rules/synthetics.ts
@@ -1,9 +1,10 @@
 import { DexterityModifierCapData } from "@actor/character/types";
 import { MovementType, LabeledSpeed } from "@actor/creature/data";
 import { CreatureSensePF2e } from "@actor/creature/sense";
-import { DamageDicePF2e, DeferredValue, ModifierAdjustment, ModifierPF2e } from "@actor/modifiers";
+import { DamageDicePF2e, DeferredPromise, DeferredValue, ModifierAdjustment, ModifierPF2e } from "@actor/modifiers";
 import { MeleePF2e, WeaponPF2e } from "@item";
-import { ActionTrait } from "@item/action/data";
+import { ActionTrait } from "@item/action";
+import { ConditionSource, EffectSource } from "@item/data";
 import { WeaponPropertyRuneType } from "@item/weapon/types";
 import { RollNotePF2e } from "@module/notes";
 import { MaterialDamageEffect } from "@system/damage";
@@ -19,6 +20,12 @@ interface RuleElementSynthetics {
     damageDice: DamageDiceSynthetics;
     degreeOfSuccessAdjustments: Record<string, DegreeOfSuccessAdjustment[]>;
     dexterityModifierCaps: DexterityModifierCapData[];
+    ephemeralEffects: {
+        [K in string]?: {
+            target: DeferredEphemeralEffect[];
+            origin: DeferredEphemeralEffect[];
+        };
+    };
     modifierAdjustments: ModifierAdjustmentSynthetics;
     movementTypes: { [K in MovementType]?: DeferredMovementType[] };
     multipleAttackPenalties: Record<string, MAPSynthetic[]>;
@@ -54,6 +61,7 @@ type ModifierAdjustmentSynthetics = { all: ModifierAdjustment[]; damage: Modifie
 type DeferredModifier = DeferredValue<ModifierPF2e>;
 type DeferredDamageDice = DeferredValue<DamageDicePF2e>;
 type DeferredMovementType = DeferredValue<BaseSpeedSynthetic | null>;
+type DeferredEphemeralEffect = DeferredPromise<EffectSource | ConditionSource | null>;
 
 interface BaseSpeedSynthetic extends Omit<LabeledSpeed, "label"> {
     type: MovementType;
@@ -120,6 +128,7 @@ export {
     DeferredDamageDice,
     DeferredModifier,
     DeferredMovementType,
+    DeferredEphemeralEffect,
     MAPSynthetic,
     ModifierAdjustmentSynthetics,
     ModifierSynthetics,

--- a/src/module/system/conditions/manager.ts
+++ b/src/module/system/conditions/manager.ts
@@ -10,7 +10,7 @@ import { CONDITION_SLUGS } from "@actor/values";
 export class ConditionManager {
     static #initialized = false;
 
-    static conditions: Map<ConditionSlug, ConditionPF2e> = new Map();
+    static conditions: Map<ConditionSlug | ItemUUID, ConditionPF2e> = new Map();
 
     /** Gets a list of condition slugs. */
     static get conditionsSlugs(): string[] {
@@ -21,8 +21,11 @@ export class ConditionManager {
         if (this.#initialized && !force) return;
 
         type ConditionCollection = CompendiumCollection<ConditionPF2e>;
-        const content = await game.packs.get<ConditionCollection>("pf2e.conditionitems")?.getDocuments();
-        const entries = content?.map((c): [ConditionSlug, ConditionPF2e] => [c.slug, c]) ?? [];
+        const content = (await game.packs.get<ConditionCollection>("pf2e.conditionitems")?.getDocuments()) ?? [];
+        const entries = [
+            ...content.map((c): [ConditionSlug, ConditionPF2e] => [c.slug, c]),
+            ...content.map((c): [ItemUUID, ConditionPF2e] => [c.uuid, c]),
+        ];
         this.conditions = new Map(entries);
         this.#initialized = true;
     }

--- a/src/module/system/statistic/index.ts
+++ b/src/module/system/statistic/index.ts
@@ -335,10 +335,10 @@ class StatisticCheck {
         const domains = this.domains;
 
         // This is required to determine the AC for attack dialogs
-        const rollContext = (() => {
-            const isCreature = actor.isOfType("creature");
+        const rollContext = await (() => {
+            const isValidAttacker = actor.isOfType("creature", "hazard");
             const isAttackItem = item?.isOfType("weapon", "melee", "spell");
-            if (isCreature && isAttackItem && ["attack-roll", "spell-attack-roll"].includes(this.type)) {
+            if (isValidAttacker && isAttackItem && ["attack-roll", "spell-attack-roll"].includes(this.type)) {
                 return actor.getAttackRollContext({ item, domains, options: new Set() });
             }
 

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -885,6 +885,7 @@
             "CriticalSpecialization": "Critical Specialization",
             "DamageDice": "Damage Dice",
             "DexterityModifierCap": "Dexterity Modifier Cap",
+            "EphemeralEffect": "Ephemeral Effect",
             "FastHealing": "Fast Healing/Regeneration",
             "FixedProficiency": "Fixed Proficiency",
             "FlatModifier": "Flat Modifier",


### PR DESCRIPTION
This rule element allows an attacker to push an effect onto a target for a single attack or damage roll--and also for the target to push an effect onto the attacker for the same roll. This is done by adding effect items to contextual clones while assembling attack/damage roll contexts.