### PR TITLE
Expand adjusted DC tooltips to all targeted checks

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -66,6 +66,7 @@ import { ActorSizePF2e } from "./data/size";
 import { calculateRangePenalty, checkAreaEffects, getRangeIncrement, isReallyPC, migrateActorSource } from "./helpers";
 import { ActorInventory } from "./inventory";
 import { ItemTransfer } from "./item-transfer";
+import { StatisticModifier } from "./modifiers";
 import { ActorSheetPF2e } from "./sheet/base";
 import { ActorSpellcasting } from "./spellcasting";
 import { TokenEffect } from "./token-effect";
@@ -919,6 +920,8 @@ class ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
                 ? {
                       scope: "attack",
                       slug: "ac",
+                      statistic:
+                          targetActor.attributes.ac instanceof StatisticModifier ? targetActor.attributes.ac : null,
                       value: targetActor.attributes.ac.value,
                   }
                 : null,

--- a/src/module/system/action-macros/helpers.ts
+++ b/src/module/system/action-macros/helpers.ts
@@ -197,7 +197,7 @@ export class ActionMacroHelpers {
                         if (dcStat) {
                             const extraRollOptions = combinedOptions.concat(targetOptions);
                             const { dc } = dcStat.withRollOptions({ extraRollOptions });
-                            const dcData: CheckDC = { label: dc.label, value: dc.value };
+                            const dcData: CheckDC = { label: dc.label, statistic: dc, value: dc.value };
                             if (setHasElement(DC_SLUGS, dcStat.slug)) dcData.slug = dcStat.slug;
 
                             return dcData;

--- a/src/module/system/check/check.ts
+++ b/src/module/system/check/check.ts
@@ -22,6 +22,7 @@ import { TextEditorPF2e } from "../text-editor";
 import { CheckRollContext } from "./types";
 import { StrikeAttackRoll } from "./strike/attack-roll";
 import { isCheckContextFlag } from "@module/chat-message/helpers";
+import { StatisticDifficultyClass } from "@system/statistic";
 
 interface RerollOptions {
     heroPoint?: boolean;
@@ -536,15 +537,14 @@ class CheckPF2e {
             );
 
             // Get any circumstance penalties or bonuses to the target's DC
-            const targetAC = targetActor?.attributes.ac;
             const circumstances =
-                dc.slug === "ac" && targetAC instanceof StatisticModifier
-                    ? targetAC.modifiers.filter((m) => m.enabled && m.type === "circumstance")
+                dc.statistic instanceof StatisticModifier || dc.statistic instanceof StatisticDifficultyClass
+                    ? dc.statistic.modifiers.filter((m) => m.enabled && m.type === "circumstance")
                     : [];
             const preadjustedDC =
-                circumstances.length > 0 && targetAC
-                    ? targetAC.value - circumstances.reduce((total, c) => total + c.modifier, 0)
-                    : targetAC?.value ?? null;
+                circumstances.length > 0 && dc.statistic
+                    ? dc.value - circumstances.reduce((total, c) => total + c.modifier, 0)
+                    : dc.value ?? null;
 
             const visible = targetActor?.hasPlayerOwner || dc.visible || game.settings.get("pf2e", "metagame_showDC");
 
@@ -552,8 +552,7 @@ class CheckPF2e {
                 const labelKey = targetData
                     ? translations.DC.Label.WithTarget
                     : customLabel ?? translations.DC.Label.NoTarget;
-                const dcValue = dc.slug === "ac" && targetAC ? targetAC.value : dc.value;
-                const markup = game.i18n.format(labelKey, { dcType, dc: dcValue, target: targetData?.name ?? null });
+                const markup = game.i18n.format(labelKey, { dcType, dc: dc.value, target: targetData?.name ?? null });
 
                 return { markup, visible };
             }

--- a/src/module/system/degree-of-success.ts
+++ b/src/module/system/degree-of-success.ts
@@ -1,7 +1,9 @@
+import { StatisticModifier } from "@actor/modifiers";
 import { DCSlug } from "@actor/types";
 import { ZeroToThree } from "@module/data";
 import { CheckRoll } from "./check";
 import { PredicatePF2e } from "./predication";
+import { StatisticDifficultyClass } from "./statistic";
 
 /** Get the degree of success from a roll and a difficulty class */
 class DegreeOfSuccess {
@@ -134,6 +136,7 @@ interface DegreeOfSuccessAdjustment {
 
 interface CheckDC {
     slug?: DCSlug;
+    statistic?: StatisticDifficultyClass | StatisticModifier | null;
     label?: string;
     scope?: "attack" | "check";
     value: number;

--- a/src/module/system/statistic/index.ts
+++ b/src/module/system/statistic/index.ts
@@ -27,7 +27,7 @@ import { StatisticChatData, StatisticTraceData, StatisticData, StatisticCheckDat
 
 export * from "./data";
 
-export interface StatisticRollParameters {
+interface StatisticRollParameters {
     /** Which attack this is (for the purposes of multiple attack penalty) */
     attackNumber?: number;
     /** Optional target for the roll */
@@ -64,7 +64,7 @@ interface RollOptionParameters {
 }
 
 /** Object used to perform checks or get dcs, or both. These are created from StatisticData which drives its behavior. */
-export class Statistic {
+class Statistic {
     /** Source of truth of all statistic data and the params used to create it. Necessary for cloning. */
     #data: StatisticData;
 
@@ -491,3 +491,5 @@ class StatisticDifficultyClass {
             .join(", ");
     }
 }
+
+export { Statistic, StatisticDifficultyClass, StatisticRollParameters };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/106829671/225541799-990610be-ae60-427e-86fc-321e1cb02170.png)

Once everything is a `Statistic`, `CheckDC` can mostly just be replaced with it.