### PR TITLE
Flip default of "lootableNPCs" setting

### DIFF
--- a/src/module/system/settings/automation.ts
+++ b/src/module/system/settings/automation.ts
@@ -59,7 +59,7 @@ export class AutomationSettings extends SettingsMenuPF2e {
             lootableNPCs: {
                 name: CONFIG.PF2E.SETTINGS.automation.lootableNPCs.name,
                 hint: CONFIG.PF2E.SETTINGS.automation.lootableNPCs.hint,
-                default: false,
+                default: true,
                 type: Boolean,
             },
         };


### PR DESCRIPTION
The GMG assumes all creatures are lootable:
> If you gave a creature gear equivalent to a PC, your PCs would gain a huge amount of treasure by defeating a large group of them. Using Table 2–4: Safe Items can help you avoid that. A creature can have a single permanent item of the listed level without issue.