### PR TITLE
Add Take Cover action implementation

### DIFF
--- a/src/module/actor/actions/simple.ts
+++ b/src/module/actor/actions/simple.ts
@@ -15,7 +15,7 @@ interface SimpleActionData extends BaseActionData<SimpleActionVariantData> {
 interface SimpleActionUseOptions extends ActionUseOptions {
     actors: ActorPF2e[];
     cost: ActionCost;
-    effect: string | EffectPF2e;
+    effect: string | EffectPF2e | false;
     traits: string[];
 }
 
@@ -58,7 +58,9 @@ class SimpleActionVariant extends BaseActionVariant {
             slug: trait,
         }));
         const effect = await toEffectItem(this.effect);
-        const name = this.name ? `${this.#action.name} - ${this.name}` : this.#action.name;
+        const name = this.name
+            ? `${game.i18n.localize(this.#action.name)} - ${game.i18n.localize(this.name)}`
+            : game.i18n.localize(this.#action.name);
         const flavor = await renderTemplate("systems/pf2e/templates/system/actions/simple/chat-message-flavor.hbs", {
             effect,
             glyph: this.glyph,

--- a/src/module/actor/actions/simple.ts
+++ b/src/module/actor/actions/simple.ts
@@ -57,7 +57,7 @@ class SimpleActionVariant extends BaseActionVariant {
             label: traitLabels[trait] ?? trait,
             slug: trait,
         }));
-        const effect = await toEffectItem(this.effect);
+        const effect = options?.effect === false ? undefined : await toEffectItem(options?.effect ?? this.effect);
         const name = this.name
             ? `${game.i18n.localize(this.#action.name)} - ${game.i18n.localize(this.name)}`
             : game.i18n.localize(this.#action.name);

--- a/src/module/actor/actions/single-check.ts
+++ b/src/module/actor/actions/single-check.ts
@@ -103,7 +103,9 @@ class SingleCheckActionVariant extends BaseActionVariant {
                 .map((note) => new RollNotePF2e(note));
             const rollOptions = this.rollOptions.concat(options?.rollOptions ?? []);
             const slug = this.statistic;
-            const title = this.name ? `${this.#action.name} - ${this.name}` : this.#action.name;
+            const title = this.name
+                ? `${game.i18n.localize(this.#action.name)} - ${game.i18n.localize(this.name)}`
+                : game.i18n.localize(this.#action.name);
             ActionMacroHelpers.simpleRollActionCheck({
                 actors: options?.actors,
                 title,

--- a/src/module/system/action-macros/basic/take-cover.ts
+++ b/src/module/system/action-macros/basic/take-cover.ts
@@ -1,0 +1,12 @@
+import { SimpleAction } from "@actor/actions";
+
+const takeCover = new SimpleAction({
+    cost: 1,
+    description: "PF2E.Actions.TakeCover.Description",
+    effect: "Compendium.pf2e.other-effects.I9lfZUiCwMiGogVi", // Effect: Cover
+    img: "systems/pf2e/icons/conditions-2/status_acup.webp",
+    name: "PF2E.Actions.TakeCover.Title",
+    slug: "take-cover",
+});
+
+export { takeCover };

--- a/src/module/system/action-macros/index.ts
+++ b/src/module/system/action-macros/index.ts
@@ -16,6 +16,7 @@ import { whirlingThrow } from "./athletics/whirling-throw";
 import { escape } from "./basic/escape";
 import { seek } from "./basic/seek";
 import { senseMotive } from "./basic/sense-motive";
+import { takeCover } from "./basic/take-cover";
 import { tamper } from "./class/inventor/tamper";
 import { craft, repair } from "./crafting";
 import { createADiversion } from "./deception/create-a-diversion";
@@ -135,4 +136,4 @@ export const ActionMacros = {
     steal,
 };
 
-export const SystemActions: Action[] = [hide.action, sneak.action, trip.action];
+export const SystemActions: Action[] = [hide.action, sneak.action, takeCover, trip.action];

--- a/static/lang/action-en.json
+++ b/static/lang/action-en.json
@@ -564,6 +564,10 @@
                 },
                 "Title": "Swim"
             },
+            "TakeCover": {
+                "Description": "<p>You press yourself against a wall or duck behind an obstacle to take better advantage of cover. If you would have standard cover, you instead gain greater cover, which provides a +4 circumstance bonus to AC; to Reflex saves against area effects; and to Stealth checks to Hide, Sneak, or otherwise avoid detection. Otherwise, you gain the benefits of standard cover (a +2 circumstance bonus instead). This lasts until you move from your current space, use an attack action, become unconscious, or end this effect as a free action.</p>",
+                "Title": "Take Cover"
+            },
             "Tamper": {
                 "Notes": {
                     "criticalFailure": "<strong>Critical Failure</strong> Your tampering backfires dramatically, creating a small explosion from your own tools or gear. You take [[/r (@actor.level)[fire] #Tamper Backfire]]{fire damage equal to your level}.",


### PR DESCRIPTION
Add an implementation of the Take Cover action to the global collection of actions in `game.pf2e.actions`.

Additionally, add a property to the action use options that allows the caller to suppress (value of `false`) or override (a UUID value or Effect item instance) the effect applied to the actor when the action is used. This is needed for specialized cases of certain action, like Take Cover with a tower shield that might not necessarily grant the usual effect of the action.

Also properly localize action names in chat card when action is used.