### PR TITLE
Override damage type of deadly dice when main damage type is changed

### DIFF
--- a/src/module/system/damage/weapon.ts
+++ b/src/module/system/damage/weapon.ts
@@ -604,10 +604,9 @@ class WeaponDamagePF2e {
                 base.dieSize = override.override?.dieSize ?? base.dieSize;
                 base.damageType = override.override?.damageType ?? base.damageType;
                 base.diceNumber = override.override?.diceNumber ?? base.diceNumber;
-                damage.dice.forEach((die) => {
-                    if (die.slug.startsWith("deadly-"))
-                        die.damageType = override.override?.damageType ?? die.damageType;
-                });
+                for (const die of damage.dice.filter((d) => d.slug.startsWith("deadly-"))) {
+                    die.damageType = override.override?.damageType ?? die.damageType;
+                }
             }
         }
 

--- a/src/module/system/damage/weapon.ts
+++ b/src/module/system/damage/weapon.ts
@@ -604,6 +604,11 @@ class WeaponDamagePF2e {
                 base.dieSize = override.override?.dieSize ?? base.dieSize;
                 base.damageType = override.override?.damageType ?? base.damageType;
                 base.diceNumber = override.override?.diceNumber ?? base.diceNumber;
+                damage.dice.forEach(({ slug, damageType }) => {
+                    if (slug.startsWith("deadly-")) {
+                      damageType = override.override?.damageType ?? damageType;
+                    }
+                });
             }
         }
 

--- a/src/module/system/damage/weapon.ts
+++ b/src/module/system/damage/weapon.ts
@@ -604,10 +604,9 @@ class WeaponDamagePF2e {
                 base.dieSize = override.override?.dieSize ?? base.dieSize;
                 base.damageType = override.override?.damageType ?? base.damageType;
                 base.diceNumber = override.override?.diceNumber ?? base.diceNumber;
-                damage.dice.forEach(({ slug, damageType }) => {
-                    if (slug.startsWith("deadly-")) {
-                      damageType = override.override?.damageType ?? damageType;
-                    }
+                damage.dice.forEach((die) => {
+                    if (die.slug.startsWith("deadly-"))
+                        die.damageType = override.override?.damageType ?? die.damageType;
                 });
             }
         }


### PR DESCRIPTION
When the the damage type of a weapon is changed, the deadly dice should use the same damage type (not size!) as the base. Otherwise, if using something like Soulforger's Planar Pain on a weapon with the Deadly trait, the deadly die will never do elemental damage when it should. See #6858
Before:
![Screenshot 2023-03-11 142035](https://user-images.githubusercontent.com/52758909/224487419-0cbfdd75-b96d-48aa-aa33-065897b5368a.png)
After:
![Screenshot 2023-03-11 142124](https://user-images.githubusercontent.com/52758909/224487422-9616a72a-64c2-4fc2-b400-283dda4a6874.png)
