### PR TITLE
Localize DoS adjustment notes for common saving throws

### DIFF
--- a/packs/data/classfeatures.db/divine-will.json
+++ b/packs/data/classfeatures.db/divine-will.json
@@ -22,8 +22,11 @@
         "rules": [
             {
                 "key": "Note",
+                "outcome": [
+                    "success"
+                ],
                 "selector": "will",
-                "text": "When you roll a success on a Will save, you get a critical success instead.",
+                "text": "PF2E.SpecificRule.SaveSuccessToCriticalSuccess.Will",
                 "title": "{item|name}"
             },
             {

--- a/packs/data/classfeatures.db/evasion.json
+++ b/packs/data/classfeatures.db/evasion.json
@@ -22,8 +22,11 @@
         "rules": [
             {
                 "key": "Note",
+                "outcome": [
+                    "success"
+                ],
                 "selector": "reflex",
-                "text": "When you roll a success on a Reflex save, you get a critical success instead.",
+                "text": "PF2E.SpecificRule.SaveSuccessToCriticalSuccess.Reflex",
                 "title": "{item|name}"
             },
             {

--- a/packs/data/classfeatures.db/fifth-doctrine-warpriest.json
+++ b/packs/data/classfeatures.db/fifth-doctrine-warpriest.json
@@ -22,8 +22,11 @@
         "rules": [
             {
                 "key": "Note",
+                "outcome": [
+                    "success"
+                ],
                 "selector": "fortitude",
-                "text": "When you roll a success on a Fortitude save, you get a critical success instead.",
+                "text": "PF2E.SpecificRule.SaveSuccessToCriticalSuccess.Fortitude",
                 "title": "{item|name}"
             },
             {

--- a/packs/data/classfeatures.db/flames.json
+++ b/packs/data/classfeatures.db/flames.json
@@ -67,7 +67,7 @@
                     "feature:lightning-reflexes"
                 ],
                 "selector": "reflex",
-                "text": "When you roll a success on a Reflex save, you get a critical success instead.",
+                "text": "PF2E.SpecificRule.SaveSuccessToCriticalSuccess.Reflex",
                 "title": "{item|name}"
             },
             {

--- a/packs/data/classfeatures.db/greater-juggernaut.json
+++ b/packs/data/classfeatures.db/greater-juggernaut.json
@@ -22,6 +22,10 @@
         "rules": [
             {
                 "key": "Note",
+                "outcome": [
+                    "criticalFailure",
+                    "failure"
+                ],
                 "selector": "fortitude",
                 "text": "When you roll a critical failure on a Fortitude save, you get a failure instead. When you fail a Fortitude save against an effect that deals damage, you halve the damage you take.",
                 "title": "{item|name}"

--- a/packs/data/classfeatures.db/indomitable-will.json
+++ b/packs/data/classfeatures.db/indomitable-will.json
@@ -22,8 +22,11 @@
         "rules": [
             {
                 "key": "Note",
+                "outcome": [
+                    "success"
+                ],
                 "selector": "will",
-                "text": "When you roll a success on a Will save, you get a critical success instead.",
+                "text": "PF2E.SpecificRule.SaveSuccessToCriticalSuccess.Will",
                 "title": "{item|name}"
             },
             {

--- a/packs/data/classfeatures.db/juggernaut.json
+++ b/packs/data/classfeatures.db/juggernaut.json
@@ -22,8 +22,11 @@
         "rules": [
             {
                 "key": "Note",
+                "outcome": [
+                    "success"
+                ],
                 "selector": "fortitude",
-                "text": "When you roll a success on a Fortitude save, you get a critical success instead.",
+                "text": "PF2E.SpecificRule.SaveSuccessToCriticalSuccess.Fortitude",
                 "title": "{item|name}"
             },
             {

--- a/packs/data/classfeatures.db/path-to-perfection-fortitude.json
+++ b/packs/data/classfeatures.db/path-to-perfection-fortitude.json
@@ -22,8 +22,11 @@
         "rules": [
             {
                 "key": "Note",
+                "outcome": [
+                    "success"
+                ],
                 "selector": "fortitude",
-                "text": "When you roll a success on a Fortitude save, you get a critical success instead.",
+                "text": "PF2E.SpecificRule.SaveSuccessToCriticalSuccess.Fortitude",
                 "title": "{item|name}"
             },
             {

--- a/packs/data/classfeatures.db/path-to-perfection-reflex.json
+++ b/packs/data/classfeatures.db/path-to-perfection-reflex.json
@@ -22,8 +22,11 @@
         "rules": [
             {
                 "key": "Note",
+                "outcome": [
+                    "success"
+                ],
                 "selector": "reflex",
-                "text": "When you roll a success on a Reflex save, you get a critical success instead.",
+                "text": "PF2E.SpecificRule.SaveSuccessToCriticalSuccess.Reflex",
                 "title": "{item|name}"
             },
             {

--- a/packs/data/classfeatures.db/path-to-perfection-will.json
+++ b/packs/data/classfeatures.db/path-to-perfection-will.json
@@ -22,8 +22,11 @@
         "rules": [
             {
                 "key": "Note",
+                "outcome": [
+                    "success"
+                ],
                 "selector": "will",
-                "text": "When you roll a success on a Will save, you get a critical success instead.",
+                "text": "PF2E.SpecificRule.SaveSuccessToCriticalSuccess.Will",
                 "title": "{item|name}"
             },
             {

--- a/packs/data/classfeatures.db/path-to-perfection.json
+++ b/packs/data/classfeatures.db/path-to-perfection.json
@@ -55,6 +55,9 @@
             },
             {
                 "key": "Note",
+                "outcome": [
+                    "success"
+                ],
                 "selector": "{item|flags.pf2e.rulesSelections.pathToPerfection}",
                 "text": "When you roll a success on a save, you get a critical success instead.",
                 "title": "{item|name}"

--- a/packs/data/classfeatures.db/resolve.json
+++ b/packs/data/classfeatures.db/resolve.json
@@ -22,8 +22,11 @@
         "rules": [
             {
                 "key": "Note",
+                "outcome": [
+                    "success"
+                ],
                 "selector": "will",
-                "text": "When you roll a success on a Will save, you get a critical success instead.",
+                "text": "PF2E.SpecificRule.SaveSuccessToCriticalSuccess.Will",
                 "title": "{item|name}"
             },
             {

--- a/packs/data/classfeatures.db/second-path-to-perfection-fortitude.json
+++ b/packs/data/classfeatures.db/second-path-to-perfection-fortitude.json
@@ -22,8 +22,11 @@
         "rules": [
             {
                 "key": "Note",
+                "outcome": [
+                    "success"
+                ],
                 "selector": "fortitude",
-                "text": "When you roll a success on a Fortitude save, you get a critical success instead.",
+                "text": "PF2E.SpecificRule.SaveSuccessToCriticalSuccess.Fortitude",
                 "title": "{item|name}"
             },
             {

--- a/packs/data/classfeatures.db/second-path-to-perfection-reflex.json
+++ b/packs/data/classfeatures.db/second-path-to-perfection-reflex.json
@@ -22,8 +22,11 @@
         "rules": [
             {
                 "key": "Note",
+                "outcome": [
+                    "success"
+                ],
                 "selector": "reflex",
-                "text": "When you roll a success on a Reflex save, you get a critical success instead.",
+                "text": "PF2E.SpecificRule.SaveSuccessToCriticalSuccess.Reflex",
                 "title": "{item|name}"
             },
             {

--- a/packs/data/classfeatures.db/second-path-to-perfection-will.json
+++ b/packs/data/classfeatures.db/second-path-to-perfection-will.json
@@ -22,8 +22,11 @@
         "rules": [
             {
                 "key": "Note",
+                "outcome": [
+                    "success"
+                ],
                 "selector": "will",
-                "text": "When you roll a success on a Will save, you get a critical success instead.",
+                "text": "PF2E.SpecificRule.SaveSuccessToCriticalSuccess.Will",
                 "title": "{item|name}"
             },
             {

--- a/packs/data/classfeatures.db/second-path-to-perfection.json
+++ b/packs/data/classfeatures.db/second-path-to-perfection.json
@@ -70,6 +70,9 @@
             },
             {
                 "key": "Note",
+                "outcome": [
+                    "success"
+                ],
                 "selector": "{item|flags.pf2e.rulesSelections.pathToPerfection}",
                 "text": "When you roll a success on a save, you get a critical success instead.",
                 "title": "{item|name}"

--- a/packs/data/classfeatures.db/shared-resolve.json
+++ b/packs/data/classfeatures.db/shared-resolve.json
@@ -22,8 +22,11 @@
         "rules": [
             {
                 "key": "Note",
+                "outcome": [
+                    "success"
+                ],
                 "selector": "will",
-                "text": "When you roll a success on a Will save, you get a critical success instead.",
+                "text": "PF2E.SpecificRule.SaveSuccessToCriticalSuccess.Will",
                 "title": "{item|name}"
             },
             {

--- a/packs/data/classfeatures.db/slippery-mind.json
+++ b/packs/data/classfeatures.db/slippery-mind.json
@@ -22,8 +22,11 @@
         "rules": [
             {
                 "key": "Note",
+                "outcome": [
+                    "success"
+                ],
                 "selector": "will",
-                "text": "When you roll a success on a Will save, you get a critical success instead.",
+                "text": "PF2E.SpecificRule.SaveSuccessToCriticalSuccess.Will",
                 "title": "{item|name}"
             },
             {

--- a/packs/data/classfeatures.db/twin-juggernauts.json
+++ b/packs/data/classfeatures.db/twin-juggernauts.json
@@ -22,8 +22,11 @@
         "rules": [
             {
                 "key": "Note",
+                "outcome": [
+                    "success"
+                ],
                 "selector": "fortitude",
-                "text": "When you roll a success on a Fortitude save, you get a critical success instead.",
+                "text": "PF2E.SpecificRule.SaveSuccessToCriticalSuccess.Fortitude",
                 "title": "{item|name}"
             },
             {

--- a/packs/data/classfeatures.db/walls-of-will.json
+++ b/packs/data/classfeatures.db/walls-of-will.json
@@ -26,7 +26,7 @@
                     "success"
                 ],
                 "selector": "will",
-                "text": "When you roll a success on a Will save, you get a critical success instead.",
+                "text": "PF2E.SpecificRule.SaveSuccessToCriticalSuccess.Will",
                 "title": "{item|name}"
             },
             {

--- a/packs/data/extinction-curse-bestiary.db/evora-yarket.json
+++ b/packs/data/extinction-curse-bestiary.db/evora-yarket.json
@@ -282,8 +282,11 @@
                     },
                     {
                         "key": "Note",
+                        "outcome": [
+                            "success"
+                        ],
                         "selector": "fortitude",
-                        "text": "When you roll a success on a Fortitude save, you get a critical success instead.",
+                        "text": "PF2E.SpecificRule.SaveSuccessToCriticalSuccess.Fortitude",
                         "title": "{item|name}"
                     }
                 ],

--- a/packs/data/feats.db/adaptive-vision.json
+++ b/packs/data/feats.db/adaptive-vision.json
@@ -42,6 +42,9 @@
             },
             {
                 "key": "Note",
+                "outcome": [
+                    "success"
+                ],
                 "predicate": [
                     "visual"
                 ],

--- a/packs/data/feats.db/alghollthu-bound.json
+++ b/packs/data/feats.db/alghollthu-bound.json
@@ -47,6 +47,9 @@
             },
             {
                 "key": "Note",
+                "outcome": [
+                    "success"
+                ],
                 "predicate": [
                     "mental"
                 ],

--- a/packs/data/feats.db/ancestral-suspicion.json
+++ b/packs/data/feats.db/ancestral-suspicion.json
@@ -42,6 +42,9 @@
             },
             {
                 "key": "Note",
+                "outcome": [
+                    "success"
+                ],
                 "selector": "saving-throw",
                 "text": "When you roll a success on a saving throw against an effect that would make you controlled, you get a critical success instead.",
                 "title": "{item|name}"

--- a/packs/data/feats.db/blast-resistance.json
+++ b/packs/data/feats.db/blast-resistance.json
@@ -22,6 +22,9 @@
         "rules": [
             {
                 "key": "Note",
+                "outcome": [
+                    "success"
+                ],
                 "predicate": [
                     "auditory",
                     "condition:deafened"

--- a/packs/data/feats.db/brine-may.json
+++ b/packs/data/feats.db/brine-may.json
@@ -23,6 +23,9 @@
         "rules": [
             {
                 "key": "Note",
+                "outcome": [
+                    "success"
+                ],
                 "predicate": [
                     "action:swim"
                 ],

--- a/packs/data/feats.db/called.json
+++ b/packs/data/feats.db/called.json
@@ -32,6 +32,9 @@
             },
             {
                 "key": "Note",
+                "outcome": [
+                    "success"
+                ],
                 "predicate": [
                     "mental"
                 ],

--- a/packs/data/feats.db/emotionless.json
+++ b/packs/data/feats.db/emotionless.json
@@ -37,6 +37,9 @@
             },
             {
                 "key": "Note",
+                "outcome": [
+                    "success"
+                ],
                 "predicate": [
                     {
                         "or": [

--- a/packs/data/feats.db/lawbringer.json
+++ b/packs/data/feats.db/lawbringer.json
@@ -33,6 +33,9 @@
             },
             {
                 "key": "Note",
+                "outcome": [
+                    "success"
+                ],
                 "predicate": [
                     "emotion"
                 ],

--- a/packs/data/feats.db/tide-hardened.json
+++ b/packs/data/feats.db/tide-hardened.json
@@ -22,6 +22,9 @@
         "rules": [
             {
                 "key": "Note",
+                "outcome": [
+                    "success"
+                ],
                 "predicate": [
                     {
                         "or": [

--- a/packs/data/feats.db/undaunted.json
+++ b/packs/data/feats.db/undaunted.json
@@ -31,6 +31,9 @@
             },
             {
                 "key": "Note",
+                "outcome": [
+                    "success"
+                ],
                 "predicate": [
                     "emotion"
                 ],

--- a/packs/data/feats.db/well-groomed.json
+++ b/packs/data/feats.db/well-groomed.json
@@ -43,6 +43,9 @@
             },
             {
                 "key": "Note",
+                "outcome": [
+                    "success"
+                ],
                 "predicate": [
                     "disease"
                 ],

--- a/packs/data/kingmaker-bestiary.db/amiri-level-11-kingmaker.json
+++ b/packs/data/kingmaker-bestiary.db/amiri-level-11-kingmaker.json
@@ -2628,8 +2628,11 @@
                 "rules": [
                     {
                         "key": "Note",
+                        "outcome": [
+                            "success"
+                        ],
                         "selector": "fortitude",
-                        "text": "When you roll a success on a Fortitude save, you get a critical success instead.",
+                        "text": "PF2E.SpecificRule.SaveSuccessToCriticalSuccess.Fortitude",
                         "title": "{item|name}"
                     },
                     {

--- a/packs/data/kingmaker-bestiary.db/kargstaad.json
+++ b/packs/data/kingmaker-bestiary.db/kargstaad.json
@@ -677,7 +677,7 @@
                             "criticalSuccess"
                         ],
                         "selector": "fortitude",
-                        "text": "When you roll a success on a Fortitude save, you get a critical success instead.",
+                        "text": "PF2E.SpecificRule.SaveSuccessToCriticalSuccess.Fortitude",
                         "title": "{item|name}"
                     },
                     {

--- a/packs/data/kingmaker-bestiary.db/nyrissa.json
+++ b/packs/data/kingmaker-bestiary.db/nyrissa.json
@@ -7922,8 +7922,11 @@
                 "rules": [
                     {
                         "key": "Note",
+                        "outcome": [
+                            "success"
+                        ],
                         "selector": "reflex",
-                        "text": "When you roll a success on a Reflex save, you get a critical success instead.",
+                        "text": "PF2E.SpecificRule.SaveSuccessToCriticalSuccess.Reflex",
                         "title": "{item|name}"
                     },
                     {

--- a/packs/data/kingmaker-bestiary.db/tristian-level-10.json
+++ b/packs/data/kingmaker-bestiary.db/tristian-level-10.json
@@ -3693,8 +3693,11 @@
                 "rules": [
                     {
                         "key": "Note",
+                        "outcome": [
+                            "success"
+                        ],
                         "selector": "will",
-                        "text": "When you roll a success on a Will save, you get a critical success instead.",
+                        "text": "PF2E.SpecificRule.SaveSuccessToCriticalSuccess.Will",
                         "title": "{item|name}"
                     },
                     {

--- a/packs/data/kingmaker-bestiary.db/valerie-level-9.json
+++ b/packs/data/kingmaker-bestiary.db/valerie-level-9.json
@@ -1985,8 +1985,11 @@
                 "rules": [
                     {
                         "key": "Note",
+                        "outcome": [
+                            "success"
+                        ],
                         "selector": "fortitude",
-                        "text": "When you roll a success on a Fortitude save, you get a critical success instead.",
+                        "text": "PF2E.SpecificRule.SaveSuccessToCriticalSuccess.Fortitude",
                         "title": "{item|name}"
                     },
                     {

--- a/packs/data/npc-gallery.db/gang-leader.json
+++ b/packs/data/npc-gallery.db/gang-leader.json
@@ -794,8 +794,11 @@
                 "rules": [
                     {
                         "key": "Note",
+                        "outcome": [
+                            "success"
+                        ],
                         "selector": "reflex",
-                        "text": "When you roll a success on a Reflex save, you get a critical success instead.",
+                        "text": "PF2E.SpecificRule.SaveSuccessToCriticalSuccess.Reflex",
                         "title": "{item|name}"
                     },
                     {

--- a/packs/data/npc-gallery.db/veteran-reclaimer.json
+++ b/packs/data/npc-gallery.db/veteran-reclaimer.json
@@ -970,8 +970,11 @@
                 "rules": [
                     {
                         "key": "Note",
+                        "outcome": [
+                            "success"
+                        ],
                         "selector": "reflex",
-                        "text": "When you roll a success on a Reflex save, you get a critical success instead.",
+                        "text": "PF2E.SpecificRule.SaveSuccessToCriticalSuccess.Reflex",
                         "title": "{item|name}"
                     },
                     {

--- a/packs/data/outlaws-of-alkenstar-bestiary.db/drela.json
+++ b/packs/data/outlaws-of-alkenstar-bestiary.db/drela.json
@@ -800,8 +800,11 @@
                 "rules": [
                     {
                         "key": "Note",
+                        "outcome": [
+                            "success"
+                        ],
                         "selector": "reflex",
-                        "text": "When you roll a success on a Reflex save, you get a critical success instead.",
+                        "text": "PF2E.SpecificRule.SaveSuccessToCriticalSuccess.Reflex",
                         "title": "{item|name}"
                     },
                     {

--- a/packs/data/outlaws-of-alkenstar-bestiary.db/hansin.json
+++ b/packs/data/outlaws-of-alkenstar-bestiary.db/hansin.json
@@ -800,8 +800,11 @@
                 "rules": [
                     {
                         "key": "Note",
+                        "outcome": [
+                            "success"
+                        ],
                         "selector": "reflex",
-                        "text": "When you roll a success on a Reflex save, you get a critical success instead.",
+                        "text": "PF2E.SpecificRule.SaveSuccessToCriticalSuccess.Reflex",
                         "title": "{item|name}"
                     },
                     {

--- a/packs/data/paizo-pregens.db/elsir-syniras.json
+++ b/packs/data/paizo-pregens.db/elsir-syniras.json
@@ -882,6 +882,9 @@
                     },
                     {
                         "key": "Note",
+                        "outcome": [
+                            "success"
+                        ],
                         "selector": "saving-throw",
                         "text": "When you roll a success on a saving throw against an effect that would make you controlled, you get a critical success instead.",
                         "title": "{item|name}"

--- a/packs/data/paizo-pregens.db/lavanna-saltspray.json
+++ b/packs/data/paizo-pregens.db/lavanna-saltspray.json
@@ -1462,6 +1462,9 @@
                 "rules": [
                     {
                         "key": "Note",
+                        "outcome": [
+                            "success"
+                        ],
                         "predicate": [
                             {
                                 "or": [

--- a/packs/data/paizo-pregens.db/reaching-rings.json
+++ b/packs/data/paizo-pregens.db/reaching-rings.json
@@ -1041,6 +1041,9 @@
                     },
                     {
                         "key": "Note",
+                        "outcome": [
+                            "success"
+                        ],
                         "predicate": [
                             "emotion"
                         ],

--- a/packs/data/pfs-season-2-bestiary.db/drandle-dreng-7-8.json
+++ b/packs/data/pfs-season-2-bestiary.db/drandle-dreng-7-8.json
@@ -577,8 +577,11 @@
                 "rules": [
                     {
                         "key": "Note",
+                        "outcome": [
+                            "success"
+                        ],
                         "selector": "reflex",
-                        "text": "When you roll a success on a Reflex save, you get a critical success instead.",
+                        "text": "PF2E.SpecificRule.SaveSuccessToCriticalSuccess.Reflex",
                         "title": "{item|name}"
                     },
                     {

--- a/packs/data/pfs-season-2-bestiary.db/drandle-dreng-9-10.json
+++ b/packs/data/pfs-season-2-bestiary.db/drandle-dreng-9-10.json
@@ -577,8 +577,11 @@
                 "rules": [
                     {
                         "key": "Note",
+                        "outcome": [
+                            "success"
+                        ],
                         "selector": "reflex",
-                        "text": "When you roll a success on a Reflex save, you get a critical success instead.",
+                        "text": "PF2E.SpecificRule.SaveSuccessToCriticalSuccess.Reflex",
                         "title": "{item|name}"
                     },
                     {

--- a/packs/data/pfs-season-4-bestiary.db/bloody-barber-gang-leader.json
+++ b/packs/data/pfs-season-4-bestiary.db/bloody-barber-gang-leader.json
@@ -794,8 +794,11 @@
                 "rules": [
                     {
                         "key": "Note",
+                        "outcome": [
+                            "success"
+                        ],
                         "selector": "reflex",
-                        "text": "When you roll a success on a Reflex save, you get a critical success instead.",
+                        "text": "PF2E.SpecificRule.SaveSuccessToCriticalSuccess.Reflex",
                         "title": "{item|name}"
                     },
                     {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2056,6 +2056,11 @@
                     "Prompt": "Select a skill to become trained in."
                 }
             },
+            "SaveSuccessToCriticalSuccess": {
+                "Fortitude": "When you roll a success on a Fortitude save, you get a critical success instead.",
+                "Reflex": "When you roll a success on a Reflex save, you get a critical success instead.",
+                "Will": "When you roll a success on a Will save, you get a critical success instead."
+            },
             "ScionOfDomora": {
                 "GuardiansEmbrace": {
                     "PhysicalAttackLabel": "Guarding Against a Physical Attack",


### PR DESCRIPTION
Also add `outcome` arrays so that they're only shown when not rolling against a DC