### PR TITLE
Return deferred damage dice that fail their predication test as disabled instead of omitting them

### DIFF
--- a/src/module/rules/rule-element/damage-dice.ts
+++ b/src/module/rules/rule-element/damage-dice.ts
@@ -91,8 +91,6 @@ class DamageDiceRuleElement extends RuleElementPF2e {
         const selector = this.resolveInjectedProperties(this.selector);
 
         const deferredDice = (params: DeferredValueParams = {}): DamageDicePF2e | null => {
-            if (!this.test(params.test ?? this.actor.getRollOptions(["damage"]))) return null;
-
             // In English (and in other languages when the same general form is used), labels patterned as
             // "Title: Subtitle (Parenthetical)" will be reduced to "Subtitle"
             // e.g., "Spell Effect: Ooze Form (Gelatinous Cube)" will become "Ooze Form"
@@ -144,7 +142,7 @@ class DamageDiceRuleElement extends RuleElementPF2e {
                 damageType,
                 predicate: this.predicate ?? {},
                 override: deepClone(this.override),
-                enabled: true,
+                enabled: this.test(params.test ?? this.actor.getRollOptions(["damage"])),
                 ...resolvedBrackets,
             });
         };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/41452412/219865718-92350d79-1f52-4f82-b958-4be2fa56f6be.png)
