### PR TITLE
Fix Dragon's Presence RE predicates

### DIFF
--- a/packs/data/feats.db/dragons-presence.json
+++ b/packs/data/feats.db/dragons-presence.json
@@ -27,7 +27,7 @@
                 "predicate": [
                     "action:demoralize",
                     {
-                        "lt": [
+                        "lte": [
                             "target:level",
                             "self:level"
                         ]


### PR DESCRIPTION
Dragon's Presence says "when you attempt to Demoralize a foe of **your level or lower**". This change fixes the rule element to also apply to equal-level foes.