### PR TITLE
Disable PF2e's GM Vision if the GM Vision module is enabled

### DIFF
--- a/src/module/system/settings/index.ts
+++ b/src/module/system/settings/index.ts
@@ -265,9 +265,16 @@ export function registerSettings(): void {
         default: false,
         type: Boolean,
         onChange: (value) => {
-            const color = value ? CONFIG.PF2E.Canvas.darkness.gmVision : CONFIG.PF2E.Canvas.darkness.default;
-            CONFIG.Canvas.darknessColor = color;
-            canvas.colorManager.initialize();
+            if (
+                canvas.ready &&
+                game.user.isGM &&
+                !game.modules.get("gm-vision")?.active &&
+                !game.modules.get("perfect-vision")?.active
+            ) {
+                const color = value ? CONFIG.PF2E.Canvas.darkness.gmVision : CONFIG.PF2E.Canvas.darkness.default;
+                CONFIG.Canvas.darknessColor = color;
+                canvas.colorManager.initialize();
+            }
         },
     });
 

--- a/src/scripts/hooks/ready.ts
+++ b/src/scripts/hooks/ready.ts
@@ -83,6 +83,7 @@ export const Ready = {
             if (
                 canvas.ready &&
                 game.user.isGM &&
+                !game.modules.get("gm-vision")?.active &&
                 !game.modules.get("perfect-vision")?.active &&
                 game.settings.get("pf2e", "gmVision")
             ) {

--- a/src/scripts/register-keybindings.ts
+++ b/src/scripts/register-keybindings.ts
@@ -6,8 +6,8 @@ export function registerKeybindings(): void {
         onUp: (): boolean => canvas.tokens.cycleStack(),
     });
 
-    // Defer to the Perfect Vision module if enabled
-    if (!game.modules.get("perfect-vision")?.active) {
+    // Defer to the GM Vision/Perfect Vision module if enabled
+    if (!game.modules.get("gm-vision")?.active && !game.modules.get("perfect-vision")?.active) {
         game.keybindings.register("pf2e", "gm-vision", {
             name: "PF2E.Keybinding.GMVision.Label",
             hint: "PF2E.Keybinding.GMVision.Hint",


### PR DESCRIPTION
The GM Vision module (https://foundryvtt.com/packages/gm-vision) increases brightness similar to PV's GM Vision.

I also added missing checks to PF2e' GM Vision setting `onChange` handler: without these checks it's possible to toggle PF2e's GM Vision via marco as non-GM and if the GM Vision or Perfect Vision module is enabled.