### PR TITLE
Allow GM to select allowed sources for the compendium browser

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -192,6 +192,7 @@ declare global {
         get(module: "pf2e", setting: "homebrew.damageTypes"): CustomDamageData[];
 
         get(module: "pf2e", setting: "compendiumBrowserPacks"): CompendiumBrowserSettings;
+        get(module: "pf2e", setting: "compendiumBrowserSources"): CompendiumBrowserSources;
         get(module: "pf2e", setting: "critFumbleButtons"): boolean;
         get(module: "pf2e", setting: "critRule"): "doubledamage" | "doubledice";
         get(module: "pf2e", setting: "deathIcon"): ImageFilePath;

--- a/src/module/apps/compendium-browser/data.ts
+++ b/src/module/apps/compendium-browser/data.ts
@@ -5,6 +5,11 @@ interface PackInfo {
     name: string;
 }
 
+interface SourceInfo {
+    load: boolean;
+    name: string;
+}
+
 interface BrowserTabs {
     action: browserTabs.Actions;
     bestiary: browserTabs.Bestiary;
@@ -31,6 +36,7 @@ export {
     PackInfo,
     SortByOption,
     SortDirection,
+    SourceInfo,
     TabData,
     TabName,
 };

--- a/src/module/apps/compendium-browser/index.ts
+++ b/src/module/apps/compendium-browser/index.ts
@@ -2,12 +2,12 @@ import { KitPF2e, PhysicalItemPF2e } from "@item";
 import { ActionTrait } from "@item/action/index.ts";
 import { ActionType } from "@item/data/base.ts";
 import { BaseSpellcastingEntry } from "@item/spellcasting-entry/index.ts";
-import { ErrorPF2e, htmlQueryAll, isObject, localizer, objectHasKey } from "@util";
+import { ErrorPF2e, htmlQuery, htmlQueryAll, isBlank, isObject, localizer, objectHasKey, sluggify } from "@util";
 import { getSelectedOrOwnActors } from "@util/token-actor-utils.ts";
 import { UserPF2e } from "@module/user/document.ts";
 import Tagify from "@yaireo/tagify";
 import noUiSlider from "nouislider";
-import { BrowserTabs, PackInfo, SortDirection, TabData, TabName } from "./data.ts";
+import { BrowserTabs, PackInfo, SortDirection, SourceInfo, TabData, TabName } from "./data.ts";
 import { Progress } from "./progress.ts";
 import * as browserTabs from "./tabs/index.ts";
 import {
@@ -30,6 +30,13 @@ class PackLoader {
         Item: Record<string, { pack: CompendiumCollection; index: CompendiumIndex } | undefined>;
     } = { Actor: {}, Item: {} };
 
+    loadedSources: string[] = [];
+    sourcesSettings: CompendiumBrowserSources;
+
+    constructor() {
+        this.sourcesSettings = game.settings.get("pf2e", "compendiumBrowserSources");
+    }
+
     async *loadPacks(
         documentType: "Actor" | "Item",
         packs: string[],
@@ -37,6 +44,7 @@ class PackLoader {
     ): AsyncGenerator<{ pack: CompendiumCollection<CompendiumDocument>; index: CompendiumIndex }, void, unknown> {
         this.loadedPacks[documentType] ??= {};
         const localize = localizer("PF2E.CompendiumBrowser.ProgressBar");
+        const sources = this.#getSources();
 
         const progress = new Progress({ steps: packs.length });
         for (const packId of packs) {
@@ -56,8 +64,9 @@ class PackLoader {
                     const firstResult: Partial<CompendiumIndexData> = index.contents.at(0) ?? {};
                     // Every result should have the "system" property otherwise the indexFields were wrong for that pack
                     if (firstResult.system) {
-                        this.setModuleArt(packId, index);
-                        data = { pack, index };
+                        const filteredIndex = this.#createFilteredIndex(index, sources);
+                        this.#setModuleArt(packId, filteredIndex);
+                        data = { pack, index: filteredIndex };
                         this.loadedPacks[documentType][packId] = data;
                     } else {
                         ui.notifications.warn(
@@ -76,13 +85,129 @@ class PackLoader {
     }
 
     /** Set art provided by a module if any is available */
-    private setModuleArt(packName: string, index: CompendiumIndex): void {
+    #setModuleArt(packName: string, index: CompendiumIndex): void {
         if (!packName.startsWith("pf2e.")) return;
         for (const record of index) {
             const uuid: CompendiumUUID = `Compendium.${packName}.${record._id}`;
             const actorArt = game.pf2e.system.moduleArt.map.get(uuid)?.img;
             record.img = actorArt ?? record.img;
         }
+    }
+
+    #getSources(): Set<string> {
+        const sources = new Set<string>();
+        for (const source of Object.values(this.sourcesSettings.sources)) {
+            if (source?.load) {
+                sources.add(source.name);
+            }
+        }
+        return sources;
+    }
+
+    #createFilteredIndex(index: CompendiumIndex, sources: Set<string>): CompendiumIndex {
+        if (sources.size === 0) {
+            // Make sure everything works as before as long as the settings are not yet defined
+            return index;
+        }
+
+        if (game.user.isGM && this.sourcesSettings.ignoreAsGM) {
+            return index;
+        }
+
+        const filteredIndex: CompendiumIndex = new Collection<CompendiumIndexData>();
+        const knownSources = Object.values(this.sourcesSettings.sources).map((value) => value?.name);
+
+        for (const document of index) {
+            const source = this.#getSourceFromDocument(document);
+            const blank = isBlank(source);
+
+            if (
+                (blank && this.sourcesSettings.showEmptySources) ||
+                sources.has(source) ||
+                (this.sourcesSettings.showUnknownSources && !blank && !knownSources.includes(source))
+            ) {
+                filteredIndex.set(document._id, document);
+            }
+        }
+        return filteredIndex;
+    }
+
+    async updateSources(packs: string[]): Promise<void> {
+        await this.#loadSources(packs);
+
+        for (const source of this.loadedSources) {
+            const slug = sluggify(source);
+            if (this.sourcesSettings.sources[slug] === undefined) {
+                this.sourcesSettings.sources[slug] = {
+                    load: this.sourcesSettings.showUnknownSources,
+                    name: source,
+                };
+            }
+        }
+
+        // Make sure it can be easily displayed sorted
+        this.sourcesSettings.sources = Object.fromEntries(
+            Object.entries(this.sourcesSettings.sources).sort((a, b) => a[0].localeCompare(b[0], game.i18n.lang))
+        );
+    }
+
+    async #loadSources(packs: string[]): Promise<void> {
+        const localize = localizer("PF2E.CompendiumBrowser.ProgressBar");
+        const progress = new Progress({ steps: packs.length });
+
+        const loadedSources = new Set<string>();
+        const indexFields = ["system.details.source.value", "system.source.value"];
+        const knownDocumentTypes = ["Actor", "Item"];
+
+        for (const packId of packs) {
+            const pack = game.packs.get(packId);
+            if (!pack || !knownDocumentTypes.includes(pack.documentName)) {
+                progress.advance("");
+                continue;
+            }
+            progress.advance(localize("LoadingPack", { pack: pack?.metadata.label ?? "" }));
+            const index = await pack.getIndex({ fields: indexFields });
+
+            for (const element of index) {
+                const source = this.#getSourceFromDocument(element);
+                if (source && source !== "") {
+                    loadedSources.add(source);
+                }
+            }
+        }
+
+        progress.close(localize("LoadingComplete"));
+        const loadedSourcesArray = Array.from(loadedSources).sort();
+        this.loadedSources = loadedSourcesArray;
+    }
+
+    #getSourceFromDocument(document: CompendiumIndexData): string {
+        // There are two possible fields where the source can be, check them in order
+        if (document.system?.details?.source?.value) {
+            return document.system.details.source.value;
+        }
+
+        if (document.system?.source?.value) {
+            return document.system.source.value;
+        }
+
+        return "";
+    }
+
+    reset(): void {
+        this.loadedPacks = { Actor: {}, Item: {} };
+        this.loadedSources = [];
+    }
+
+    async hardReset(packs: string[]): Promise<void> {
+        this.reset();
+        this.sourcesSettings = {
+            ignoreAsGM: true,
+            showEmptySources: true,
+            showUnknownSources: true,
+            sources: {},
+        };
+        await this.updateSources(packs);
     }
 }
 
@@ -306,6 +431,7 @@ class CompendiumBrowser extends Application {
         this.activeTab = tabName;
         // Settings tab
         if (tabName === "settings") {
+            await this.packLoader.updateSources(this.loadedPacksAll());
             await this.render(true);
             return;
         }
@@ -331,6 +457,14 @@ class CompendiumBrowser extends Application {
         });
     }
 
+    loadedPacksAll(): string[] {
+        const loadedPacks = new Set<string>();
+        for (const tabName of this.dataTabsList) {
+            this.loadedPacks(tabName).forEach((item) => loadedPacks.add(item));
+        }
+        return Array.from(loadedPacks).sort();
+    }
+
     override activateListeners($html: JQuery): void {
         super.activateListeners($html);
         const html = $html[0];
@@ -354,13 +488,76 @@ class CompendiumBrowser extends Application {
                         }
                     }
                     await game.settings.set("pf2e", "compendiumBrowserPacks", this.settings);
-                    for (const tab of Object.values(this.tabs)) {
-                        if (tab.isInitialized) {
-                            await tab.init();
-                            tab.scrollLimit = 100;
+
+                    for (const [key, source] of Object.entries(this.packLoader.sourcesSettings.sources)) {
+                        if (!source || isBlank(source.name)) {
+                            delete this.packLoader.sourcesSettings.sources[key]; // just to make sure we clean up
+                            continue;
+                        }
+                        source.load = formData.has(`source-${key}`);
+                    }
+
+                    this.packLoader.sourcesSettings.showEmptySources = formData.has("show-empty-sources");
+                    this.packLoader.sourcesSettings.showUnknownSources = formData.has("show-unknown-sources");
+                    this.packLoader.sourcesSettings.ignoreAsGM = formData.has("ignore-as-gm");
+                    await game.settings.set("pf2e", "compendiumBrowserSources", this.packLoader.sourcesSettings);
+
+                    await this.#resetInitializedTabs();
+                    this.render(true);
+                });
+
+                const sourceSearch = htmlQuery<HTMLInputElement>(form, "input[data-element=setting-sources-search]");
+                const sourceToggle = htmlQuery<HTMLInputElement>(
+                    form,
+                    "input[data-action=setting-sources-toggle-visible]"
+                );
+                const sourceSettings = htmlQueryAll<HTMLElement>(form, "label[data-element=setting-source]");
+
+                sourceSearch?.addEventListener("input", () => {
+                    const value = sourceSearch.value?.trim().toLocaleLowerCase(game.i18n.lang);
+
+                    for (const element of sourceSettings) {
+                        const name = element.dataset.name?.toLocaleLowerCase(game.i18n.lang);
+                        const shouldBeHidden = !isBlank(value) && !isBlank(name) && !name.includes(value);
+
+                        element.classList.toggle("hidden", shouldBeHidden);
+                    }
+
+                    if (sourceToggle) {
+                        sourceToggle.checked = false;
+                    }
+                });
+
+                sourceToggle?.addEventListener("click", () => {
+                    for (const element of sourceSettings) {
+                        const checkbox = htmlQuery<HTMLInputElement>(element, "input[type=checkbox]");
+                        if (!element.classList.contains("hidden") && checkbox) {
+                            checkbox.checked = sourceToggle.checked;
                         }
                     }
-                    this.render(true);
+                });
+
+                const deleteButton = htmlQuery<HTMLInputElement>(form, "button[data-action=settings-sources-delete]");
+                deleteButton?.addEventListener("click", async () => {
+                    const localize = localizer("PF2E.SETTINGS.CompendiumBrowserSources");
+                    const confirm = await Dialog.confirm({
+                        title: localize("DeleteAllTitle"),
+                        content: `
+                        <p>
+                            ${localize("DeleteAllQuestion")}
+                        </p>
+                        <p>
+                            ${localize("DeleteAllInfo")}
+                        </p>
+                        `,
+                    });
+
+                    if (confirm) {
+                        await this.packLoader.hardReset(this.loadedPacksAll());
+                        await game.settings.set("pf2e", "compendiumBrowserSources", this.packLoader.sourcesSettings);
+                        await this.#resetInitializedTabs();
+                        this.render(true);
+                    }
                 });
             }
             return;
@@ -376,8 +573,8 @@ class CompendiumBrowser extends Application {
         if (search) {
             search.addEventListener("input", () => {
                 currentTab.filterData.search.text = search.value;
-                this.clearScrollLimit();
-                this.renderResultList({ replace: true });
+                this.#clearScrollLimit();
+                this.#renderResultList({ replace: true });
             });
         }
 
@@ -389,7 +586,7 @@ class CompendiumBrowser extends Application {
                 order.addEventListener("change", () => {
                     const orderBy = order.value ?? "name";
                     currentTab.filterData.order.by = orderBy;
-                    this.clearScrollLimit(true);
+                    this.#clearScrollLimit(true);
                 });
             }
             const directionAnchor = sortContainer.querySelector<HTMLAnchorElement>("a.direction");
@@ -397,7 +594,7 @@ class CompendiumBrowser extends Application {
                 directionAnchor.addEventListener("click", () => {
                     const direction = (directionAnchor.dataset.direction as SortDirection) ?? "asc";
                     currentTab.filterData.order.direction = direction === "asc" ? "desc" : "asc";
-                    this.clearScrollLimit(true);
+                    this.#clearScrollLimit(true);
                 });
             }
         }
@@ -410,15 +607,15 @@ class CompendiumBrowser extends Application {
                     const filterData = currentTab.filterData;
                     if (!filterData.selects?.timefilter) return;
                     filterData.selects.timefilter.selected = timeFilter.value;
-                    this.clearScrollLimit(true);
+                    this.#clearScrollLimit(true);
                 });
             }
         }
 
         // Clear all filters button
         controlArea.querySelector<HTMLButtonElement>("button.clear-filters")?.addEventListener("click", () => {
-            this.resetFilters();
-            this.clearScrollLimit(true);
+            this.#resetFilters();
+            this.#clearScrollLimit(true);
         });
 
         // Filters
@@ -502,7 +699,7 @@ class CompendiumBrowser extends Application {
                             option.selected
                                 ? checkbox.selected.push(optionName)
                                 : (checkbox.selected = checkbox.selected.filter((name) => name !== optionName));
-                            this.clearScrollLimit(true);
+                            this.#clearScrollLimit(true);
                         }
                     });
                 });
@@ -523,7 +720,7 @@ class CompendiumBrowser extends Application {
                             const values = currentTab.parseRangeFilterInput(filterName, lowerBound, upperBound);
                             range.values = values;
                             range.changed = true;
-                            this.clearScrollLimit(true);
+                            this.#clearScrollLimit(true);
                         }
                     });
                 });
@@ -640,7 +837,7 @@ class CompendiumBrowser extends Application {
                         $minLabel.text(min);
                         $maxLabel.text(max);
 
-                        this.clearScrollLimit(true);
+                        this.#clearScrollLimit(true);
                     });
 
                     // Set styling
@@ -662,13 +859,22 @@ class CompendiumBrowser extends Application {
                 const maxValue = currentTab.totalItemCount ?? 0;
                 if (currentValue < maxValue) {
                     currentTab.scrollLimit = Math.clamped(currentValue + 100, 100, maxValue);
-                    this.renderResultList({ list, start: currentValue });
+                    this.#renderResultList({ list, start: currentValue });
                 }
             }
         });
 
         // Initial result list render
-        this.renderResultList({ list });
+        this.#renderResultList({ list });
+    }
+
+    async #resetInitializedTabs(): Promise<void> {
+        for (const tab of Object.values(this.tabs)) {
+            if (tab.isInitialized) {
+                await tab.init();
+                tab.scrollLimit = 100;
+            }
+        }
     }
 
     /**
@@ -678,7 +884,7 @@ class CompendiumBrowser extends Application {
      * @param options.start The index position to start from
      * @param options.replace Replace the current list with the new results?
      */
-    private async renderResultList({ list, start = 0, replace = false }: RenderResultListOptions): Promise<void> {
+    async #renderResultList({ list, start = 0, replace = false }: RenderResultListOptions): Promise<void> {
         const currentTab = this.activeTab !== "settings" ? this.tabs[this.activeTab] : null;
         const html = this.element[0];
         if (!currentTab) return;
@@ -692,7 +898,7 @@ class CompendiumBrowser extends Application {
         // Get new results from index
         const newResults = await currentTab.renderResults(start);
         // Add listeners to new results only
-        this.activateResultListeners(newResults);
+        this.#activateResultListeners(newResults);
         // Add the results to the DOM
         const fragment = document.createDocumentFragment();
         fragment.append(...newResults);
@@ -708,7 +914,7 @@ class CompendiumBrowser extends Application {
     }
 
     /** Activate click listeners on loaded actors and items */
-    private activateResultListeners(liElements: HTMLLIElement[] = []): void {
+    #activateResultListeners(liElements: HTMLLIElement[] = []): void {
         for (const liElement of liElements) {
             const { entryUuid } = liElement.dataset;
             if (!entryUuid) continue;
@@ -728,20 +934,20 @@ class CompendiumBrowser extends Application {
                 liElement
                     .querySelector<HTMLAnchorElement>("a[data-action=take-item]")
                     ?.addEventListener("click", () => {
-                        this.takePhysicalItem(entryUuid);
+                        this.#takePhysicalItem(entryUuid);
                     });
 
                 // Attempt to buy an item with the selected tokens' actors'
                 liElement.querySelector<HTMLAnchorElement>("a[data-action=buy-item]")?.addEventListener("click", () => {
-                    this.buyPhysicalItem(entryUuid);
+                    this.#buyPhysicalItem(entryUuid);
                 });
             }
         }
     }
 
-    private async takePhysicalItem(uuid: string): Promise<void> {
+    async #takePhysicalItem(uuid: string): Promise<void> {
         const actors = getSelectedOrOwnActors(["character", "npc"]);
-        const item = await this.getPhysicalItem(uuid);
+        const item = await this.#getPhysicalItem(uuid);
 
         if (actors.length === 0) {
             ui.notifications.error(game.i18n.format("PF2E.ErrorMessage.NoTokenSelected"));
@@ -764,9 +970,9 @@ class CompendiumBrowser extends Application {
         }
     }
 
-    private async buyPhysicalItem(uuid: string): Promise<void> {
+    async #buyPhysicalItem(uuid: string): Promise<void> {
         const actors = getSelectedOrOwnActors(["character", "npc"]);
-        const item = await this.getPhysicalItem(uuid);
+        const item = await this.#getPhysicalItem(uuid);
 
         if (actors.length === 0) {
             ui.notifications.error(game.i18n.format("PF2E.ErrorMessage.NoTokenSelected"));
@@ -815,7 +1021,7 @@ class CompendiumBrowser extends Application {
         }
     }
 
-    private async getPhysicalItem(uuid: string): Promise<PhysicalItemPF2e | KitPF2e> {
+    async #getPhysicalItem(uuid: string): Promise<PhysicalItemPF2e | KitPF2e> {
         const item = await fromUuid(uuid);
         if (!(item instanceof PhysicalItemPF2e || item instanceof KitPF2e)) {
             throw ErrorPF2e("Unexpected failure retrieving compendium item");
@@ -862,13 +1068,22 @@ class CompendiumBrowser extends Application {
         this.element.css({ pointerEvents: "none" });
     }
 
-    override getData(): { user: Active<UserPF2e>; settings?: CompendiumBrowserSettings; scrollLimit?: number } {
+    override getData(): {
+        user: Active<UserPF2e>;
+        settings?: { settings: CompendiumBrowserSettings; sources: CompendiumBrowserSources };
+        scrollLimit?: number;
+    } {
         const activeTab = this.activeTab;
         // Settings
         if (activeTab === "settings") {
+            const settings = {
+                settings: this.settings,
+                sources: this.packLoader.sourcesSettings,
+            };
+
             return {
                 user: game.user,
-                settings: this.settings,
+                settings: settings,
             };
         }
         // Active tab
@@ -888,14 +1103,14 @@ class CompendiumBrowser extends Application {
         };
     }
 
-    private resetFilters(): void {
+    #resetFilters(): void {
         const activeTab = this.activeTab;
         if (activeTab !== "settings") {
             this.tabs[activeTab].resetFilters();
         }
     }
 
-    private clearScrollLimit(render = false) {
+    #clearScrollLimit(render = false): void {
         const tab = this.activeTab;
         if (tab === "settings") return;
 
@@ -912,4 +1127,12 @@ class CompendiumBrowser extends Application {
 
 type CompendiumBrowserSettings = Omit<TabData<Record<string, PackInfo | undefined>>, "settings">;
 
-export { CompendiumBrowser, CompendiumBrowserSettings };
+type CompendiumBrowserSourcesList = Record<string, SourceInfo | undefined>;
+interface CompendiumBrowserSources {
+    ignoreAsGM: boolean;
+    showEmptySources: boolean;
+    showUnknownSources: boolean;
+    sources: CompendiumBrowserSourcesList;
+}
+
+export { CompendiumBrowser, CompendiumBrowserSettings, CompendiumBrowserSources };

--- a/src/module/apps/compendium-browser/tabs/action.ts
+++ b/src/module/apps/compendium-browser/tabs/action.ts
@@ -54,9 +54,9 @@ export class CompendiumBrowserActionTab extends CompendiumBrowserTab {
 
                     // Prepare source
                     const source = actionData.system.source.value;
+                    const sourceSlug = sluggify(source);
                     if (source) {
                         sources.add(source);
-                        actionData.system.source.value = sluggify(source);
                     }
                     actions.push({
                         type: actionData.type,
@@ -65,7 +65,7 @@ export class CompendiumBrowserActionTab extends CompendiumBrowserTab {
                         uuid: `Compendium.${pack.collection}.${actionData._id}`,
                         traits: actionData.system.traits.value,
                         actionType: actionData.system.actionType.value,
-                        source: actionData.system.source.value,
+                        source: sourceSlug,
                     });
                 }
             }

--- a/src/module/apps/compendium-browser/tabs/bestiary.ts
+++ b/src/module/apps/compendium-browser/tabs/bestiary.ts
@@ -62,9 +62,9 @@ export class CompendiumBrowserBestiaryTab extends CompendiumBrowserTab {
                     }
                     // Prepare source
                     const source = actorData.system.details.source.value;
+                    const sourceSlug = sluggify(source);
                     if (source) {
                         sources.add(source);
-                        actorData.system.details.source.value = sluggify(source);
                     }
 
                     bestiaryActors.push({
@@ -77,7 +77,7 @@ export class CompendiumBrowserBestiaryTab extends CompendiumBrowserTab {
                         actorSize: actorData.system.traits.size.value,
                         traits: actorData.system.traits.value,
                         rarity: actorData.system.traits.rarity,
-                        source: actorData.system.details.source.value,
+                        source: sourceSlug,
                     });
                 }
             }

--- a/src/module/apps/compendium-browser/tabs/equipment.ts
+++ b/src/module/apps/compendium-browser/tabs/equipment.ts
@@ -97,9 +97,9 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
 
                     // Prepare source
                     const source = itemData.system.source.value;
+                    const sourceSlug = sluggify(source);
                     if (source) {
                         sources.add(source);
-                        itemData.system.source.value = sluggify(source);
                     }
 
                     // Infer magical trait from runes
@@ -124,7 +124,7 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
                         priceInCopper: coinValue,
                         traits: itemData.system.traits.value,
                         rarity: itemData.system.traits.rarity,
-                        source: itemData.system.source.value,
+                        source: sourceSlug,
                     });
                 }
             }

--- a/src/module/apps/compendium-browser/tabs/feat.ts
+++ b/src/module/apps/compendium-browser/tabs/feat.ts
@@ -98,9 +98,9 @@ export class CompendiumBrowserFeatTab extends CompendiumBrowserTab {
 
                     // Prepare source
                     const source = featData.system.source.value;
+                    const sourceSlug = sluggify(source);
                     if (source) {
                         sources.add(source);
-                        featData.system.source.value = sluggify(source);
                     }
 
                     // Only store essential data
@@ -114,7 +114,7 @@ export class CompendiumBrowserFeatTab extends CompendiumBrowserTab {
                         skills: [...skills],
                         traits: featData.system.traits.value,
                         rarity: featData.system.traits.rarity,
-                        source: featData.system.source.value,
+                        source: sourceSlug,
                     });
                 }
             }

--- a/src/module/apps/compendium-browser/tabs/hazard.ts
+++ b/src/module/apps/compendium-browser/tabs/hazard.ts
@@ -45,9 +45,9 @@ export class CompendiumBrowserHazardTab extends CompendiumBrowserTab {
                     }
                     // Prepare source
                     const source = actorData.system.details.source?.value;
+                    const sourceSlug = sluggify(source);
                     if (source) {
                         sources.add(source);
-                        actorData.system.details.source.value = sluggify(source);
                     } else {
                         actorData.system.details.source = { value: "" };
                     }
@@ -61,7 +61,7 @@ export class CompendiumBrowserHazardTab extends CompendiumBrowserTab {
                         complexity: actorData.system.details.isComplex ? "complex" : "simple",
                         traits: actorData.system.traits.value,
                         rarity: actorData.system.traits.rarity,
-                        source: actorData.system.details.source.value,
+                        source: sourceSlug,
                     });
                 }
             }

--- a/src/module/apps/compendium-browser/tabs/spell.ts
+++ b/src/module/apps/compendium-browser/tabs/spell.ts
@@ -91,9 +91,9 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
 
                     // Prepare source
                     const source = spellData.system.source.value;
+                    const sourceSlug = sluggify(source);
                     if (source) {
                         sources.add(source);
-                        spellData.system.source.value = sluggify(source);
                     }
 
                     spells.push({
@@ -108,7 +108,7 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
                         traditions: spellData.system.traditions.value,
                         traits: spellData.system.traits.value,
                         rarity: spellData.system.traits.rarity,
-                        source: spellData.system.source.value,
+                        source: sourceSlug,
                     });
                 }
             }

--- a/src/module/system/settings/index.ts
+++ b/src/module/system/settings/index.ts
@@ -68,6 +68,23 @@ export function registerSettings(): void {
         },
     });
 
+    game.settings.register("pf2e", "compendiumBrowserSources", {
+        name: "PF2E.SETTINGS.compendiumBrowserSources.Name",
+        hint: "PF2E.SETTINGS.compendiumBrowserSources.Hint",
+        default: {
+            ignoreAsGM: true,
+            showEmptySources: true,
+            showUnknownSources: true,
+            sources: {},
+        },
+        type: Object,
+        scope: "world",
+        onChange: () => {
+            game.pf2e.compendiumBrowser.packLoader.reset();
+            game.pf2e.compendiumBrowser.initCompendiumList();
+        },
+    });
+
     game.settings.register("pf2e", "enabledRulesUI", {
         name: "PF2E.SETTINGS.EnabledRulesUI.Name",
         hint: "PF2E.SETTINGS.EnabledRulesUI.Hint",

--- a/src/styles/packs/_settings.scss
+++ b/src/styles/packs/_settings.scss
@@ -2,63 +2,73 @@
     height: 100%;
 
     form {
-      display: flex;
-      height: 100%;
-      flex-direction: column;
+        display: flex;
+        height: 100%;
+        flex-direction: column;
 
-      .setting-section {
-          border: 1px solid #bbb;
-          border-radius: 5px;
-          margin-top: 5px;
-          padding:2px;
+        .setting-section {
+            border: 1px solid #bbb;
+            border-radius: 5px;
+            margin-top: 5px;
+            padding: 2px;
 
-          h3 {
-              margin:0;
-              cursor:pointer;
-          }
+            h3 {
+                margin: 0;
+                cursor: pointer;
+            }
 
-          dt {
-              width:10%;
-          }
+            dt {
+                width: 10%;
+            }
 
-          /* Checkbox */
-          dt > input[type="checkbox"] {
-              transform: none;
-              flex: none;
-              height: auto;
-              margin: 3px 3px;
-          }
+            /* Checkbox */
+            dt > input[type="checkbox"] {
+                transform: none;
+                flex: none;
+                height: auto;
+                margin: 3px 3px;
+            }
 
-          dd {
-              width:88%;
-          }
-      }
+            dd {
+                width: 88%;
+            }
+        }
 
-      dl {
-          margin: 5px 0;
-      }
+        dl {
+            margin: 5px 0;
+        }
 
-      dt {
-          display:inline-block;
-          width:40%;
-          padding-left:5px;
-      }
+        dt {
+            display: inline-block;
+            width: 40%;
+            padding-left: 5px;
+        }
 
-      dd {
-          display:inline-block;
-          width:58%;
-          margin-left:0;
-      }
+        dd {
+            display: inline-block;
+            width: 58%;
+            margin-left: 0;
+        }
 
-      .settings-container {
-          overflow-y: auto;
-          display: flex;
-          flex-wrap: wrap;
+        .settings-container {
+            overflow-y: auto;
+            display: flex;
+            flex-wrap: wrap;
 
-          div {
-              width: 375px;
-              margin-right: 1em;
-          }
-      }
-  }
+            .single-column {
+                width: 100%;
+            }
+
+            h2 {
+                margin-top: 1em;
+                margin-bottom: 0.5em;
+                width: 100%;
+            }
+
+            div {
+                width: 375px;
+                margin-right: 1em;
+            }
+        }
+    }
 }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2680,12 +2680,12 @@
                 "Name": "Compendium Browser Packs"
             },
             "CompendiumBrowserSources": {
-                "DeleteAllInfo": "This can not be undone, but you may reconfigure this. The settings will be set to allow all sources, which include known sources, empty sources and unknown sources.",
-                "DeleteAllQuestion": "Are you sure you want to delete the filter sources settings?",
-                "DeleteAllTitle": "Delete filter sources settings",
+                "DeleteAllInfo": "All compendium documents will become browseable, including those with empty sources.",
+                "DeleteAllQuestion": "Are you sure you want to reset all settings for included sources?",
+                "DeleteAllTitle": "Reset Settings",
                 "Hint": "Settings to display only entries with specified sources in the compendium browser.",
                 "IgnoreAsGM": "Let GMs ignore filtering and see all entries.",
-                "Name": "Compendium Browser Specify Sources",
+                "Name": "Included Sources",
                 "ShowEmptySources": "Do not filter entries with empty sources.",
                 "ShowUnknownSources": "Do not filter entries with unknown sources.",
                 "SourcesListHeader": "Specified Sources"

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -706,7 +706,7 @@
             "TabEquipment": "Equipment",
             "TabFeat": "Feats/Features",
             "TabHazard": "Hazards",
-            "TabSettings": "Load Packs",
+            "TabSettings": "Settings",
             "TabSpell": "Spells",
             "TakeLabel": "Take Item",
             "Title": "Compendium Browser"
@@ -2678,6 +2678,17 @@
             "CompendiumBrowserPacks": {
                 "Hint": "Settings to exclude packs from loading",
                 "Name": "Compendium Browser Packs"
+            },
+            "CompendiumBrowserSources": {
+                "DeleteAllInfo": "This can not be undone, but you may reconfigure this. The settings will be set to allow all sources, which include known sources, empty sources and unknown sources.",
+                "DeleteAllQuestion": "Are you sure you want to delete the filter sources settings?",
+                "DeleteAllTitle": "Delete filter sources settings",
+                "Hint": "Settings to display only entries with specified sources in the compendium browser.",
+                "IgnoreAsGM": "Let GMs ignore filtering and see all entries.",
+                "Name": "Compendium Browser Specify Sources",
+                "ShowEmptySources": "Do not filter entries with empty sources.",
+                "ShowUnknownSources": "Do not filter entries with unknown sources.",
+                "SourcesListHeader": "Specified Sources"
             },
             "CritRule": {
                 "Choices": {

--- a/static/templates/compendium-browser/browser-settings.hbs
+++ b/static/templates/compendium-browser/browser-settings.hbs
@@ -1,10 +1,11 @@
 <div class="compendium-browser-settings">
     <form autocomplete="off">
         <div class="settings-container">
+            <h2>{{localize "PF2E.SETTINGS.CompendiumBrowserPacks.Name"}}</h2>
             <div class="setting-section">
                 <h3>{{localize "PF2E.CompendiumBrowser.TabAction"}}</h3>
                 <dl>
-                    {{#each action as |conf pack|}}
+                    {{#each settings.action as |conf pack|}}
                         <label><dt><input type="checkbox" name="action-{{pack}}" {{checked conf.load}}></dt><dd>{{conf.name}}</dd></label>
                     {{/each}}
                 </dl>
@@ -13,7 +14,7 @@
             <div class="setting-section">
                 <h3>{{localize "PF2E.CompendiumBrowser.TabBestiary"}}</h3>
                 <dl>
-                    {{#each bestiary as |conf pack|}}
+                    {{#each settings.bestiary as |conf pack|}}
                         <label><dt><input type="checkbox" name="bestiary-{{pack}}" {{checked conf.load}}></dt><dd>{{conf.name}}</dd></label>
                     {{/each}}
                 </dl>
@@ -22,7 +23,7 @@
             <div class="setting-section">
                 <h3>{{localize "PF2E.CompendiumBrowser.TabEquipment"}}</h3>
                 <dl>
-                    {{#each equipment as |conf pack|}}
+                    {{#each settings.equipment as |conf pack|}}
                         <label><dt><input type="checkbox" name="equipment-{{pack}}" {{checked conf.load}}></dt><dd>{{conf.name}}</dd></label>
                     {{/each}}
                 </dl>
@@ -31,7 +32,7 @@
             <div class="setting-section">
                 <h3>{{localize "PF2E.CompendiumBrowser.TabFeat"}}</h3>
                 <dl>
-                    {{#each feat as |conf pack|}}
+                    {{#each settings.feat as |conf pack|}}
                         <label><dt><input type="checkbox" name="feat-{{pack}}" {{checked conf.load}}></dt><dd>{{conf.name}}</dd></label>
                     {{/each}}
                 </dl>
@@ -40,7 +41,7 @@
             <div class="setting-section">
                 <h3>{{localize "PF2E.CompendiumBrowser.TabHazard"}}</h3>
                 <dl>
-                    {{#each hazard as |conf pack|}}
+                    {{#each settings.hazard as |conf pack|}}
                         <label><dt><input type="checkbox" name="hazard-{{pack}}" {{checked conf.load}}></dt><dd>{{conf.name}}</dd></label>
                     {{/each}}
                 </dl>
@@ -49,10 +50,55 @@
             <div class="setting-section">
                 <h3>{{localize "PF2E.CompendiumBrowser.TabSpell"}}</h3>
                 <dl>
-                    {{#each spell as |conf pack|}}
+                    {{#each settings.spell as |conf pack|}}
                         <label><dt><input type="checkbox" name="spell-{{pack}}" {{checked conf.load}}></dt><dd>{{conf.name}}</dd></label>
                     {{/each}}
                 </dl>
+            </div>
+
+            <h2>{{localize "PF2E.SETTINGS.CompendiumBrowserSources.Name"}}</h2>
+            <p>
+                {{localize "PF2E.SETTINGS.CompendiumBrowserSources.Hint"}}
+            </p>
+
+            <div class="setting-section single-column">
+                <h3>{{localize "PF2E.SETTINGS.Settings"}}</h3>
+                <dl>
+                    <label>
+                        <dt><input type="checkbox" name="show-empty-sources" {{checked sources.showEmptySources}}></dt>
+                        <dd>{{localize "PF2E.SETTINGS.CompendiumBrowserSources.ShowEmptySources"}}</dd>
+                    </label>
+                </dl>
+
+                <dl>
+                    <label>
+                        <dt><input type="checkbox" name="show-unknown-sources" {{checked sources.showUnknownSources}}></dt>
+                        <dd>{{localize "PF2E.SETTINGS.CompendiumBrowserSources.ShowUnknownSources"}}</dd>
+                    </label>
+                </dl>
+
+                <dl>
+                    <label>
+                        <dt><input type="checkbox" name="ignore-as-gm" {{checked sources.ignoreAsGM}}></dt>
+                        <dd>{{localize "PF2E.SETTINGS.CompendiumBrowserSources.IgnoreAsGM"}}</dd>
+                    </label>
+                </dl>
+
+                <button type="button" data-action="settings-sources-delete">{{localize "PF2E.SETTINGS.CompendiumBrowserSources.DeleteAllTitle"}}</button>
+            </div>
+
+            <div class="setting-section single-column">
+                <h3>{{localize "PF2E.SETTINGS.CompendiumBrowserSources.SourcesListHeader"}}</h3>
+                <dl>
+                    <dt><input type="checkbox" data-action="setting-sources-toggle-visible" /></dt>
+                    <dd><input type="text" data-element="setting-sources-search" /></dd>
+                    {{#each sources.sources}}
+                        <label data-element="setting-source" data-name="{{this.name}}">
+                            <dt><input type="checkbox" name="source-{{@key}}" {{checked this.load}}></dt>
+                            <dd>{{this.name}}</dd>
+                        </label>
+                    {{/each}}
+                <dl>
             </div>
         </div>
 


### PR DESCRIPTION
This adds a new world setting, to save, which entries should to be displayed in the compendium browser by specifying wanted sources. For the GM a new section in the "Load Packs"/Settings page is added to set this up. By default this behaves as before, letting all entries show up.

In the bellow screenshots it shows the equipment tab before setting up the new settings, setting up the settings and then the filtered equipment list.

Equipment Before:

![1_equipment_before](https://user-images.githubusercontent.com/1103564/233772286-50beb233-fdc4-4ca0-91a9-daae6051bf3e.png)

New Settings:

![2_settings_example](https://user-images.githubusercontent.com/1103564/233772296-cdb2be23-bdad-4958-bee7-45321017b543.png)

Equipment After, note the changed sources filter. Also the Alchemical Crossbow is not showing up anymore:

![3_equipment_after](https://user-images.githubusercontent.com/1103564/233772301-12ff815d-4c09-4b77-b6db-83e6e14ae607.png)

This mostly works, but there are at least the following issues:

- [x] ~Settings UI is pretty bad, though it only concerns GMs~. It is still not great, but it should be ok. I would expect a GM would not change this setting all that often, after they have it set up the first time. Of course they may want to change it in case new content came out.
    - [x] ~Checking 200 Checkboxes for if you want the source or not is annoying.~ Sources can be filtered via a text box and toggled on and off in bulk, this should mostly solve this.
    - [x] ~After changing the sources, the GM will see the sources as slugs of already loaded documents until they reload the application.~ This is fixed
- [ ] Now the reason some information is not shown can be that either the pack is not loaded OR the source is not allowed. Not sure how to avoid this easily. It still makes sense to disallow whole packs, to improve loading.
- [x] New Sources are automatically marked allowed on settings screen by default, there is a setting to change this
    - [x] ~this could be an additional setting~. Added additional setting
    - [x] ~GM still needs to got to the settings page and click save, so that new sources become active.~ This is fixed
- [x] ~Items with no sources are currently displayed, this could be an additional setting~. Added additional setting
- [x] ~Using translated content adds additional checkboxes to the settings UI, because now there are new sources. This is mostly fine, but GMs may need to switch languages to set this up. I'm not sure if there are many groups using different languages, but who knows.~ The sources settings can be deleted, which should remove non existent sources from the settings UI.
- [x] Nonexistent sources are not deleted. This makes it possible to use multiple languages, ~but also means the list will get longer, the more is translated.~ The GM can now delete / reset the sources settings, which will go back to the defaults of allowing all sources, including known sources, new / unknown sources and empty sources.
- [x] ~Loading the settings page is slower, because all sources need to be found. I did only test this on my local machine. It mostly did not feel worse, but that could be different, depending on the situation (server performance, internet connection, client performance, ...)~ Tested on a VM for both client and server, where foundry itself is barely usable, and the impact is negligible.
- [x] ~Normal loading did seem to be not really impacted, but again I did not test this excessively.~ Tested on a VM for both client and server, where foundry itself is barely usable, and the impact is negligible.

It may be possible to add the new world setting to the existing CompendiumBrowserSettings. I'm not sure if that is the best idea, it would at least require a new migration and It may make sense to split the configuration up for ease of use / better ui/ux, later on anyways. I'm also not super great with creating Types in TypeScript (yet) and did not want to do to many changes on the existing code if I can avoid that.

See also: #3957