### PR TITLE
Add a critical damage overlay for spell damage

### DIFF
--- a/src/module/item/spell/data.ts
+++ b/src/module/item/spell/data.ts
@@ -50,6 +50,9 @@ interface SpellSystemSource extends ItemSystemSource {
     damage: {
         value: Record<string, SpellDamage>;
     };
+    critical?: {
+        value: Record<string, SpellDamage>;
+    };
     heightening?: SpellHeighteningFixed | SpellHeighteningInterval;
     overlays?: Record<string, SpellOverlay>;
     save: {
@@ -99,6 +102,7 @@ export interface SpellDamage {
 export interface SpellHeighteningInterval {
     type: "interval";
     interval: number;
+    critical?: Record<string, string>;
     damage: Record<string, string>;
 }
 

--- a/src/module/item/spell/data.ts
+++ b/src/module/item/spell/data.ts
@@ -47,10 +47,10 @@ interface SpellSystemSource extends ItemSystemSource {
     duration: {
         value: string;
     };
-    damage: {
-        value: Record<string, SpellDamage>;
+    criticalDamage?: {
+        override: Record<string, SpellDamage>;
     };
-    critical?: {
+    damage: {
         value: Record<string, SpellDamage>;
     };
     heightening?: SpellHeighteningFixed | SpellHeighteningInterval;
@@ -102,7 +102,7 @@ export interface SpellDamage {
 export interface SpellHeighteningInterval {
     type: "interval";
     interval: number;
-    critical?: Record<string, string>;
+    criticalOverride?: Record<string, string>;
     damage: Record<string, string>;
 }
 

--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -165,7 +165,7 @@ class SpellPF2e extends ItemPF2e {
     }
 
     get hasCriticalOverride(): boolean {
-        return !!this.system.critical;
+        return !!this.system.criticalDamage?.override;
     }
 
     override get uuid(): ItemUUID {
@@ -525,13 +525,13 @@ class SpellPF2e extends ItemPF2e {
             }
 
             // Replace normal damage with critical damage overlay if requested
-            if (criticalDamage && source.system.critical) {
-                source.system.damage.value = source.system.critical.value;
+            if (criticalDamage && source.system.criticalDamage?.override) {
+                source.system.damage.value = source.system.criticalDamage.override;
 
                 // Handle interval heightening
                 const heightening = source.system.heightening;
-                if (heightening?.type === "interval" && heightening.critical) {
-                    heightening.damage = heightening.critical;
+                if (heightening?.type === "interval" && heightening.criticalOverride) {
+                    heightening.damage = heightening.criticalOverride;
                 }
             }
 

--- a/src/module/item/spell/sheet.ts
+++ b/src/module/item/spell/sheet.ts
@@ -24,7 +24,7 @@ const spellOverridable: Partial<Record<keyof SpellSystemData, string>> = {
     area: "PF2E.AreaLabel",
     range: "PF2E.SpellRangeLabel",
     damage: "PF2E.DamageLabel",
-    critical: "PF2E.CriticalDamageLabel",
+    criticalDamage: "PF2E.CriticalDamageLabel",
 };
 
 const DEFAULT_INTERVAL_SCALING: SpellHeighteningInterval = {
@@ -301,7 +301,7 @@ export class SpellSheetPF2e extends ItemSheetPF2e<SpellPF2e> {
             element.addEventListener("click", () => {
                 const baseKey = this.#getOverlayFromElement(element)?.base ?? "system";
                 const emptyDamage: SpellDamage = { value: "", type: { value: "bludgeoning", categories: [] } };
-                this.item.update({ [`${baseKey}.critical.value.${randomID()}`]: emptyDamage });
+                this.item.update({ [`${baseKey}.criticalDamage.override.${randomID()}`]: emptyDamage });
             });
         }
 
@@ -310,12 +310,15 @@ export class SpellSheetPF2e extends ItemSheetPF2e<SpellPF2e> {
                 const id = element.dataset.id;
                 if (!id) return;
                 const baseKey = this.#getOverlayFromElement(element)?.base ?? "system";
-                await this.item.update({ [`${baseKey}.critical.value.-=${id}`]: null });
+                await this.item.update({ [`${baseKey}.criticalDamage.override.-=${id}`]: null });
 
                 // Delete the whole critical property if it's empty
-                const critical = getProperty(this.item, `${baseKey}.critical.value`);
+                const critical = getProperty(this.item, `${baseKey}.criticalDamage.override`);
                 if (Object.keys(critical ?? {}).length === 0) {
-                    this.item.update({ [`${baseKey}.-=critical`]: null });
+                    this.item.update({
+                        [`${baseKey}.criticalDamage.-=override`]: null,
+                        [`${baseKey}.-=criticalDamage`]: null,
+                    });
                 }
             });
         }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -3731,6 +3731,8 @@
         "SpellScalingLabel": "Scaling",
         "SpellScalingOverlay": {
             "Add": "Add Heightening (Fixed)",
+            "CriticalFormulaInfo": "Set a critical damage override formula. This formula will be used instead of the normal dice or damage doubling.",
+            "CriticalFormulaLabel": "Critical Formula",
             "Label": "Heightened Level",
             "Selection": "Heightened ({level})"
         },

--- a/static/templates/items/spell-details.hbs
+++ b/static/templates/items/spell-details.hbs
@@ -218,6 +218,55 @@
             </div>
         {{/each}}
     </div>
+
+    <div class="damage-formulas">
+        <h3>
+            {{localize "PF2E.SpellScalingOverlay.CriticalFormulaLabel"}}
+            <i class="fas fa-info-circle small" data-tooltip="PF2E.SpellScalingOverlay.CriticalFormulaInfo" data-tooltip-direction="UP"></i>
+            <div class="item-controls">
+                <i class="fas fa-fw fa-plus" data-action="critical-damage-create"></i>
+            </div>
+        </h3>
+
+        {{#each data.critical.value as |damage id|}}
+            <div class="formula-section">
+                <div class="details-container-flex-row">
+                    <input type="text" name="system.critical.value.{{id}}.value" value="{{damage.value}}" placeholder="{{localize "PF2E.FormulaPlaceholder"}}" />
+                    <label>
+                        <span>&nbsp;{{localize "PF2E.SpellAbilityModLabel"}}</span>
+                        <input type="checkbox" name="system.critical.value.{{id}}.applyMod" {{checked damage.applyMod}} />
+                    </label>
+                    <select name="system.critical.value.{{id}}.type.subtype">
+                        {{#select damage.type.subtype}}
+                            <option></option>
+                            {{#each @root.damageSubtypes as |name type|}}
+                                <option value="{{type}}">{{localize name}}</option>
+                            {{/each}}
+                        {{/select}}
+                    </select>
+                    <select name="system.critical.value.{{id}}.type.value">
+                        {{#select damage.type.value}}
+                            <option value=""></option>
+                            {{#each @root.damageTypes as |name type|}}
+                                <option value="{{type}}">{{localize name}}</option>
+                            {{/each}}
+                        {{/select}}
+                    </select>
+                    <div class="item-controls">
+                        <a class="tag-selector" data-tag-selector="basic" data-title="PF2E.DamageCategoriesLabel" data-config-types="materialDamageEffects" data-property="system.critical.value.{{id}}.type.categories"><i class="fas fa-fw fa-edit"></i></a>
+                        <a data-action="critical-damage-delete" data-id="{{id}}"><i class="fas fa-fw fa-trash"></i></a>
+                    </div>
+                </div>
+                {{#if damage.type.categories}}
+                    <div class="traits-list">
+                        {{#each damage.type.categories}}
+                            <div class="tag-legacy">{{localize (lookup @root.damageCategories this)}}</div>
+                        {{/each}}
+                    </div>
+                {{/if}}
+            </div>
+        {{/each}}
+    </div>
 </ol>
 
 {{#unless data.heightening.type}}
@@ -252,6 +301,19 @@
                 <input type="text" name="system.heightening.damage.{{idx}}" value="{{lookup ../data.heightening.damage idx}}" />
             </div>
         {{/each}}
+        {{#if data.critical.value}}
+            <hr>
+            <h3>
+                {{localize "PF2E.SpellScalingOverlay.CriticalFormulaLabel"}}
+                <i class="fas fa-info-circle small" data-tooltip="PF2E.SpellScalingOverlay.CriticalFormulaInfo" data-tooltip-direction="UP"></i>
+            </h3>
+            {{#each data.critical.value as |damage idx|}}
+                <div class="form-group">
+                    <label class="short">{{localize (lookup @root.damageTypes damage.type.value)}}</label>
+                    <input type="text" name="system.heightening.critical.{{idx}}" value="{{lookup ../data.heightening.critical idx}}" />
+                </div>
+            {{/each}}
+        {{/if}}
     </div>
 {{/if}}
 

--- a/static/templates/items/spell-details.hbs
+++ b/static/templates/items/spell-details.hbs
@@ -228,15 +228,15 @@
             </div>
         </h3>
 
-        {{#each data.critical.value as |damage id|}}
+        {{#each data.criticalDamage.override as |damage id|}}
             <div class="formula-section">
                 <div class="details-container-flex-row">
-                    <input type="text" name="system.critical.value.{{id}}.value" value="{{damage.value}}" placeholder="{{localize "PF2E.FormulaPlaceholder"}}" />
+                    <input type="text" name="system.criticalDamage.override.{{id}}.value" value="{{damage.value}}" placeholder="{{localize "PF2E.FormulaPlaceholder"}}" />
                     <label>
                         <span>&nbsp;{{localize "PF2E.SpellAbilityModLabel"}}</span>
-                        <input type="checkbox" name="system.critical.value.{{id}}.applyMod" {{checked damage.applyMod}} />
+                        <input type="checkbox" name="system.criticalDamage.override.{{id}}.applyMod" {{checked damage.applyMod}} />
                     </label>
-                    <select name="system.critical.value.{{id}}.type.subtype">
+                    <select name="system.criticalDamage.override.{{id}}.type.subtype">
                         {{#select damage.type.subtype}}
                             <option></option>
                             {{#each @root.damageSubtypes as |name type|}}
@@ -244,7 +244,7 @@
                             {{/each}}
                         {{/select}}
                     </select>
-                    <select name="system.critical.value.{{id}}.type.value">
+                    <select name="system.criticalDamage.override.{{id}}.type.value">
                         {{#select damage.type.value}}
                             <option value=""></option>
                             {{#each @root.damageTypes as |name type|}}
@@ -253,7 +253,7 @@
                         {{/select}}
                     </select>
                     <div class="item-controls">
-                        <a class="tag-selector" data-tag-selector="basic" data-title="PF2E.DamageCategoriesLabel" data-config-types="materialDamageEffects" data-property="system.critical.value.{{id}}.type.categories"><i class="fas fa-fw fa-edit"></i></a>
+                        <a class="tag-selector" data-tag-selector="basic" data-title="PF2E.DamageCategoriesLabel" data-config-types="materialDamageEffects" data-property="system.criticalDamage.override.{{id}}.type.categories"><i class="fas fa-fw fa-edit"></i></a>
                         <a data-action="critical-damage-delete" data-id="{{id}}"><i class="fas fa-fw fa-trash"></i></a>
                     </div>
                 </div>
@@ -301,16 +301,16 @@
                 <input type="text" name="system.heightening.damage.{{idx}}" value="{{lookup ../data.heightening.damage idx}}" />
             </div>
         {{/each}}
-        {{#if data.critical.value}}
+        {{#if data.criticalDamage.override}}
             <hr>
             <h3>
                 {{localize "PF2E.SpellScalingOverlay.CriticalFormulaLabel"}}
                 <i class="fas fa-info-circle small" data-tooltip="PF2E.SpellScalingOverlay.CriticalFormulaInfo" data-tooltip-direction="UP"></i>
             </h3>
-            {{#each data.critical.value as |damage idx|}}
+            {{#each data.criticalDamage.override as |damage idx|}}
                 <div class="form-group">
                     <label class="short">{{localize (lookup @root.damageTypes damage.type.value)}}</label>
-                    <input type="text" name="system.heightening.critical.{{idx}}" value="{{lookup ../data.heightening.critical idx}}" />
+                    <input type="text" name="system.heightening.criticalOverride.{{idx}}" value="{{lookup ../data.heightening.criticalOverride idx}}" />
                 </div>
             {{/each}}
         {{/if}}

--- a/static/templates/items/spell-overlay.hbs
+++ b/static/templates/items/spell-overlay.hbs
@@ -181,4 +181,61 @@
             {{/each}}
         </div>
     {{/if}}
+
+    {{#if system.critical}}
+        <div class="damage-formulas">
+            <h3>
+                <a data-action="overlay-remove-property" data-property="critical"><i class="fa fa-times" ></i></a>
+                {{localize "PF2E.SpellScalingOverlay.CriticalFormulaLabel"}}
+                <i class="fas fa-info-circle small" data-tooltip="PF2E.SpellScalingOverlay.CriticalFormulaInfo" data-tooltip-direction="UP"></i>
+                <div class="item-controls">
+                    <i class="fas fa-plus" data-action="critical-damage-create"></i>
+                </div>
+            </h3>
+
+            {{#each system.critical.value as |damage id|}}
+                <div class="formula-section">
+                    <div class="details-container-flex-row">
+                        <input type="text" name="{{../dataPath}}.critical.value.{{id}}.value" value="{{damage.value}}" placeholder="{{localize "PF2E.FormulaPlaceholder"}}" />
+                        <label>
+                            <span>&nbsp;{{localize "PF2E.SpellAbilityModLabel"}}</span>
+                            <input type="checkbox" name="{{../dataPath}}.critical.value.{{id}}.applyMod" {{checked damage.applyMod}} />
+                        </label>
+                        <select name="{{../dataPath}}.critical.value.{{id}}.type.subtype">
+                            {{#select damage.type.subtype}}
+                                <option></option>
+                                {{#each @root.damageSubtypes as |name type|}}
+                                    <option value="{{type}}">{{localize name}}</option>
+                                {{/each}}
+                            {{/select}}
+                        </select>
+                        <select name="{{../dataPath}}.critical.value.{{id}}.type.value">
+                            {{#select damage.type.value}}
+                                <option value=""></option>
+                                {{#each @root.damageTypes as |name type|}}
+                                    <option value="{{type}}">{{localize name}}</option>
+                                {{/each}}
+                            {{/select}}
+                        </select>
+                        <div class="item-controls">
+                            <a class="tag-selector"
+                                data-tag-selector="basic"
+                                data-title="PF2E.DamageCategoriesLabel"
+                                data-config-types="damageCategories"
+                                data-property="{{../dataPath}}.critical.value.{{id}}.type.categories"
+                            ><i class="fas fa-edit"></i></a>
+                            <a data-action="critical-damage-delete" data-id="{{id}}"><i class="fas fa-trash"></i></a>
+                        </div>
+                    </div>
+                    {{#if damage.type.categories}}
+                        <div class="traits-list">
+                            {{#each damage.type.categories}}
+                                <div class="tag-legacy">{{localize (lookup @root.damageCategories this)}}</div>
+                            {{/each}}
+                        </div>
+                    {{/if}}
+                </div>
+            {{/each}}
+        </div>
+    {{/if}}
 </div>

--- a/static/templates/items/spell-overlay.hbs
+++ b/static/templates/items/spell-overlay.hbs
@@ -182,7 +182,7 @@
         </div>
     {{/if}}
 
-    {{#if system.critical}}
+    {{#if system.criticalDamage.override}}
         <div class="damage-formulas">
             <h3>
                 <a data-action="overlay-remove-property" data-property="critical"><i class="fa fa-times" ></i></a>
@@ -193,15 +193,15 @@
                 </div>
             </h3>
 
-            {{#each system.critical.value as |damage id|}}
+            {{#each system.criticalDamage.override as |damage id|}}
                 <div class="formula-section">
                     <div class="details-container-flex-row">
-                        <input type="text" name="{{../dataPath}}.critical.value.{{id}}.value" value="{{damage.value}}" placeholder="{{localize "PF2E.FormulaPlaceholder"}}" />
+                        <input type="text" name="{{../dataPath}}.criticalDamage.override.{{id}}.value" value="{{damage.value}}" placeholder="{{localize "PF2E.FormulaPlaceholder"}}" />
                         <label>
                             <span>&nbsp;{{localize "PF2E.SpellAbilityModLabel"}}</span>
-                            <input type="checkbox" name="{{../dataPath}}.critical.value.{{id}}.applyMod" {{checked damage.applyMod}} />
+                            <input type="checkbox" name="{{../dataPath}}.criticalDamage.override.{{id}}.applyMod" {{checked damage.applyMod}} />
                         </label>
-                        <select name="{{../dataPath}}.critical.value.{{id}}.type.subtype">
+                        <select name="{{../dataPath}}.criticalDamage.override.{{id}}.type.subtype">
                             {{#select damage.type.subtype}}
                                 <option></option>
                                 {{#each @root.damageSubtypes as |name type|}}
@@ -209,7 +209,7 @@
                                 {{/each}}
                             {{/select}}
                         </select>
-                        <select name="{{../dataPath}}.critical.value.{{id}}.type.value">
+                        <select name="{{../dataPath}}.criticalDamage.override.{{id}}.type.value">
                             {{#select damage.type.value}}
                                 <option value=""></option>
                                 {{#each @root.damageTypes as |name type|}}
@@ -222,7 +222,7 @@
                                 data-tag-selector="basic"
                                 data-title="PF2E.DamageCategoriesLabel"
                                 data-config-types="damageCategories"
-                                data-property="{{../dataPath}}.critical.value.{{id}}.type.categories"
+                                data-property="{{../dataPath}}.criticalDamage.override.{{id}}.type.categories"
                             ><i class="fas fa-edit"></i></a>
                             <a data-action="critical-damage-delete" data-id="{{id}}"><i class="fas fa-trash"></i></a>
                         </div>


### PR DESCRIPTION
The critical damage overlay is a full replacement for the normal damage data so it should be the absolute critical damage.
A critical damage override can be loaded with `spell.loadVariant({ criticalDamage: true })` if one is available.

Acid Splash:
![image](https://user-images.githubusercontent.com/41452412/223555721-d75369d0-b2a1-4056-9250-502c118aaa61.png)

![image](https://user-images.githubusercontent.com/41452412/223557609-65222185-791a-4f61-ad72-9a0b7e0c1658.png)

Acid Arrow:
![image](https://user-images.githubusercontent.com/41452412/223563273-0f374108-b944-4f26-8a88-4f820aaac631.png)

![image](https://user-images.githubusercontent.com/41452412/223563462-7ee6addb-e3d9-4e40-ac70-50f19005e240.png)