### PR TITLE
Fix perception label in modifiers dialog

### DIFF
--- a/src/module/actor/creature/document.ts
+++ b/src/module/actor/creature/document.ts
@@ -208,7 +208,15 @@ abstract class CreaturePF2e<
 
     get perception(): Statistic {
         const stat = this.system.attributes.perception;
-        return Statistic.from(this, stat, "perception", "PF2E.PerceptionCheck", "perception-check");
+        return new Statistic(this, {
+            slug: "perception",
+            label: "PF2E.PerceptionLabel",
+            check: {
+                label: "PF2E.PerceptionCheck",
+                type: "perception-check",
+            },
+            modifiers: [...stat.modifiers],
+        });
     }
 
     get wornArmor(): ArmorPF2e<this> | null {

--- a/src/module/system/statistic/index.ts
+++ b/src/module/system/statistic/index.ts
@@ -137,24 +137,6 @@ class Statistic {
         }
     }
 
-    /** Compatibility function which creates a statistic from a StatisticModifier instead of from StatisticData. */
-    static from(
-        actor: ActorPF2e,
-        stat: StatisticModifier,
-        slug: string,
-        label: string,
-        type: CheckType,
-        domains?: string[]
-    ) {
-        return new Statistic(actor, {
-            slug,
-            domains,
-            label,
-            check: { type },
-            modifiers: [...stat.modifiers],
-        });
-    }
-
     /** Convenience getter to the statistic's total modifier */
     get mod(): number {
         return this.check.mod;


### PR DESCRIPTION
Doesn't change the check label, but makes it match what the skills do.