### PR TITLE
Append numeric badge values to condition names

### DIFF
--- a/src/module/canvas/token/object.ts
+++ b/src/module/canvas/token/object.ts
@@ -259,7 +259,7 @@ class TokenPF2e extends Token<TokenDocumentPF2e> {
                 const [change, details] = Object.entries(params)[0];
                 const isAdded = change === "create";
                 const sign = isAdded ? "+ " : "- ";
-                const appendedNumber = details.value ? ` ${details.value}` : "";
+                const appendedNumber = !/ \d+$/.test(details.name) && details.value ? ` ${details.value}` : "";
                 const content = `${sign}${details.name}${appendedNumber}`;
                 const anchorDirection = isAdded ? CONST.TEXT_ANCHOR_POINTS.TOP : CONST.TEXT_ANCHOR_POINTS.BOTTOM;
                 const textStyle = pick(this._getTextStyle(), ["fill", "fontSize", "stroke", "strokeThickness"]);

--- a/src/module/item/condition/document.ts
+++ b/src/module/item/condition/document.ts
@@ -125,6 +125,10 @@ class ConditionPF2e extends AbstractEffectPF2e {
         const systemData = this.system;
         systemData.value.value = systemData.value.isValued ? Number(systemData.value.value) || 1 : null;
 
+        // Append numeric badge value to condition name, set item image according to configured style
+        if (typeof this.badge?.value === "number") {
+            this.name = `${this.name} ${this.badge.value}`;
+        }
         const folder = CONFIG.PF2E.statusEffects.iconDir;
         this.img = `${folder}${this.slug}.webp`;
 


### PR DESCRIPTION
This is fixing an old enough issue that its restoration might be considered an "enhancement" again.