### PR TITLE
Formally restrict GrantItem from being usable on physical items

### DIFF
--- a/src/module/rules/rule-element/grant-item/rule-element.ts
+++ b/src/module/rules/rule-element/grant-item/rule-element.ts
@@ -54,6 +54,10 @@ class GrantItemRuleElement extends RuleElementPF2e<GrantItemSchema> {
             const grantedItem = this.actor.inventory.get(this.grantedId ?? "") ?? null;
             this.#trackItem(grantedItem);
         }
+
+        if (item.isOfType("physical")) {
+            this.failValidation("parent item must not be physical");
+        }
     }
 
     static override defineSchema(): GrantItemSchema {


### PR DESCRIPTION
This has never actually worked but lacked messaging saying as much.