### PR TITLE
Include "splash" in inline damage roll descriptions

### DIFF
--- a/src/module/system/damage/roll.ts
+++ b/src/module/system/damage/roll.ts
@@ -396,9 +396,15 @@ class DamageInstance extends AbstractDamageRoll {
 
     override get formula(): string {
         const typeFlavor = game.i18n.localize(CONFIG.PF2E.damageRollFlavors[this.type] ?? this.type);
+        const isSplash = () => {
+            const head = this.head instanceof Grouping ? this.head.term : this.head;
+            return head.flavor === "splash";
+        };
         const damageType =
             this.persistent && this.type !== "bleed"
                 ? game.i18n.format("PF2E.Damage.RollFlavor.persistent", { damageType: typeFlavor })
+                : isSplash()
+                ? game.i18n.format("PF2E.Damage.RollFlavor.splash", { damageType: typeFlavor })
                 : this.type !== "untyped"
                 ? typeFlavor
                 : "";

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1639,7 +1639,7 @@
                 "precision": "precision",
                 "slashing": "slashing",
                 "sonic": "sonic",
-                "splash": "splash",
+                "splash": "{damageType} splash",
                 "untyped": "untyped"
             },
             "Scatter": "Scatter Damage"


### PR DESCRIPTION
Before:
<img width="103" alt="Screen Shot 2023-03-06 at 10 01 57 AM" src="https://user-images.githubusercontent.com/1904698/223193860-a822281d-810e-4094-a55b-127dab2de358.png">

After:
<img width="139" alt="Screen Shot 2023-03-06 at 10 00 12 AM" src="https://user-images.githubusercontent.com/1904698/223193904-94c73b94-cf78-4fc0-b5fc-b4235d1bb395.png">
