### PR TITLE
Filter compendium results based on action "Browse" button's context

### DIFF
--- a/src/module/actor/creature/sheet.ts
+++ b/src/module/actor/creature/sheet.ts
@@ -2,8 +2,10 @@ import { CreaturePF2e } from "@actor";
 import { createSpellcastingDialog } from "@actor/sheet/spellcasting-dialog";
 import { ABILITY_ABBREVIATIONS, SKILL_DICTIONARY } from "@actor/values";
 import { ItemPF2e, SpellPF2e } from "@item";
+import { ActionTrait } from "@item/action";
 import { SpellcastingEntryPF2e, SpellcastingSheetData } from "@item/spellcasting-entry";
 import { ItemSourcePF2e } from "@item/data";
+import { ActionType } from "@item/data/base";
 import { ITEM_CARRY_TYPES } from "@item/data/values";
 import { DropCanvasItemDataPF2e } from "@module/canvas/drop-canvas-data";
 import { goesToEleven, ZeroToFour } from "@module/data";
@@ -367,7 +369,7 @@ export abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends Act
 
         // Action Browser
         for (const button of htmlQueryAll(html, ".action-browse")) {
-            button.addEventListener("click", () => game.pf2e.compendiumBrowser.openTab("action"));
+            button.addEventListener("click", () => this.#onClickBrowseActions(button));
         }
 
         // Spell Browser
@@ -512,6 +514,13 @@ export abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends Act
         }
 
         spell.update({ "system.location.signature": !spell.system.location.signature });
+    }
+
+    #onClickBrowseActions(button: HTMLElement) {
+        const actionTypes = (button.dataset.actionType || '').split(',') as ActionType[];
+        const actionTraits = (button.dataset.actionTrait || '').split(',') as ActionTrait[];
+
+        game.pf2e.compendiumBrowser.openActionTab(actionTypes, actionTraits);
     }
 
     #onClickBrowseSpellCompendia(button: HTMLElement) {

--- a/src/module/actor/creature/sheet.ts
+++ b/src/module/actor/creature/sheet.ts
@@ -517,8 +517,8 @@ export abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends Act
     }
 
     #onClickBrowseActions(button: HTMLElement) {
-        const actionTypes = (button.dataset.actionType || '').split(',') as ActionType[];
-        const actionTraits = (button.dataset.actionTrait || '').split(',') as ActionTrait[];
+        const actionTypes = (button.dataset.actionType || "").split(",") as ActionType[];
+        const actionTraits = (button.dataset.actionTrait || "").split(",") as ActionTrait[];
 
         game.pf2e.compendiumBrowser.openActionTab(actionTypes, actionTraits);
     }

--- a/src/module/apps/compendium-browser/index.ts
+++ b/src/module/apps/compendium-browser/index.ts
@@ -264,7 +264,9 @@ class CompendiumBrowser extends Application {
             }
         }
 
-        traits.selected = traitFilters.length ? traits.options.filter(trait => traitFilters.includes(trait.value)) : [];
+        traits.selected = traitFilters.length
+            ? traits.options.filter((trait) => traitFilters.includes(trait.value))
+            : [];
 
         actionTab.open(filter);
     }

--- a/src/module/apps/compendium-browser/index.ts
+++ b/src/module/apps/compendium-browser/index.ts
@@ -1,4 +1,6 @@
 import { KitPF2e, PhysicalItemPF2e } from "@item";
+import { ActionTrait } from "@item/action";
+import { ActionType } from "@item/data/base";
 import { BaseSpellcastingEntry } from "@item/spellcasting-entry";
 import { LocalizePF2e } from "@system/localize";
 import { ErrorPF2e, htmlQueryAll, isObject, objectHasKey } from "@util";
@@ -246,6 +248,25 @@ class CompendiumBrowser extends Application {
             return this.tabs[tabName].open(filter);
         }
         return this.loadTab(tabName);
+    }
+
+    async openActionTab(typeFilters: ActionType[], traitFilters: ActionTrait[]): Promise<void> {
+        const actionTab = this.tabs.action;
+        const filter = await actionTab.getFilterData();
+        const { types } = filter.checkboxes;
+        const { traits } = filter.multiselects;
+
+        types.selected = [];
+        for (const type in types.options) {
+            if (typeFilters.includes(type as ActionType)) {
+                types.options[type].selected = true;
+                types.selected.push(type);
+            }
+        }
+
+        traits.selected = traitFilters.length ? traits.options.filter(trait => traitFilters.includes(trait.value)) : [];
+
+        actionTab.open(filter);
     }
 
     async openSpellTab(entry: BaseSpellcastingEntry, maxLevel = 10): Promise<void> {

--- a/src/module/apps/compendium-browser/tabs/action.ts
+++ b/src/module/apps/compendium-browser/tabs/action.ts
@@ -26,7 +26,7 @@ export class CompendiumBrowserActionTab extends CompendiumBrowserTab {
         console.debug("PF2e System | Compendium Browser | Started loading actions");
 
         const actions: CompendiumBrowserIndexData[] = [];
-        const indexFields = ["img", "system.actionType.value", "system.traits.value", "system.source.value"];
+        const indexFields = ["img", "system.actionType.value", "system.traits.value", "system.actionType.value", "system.source.value"];
         const sources: Set<string> = new Set();
 
         for await (const { pack, index } of this.browser.packLoader.loadPacks(
@@ -58,6 +58,7 @@ export class CompendiumBrowserActionTab extends CompendiumBrowserTab {
                         img: actionData.img,
                         uuid: `Compendium.${pack.collection}.${actionData._id}`,
                         traits: actionData.system.traits.value,
+                        actionType: actionData.system.actionType.value,
                         source: actionData.system.source.value,
                     });
                 }
@@ -69,6 +70,7 @@ export class CompendiumBrowserActionTab extends CompendiumBrowserTab {
 
         // Set Filters
         this.filterData.multiselects.traits.options = this.generateMultiselectOptions(CONFIG.PF2E.actionTraits);
+        this.filterData.checkboxes.types.options = this.generateCheckboxOptions(CONFIG.PF2E.actionTypes);
         this.filterData.checkboxes.source.options = this.generateSourceCheckboxOptions(sources);
 
         console.debug("PF2e System | Compendium Browser | Finished loading actions");
@@ -77,6 +79,10 @@ export class CompendiumBrowserActionTab extends CompendiumBrowserTab {
     protected override filterIndexData(entry: CompendiumBrowserIndexData): boolean {
         const { checkboxes, multiselects } = this.filterData;
 
+        // Types
+        if (checkboxes.types.selected.length) {
+            if (!checkboxes.types.selected.includes(entry.actionType)) return false;
+        }
         // Traits
         if (!this.filterTraits(entry.traits, multiselects.traits.selected, multiselects.traits.conjunction))
             return false;
@@ -90,6 +96,12 @@ export class CompendiumBrowserActionTab extends CompendiumBrowserTab {
     protected override prepareFilterData(): ActionFilters {
         return {
             checkboxes: {
+                types: {
+                    isExpanded: true,
+                    label: "PF2E.ActionActionTypeLabel",
+                    options: {},
+                    selected: [],
+                },
                 source: {
                     isExpanded: false,
                     label: "PF2E.BrowserFilterSource",

--- a/src/module/apps/compendium-browser/tabs/action.ts
+++ b/src/module/apps/compendium-browser/tabs/action.ts
@@ -26,7 +26,13 @@ export class CompendiumBrowserActionTab extends CompendiumBrowserTab {
         console.debug("PF2e System | Compendium Browser | Started loading actions");
 
         const actions: CompendiumBrowserIndexData[] = [];
-        const indexFields = ["img", "system.actionType.value", "system.traits.value", "system.actionType.value", "system.source.value"];
+        const indexFields = [
+            "img",
+            "system.actionType.value",
+            "system.traits.value",
+            "system.actionType.value",
+            "system.source.value",
+        ];
         const sources: Set<string> = new Set();
 
         for await (const { pack, index } of this.browser.packLoader.loadPacks(

--- a/src/module/apps/compendium-browser/tabs/data.ts
+++ b/src/module/apps/compendium-browser/tabs/data.ts
@@ -67,6 +67,7 @@ interface BaseFilterData {
 
 interface ActionFilters extends BaseFilterData {
     checkboxes: {
+        types: CheckboxData;
         source: CheckboxData;
     };
     multiselects: {

--- a/static/templates/actors/character/tabs/actions.hbs
+++ b/static/templates/actors/character/tabs/actions.hbs
@@ -122,7 +122,7 @@
                                     <button type="button" class="item-control item-create" data-type="action" data-action-type="{{sid}}">
                                         <i class="fas fa-fw fa-plus"></i>{{localize "PF2E.CreateActionTitle"}}
                                     </button>
-                                    <button type="button" class="item-control action-browse" data-type="feat">
+                                    <button type="button" class="item-control action-browse" data-type="action" data-action-type="{{sid}}">
                                         <i class="fas fa-fw fa-search"></i>{{localize "PF2E.BrowseLabel"}}
                                     </button>
                                 </div>
@@ -173,7 +173,7 @@
                                 <button type="button" class="item-control item-create" data-type="action" data-action-type="free">
                                     <i class="fas fa-fw fa-plus"></i>{{localize "PF2E.CreateActionTitle"}}
                                 </button>
-                                <button type="button" class="item-control action-browse" data-type="feat">
+                                <button type="button" class="item-control action-browse" data-type="action" data-action-type="passive" data-action-trait="exploration">
                                     <i class="fas fa-fw fa-search"></i>{{localize "PF2E.BrowseLabel"}}
                                 </button>
                             </div>
@@ -212,7 +212,7 @@
                                 <button type="button" class="item-control item-create" data-type="action" data-action-type="free">
                                     <i class="fas fa-fw fa-plus"></i>{{localize "PF2E.CreateActionTitle"}}
                                 </button>
-                                <button type="button" class="item-control action-browse" data-type="feat">
+                                <button type="button" class="item-control action-browse" data-type="action" data-action-type="passive" data-action-trait="downtime">
                                     <i class="fas fa-fw fa-search"></i>{{localize "PF2E.BrowseLabel"}}
                                 </button>
                             </div>


### PR DESCRIPTION
The intent of this PR is to make the "Browse" buttons on the Actions tab of the player sheet more intuitive.

The PR fulfills this by filtering the resulting compendium list based on which button was pressed. In order to do so I needed to add the "Action Type" checkbox filter to the action compendium so that actions / reactions / free actions were filtered correctly.

I expect there to be feedback on this as this is my first submission and my primary motivation was getting it working for my upcoming sessions.