### PR TITLE
Add silversheen equipment effect

### DIFF
--- a/packs/data/equipment-effects.db/effect-silversheen.json
+++ b/packs/data/equipment-effects.db/effect-silversheen.json
@@ -1,0 +1,62 @@
+{
+    "_id": "dfnhwI5pJgLtXh2k",
+    "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-tools/silversheen.webp",
+    "name": "Effect: Silversheen",
+    "system": {
+        "badge": {
+            "type": "counter",
+            "value": 10
+        },
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.equipment-srd.Silversheen]{Silversheen}</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "hours",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "rules": [
+            {
+                "choices": {
+                    "ownedItems": true,
+                    "types": [
+                        "weapon"
+                    ]
+                },
+                "flag": "effectSilversheen",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.Weapon"
+            },
+            {
+                "definition": [
+                    "item:id:{item|flags.pf2e.rulesSelections.effectSilversheen}"
+                ],
+                "key": "AdjustStrike",
+                "mode": "add",
+                "property": "materials",
+                "value": "silver"
+            }
+        ],
+        "source": {
+            "value": "Pathfinder Core Rulebook"
+        },
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "target": null,
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "rarity": "common",
+            "value": []
+        },
+        "unidentified": false
+    },
+    "type": "effect"
+}

--- a/packs/data/equipment.db/silversheen.json
+++ b/packs/data/equipment.db/silversheen.json
@@ -19,7 +19,7 @@
         },
         "containerId": null,
         "description": {
-            "value": "<p><strong>Activate</strong> <span class=\"pf2-icon\">A</span> Interact</p>\n<p>You can slather this silvery paste onto one melee weapon, one thrown weapon, or 10 pieces of ammunition. Silversheen spoils quickly, so once you open a vial, you must use it all at once, rather than saving it.</p>\n<p>For the next hour, the weapon or ammunition counts as silver instead of its normal precious material (such as cold iron) for any physical damage it deals.</p>"
+            "value": "<p><strong>Activate</strong> <span class=\"pf2-icon\">A</span> Interact</p>\n<p>You can slather this silvery paste onto one melee weapon, one thrown weapon, or 10 pieces of ammunition. Silversheen spoils quickly, so once you open a vial, you must use it all at once, rather than saving it.</p>\n<p>For the next hour, the weapon or ammunition counts as silver instead of its normal precious material (such as cold iron) for any physical damage it deals.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Effect: Silversheen]{Effect: Silversheen}</p>"
         },
         "equippedBulk": {
             "value": ""


### PR DESCRIPTION
This helps further automate IWR with respect to silvered weapons.
This was inspired by the automation of the monk class feat Metal Strikes https://2e.aonprd.com/Classes.aspx?ID=8

The reason for the counter being 10 is for ammunition