### PR TITLE
Change order of roll notes for action macros

### DIFF
--- a/src/module/system/action-macros/helpers.ts
+++ b/src/module/system/action-macros/helpers.ts
@@ -236,7 +236,7 @@ export class ActionMacroHelpers {
                     target && targetActor && typeof distance === "number"
                         ? { token: target, actor: targetActor, distance, rangeIncrement }
                         : null;
-                const notes = [options.extraNotes?.(statistic.slug) ?? [], statistic.notes ?? []].flat();
+                const notes = [statistic.notes ?? [], options.extraNotes?.(statistic.slug) ?? []].flat();
                 const substitutions = extractRollSubstitutions(
                     actor.synthetics.rollSubstitutions,
                     [statistic.slug],


### PR DESCRIPTION
Move the extra roll notes for action macros after the roll notes for the used statistic. These extra notes are usually related to the degree of success and makes most sense at the bottom of the list.