### PR TITLE
Don't rerender actor sheets every turn change

### DIFF
--- a/src/module/actor/helpers.ts
+++ b/src/module/actor/helpers.ts
@@ -29,7 +29,7 @@ import { ZeroToTwo } from "@module/data";
 import { UUIDUtils } from "@util/uuid-utils";
 
 /** Reset and rerender a provided list of actors. Omit argument to reset all world and synthetic actors */
-async function resetAndRerenderActors(actors?: Iterable<ActorPF2e>): Promise<void> {
+async function resetActors(actors?: Iterable<ActorPF2e>, { rerender = true } = {}): Promise<void> {
     actors ??= [
         game.actors.contents,
         game.scenes.contents.flatMap((s) => s.tokens.contents).flatMap((t) => t.actor ?? []),
@@ -37,7 +37,7 @@ async function resetAndRerenderActors(actors?: Iterable<ActorPF2e>): Promise<voi
 
     for (const actor of actors) {
         actor.reset();
-        ui.windows[actor.sheet.appId]?.render();
+        if (rerender) actor.render();
     }
     game.pf2e.effectPanel.refresh();
 
@@ -461,6 +461,6 @@ export {
     getRangeIncrement,
     isReallyPC,
     migrateActorSource,
-    resetAndRerenderActors,
+    resetActors,
     strikeFromMeleeItem,
 };

--- a/src/module/canvas/status-effects.ts
+++ b/src/module/canvas/status-effects.ts
@@ -5,7 +5,7 @@ import { TokenPF2e } from "@module/canvas/token";
 import { EncounterPF2e } from "@module/encounter";
 import { ChatMessagePF2e } from "@module/chat-message";
 import { PersistentDialog } from "@item/condition/persistent-damage-dialog";
-import { resetAndRerenderActors } from "@actor/helpers";
+import { resetActors } from "@actor/helpers";
 
 const debouncedRender = foundry.utils.debounce(() => {
     canvas.tokens.hud.render();
@@ -51,7 +51,7 @@ export class StatusEffects {
         CONFIG.PF2E.statusEffects.iconDir = iconDir;
         CONFIG.PF2E.statusEffects.lastIconTheme = chosenSetting;
         this.#updateStatusIcons();
-        await resetAndRerenderActors();
+        await resetActors();
         if (canvas.ready) {
             for (const token of canvas.tokens.placeables) {
                 token.drawEffects();

--- a/src/module/encounter/document.ts
+++ b/src/module/encounter/document.ts
@@ -1,7 +1,7 @@
 import { CharacterPF2e, NPCPF2e } from "@actor";
 import { CharacterSheetPF2e } from "@actor/character/sheet";
 import { RollInitiativeOptionsPF2e } from "@actor/data";
-import { resetAndRerenderActors } from "@actor/helpers";
+import { resetActors } from "@actor/helpers";
 import { SKILL_DICTIONARY } from "@actor/values";
 import { ScenePF2e } from "@scene";
 import { LocalizePF2e } from "@system/localize";
@@ -126,7 +126,7 @@ class EncounterPF2e extends Combat {
     /** Rerun data preparation for participating actors and the scene, refresh perception */
     #resetActorAndSceneData(): void {
         const actors = this.combatants.contents.flatMap((c) => c.actor ?? []);
-        resetAndRerenderActors(actors);
+        resetActors(actors, { rerender: false });
     }
 
     /* -------------------------------------------- */

--- a/src/module/system/effect-tracker.ts
+++ b/src/module/system/effect-tracker.ts
@@ -1,5 +1,5 @@
 import { ActorPF2e } from "@actor";
-import { resetAndRerenderActors } from "@actor/helpers";
+import { resetActors } from "@actor/helpers";
 import type { EffectPF2e } from "@item/index";
 import { EncounterPF2e } from "@module/encounter";
 
@@ -97,7 +97,7 @@ export class EffectTracker {
                 await this.#removeExpired(actor);
             }
         } else if (game.settings.get("pf2e", "automation.effectExpiration")) {
-            resetAndRerenderActors(actorsToUpdate);
+            resetActors(actorsToUpdate);
         }
     }
 

--- a/src/module/system/settings/index.ts
+++ b/src/module/system/settings/index.ts
@@ -1,4 +1,4 @@
-import { resetAndRerenderActors } from "@actor/helpers";
+import { resetActors } from "@actor/helpers";
 import { ActorSheetPF2e } from "@actor/sheet/base";
 import { ItemPF2e, ItemSheetPF2e } from "@item";
 import { StatusEffects } from "@module/canvas/status-effects";
@@ -130,7 +130,7 @@ export function registerSettings(): void {
         default: false,
         type: Boolean,
         onChange: () => {
-            resetAndRerenderActors();
+            resetActors();
         },
     });
 

--- a/src/module/system/settings/variant-rules.ts
+++ b/src/module/system/settings/variant-rules.ts
@@ -1,4 +1,4 @@
-import { resetAndRerenderActors } from "@actor/helpers";
+import { resetActors } from "@actor/helpers";
 
 const SETTINGS: Record<string, SettingRegistration> = {
     gradualBoostsVariant: {
@@ -46,7 +46,7 @@ const SETTINGS: Record<string, SettingRegistration> = {
             ABPRulesAsWritten: "PF2E.SETTINGS.Variant.AutomaticBonus.Choices.ABPRulesAsWritten",
         },
         onChange: () => {
-            resetAndRerenderActors(game.actors.filter((a) => a.type === "character"));
+            resetActors(game.actors.filter((a) => a.type === "character"));
         },
     },
     proficiencyVariant: {

--- a/src/scripts/hooks/ready.ts
+++ b/src/scripts/hooks/ready.ts
@@ -1,4 +1,4 @@
-import { resetAndRerenderActors } from "@actor/helpers";
+import { resetActors } from "@actor/helpers";
 import { MigrationSummary } from "@module/apps/migration-summary";
 import { SceneDarknessAdjuster } from "@module/apps/scene-darkness-adjuster";
 import { SetAsInitiative } from "@module/chat-message/listeners/set-as-initiative";
@@ -108,7 +108,7 @@ export const Ready = {
             // Now that all game data is available, reprepare actor data among those actors currently in an encounter
             const participants = game.combats.contents.flatMap((e) => e.combatants.contents);
             const fightyActors = new Set(participants.flatMap((c) => c.actor ?? []));
-            resetAndRerenderActors(fightyActors);
+            resetActors(fightyActors);
 
             // Prepare familiars now that all actors are initialized
             for (const familiar of game.actors.filter((a) => a.type === "familiar")) {


### PR DESCRIPTION
This turned out to be extremely annoying for anyone doing something in their actor sheet when a turn changes