### PR TITLE
Fix `EphemeralEffect` looping over the same item alterations multiple times

### DIFF
--- a/src/module/rules/rule-element/ephemeral-effect.ts
+++ b/src/module/rules/rule-element/ephemeral-effect.ts
@@ -93,11 +93,14 @@ class EphemeralEffectRuleElement extends RuleElementPF2e<EphemeralEffectSchema> 
 
             const resolvables = params.resolvables ?? {};
             for (const alteration of this.alterations) {
-                const value = this.resolveValue(alteration.value, { resolvables });
-                if (!this.itemCanBeAltered(source, value)) {
+                const resolvedValue = this.resolveValue(alteration.value, { resolvables });
+                if (
+                    !this.isValidItemAlteration("value", resolvedValue) ||
+                    !this.itemCanBeAltered(source, resolvedValue)
+                ) {
                     return null;
                 }
-                this.applyAlterations(source);
+                this.applyAlteration({ itemSource: source, alteration, resolvedValue });
             }
 
             return source;

--- a/src/module/rules/rule-element/grant-item/rule-element.ts
+++ b/src/module/rules/rule-element/grant-item/rule-element.ts
@@ -57,7 +57,8 @@ class GrantItemRuleElement extends RuleElementPF2e {
 
         this.grantedId = this.item.flags.pf2e.itemGrants[this.flag ?? ""]?.id ?? null;
 
-        this.alterations = data.alterations && this.isValidItemAlteration(data.alterations) ? data.alterations : [];
+        this.alterations =
+            data.alterations && this.isValidItemAlteration("array", data.alterations) ? data.alterations : [];
     }
 
     static ON_DELETE_ACTIONS = ["cascade", "detach", "restrict"] as const;


### PR DESCRIPTION
Splits off a new method `WithAlteration#applyAlteration` from `WithAlteration#applyAlterations` to allow for manual looping over the alterations that will be applied,
Also adds a new `type: "array" | "value"` param to `WithAlteration#isValidItemAlteration` to provide a typeguard for alteration values.