### PR TITLE
Propagate aura level to effect level by default

### DIFF
--- a/packs/data/spell-effects.db/aura-protective-ward.json
+++ b/packs/data/spell-effects.db/aura-protective-ward.json
@@ -35,7 +35,6 @@
                         "events": [
                             "enter"
                         ],
-                        "level": "ceil(@actor.level/2)",
                         "uuid": "Compendium.pf2e.spell-effects.Spell Effect: Protective Ward"
                     }
                 ],

--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -404,7 +404,7 @@ class ActorPF2e extends Actor<TokenDocumentPF2e, ItemTypeMap> {
                 };
 
                 const source = mergeObject(effect.toObject(), { flags });
-                source.system.level.value = data.level ?? source.system.level.value;
+                source.system.level.value = data.level ?? aura.level ?? source.system.level.value;
                 source.system.duration.unit = "unlimited";
                 source.system.duration.expiry = null;
                 // Only transfer traits from the aura if the effect lacks its own

--- a/src/module/actor/types.ts
+++ b/src/module/actor/types.ts
@@ -36,6 +36,7 @@ type SaveType = (typeof SAVE_TYPES)[number];
 
 interface AuraData {
     slug: string;
+    level?: number;
     radius: number;
     effects: AuraEffectData[];
     colors: AuraColors | null;

--- a/src/module/rules/rule-element/aura.ts
+++ b/src/module/rules/rule-element/aura.ts
@@ -57,6 +57,7 @@ export class AuraRuleElement extends RuleElementPF2e {
         if (typeof Number.isInteger(radius) && radius > 0 && radius % 5 === 0) {
             const data = {
                 slug: this.slug,
+                level: this.item.system.level?.value,
                 radius,
                 effects: this.#processEffects(),
                 traits: this.traits,


### PR DESCRIPTION
When creating an effect from an aura, use the aura's level as the effect's level, unless overridden when defining the effect in the aura's rule element.

Also removed the explicit level set in the Protective Ward aura as it's no longer needed.