### PR TITLE
Fix pair of construction quirks in ActiveEffectLike and Strike REs

### DIFF
--- a/src/module/rules/rule-element/ae-like.ts
+++ b/src/module/rules/rule-element/ae-like.ts
@@ -22,9 +22,6 @@ class AELikeRuleElement<TSchema extends AELikeSchema> extends RuleElementPF2e<TS
         const hasExplicitPriority = typeof data.priority === "number";
         super(data, item, options);
 
-        // Legacy accommodation for pre-V10 paths
-        this.path = this.path.replace(/^data\./, "system.");
-
         // Set priority according to AE change mode if no priority was explicitly set
         if (!hasExplicitPriority) {
             this.priority = AELikeRuleElement.CHANGE_MODES[this.mode];

--- a/src/module/rules/rule-element/strike.ts
+++ b/src/module/rules/rule-element/strike.ts
@@ -123,7 +123,7 @@ class StrikeRuleElement extends RuleElementPF2e<StrikeSchema> {
 
     /** Allow shorthand `fist` StrikeRuleElement data to pass `DataModel` validation */
     override validate(options?: {
-        changes?: object;
+        changes?: Record<string, unknown>;
         clean?: boolean;
         fallback?: boolean;
         strict?: boolean;
@@ -131,9 +131,7 @@ class StrikeRuleElement extends RuleElementPF2e<StrikeSchema> {
         joint?: boolean;
     }): boolean {
         const source = options?.changes ?? this._source;
-        return Object.keys(source).length === 2 && "fist" in source && source.fist === true
-            ? true
-            : super.validate(options);
+        return source.fist === true ? true : super.validate(options);
     }
 
     /** Keep shorthand `fist` source data to its minimum form */


### PR DESCRIPTION
* If AELike construction fails, `this.path` will be undefined
* Check for `fist` shorthand in Strike REs were tripping over automatically set labels