### PR TITLE
Fix regressions with rolling initiative

### DIFF
--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -44,7 +44,6 @@ import { IWREditor } from "./popups/iwr-editor";
 import { RemoveCoinsPopup } from "./popups/remove-coins-popup";
 import { CraftingFormula } from "@actor/character/crafting";
 import { UUIDUtils } from "@util/uuid-utils";
-import { CombatantPF2e, EncounterPF2e } from "@module/encounter";
 
 /**
  * Extend the basic ActorSheet class to do all the PF2e things!
@@ -265,18 +264,9 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
         }
 
         const rollInitElem = htmlQuery(html, ".roll-init");
-        rollInitElem?.addEventListener("click", (): void => {
+        rollInitElem?.addEventListener("click", (event): void => {
             if (!rollInitElem.classList.contains("disabled") && this.actor.initiative) {
-                if (!game.combat) return;
-                const { actor } = this;
-                const combatant = ((): CombatantPF2e<EncounterPF2e> | null => {
-                    const existing = game.combat.combatants.find((c) => c.actor === actor);
-                    if (existing) return existing;
-                    ui.notifications.error(game.i18n.format("PF2E.Encounter.NotParticipating", { actor: actor.name }));
-                    return null;
-                })();
-                if (!combatant) return;
-                game.combat.rollInitiative([combatant.id]);
+                this.actor.initiative.roll(eventToRollParams(event));
             }
         });
 

--- a/src/module/encounter/document.ts
+++ b/src/module/encounter/document.ts
@@ -145,6 +145,20 @@ class EncounterPF2e extends Combat {
         await this.update({ turn: this.turns.findIndex((c) => c.id === currentId) });
     }
 
+    override async setInitiative(id: string, value: number): Promise<void> {
+        const combatant = this.combatants.get(id, { strict: true });
+        if (combatant.actor?.isOfType("character", "npc")) {
+            return this.setMultipleInitiatives([
+                {
+                    id: combatant.id,
+                    value,
+                    statistic: combatant.actor.attributes.initiative.statistic || "perception",
+                },
+            ]);
+        }
+        super.setInitiative(id, value);
+    }
+
     /**
      * Rerun data preparation for participating actors
      * `async` since this is usually called from CRUD hooks, which are called prior to encounter/combatant data resets

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1837,7 +1837,6 @@
             "InitiativeSet": "Inititative of {actor} was set to {initiative}.",
             "NoActiveEncounter": "There is no active encounter.",
             "NoTokenInScene": "{actor} has no token in the scene.",
-            "NotParticipating": "{actor} is not participating in the active encounter.",
             "RevealName": "Reveal Name"
         },
         "EquipmentEquippedLabel": "Equipped",

--- a/types/foundry/common/documents/combatant.d.ts
+++ b/types/foundry/common/documents/combatant.d.ts
@@ -44,6 +44,7 @@ declare module foundry {
         interface CombatantSource {
             _id: string | null;
             actorId: string;
+            sceneId: string;
             tokenId: string;
             img: VideoFilePath;
             initiative: number | null;


### PR DESCRIPTION
- A combatant is created on rolling initiative if one doesn't exist already
- Roll params are passed from the character sheet again
- The `initiativeStatistic` is always set for characters and npcs

Closes #7164