### PR TITLE
Fix damage types on thunderburst

### DIFF
--- a/packs/data/spells.db/thunderburst.json
+++ b/packs/data/spells.db/thunderburst.json
@@ -25,11 +25,20 @@
         "damage": {
             "value": {
                 "0": {
-                    "applyMod": null,
+                    "applyMod": false,
                     "type": {
                         "categories": [],
                         "subtype": "",
-                        "value": ""
+                        "value": "bludgeoning"
+                    },
+                    "value": "2d6"
+                },
+                "I7vz0Yz4V7i1x8HW": {
+                    "applyMod": false,
+                    "type": {
+                        "categories": [],
+                        "subtype": "",
+                        "value": "sonic"
                     },
                     "value": "2d6"
                 }
@@ -42,11 +51,12 @@
             "value": ""
         },
         "hasCounteractCheck": {
-            "value": null
+            "value": false
         },
         "heightening": {
             "damage": {
-                "0": "2d6"
+                "0": "2d6",
+                "I7vz0Yz4V7i1x8HW": "2d6"
             },
             "interval": 2,
             "type": "interval"

--- a/packs/data/spells.db/thunderburst.json
+++ b/packs/data/spells.db/thunderburst.json
@@ -33,7 +33,7 @@
                     },
                     "value": "2d6"
                 },
-                "I7vz0Yz4V7i1x8HW": {
+                "1": {
                     "applyMod": false,
                     "type": {
                         "categories": [],
@@ -56,7 +56,7 @@
         "heightening": {
             "damage": {
                 "0": "2d6",
-                "I7vz0Yz4V7i1x8HW": "2d6"
+                "1": "2d6"
             },
             "interval": 2,
             "type": "interval"


### PR DESCRIPTION
Bludgeoning was marked untyped, and was missing Sonic damage