### PR TITLE
Fix `CompendiumBrowser#openSpellTab` using `number`s instead of `string`s for level

### DIFF
--- a/src/module/apps/compendium-browser/index.ts
+++ b/src/module/apps/compendium-browser/index.ts
@@ -251,7 +251,7 @@ class CompendiumBrowser extends Application {
     }
 
     async openSpellTab(entry: BaseSpellcastingEntry, level = 10): Promise<void> {
-        const filter: { category: string[]; level: number[]; traditions: string[] } = {
+        const filter: { category: string[]; level: string[]; traditions: string[] } = {
             category: [],
             level: [],
             traditions: [],
@@ -262,7 +262,7 @@ class CompendiumBrowser extends Application {
         }
 
         if (level) {
-            filter.level.push(...Array.from(Array(level).keys()).map((l) => l + 1));
+            filter.level.push(...Array.from(Array(level).keys()).map((l) => String(l + 1)));
 
             if (entry.isPrepared || entry.isSpontaneous || entry.isInnate) {
                 filter.category.push("spell");

--- a/src/module/apps/compendium-browser/tabs/data.ts
+++ b/src/module/apps/compendium-browser/tabs/data.ts
@@ -172,7 +172,7 @@ interface InitialSpellFilters extends BaseInitialFilters {
     timefilter?: string;
     category?: string[];
     classes?: string[];
-    level?: number[];
+    level?: string[];
     rarity?: string[];
     school?: string[];
     source?: string[];


### PR DESCRIPTION
The checkbox listeners expects string values so it's comparing 🍎 to 🟠 when the value is set by `openSpellTab`,