### PR TITLE
Fix some issues with price inputs on item sheets

### DIFF
--- a/src/module/item/physical/sheet.ts
+++ b/src/module/item/physical/sheet.ts
@@ -200,7 +200,7 @@ class PhysicalItemSheetPF2e<TItem extends PhysicalItemPF2e> extends ItemSheetPF2
         }
 
         // Convert price from a string to an actual object
-        if (formData["system.price.value"]) {
+        if ("system.price.value" in formData) {
             formData["system.price.value"] = CoinsPF2e.fromString(String(formData["system.price.value"]));
         }
 

--- a/static/templates/items/armor-sidebar.hbs
+++ b/static/templates/items/armor-sidebar.hbs
@@ -46,7 +46,7 @@
             {{#if (eq priceAdjustment "higher")}}class="adjusted-higher"{{else if (eq priceAdjustment "lower")}}class="adjusted-lower"{{/if}}
             data-property="system.price.value"
             data-value-base="{{basePrice}}"
-            value="{{this.item.price.value}}"
+            value="{{item.price.value}}"
             spellcheck="false"
         />
     </div>

--- a/static/templates/items/backpack-sidebar.hbs
+++ b/static/templates/items/backpack-sidebar.hbs
@@ -58,7 +58,7 @@
             {{#if (eq priceAdjustment "higher")}}class="adjusted-higher"{{else if (eq priceAdjustment "lower")}}class="adjusted-lower"{{/if}}
             data-property="system.price.value"
             data-value-base="{{basePrice}}"
-            value="{{this.item.price.value}}"
+            value="{{item.price.value}}"
             spellcheck="false"
         />
     </div>

--- a/static/templates/items/book-sidebar.hbs
+++ b/static/templates/items/book-sidebar.hbs
@@ -36,6 +36,13 @@
     </div>
     <div class="form-group">
         <label>{{localize "PF2E.PriceLabel"}}</label>
-        <input type="text" name="system.price.value" value="{{priceString}}" />
+        <input
+            type="text"
+            {{#if (eq priceAdjustment "higher")}}class="adjusted-higher"{{else if (eq priceAdjustment "lower")}}class="adjusted-lower"{{/if}}
+            data-property="system.price.value"
+            data-value-base="{{basePrice}}"
+            value="{{item.price.value}}"
+            spellcheck="false"
+        />
     </div>
 </div>

--- a/static/templates/items/consumable-sidebar.hbs
+++ b/static/templates/items/consumable-sidebar.hbs
@@ -69,7 +69,7 @@
                 {{#if (eq priceAdjustment "higher")}}class="adjusted-higher"{{else if (eq priceAdjustment "lower")}}class="adjusted-lower"{{/if}}
                 data-property="system.price.value"
                 data-value-base="{{basePrice}}"
-                value="{{this.item.price.value}}"
+                value="{{item.price.value}}"
                 spellcheck="false"
             />
             /

--- a/static/templates/items/equipment-sidebar.hbs
+++ b/static/templates/items/equipment-sidebar.hbs
@@ -68,7 +68,7 @@
             {{#if (eq priceAdjustment "higher")}}class="adjusted-higher"{{else if (eq priceAdjustment "lower")}}class="adjusted-lower"{{/if}}
             data-property="system.price.value"
             data-value-base="{{basePrice}}"
-            value="{{this.item.price.value}}"
+            value="{{item.price.value}}"
             spellcheck="false"
         />
     </div>

--- a/static/templates/items/formula-sidebar.hbs
+++ b/static/templates/items/formula-sidebar.hbs
@@ -1,6 +1,0 @@
-<div class="inventory-details">
-    <div class="form-group">
-        <label>Item ID</label>
-        <input type="text" name="system.craftedItem.uuid" value="{{data.craftedItem.uuid}}" />
-    </div>
-</div>

--- a/static/templates/items/treasure-sidebar.hbs
+++ b/static/templates/items/treasure-sidebar.hbs
@@ -41,6 +41,6 @@
 
     <div class="form-group">
         <label>{{localize "PF2E.PriceLabel"}}</label>
-        <input type="text" name="system.price.value" value="{{priceString}}" />
+        <input type="text" name="system.price.value" value="{{item.price.value}}" spellcheck="false" />
     </div>
 </div>

--- a/static/templates/items/weapon-sidebar.hbs
+++ b/static/templates/items/weapon-sidebar.hbs
@@ -57,7 +57,7 @@
             {{#if (eq priceAdjustment "higher")}}class="adjusted adjusted-higher"{{else if (eq priceAdjustment "lower")}}class="adjusted-lower"{{/if}}
             data-property="system.price.value"
             data-value-base="{{basePrice}}"
-            value="{{this.item.price.value}}"
+            value="{{item.price.value}}"
             spellcheck="false"
         />
     </div>


### PR DESCRIPTION
- Use correct variable name in treasure sidebar template
- Remove superfluous `this` in all physical-item sidebar templates
- Have `PhysicalItemSheetPF2e#_updateObject` normalize falsish price strings