### PR TITLE
Broaden usability of `ActorPF2e#getStrikeRollContext`

### DIFF
--- a/src/module/actor/helpers.ts
+++ b/src/module/actor/helpers.ts
@@ -268,9 +268,10 @@ function strikeFromMeleeItem(item: Embedded<MeleePF2e>): NPCStrike {
 
                 params.options ??= [];
                 // Always add all weapon traits as options
-                const context = await actor.getAttackRollContext({
+                const context = await actor.getCheckRollContext({
                     item,
-                    viewOnly: false,
+                    viewOnly: params.getFormula ?? false,
+                    statistic: strike,
                     domains,
                     options: new Set([...baseOptions, ...params.options]),
                 });
@@ -291,7 +292,7 @@ function strikeFromMeleeItem(item: Embedded<MeleePF2e>): NPCStrike {
                 );
 
                 const roll = await CheckPF2e.roll(
-                    new CheckModifier(checkName, strike, otherModifiers),
+                    new CheckModifier(checkName, context.self.statistic ?? strike, otherModifiers),
                     {
                         type: "attack-roll",
                         actor: context.self.actor,
@@ -329,9 +330,10 @@ function strikeFromMeleeItem(item: Embedded<MeleePF2e>): NPCStrike {
         (outcome: "success" | "criticalSuccess"): DamageRollFunction =>
         async (params: DamageRollParams = {}): Promise<Rolled<DamageRoll> | string | null> => {
             const domains = ["all", `{item.id}-damage`, "strike-damage", "damage-roll"];
-            const context = await actor.getStrikeRollContext({
+            const context = await actor.getRollContext({
                 item,
-                viewOnly: false,
+                statistic: strike,
+                viewOnly: params.getFormula ?? false,
                 domains,
                 options: new Set(params.options ?? []),
             });

--- a/src/module/actor/types.ts
+++ b/src/module/actor/types.ts
@@ -7,7 +7,7 @@ import { DamageRoll } from "@system/damage/roll";
 import { CheckDC } from "@system/degree-of-success";
 import { PredicatePF2e } from "@system/predication";
 import { TraitViewData } from "./data/base";
-import { ModifierPF2e } from "./modifiers";
+import { ModifierPF2e, StatisticModifier } from "./modifiers";
 import {
     ABILITY_ABBREVIATIONS,
     DC_SLUGS,
@@ -16,6 +16,7 @@ import {
     SKILL_LONG_FORMS,
     UNAFFECTED_TYPES,
 } from "./values";
+import { StatisticCheck } from "@system/statistic";
 
 type AbilityString = SetElement<typeof ABILITY_ABBREVIATIONS>;
 
@@ -68,11 +69,17 @@ interface AuraColors {
 
 type AttackItem = WeaponPF2e | MeleePF2e | SpellPF2e;
 
-interface StrikeSelf<A extends ActorPF2e = ActorPF2e, I extends AttackItem = AttackItem> {
-    actor: A;
+interface StrikeSelf<
+    TActor extends ActorPF2e = ActorPF2e,
+    TStatistic extends StatisticCheck | StatisticModifier | null = StatisticCheck | StatisticModifier | null,
+    TItem extends AttackItem | null = AttackItem | null
+> {
+    actor: TActor;
     token: TokenDocumentPF2e | null;
+    /** The Strike statistic in use */
+    statistic: TStatistic;
     /** The item used for the strike */
-    item: I;
+    item: TItem;
     /** Bonuses and penalties added at the time of a strike */
     modifiers: ModifierPF2e[];
 }
@@ -85,17 +92,26 @@ interface AttackTarget {
 }
 
 /** Context for the attack or damage roll of a strike */
-interface StrikeRollContext<A extends ActorPF2e, I extends AttackItem> {
+interface StrikeRollContext<
+    TActor extends ActorPF2e,
+    TStatistic extends StatisticCheck | StatisticModifier | null = StatisticCheck | StatisticModifier | null,
+    TItem extends AttackItem | null = AttackItem | null
+> {
     /** Roll options */
     options: Set<string>;
-    self: StrikeSelf<A, I>;
+    self: StrikeSelf<TActor, TStatistic, TItem>;
     target: AttackTarget | null;
     traits: TraitViewData[];
 }
 
-interface StrikeRollContextParams<T extends AttackItem> {
+interface StrikeRollContextParams<
+    TStatistic extends StatisticCheck | StatisticModifier | null = StatisticCheck | StatisticModifier | null,
+    TItem extends AttackItem | null = AttackItem | null
+> {
+    /** The statistic used for the roll */
+    statistic: TStatistic;
     /** The item being used in the attack or damage roll */
-    item: T;
+    item?: TItem;
     /** Domains from which to draw roll options */
     domains: string[];
     /** Initial roll options for the strike */
@@ -104,7 +120,16 @@ interface StrikeRollContextParams<T extends AttackItem> {
     viewOnly?: boolean;
 }
 
-interface AttackRollContext<A extends ActorPF2e, I extends AttackItem> extends StrikeRollContext<A, I> {
+type AttackRollContextParams<
+    TStatistic extends StatisticCheck | StatisticModifier = StatisticCheck | StatisticModifier,
+    TItem extends AttackItem | null = AttackItem | null
+> = StrikeRollContextParams<TStatistic, TItem>;
+
+interface AttackRollContext<
+    TActor extends ActorPF2e,
+    TStatistic extends StatisticCheck | StatisticModifier = StatisticCheck | StatisticModifier,
+    TItem extends AttackItem | null = AttackItem | null
+> extends StrikeRollContext<TActor, TStatistic, TItem> {
     dc: CheckDC | null;
 }
 
@@ -131,6 +156,7 @@ export {
     ApplyDamageParams,
     AttackItem,
     AttackRollContext,
+    AttackRollContextParams,
     AttackTarget,
     AuraColors,
     AuraData,

--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -282,6 +282,7 @@ class SpellPF2e extends ItemPF2e {
             self: {
                 actor: this.actor,
                 item: this,
+                statistic: null,
                 token: this.actor.token,
                 modifiers: [],
             },

--- a/src/module/rules/helpers.ts
+++ b/src/module/rules/helpers.ts
@@ -73,7 +73,7 @@ async function extractEphemeralEffects({
 
     const [effectsFrom, effectsTo] = affects === "target" ? [origin, target] : [target, origin];
     const fullOptions = [...options, ...effectsTo.getSelfRollOptions(affects)];
-    const resolvables = item.isOfType("spell") ? { spell: item } : { weapon: item };
+    const resolvables = item ? (item.isOfType("spell") ? { spell: item } : { weapon: item }) : {};
     return (
         await Promise.all(
             domains
@@ -87,7 +87,7 @@ interface ExtractEphemeralEffectsParams {
     affects: "target" | "origin";
     origin: ActorPF2e;
     target: Maybe<ActorPF2e>;
-    item: AttackItem;
+    item: AttackItem | null;
     domains: string[];
     options: Set<string> | string[];
 }

--- a/src/module/system/action-macros/helpers.ts
+++ b/src/module/system/action-macros/helpers.ts
@@ -22,6 +22,7 @@ import { CheckContextOptions, CheckContext, SimpleRollActionCheckOptions, CheckC
 import { getRangeIncrement } from "@actor/helpers";
 import { CheckPF2e, CheckType } from "@system/check";
 import { AutomaticBonusProgression } from "@actor/character/automatic-bonus-progression";
+import { TokenDocumentPF2e } from "@scene";
 
 export class ActionMacroHelpers {
     static resolveStat(stat: string): {
@@ -282,7 +283,10 @@ export class ActionMacroHelpers {
         }
     }
 
-    static target() {
+    static target(): {
+        token: TokenDocumentPF2e<ActorPF2e> | null;
+        actor: ActorPF2e | null;
+    } {
         const targets = Array.from(game.user.targets).filter((t) => t.actor instanceof CreaturePF2e);
         const target = targets.shift()?.document ?? null;
         const targetActor = target?.actor ?? null;

--- a/src/module/system/check/types.ts
+++ b/src/module/system/check/types.ts
@@ -23,6 +23,7 @@ type CheckType =
 interface CheckRollContext extends BaseRollContext {
     /** The type of this roll, like 'perception-check' or 'saving-throw'. */
     type?: CheckType;
+    /** Targeting data for the check, if applicable */
     target?: AttackTarget | null;
     /** Should this roll be rolled twice? If so, should it keep highest or lowest? */
     rollTwice?: RollTwiceOption;

--- a/src/module/system/statistic/index.ts
+++ b/src/module/system/statistic/index.ts
@@ -342,7 +342,7 @@ class StatisticCheck {
             const isValidAttacker = actor.isOfType("creature", "hazard");
             const isAttackItem = item?.isOfType("weapon", "melee", "spell");
             if (isValidAttacker && isAttackItem && ["attack-roll", "spell-attack-roll"].includes(this.type)) {
-                return actor.getAttackRollContext({ item, domains, options: new Set() });
+                return actor.getCheckRollContext({ item, domains, statistic: this, options: new Set() });
             }
 
             return null;
@@ -495,4 +495,4 @@ class StatisticDifficultyClass {
     }
 }
 
-export { Statistic, StatisticDifficultyClass, StatisticRollParameters };
+export { Statistic, StatisticCheck, StatisticDifficultyClass, StatisticRollParameters };


### PR DESCRIPTION
- Rename to `#getRollContext` (and `#getAttackRollContext` to `#getCheckRollContext`)
- Permit itemless rolls to utilize the methods (but guarantee that if an item is passed, one will be returned)