### PR TITLE
Add confirmation popup when deleting a formula

### DIFF
--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -485,16 +485,26 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
             .on("click", (event) => this.onClickItemToChat(event));
 
         // Delete Formula
-        $html.find(".formula-delete").on("click", (event) => {
+        $html.find(".formula-delete").on("click", async (event) => {
             event.preventDefault();
 
-            const itemUuid = $(event.currentTarget).parents(".item").attr("data-item-id");
-            if (!itemUuid) return;
+            const itemElement = event.currentTarget.closest(".item");
+            const itemUuid = itemElement?.getAttribute("data-item-id");
+            if (!itemUuid || !itemElement) return;
 
             if (this.actor.isOfType("character")) {
-                const actorFormulas = (this.actor.toObject().system as CharacterPF2e["system"]).crafting.formulas ?? [];
-                actorFormulas.findSplice((f) => f.uuid === itemUuid);
-                this.actor.update({ "system.crafting.formulas": actorFormulas });
+                const itemName = itemElement.getAttribute("data-item-name");
+                const title = game.i18n.localize("PF2E.DeleteItemTitle");
+                const content = await renderTemplate("systems/pf2e/templates/actors/delete-item-dialog.hbs", {
+                    name: itemName,
+                });
+
+                if (await Dialog.confirm({ title, content })) {
+                    const actorFormulas =
+                        (this.actor.toObject().system as CharacterPF2e["system"]).crafting.formulas ?? [];
+                    actorFormulas.findSplice((f) => f.uuid === itemUuid);
+                    this.actor.update({ "system.crafting.formulas": actorFormulas });
+                }
             }
         });
 

--- a/static/templates/actors/character/tabs/crafting.hbs
+++ b/static/templates/actors/character/tabs/crafting.hbs
@@ -44,7 +44,7 @@
                     </li>
                     <!-- Add formula items for each formula level -->
                     {{#each section as |craftedItem i|}}
-                        <li class="item formula-item" data-formula-lvl="{{lvl}}" data-item-id="{{craftedItem.uuid}}" data-is-formula="true">
+                        <li class="item formula-item" data-formula-lvl="{{lvl}}" data-item-id="{{craftedItem.uuid}}" data-item-name="{{craftedItem.name}}" data-is-formula="true">
                             <div class="item-name rollable">
                                 <div class="item-image">
                                     <img class="item-icon" src="{{craftedItem.img}}" alt="{{craftedItem.name}}">


### PR DESCRIPTION
When deleting other options like items or spells a confirmation popup is already used, this updates the crafting tab, so formulas are not accidentally deleted.

See also: #6086 