### PR TITLE
Update Singular Expertise to use crossbow-damage selector

### DIFF
--- a/packs/data/classfeatures.db/singular-expertise.json
+++ b/packs/data/classfeatures.db/singular-expertise.json
@@ -28,10 +28,7 @@
             },
             {
                 "key": "FlatModifier",
-                "predicate": [
-                    "item:tag:crossbow"
-                ],
-                "selector": "bow-weapon-group-damage",
+                "selector": "crossbow-damage",
                 "type": "circumstance",
                 "value": 1
             }


### PR DESCRIPTION
Removes the predicate and uses the "crossbow-damage" selector instead.