### PR TITLE
Effect panel shows effect descriptions and can send effects to chat

### DIFF
--- a/src/module/apps/effects-panel.ts
+++ b/src/module/apps/effects-panel.ts
@@ -34,7 +34,14 @@ export class EffectsPanel extends Application {
     override async getData(options?: ApplicationOptions): Promise<EffectsPanelData> {
         const { actor } = this;
         if (!actor || !game.user.settings.showEffectPanel) {
-            return { afflictions: [], conditions: [], effects: [], descriptions: ({} as EffectsDescriptionData), actor: null, user: { isGM: false } };
+            return {
+                afflictions: [],
+                conditions: [],
+                effects: [],
+                descriptions: {} as EffectsDescriptionData,
+                actor: null,
+                user: { isGM: false },
+            };
         }
 
         const effects =
@@ -65,12 +72,12 @@ export class EffectsPanel extends Application {
         const conditions = game.pf2e.ConditionManager.getFlattenedConditions(actor.itemTypes.condition);
 
         const afflictions = actor.itemTypes.affliction;
-        
+
         const descriptions = {
             afflictions: await this.#getEnrichedDescriptions(afflictions),
             conditions: await this.#getEnrichedDescriptions(conditions),
             effects: await this.#getEnrichedDescriptions(effects),
-        }
+        };
 
         return {
             ...(await super.getData(options)),
@@ -213,12 +220,10 @@ export class EffectsPanel extends Application {
         }
     }
 
-    async #getEnrichedDescriptions(
-        effects: AfflictionPF2e[] | EffectPF2e[] | FlattenedCondition[] 
-    ): Promise<String[]> {
-        return await Promise.all(effects.map(async effect =>
-            await TextEditor.enrichHTML(effect.description, { async: true })
-        ));
+    async #getEnrichedDescriptions(effects: AfflictionPF2e[] | EffectPF2e[] | FlattenedCondition[]): Promise<String[]> {
+        return await Promise.all(
+            effects.map(async (effect) => await TextEditor.enrichHTML(effect.description, { async: true }))
+        );
     }
 }
 

--- a/src/module/apps/effects-panel.ts
+++ b/src/module/apps/effects-panel.ts
@@ -3,6 +3,7 @@ import { AbstractEffectPF2e, EffectPF2e } from "@item";
 import { AfflictionPF2e } from "@item/affliction";
 import { EffectExpiryType } from "@item/effect/data";
 import { TokenDocumentPF2e } from "@scene";
+import { InlineRollLinks } from "@scripts/ui/inline-roll-links";
 import { htmlQuery, htmlQueryAll } from "@util";
 import { FlattenedCondition } from "../system/conditions";
 
@@ -33,7 +34,7 @@ export class EffectsPanel extends Application {
     override async getData(options?: ApplicationOptions): Promise<EffectsPanelData> {
         const { actor } = this;
         if (!actor || !game.user.settings.showEffectPanel) {
-            return { afflictions: [], conditions: [], effects: [], actor: null, user: { isGM: false } };
+            return { afflictions: [], conditions: [], effects: [], descriptions: ({} as EffectsDescriptionData), actor: null, user: { isGM: false } };
         }
 
         const effects =
@@ -63,12 +64,21 @@ export class EffectsPanel extends Application {
 
         const conditions = game.pf2e.ConditionManager.getFlattenedConditions(actor.itemTypes.condition);
 
+        const afflictions = actor.itemTypes.affliction;
+        
+        const descriptions = {
+            afflictions: await this.#getEnrichedDescriptions(afflictions),
+            conditions: await this.#getEnrichedDescriptions(conditions),
+            effects: await this.#getEnrichedDescriptions(effects),
+        }
+
         return {
             ...(await super.getData(options)),
-            actor,
-            effects,
+            afflictions,
             conditions,
-            afflictions: actor.itemTypes.affliction,
+            descriptions,
+            effects,
+            actor,
             user: { isGM: game.user.isGM },
         };
     }
@@ -76,6 +86,9 @@ export class EffectsPanel extends Application {
     override activateListeners($html: JQuery): void {
         super.activateListeners($html);
         const html = $html[0]!;
+
+        // For inline roll links in descriptions
+        InlineRollLinks.listen(html, this.actor || undefined);
 
         for (const effectEl of htmlQueryAll(html, ".effect-item[data-item-id]")) {
             const itemId = effectEl.dataset.itemId;
@@ -110,6 +123,13 @@ export class EffectsPanel extends Application {
                 if (item?.isOfType("condition")) {
                     item.rollRecovery();
                 }
+            });
+
+            // Send effect to chat
+            effectEl.querySelector("[data-action=send-to-chat]")?.addEventListener("click", async () => {
+                const { actor } = this;
+                const effect = actor?.items.get(itemId);
+                if (effect) await effect.toMessage();
             });
 
             // Uses a scale transform to fit the text within the box
@@ -192,11 +212,26 @@ export class EffectsPanel extends Application {
             return game.i18n.format(key, { initiative });
         }
     }
+
+    async #getEnrichedDescriptions(
+        effects: AfflictionPF2e[] | EffectPF2e[] | FlattenedCondition[] 
+    ): Promise<String[]> {
+        return await Promise.all(effects.map(async effect =>
+            await TextEditor.enrichHTML(effect.description, { async: true })
+        ));
+    }
+}
+
+interface EffectsDescriptionData {
+    afflictions: String[];
+    conditions: String[];
+    effects: String[];
 }
 
 interface EffectsPanelData {
     afflictions: AfflictionPF2e[];
     conditions: FlattenedCondition[];
+    descriptions: EffectsDescriptionData;
     effects: EffectPF2e[];
     actor: ActorPF2e | null;
     user: { isGM: boolean };

--- a/src/module/apps/effects-panel.ts
+++ b/src/module/apps/effects-panel.ts
@@ -38,7 +38,7 @@ export class EffectsPanel extends Application {
                 afflictions: [],
                 conditions: [],
                 effects: [],
-                descriptions: {} as EffectsDescriptionData,
+                descriptions: { afflictions: [], conditions: [], effects: [] },
                 actor: null,
                 user: { isGM: false },
             };

--- a/src/styles/system/_effects-panel.scss
+++ b/src/styles/system/_effects-panel.scss
@@ -45,6 +45,7 @@
         .effect-info {
             display: none;
             height: min-content;
+            max-width: 300px;
             margin-right: 0.5em;
             padding: 0.25em 0.5rem;
             background-color: rgba(0, 0, 0, 0.75);
@@ -55,6 +56,14 @@
                 text-align: right;
                 border: none;
                 @include p-reset;
+
+                i.fas.fa-comment-alt {
+                    margin-left: 2px;
+                }
+
+                i.fas.fa-comment-alt:hover {
+                    text-shadow: 0 0 8px var(--color-shadow-primary);
+                }
             }
 
             .tags {
@@ -75,12 +84,29 @@
                 border: 1px outset white;
                 font-size: var(--font-size-10);
                 margin-top: 0.125rem;
-                padding: 0.125rem;
+                padding: 0.125rem;   
+                &.content-link, &.inline-roll {
+                    padding: 1px 4px;
+                    border: 1px solid var(--color-border-dark-tertiary);
+                    width: fit-content;
+                    display: inline;
+                    color: var(--color-text-dark-primary);
+                } 
             }
 
-            .instructions {
+            span[data-pf2-check] {
+                color: var(--color-text-dark-primary);
+            }
+
+            .instructions, .effect-description {
                 font-size: 0.75em;
                 text-align: right;
+            }
+
+            .effect-description {
+                max-height: 100px;
+                overflow-y: auto;
+                text-align: justify;
             }
         }
 

--- a/static/templates/system/effects-panel.hbs
+++ b/static/templates/system/effects-panel.hbs
@@ -6,7 +6,7 @@
     {{#if (and afflictions.length conditions.length)}}<hr />{{/if}}
 
     {{#each conditions as |condition|}}
-        {{> effect effect=condition}}
+        {{> effect effect=condition descriptions=../descriptions.conditions}}
     {{/each}}
 
     {{#if (and conditions.length effects.length)}}<hr />{{/if}}

--- a/static/templates/system/effects-panel.hbs
+++ b/static/templates/system/effects-panel.hbs
@@ -1,18 +1,17 @@
 <section class="effect-panel">
     {{#each conditions as |condition|}}
-        {{> effect effect=condition}}
+        {{> effect effect=condition descriptions=../descriptions.conditions}}
     {{/each}}
 
     {{#if (and conditions.length afflictions.length)}}<hr />{{/if}}
 
     {{#each afflictions as |affliction|}}
-        {{> effect effect=affliction}}
+        {{> effect effect=affliction descriptions=../descriptions.afflictions}}
     {{/each}}
 
     {{#if (and afflictions.length effects.length)}}<hr />{{/if}}
-
     {{#each effects as |effect|}}
-        {{> effect effect=effect}}
+        {{> effect effect=effect descriptions=../descriptions.effects}}
     {{/each}}
 </section>
 
@@ -20,7 +19,10 @@
 {{#if (or effect.isIdentified @root.user.isGM)}}
 <div class="effect-item" data-item-id="{{effect.id}}" data-badge-type="{{effect.badge.type}}">
     <div class="effect-info">
-        <h1>{{effect.name}}</h1>
+        <h1>
+            {{effect.name}}
+            <i class="fas fa-comment-alt" data-action="send-to-chat" title="{{localize "PF2E.NPC.SendToChat"}}"></i>
+        </h1>
         {{#if (or (eq effect.type "effect") effect.breakdown)}}
             <div class="tags">
                 {{#if (and effect.system.duration.sustained (not effect.system.expired))}}
@@ -42,6 +44,9 @@
                 {{localize "PF2E.Item.Condition.PersistentDamage.AssistedRecovery"}}
             </a>
         {{/if}}
+        <div class="effect-description">
+            {{{ lookup descriptions @index }}}    
+        </div>
         <div class="instructions">
             {{#if (not effect.isLocked)}}
                 {{#if (eq effect.badge.type "formula")}}


### PR DESCRIPTION
This PR addresses feature request https://github.com/foundryvtt/pf2e/issues/4316. Specifically, it:

- Modifies the Effect Panel so that afflictions, conditions, and effects show effect descriptions in the hovering effect information. The description can be scrolled in its own UI element if the effect description is overly long. The description text can display enriched document links, which can be interacted with. 
- Adds an icon to the right of the effect name in the hovering effect information that allows the full effect description to be sent to chat. The send to chat icon uses the same hover indication as the effect info persistent damage recovery roll link (orange text-shadow).

I've added screenshots below that demonstrate the changes. This PR does potentially overlap with https://github.com/foundryvtt/pf2e/pull/4527. Sorry for that, I didn't see that PR until after I made these changes (primarily to familiarize myself with the system). I'll of course be happy to close this PR if desired due to that.

For any questions or more information, I'm on the discord as JellyfishJail#3956. 

<img width="1511" alt="Screen Shot 2023-03-18 at 9 26 24 PM" src="https://user-images.githubusercontent.com/14943160/226152099-25133af8-774b-4791-9a33-e42306e8d7d7.png">

<img width="1510" alt="Screen Shot 2023-03-18 at 9 25 58 PM" src="https://user-images.githubusercontent.com/14943160/226152117-6cc755e6-3e94-4ffc-833a-6af449ce5a57.png">

<img width="1511" alt="Screen Shot 2023-03-18 at 9 26 10 PM" src="https://user-images.githubusercontent.com/14943160/226152123-d9a91d5d-e693-4a2c-b71b-8b7d8503cc06.png">



