### PR TITLE
Set Hydra Heads effect counter default to 1

### DIFF
--- a/packs/data/bestiary-effects.db/effect-hydra-heads.json
+++ b/packs/data/bestiary-effects.db/effect-hydra-heads.json
@@ -5,7 +5,7 @@
     "system": {
         "badge": {
             "type": "counter",
-            "value": 5
+            "value": 1
         },
         "description": {
             "value": "<p>The number of heads the hydra currently has.</p>"


### PR DESCRIPTION
the effect will still be changed to the hydras starting amount of heads on the npc actor, this will just make it so when a hydra grows more heads from 0, dragging on the effect again will not jump the head count to 5 