### PR TITLE
Fix Order Explorer automation

### DIFF
--- a/packs/data/feats.db/order-explorer.json
+++ b/packs/data/feats.db/order-explorer.json
@@ -83,14 +83,14 @@
                         "value": "Compendium.pf2e.classfeatures.Wild Order"
                     }
                 ],
-                "flag": "second-order",
+                "flag": "secondorder",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Druid.DruidicOrder.Prompt",
                 "rollOption": "feat:order-explorer"
             },
             {
                 "key": "GrantItem",
-                "uuid": "{item|flags.pf2e.rulesSelections.second-order}"
+                "uuid": "{item|flags.pf2e.rulesSelections.secondorder}"
             }
         ],
         "source": {


### PR DESCRIPTION
Removing the dash in the flag makes it work
![image](https://user-images.githubusercontent.com/63196064/221895018-c21ef7a1-2e8b-414c-bb2d-2b7df82ace9a.png)
Fixes #6681 