### PR TITLE
Revert "Fix Dread Marshal Stance extra damage to be on strike damage"

### DIFF
--- a/packs/data/feat-effects.db/effect-dread-marshal-stance.json
+++ b/packs/data/feat-effects.db/effect-dread-marshal-stance.json
@@ -28,7 +28,7 @@
             },
             {
                 "key": "FlatModifier",
-                "selector": "strike-damage",
+                "selector": "damage",
                 "type": "status",
                 "value": "@item.origin.flags.pf2e.highestWeaponDamageDice"
             }


### PR DESCRIPTION
This reverts commit f9841fd4d678071d8b7af163d2225ee49d03b324.

> Your marshal's aura increases to a 20-foot emanation, and it grants you and allies a status bonus to damage rolls equal to the number of weapon damage dice of the unarmed attack or weapon you are wielding that has the most weapon damage dice.