### PR TITLE
automate Thaumaturge regalia through GrantItem

### DIFF
--- a/packs/data/classfeatures.db/regalia.json
+++ b/packs/data/classfeatures.db/regalia.json
@@ -21,7 +21,12 @@
         "prerequisites": {
             "value": []
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.equipment-srd.DwwBKOtRJDjw0pvy"
+            }
+        ],
         "source": {
             "value": "Pathfinder Dark Archive"
         },

--- a/packs/data/equipment.db/regalia.json
+++ b/packs/data/equipment.db/regalia.json
@@ -1,0 +1,204 @@
+{
+    "_id": "DwwBKOtRJDjw0pvy",
+    "img": "systems/pf2e/icons/features/classes/regalia.webp",
+    "name": "Regalia",
+    "system": {
+        "baseItem": null,
+        "containerId": null,
+        "description": {
+            "value": "<p>Regalia implements represent rulership, leadership, and social connections. While they differ in shape depending on regional customs and markers used to signify authority, common regalia implements are scepters, jeweled orbs, and heraldic banners. Regalia implements are associated with the harrow suit of crowns and the astrological signs of the patriarch and the sovereign dragon.</p>\n<h3><strong>Initiate Benefit</strong></h3>\n<p>While you hold your regalia, you gain an air of authority and bolster the courage of allies who believe in you. Your regalia aids you when you attempt to convince others. You gain a +1 circumstance bonus to Deception, Diplomacy, and Intimidation checks. Allies who can see you can use Follow the Expert to follow you even if you're only trained in a skill and not an expert, due to the competence you clearly exude. When they do, the circumstance bonus they gain from Following the Expert is +1.</p>\n<p>When you are holding your regalia, you gain an inspiring aura that stokes the courage of you and all allies in a @Template[type:emanation|distance:15] who can see you, granting them a +1 status bonus to saving throws against fear. At the end of your turn, at the same time you would reduce your frightened value by 1, you reduce the frightened value of all allies within your inspiring aura by 1. Your aura has the emotion, mental, and visual traits.</p>\n<h3><strong>Adept Benefit</strong></h3>\n<p>Your regalia's power increases, and so do the abilities it grants. The circumstance bonus you gain to Deception, Diplomacy, and Intimidation increases to +2, as long as you have master proficiency in each skill. When others use Follow the Expert to follow you, you grant them a +2 circumstance bonus if you are trained, +3 if you have expert proficiency, or +4 if you have master or legendary proficiency.</p>\n<p>The courage your aura instills grows stronger. The +1 status bonus now applies to all saving throws against mental effects, rather than only against fear, and you and allies in your aura gain a +2 status bonus to damage rolls. At 11th level, this increases to a +3 status bonus to damage rolls, and at 17th level, this increases to a +4 status bonus to damage rolls.</p>\n<h3><strong>Intensify Vulnerability</strong></h3>\n<p>Your regalia implement makes you seem more confident and inspiring with each success. Whenever you successfully Strike the target of your Exploit Vulnerability, choose an ally that you can see. That ally gains a +1 circumstance bonus to its attack rolls against the creature until the beginning of your next turn. If the attack roll was a critical hit, the circumstance bonus increases to +2.</p>\n<h3><strong>Paragon Benefit</strong></h3>\n<p>Your regalia grants you the true gravitas of rulership, tying together the hearts and minds of your allies and making it impossible for you to leave a bad impression. If you roll a critical failure on a check to @UUID[Compendium.pf2e.actionspf2e.Coerce]{Coerce}, Make an Impression, or Request, you get a failure instead. When others use Follow the Expert to follow you, you grant them a +3 circumstance bonus if you are trained or +4 if you are an expert or above.</p>\n<p>Allies in your inspiring aura aren't @UUID[Compendium.pf2e.conditionitems.Flat-Footed]{Flat-Footed} from being flanked unless you too are flanked. If one of your allies in the aura is clumsy, enfeebled, frightened, sickened, or stupefied, the status penalty your ally takes from the condition is 1 lower than the condition's value as long as the ally remains in the aura, unless you too are affected by the same condition.</p>"
+        },
+        "equippedBulk": {
+            "value": ""
+        },
+        "hardness": 0,
+        "hp": {
+            "brokenThreshold": 0,
+            "max": 0,
+            "value": 0
+        },
+        "level": {
+            "value": 0
+        },
+        "negateBulk": {
+            "value": "0"
+        },
+        "preciousMaterial": {
+            "value": null
+        },
+        "preciousMaterialGrade": {
+            "value": null
+        },
+        "price": {
+            "value": {}
+        },
+        "quantity": 1,
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "label": "Regalia Initiate",
+                "selector": [
+                    "deception",
+                    "intimidation",
+                    "diplomacy"
+                ],
+                "slug": "regaliaFlat",
+                "type": "circumstance",
+                "value": 1
+            },
+            {
+                "key": "FlatModifier",
+                "label": "Inspiring Aura (vs fear)",
+                "predicate": [
+                    "fear"
+                ],
+                "selector": "saving-throw",
+                "type": "status",
+                "value": 1
+            },
+            {
+                "key": "AdjustModifier",
+                "mode": "add",
+                "predicate": [
+                    "adept:regalia"
+                ],
+                "relabel": "Regalia Adept",
+                "selector": "deception",
+                "slug": "regaliaFlat",
+                "value": 1
+            },
+            {
+                "key": "AdjustModifier",
+                "mode": "add",
+                "predicate": [
+                    "adept:regalia"
+                ],
+                "relabel": "Regalia Adept",
+                "selector": "intimidation",
+                "slug": "regaliaFlat",
+                "value": 1
+            },
+            {
+                "key": "AdjustModifier",
+                "mode": "add",
+                "predicate": [
+                    "adept:regalia"
+                ],
+                "relabel": "Regalia Adept",
+                "selector": "diplomacy",
+                "slug": "regaliaFlat",
+                "value": 1
+            },
+            {
+                "colors": {
+                    "border": "#7851a9",
+                    "fill": "#7851a9"
+                },
+                "effects": [
+                    {
+                        "affects": "allies",
+                        "events": [
+                            "enter"
+                        ],
+                        "includesSelf": false,
+                        "uuid": "Compendium.pf2e.feat-effects.dOLqJ7ihRltOsMDI"
+                    }
+                ],
+                "key": "Aura",
+                "predicate": [
+                    {
+                        "nor": [
+                            "adept:regalia"
+                        ]
+                    }
+                ],
+                "radius": 15,
+                "slug": "inspiring-aura-regalia",
+                "traits": [
+                    "emotion",
+                    "mental",
+                    "visual"
+                ]
+            },
+            {
+                "colors": {
+                    "border": "#7851a9",
+                    "fill": "#7851a9"
+                },
+                "effects": [
+                    {
+                        "affects": "allies",
+                        "events": [
+                            "enter"
+                        ],
+                        "includesSelf": false,
+                        "uuid": "Compendium.pf2e.feat-effects.qhVeAj8VHHtSP1iu"
+                    }
+                ],
+                "key": "Aura",
+                "predicate": [
+                    "adept:regalia"
+                ],
+                "radius": 15,
+                "slug": "inspiring-aura-regalia",
+                "traits": [
+                    "emotion",
+                    "mental",
+                    "visual"
+                ]
+            },
+            {
+                "adjustment": {
+                    "criticalFailure": "one-degree-better"
+                },
+                "key": "AdjustDegreeOfSuccess",
+                "predicate": [
+                    "action:coerce",
+                    "paragon:regalia"
+                ],
+                "selector": "intimidation",
+                "type": "skill"
+            },
+            {
+                "adjustment": {
+                    "criticalFailure": "one-degree-better"
+                },
+                "key": "AdjustDegreeOfSuccess",
+                "predicate": [
+                    "action:make-an-impression",
+                    "paragon:regalia"
+                ],
+                "selector": "diplomacy",
+                "type": "skill"
+            },
+            {
+                "adjustment": {
+                    "criticalFailure": "one-degree-better"
+                },
+                "key": "AdjustDegreeOfSuccess",
+                "predicate": [
+                    "action:request",
+                    "paragon:regalia"
+                ],
+                "selector": "diplomacy",
+                "type": "skill"
+            }
+        ],
+        "size": "med",
+        "source": {
+            "value": "Pathfinder Dark Archive"
+        },
+        "stackGroup": null,
+        "traits": {
+            "rarity": "common",
+            "value": []
+        },
+        "usage": {
+            "value": "held-in-one-hand"
+        },
+        "weight": {
+            "value": "-"
+        }
+    },
+    "type": "equipment"
+}

--- a/packs/data/feat-effects.db/effect-inspiring-aura-adept.json
+++ b/packs/data/feat-effects.db/effect-inspiring-aura-adept.json
@@ -1,0 +1,72 @@
+{
+    "_id": "qhVeAj8VHHtSP1iu",
+    "img": "systems/pf2e/icons/features/classes/regalia.webp",
+    "name": "Effect: Inspiring Aura (Adept)",
+    "system": {
+        "badge": null,
+        "description": {
+            "value": ""
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "unlimited",
+            "value": -1
+        },
+        "level": {
+            "value": 1
+        },
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "label": "Inspiring Aura (vs mental)",
+                "predicate": [
+                    "mental"
+                ],
+                "selector": "saving-throw",
+                "type": "status",
+                "value": 1
+            },
+            {
+                "key": "FlatModifier",
+                "label": "Inspiring Aura",
+                "selector": "damage",
+                "type": "status",
+                "value": {
+                    "brackets": [
+                        {
+                            "end": 10,
+                            "start": 1,
+                            "value": 2
+                        },
+                        {
+                            "end": 16,
+                            "start": 11,
+                            "value": 3
+                        },
+                        {
+                            "start": 17,
+                            "value": 4
+                        }
+                    ]
+                }
+            }
+        ],
+        "source": {
+            "value": ""
+        },
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "target": null,
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        },
+        "unidentified": false
+    },
+    "type": "effect"
+}

--- a/packs/data/feat-effects.db/effect-inspiring-aura-initiate.json
+++ b/packs/data/feat-effects.db/effect-inspiring-aura-initiate.json
@@ -1,0 +1,48 @@
+{
+    "_id": "dOLqJ7ihRltOsMDI",
+    "img": "systems/pf2e/icons/features/classes/regalia.webp",
+    "name": "Effect: Inspiring Aura (Initiate)",
+    "system": {
+        "badge": null,
+        "description": {
+            "value": ""
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "unlimited",
+            "value": -1
+        },
+        "level": {
+            "value": 1
+        },
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "label": "Inspiring Aura (vs fear)",
+                "predicate": [
+                    "fear"
+                ],
+                "selector": "saving-throw",
+                "type": "status",
+                "value": 1
+            }
+        ],
+        "source": {
+            "value": ""
+        },
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "target": null,
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        },
+        "unidentified": false
+    },
+    "type": "effect"
+}


### PR DESCRIPTION
Selecting "Regalia" as a thaumaturge implement grants a "Regalia" item. This item grants the regalia benefits that can be automated when wielded, checking the flags set by the choices built into the class features to upgrade the abilities appropriately.

