### PR TITLE
Add frying pan training to Halfling Weapon Familiarity

### DIFF
--- a/packs/data/feats.db/halfling-weapon-familiarity.json
+++ b/packs/data/feats.db/halfling-weapon-familiarity.json
@@ -41,6 +41,12 @@
                 "value": 1
             },
             {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "system.martial.weapon-base-frying-pan.rank",
+                "value": 1
+            },
+            {
                 "definition": [
                     "item:trait:halfling",
                     "item:category:advanced"


### PR DESCRIPTION
> Characters with the Halfling Weapon Familiarity ancestry feat are trained in the frying pan.