### PR TITLE
Fix spell variant interval heightening creation, chat card display for saves and action icons for variants with no action override

### DIFF
--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -721,20 +721,14 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
         }
 
         const variants = this.overlays.overrideVariants
-            .flatMap((variant): SpellVariantChatData => {
-                const overlayIds = [...variant.appliedOverlays!.values()];
-                const actions = (() => {
-                    const actionIcon = getActionIcon(variant.system.time.value, null);
-                    return variant.system.time.value !== this.system.time.value && actionIcon ? actionIcon : null;
-                })();
-
-                return {
-                    actions,
+            .map(
+                (variant): SpellVariantChatData => ({
+                    actions: getActionIcon(variant.system.time.value, null),
                     name: variant.name,
-                    overlayIds,
+                    overlayIds: [...variant.appliedOverlays!.values()],
                     sort: variant.sort,
-                };
-            })
+                })
+            )
             .sort((a, b) => a.sort - b.sort);
 
         const rollData = htmlOptions.rollData ?? this.getRollData({ castLevel });
@@ -961,7 +955,7 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
 
     override async update(data: DocumentUpdateData<this>, options: DocumentUpdateContext<TParent> = {}): Promise<this> {
         // Redirect the update of override spell variants to the appropriate update method if the spell sheet is currently rendered
-        if (options.parent && this.original && this.appliedOverlays!.has("override") && this.sheet.rendered) {
+        if (this.original && this.appliedOverlays!.has("override") && this.sheet.rendered) {
             return this.original.overlays.updateOverride(
                 this as SpellPF2e<ActorPF2e>,
                 data,

--- a/src/module/item/spell/sheet.ts
+++ b/src/module/item/spell/sheet.ts
@@ -139,7 +139,7 @@ export class SpellSheetPF2e extends ItemSheetPF2e<SpellPF2e> {
         $html.find("[data-action=damage-delete]").on("click", (event) => {
             event.preventDefault();
             const overlayData = this.getOverlayFromEvent(event);
-            const baseKey = overlayData?.base ?? "data";
+            const baseKey = overlayData?.base ?? "system";
             const id = $(event.target).closest("[data-action=damage-delete]").attr("data-id");
             if (id) {
                 const values = { [`${baseKey}.damage.value.-=${id}`]: null };
@@ -152,7 +152,7 @@ export class SpellSheetPF2e extends ItemSheetPF2e<SpellPF2e> {
 
         $html.find("[data-action=heightening-interval-create]").on("click", (event) => {
             event.preventDefault();
-            const baseKey = this.getOverlayFromEvent(event)?.base ?? "data";
+            const baseKey = this.getOverlayFromEvent(event)?.base ?? "system";
             this.item.update({ [`${baseKey}.heightening`]: DEFAULT_INTERVAL_SCALING });
         });
 

--- a/static/templates/chat/spell-card.hbs
+++ b/static/templates/chat/spell-card.hbs
@@ -32,19 +32,17 @@
     </section>
 
     <section class="card-buttons">
-        {{#if data.isSave}}
-            <button type="button" data-action="save" data-save="{{data.save.type}}" data-dc="{{data.save.value}}" data-owner-title="{{data.save.breakdown}}">{{data.save.label}}</button>
-        {{/if}}
-        {{#if (or data.check data.hasDamage data.hasCounteractCheck.value data.area.type)}}
-            <section class="owner-buttons">
-                {{#if item.hasVariants}}
-                    {{#each data.variants as |variant|}}
-                        <button type="button" data-action="selectVariant" data-overlay-ids="{{variant.overlayIds}}"{{#if variant.actions}} class="with-image"{{/if}}>
-                            {{#if variant.actions}}<img src="{{variant.actions}}" />{{/if}}
-                            <span>{{variant.name}}</span>
-                        </button>
-                    {{/each}}
-                {{else}}
+        {{#each data.variants as |variant|}}
+            <button type="button" data-action="selectVariant" data-overlay-ids="{{variant.overlayIds}}"{{#if variant.actions}} class="with-image"{{/if}}>
+                {{#if variant.actions}}<img src="{{variant.actions}}" />{{/if}}
+                <span>{{variant.name}}</span>
+            </button>
+        {{else}}
+            {{#if data.isSave}}
+                <button type="button" data-action="save" data-save="{{data.save.type}}" data-dc="{{data.save.value}}" data-owner-title="{{data.save.breakdown}}">{{data.save.label}}</button>
+            {{/if}}
+            {{#if (or data.check data.hasDamage data.hasCounteractCheck.value data.area.type)}}
+                <section class="owner-buttons">
                     {{#if data.check}}
                         <div class="spell-attack-buttons">
                             <button type="button" data-action="spellAttack">{{localize "PF2E.AttackLabel"}}</button>
@@ -70,9 +68,9 @@
                     {{#if item.isVariant}}
                         <button type="button" data-action="selectVariant" data-original-id="{{item.original.id}}">{{localize "PF2E.Item.Spell.Variants.SelectOtherVariantLabel"}}</button>
                     {{/if}}
-                {{/if}}
-            </section>
-        {{/if}}
+                </section>
+            {{/if}}
+        {{/each}}
     </section>
 
     <footer class="card-footer">


### PR DESCRIPTION
- Variant buttons for spells that deal no damage are now displayed.
- Creation of interval heightening entries was using `data` as fallback property which lead to the update being silently dropped for variants. Not sure why.
- Variants that had the same action time as their parent were not displaying any action icon. Now they show the parents action icon instead.
- Updating of non-embedded variants was failing because of the `options.parent` check in `SpellPF2e#update`. Removing that should have no side effects.

![image](https://user-images.githubusercontent.com/41452412/226912196-9e5d39ce-1aee-455b-a0fe-5c2db86c5ce7.png)

![image](https://user-images.githubusercontent.com/41452412/226912285-7b5de484-b071-4d8d-b0c1-c20cdf710895.png)
