### PR TITLE
Skip building packs if all local pack data files are unchanged

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ packs/temp-data
 static/packs/
 types/foundry/node_modules/
 types/foundry/package-lock.json
+.pack-changes.json

--- a/packs/scripts/build.ts
+++ b/packs/scripts/build.ts
@@ -4,14 +4,41 @@ import { CompendiumPack, PackError } from "./packman/compendium-pack";
 
 const packsDataPath = path.resolve(__dirname, "../data");
 const packDirPaths = fs.readdirSync(packsDataPath).map((dirName) => path.resolve(__dirname, packsDataPath, dirName));
+const lastChangedFile = path.resolve(process.cwd(), ".pack-changes.json");
 
-// Loads all packs into memory for the sake of making all entity name/id mappings available
-const packs = packDirPaths.map((p) => CompendiumPack.loadJSON(p));
-const documentCounts = packs.map((p) => p.save());
-const total = documentCounts.reduce((total, c) => total + c, 0);
+(() => {
+    const lastChanged: Record<string, Record<string, number>> = {};
+    for (const dir of packDirPaths) {
+        const dirName = path.basename(dir);
+        lastChanged[dirName] ??= {};
+        const files = fs.readdirSync(dir).map((fileName) => path.resolve(__dirname, dir, fileName));
+        for (const file of files) {
+            const stats = fs.statSync(file);
+            lastChanged[dirName][path.basename(file)] = stats.mtimeMs;
+        }
+    }
+    const currentData = JSON.stringify(lastChanged);
 
-if (documentCounts.length > 0) {
-    console.log(`Created ${documentCounts.length} packs with ${total} entities.`);
-} else {
-    throw PackError("No data available to build packs.");
-}
+    if (fs.existsSync(lastChangedFile)) {
+        const lastChangedData = fs.readFileSync(lastChangedFile, { encoding: "utf-8" });
+        if (currentData === lastChangedData) {
+            console.log("Pack data is unchanged. Skipping rebuild.");
+            return;
+        } else {
+            fs.writeFileSync(lastChangedFile, currentData);
+        }
+    } else {
+        fs.writeFileSync(lastChangedFile, currentData);
+    }
+
+    // Loads all packs into memory for the sake of making all entity name/id mappings available
+    const packs = packDirPaths.map((p) => CompendiumPack.loadJSON(p));
+    const documentCounts = packs.map((p) => p.save());
+    const total = documentCounts.reduce((total, c) => total + c, 0);
+
+    if (documentCounts.length > 0) {
+        console.log(`Created ${documentCounts.length} packs with ${total} entities.`);
+    } else {
+        throw PackError("No data available to build packs.");
+    }
+})();


### PR DESCRIPTION
This records the last modified time of all pack files and compares to an exisiting record of the last build run if available.
Only tested on windows. Collection of file stats takes <1 second on my test machine.
It could also be expanded to only build changed packs.

This should have no effect on CI/CD scripts because the `.pack-changes.json` file doesn't exist there.