### PR TITLE
Always include token name when retrieving message speaker for checks

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -1717,8 +1717,11 @@ interface ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
     ): ConditionPF2e<this>[] | ConditionPF2e<this> | null;
 
     getActiveTokens(linked: boolean | undefined, document: true): TokenDocumentPF2e<ScenePF2e>[];
-    getActiveTokens(linked?: undefined, document?: undefined): TokenPF2e[];
-    getActiveTokens(linked?: boolean, document?: boolean): TokenDocumentPF2e<ScenePF2e>[] | TokenPF2e[];
+    getActiveTokens(linked?: undefined, document?: undefined): TokenPF2e<TokenDocumentPF2e<ScenePF2e>>[];
+    getActiveTokens(
+        linked?: boolean,
+        document?: boolean
+    ): TokenDocumentPF2e<ScenePF2e>[] | TokenPF2e<TokenDocumentPF2e<ScenePF2e>>[];
 
     /** Added as debounced method */
     checkAreaEffects(): void;

--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -1789,6 +1789,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
                     const checkContext: CheckRollContext = {
                         type: "attack-roll",
                         actor: context.self.actor,
+                        token: context.self.token,
                         target: context.target,
                         item: context.self.item,
                         altUsage: params.altUsage ?? null,

--- a/src/module/actor/helpers.ts
+++ b/src/module/actor/helpers.ts
@@ -297,6 +297,7 @@ function strikeFromMeleeItem(item: MeleePF2e<ActorPF2e>): NPCStrike {
                     {
                         type: "attack-roll",
                         actor: context.self.actor,
+                        token: context.self.token,
                         item: context.self.item,
                         target: context.target,
                         domains,

--- a/src/module/system/check/types.ts
+++ b/src/module/system/check/types.ts
@@ -3,7 +3,6 @@ import { AttackTarget } from "@actor/types";
 import { ItemPF2e } from "@item";
 import { ZeroToTwo } from "@module/data";
 import { RollSubstitution } from "@module/rules/synthetics";
-import { ScenePF2e } from "@scene";
 import { TokenDocumentPF2e } from "@scene/token-document";
 import { CheckDC, DegreeOfSuccessAdjustment } from "@system/degree-of-success";
 import { BaseRollContext } from "@system/rolls";
@@ -31,7 +30,7 @@ interface CheckRollContext extends BaseRollContext {
     /** The actor which initiated this roll. */
     actor?: ActorPF2e;
     /** The token which initiated this roll. */
-    token?: TokenDocumentPF2e<ScenePF2e>;
+    token?: TokenDocumentPF2e | null;
     /** The originating item of this attack, if any */
     item?: ItemPF2e<ActorPF2e> | null;
     /** Optional title of the roll options dialog; defaults to the check name */


### PR DESCRIPTION
Closes #7141 