### PR TITLE
Refactor initial filtering of Compendium Browser tabs

### DIFF
--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -20,6 +20,7 @@ import {
     isObject,
     objectHasKey,
     setHasElement,
+    tupleHasValue,
 } from "@util";
 import { CharacterPF2e } from ".";
 import { CreatureSheetPF2e } from "../creature/sheet";
@@ -774,27 +775,36 @@ class CharacterSheetPF2e extends CreatureSheetPF2e<CharacterPF2e> {
         if (checkboxesFilterCodes.includes("feattype-general")) checkboxesFilterCodes.push("feattype-skill");
         if (checkboxesFilterCodes.includes("feattype-class")) checkboxesFilterCodes.push("feattype-archetype");
 
-        const feattype: string[] = [];
-        const traits: { values: string[]; conjunction?: "and" | "or" } = {
-            values: [],
-        };
+        const featTab = game.pf2e.compendiumBrowser.tabs.feat;
+        const filter = await featTab.getFilterData();
+        const level = filter.sliders.level;
+        level.values.max = Math.min(maxLevel, level.values.upperLimit);
+        level.isExpanded = level.values.max !== level.values.upperLimit;
+
+        const { feattype } = filter.checkboxes;
+        const { traits } = filter.multiselects;
+
         for (const filterCode of checkboxesFilterCodes) {
             const [filterType, value] = filterCode.split("-");
             if (!(filterType && value)) {
-                const codesData = JSON.stringify(checkboxesFilterCodes);
-                throw ErrorPF2e(`Invalid filter value for opening the compendium browser:\n${codesData}`);
+                throw ErrorPF2e(`Invalid filter value for opening the compendium browser: "${filterCode}"`);
             }
             if (filterType === "feattype") {
-                feattype.push(value);
+                if (value in feattype.options) {
+                    feattype.isExpanded = true;
+                    feattype.options[value].selected = true;
+                    feattype.selected.push(value);
+                }
             } else if (filterType === "traits") {
-                traits.values.push(value);
+                if (tupleHasValue(traits.options, value)) {
+                    traits.selected.push(value);
+                }
             } else if (filterType === "conjunction" && (value === "and" || value === "or")) {
-                traits.conjunction = value;
+                filter.multiselects.traits.conjunction = value;
             }
         }
 
-        const filter = { level: { max: maxLevel }, feattype, traits };
-        await game.pf2e.compendiumBrowser.openTab("feat", filter);
+        return featTab.open(filter);
     }
 
     /** Handle changing of proficiency-rank via dropdown */

--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -761,17 +761,18 @@ class CharacterSheetPF2e extends CreatureSheetPF2e<CharacterPF2e> {
 
         // Feat Browser shortcut links
         for (const link of html.querySelectorAll<HTMLElement>(".feat-browse").values()) {
-            link.addEventListener("click", (event) => this.#onClickBrowseFeats(event));
+            link.addEventListener("click", () => this.#onClickBrowseFeats(link));
         }
     }
 
     /** Contextually search the feats tab of the Compendium Browser */
-    async #onClickBrowseFeats(event: MouseEvent): Promise<void> {
-        if (!(event.currentTarget instanceof HTMLElement)) return;
+    async #onClickBrowseFeats(element: HTMLElement): Promise<void> {
+        const maxLevel = Number(element.dataset.level) || this.actor.level;
+        const checkboxesFilterCodes = (element.dataset.filter ?? "")
+            .split(",")
+            .filter((s) => !!s)
+            .map((s) => s.trim());
 
-        const maxLevel = Number(event.currentTarget.dataset.level) || this.actor.level;
-        const button: HTMLElement = event.currentTarget;
-        const checkboxesFilterCodes = button.dataset.filter?.split(",").filter((f) => !!f) ?? [];
         if (checkboxesFilterCodes.includes("feattype-general")) checkboxesFilterCodes.push("feattype-skill");
         if (checkboxesFilterCodes.includes("feattype-class")) checkboxesFilterCodes.push("feattype-archetype");
 

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -394,7 +394,9 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
         $html.find(".sell-all-treasure button").on("click", (event) => this.onSellAllTreasure(event));
 
         // Inventory Browser
-        $html.find(".inventory-browse").on("click", (event) => this.onClickBrowseEquipmentCompendia(event));
+        for (const link of htmlQueryAll(html, ".inventory-browse")) {
+            link.addEventListener("click", () => this.#onClickBrowseEquipmentCompendia(link));
+        }
 
         const $spellcasting = $html.find(".tab.spellcasting, .tab.spells");
         const $spellControls = $spellcasting.find(".item-control");
@@ -628,10 +630,11 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
         }
     }
 
-    private async onClickBrowseEquipmentCompendia(event: JQuery.ClickEvent<HTMLElement>): Promise<void> {
-        const checkboxesFilterCodes: string[] = [$(event.currentTarget).attr("data-filter")].filter(
-            (element): element is string => !!element
-        );
+    async #onClickBrowseEquipmentCompendia(element: HTMLElement): Promise<void> {
+        const checkboxesFilterCodes = (element.dataset.filter ?? "")
+            .split(",")
+            .filter((s) => !!s)
+            .map((s) => s.trim());
 
         const eqTab = game.pf2e.compendiumBrowser.tabs.equipment;
         const filter = await eqTab.getFilterData();
@@ -640,8 +643,7 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
         for (const filterCode of checkboxesFilterCodes) {
             const splitValues = filterCode.split("-");
             if (splitValues.length !== 2) {
-                console.error(`Invalid filter value for opening the compendium browser: "${filterCode}"`);
-                return;
+                throw ErrorPF2e(`Invalid filter value for opening the compendium browser: "${filterCode}"`);
             }
             const [filterType, value] = splitValues;
             if (objectHasKey(checkboxes, filterType)) {

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -633,24 +633,28 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
             (element): element is string => !!element
         );
 
-        const filter: Record<string, string[]> = {};
+        const eqTab = game.pf2e.compendiumBrowser.tabs.equipment;
+        const filter = await eqTab.getFilterData();
+        const { checkboxes } = filter;
+
         for (const filterCode of checkboxesFilterCodes) {
             const splitValues = filterCode.split("-");
             if (splitValues.length !== 2) {
-                console.error(
-                    `Invalid filter value for opening the compendium browser:\n'${JSON.stringify(
-                        checkboxesFilterCodes
-                    )}'`
-                );
+                console.error(`Invalid filter value for opening the compendium browser: "${filterCode}"`);
                 return;
             }
-
             const [filterType, value] = splitValues;
-            const filterCategory = filter[filterType] ?? (filter[filterType] = []);
-            filterCategory.push(value);
+            if (objectHasKey(checkboxes, filterType)) {
+                const checkbox = checkboxes[filterType];
+                if (objectHasKey(checkbox.options, value)) {
+                    checkbox.options[value].selected = true;
+                    checkbox.selected.push(value);
+                    checkbox.isExpanded = true;
+                }
+            }
         }
 
-        await game.pf2e.compendiumBrowser.openTab("equipment", filter);
+        eqTab.open(filter);
     }
 
     protected override _canDragStart(selector: string): boolean {

--- a/src/module/apps/compendium-browser/data.ts
+++ b/src/module/apps/compendium-browser/data.ts
@@ -1,14 +1,36 @@
 import * as browserTabs from "./tabs";
 
-export interface PackInfo {
+interface PackInfo {
     load: boolean;
     name: string;
 }
-export type TabName = "action" | "bestiary" | "equipment" | "feat" | "hazard" | "spell" | "settings";
-export type BrowserTab = InstanceType<(typeof browserTabs)[keyof typeof browserTabs]>;
-export type TabData<T> = Record<TabName, T | null>;
 
-export type CommonSortByOption = "name" | "level";
+interface BrowserTabs {
+    action: browserTabs.Actions;
+    bestiary: browserTabs.Bestiary;
+    equipment: browserTabs.Equipment;
+    feat: browserTabs.Feats;
+    hazard: browserTabs.Hazards;
+    spell: browserTabs.Spells;
+}
 
-export type SortByOption = CommonSortByOption | "price";
-export type SortDirection = "asc" | "desc";
+type TabName = "action" | "bestiary" | "equipment" | "feat" | "hazard" | "spell" | "settings";
+type ContentTabName = Exclude<TabName, "settings">;
+type BrowserTab = InstanceType<(typeof browserTabs)[keyof typeof browserTabs]>;
+type TabData<T> = Record<TabName, T | null>;
+
+type CommonSortByOption = "name" | "level";
+type SortByOption = CommonSortByOption | "price";
+type SortDirection = "asc" | "desc";
+
+export {
+    BrowserTab,
+    BrowserTabs,
+    CommonSortByOption,
+    ContentTabName,
+    PackInfo,
+    SortByOption,
+    SortDirection,
+    TabData,
+    TabName,
+};

--- a/src/module/apps/compendium-browser/index.ts
+++ b/src/module/apps/compendium-browser/index.ts
@@ -1,5 +1,4 @@
 import { KitPF2e, PhysicalItemPF2e } from "@item";
-import { CoinsPF2e } from "@item/physical/helpers";
 import { BaseSpellcastingEntry } from "@item/spellcasting-entry";
 import { LocalizePF2e } from "@system/localize";
 import { ErrorPF2e, htmlQueryAll, isObject, objectHasKey } from "@util";
@@ -7,21 +6,21 @@ import { getSelectedOrOwnActors } from "@util/token-actor-utils";
 import { UUIDUtils } from "@util/uuid-utils";
 import Tagify from "@yaireo/tagify";
 import noUiSlider from "nouislider";
-import { BrowserTab, PackInfo, SortDirection, TabData, TabName } from "./data";
+import { BrowserTabs, PackInfo, SortDirection, TabData, TabName } from "./data";
 import { Progress } from "./progress";
 import * as browserTabs from "./tabs";
 import {
-    BaseFilterData,
+    ActionFilters,
+    BestiaryFilters,
+    BrowserFilter,
     CheckboxData,
-    InitialActionFilters,
-    InitialBestiaryFilters,
-    InitialEquipmentFilters,
-    InitialFeatFilters,
-    InitialFilters,
-    InitialHazardFilters,
-    InitialSpellFilters,
+    EquipmentFilters,
+    FeatFilters,
+    HazardFilters,
     RangesData,
     RenderResultListOptions,
+    SliderData,
+    SpellFilters,
 } from "./tabs/data";
 
 class PackLoader {
@@ -85,17 +84,17 @@ class PackLoader {
 class CompendiumBrowser extends Application {
     settings: CompendiumBrowserSettings;
     dataTabsList = ["action", "bestiary", "equipment", "feat", "hazard", "spell"] as const;
-    tabs: Record<Exclude<TabName, "settings">, BrowserTab>;
+    navigationTab: Tabs;
+    tabs: BrowserTabs;
+
     packLoader = new PackLoader();
     activeTab!: TabName;
-    navigationTab!: Tabs;
-
-    /** An initial filter to be applied upon loading a tab */
-    private initialFilter: InitialFilters = {};
 
     constructor(options = {}) {
         super(options);
 
+        this.settings = game.settings.get("pf2e", "compendiumBrowserPacks");
+        this.navigationTab = this.hookTab();
         this.tabs = {
             action: new browserTabs.Actions(this),
             bestiary: new browserTabs.Bestiary(this),
@@ -105,11 +104,8 @@ class CompendiumBrowser extends Application {
             spell: new browserTabs.Spells(this),
         };
 
-        this.settings = game.settings.get("pf2e", "compendiumBrowserPacks");
-
         this.initCompendiumList();
         this.injectActorDirectory();
-        this.hookTab();
     }
 
     override get title(): string {
@@ -136,14 +132,26 @@ class CompendiumBrowser extends Application {
         });
     }
 
+    override async render(force?: boolean, options?: RenderOptions): Promise<this> {
+        return super.render(force, options);
+    }
+
     /** Reset initial filtering */
     override async close(options?: { force?: boolean }): Promise<void> {
-        this.initialFilter = {};
         for (const tab of Object.values(this.tabs)) {
             tab.filterData.search.text = "";
         }
-
         await super.close(options);
+    }
+
+    hookTab(): Tabs {
+        const navigationTab = this._tabs[0];
+        const tabCallback = navigationTab.callback;
+        navigationTab.callback = async (event: JQuery.TriggeredEvent | null, tabs: Tabs, active: TabName) => {
+            tabCallback?.(event, tabs, active);
+            await this.loadTab(active);
+        };
+        return navigationTab;
     }
 
     initCompendiumList(): void {
@@ -227,245 +235,71 @@ class CompendiumBrowser extends Application {
         this.settings = settings;
     }
 
-    hookTab(): void {
-        this.navigationTab = this._tabs[0];
-        const tabCallback = this.navigationTab.callback;
-        this.navigationTab.callback = async (event: JQuery.TriggeredEvent | null, tabs: Tabs, active: TabName) => {
-            tabCallback?.(event, tabs, active);
-            await this.loadTab(active);
-        };
+    openTab(name: "action", filter?: ActionFilters): Promise<void>;
+    openTab(name: "bestiary", filter?: BestiaryFilters): Promise<void>;
+    openTab(name: "equipment", filter?: EquipmentFilters): Promise<void>;
+    openTab(name: "feat", filter?: FeatFilters): Promise<void>;
+    openTab(name: "hazard", filter?: HazardFilters): Promise<void>;
+    openTab(name: "spell", filter?: SpellFilters): Promise<void>;
+    openTab(name: "settings"): Promise<void>;
+    async openTab(tabName: TabName, filter?: BrowserFilter): Promise<void> {
+        this.activeTab = tabName;
+        if (tabName !== "settings" && filter) {
+            return this.tabs[tabName].open(filter);
+        }
+        return this.loadTab(tabName);
     }
 
-    openTab(tab: "action", filter?: InitialActionFilters): Promise<void>;
-    openTab(tab: "bestiary", filter?: InitialBestiaryFilters): Promise<void>;
-    openTab(tab: "equipment", filter?: InitialEquipmentFilters): Promise<void>;
-    openTab(tab: "feat", filter?: InitialFeatFilters): Promise<void>;
-    openTab(tab: "hazard", filter?: InitialHazardFilters): Promise<void>;
-    openTab(tab: "spell", filter?: InitialSpellFilters): Promise<void>;
-    openTab(tab: "settings"): Promise<void>;
-    async openTab(tab: TabName, filter: InitialFilters = {}): Promise<void> {
-        this.initialFilter = filter;
-        await this._render(true);
-        this.initialFilter = filter; // Reapply in case of a double-render (need to track those down)
-        this.navigationTab.activate(tab, { triggerCallback: true });
-    }
-
-    async openSpellTab(entry: BaseSpellcastingEntry, level = 10): Promise<void> {
-        const filter: { category: string[]; level: string[]; traditions: string[] } = {
-            category: [],
-            level: [],
-            traditions: [],
-        };
+    async openSpellTab(entry: BaseSpellcastingEntry, maxLevel = 10): Promise<void> {
+        const spellTab = this.tabs.spell;
+        const filter = await spellTab.getFilterData();
+        const { category, level, traditions } = filter.checkboxes;
 
         if (entry.isRitual || entry.isFocusPool) {
-            filter.category.push(entry.category);
+            category.options[entry.category].selected = true;
+            category.selected.push(entry.category);
         }
 
-        if (level) {
-            filter.level.push(...Array.from(Array(level).keys()).map((l) => String(l + 1)));
-
+        if (maxLevel) {
+            const levels = Array.from(Array(maxLevel).keys()).map((l) => String(l + 1));
+            for (const l of levels) {
+                level.options[l].selected = true;
+                level.selected.push(l);
+            }
             if (entry.isPrepared || entry.isSpontaneous || entry.isInnate) {
-                filter.category.push("spell");
+                category.options["spell"].selected = true;
+                category.selected.push("spell");
             }
         }
 
         if (entry.tradition && !entry.isFocusPool && !entry.isRitual) {
-            filter.traditions.push(entry.tradition);
+            traditions.options[entry.tradition].selected = true;
+            traditions.selected.push(entry.tradition);
         }
 
-        this.openTab("spell", filter);
+        spellTab.open(filter);
     }
 
-    async loadTab(tab: TabName): Promise<void> {
-        this.activeTab = tab;
+    async loadTab(tabName: TabName): Promise<void> {
+        this.activeTab = tabName;
         // Settings tab
-        if (tab === "settings") {
+        if (tabName === "settings") {
             await this.render(true);
             return;
         }
 
-        if (!this.dataTabsList.includes(tab)) {
-            throw ErrorPF2e(`Unknown tab "${tab}"`);
+        if (!this.dataTabsList.includes(tabName)) {
+            throw ErrorPF2e(`Unknown tab "${tabName}"`);
         }
 
-        const currentTab = this.tabs[tab];
+        const currentTab = this.tabs[tabName];
 
         // Initialize Tab if it is not already initialzed
-        if (!currentTab?.isInitialized) {
-            await currentTab?.init();
+        if (!currentTab.isInitialized) {
+            await currentTab.init();
         }
 
-        this.processInitialFilters(currentTab);
-
-        this.render(true);
-    }
-
-    private processInitialFilters(currentTab: BrowserTab): void {
-        // Reset filters if new filters were provided
-        if (this.initialFilter && Object.keys(this.initialFilter).length > 0) {
-            currentTab.resetFilters();
-        }
-
-        // Search text filter
-        if (this.initialFilter.searchText) {
-            currentTab.filterData.search.text = this.initialFilter.searchText;
-        }
-
-        // Sorting
-        currentTab.filterData.order.by = this.initialFilter.orderBy ?? currentTab.filterData.order.by;
-        currentTab.filterData.order.direction =
-            this.initialFilter.orderDirection ?? currentTab.filterData.order.direction;
-
-        for (const [filterType, filterValue] of Object.entries(this.initialFilter)) {
-            const mappedFilterType = (() => {
-                if (filterType === "levelRange") {
-                    return "level";
-                } else if (filterType === "priceRange") {
-                    return "price";
-                }
-                return filterType;
-            })();
-
-            if (
-                currentTab.filterData.checkboxes &&
-                objectHasKey(currentTab.filterData.checkboxes, mappedFilterType) &&
-                Array.isArray(filterValue)
-            ) {
-                // Checkboxes
-                const checkbox = currentTab.filterData.checkboxes[mappedFilterType];
-                for (const value of filterValue) {
-                    const option = checkbox.options[value];
-                    if (option) {
-                        checkbox.isExpanded = true;
-                        checkbox.selected.push(value);
-                        option.selected = true;
-                    } else {
-                        console.warn(
-                            `Tab '${currentTab.tabName}' checkboxes filter '${mappedFilterType}' has no option: '${value}'`
-                        );
-                    }
-                }
-            } else if (
-                currentTab.filterData.selects &&
-                objectHasKey(currentTab.filterData.selects, mappedFilterType) &&
-                typeof filterValue === "string"
-            ) {
-                // Selects
-                const select = currentTab.filterData.selects[mappedFilterType];
-                const option = select.options[filterValue];
-                if (option) {
-                    select.selected = filterValue;
-                } else {
-                    console.warn(
-                        `Tab '${currentTab.tabName}' select filter '${mappedFilterType}' has no option: '${filterValue}'`
-                    );
-                }
-            } else if (
-                currentTab.filterData.multiselects &&
-                objectHasKey(currentTab.filterData.multiselects, mappedFilterType) &&
-                Array.isArray(filterValue.values)
-            ) {
-                // Multiselects
-                // A convoluted cast is necessary here to not get an infered type of MultiSelectData<PhysicalItem> since MultiSelectData is not exported
-                const multiselects = (currentTab.filterData.multiselects as BaseFilterData["multiselects"])!;
-                const multiselect = multiselects[mappedFilterType];
-                for (const value of filterValue.values) {
-                    const option = multiselect.options.find((opt) => opt.value === value);
-                    if (option) {
-                        multiselect.selected.push(option);
-                    } else {
-                        console.warn(
-                            `Tab '${currentTab.tabName}' multiselect filter '${mappedFilterType}' has no option: '${value}'`
-                        );
-                    }
-                }
-                if (filterValue.conjunction === "and" || filterValue.conjunction === "or") {
-                    multiselect.conjunction = filterValue.conjunction;
-                }
-            } else if (
-                currentTab.filterData.ranges &&
-                objectHasKey(currentTab.filterData.ranges, mappedFilterType) &&
-                this.#isRange(filterValue)
-            ) {
-                // Ranges (e.g. price)
-                if (
-                    (filterValue.min !== undefined && filterValue.min !== null) ||
-                    (filterValue.max !== undefined && filterValue.max !== null)
-                ) {
-                    const range = currentTab.filterData.ranges[mappedFilterType];
-                    if (filterType === "priceRange") {
-                        if (filterValue.min !== null && filterValue.min !== undefined) {
-                            if (typeof filterValue.min === "number") {
-                                // Number values are handled as a price in gold pieces
-                                range.values.min = new CoinsPF2e({ gp: filterValue.min }).copperValue;
-                                range.values.inputMin = filterValue.min + "gp";
-                            } else if (typeof filterValue.min === "string") {
-                                range.values.min = CoinsPF2e.fromString(filterValue.min).copperValue;
-                                range.values.inputMin = filterValue.min;
-                            }
-                        }
-                        if (filterValue.max !== null && filterValue.max !== undefined) {
-                            if (typeof filterValue.max === "number") {
-                                // Number values are handled as a price in gold pieces
-                                range.values.max = new CoinsPF2e({ gp: filterValue.max }).copperValue;
-                                range.values.inputMax = filterValue.max + "gp";
-                            } else if (typeof filterValue.max === "string") {
-                                range.values.max = CoinsPF2e.fromString(filterValue.max).copperValue;
-                                range.values.inputMax = filterValue.max;
-                            }
-                        }
-                    } else {
-                        // If there is ever another range filter, it should be handled here
-                        console.error("Initital filtering for ranges other than price aren't implemented yet.");
-                        continue;
-                    }
-
-                    // Set max value to min value if min value is higher
-                    if (range.values.min > range.values.max) {
-                        range.values.max = range.values.min;
-                        range.values.inputMax = range.values.inputMin;
-                    }
-
-                    range.isExpanded = true;
-                }
-            } else if (
-                currentTab.filterData.sliders &&
-                objectHasKey(currentTab.filterData.sliders, mappedFilterType) &&
-                this.#isRange(filterValue) &&
-                (typeof filterValue.min === "number" || typeof filterValue.max === "number")
-            ) {
-                // Sliders (e.g. level)
-                const slider = currentTab.filterData.sliders[mappedFilterType];
-
-                const minValue =
-                    typeof filterValue.min === "number"
-                        ? Math.clamped(filterValue.min, slider.values.lowerLimit, slider.values.upperLimit) || 0
-                        : slider.values.lowerLimit;
-                const maxValue = Math.max(
-                    minValue,
-                    typeof filterValue.max === "number"
-                        ? Math.clamped(filterValue.max, slider.values.lowerLimit, slider.values.upperLimit) || 0
-                        : slider.values.upperLimit
-                );
-
-                slider.values.min = minValue;
-                slider.values.max = maxValue;
-                slider.isExpanded = true;
-            }
-            // Filter name did not match a filter on the tab
-            else {
-                console.warn(`'${filterType}' is not a valid filter for tab '${currentTab.tabName}'.`);
-            }
-        }
-
-        this.initialFilter = {};
-    }
-
-    #isRange(value: unknown): value is { min?: number | string; max?: number | string } {
-        return (
-            isObject<{ min: unknown; max: unknown }>(value) &&
-            (["number", "string"].includes(typeof value.min) || ["number", "string"].includes(typeof value.max))
-        );
+        await this.render(true);
     }
 
     loadedPacks(tab: TabName): string[] {
@@ -479,6 +313,12 @@ class CompendiumBrowser extends Application {
         super.activateListeners($html);
         const html = $html[0];
         const activeTabName = this.activeTab;
+
+        // Set the navigation tab. This is only needed when the browser is openend
+        // with CompendiumBrowserTab#open
+        if (this.navigationTab.active !== activeTabName) {
+            this.navigationTab.activate(activeTabName);
+        }
 
         // Settings Tab
         if (activeTabName === "settings") {
@@ -544,8 +384,10 @@ class CompendiumBrowser extends Application {
             const timeFilter = controlArea.querySelector<HTMLSelectElement>("select[name=timefilter]");
             if (timeFilter) {
                 timeFilter.addEventListener("change", () => {
-                    if (!currentTab.filterData?.selects?.timefilter) return;
-                    currentTab.filterData.selects.timefilter.selected = timeFilter.value;
+                    if (!currentTab.isOfType("spell")) return;
+                    const filterData = currentTab.filterData;
+                    if (!filterData.selects?.timefilter) return;
+                    filterData.selects.timefilter.selected = timeFilter.value;
                     this.clearScrollLimit(true);
                 });
             }
@@ -579,11 +421,13 @@ class CompendiumBrowser extends Application {
                             break;
                         }
                         case "ranges": {
-                            const ranges = currentTab.filterData.ranges!;
-                            if (objectHasKey(ranges, filterName)) {
-                                ranges[filterName].values = currentTab.defaultFilterData.ranges![filterName].values;
-                                ranges[filterName].changed = false;
-                                this.render(true);
+                            if (currentTab.isOfType("equipment")) {
+                                const ranges = currentTab.filterData.ranges;
+                                if (objectHasKey(ranges, filterName)) {
+                                    ranges[filterName].values = currentTab.defaultFilterData.ranges[filterName].values;
+                                    ranges[filterName].changed = false;
+                                    this.render(true);
+                                }
                             }
                         }
                     }
@@ -592,18 +436,35 @@ class CompendiumBrowser extends Application {
             // Toggle visibility of filter container
             const title = container.querySelector<HTMLDivElement>("div.title");
             title?.addEventListener("click", () => {
-                if (filterType === "checkboxes" || filterType === "ranges" || filterType === "sliders") {
-                    const filters = currentTab.filterData[filterType];
-                    if (filters && objectHasKey(filters, filterName)) {
-                        // This needs a type assertion because it resolves to never for some reason
-                        const filter = filters[filterName] as CheckboxData | RangesData;
-                        filter.isExpanded = !filter.isExpanded;
-                        const contentElement = title.nextElementSibling;
-                        if (contentElement instanceof HTMLElement) {
-                            filter.isExpanded
-                                ? (contentElement.style.display = "")
-                                : (contentElement.style.display = "none");
+                const toggleFilter = (filter: CheckboxData | RangesData | SliderData) => {
+                    filter.isExpanded = !filter.isExpanded;
+                    const contentElement = title.nextElementSibling;
+                    if (contentElement instanceof HTMLElement) {
+                        filter.isExpanded
+                            ? (contentElement.style.display = "")
+                            : (contentElement.style.display = "none");
+                    }
+                };
+                switch (filterType) {
+                    case "checkboxes": {
+                        if (objectHasKey(currentTab.filterData.checkboxes, filterName)) {
+                            toggleFilter(currentTab.filterData.checkboxes[filterName]);
                         }
+                        break;
+                    }
+                    case "ranges": {
+                        if (!currentTab.isOfType("equipment")) return;
+                        if (objectHasKey(currentTab.filterData.ranges, filterName)) {
+                            toggleFilter(currentTab.filterData.ranges[filterName]);
+                        }
+                        break;
+                    }
+                    case "sliders": {
+                        if (!currentTab.isOfType("bestiary", "equipment", "feat", "hazard")) return;
+                        if (objectHasKey(currentTab.filterData.sliders, filterName)) {
+                            toggleFilter(currentTab.filterData.sliders[filterName]);
+                        }
+                        break;
                     }
                 }
             });
@@ -628,6 +489,7 @@ class CompendiumBrowser extends Application {
             if (filterType === "ranges") {
                 container.querySelectorAll<HTMLInputElement>("input[name*=Bound]").forEach((range) => {
                     range.addEventListener("keyup", (event) => {
+                        if (!currentTab.isOfType("equipment")) return;
                         if (event.key !== "Enter") return;
                         const ranges = currentTab.filterData.ranges;
                         if (ranges && objectHasKey(ranges, filterName)) {
@@ -721,6 +583,7 @@ class CompendiumBrowser extends Application {
 
             if (filterType === "sliders") {
                 // Slider filters
+                if (!currentTab.isOfType("bestiary", "equipment", "feat", "hazard")) return;
                 const sliders = currentTab.filterData.sliders;
                 if (!sliders) continue;
 

--- a/src/module/apps/compendium-browser/tabs/action.ts
+++ b/src/module/apps/compendium-browser/tabs/action.ts
@@ -1,11 +1,14 @@
 import { getActionIcon, sluggify } from "@util";
 import { CompendiumBrowser } from "..";
+import { ContentTabName } from "../data";
 import { CompendiumBrowserTab } from "./base";
 import { ActionFilters, CompendiumBrowserIndexData } from "./data";
 
 export class CompendiumBrowserActionTab extends CompendiumBrowserTab {
-    override filterData!: ActionFilters;
-    override templatePath = "systems/pf2e/templates/compendium-browser/partials/action.hbs";
+    tabName: ContentTabName = "action";
+    filterData: ActionFilters;
+    templatePath = "systems/pf2e/templates/compendium-browser/partials/action.hbs";
+
     /* MiniSearch */
     override searchFields = ["name"];
     override storeFields = ["type", "name", "img", "uuid", "traits", "source"];
@@ -13,13 +16,13 @@ export class CompendiumBrowserActionTab extends CompendiumBrowserTab {
     protected index = ["img", "system.actionType.value", "system.traits.value", "system.source.value"];
 
     constructor(browser: CompendiumBrowser) {
-        super(browser, "action");
+        super(browser);
 
         // Set the filterData object of this tab
-        this.prepareFilterData();
+        this.filterData = this.prepareFilterData();
     }
 
-    protected override async loadData() {
+    protected override async loadData(): Promise<void> {
         console.debug("PF2e System | Compendium Browser | Started loading actions");
 
         const actions: CompendiumBrowserIndexData[] = [];
@@ -84,8 +87,8 @@ export class CompendiumBrowserActionTab extends CompendiumBrowserTab {
         return true;
     }
 
-    protected override prepareFilterData(): void {
-        this.filterData = {
+    protected override prepareFilterData(): ActionFilters {
+        return {
             checkboxes: {
                 source: {
                     isExpanded: false,

--- a/src/module/apps/compendium-browser/tabs/base.ts
+++ b/src/module/apps/compendium-browser/tabs/base.ts
@@ -1,26 +1,26 @@
 import { CompendiumBrowser } from "..";
-import { BaseFilterData, CheckboxOptions, CompendiumBrowserIndexData, MultiselectData, RangesData } from "./data";
+import { BrowserFilter, CheckboxOptions, CompendiumBrowserIndexData, MultiselectData, RangesData } from "./data";
 import { ErrorPF2e, sluggify } from "@util";
-import { TabName } from "../data";
+import { BrowserTabs, ContentTabName } from "../data";
 import MiniSearch from "minisearch";
 
 export abstract class CompendiumBrowserTab {
     /** A reference to the parent CompendiumBrowser */
     protected browser: CompendiumBrowser;
+    /** The filter schema for this tab; The tabs filters are rendered based on this.*/
+    abstract filterData: BrowserFilter;
     /** An unmodified copy of this.filterData */
-    defaultFilterData!: BaseFilterData;
+    defaultFilterData!: this["filterData"];
     /** The full CompendiumIndex of this tab */
     protected indexData: CompendiumBrowserIndexData[] = [];
     /** Is this tab initialized? */
     isInitialized = false;
-    /** The filter schema for this tab; The tabs filters are rendered based on this.*/
-    filterData!: BaseFilterData;
     /** The total count of items in the currently filtered index */
     totalItemCount = 0;
     /** The initial display limit for this tab; Scrolling is currently hardcoded to +100 */
     scrollLimit = 100;
     /** The name of this tab */
-    tabName: Exclude<TabName, "settings">;
+    abstract tabName: ContentTabName;
     /** A DOMParser instance */
     #domParser = new DOMParser();
     /** The path to the result list template of this tab */
@@ -33,9 +33,8 @@ export abstract class CompendiumBrowserTab {
      *  By default none, so resuts would only contain the id field. */
     storeFields: string[] = [];
 
-    constructor(browser: CompendiumBrowser, tabName: Exclude<TabName, "settings">) {
+    constructor(browser: CompendiumBrowser) {
         this.browser = browser;
-        this.tabName = tabName;
     }
 
     /** Initialize this this tab */
@@ -56,6 +55,19 @@ export abstract class CompendiumBrowserTab {
         this.isInitialized = true;
     }
 
+    /** Open this tab
+     * @param filter An optional initial filter for this tab
+     */
+    async open(filter?: BrowserFilter): Promise<void> {
+        if (filter) {
+            if (!this.isInitialized) {
+                throw ErrorPF2e(`Tried to pass an initial filter to uninitialized tab "${this.tabName}"`);
+            }
+            this.filterData = filter;
+        }
+        await this.browser.loadTab(this.tabName);
+    }
+
     /** Filter indexData and return slice based on current scrollLimit */
     getIndexData(start: number): CompendiumBrowserIndexData[] {
         if (!this.isInitialized) {
@@ -74,16 +86,30 @@ export abstract class CompendiumBrowserTab {
         return currentIndex.slice(start, this.scrollLimit);
     }
 
+    /** Returns a clean copy of the filterData for this tab. Initializes the tab if necessary. */
+    async getFilterData(): Promise<this["filterData"]> {
+        if (!this.isInitialized) {
+            await this.init();
+        }
+        return deepClone(this.defaultFilterData);
+    }
+
     /** Reset all filters */
     resetFilters(): void {
         this.filterData = deepClone(this.defaultFilterData);
     }
 
+    /** Check this tabs type */
+    isOfType<T extends ContentTabName>(...types: T[]): this is BrowserTabs[T];
+    isOfType(...types: string[]): boolean {
+        return types.some((t) => this.tabName === t);
+    }
+
     /** Load and prepare the compendium index and set filter options */
-    protected async loadData(): Promise<void> {}
+    protected abstract loadData(): Promise<void>;
 
     /** Prepare the the filterData object of this tab */
-    protected prepareFilterData(): void {}
+    protected abstract prepareFilterData(): this["filterData"];
 
     /** Filter indexData */
     protected filterIndexData(_entry: CompendiumBrowserIndexData): boolean {
@@ -218,7 +244,7 @@ export abstract class CompendiumBrowserTab {
     }
 
     /** Provide a best-effort sort of an object (e.g. CONFIG.PF2E.monsterTraits) */
-    protected sortedConfig(obj: Record<string, string>) {
+    protected sortedConfig(obj: Record<string, string>): Record<string, string> {
         return Object.fromEntries(
             [...Object.entries(obj)].sort((entryA, entryB) => entryA[1].localeCompare(entryB[1], game.i18n.lang))
         );

--- a/src/module/apps/compendium-browser/tabs/bestiary.ts
+++ b/src/module/apps/compendium-browser/tabs/bestiary.ts
@@ -1,9 +1,14 @@
 import { sluggify } from "@util";
 import { CompendiumBrowser } from "..";
+import { ContentTabName } from "../data";
 import { CompendiumBrowserTab } from "./base";
 import { BestiaryFilters, CompendiumBrowserIndexData } from "./data";
 
 export class CompendiumBrowserBestiaryTab extends CompendiumBrowserTab {
+    tabName: ContentTabName = "bestiary";
+    filterData: BestiaryFilters;
+    templatePath = "systems/pf2e/templates/compendium-browser/partials/bestiary.hbs";
+
     protected index = [
         "img",
         "system.details.level.value",
@@ -12,8 +17,6 @@ export class CompendiumBrowserBestiaryTab extends CompendiumBrowserTab {
         "system.traits",
     ];
 
-    override filterData!: BestiaryFilters;
-    override templatePath = "systems/pf2e/templates/compendium-browser/partials/bestiary.hbs";
     /* MiniSearch */
     override searchFields = ["name"];
     override storeFields = [
@@ -30,13 +33,13 @@ export class CompendiumBrowserBestiaryTab extends CompendiumBrowserTab {
     ];
 
     constructor(browser: CompendiumBrowser) {
-        super(browser, "bestiary");
+        super(browser);
 
         // Set the filterData object of this tab
-        this.prepareFilterData();
+        this.filterData = this.prepareFilterData();
     }
 
-    protected override async loadData() {
+    protected override async loadData(): Promise<void> {
         console.debug("PF2e System | Compendium Browser | Started loading Bestiary actors");
 
         const bestiaryActors: CompendiumBrowserIndexData[] = [];
@@ -121,8 +124,8 @@ export class CompendiumBrowserBestiaryTab extends CompendiumBrowserTab {
         return true;
     }
 
-    protected override prepareFilterData(): void {
-        this.filterData = {
+    protected override prepareFilterData(): BestiaryFilters {
+        return {
             checkboxes: {
                 sizes: {
                     isExpanded: true,

--- a/src/module/apps/compendium-browser/tabs/data.ts
+++ b/src/module/apps/compendium-browser/tabs/data.ts
@@ -4,7 +4,7 @@ import { ActionTrait } from "@item/action";
 import { FeatTrait } from "@item/feat/data";
 import { PhysicalItemTrait } from "@item/physical/data";
 import { SearchResult } from "minisearch";
-import { CommonSortByOption, SortByOption, SortDirection } from "../data";
+import { SortDirection } from "../data";
 
 type CheckboxOptions = Record<string, { label: string; selected: boolean }>;
 interface CheckboxData {
@@ -59,52 +59,102 @@ interface SliderData {
 }
 
 interface BaseFilterData {
-    checkboxes?: Record<string, CheckboxData>;
-    selects?: Record<string, SelectData>;
-    multiselects?: Record<string, MultiselectData>;
     order: OrderData;
-    ranges?: Record<string, RangesData>;
     search: {
         text: string;
     };
-    sliders?: Record<string, SliderData>;
 }
 
 interface ActionFilters extends BaseFilterData {
-    checkboxes: Record<"source", CheckboxData>;
-    multiselects: Record<"traits", MultiselectData<ActionTrait>>;
+    checkboxes: {
+        source: CheckboxData;
+    };
+    multiselects: {
+        traits: MultiselectData<ActionTrait>;
+    };
 }
 
 interface BestiaryFilters extends BaseFilterData {
-    checkboxes: Record<"alignments" | "rarity" | "sizes" | "source", CheckboxData>;
-    multiselects: Record<"traits", MultiselectData<CreatureTrait>>;
-    sliders: Record<"level", SliderData>;
+    checkboxes: {
+        alignments: CheckboxData;
+        rarity: CheckboxData;
+        sizes: CheckboxData;
+        source: CheckboxData;
+    };
+    multiselects: {
+        traits: MultiselectData<CreatureTrait>;
+    };
+    sliders: {
+        level: SliderData;
+    };
 }
 
 interface EquipmentFilters extends BaseFilterData {
-    checkboxes: Record<"armorTypes" | "weaponTypes" | "itemtypes" | "rarity" | "source", CheckboxData>;
-    multiselects: Record<"traits", MultiselectData<PhysicalItemTrait>>;
-    ranges: Record<"price", RangesData>;
-    sliders: Record<"level", SliderData>;
+    checkboxes: {
+        armorTypes: CheckboxData;
+        itemtypes: CheckboxData;
+        rarity: CheckboxData;
+        source: CheckboxData;
+        weaponTypes: CheckboxData;
+    };
+    multiselects: {
+        traits: MultiselectData<PhysicalItemTrait>;
+    };
+    ranges: {
+        price: RangesData;
+    };
+    sliders: {
+        level: SliderData;
+    };
 }
 
 interface FeatFilters extends BaseFilterData {
-    checkboxes: Record<"feattype" | "skills" | "rarity" | "source", CheckboxData>;
-    multiselects: Record<"traits", MultiselectData<FeatTrait>>;
-    sliders: Record<"level", SliderData>;
+    checkboxes: {
+        feattype: CheckboxData;
+        skills: CheckboxData;
+        rarity: CheckboxData;
+        source: CheckboxData;
+    };
+    multiselects: {
+        traits: MultiselectData<FeatTrait>;
+    };
+    sliders: {
+        level: SliderData;
+    };
 }
 
 interface HazardFilters extends BaseFilterData {
-    checkboxes: Record<"complexity" | "rarity" | "source", CheckboxData>;
-    multiselects: Record<"traits", MultiselectData<HazardTrait>>;
-    sliders: Record<"level", SliderData>;
+    checkboxes: {
+        complexity: CheckboxData;
+        rarity: CheckboxData;
+        source: CheckboxData;
+    };
+    multiselects: {
+        traits: MultiselectData<HazardTrait>;
+    };
+    sliders: {
+        level: SliderData;
+    };
 }
 
 interface SpellFilters extends BaseFilterData {
-    checkboxes: Record<"category" | "level" | "rarity" | "school" | "source" | "traditions", CheckboxData>;
-    multiselects: Record<"traits", MultiselectData<string>>;
-    selects: Record<"timefilter", SelectData>;
+    checkboxes: {
+        category: CheckboxData;
+        level: CheckboxData;
+        rarity: CheckboxData;
+        school: CheckboxData;
+        source: CheckboxData;
+        traditions: CheckboxData;
+    };
+    multiselects: {
+        traits: MultiselectData<string>;
+    };
+    selects: {
+        timefilter: SelectData;
+    };
 }
+
+type BrowserFilter = ActionFilters | BestiaryFilters | EquipmentFilters | FeatFilters | HazardFilters | SpellFilters;
 
 type CompendiumBrowserIndexData = Omit<CompendiumIndexData, "_id"> & Partial<SearchResult>;
 
@@ -114,84 +164,11 @@ interface RenderResultListOptions {
     replace?: boolean;
 }
 
-// Models used for initializing filters
-interface BaseInitialFilters {
-    searchText?: string;
-    traits?: {
-        values: string[];
-        conjunction?: MultiselectData["conjunction"];
-    };
-    orderBy?: SortByOption;
-    orderDirection?: SortDirection;
-}
-
-interface InitialActionFilters extends BaseInitialFilters {
-    source?: string[];
-    orderBy?: CommonSortByOption;
-}
-
-interface InitialBestiaryFilters extends BaseInitialFilters {
-    alignments?: string[];
-    rarity?: string[];
-    sizes?: string[];
-    source?: string[];
-    orderBy?: CommonSortByOption;
-}
-
-interface InitialEquipmentFilters extends BaseInitialFilters {
-    armorTypes?: string[];
-    weaponTypes?: string[];
-    itemtypes?: string[];
-    rarity?: string[];
-    source?: string[];
-    priceRange?: { min?: number | string; max?: number | string };
-    levelRange?: { min?: number; max?: number };
-    orderBy?: CommonSortByOption | "price";
-}
-
-interface InitialFeatFilters extends BaseInitialFilters {
-    ancestry?: string[];
-    classes?: string[];
-    feattype?: string[];
-    skills?: string[];
-    rarity?: string[];
-    source?: string[];
-    level?: { min?: number; max?: number };
-    orderBy?: CommonSortByOption;
-}
-
-interface InitialHazardFilters extends BaseInitialFilters {
-    complexity?: string[];
-    rarity?: string[];
-    source?: string[];
-    levelRange?: { min?: number; max?: number };
-    orderBy?: CommonSortByOption;
-}
-
-interface InitialSpellFilters extends BaseInitialFilters {
-    timefilter?: string;
-    category?: string[];
-    classes?: string[];
-    level?: string[];
-    rarity?: string[];
-    school?: string[];
-    source?: string[];
-    traditions?: string[];
-    orderBy?: CommonSortByOption;
-}
-
-type InitialFilters =
-    | InitialActionFilters
-    | InitialBestiaryFilters
-    | InitialEquipmentFilters
-    | InitialFeatFilters
-    | InitialHazardFilters
-    | InitialSpellFilters;
-
 export {
     ActionFilters,
     BaseFilterData,
     BestiaryFilters,
+    BrowserFilter,
     CheckboxData,
     CheckboxOptions,
     CompendiumBrowserIndexData,
@@ -201,12 +178,6 @@ export {
     MultiselectData,
     RangesData,
     RenderResultListOptions,
+    SliderData,
     SpellFilters,
-    InitialFilters,
-    InitialActionFilters,
-    InitialBestiaryFilters,
-    InitialEquipmentFilters,
-    InitialFeatFilters,
-    InitialHazardFilters,
-    InitialSpellFilters,
 };

--- a/src/module/apps/compendium-browser/tabs/equipment.ts
+++ b/src/module/apps/compendium-browser/tabs/equipment.ts
@@ -2,12 +2,15 @@ import { CoinsPF2e } from "@item/physical/helpers";
 import { LocalizePF2e } from "@system/localize";
 import { sluggify } from "@util";
 import { CompendiumBrowser } from "..";
+import { ContentTabName } from "../data";
 import { CompendiumBrowserTab } from "./base";
 import { CompendiumBrowserIndexData, EquipmentFilters, RangesData } from "./data";
 
 export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
-    override filterData!: EquipmentFilters;
-    override templatePath = "systems/pf2e/templates/compendium-browser/partials/equipment.hbs";
+    tabName: ContentTabName = "equipment";
+    filterData: EquipmentFilters;
+    templatePath = "systems/pf2e/templates/compendium-browser/partials/equipment.hbs";
+
     /* MiniSearch */
     override searchFields = ["name"];
     override storeFields = [
@@ -26,13 +29,13 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
     ];
 
     constructor(browser: CompendiumBrowser) {
-        super(browser, "equipment");
+        super(browser);
 
         // Set the filterData object of this tab
-        this.prepareFilterData();
+        this.filterData = this.prepareFilterData();
     }
 
-    protected override async loadData() {
+    protected override async loadData(): Promise<void> {
         console.debug("PF2e System | Compendium Browser | Started loading inventory items");
 
         const inventoryItems: CompendiumBrowserIndexData[] = [];
@@ -206,9 +209,9 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
         return super.parseRangeFilterInput(name, lower, upper);
     }
 
-    protected override prepareFilterData(): void {
+    protected override prepareFilterData(): EquipmentFilters {
         const coins = LocalizePF2e.translations.PF2E.CurrencyAbbreviations;
-        this.filterData = {
+        return {
             checkboxes: {
                 itemtypes: {
                     isExpanded: true,

--- a/src/module/apps/compendium-browser/tabs/feat.ts
+++ b/src/module/apps/compendium-browser/tabs/feat.ts
@@ -1,23 +1,26 @@
 import { sluggify } from "@util";
 import { CompendiumBrowser } from "..";
+import { ContentTabName } from "../data";
 import { CompendiumBrowserTab } from "./base";
 import { CompendiumBrowserIndexData, FeatFilters } from "./data";
 
 export class CompendiumBrowserFeatTab extends CompendiumBrowserTab {
-    override filterData!: FeatFilters;
-    override templatePath = "systems/pf2e/templates/compendium-browser/partials/feat.hbs";
+    tabName: ContentTabName = "feat";
+    filterData: FeatFilters;
+    templatePath = "systems/pf2e/templates/compendium-browser/partials/feat.hbs";
+
     /* MiniSearch */
     override searchFields = ["name"];
     override storeFields = ["type", "name", "img", "uuid", "level", "featType", "skills", "traits", "rarity", "source"];
 
     constructor(browser: CompendiumBrowser) {
-        super(browser, "feat");
+        super(browser);
 
         // Set the filterData object of this tab
-        this.prepareFilterData();
+        this.filterData = this.prepareFilterData();
     }
 
-    protected override async loadData() {
+    protected override async loadData(): Promise<void> {
         console.debug("PF2e System | Compendium Browser | Started loading feats");
 
         const feats: CompendiumBrowserIndexData[] = [];
@@ -140,8 +143,8 @@ export class CompendiumBrowserFeatTab extends CompendiumBrowserTab {
         return true;
     }
 
-    protected override prepareFilterData(): void {
-        this.filterData = {
+    protected override prepareFilterData(): FeatFilters {
+        return {
             checkboxes: {
                 feattype: {
                     isExpanded: false,

--- a/src/module/apps/compendium-browser/tabs/hazard.ts
+++ b/src/module/apps/compendium-browser/tabs/hazard.ts
@@ -1,11 +1,14 @@
 import { sluggify } from "@util";
 import { CompendiumBrowser } from "..";
+import { ContentTabName } from "../data";
 import { CompendiumBrowserTab } from "./base";
 import { CompendiumBrowserIndexData, HazardFilters } from "./data";
 
 export class CompendiumBrowserHazardTab extends CompendiumBrowserTab {
-    override filterData!: HazardFilters;
-    override templatePath = "systems/pf2e/templates/compendium-browser/partials/hazard.hbs";
+    tabName: ContentTabName = "hazard";
+    filterData: HazardFilters;
+    templatePath = "systems/pf2e/templates/compendium-browser/partials/hazard.hbs";
+
     /* MiniSearch */
     override searchFields = ["name"];
     override storeFields = ["type", "name", "img", "uuid", "level", "complexity", "traits", "rarity", "source"];
@@ -13,13 +16,13 @@ export class CompendiumBrowserHazardTab extends CompendiumBrowserTab {
     protected index = ["img", "system.details.level.value", "system.details.isComplex", "system.traits"];
 
     constructor(browser: CompendiumBrowser) {
-        super(browser, "hazard");
+        super(browser);
 
         // Set the filterData object of this tab
-        this.prepareFilterData();
+        this.filterData = this.prepareFilterData();
     }
 
-    protected override async loadData() {
+    protected override async loadData(): Promise<void> {
         console.debug("PF2e System | Compendium Browser | Started loading Hazard actors");
 
         const hazardActors: CompendiumBrowserIndexData[] = [];
@@ -106,8 +109,8 @@ export class CompendiumBrowserHazardTab extends CompendiumBrowserTab {
         return true;
     }
 
-    protected override prepareFilterData(): void {
-        this.filterData = {
+    protected override prepareFilterData(): HazardFilters {
+        return {
             checkboxes: {
                 complexity: {
                     isExpanded: true,

--- a/src/module/apps/compendium-browser/tabs/spell.ts
+++ b/src/module/apps/compendium-browser/tabs/spell.ts
@@ -1,11 +1,14 @@
 import { getActionIcon, sluggify } from "@util";
 import { CompendiumBrowser } from "..";
+import { ContentTabName } from "../data";
 import { CompendiumBrowserTab } from "./base";
 import { CompendiumBrowserIndexData, SpellFilters } from "./data";
 
 export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
-    override filterData!: SpellFilters;
-    override templatePath = "systems/pf2e/templates/compendium-browser/partials/spell.hbs";
+    tabName: ContentTabName = "spell";
+    filterData: SpellFilters;
+    templatePath = "systems/pf2e/templates/compendium-browser/partials/spell.hbs";
+
     /* MiniSearch */
     override searchFields = ["name"];
     override storeFields = [
@@ -24,13 +27,13 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
     ];
 
     constructor(browser: CompendiumBrowser) {
-        super(browser, "spell");
+        super(browser);
 
         // Set the filterData object of this tab
-        this.prepareFilterData();
+        this.filterData = this.prepareFilterData();
     }
 
-    protected override async loadData() {
+    protected override async loadData(): Promise<void> {
         console.debug("PF2e System | Compendium Browser | Started loading spells");
 
         const spells: CompendiumBrowserIndexData[] = [];
@@ -181,8 +184,8 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
         return true;
     }
 
-    protected override prepareFilterData(): void {
-        this.filterData = {
+    protected override prepareFilterData(): SpellFilters {
+        return {
             checkboxes: {
                 category: {
                     isExpanded: true,


### PR DESCRIPTION
This replaces the current clunky (and not type aware) initial filtering implementation. The initial filter is now a copy of the initialized `filterData` of a `CompendiumBrowserTab` that can be requested by calling `CompendiumBrowserTab#getFilterData`.
The returned object is fully typed (this could still be improved by narrowing the type of `CheckboxData.options`) and can be savely mutated.
`CompendiumBrowser#openTab` now expects a full `filterData` object as an optional second parameter.
A tab can now also be opened by calling `CompendiumBrowserTab#open` which also accepts initial `filterData` for that tab as an optional parameter.