### PR TITLE
Check if the item is null when repairing an item

### DIFF
--- a/src/module/system/action-macros/crafting/repair.ts
+++ b/src/module/system/action-macros/crafting/repair.ts
@@ -11,6 +11,12 @@ async function repair(options: RepairActionOptions) {
     const item =
         options.item ?? (options.uuid ? await fromUuid(options.uuid) : await SelectItemDialog.getItem("repair"));
 
+    if (item === null) {
+        // Don't do anything if passed a null item.
+        // TODO: do something smart here. Like possibly rolling the result and the recovered amount both.
+        return;
+    }
+
     // ensure specified item is a valid crafting target
     if (item && !(item instanceof PhysicalItemPF2e)) {
         ui.notifications.warn(game.i18n.format("PF2E.Actions.Repair.Warning.NotPhysicalItem", { item: item.name }));


### PR DESCRIPTION
## What

Currently if you hit cancel or the [x] button before providing an item it will continue and attempt to roll a skill check. But then will not post the results of the skill roll.

This change makes it so that this won't happen. e.g. if the cancel or [x] button are pressed on the previous display.

Ideally this should do more. Such as rolling skill, and then having various repair buttons available for the player to select depending upon the DM's guidance. That said that is outside of my skill level in terms of JS and my knowledge of the project, so you are getting this tiny bug fix.

## Other Issues

Relates to: #6382 