### PR TITLE
Add Deadly D4 trait

### DIFF
--- a/src/scripts/config/index.ts
+++ b/src/scripts/config/index.ts
@@ -306,6 +306,7 @@ const traitsDescriptions = {
     "deadly-d12": "PF2E.TraitDescriptionDeadly",
     "deadly-d6": "PF2E.TraitDescriptionDeadly",
     "deadly-d8": "PF2E.TraitDescriptionDeadly",
+    "deadly-d4": "PF2E.TraitDescriptionDeadly",
     death: "PF2E.TraitDescriptionDeath",
     "deflecting-bludgeoning": "PF2E.TraitDescriptionDeflecting",
     "deflecting-physical-ranged": "PF2E.TraitDescriptionDeflecting",

--- a/src/scripts/config/traits.ts
+++ b/src/scripts/config/traits.ts
@@ -398,6 +398,7 @@ const weaponTraits = {
     consumable: "PF2E.TraitConsumable",
     "critical-fusion": "PF2E.TraitCriticalFusion",
     cursed: "PF2E.TraitCursed",
+    "deadly-d4": "PF2E.TraitDeadlyD4",
     "deadly-d6": "PF2E.TraitDeadlyD6",
     "deadly-d8": "PF2E.TraitDeadlyD8",
     "deadly-2d8": "PF2E.TraitDeadly2D8",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -3420,6 +3420,7 @@
         "TraitDeadly4D8": "Deadly 4d8",
         "TraitDeadlyD10": "Deadly d10",
         "TraitDeadlyD12": "Deadly d12",
+        "TraitDeadlyD4": "Deadly d4",
         "TraitDeadlyD6": "Deadly d6",
         "TraitDeadlyD8": "Deadly d8",
         "TraitDeath": "Death",


### PR DESCRIPTION
After checking how Deadly traits work, there is no code-change needed beyond adding it to the index.