### PR TITLE
Fix item id in strike damage domains

### DIFF
--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -1826,7 +1826,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
 
         for (const method of ["damage", "critical"] as const) {
             action[method] = async (params: DamageRollParams = {}): Promise<string | Rolled<DamageRoll> | null> => {
-                const domains = ["all", `{weapon.id}-damage`, "strike-damage", "damage-roll"];
+                const domains = ["all", `${weapon.id}-damage`, "strike-damage", "damage-roll"];
                 params.options ??= [];
 
                 const context = await this.getRollContext({

--- a/src/module/actor/helpers.ts
+++ b/src/module/actor/helpers.ts
@@ -331,7 +331,7 @@ function strikeFromMeleeItem(item: MeleePF2e<ActorPF2e>): NPCStrike {
     const damageRoll =
         (outcome: "success" | "criticalSuccess"): DamageRollFunction =>
         async (params: DamageRollParams = {}): Promise<Rolled<DamageRoll> | string | null> => {
-            const domains = ["all", `{item.id}-damage`, "strike-damage", "damage-roll"];
+            const domains = ["all", `${item.id}-damage`, "strike-damage", "damage-roll"];
             const context = await actor.getRollContext({
                 item,
                 statistic: strike,


### PR DESCRIPTION
This cropped up when I was testing out linting with [Rome](https://rome.tools) which checks for unused template literals.