### PR TITLE
Highlight grid area of `MeasuredTemplatePF2e` previews

### DIFF
--- a/src/module/canvas/helpers.ts
+++ b/src/module/canvas/helpers.ts
@@ -167,9 +167,16 @@ function measureDistanceOnGrid(
 }
 
 /** Highlight grid according to Pathfinder 2e effect-area shapes */
-function highlightGrid({ type, object, colors, document, collisionType = "move" }: HighlightGridParams): void {
+function highlightGrid({
+    type,
+    object,
+    colors,
+    document,
+    collisionType = "move",
+    preview = false,
+}: HighlightGridParams): void {
     // Only highlight for objects that are non-previews (have IDs)
-    if (!object.id) return;
+    if (!object.id && !preview) return;
 
     const { grid, dimensions } = canvas;
     if (!(grid && dimensions)) return;
@@ -311,6 +318,7 @@ interface HighlightGridParams {
         width: number;
     }>;
     collisionType?: WallRestrictionType;
+    preview?: boolean;
 }
 
 export { highlightGrid, measureDistanceCuboid };

--- a/src/module/canvas/measured-template.ts
+++ b/src/module/canvas/measured-template.ts
@@ -29,6 +29,7 @@ class MeasuredTemplatePF2e extends MeasuredTemplate<MeasuredTemplateDocumentPF2e
             object: this,
             document: this.document,
             colors: { border: this.borderColor, fill: this.fillColor },
+            preview: true,
         });
     }
 


### PR DESCRIPTION
I'm pretty sure this used to be a thing so it's either a bugfix or an enhancement.

Before:
![before](https://user-images.githubusercontent.com/41452412/221370775-79c11f92-708a-4c2c-8d50-0f4b4f123bcd.png)

After:
![after](https://user-images.githubusercontent.com/41452412/221370777-a8bfba7e-87bb-47c6-b16f-69d37ad24bee.png)
