### PR TITLE
Allow Elemental Bloodline Sorcerer to select an Elemental Type

### DIFF
--- a/packs/data/classfeatures.db/bloodline-elemental.json
+++ b/packs/data/classfeatures.db/bloodline-elemental.json
@@ -50,6 +50,67 @@
                 "path": "system.proficiencies.aliases.sorcerer",
                 "priority": 39,
                 "value": "primal"
+            },
+            {
+                "choices": [
+                    {
+                        "label": "PF2E.TraitAir",
+                        "value": "air"
+                    },
+                    {
+                        "label": "PF2E.TraitEarth",
+                        "value": "earth"
+                    },
+                    {
+                        "label": "PF2E.TraitFire",
+                        "value": "fire"
+                    },
+                    {
+                        "label": "PF2E.TraitWater",
+                        "value": "water"
+                    }
+                ],
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Sorcerer.Elemental.Prompt",
+                "rollOption": "elemental-bloodline"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.sorcerer.elementalBloodline.damageType",
+                "predicate": [
+                    {
+                        "not": "elemental-bloodline:fire"
+                    }
+                ],
+                "value": "bludgeoning"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.sorcerer.elementalBloodline.damageType",
+                "predicate": [
+                    "elemental-bloodline:fire"
+                ],
+                "value": "fire"
+            },
+            {
+                "key": "DamageDice",
+                "override": {
+                    "damageType": "{actor|flags.pf2e.sorcerer.elementalBloodline.damageType}"
+                },
+                "predicate": [
+                    {
+                        "or": [
+                            "item:slug:produce-flame",
+                            "item:slug:burning-hands",
+                            "item:slug:fireball",
+                            "item:slug:elemental-toss",
+                            "item:slug:elemental-blast"
+                        ]
+                    }
+                ],
+                "selector": "spell-damage"
             }
         ],
         "source": {

--- a/packs/data/classfeatures.db/bloodline-elemental.json
+++ b/packs/data/classfeatures.db/bloodline-elemental.json
@@ -71,7 +71,7 @@
                     }
                 ],
                 "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.Sorcerer.Elemental.Prompt",
+                "prompt": "PF2E.SpecificRule.Prompt.Element",
                 "rollOption": "elemental-bloodline"
             },
             {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2090,9 +2090,6 @@
             "Sorcerer": {
                 "Bloodline": {
                     "Prompt": "Select a bloodline."
-                },
-                "Elemental": {
-                    "Prompt": "Select your elemental type"
                 }
             },
             "SoulWarden": {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2090,6 +2090,9 @@
             "Sorcerer": {
                 "Bloodline": {
                     "Prompt": "Select a bloodline."
+                },
+                "Elemental": {
+                    "Prompt": "Select your elemental type"
                 }
             },
             "SoulWarden": {


### PR DESCRIPTION
The damage type override doesn't work, we can either leave it off or just let it sit there until it does function.