### PR TITLE
Update Jellyfish Stance per FotRP Hardcover

### DIFF
--- a/packs/data/feat-effects.db/stance-jellyfish-stance.json
+++ b/packs/data/feat-effects.db/stance-jellyfish-stance.json
@@ -23,7 +23,7 @@
                     "base": {
                         "damageType": "slashing",
                         "dice": 1,
-                        "die": "d8"
+                        "die": "d6"
                     }
                 },
                 "group": "brawling",

--- a/packs/data/feat-effects.db/stance-jellyfish-stance.json
+++ b/packs/data/feat-effects.db/stance-jellyfish-stance.json
@@ -5,7 +5,7 @@
     "system": {
         "badge": null,
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Jellyfish Stance]{Jellyfish Stance}</p>\n<p><strong>Requirements</strong> You are unarmored.</p>\n<p>You relax your posture and loosen your joints, allowing yourself to move with incredible fluidity. You can make stinging lash attacks that deal 1d8 slashing damage. These attacks are in the brawling group, and have the finesse, nonlethal, reach, and unarmed traits.</p>\n<p>While in Jellyfish Stance, you gain a +2 circumstance bonus to Reflex saves and on checks to @UUID[Compendium.pf2e.actionspf2e.Escape]{Escape} and @UUID[Compendium.pf2e.actionspf2e.Squeeze]{Squeeze}.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Jellyfish Stance]{Jellyfish Stance}</p>\n<p><strong>Requirements</strong> You are unarmored.</p>\n<p>You relax your posture and loosen your joints, allowing yourself to move with incredible fluidity. You can make stinging lash attacks that deal 1d6 slashing damage. These attacks are in the brawling group, and have the finesse, nonlethal, reach, and unarmed traits.</p>\n<p>While in Jellyfish Stance, you gain a +2 circumstance bonus to Reflex saves and on checks to @UUID[Compendium.pf2e.actionspf2e.Escape]{Escape} and @UUID[Compendium.pf2e.actionspf2e.Squeeze]{Squeeze}.</p>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -80,7 +80,7 @@
             }
         ],
         "source": {
-            "value": "Pathfinder #167: Ready? Fight!"
+            "value": "Pathfinder Fists of the Ruby Phoenix Hardcover Compilation"
         },
         "start": {
             "initiative": null,

--- a/packs/data/feats.db/jellyfish-stance.json
+++ b/packs/data/feats.db/jellyfish-stance.json
@@ -23,7 +23,7 @@
         },
         "rules": [],
         "source": {
-            "value": "Fists of the Ruby Phoenix Hardcover Compilation"
+            "value": "Pathfinder Fists of the Ruby Phoenix Hardcover Compilation"
         },
         "traits": {
             "rarity": "uncommon",

--- a/packs/data/feats.db/jellyfish-stance.json
+++ b/packs/data/feats.db/jellyfish-stance.json
@@ -10,20 +10,20 @@
             "value": 1
         },
         "description": {
-            "value": "<p><strong>Requirements</strong> You are unarmored.</p>\n<p>You relax your posture and loosen your joints, allowing yourself to move with incredible fluidity. You can make stinging lash attacks that deal 1d8 slashing damage. These attacks are in the brawling group, and have the finesse, nonlethal, reach, and unarmed traits.</p>\n<p>While in Jellyfish Stance, you gain a +2 circumstance bonus to Reflex saves and on checks to @UUID[Compendium.pf2e.actionspf2e.Escape]{Escape} and @UUID[Compendium.pf2e.actionspf2e.Squeeze]{Squeeze}.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Stance: Jellyfish Stance]{Stance: Jellyfish Stance}</p>"
+            "value": "<p><strong>Requirements</strong> You are unarmored.</p>\n<p>You relax your posture and loosen your joints, allowing yourself to move with incredible fluidity. You can make stinging lash attacks that deal 1d6 slashing damage. These attacks are in the brawling group, and have the finesse, nonlethal, reach, and unarmed traits.</p>\n<p>While in Jellyfish Stance, you gain a +2 circumstance bonus to Reflex saves and on checks to @UUID[Compendium.pf2e.actionspf2e.Escape]{Escape} and @UUID[Compendium.pf2e.actionspf2e.Squeeze]{Squeeze}.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Stance: Jellyfish Stance]{Stance: Jellyfish Stance}</p>"
         },
         "featType": {
             "value": "class"
         },
         "level": {
-            "value": 6
+            "value": 8
         },
         "prerequisites": {
             "value": []
         },
         "rules": [],
         "source": {
-            "value": "Pathfinder #167: Ready? Fight!"
+            "value": "Fists of the Ruby Phoenix Hardcover Compilation"
         },
         "traits": {
             "rarity": "uncommon",


### PR DESCRIPTION
FotRP Hardcover changed this to level 8 (from 6) and 1d6 damage (from 1d8)