### PR TITLE
Add `CanvasDocumentMixin2` type definition

### DIFF
--- a/types/foundry/client/documents/mixins/canvas-document-mixin2.d.ts
+++ b/types/foundry/client/documents/mixins/canvas-document-mixin2.d.ts
@@ -1,0 +1,61 @@
+/**
+ * A specialized sub-class of the ClientDocumentMixin which is used for document types that are intended to be
+ * represented upon the game Canvas.
+ * @category - Mixins
+ */
+declare class CanvasDocument2<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    TParent extends ClientDocument2<any> | null = ClientDocument2<any> | null
+> extends ClientDocument2<TParent> {
+    /** A reference to the PlaceableObject instance which represents this Embedded Document. */
+    _object: PlaceableObject<this> | null;
+
+    /** Has this object been deliberately destroyed as part of the deletion workflow? */
+    protected _destroyed: boolean;
+
+    constructor(data: object, context: DocumentConstructionContext<TParent>);
+
+    /* -------------------------------------------- */
+    /*  Properties                                  */
+    /* -------------------------------------------- */
+
+    /** A lazily constructed PlaceableObject instance which can represent this Document on the game canvas. */
+    get object(): this["_object"];
+
+    /** A reference to the CanvasLayer which contains Document objects of this type. */
+    get layer(): NonNullable<this["object"]>["layer"] | null;
+
+    /** An indicator for whether this document is currently rendered on the game canvas. */
+    get rendered(): boolean;
+
+    /* -------------------------------------------- */
+    /*  Event Handlers                              */
+    /* -------------------------------------------- */
+
+    /**
+     * @see abstract.Document#_onCreate
+     */
+    protected _onCreate(data: this["_source"], options: DocumentModificationContext<this>, userId: string): void;
+
+    /**
+     * @see abstract.Document#_onUpdate
+     */
+    protected _onUpdate(
+        changed: DeepPartial<this["_source"]>,
+        options: DocumentUpdateContext<this>,
+        userId: string
+    ): void;
+
+    /**
+     * @see abstract.Document#_onDelete
+     */
+    protected _onDelete(options: DocumentModificationContext<this>, userId: string): void;
+}
+
+declare interface CanvasDocument2<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    TParent extends ClientDocument2<any> | null = ClientDocument2<any> | null
+> extends ClientDocument2<TParent> {
+    // System note: in most but not all canvas documents
+    hidden?: boolean;
+}

--- a/types/foundry/client/documents/mixins/index.d.ts
+++ b/types/foundry/client/documents/mixins/index.d.ts
@@ -1,3 +1,4 @@
 import "./canvas-document-mixin";
+import "./canvas-document-mixin2";
 import "./client-document-mixin";
 import "./client-document-mixin2";

--- a/types/foundry/client/pixi/placeable-object/base.d.ts
+++ b/types/foundry/client/pixi/placeable-object/base.d.ts
@@ -5,7 +5,9 @@ declare global {
      * An Abstract Base Class which defines a Placeable Object which represents an Entity placed on the Canvas
      * @param document The Document instance which is represented by this object
      */
-    abstract class PlaceableObject<TDocument extends CanvasDocument = CanvasDocument> extends PIXI.Container {
+    abstract class PlaceableObject<
+        TDocument extends CanvasDocument | CanvasDocument2 = CanvasDocument | CanvasDocument2
+    > extends PIXI.Container {
         constructor(document: TDocument);
 
         /** Retain a reference to the Scene within which this Placeable Object resides */
@@ -287,7 +289,8 @@ declare global {
         protected _onDragLeftCancel(event: PIXI.InteractionEvent): void;
     }
 
-    interface PlaceableObject<TDocument extends CanvasDocument = CanvasDocument> extends PIXI.Container {
+    interface PlaceableObject<TDocument extends CanvasDocument | CanvasDocument2 = CanvasDocument | CanvasDocument2>
+        extends PIXI.Container {
         hitArea: PIXI.Rectangle;
     }
 }


### PR DESCRIPTION
Continuing the refactor and eventual replacement of the `ClientDocument` and `CanvasDocument` types