### PR TITLE
Fix some quirks and tweak styling of effects panel info boxes

### DIFF
--- a/src/module/apps/effects-panel.ts
+++ b/src/module/apps/effects-panel.ts
@@ -133,15 +133,15 @@ export class EffectsPanel extends Application {
             });
 
             // Send effect to chat
-            effectEl.querySelector("[data-action=send-to-chat]")?.addEventListener("click", async () => {
+            effectEl.querySelector("[data-action=send-to-chat]")?.addEventListener("click", () => {
                 const { actor } = this;
-                const effect = actor?.items.get(itemId);
-                if (effect) await effect.toMessage();
+                const effect = actor?.conditions.get(itemId) ?? actor?.items.get(itemId);
+                effect?.toMessage();
             });
 
             // Uses a scale transform to fit the text within the box
             // Note that the value container cannot have padding or measuring will fail.
-            // They cannot be inline elements pre-computation, but most be post-computation (for ellipses)
+            // They cannot be inline elements pre-computation, but must be post-computation (for ellipses)
             const valueContainer = htmlQuery(iconElem, ".value");
             const textElement = htmlQuery(valueContainer, "strong");
             if (valueContainer && textElement) {

--- a/src/styles/system/_effects-panel.scss
+++ b/src/styles/system/_effects-panel.scss
@@ -15,22 +15,21 @@
 
         &[data-badge-type=formula] .icon {
             cursor: pointer;
-            &:hover {
-                &::before {
-                    content: "\f6cf";
-                    background: rgba(0, 0, 0, 0.5);
-                    font-family: "Font Awesome 5 Free";
-                    font-weight: 900;
-                    font-size: var(--font-size-26);
-                    color: white;
-                    position: absolute;
-                    width: 100%;
-                    height: 100%;
-                    display: flex;
-                    align-items: center;
-                    justify-content: center;
-                    padding-bottom: 4px; // offset
-                }
+
+            &:hover::before {
+                content: "\f6cf";
+                background: rgba(0, 0, 0, 0.5);
+                font-family: "Font Awesome 5 Free";
+                font-weight: 900;
+                font-size: var(--font-size-26);
+                color: white;
+                position: absolute;
+                width: 100%;
+                height: 100%;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                padding-bottom: 4px; // offset
             }
         }
 
@@ -43,26 +42,23 @@
         }
 
         .effect-info {
-            display: none;
-            height: min-content;
-            max-width: 300px;
-            margin-right: 0.5em;
-            padding: 0.25em 0.5rem;
             background-color: rgba(0, 0, 0, 0.75);
             color: white;
+            display: none;
+            height: min-content;
+            margin-right: 0.5em;
+            max-width: 300px;
+            padding: 0.25em 0.5rem;
 
             h1 {
-                font-size: var(--font-size-12);
-                text-align: right;
-                border: none;
                 @include p-reset;
+                border: none;
+                font-size: var(--font-size-12);
+                padding-top: 0.25em;
+                text-align: right;
 
-                i.fas.fa-comment-alt {
+                i.fa-comment-alt {
                     margin-left: 2px;
-                }
-
-                i.fas.fa-comment-alt:hover {
-                    text-shadow: 0 0 8px var(--color-shadow-primary);
                 }
             }
 
@@ -79,32 +75,33 @@
                 }
             }
 
-            a {
+            > a, .description a {
                 display: block;
                 border: 1px outset white;
                 font-size: var(--font-size-10);
                 margin-top: 0.125rem;
-                padding: 0.125rem;   
+                padding: 0.125rem;
+
                 &.content-link, &.inline-roll {
                     padding: 1px 4px;
                     border: 1px solid var(--color-border-dark-tertiary);
                     width: fit-content;
                     display: inline;
                     color: var(--color-text-dark-primary);
-                } 
+                }
             }
 
             span[data-pf2-check] {
                 color: var(--color-text-dark-primary);
             }
 
-            .instructions, .effect-description {
+            .instructions, .description {
                 font-size: 0.75em;
                 text-align: right;
             }
 
-            .effect-description {
-                max-height: 100px;
+            .description {
+                max-height: 15em;
                 overflow-y: auto;
                 text-align: justify;
             }
@@ -180,8 +177,8 @@
         }
     }
 
-    hr {
+    > hr {
         margin-right: 0;
-        width: 40px;
+        width: 48px;
     }
 }

--- a/static/templates/system/effects-panel.hbs
+++ b/static/templates/system/effects-panel.hbs
@@ -22,7 +22,7 @@
     <div class="effect-info">
         <h1>
             {{effect.name}}
-            <i class="fas fa-comment-alt" data-action="send-to-chat" title="{{localize "PF2E.NPC.SendToChat"}}"></i>
+            <a data-action="send-to-chat" title="{{localize "PF2E.NPC.SendToChat"}}"><i class="fa-solid fa-comment-alt" ></i></a>
         </h1>
         {{#if (or (eq effect.type "effect") effect.breakdown)}}
             <div class="tags">
@@ -45,9 +45,6 @@
                 {{localize "PF2E.Item.Condition.PersistentDamage.AssistedRecovery"}}
             </a>
         {{/if}}
-        <div class="effect-description">
-            {{{ lookup descriptions @index }}}    
-        </div>
         <div class="instructions">
             {{#if (not effect.isLocked)}}
                 {{#if (eq effect.badge.type "formula")}}
@@ -62,10 +59,14 @@
                 {{/if}}
             {{/if}}
         </div>
+
+        <div class="description">
+            {{{lookup descriptions @index}}}
+        </div>
     </div>
     <div class="icon{{#if effect.isAura}} aura{{/if}}{{#unless effect.isIdentified}} unidentified{{/unless}}" data-locked="{{#if effect.isLocked}}true{{/if}}" style="background-image: url({{effect.img}})">
         {{#if effect.isLocked}}
-            <div class="linked"><i class="fas fa-link"></i></div>
+            <div class="linked"><i class="fa-solid fa-link"></i></div>
         {{/if}}
         {{#if effect.system.expired}}
             <span class="expired">{{localize "PF2E.EffectPanel.Expired"}}</span>


### PR DESCRIPTION
- Fixed in-memory conditions not going to chat
- Move left-click/right-click instructions to directly below effect name
- Set cursor of to-chat link to pointer by wrapping it in an anchor tag
- Add a small amount of padding above to-chat link to reduce chance of accidentally moving cursor to preceding effect

Before:
![image](https://user-images.githubusercontent.com/106829671/229265915-cc88f664-1842-4e23-a004-9c2b7014ea4f.png)

After:
![image](https://user-images.githubusercontent.com/106829671/229265938-4cc19d36-e297-416e-b828-2c2d3dbb74a9.png)
