### PR TITLE
Prevent GM notes button from appearing on variant spell sheets

### DIFF
--- a/src/module/item/sheet/base.ts
+++ b/src/module/item/sheet/base.ts
@@ -434,7 +434,12 @@ export class ItemSheetPF2e<TItem extends ItemPF2e> extends ItemSheet<TItem> {
         }
 
         // Add a link to add GM notes
-        if (this.isEditable && game.user.isGM && !this.item.system.description.gm) {
+        if (
+            this.isEditable &&
+            game.user.isGM &&
+            !this.item.system.description.gm &&
+            !(this.item.isOfType("spell") && this.item.isVariant)
+        ) {
             const descriptionEditors = htmlQuery(html, ".descriptions");
             const mainEditor = htmlQuery(descriptionEditors, ".main .editor");
             if (!mainEditor) throw ErrorPF2e("Unexpected error retrieving description editor");


### PR DESCRIPTION
Currently an error is thrown when a spell variant sheet is openend because it doesn't have a description editor.