### PR TITLE
Limited support for target-specific healing received modifiers and roll notes

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -1124,6 +1124,9 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
         rollOptions = new Set(),
         skipIWR = false,
         shieldBlockRequest = false,
+        breakdown = [],
+        notes = [],
+        rolls = [],
     }: ApplyDamageParams): Promise<this> {
         const { hitPoints } = this;
         if (!hitPoints) return this;
@@ -1313,6 +1316,8 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
 
         const canUndoDamage = !!(hpDamage || shieldDamage || persistentCreated.length);
         const content = await renderTemplate("systems/pf2e/templates/chat/damage/damage-taken.hbs", {
+            breakdown,
+            notes,
             statements,
             persistent: persistentCreated.map((p) => p.system.persistent!.damage.formula),
             iwr: {
@@ -1350,13 +1355,14 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
 
         await ChatMessagePF2e.create({
             speaker: ChatMessagePF2e.getSpeaker({ token }),
-            content,
             flags: {
                 pf2e: {
                     appliedDamage,
                 },
             },
-            type: CONST.CHAT_MESSAGE_TYPES.EMOTE,
+            flavor: content,
+            rolls: rolls.map((roll) => roll.toJSON()),
+            type: rolls.length ? CONST.CHAT_MESSAGE_TYPES.ROLL : CONST.CHAT_MESSAGE_TYPES.OTHER,
             whisper:
                 game.settings.get("pf2e", "metagame_secretDamage") && !token.actor?.hasPlayerOwner
                     ? ChatMessagePF2e.getWhisperRecipients("GM").map((u) => u.id)

--- a/src/module/actor/types.ts
+++ b/src/module/actor/types.ts
@@ -170,6 +170,9 @@ interface ApplyDamageParams {
     /** Predicate statements from the damage roll */
     rollOptions?: Set<string>;
     shieldBlockRequest?: boolean;
+    breakdown?: string[];
+    notes?: string[];
+    rolls?: Rolled<Roll>[];
 }
 
 type ImmunityType = keyof typeof immunityTypes;

--- a/src/module/chat-message/data.ts
+++ b/src/module/chat-message/data.ts
@@ -103,6 +103,7 @@ interface SpellCastContextFlag {
     type: "spell-cast";
     domains: string[];
     options: string[];
+    outcome?: DegreeOfSuccessString;
     /** The roll mode (i.e., 'roll', 'blindroll', etc) to use when rendering this roll. */
     rollMode?: RollMode;
 }

--- a/src/styles/ui/sidebar/chat/_damage.scss
+++ b/src/styles/ui/sidebar/chat/_damage.scss
@@ -420,6 +420,9 @@
 
 
     .damage-taken {
+        section.roll-note {
+            font-size: var(--font-size-12);
+        }
         .persistent {
             font-style: normal;
             margin-top: 1em;

--- a/static/templates/chat/damage/damage-taken.hbs
+++ b/static/templates/chat/damage/damage-taken.hbs
@@ -1,4 +1,15 @@
 <section class="damage-taken">
+    <ul class="tags">
+        {{#each breakdown as |modifier|}}
+        <li class="tag tag_transparent">{{modifier}}</li>
+        {{/each}}
+    </ul>
+    <div class="notes">
+        {{#each notes as |note|}}
+            {{{note}}}
+        {{/each}}
+    </div>
+    {{#if (or breakdown.length notes.length)}}<hr>{{/if}}
     <span class="statements">{{{statements}}}</span>
     {{#if iwr.applications}}
         <span class="iwr" data-visibility="{{iwr.visibility}}" data-applications="{{json iwr.applications}}"><i class="fas fa-info-circle small"></i></span>


### PR DESCRIPTION
```json
{
  "key": "FlatModifier",
  "selector": "healing-received",
  "value": 5,
  "predicate": [
    {
      "or": [
        "action:treat-wounds",
        "action:battle-medicine"
      ]
    }
  ]
}
```

```json
{
  "key": "Note",
  "selector": "healing-received",
  "text": "You recover an additional 5 Hit Points from a successful attempt to Treat your Wounds or use Battle Medicine on you. After you or an ally use Battle Medicine on you, you become temporarily immune to that Battle Medicine for only 1 hour, instead of 1 day.",
  "title": "{item|name}",
  "predicate": [
    {
      "or": [
        "action:treat-wounds",
        "action:battle-medicine"
      ]
    }
  ]
}
```

<img width="288" alt="Healing Chat Card" src="https://user-images.githubusercontent.com/6374503/228452693-30957e7e-f4c1-4b6e-a268-01caa3892e03.png">
