### PR TITLE
Add scope to roll option rule element

### DIFF
--- a/src/module/rules/rule-element/roll-option.ts
+++ b/src/module/rules/rule-element/roll-option.ts
@@ -64,6 +64,12 @@ class RollOptionRuleElement extends RuleElementPF2e<RollOptionSchema> {
     static override defineSchema(): RollOptionSchema {
         return {
             ...super.defineSchema(),
+            scope: new fields.StringField({
+                required: false,
+                nullable: false,
+                initial: "actions-tab",
+                choices: ["actions-tab"],
+            }),
             domain: new fields.StringField({
                 required: true,
                 nullable: false,
@@ -180,6 +186,7 @@ class RollOptionRuleElement extends RuleElementPF2e<RollOptionSchema> {
                 const toggle: RollOptionToggle = {
                     itemId: this.item.id,
                     label,
+                    scope: this.scope,
                     domain: this.domain,
                     option,
                     suboptions: this.suboptions,
@@ -281,6 +288,7 @@ class RollOptionRuleElement extends RuleElementPF2e<RollOptionSchema> {
 interface RollOptionRuleElement extends RuleElementPF2e<RollOptionSchema>, ModelPropsFromSchema<RollOptionSchema> {}
 
 type RollOptionSchema = RuleElementSchema & {
+    scope: StringField<string, string, false, false, true>;
     domain: StringField<string, string, true, false, true>;
     option: StringField<string, string, true, false, false>;
     /** Suboptions for a toggle, appended to the option string */
@@ -305,6 +313,7 @@ type SuboptionData = {
 };
 
 interface RollOptionSource extends RuleElementSource {
+    scope?: unknown;
     domain?: unknown;
     option?: unknown;
     toggleable?: unknown;

--- a/src/module/rules/synthetics.ts
+++ b/src/module/rules/synthetics.ts
@@ -92,6 +92,7 @@ interface RollOptionToggle {
     /** The ID of the item with a rule element for this toggle */
     itemId?: string;
     label: string;
+    scope?: string;
     domain: string;
     option: string;
     suboptions: { label: string; selected: boolean }[];

--- a/static/templates/actors/character/tabs/actions.hbs
+++ b/static/templates/actors/character/tabs/actions.hbs
@@ -11,19 +11,21 @@
                     {{#if toggles}}
                         <div class="actions-options item-list">
                             {{#each toggles as |toggle idx|}}
-                                <div class="actions-option item"{{#if toggle.itemId}} data-item-id="{{toggle.itemId}}"{{/if}} >
-                                    <label>
-                                        <input type="checkbox" data-action="toggle-roll-option"{{#if toggle.itemId}} data-item-id="{{toggle.itemId}}"{{/if}} data-domain="{{toggle.domain}}" data-option="{{toggle.option}}" {{disabled (not toggle.enabled)}} {{checked toggle.checked}} />
-                                        <span{{#if (not (or toggle.checked toggle.enabled))}} class="unchecked-disabled"{{/if}}>{{localize toggle.label}}</span>
-                                        {{#if toggle.suboptions}}
-                                            <select data-action="set-suboption">
-                                                {{#each toggle.suboptions as |suboption|}}
-                                                    <option value="{{suboption.value}}"{{#if suboption.selected}} selected{{/if}}>{{localize suboption.label}}</option>
-                                                {{/each}}
-                                            </select>
-                                        {{/if}}
-                                    </label>
-                                </div>
+                                {{#if (or (not toggle.scope) (eq toggle.scope "actions-tab"))}}
+                                    <div class="actions-option item"{{#if toggle.itemId}} data-item-id="{{toggle.itemId}}"{{/if}} data-scope="{{toggle.scope}}">
+                                        <label>
+                                            <input type="checkbox" data-action="toggle-roll-option"{{#if toggle.itemId}} data-item-id="{{toggle.itemId}}"{{/if}} data-domain="{{toggle.domain}}" data-option="{{toggle.option}}" {{disabled (not toggle.enabled)}} {{checked toggle.checked}} />
+                                            <span{{#if (not (or toggle.checked toggle.enabled))}} class="unchecked-disabled"{{/if}}>{{localize toggle.label}}</span>
+                                            {{#if toggle.suboptions}}
+                                                <select data-action="set-suboption">
+                                                    {{#each toggle.suboptions as |suboption|}}
+                                                        <option value="{{suboption.value}}"{{#if suboption.selected}} selected{{/if}}>{{localize suboption.label}}</option>
+                                                    {{/each}}
+                                                </select>
+                                            {{/if}}
+                                        </label>
+                                    </div>
+                                {{/if}}
                             {{/each}}
                         </div>
                     {{/if}}


### PR DESCRIPTION
Add a scope field to the RollOption rule element, which will allow restricting a roll option toggle to specific UI regions. If scope is omitted or set to "actions-tab", the toggle will show up in the default region on the Actions tab.