### PR TITLE
Data entry: Changed wrong damage type necrotic in lazurite-infused stone golem

### DIFF
--- a/packs/data/age-of-ashes-bestiary.db/lazurite-infused-stone-golem.json
+++ b/packs/data/age-of-ashes-bestiary.db/lazurite-infused-stone-golem.json
@@ -269,7 +269,7 @@
                     "value": 1
                 },
                 "description": {
-                    "value": "<p>Each creature in a @Template[type:emanation|distance:10] must succeed at a @Check[type:fortitude|dc:32|name:Necrotic Pulese] save or take [[/r 1d6[persistent,necrotic]]] damage and be @UUID[Compendium.pf2e.conditionitems.Slowed]{Slowed 1} for 1 minute as their flesh and bones temporarily atrophy.</p>\n<p data-visibility=\"owner\">The golem can't use Necrotic Pulse again for [[/br 1d4 #rounds]]{1d4 rounds}.</p>"
+                    "value": "<p>Each creature in a @Template[type:emanation|distance:10] must succeed at a @Check[type:fortitude|dc:32|name:Necrotic Pulse] save or take [[/r 1d6[persistent,negative]]] damage and be @UUID[Compendium.pf2e.conditionitems.Slowed]{Slowed 1} for 1 minute as their flesh and bones temporarily atrophy.</p>\n<p data-visibility=\"owner\">The golem can't use Necrotic Pulse again for [[/br 1d4 #rounds]]{1d4 rounds}.</p>"
                 },
                 "requirements": {
                     "value": ""


### PR DESCRIPTION
Changed wrong damage type necrotic to negative in lazurite-infused stone golem from age-of-ashes-bestiary