### PR TITLE
Fix hearing range test

### DIFF
--- a/src/module/canvas/perception/modes.ts
+++ b/src/module/canvas/perception/modes.ts
@@ -116,15 +116,6 @@ class HearingDetectionMode extends DetectionMode {
 
         return hasLOH;
     }
-
-    protected override _testRange(
-        _visionSource: VisionSource<Token>,
-        _mode: TokenDetectionMode,
-        _target: PlaceableObject,
-        _test: CanvasVisibilityTest
-    ): boolean {
-        return true;
-    }
 }
 
 declare namespace HearingDetectionMode {


### PR DESCRIPTION
The hearing range is ignored (#5819). I understand that this is an optimization, but, if RBV is disabled, the hearing range configured by the user isn't necessarily infinite. Also this override breaks Perfect Vision's Vision Limitation for the Hearing mode: the limit is applied in a patch of `DetectionMode.prototype._testRange`, which is bypassed by the current hearing mode implementation.