### PR TITLE
Fix creation of damage instances for fixed heightened overlays

### DIFF
--- a/src/module/item/spell/sheet.ts
+++ b/src/module/item/spell/sheet.ts
@@ -129,7 +129,8 @@ export class SpellSheetPF2e extends ItemSheetPF2e<SpellPF2e> {
 
         $html.find("[data-action=damage-create]").on("click", (event) => {
             event.preventDefault();
-            const baseKey = this.getOverlayFromEvent(event) ?? "data";
+            const overlayData = this.getOverlayFromEvent(event);
+            const baseKey = overlayData?.base ?? "system";
             const emptyDamage: SpellDamage = { value: "", type: { value: "bludgeoning", categories: [] } };
             this.item.update({ [`${baseKey}.damage.value.${randomID()}`]: emptyDamage });
         });

--- a/static/templates/items/spell-overlay.hbs
+++ b/static/templates/items/spell-overlay.hbs
@@ -64,7 +64,7 @@
                     <span>{{localize "PF2E.SpellComponentShortM"}}</span>
                 </label>
                 <label>
-                    <input type="checkbox" name="{{dataPath}}.components.somatic" {{checked system.components.somatic}} "/>
+                    <input type="checkbox" name="{{dataPath}}.components.somatic" {{checked system.components.somatic}} />
                     <span>{{localize "PF2E.SpellComponentShortS"}}</span>
                 </label>
                 <label>


### PR DESCRIPTION
Also removes an errant quote in `spell-overlay.hbs`.