### PR TITLE
Fix unlocked lower value conditions out-prioritizing higher value ones

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -1407,27 +1407,23 @@ class ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
     /* Conditions                                   */
     /* -------------------------------------------- */
 
-    /**
-     * Get a condition on this actor, returning:
-     *   - the highest-valued if there are multiple of a valued condition
-     *   - the longest-lasting if there are multiple of a condition with a duration
-     *   - the last applied if any are present and are neither valued nor with duration
-     *   - otherwise `null`
-     * @param slug the slug of a core condition (subject to change when user-created conditions are introduced)
-     * @param [options.all=false] return all conditions of the requested type in the order described above
-     */
+    /** Gets an active condition on the actor or a list of conditions sorted by descending value. */
     getCondition(
         slug: ConditionKey,
         { all }: { all: boolean } = { all: false }
     ): Embedded<ConditionPF2e>[] | Embedded<ConditionPF2e> | null {
-        const conditions = this.itemTypes.condition
-            .filter((condition) => condition.key === slug || condition.slug === slug)
-            .sort((conditionA, conditionB) => {
-                const [valueA, valueB] = [conditionA.value ?? 0, conditionB.value ?? 0] as const;
-                return valueA > valueB ? 1 : valueB < valueB ? -1 : 0;
-            });
+        const conditions = this.itemTypes.condition.filter(
+            (condition) => condition.key === slug || condition.slug === slug
+        );
 
-        return all ? conditions : conditions[0] ?? null;
+        if (all) {
+            return conditions.sort((conditionA, conditionB) => {
+                const [valueA, valueB] = [conditionA.value ?? 0, conditionB.value ?? 0] as const;
+                return valueA > valueB ? -1 : valueA < valueB ? 1 : 0;
+            });
+        } else {
+            return conditions.find((c) => c.active) ?? null;
+        }
     }
 
     /**

--- a/src/module/item/condition/document.ts
+++ b/src/module/item/condition/document.ts
@@ -179,14 +179,14 @@ class ConditionPF2e extends AbstractEffectPF2e {
                 if (thisValue >= otherValue) {
                     deactivate(condition);
                 }
+            } else if (this.value === condition.value && !this.isLocked) {
+                // Deactivate other equal valued conditions if this condition isn't locked
+                deactivate(condition);
             } else if (this.value && condition.value && this.value >= condition.value) {
                 // Deactivate other conditions with a lower or equal value
                 deactivate(condition);
-            } else if (!this.isLocked) {
-                // Deactivate other conditions if this condition isn't locked
-                deactivate(condition);
-            } else if (this.isLocked && ofSameType.every((c) => c.isLocked)) {
-                // Deactivate other conditions if all conditions of this type are locked
+            } else if (this.isLocked && ofSameType.filter((c) => c.active).every((c) => c.isLocked)) {
+                // Deactivate other conditions if all remaining conditions of this type are locked
                 deactivate(condition);
             }
         }


### PR DESCRIPTION
* If you make someone frightened 1, then grant frightened 2, this now sets frightened 2 to the active condition.
* getCondition() without an argument now returns the active condition, and getCondition({ all: true }) now sorts properly.