### PR TITLE
Prevent double data preparation of embedded items

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -75,8 +75,11 @@ import { CREATURE_ACTOR_TYPES, UNAFFECTED_TYPES } from "./values";
  * @category Actor
  */
 class ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
-    /** Has this actor gone through at least one cycle of data preparation? */
-    private initialized = true;
+    /** Has this actor completed construction? */
+    private constructed = true;
+
+    /** Is this actor preparing its embedded documents? */
+    preparingEmbeds?: boolean;
 
     /** A separate collection of owned physical items for convenient access */
     inventory!: ActorInventory;
@@ -592,7 +595,7 @@ class ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
         }
 
         this.preparePrototypeToken();
-        if (this.initialized && canvas.ready) {
+        if (this.constructed && canvas.ready) {
             // Work around `t.actor` potentially being a lazy getter for a synthetic actor (viz. this one)
             const thisTokenIsControlled = canvas.tokens.controlled.some(
                 (t) => t.document === this.parent || (t.document.actorLink && t.actor === this)
@@ -631,7 +634,9 @@ class ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
 
     /** Prepare the physical-item collection on this actor, item-sibling data, and rule elements */
     override prepareEmbeddedDocuments(): void {
+        this.preparingEmbeds = true;
         super.prepareEmbeddedDocuments();
+        this.preparingEmbeds = false;
         const physicalItems: Embedded<PhysicalItemPF2e>[] = this.items.filter(
             (item) => item instanceof PhysicalItemPF2e
         );

--- a/src/module/item/armor/document.ts
+++ b/src/module/item/armor/document.ts
@@ -100,7 +100,7 @@ class ArmorPF2e extends PhysicalItemPF2e {
         this.system.potencyRune.value ||= null;
         this.system.resiliencyRune.value ||= null;
         // Strip out fundamental runes if ABP is enabled: requires this item and its actor (if any) to be initialized
-        if (this.initialized) ABP.cleanupRunes(this);
+        ABP.cleanupRunes(this);
 
         // Add traits from potency rune
         const baseTraits = this.system.traits.value;

--- a/src/module/item/base.ts
+++ b/src/module/item/base.ts
@@ -28,9 +28,6 @@ import { UUIDUtils } from "@util/uuid-utils";
 
 /** Override and extend the basic :class:`Item` implementation */
 class ItemPF2e extends Item<ActorPF2e> {
-    /** Has this item gone through at least one cycle of data preparation? */
-    protected initialized?: true;
-
     /** Prepared rule elements from this item */
     rules!: RuleElementPF2e[];
 
@@ -183,13 +180,18 @@ class ItemPF2e extends Item<ActorPF2e> {
     protected override _initialize(): void {
         this.rules = [];
         super._initialize();
-        this.initialized = true;
     }
 
-    /** Refresh the Item Directory if this item isn't owned */
     override prepareData(): void {
+        // If embedded, don't prepare data if not requested by this item's actor
+        if (this.parent?.items?.get(this.id) === this && !this.parent.preparingEmbeds) {
+            return;
+        }
+
         super.prepareData();
-        if (!this.isOwned && ui.items && this.initialized) ui.items.render();
+
+        // Refresh the Item Directory if this item isn't embedded
+        if (!this.isOwned && game.ready) ui.items.render();
     }
 
     /** Ensure the presence of the pf2e flag scope with default properties and values */

--- a/src/module/item/weapon/document.ts
+++ b/src/module/item/weapon/document.ts
@@ -249,9 +249,7 @@ class WeaponPF2e extends PhysicalItemPF2e {
             systemData.damage.modifier ||= systemData.damage.dice;
         }
 
-        // This method checks data on the actor that may not yet be initialized:
-        // use the item's initialization status as a proxy check
-        if (this.initialized) ABP.cleanupRunes(this);
+        ABP.cleanupRunes(this);
 
         const traitsArray = systemData.traits.value;
         // Thrown weapons always have a reload of "-"


### PR DESCRIPTION
Workaround of https://github.com/foundryvtt/foundryvtt/issues/7987

This will halt embedded item data preparation if not called by the parent actor's `prepareEmbeddedDocuments` method. Besides the unecessary CPU cycle expenditure, it also creates some peril for system workflows in cases where an item inspects its parent on the assumption that the parent has begun its own data (re-)preparation.