### PR TITLE
Ensure status effect hud condition increases go to unlocked conditions

### DIFF
--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -876,9 +876,7 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
                 ui.notifications.error(translations.ErrorMessage.NoUpdatePermission);
                 return [];
             } else {
-                const updated = await actor.increaseCondition(itemSource.system.slug, {
-                    min: itemSource.system.value.value,
-                });
+                const updated = await actor.increaseCondition(itemSource.system.slug, { value });
                 return [updated ?? []].flat();
             }
         } else if (itemSource.type === "effect" || itemSource.type === "affliction") {

--- a/src/module/canvas/status-effects.ts
+++ b/src/module/canvas/status-effects.ts
@@ -206,9 +206,7 @@ export class StatusEffects {
                 continue;
             }
 
-            const condition = actor.itemTypes.condition.find(
-                (c) => c.slug === slug && c.isInHUD && !c.system.references.parent
-            );
+            const condition = actor.itemTypes.condition.find((c) => c.slug === slug && c.isInHUD && !c.isLocked);
 
             if (event.type === "click") {
                 if (typeof condition?.value === "number") {


### PR DESCRIPTION
This one is tough to explain with a title, so including a video. I think this can be further improved by removing unlocked unparented conditions that go below the active one as well. Maybe.

https://user-images.githubusercontent.com/1286721/223328240-c6ee89bd-c780-4a79-8e35-140b1d6f0184.mp4

