### PR TITLE
Initial structure for more data-driven actions

### DIFF
--- a/src/module/actor/actions/base.ts
+++ b/src/module/actor/actions/base.ts
@@ -1,0 +1,140 @@
+import { Action, ActionCost, ActionUseOptions, ActionVariant, ActionVariantUseOptions } from "./types";
+import { getActionGlyph, sluggify } from "@util";
+
+interface BaseActionVariantData {
+    cost?: ActionCost;
+    description?: string;
+    name?: string;
+    slug?: string;
+    traits?: string[];
+}
+
+interface BaseActionData<ActionVariantDataType extends BaseActionVariantData = BaseActionVariantData> {
+    cost?: ActionCost;
+    description: string;
+    img?: string;
+    name: string;
+    slug?: string | null;
+    traits?: string[];
+    variants?: ActionVariantDataType | ActionVariantDataType[];
+}
+
+abstract class BaseActionVariant implements ActionVariant {
+    readonly #action: BaseAction<BaseActionVariantData, BaseActionVariant>;
+    readonly #cost?: ActionCost;
+    readonly #description?: string;
+    readonly name?: string;
+    readonly #slug?: string;
+    readonly #traits?: string[];
+
+    protected constructor(action: BaseAction<BaseActionVariantData, BaseActionVariant>, data?: BaseActionVariantData) {
+        this.#action = action;
+        if (data) {
+            this.#cost = data.cost;
+            this.#description = data.description;
+            this.name = data.name?.trim();
+            this.#slug = data.slug?.trim();
+            this.#traits = data.traits;
+        }
+    }
+
+    get cost() {
+        return this.#cost ?? this.#action.cost;
+    }
+
+    get description() {
+        return this.#description?.trim() || this.#action.description;
+    }
+
+    get glyph() {
+        return getActionGlyph(this.cost ?? null);
+    }
+
+    get slug() {
+        return this.#slug || sluggify(this.name ?? "") || this.#action.slug;
+    }
+
+    get traits() {
+        return this.#traits ?? this.#action.traits;
+    }
+
+    abstract use(options?: Partial<ActionVariantUseOptions>): Promise<unknown>;
+}
+
+abstract class BaseAction<TData extends BaseActionVariantData, TAction extends BaseActionVariant> implements Action {
+    readonly cost?: ActionCost;
+    readonly description?: string;
+    readonly img?: string;
+    readonly name: string;
+    readonly slug: string;
+    readonly traits: string[];
+    readonly #variants: TAction[];
+
+    protected constructor(data: BaseActionData<TData>) {
+        this.cost = data.cost;
+        this.description = data.description;
+        this.img = data.img;
+        this.name = data.name.trim();
+        this.slug = data.slug?.trim() || sluggify(this.name);
+        this.traits = data.traits ?? [];
+        this.#variants = Array.isArray(data.variants)
+            ? data.variants.map(this.toActionVariant.bind(this))
+            : data.variants
+            ? [this.toActionVariant(data.variants)]
+            : [];
+    }
+
+    get glyph() {
+        if (this.#variants.length === 1) {
+            return this.#variants[0].glyph;
+        }
+        const numbers = this.#variants.filter((variant) => typeof variant.cost === "number").sort();
+        if (this.#variants.length === numbers.length && numbers.length > 1) {
+            const first = numbers.shift()?.cost;
+            const last = numbers.pop()?.cost;
+            const key =
+                first === last
+                    ? String(first)
+                    : first === 2 || last === 2
+                    ? `${first} or ${last}`
+                    : `${first} to ${last}`;
+            return getActionGlyph(key);
+        }
+        return getActionGlyph(this.cost ?? "");
+    }
+
+    get variants() {
+        const variants: [string, ActionVariant][] = this.#variants.map((variant) => [variant.slug, variant]);
+        return new Collection(variants);
+    }
+
+    use(options?: Partial<ActionUseOptions>): Promise<unknown> {
+        const variants = this.variants;
+        if (options?.variant && !variants.size) {
+            const reason = game.i18n.format("PF2E.ActionsWarning.Variants.None", {
+                action: this.name,
+                variant: options.variant,
+            });
+            return Promise.reject(reason);
+        }
+        if (!options?.variant && variants.size > 1) {
+            const reason = game.i18n.format("PF2E.ActionsWarning.Variants.Multiple", {
+                action: this.name,
+            });
+            return Promise.reject(reason);
+        }
+        const variant = variants.get(options?.variant ?? "");
+        if (options?.variant && !variant) {
+            const reason = game.i18n.format("PF2E.ActionsWarning.Variants.Nonexisting", {
+                action: this.name,
+                variant: options.variant,
+            });
+            return Promise.reject(reason);
+        }
+        return (variant ?? this.toActionVariant()).use(options);
+    }
+
+    protected abstract toActionVariant(data?: TData): TAction;
+}
+
+export { BaseAction, BaseActionData, BaseActionVariant, BaseActionVariantData };

--- a/src/module/actor/actions/index.ts
+++ b/src/module/actor/actions/index.ts
@@ -1,0 +1,4 @@
+export * from "./types";
+export * from "./base";
+export * from "./simple";
+export * from "./single-check";

--- a/src/module/actor/actions/simple.ts
+++ b/src/module/actor/actions/simple.ts
@@ -1,0 +1,95 @@
+import { ActionCost, ActionUseOptions } from "./types";
+import { ActorPF2e } from "@actor";
+import { getSelectedOrOwnActors } from "@util/token-actor-utils";
+import { BaseAction, BaseActionData, BaseActionVariant, BaseActionVariantData } from "./base";
+import { EffectPF2e } from "@item";
+
+interface SimpleActionVariantData extends BaseActionVariantData {
+    effect?: string | EffectPF2e;
+}
+
+interface SimpleActionData extends BaseActionData<SimpleActionVariantData> {
+    effect?: string | EffectPF2e;
+}
+
+interface SimpleActionUseOptions extends ActionUseOptions {
+    actors: ActorPF2e[];
+    cost: ActionCost;
+    effect: string | EffectPF2e;
+    traits: string[];
+}
+
+async function toEffectItem(effect?: string | EffectPF2e) {
+    return typeof effect === "string" ? await fromUuid(effect) : effect;
+}
+
+class SimpleActionVariant extends BaseActionVariant {
+    readonly #action: SimpleAction;
+    readonly #effect?: string | EffectPF2e;
+
+    constructor(action: SimpleAction, data?: SimpleActionVariantData) {
+        super(action, data);
+        this.#action = action;
+        this.#effect = data?.effect ?? action.effect;
+    }
+
+    get effect() {
+        return this.#effect ?? this.#action.effect;
+    }
+
+    override async use(options: Partial<SimpleActionUseOptions> = {}) {
+        const actors: ActorPF2e[] = [];
+        if (Array.isArray(options.actors)) {
+            actors.push(...options.actors);
+        } else if (options.actors) {
+            actors.push(options.actors);
+        } else {
+            actors.push(...getSelectedOrOwnActors());
+        }
+        if (actors.length === 0) {
+            return ui.notifications.warn(game.i18n.localize("PF2E.ActionsWarning.NoActor"));
+        }
+
+        const traitLabels: Record<string, string | undefined> = CONFIG.PF2E.actionTraits;
+        const traitDescriptions: Record<string, string | undefined> = CONFIG.PF2E.traitsDescriptions;
+        const traits = this.traits.concat(options.traits ?? []).map((trait) => ({
+            description: traitDescriptions[trait],
+            label: traitLabels[trait] ?? trait,
+            slug: trait,
+        }));
+        const effect = await toEffectItem(this.effect);
+        const name = this.name ? `${this.#action.name} - ${this.name}` : this.#action.name;
+        const flavor = await renderTemplate("systems/pf2e/templates/system/actions/simple/chat-message-flavor.hbs", {
+            effect,
+            glyph: this.glyph,
+            name,
+            traits,
+        });
+        const messages = [];
+        for (const actor of actors) {
+            messages.push({
+                flavor,
+                speaker: ChatMessage.getSpeaker({ actor }),
+            });
+            if (effect && actor.isOwner) {
+                await actor.createEmbeddedDocuments("Item", [effect.toObject()]);
+            }
+        }
+        await ChatMessage.create(messages);
+    }
+}
+
+class SimpleAction extends BaseAction<SimpleActionVariantData, SimpleActionVariant> {
+    readonly effect?: string | EffectPF2e;
+
+    public constructor(data: SimpleActionData) {
+        super(data);
+        this.effect = data.effect;
+    }
+
+    protected override toActionVariant(data?: SimpleActionVariantData): SimpleActionVariant {
+        return new SimpleActionVariant(this, data);
+    }
+}
+
+export { SimpleAction, SimpleActionVariantData };

--- a/src/module/actor/actions/single-check.ts
+++ b/src/module/actor/actions/single-check.ts
@@ -1,0 +1,141 @@
+import { ActionGlyph, CheckResultCallback } from "@system/action-macros/types";
+import { ActionUseOptions } from "./types";
+import { ModifierPF2e } from "@actor/modifiers";
+import { ActionMacroHelpers } from "@system/action-macros";
+import { CheckDC } from "@system/degree-of-success";
+import { Statistic } from "@system/statistic";
+import { RollNotePF2e, RollNoteSource } from "@module/notes";
+import { BaseAction, BaseActionData, BaseActionVariant, BaseActionVariantData } from "./base";
+import { getActionGlyph } from "@util";
+import { ActorPF2e } from "@actor";
+
+type SingleCheckActionRollNoteData = Omit<RollNoteSource, "selector"> & { selector?: string };
+function toRollNoteSource(data: SingleCheckActionRollNoteData): RollNoteSource {
+    data.selector ??= "";
+    return data as RollNoteSource;
+}
+
+interface SingleCheckActionVariantData extends BaseActionVariantData {
+    difficultyClass?: CheckDC | string;
+    notes?: SingleCheckActionRollNoteData[];
+    rollOptions?: string[];
+    statistic?: string;
+}
+
+interface SingleCheckActionData extends BaseActionData<SingleCheckActionVariantData> {
+    difficultyClass?: CheckDC | string;
+    notes?: SingleCheckActionRollNoteData[];
+    rollOptions?: string[];
+    statistic: string;
+}
+
+interface SingleCheckActionRollOptions extends ActionUseOptions {
+    actors: ActorPF2e | ActorPF2e[];
+    difficultyClass: CheckDC | string;
+    modifiers: ModifierPF2e[];
+    multipleAttackPenalty: number;
+    notes: SingleCheckActionRollNoteData[];
+    rollOptions?: string[];
+    statistic: string;
+}
+
+function isCheckDC(dc?: CheckDC | string | null): dc is CheckDC {
+    return !!dc && typeof dc !== "string" && "value" in dc;
+}
+
+function isString(dc?: CheckDC | string | null): dc is string {
+    return !!dc && typeof dc === "string";
+}
+
+class SingleCheckActionVariant extends BaseActionVariant {
+    readonly #action: SingleCheckAction;
+    readonly #difficultyClass?: CheckDC | string;
+    readonly #notes?: RollNoteSource[];
+    readonly #rollOptions?: string[];
+    readonly #statistic?: string;
+
+    constructor(action: SingleCheckAction, data?: SingleCheckActionVariantData) {
+        super(action, data);
+        this.#action = action;
+        if (data) {
+            this.#difficultyClass = data.difficultyClass;
+            this.#notes = data.notes ? data.notes.map(toRollNoteSource) : undefined;
+            this.#rollOptions = data.rollOptions;
+            this.#statistic = data.statistic;
+        }
+    }
+
+    get difficultyClass() {
+        return this.#difficultyClass ?? this.#action.difficultyClass;
+    }
+
+    get notes() {
+        return this.#notes ?? this.#action.notes;
+    }
+
+    get rollOptions() {
+        return this.#rollOptions ?? this.#action.rollOptions;
+    }
+
+    get statistic() {
+        return this.#statistic ?? this.#action.statistic;
+    }
+
+    override async use(options: Partial<SingleCheckActionRollOptions> = {}) {
+        return new Promise((resolve: (result: CheckResultCallback) => void) => {
+            const difficultyClass = options?.difficultyClass ?? this.difficultyClass;
+            const modifiers = options?.modifiers ?? [];
+            if (options?.multipleAttackPenalty) {
+                const map = options.multipleAttackPenalty;
+                const modifier = map > 0 ? Math.min(2, map) * -5 : map;
+                modifiers.push(new ModifierPF2e({ label: "PF2E.MultipleAttackPenalty", modifier }));
+            }
+            const notes = (this.notes as SingleCheckActionRollNoteData[])
+                .concat(options?.notes ?? [])
+                .map(toRollNoteSource)
+                .map((note) => new RollNotePF2e(note));
+            const rollOptions = this.rollOptions.concat(options?.rollOptions ?? []);
+            const slug = this.statistic;
+            const title = this.name ? `${this.#action.name} - ${this.name}` : this.#action.name;
+            ActionMacroHelpers.simpleRollActionCheck({
+                actors: options?.actors,
+                title,
+                actionGlyph: getActionGlyph(this.cost ?? null) as ActionGlyph,
+                callback: resolve,
+                checkContext: (opts) => ActionMacroHelpers.defaultCheckContext(opts, { modifiers, rollOptions, slug }),
+                difficultyClass: isCheckDC(difficultyClass) ? difficultyClass : undefined,
+                difficultyClassStatistic: isString(difficultyClass)
+                    ? (target) => getProperty(target, difficultyClass) as Statistic
+                    : undefined,
+                event: options?.event,
+                extraNotes: (selector) =>
+                    notes.map((note) => {
+                        note.selector ||= selector; // treat empty selectors as always applicable to this check
+                        return note;
+                    }),
+                traits: this.traits,
+            });
+        });
+    }
+}
+
+class SingleCheckAction extends BaseAction<SingleCheckActionVariantData, SingleCheckActionVariant> {
+    readonly difficultyClass?: CheckDC | string;
+    readonly notes: RollNoteSource[];
+    readonly rollOptions: string[];
+    readonly statistic: string;
+
+    public constructor(data: SingleCheckActionData) {
+        super(data);
+        this.difficultyClass = data.difficultyClass;
+        this.notes = (data.notes ?? []).map(toRollNoteSource);
+        this.rollOptions = data.rollOptions ?? [];
+        this.statistic = data.statistic;
+    }
+
+    protected override toActionVariant(data?: SingleCheckActionVariantData): SingleCheckActionVariant {
+        return new SingleCheckActionVariant(this, data);
+    }
+}
+
+export { SingleCheckAction, SingleCheckActionVariantData };

--- a/src/module/actor/actions/types.ts
+++ b/src/module/actor/actions/types.ts
@@ -1,0 +1,38 @@
+import { ActorPF2e } from "@actor";
+
+const ACTION_COST = ["free", "reaction", 1, 2, 3] as const;
+type ActionCost = (typeof ACTION_COST)[number];
+
+interface ActionVariantUseOptions extends Record<string, unknown> {
+    actors?: ActorPF2e | ActorPF2e[];
+    event: Event;
+}
+
+interface ActionVariant {
+    cost?: ActionCost;
+    description?: string;
+    glyph?: string;
+    name?: string;
+    slug: string;
+    traits: string[];
+    use(options?: Partial<ActionVariantUseOptions>): Promise<unknown>;
+}
+
+interface ActionUseOptions extends ActionVariantUseOptions {
+    variant: string;
+}
+
+interface Action {
+    cost?: ActionCost;
+    description?: string;
+    glyph?: string;
+    img?: string;
+    name: string;
+    slug: string;
+    traits: string[];
+    variants: Collection<ActionVariant>;
+    /** Uses the default variant for this action, which will usually be the first one in the collection. */
+    use(options?: Partial<ActionUseOptions>): Promise<unknown>;
+}
+
+export { ACTION_COST, Action, ActionCost, ActionUseOptions, ActionVariant, ActionVariantUseOptions };

--- a/src/styles/ui/sidebar/chat/_check.scss
+++ b/src/styles/ui/sidebar/chat/_check.scss
@@ -45,6 +45,16 @@
                 }
             }
         }
+
+        .effect {
+            display: flex;
+            align-items: center;
+            column-gap: 5px;
+            img {
+                height: 32px;
+                width: 32px;
+            }
+        }
     }
 }
 

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -822,7 +822,12 @@
         "ActionsReactionsHeader": "Reactions",
         "ActionsWarning": {
             "NoActor": "Select at least one token before rolling, or assign a default character.",
-            "NoStatistic": "Actor {name} ({id}) does not have a statistic for {statistic}."
+            "NoStatistic": "Actor {name} ({id}) does not have a statistic for {statistic}.",
+            "Variants": {
+                "None": "Action '{action}' has no variants, but variant '{variant}' was requested.",
+                "Multiple": "Action '{action}' has multiple variants, but no variant was requested.",
+                "Nonexisting": "Specified variant '{variant}' does not exist for action '{action}'"
+            }
         },
         "Actor": {
             "ApplyDamage": {

--- a/static/templates/system/actions/simple/chat-message-flavor.hbs
+++ b/static/templates/system/actions/simple/chat-message-flavor.hbs
@@ -1,0 +1,17 @@
+<h4 class="action">
+    {{#if glyph}}
+        <span class="pf2-icon larger">{{glyph}}</span>
+    {{/if}}
+    <strong>{{name}}</strong>
+</h4>
+<div class="tags">
+    {{#each traits as |trait|}}
+        <span class="tag tooltipstered" data-slug="{{trait.slug}}" data-description="{{trait.description}}">{{localize trait.label}}</span>
+    {{/each}}
+</div>
+{{#if effect}}
+    <div class="effect">
+        <img src="{{effect.img}}" alt="{{effect.img}}">
+        <span>{{effect.name}}</span>
+    </div>
+{{/if}}


### PR DESCRIPTION
Define an initial interface for actions, as well an implementation and data structures for simple actions without any check involved and actions involving a single check.

### Simple Action Examples

**Take Cover**
```js
const action = new SimpleAction({
  cost: 1,
  description: "You press yourself against a wall or duck behind an obstacle to take better advantage of cover. If you would have standard cover, you instead gain greater cover, which provides a +4 circumstance bonus to AC; to Reflex saves against area effects; and to Stealth checks to Hide, Sneak, or otherwise avoid detection. Otherwise, you gain the benefits of standard cover (a +2 circumstance bonus instead). This lasts until you move from your current space, use an attack action, become unconscious, or end this effect as a free action.",
  effect: "Compendium.pf2e.other-effects.I9lfZUiCwMiGogVi", // Effect: Cover
  name: "Take Cover",
  requirements: "You are benefiting from cover, are near a feature that allows you to take cover, or are prone.",
});

action.use({ event }).catch(reason => ui.notifications.error(reason));
```
<img width="296" alt="Take Cover Chat Card" src="https://user-images.githubusercontent.com/6374503/227751667-3ba2bbc6-fa6b-416f-b35a-378dce1de5b9.png">

**Raise a Shield**
```js
const action = new SimpleAction({
  cost: 1,
  description: "You position your shield to protect yourself. When you have Raised a Shield, you gain its listed circumstance bonus to AC. Your shield remains raised until the start of your next turn.",
  effect: "Compendium.pf2e.equipment-effects.2YgXoHvJfrDHucMr", // Effect: Raise a Shield
  name: "Raise a Shield",
  requirements: "You are wielding a shield.",
});

action.use({ event }).catch(reason => ui.notifications.error(reason));
```
<img width="296" alt="Raise a Shield Chat Card" src="https://user-images.githubusercontent.com/6374503/227751696-7613550e-c6eb-4dc7-ad04-30ed877ac597.png">

### Single Check Action Examples

**Treat Poison**
```js
const action = new SingleCheckAction({
  cost: 1,
  description: "You treat a patient to prevent the spread of poison. Attempt a Medicine check against the poison's DC. After you attempt to Treat a Poison for a creature, you can't try again until after the next time that creature attempts a save against the poison.",
  name: "Treat Poison",
  notes: [
    { outcome: ["criticalSuccess"], text: "You grant the creature a +4 circumstance bonus to its next saving throw against the poison.", title: "Critical Success" },
    { outcome: ["success"], text: "You grant the creature a +2 circumstance bonus to its next saving throw against the poison.", title: "Success" },
    { outcome: ["criticalFailure"], text: "Your efforts cause the creature to take a -2 circumstance penalty to its next save against the poison.", title: "Critical Failure" },
  ],
  requirements: "You are holding healer's tools, or you are wearing them and have a hand free",
  statistic: "medicine",
  traits: ["manipulate"],
});

action.use({
  difficultyClass: { label: "Giant Centipede Venom DC", value: 17 },
  event,
}).catch(reason => ui.notifications.error(reason));
```
<img width="296" alt="Treat Poison Chat Card" src="https://user-images.githubusercontent.com/6374503/227751728-a4acfa88-5114-4e50-80a8-e495aab601a8.png">

**Trip**
```js
const action = new SingleCheckAction({
  cost: 1,
  description: "You try to knock a creature to the ground. Attempt an Athletics check against the target's Reflex DC.",
  difficultyClass: "saves.reflex",
  name: "Trip",
  notes: [
    { outcome: ["criticalSuccess"], text: "The target falls and lands prone and takes 1d6 bludgeoning damage.", title: "Critical Success" },
    { outcome: ["success"], text: "The target falls and lands prone.", title: "Success" },
    { outcome: ["criticalFailure"], text: "You lose your balance and fall and land prone.", title: "Critical Failure" },
  ],
  requirements: "You have at least one hand free. Your target can't be more than one size larger than you.",
  statistic: "athletics",
  traits: ["attack"],
});

action.use({ event }).catch(reason => ui.notifications.error(reason));
```
<img width="296" alt="Trip Chat Card" src="https://user-images.githubusercontent.com/6374503/227751792-19653bd4-ec77-42a1-a216-bd600bbfd2da.png">

**Administer First Aid - Stop Bleeding**
```js
const action = new game.pf2e.SingleCheckAction({
  cost: 2,
  description: "<p>You perform first aid on an adjacent creature that is dying or bleeding. If a creature is both dying and bleeding, choose which ailment you're trying to treat before you roll. You can Administer First Aid again to attempt to remedy the other effect.</p><ol><li><strong>Stabilize</strong> Attempt a Medicine check on a creature that has 0 Hit Points and the dying condition. The DC is equal to 5 + that creature's recovery roll DC (typically 15 + its dying value).</li><li><strong>Stop Bleeding</strong> Attempt a Medicine check on a creature that is taking persistent bleed damage, giving them a chance to make another flat check to remove the persistent damage. The DC is usually the DC of the effect that caused the bleed.</li></ol><p><strong>Success</strong> If you're trying to stabilize, the creature loses the dying condition (but remains unconscious). If you're trying to stop bleeding, the creature attempts a flat check to end the bleeding.<br><strong>Critical Failure</strong> If you were trying to stabilize, the creature's dying value increases by 1. If you were trying to stop bleeding, it immediately takes an amount of damage equal to its persistent bleed damage.<p>",
  name: "Administer First Aid",
  requirements: "You are holding healer's tools, or you are wearing them and have a hand free",
  statistic: "medicine",
  traits: ["manipulate"],
  variants: [
    {
      name: "Stabilize",
      notes: [{
        outcome: ["criticalSuccess", "success"],
        text: "The creature loses the dying condition (but remains unconscious).",
        title: "Success",
      }, {
        outcome: ["criticalFailure"],
        text: "The creature's dying value increases by 1.",
        title: "Critical Failure",
      }],
    }, {
      name: "Stop Bleeding",
      notes: [{
        outcome: ["criticalSuccess", "success"],
        text: "The creature attempts a flat check to end the bleeding.",
        title: "Success",
      }, {
        outcome: ["criticalFailure"],
        text: "The creature immediately takes an amount of damage equal to its persistent bleed damage.",
        title: "Critical Failure",
      }],
    },
  ],
});

action.use({
  difficultyClass: { label: "Serrating Rune Bleed DC", value: 28 },
  event,
  variant: "stop-bleeding",
}).catch(reason => ui.notifications.error(reason));
```
<img width="289" alt="Administer First Aid - Stop Bleeding Chat Card" src="https://user-images.githubusercontent.com/6374503/227751838-41883a11-d65a-404f-9226-c89a37415916.png">

