### PR TITLE
Allow more actor sheet images to be shown to players

### DIFF
--- a/src/styles/actor/_index.scss
+++ b/src/styles/actor/_index.scss
@@ -12,6 +12,10 @@ $header-height: 89px;   /* Adjust height of the header */
     .image-container {
         position: relative;
 
+        .actor-image {
+            cursor: pointer;
+        }
+
         .hover-icon {
             display: none;
             font-size: var(--font-size-16);

--- a/src/styles/actor/_index.scss
+++ b/src/styles/actor/_index.scss
@@ -10,6 +10,8 @@ $header-height: 89px;   /* Adjust height of the header */
 
 .actor.sheet {
     .image-container {
+        position: relative;
+
         .hover-icon {
             display: none;
             font-size: var(--font-size-16);
@@ -17,6 +19,12 @@ $header-height: 89px;   /* Adjust height of the header */
 
         &:hover .hover-icon {
             display: block;
+        }
+
+        [data-action=show-image] {
+            position: absolute;
+            bottom: 0;
+            right: 0;
         }
     }
 

--- a/src/styles/actor/character/_character.scss
+++ b/src/styles/actor/character/_character.scss
@@ -60,14 +60,13 @@
         }
         .frame {
             z-index: 3;
-            .player-image {
+            .actor-image {
                 object-fit: cover;
                 object-position: top;
                 border: none;
                 border-radius: 0;
                 max-height: 178px;
                 width: 100%;
-                cursor: pointer;
                 @include brown-border;
             }
             [data-action=show-image] {

--- a/src/styles/actor/character/_character.scss
+++ b/src/styles/actor/character/_character.scss
@@ -59,7 +59,6 @@
             margin-left: 5px;
         }
         .frame {
-            position: relative;
             z-index: 3;
             .player-image {
                 object-fit: cover;
@@ -72,9 +71,7 @@
                 @include brown-border;
             }
             [data-action=show-image] {
-                position: absolute;
                 bottom: 5px;
-                right: 0;
             }
         }
 

--- a/src/styles/actor/familiar/_index.scss
+++ b/src/styles/actor/familiar/_index.scss
@@ -35,7 +35,8 @@
             padding: 4px 6px 0;
 
             .image-container {
-                img {
+                display: flex;
+                img.actor-image {
                     flex: 0;
                     width: 125px;
                     height: 100%;

--- a/src/styles/actor/familiar/_index.scss
+++ b/src/styles/actor/familiar/_index.scss
@@ -34,11 +34,17 @@
             flex-direction: row;
             padding: 4px 6px 0;
 
-            img {
-                flex: 0;
-                width: 125px;
-                height: 100%;
-                border-radius: 0;
+            .image-container {
+                img {
+                    flex: 0;
+                    width: 125px;
+                    height: 100%;
+                    border-radius: 0;
+                }
+                [data-action=show-image] {
+                    bottom: 2px;
+                    right: 2px;    
+                }
             }
 
             .header-content {

--- a/src/styles/actor/hazard/_header.scss
+++ b/src/styles/actor/hazard/_header.scss
@@ -36,14 +36,13 @@ form > header {
             }
         }
 
-        .player-image {
+        .actor-image {
             object-fit: cover;
             object-position: top;
             border: none;
             border-radius: 0;
             max-height: 178px;
             width: 100%;
-            cursor: pointer;
             @include brown-border;
         }
 

--- a/src/styles/actor/hazard/_header.scss
+++ b/src/styles/actor/hazard/_header.scss
@@ -26,9 +26,14 @@ form > header {
         margin: 16px 0;
 
         .frame {
-            position: relative;
             width: 60px;
             height: 60px;
+        }
+
+        .image-container {
+            [data-action=show-image] {
+                color: var(--color-text-dark-primary);    
+            }
         }
 
         .player-image {

--- a/src/styles/actor/loot/_index.scss
+++ b/src/styles/actor/loot/_index.scss
@@ -26,7 +26,7 @@
 
         .image-container {
             display: flex;
-            > img.actor-icon {
+            > img.actor-image {
                 flex: none;
                 border: none;
                 border-bottom: 1px solid #888;

--- a/src/styles/actor/loot/_index.scss
+++ b/src/styles/actor/loot/_index.scss
@@ -24,10 +24,17 @@
             flex: 0;
         }
 
-        > img.actor-icon {
-            flex: none;
-            border: none;
-            border-bottom: 1px solid #888;
+        .image-container {
+            display: flex;
+            > img.actor-icon {
+                flex: none;
+                border: none;
+                border-bottom: 1px solid #888;
+            }
+            [data-action=show-image] {
+                bottom: 3px;
+                right: 2px;
+            }
         }
 
         .gm-settings, .sidebar-meta {

--- a/src/styles/actor/npc/_index.scss
+++ b/src/styles/actor/npc/_index.scss
@@ -75,14 +75,8 @@ $light-text: #f5efe0;
 
         .image-container {
             border: 1px solid var(--color-border-dark);
-            position: relative;
             img {
                 border: none;
-            }
-            [data-action=show-image] {
-                position: absolute;
-                bottom: 0;
-                right: 0;
             }
         }
 

--- a/src/styles/actor/npc/_index.scss
+++ b/src/styles/actor/npc/_index.scss
@@ -75,7 +75,7 @@ $light-text: #f5efe0;
 
         .image-container {
             border: 1px solid var(--color-border-dark);
-            img {
+            img.actor-image {
                 border: none;
             }
         }

--- a/src/styles/actor/vehicle/_index.scss
+++ b/src/styles/actor/vehicle/_index.scss
@@ -63,7 +63,6 @@ header.char-header {
                     max-height: 90%;
                     object-fit: contain;
                     border-radius: 0;
-                    cursor: pointer;
                     border: none;
                     box-shadow: 0 0 0 1px #918c88, 0 0 0 2px #e1d8cf, 0 0 0 3px #a98f39, inset 0 0 8px rgba(0, 0, 0, 0.5), 0 0 8px black;
                 }

--- a/src/styles/actor/vehicle/_index.scss
+++ b/src/styles/actor/vehicle/_index.scss
@@ -69,6 +69,13 @@ header.char-header {
                 }
             }
 
+            .image-container {
+                [data-action=show-image] {
+                    bottom: 3px;
+                    right: 1px;    
+                } 
+            }
+
             .detail-sheet {
                 display: grid;
                 grid: repeat(2, 42px) / 3fr 2fr;

--- a/static/templates/actors/character/tabs/general.hbs
+++ b/static/templates/actors/character/tabs/general.hbs
@@ -2,7 +2,7 @@
     <section class="character-details">
         <div class="frame-container">
             <div class="frame image-container">
-                <img class="player-image" alt="{{actor.name}}" src="{{actor.img}}" title="{{actor.name}}" data-edit="img" />
+                <img class="actor-image" alt="{{actor.name}}" src="{{actor.img}}" title="{{actor.name}}" data-edit="img" />
                 <a class="hover-icon" data-action="show-image"><i class="fas fa-image fa-fw"></i></a>
             </div>
         </div>

--- a/static/templates/actors/familiar-sheet.hbs
+++ b/static/templates/actors/familiar-sheet.hbs
@@ -2,7 +2,7 @@
     <!-- HEADER -->
     <div class="familiar-sheet-header">
         <div class="image-container">
-            <img src="{{actor.img}}" data-edit="img" title="{{actor.name}}" />
+            <img class="actor-image" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" />
             <a class="hover-icon" data-action="show-image"><i class="fas fa-image fa-fw"></i></a>
         </div>
         

--- a/static/templates/actors/familiar-sheet.hbs
+++ b/static/templates/actors/familiar-sheet.hbs
@@ -1,7 +1,11 @@
 <form class="{{cssClass}}" autocomplete="off" spellcheck="false">
     <!-- HEADER -->
     <div class="familiar-sheet-header">
-        <img src="{{actor.img}}" data-edit="img" title="{{actor.name}}" />
+        <div class="image-container">
+            <img src="{{actor.img}}" data-edit="img" title="{{actor.name}}" />
+            <a class="hover-icon" data-action="show-image"><i class="fas fa-image fa-fw"></i></a>
+        </div>
+        
         <div class="header-content">
             <div class="charname">
                 <input class=" charname-value" name="name" type="text" value="{{actor.name}}"

--- a/static/templates/actors/hazard/partials/header.hbs
+++ b/static/templates/actors/hazard/partials/header.hbs
@@ -1,8 +1,9 @@
 <!-- HEADER -->
 <header>
     <div class="frame-container">
-        <div class="frame">
+        <div class="frame image-container">
             <img class="player-image" alt="{{actor.name}}" src="{{actor.img}}" title="{{actor.name}}" data-edit="img" />
+            <a class="hover-icon" data-action="show-image"><i class="fas fa-image fa-fw"></i></a>
             {{#if editable}}
                 <div class="edit-mode-button" title="{{localize "PF2E.EditHazardLabel"}}"><i class="fa-solid fa-lock{{#if editing}}-open{{/if}}"></i></div>
             {{/if}}

--- a/static/templates/actors/hazard/partials/header.hbs
+++ b/static/templates/actors/hazard/partials/header.hbs
@@ -2,7 +2,7 @@
 <header>
     <div class="frame-container">
         <div class="frame image-container">
-            <img class="player-image" alt="{{actor.name}}" src="{{actor.img}}" title="{{actor.name}}" data-edit="img" />
+            <img class="actor-image" alt="{{actor.name}}" src="{{actor.img}}" title="{{actor.name}}" data-edit="img" />
             <a class="hover-icon" data-action="show-image"><i class="fas fa-image fa-fw"></i></a>
             {{#if editable}}
                 <div class="edit-mode-button" title="{{localize "PF2E.EditHazardLabel"}}"><i class="fa-solid fa-lock{{#if editing}}-open{{/if}}"></i></div>

--- a/static/templates/actors/loot/sidebar.hbs
+++ b/static/templates/actors/loot/sidebar.hbs
@@ -1,6 +1,9 @@
 <section class="sheet-sidebar sidebar sidebar-loot">
-    <img class="actor-icon" src="{{actor.img}}" title="{{actor.name}}" data-edit="img" />
-
+    <div class="image-container">
+        <img class="actor-icon" src="{{actor.img}}" title="{{actor.name}}" data-edit="img" />
+        <a class="hover-icon" data-action="show-image"><i class="fas fa-image fa-fw"></i></a>
+    </div>
+    
     {{#if (and user.isGM isLoot)}}
         <section class="gm-settings">
             <section class="loot-distribution">

--- a/static/templates/actors/loot/sidebar.hbs
+++ b/static/templates/actors/loot/sidebar.hbs
@@ -1,6 +1,6 @@
 <section class="sheet-sidebar sidebar sidebar-loot">
     <div class="image-container">
-        <img class="actor-icon" src="{{actor.img}}" title="{{actor.name}}" data-edit="img" />
+        <img class="actor-image" src="{{actor.img}}" title="{{actor.name}}" data-edit="img" />
         <a class="hover-icon" data-action="show-image"><i class="fas fa-image fa-fw"></i></a>
     </div>
     

--- a/static/templates/actors/npc/partials/sidebar.hbs
+++ b/static/templates/actors/npc/partials/sidebar.hbs
@@ -1,5 +1,5 @@
 <div class="image-container">
-    <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="auto" width="100%" style="margin: 0 auto"/>
+    <img class="actor-image" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="auto" width="100%" style="margin: 0 auto"/>
     <a class="hover-icon" data-action="show-image"><i class="fas fa-image fa-fw"></i></a>
 </div>
 

--- a/static/templates/actors/vehicle/tabs/vehicle-details.hbs
+++ b/static/templates/actors/vehicle/tabs/vehicle-details.hbs
@@ -2,8 +2,9 @@
     <div class="details-content">
         <div class="bio-item trait-size">
             <section class="vehicle-details">
-                <div class="frame">
+                <div class="frame image-container">
                     <img class="actor-image" src="{{actor.img}}" title="{{actor.name}}" height="auto" width="100%" data-edit="img" />
+                    <a class="hover-icon" data-action="show-image"><i class="fas fa-image fa-fw"></i></a>
                 </div>
                 <div class="detail-sheet">
                     <div class="detail-small row-nr-1 span-2-columns" title="{{localize "PF2E.vehicle.PropertyDescriptionSpace"}}">


### PR DESCRIPTION
This PR resolves https://github.com/foundryvtt/pf2e/issues/6851. It:
- Adds "show image" functionality to most actor sheet types, with a show image icon that appears only when the actor image is hovered. Player Character and NPC sheets already had this, and this PR adds it to Hazard, Loot, Familiar, and Vehicle sheets. I wasn't able to check or work with Party sheets due to errors. 
- HTML/CSS classes for actor images are now more consistent across these sheets. 
- The mouse cursor switches to pointer on hover for all of these six sheet types. Previously, I think only Player Characters, Hazards, and Vehicles used pointer cursor.

I'll add images of the various sheets with the show image icon displayed. Since there are a variety of actor image sizes and frame styles, each of the Show Image icons has slightly different positioning over the actor image.

For more info, I'm on the discord as JellyfishJail#3956.

<img width="652" alt="Screen Shot 2023-04-01 at 7 02 13 PM" src="https://user-images.githubusercontent.com/14943160/229323501-b439b62a-c481-47c7-826f-06121672867f.png">

<img width="707" alt="Screen Shot 2023-04-01 at 7 02 24 PM" src="https://user-images.githubusercontent.com/14943160/229323490-4e2d2240-f250-4d5f-beae-973dd295ed1b.png">

<img width="653" alt="Screen Shot 2023-04-01 at 7 02 40 PM" src="https://user-images.githubusercontent.com/14943160/229323505-30537a4e-53f4-4271-b8ab-cec3e19751dc.png">

<img width="674" alt="Screen Shot 2023-04-01 at 7 02 52 PM" src="https://user-images.githubusercontent.com/14943160/229323508-398474eb-8faa-4668-96e0-3b0e66d1900f.png">




