### PR TITLE
Add action roll notes informing swashbucklers when they gain panache

### DIFF
--- a/packs/data/classfeatures.db/battledancer.json
+++ b/packs/data/classfeatures.db/battledancer.json
@@ -10,7 +10,7 @@
             "value": null
         },
         "description": {
-            "value": "<p>To you, a fight is a kind of performance art, and you command your foes' attention with mesmerizing motions.</p>\n<p>You are trained in Performance and gain the @UUID[Compendium.pf2e.feats-srd.Fascinating Performance]{Fascinating Performance} skill feat. You gain @UUID[Compendium.pf2e.classfeatures.Panache]{Panache} during an encounter when the result of your Performance check to Perform exceeds the Will DC of an observing foe, even if the foe isn't fascinated.</p>"
+            "value": "<p>To you, a fight is a kind of performance art, and you command your foes' attention with mesmerizing motions.</p>\n<p>You are trained in Performance and gain the @UUID[Compendium.pf2e.feats-srd.Fascinating Performance]{Fascinating Performance} skill feat. You gain @UUID[Compendium.pf2e.classfeatures.Panache]{Panache} during an encounter when the result of your Performance check to @UUID[Compendium.pf2e.actionspf2e.Perform]{Perform} exceeds the Will DC of an observing foe, even if the foe isn't fascinated.</p>"
         },
         "featType": {
             "value": "classfeature"
@@ -48,6 +48,22 @@
                     "class:swashbuckler"
                 ],
                 "uuid": "Compendium.pf2e.feats-srd.Fascinating Performance"
+            },
+            {
+                "key": "Note",
+                "outcome": [
+                    "success",
+                    "criticalSuccess"
+                ],
+                "predicate": [
+                    "action:perform",
+                    {
+                        "not": "self:effect:panache"
+                    }
+                ],
+                "selector": "performance",
+                "text": "PF2E.SpecificRule.Swashbuckler.Panache",
+                "title": "{item|name}"
             }
         ],
         "source": {

--- a/packs/data/classfeatures.db/braggart.json
+++ b/packs/data/classfeatures.db/braggart.json
@@ -44,6 +44,22 @@
                     "class:swashbuckler"
                 ],
                 "value": 1
+            },
+            {
+                "key": "Note",
+                "outcome": [
+                    "success",
+                    "criticalSuccess"
+                ],
+                "predicate": [
+                    "action:demoralize",
+                    {
+                        "not": "self:effect:panache"
+                    }
+                ],
+                "selector": "intimidation",
+                "text": "PF2E.SpecificRule.Swashbuckler.Panache",
+                "title": "{item|name}"
             }
         ],
         "source": {

--- a/packs/data/classfeatures.db/fencer.json
+++ b/packs/data/classfeatures.db/fencer.json
@@ -45,6 +45,27 @@
                     "class:swashbuckler"
                 ],
                 "value": 1
+            },
+            {
+                "key": "Note",
+                "outcome": [
+                    "success",
+                    "criticalSuccess"
+                ],
+                "predicate": [
+                    {
+                        "or": [
+                            "action:feint",
+                            "action:create-a-diversion"
+                        ]
+                    },
+                    {
+                        "not": "self:effect:panache"
+                    }
+                ],
+                "selector": "deception",
+                "text": "PF2E.SpecificRule.Swashbuckler.Panache",
+                "title": "{item|name}"
             }
         ],
         "source": {

--- a/packs/data/classfeatures.db/gymnast.json
+++ b/packs/data/classfeatures.db/gymnast.json
@@ -46,6 +46,28 @@
                     "class:swashbuckler"
                 ],
                 "value": 1
+            },
+            {
+                "key": "Note",
+                "outcome": [
+                    "success",
+                    "criticalSuccess"
+                ],
+                "predicate": [
+                    {
+                        "or": [
+                            "action:grapple",
+                            "action:shove",
+                            "action:trip"
+                        ]
+                    },
+                    {
+                        "not": "self:effect:panache"
+                    }
+                ],
+                "selector": "athletics",
+                "text": "PF2E.SpecificRule.Swashbuckler.Panache",
+                "title": "{item|name}"
             }
         ],
         "source": {

--- a/packs/data/classfeatures.db/panache.json
+++ b/packs/data/classfeatures.db/panache.json
@@ -21,7 +21,24 @@
         "prerequisites": {
             "value": []
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "Note",
+                "outcome": [
+                    "success",
+                    "criticalSuccess"
+                ],
+                "predicate": [
+                    "action:tumble-through",
+                    {
+                        "not": "self:effect:panache"
+                    }
+                ],
+                "selector": "acrobatics",
+                "text": "PF2E.SpecificRule.Swashbuckler.Panache",
+                "title": "{item|name}"
+            }
+        ],
         "source": {
             "value": "Pathfinder Advanced Player's Guide"
         },

--- a/packs/data/classfeatures.db/wit.json
+++ b/packs/data/classfeatures.db/wit.json
@@ -51,6 +51,22 @@
                     "class:swashbuckler"
                 ],
                 "uuid": "Compendium.pf2e.feats-srd.Bon Mot"
+            },
+            {
+                "key": "Note",
+                "outcome": [
+                    "success",
+                    "criticalSuccess"
+                ],
+                "predicate": [
+                    "action:bon-mot",
+                    {
+                        "not": "self:effect:panache"
+                    }
+                ],
+                "selector": "diplomacy",
+                "text": "PF2E.SpecificRule.Swashbuckler.Panache",
+                "title": "{item|name}"
             }
         ],
         "source": {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2031,6 +2031,7 @@
                 "ManualPower": "Manual Power Driver Dynamo"
             },
             "Swashbuckler": {
+                "Panache": "You gain @UUID[Compendium.pf2e.feat-effects.uBJsxCzNhje8m8jj]{Panache}.",
                 "Style": {
                     "Prompt": "Select a style."
                 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/106829671/219576595-a5cf96e0-3761-4a76-a7e4-b74b1602d3b0.png)
