### PR TITLE
Adjust "Formulated Sunlight" quantity and charges to match rations

### DIFF
--- a/packs/data/equipment.db/formulated-sunlight.json
+++ b/packs/data/equipment.db/formulated-sunlight.json
@@ -8,8 +8,8 @@
         },
         "baseItem": null,
         "charges": {
-            "max": "1",
-            "value": "1"
+            "max": "7",
+            "value": "7"
         },
         "consumableType": {
             "value": "other"
@@ -47,7 +47,7 @@
                 "sp": 40
             }
         },
-        "quantity": 7,
+        "quantity": 1,
         "rules": [],
         "size": "med",
         "source": {

--- a/packs/data/equipment.db/formulated-sunlight.json
+++ b/packs/data/equipment.db/formulated-sunlight.json
@@ -8,8 +8,8 @@
         },
         "baseItem": null,
         "charges": {
-            "max": "7",
-            "value": "7"
+            "max": 7,
+            "value": 7
         },
         "consumableType": {
             "value": "other"


### PR DESCRIPTION
Since the quantity and charges were swapped, it counted as 7 separate objects for purposes of bulk and wealth calculations.