### PR TITLE
Build out `EphemeralEffect` item alteration and add support for multiple alteration properties to the mixin

### DIFF
--- a/src/module/rules/rule-element/grant-item/rule-element.ts
+++ b/src/module/rules/rule-element/grant-item/rule-element.ts
@@ -58,6 +58,7 @@ class GrantItemRuleElement extends RuleElementPF2e {
         this.grantedId = this.item.flags.pf2e.itemGrants[this.flag ?? ""]?.id ?? null;
 
         this.alterations = data.alterations && this.isValidItemAlteration(data.alterations) ? data.alterations : [];
+        this.allowedAlterations = ["badge-value"];
     }
 
     static ON_DELETE_ACTIONS = ["cascade", "detach", "restrict"] as const;

--- a/src/module/rules/rule-element/mixins.ts
+++ b/src/module/rules/rule-element/mixins.ts
@@ -1,12 +1,22 @@
 import { ItemSourcePF2e } from "@item/data";
+import { tupleHasValue } from "@util";
 import { AELikeChangeMode } from "./ae-like";
 import { RuleElementPF2e } from "./base";
 import { RuleElementSchema } from "./data";
 
 /** A mixin for rule elements that allow item alterations */
 abstract class WithItemAlterations<TSchema extends RuleElementSchema> {
+    /** Every class using the mixin must define its allowed alterations here */
+    allowedAlterations: AllowedItemAlteration[] = [];
+
     static apply<TSchema extends RuleElementSchema>(Class: typeof RuleElementPF2e<TSchema>): void {
-        for (const methodName of ["itemCanBeAltered", "isValidItemAlteration", "applyAlterations"] as const) {
+        for (const methodName of [
+            "itemCanBeAltered",
+            "isValidItemAlteration",
+            "isValidItemAlterationValue",
+            "applyAlteration",
+            "applyAlterations",
+        ] as const) {
             Object.defineProperty(Class.prototype, methodName, {
                 enumerable: false,
                 writable: false,
@@ -25,65 +35,114 @@ abstract class WithItemAlterations<TSchema extends RuleElementSchema> {
                     "mode" in d &&
                     d.mode === "override" &&
                     "property" in d &&
-                    d.property === "badge-value" &&
+                    tupleHasValue(this.allowedAlterations, d.property) &&
                     "value" in d &&
                     (["string", "number"].includes(typeof d.value) || d.value === null)
             )
         );
     }
 
+    isValidItemAlterationValue(value: unknown): value is string | number | null {
+        const valid = typeof value === "string" || typeof value === "number" || value === null;
+        if (!valid) {
+            this.failValidation(`alteration value "${value}" has wrong type "${typeof value}"`);
+        }
+        return valid;
+    }
+
     /** Is the item alteration valid for the item type? */
-    itemCanBeAltered(this: RuleElementPF2e, source: ItemSourcePF2e, value: unknown): boolean | null {
+    itemCanBeAltered(
+        this: WithItemAlterations<TSchema>,
+        source: ItemSourcePF2e,
+        property: AllowedItemAlteration,
+        value: unknown
+    ): boolean | null {
         const sourceId = source.flags.core?.sourceId ? ` (${source.flags.core.sourceId})` : "";
         if (source.type !== "condition" && source.type !== "effect") {
             this.failValidation(`unable to alter "${source.name}"${sourceId}: must be condition or effect`);
             return false;
         }
-
-        const hasBadge =
-            source.type === "condition"
-                ? typeof source.system.value.value === "number"
-                : source.type === "effect"
-                ? source.system.badge?.type === "counter"
-                : false;
-        if (!hasBadge) {
-            this.failValidation(`unable to alter "${source.name}"${sourceId}: effect lacks a badge`);
-        }
-
-        const positiveInteger = typeof value === "number" && Number.isInteger(value) && value > 0;
-        // Hard-coded until condition data can indicate that it can operate valueless
-        const nullValuedStun = value === null && source.system.slug === "stunned";
-        if (!(positiveInteger || nullValuedStun)) {
-            this.failValidation("badge-value alteration not applicable to item");
+        if (!this.isValidItemAlterationValue(value)) {
             return false;
         }
 
-        return hasBadge;
+        switch (property) {
+            case "badge-value": {
+                const hasBadge =
+                    source.type === "condition"
+                        ? typeof source.system.value.value === "number"
+                        : source.type === "effect"
+                        ? source.system.badge?.type === "counter"
+                        : false;
+                if (!hasBadge) {
+                    this.failValidation(`unable to alter "${source.name}"${sourceId}: effect lacks a badge`);
+                    return false;
+                }
+                const positiveInteger = typeof value === "number" && Number.isInteger(value) && value > 0;
+                // Hard-coded until condition data can indicate that it can operate valueless
+                const nullValuedStun = value === null && source.system.slug === "stunned";
+                if (!(positiveInteger || nullValuedStun)) {
+                    this.failValidation("badge-value alteration not applicable to item");
+                    return false;
+                }
+                return true;
+            }
+            default:
+                this.failValidation(`"${property}" is not a valid item alteration`);
+                return false;
+        }
     }
 
-    /** Set the badge value of a condition or effect */
-    applyAlterations(this: WithItemAlterations<TSchema>, itemSource: ItemSourcePF2e): void {
-        for (const alteration of this.alterations) {
-            const value: unknown = this.resolveValue(alteration.value);
-            if (!this.itemCanBeAltered(itemSource, value)) continue;
+    /** Apply one alteration to the item source */
+    applyAlteration(
+        this: WithItemAlterations<TSchema>,
+        { alteration, itemSource, resolvedValue, resolvables }: ApplyAlterationParams
+    ): void {
+        const value = resolvedValue ?? this.resolveValue(alteration.value, { resolvables });
+        if (!this.itemCanBeAltered(itemSource, alteration.property, value)) return;
 
-            if (itemSource.type === "condition" && (typeof value === "number" || value === null)) {
-                itemSource.system.value.value = value;
-            } else if (itemSource.type === "effect" && typeof value === "number") {
-                itemSource.system.badge!.value = value;
+        switch (alteration.property) {
+            case "badge-value": {
+                if (itemSource.type === "condition" && (typeof value === "number" || value === null)) {
+                    itemSource.system.value.value = value;
+                } else if (itemSource.type === "effect" && typeof value === "number") {
+                    itemSource.system.badge!.value = value;
+                }
+                break;
             }
         }
     }
+
+    /** Apply all alterations to the item source */
+    applyAlterations(
+        this: WithItemAlterations<TSchema>,
+        itemSource: ItemSourcePF2e,
+        resolvables?: Record<string, unknown>
+    ): void {
+        for (const alteration of this.alterations) {
+            this.applyAlteration({ itemSource, alteration, resolvables });
+        }
+    }
+}
+
+type AllowedItemAlteration = "badge-value";
+
+interface ApplyAlterationParams {
+    alteration: ItemAlterationData;
+    itemSource: ItemSourcePF2e;
+    resolvedValue?: ItemAlterationData["value"];
+    resolvables?: Record<string, unknown>;
 }
 
 interface WithItemAlterations<TSchema extends RuleElementSchema> extends RuleElementPF2e<TSchema> {
     alterations: ItemAlterationData[];
+    allowedAlterations: AllowedItemAlteration[];
 }
 
 interface ItemAlterationData {
     mode: AELikeChangeMode;
-    property: string;
+    property: AllowedItemAlteration;
     value: string | number | null;
 }
 
-export { ItemAlterationData, WithItemAlterations };
+export { AllowedItemAlteration, ItemAlterationData, WithItemAlterations };

--- a/src/module/system/schema-data-fields.ts
+++ b/src/module/system/schema-data-fields.ts
@@ -100,4 +100,28 @@ class PredicateField<
     }
 }
 
-export { LaxSchemaField, PredicateField, SlugField };
+class ItemAlterationValueField extends fields.DataField<
+    string | number | null,
+    string | number | null,
+    true,
+    true,
+    true
+> {
+    static override get _defaults() {
+        return mergeObject(super._defaults, {
+            required: true,
+            nullable: true,
+            initial: null,
+        });
+    }
+
+    protected _cast(value: unknown): string | number | null {
+        return typeof value === "string" || typeof value === "number" || value === null ? value : null;
+    }
+
+    protected override _validateType(value: unknown): boolean {
+        return typeof value === "string" || typeof value === "number" || value === null;
+    }
+}
+
+export { LaxSchemaField, PredicateField, SlugField, ItemAlterationValueField };


### PR DESCRIPTION
- Added new `ItemAlterationValueField` that allows `string`, `number` or `null` values for now.
- Built out the `alteration` schema in `EphemeralEffect` using the new field.
- Added rudimentary support for other allowed alteration properties which can be defined per class that uses the mixin by overriding the `this.allowedAlterations` array.
- Split off `applyAlteration` method from `applyAlterations` so it's possible to iterate through the alterations in a subclass without that happening in `applyAlterations` again.
- Added parameters to pass `resolvables` or an already `resolvedValue` to `applyAlteration`.
