### PR TITLE
Allow checks as the source of damage rolls

### DIFF
--- a/src/module/system/damage/damage.ts
+++ b/src/module/system/damage/damage.ts
@@ -28,6 +28,9 @@ export class DamagePF2e {
         if (context.sourceType === "attack") {
             const outcomeLabel = game.i18n.localize(`PF2E.Check.Result.Degree.Attack.${outcome}`);
             flavor += ` (${outcomeLabel})`;
+        } else if (context.sourceType === "check") {
+            const outcomeLabel = game.i18n.localize(`PF2E.Check.Result.Degree.Check.${outcome}`);
+            flavor += ` (${outcomeLabel})`;
         }
 
         if (data.traits) {

--- a/src/module/system/damage/types.ts
+++ b/src/module/system/damage/types.ts
@@ -42,7 +42,7 @@ interface DamageRollRenderData {
 
 interface DamageRollContext extends BaseRollContext {
     type: "damage-roll";
-    sourceType: "attack" | "save";
+    sourceType: "attack" | "check" | "save";
     outcome?: DegreeOfSuccessString;
     self?: StrikeSelf | null;
     target?: AttackTarget | null;


### PR DESCRIPTION
Show the degree of success as critical success, success, failure, and critical failure instead of critical hit, hit, miss, and critical miss when the source of the damage roll is set to check.

![image](https://user-images.githubusercontent.com/6374503/224229972-6bb19ad0-d40b-4086-a1e2-a6b32933c1a5.png)
