### PR TITLE
Use `declare` instead of non-nullish assertions on class fields 

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -87,33 +87,33 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
     private constructed = true;
 
     /** Is this actor preparing its embedded documents? Used to prevent premature data preparation of embedded items */
-    preparingEmbeds?: boolean;
+    preparingEmbeds = false;
 
     /** Handles rolling initiative for the current actor */
-    initiative?: ActorInitiative;
+    declare initiative?: ActorInitiative;
 
     /** A separate collection of owned physical items for convenient access */
-    inventory!: ActorInventory<this>;
+    declare inventory: ActorInventory<this>;
 
     /** A separate collection of owned spellcasting entries for convenience */
-    spellcasting!: ActorSpellcasting<this>;
+    declare spellcasting: ActorSpellcasting<this>;
 
     /** Rule elements drawn from owned items */
-    rules!: RuleElementPF2e[];
+    declare rules: RuleElementPF2e[];
 
-    synthetics!: RuleElementSynthetics;
+    declare synthetics: RuleElementSynthetics;
 
     /** Saving throw statistics */
-    saves?: { [K in SaveType]?: Statistic };
+    declare saves?: { [K in SaveType]?: Statistic };
 
     /** Data from rule elements for auras this actor may be emanating */
-    auras!: Map<string, AuraData>;
+    declare auras: Map<string, AuraData>;
 
     /** A collection of this actor's conditions */
-    conditions!: ActorConditions<this>;
+    declare conditions: ActorConditions<this>;
 
     /** A cached copy of `Actor#itemTypes`, lazily regenerated every data preparation cycle */
-    private _itemTypes?: EmbeddedItemInstances<this> | null;
+    private declare _itemTypes: EmbeddedItemInstances<this> | null;
 
     constructor(data: PreCreate<ActorSourcePF2e>, context: DocumentConstructionContext<TParent> = {}) {
         super(data, context);
@@ -543,6 +543,7 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
 
     protected override _initialize(): void {
         this.constructed ??= false;
+        this._itemTypes = null;
         this.rules = [];
         this.conditions = new ActorConditions();
         this.auras = new Map();
@@ -605,8 +606,6 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
 
     /** Prepare token data derived from this actor, refresh Effects Panel */
     override prepareData(): void {
-        delete this._itemTypes;
-
         // To prevent (or delay) console spam, will send out a deprecation notice in a later release
         Object.defineProperty(this.system, "toggles", {
             get: (): RollOptionToggle[] => this.synthetics.toggles,

--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -109,28 +109,28 @@ import { CHARACTER_SHEET_TABS } from "./values";
 
 class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | null> extends CreaturePF2e<TParent> {
     /** Core singular embeds for PCs */
-    ancestry!: AncestryPF2e<this> | null;
-    heritage!: HeritagePF2e<this> | null;
-    background!: BackgroundPF2e<this> | null;
-    class!: ClassPF2e<this> | null;
-    deity!: DeityPF2e<this> | null;
+    declare ancestry: AncestryPF2e<this> | null;
+    declare heritage: HeritagePF2e<this> | null;
+    declare background: BackgroundPF2e<this> | null;
+    declare class: ClassPF2e<this> | null;
+    declare deity: DeityPF2e<this> | null;
 
     /** A cached reference to this PC's familiar */
-    familiar: FamiliarPF2e | null = null;
+    declare familiar: FamiliarPF2e | null;
 
-    feats!: CharacterFeats<this>;
-    pfsBoons!: FeatPF2e<this>[];
-    deityBoonsCurses!: FeatPF2e<this>[];
+    declare feats: CharacterFeats<this>;
+    declare pfsBoons: FeatPF2e<this>[];
+    declare deityBoonsCurses: FeatPF2e<this>[];
 
     /** All base casting tradition proficiences, which spellcasting build off of */
-    traditions!: Record<MagicTradition, Statistic>;
+    declare traditions: Record<MagicTradition, Statistic>;
 
     /** The primary class DC */
-    classDC!: Statistic | null;
-    /** All class DCs regardless of whether or not its the primary */
-    classDCs!: Record<string, Statistic>;
+    declare classDC: Statistic | null;
+    /** All class DCs, including the primary */
+    declare classDCs: Record<string, Statistic>;
 
-    override initiative!: ActorInitiative;
+    declare initiative: ActorInitiative;
 
     // Internal cached value of character skills
     protected override _skills: CharacterSkills | null = null;
@@ -260,6 +260,11 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
                 await this.addToInventory(itemSource);
             }
         }
+    }
+
+    protected override _initialize() {
+        this.familiar ??= null;
+        super._initialize();
     }
 
     /** If one exists, prepare this character's familiar */

--- a/src/module/actor/modifiers.ts
+++ b/src/module/actor/modifiers.ts
@@ -440,7 +440,7 @@ class StatisticModifier {
     /** The list of modifiers which affect the statistic. */
     protected _modifiers: ModifierPF2e[];
     /** The total modifier for the statistic, after applying stacking rules. */
-    totalModifier!: number;
+    declare totalModifier: number;
     /** A textual breakdown of the modifiers factoring into this statistic */
     breakdown = "";
     /** Optional notes, which are often added to statistic modifiers */

--- a/src/module/actor/npc/document.ts
+++ b/src/module/actor/npc/document.ts
@@ -30,7 +30,7 @@ import { NPCSheetPF2e } from "./sheet";
 import { VariantCloneParams } from "./types";
 
 class NPCPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | null> extends CreaturePF2e<TParent> {
-    override initiative!: ActorInitiative;
+    declare initiative: ActorInitiative;
 
     override get allowedItemTypes(): (ItemType | "physical")[] {
         return [...super.allowedItemTypes, "physical", "spellcastingEntry", "spell", "action", "melee", "lore"];

--- a/src/module/actor/sheet/trick-magic-item-popup.ts
+++ b/src/module/actor/sheet/trick-magic-item-popup.ts
@@ -10,7 +10,7 @@ export class TrickMagicItemPopup {
     readonly item: ConsumablePF2e<ActorPF2e>;
 
     /** The actor doing the tricking */
-    readonly actor!: CharacterPF2e;
+    declare readonly actor: CharacterPF2e;
 
     /** The skill DC of the action's check */
     readonly checkDC: TrickMagicItemDifficultyData;

--- a/src/module/apps/compendium-browser/index.ts
+++ b/src/module/apps/compendium-browser/index.ts
@@ -89,7 +89,7 @@ class CompendiumBrowser extends Application {
     tabs: BrowserTabs;
 
     packLoader = new PackLoader();
-    activeTab!: TabName;
+    declare activeTab: TabName;
 
     constructor(options = {}) {
         super(options);

--- a/src/module/apps/compendium-browser/tabs/base.ts
+++ b/src/module/apps/compendium-browser/tabs/base.ts
@@ -10,7 +10,7 @@ export abstract class CompendiumBrowserTab {
     /** The filter schema for this tab; The tabs filters are rendered based on this.*/
     abstract filterData: BrowserFilter;
     /** An unmodified copy of this.filterData */
-    defaultFilterData!: this["filterData"];
+    declare defaultFilterData: this["filterData"];
     /** The full CompendiumIndex of this tab */
     protected indexData: CompendiumBrowserIndexData[] = [];
     /** Is this tab initialized? */
@@ -26,7 +26,7 @@ export abstract class CompendiumBrowserTab {
     /** The path to the result list template of this tab */
     abstract templatePath: string;
     /** Minisearch */
-    searchEngine!: MiniSearch;
+    declare searchEngine: MiniSearch;
     /** Names of the document fields to be indexed. */
     searchFields: string[] = [];
     /** Names of fields to store, so that search results would include them.

--- a/src/module/apps/sidebar/encounter-tracker.ts
+++ b/src/module/apps/sidebar/encounter-tracker.ts
@@ -6,7 +6,7 @@ import { ErrorPF2e, createHTMLElement, fontAwesomeIcon, htmlQuery, htmlQueryAll,
 import Sortable, { SortableEvent } from "sortablejs";
 
 export class EncounterTrackerPF2e<TEncounter extends EncounterPF2e | null> extends CombatTracker<TEncounter> {
-    sortable!: Sortable;
+    declare sortable: Sortable;
 
     /** Make the combatants sortable */
     override activateListeners($html: JQuery): void {

--- a/src/module/item/abstract-effect/document.ts
+++ b/src/module/item/abstract-effect/document.ts
@@ -12,7 +12,7 @@ import { AfflictionSource, AfflictionSystemData } from "@item/affliction";
 /** Base effect type for all PF2e effects including conditions and afflictions */
 abstract class AbstractEffectPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends ItemPF2e<TParent> {
     /** A normalized version of the slug that shows in roll options, removing certain prefixes */
-    rollOptionSlug!: string;
+    declare rollOptionSlug: string;
 
     abstract get badge(): EffectBadge | null;
 

--- a/src/module/item/base.ts
+++ b/src/module/item/base.ts
@@ -30,7 +30,7 @@ import { UUIDUtils } from "@util/uuid-utils";
 /** Override and extend the basic :class:`Item` implementation */
 class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item<TParent> {
     /** Prepared rule elements from this item */
-    rules!: RuleElementPF2e[];
+    declare rules: RuleElementPF2e[];
 
     /** The sluggified name of the item **/
     get slug(): string | null {

--- a/src/module/item/condition/document.ts
+++ b/src/module/item/condition/document.ts
@@ -15,7 +15,7 @@ import { ConditionSource, ConditionSystemData, PersistentDamageData } from "./da
 import { ConditionKey, ConditionSlug } from "./types";
 
 class ConditionPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends AbstractEffectPF2e<TParent> {
-    active!: boolean;
+    declare active: boolean;
 
     override get badge(): EffectBadge | null {
         if (this.system.persistent) {

--- a/src/module/item/feat/document.ts
+++ b/src/module/item/feat/document.ts
@@ -10,7 +10,7 @@ import { FeatSource, FeatSystemData } from "./data";
 import { FeatCategory, FeatTrait } from "./types";
 
 class FeatPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends ItemPF2e<TParent> {
-    group!: FeatGroup | null;
+    declare group: FeatGroup | null;
 
     get category(): FeatCategory {
         return this.system.category;

--- a/src/module/item/melee/document.ts
+++ b/src/module/item/melee/document.ts
@@ -12,9 +12,9 @@ import { MeleeFlags, MeleeSource, MeleeSystemData, NPCAttackTrait } from "./data
 
 class MeleePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends ItemPF2e<TParent> {
     /** Set during data preparation if a linked weapon is found */
-    category!: WeaponCategory | null;
-    group!: WeaponGroup | null;
-    baseType!: BaseWeaponType | null;
+    declare category: WeaponCategory | null;
+    declare group: WeaponGroup | null;
+    declare baseType: BaseWeaponType | null;
 
     get traits(): Set<NPCAttackTrait> {
         return new Set(this.system.traits.value);

--- a/src/module/item/physical/document.ts
+++ b/src/module/item/physical/document.ts
@@ -23,7 +23,7 @@ import { DENOMINATIONS } from "./values";
 
 abstract class PhysicalItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends ItemPF2e<TParent> {
     // The cached container of this item, if in a container, or null
-    private _container: ContainerPF2e<ActorPF2e> | null = null;
+    private declare _container: ContainerPF2e<ActorPF2e> | null;
 
     get level(): number {
         return this.system.level.value;
@@ -175,6 +175,11 @@ abstract class PhysicalItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | n
             .concat(this.system.traits.otherTags.map((t) => `${prefix}:tag:${t}`));
 
         return [baseOptions, physicalItemOptions].flat();
+    }
+
+    protected override _initialize(): void {
+        this._container = null;
+        super._initialize();
     }
 
     override prepareBaseData(): void {

--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -44,14 +44,14 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
     readonly isFromConsumable: boolean;
 
     /** The original spell. Only exists if this is a variant */
-    original?: SpellPF2e<NonNullable<TParent>>;
+    declare original?: SpellPF2e<NonNullable<TParent>>;
     /** The overlays that were applied to create this variant */
-    appliedOverlays?: Map<SpellOverlayType, string>;
+    declare appliedOverlays?: Map<SpellOverlayType, string>;
 
     /** Set if casted with trick magic item. Will be replaced via overriding spellcasting on cast later. */
     trickMagicEntry: TrickMagicItemEntry<NonNullable<TParent>> | null = null;
 
-    overlays!: SpellOverlayCollection;
+    declare overlays: SpellOverlayCollection;
 
     constructor(data: PreCreate<ItemSourcePF2e>, context: SpellConstructionContext<TParent> = {}) {
         super(data, context);

--- a/src/module/item/spellcasting-entry/document.ts
+++ b/src/module/item/spellcasting-entry/document.ts
@@ -20,10 +20,10 @@ class SpellcastingEntryPF2e<TParent extends ActorPF2e | null = ActorPF2e | null>
     extends ItemPF2e<TParent>
     implements SpellcastingEntry<TParent>
 {
-    spells!: SpellCollection<NonNullable<TParent>, this> | null;
+    declare spells: SpellCollection<NonNullable<TParent>, this> | null;
 
     /** Spellcasting attack and dc data created during actor preparation */
-    statistic!: Statistic;
+    declare statistic: Statistic;
 
     get ability(): AbilityString {
         return this.system.ability.value || "int";

--- a/src/module/scene/token-document/document.ts
+++ b/src/module/scene/token-document/document.ts
@@ -12,9 +12,9 @@ import { DataModel } from "types/foundry/common/abstract/module.mjs";
 
 class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> extends TokenDocument<TParent> {
     /** Has this token gone through at least one cycle of data preparation? */
-    private initialized?: boolean;
+    private constructed = true;
 
-    auras!: Map<string, TokenAura>;
+    declare auras: Map<string, TokenAura>;
 
     /** Check actor for effects found in `CONFIG.specialStatusEffects` */
     override hasStatusEffect(statusId: string): boolean {
@@ -70,6 +70,7 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
     }
 
     protected override _initialize(): void {
+        this.constructed ??= false;
         this.auras = new Map();
         this._source.flags.pf2e ??= {};
         this._source.flags.pf2e.linkToActorSize ??= true;
@@ -78,8 +79,6 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
             : false;
 
         super._initialize();
-
-        this.initialized = true;
     }
 
     /** Is this token emitting light with a negative value */
@@ -164,7 +163,7 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
             );
         }
 
-        if (!this.initialized) return;
+        if (!this.constructed) return;
 
         // Dimensions and scale
         const linkDefault = !["hazard", "loot", "party"].includes(this.actor.type ?? "");
@@ -202,7 +201,7 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
 
     /** Reset sight defaults if using rules-based vision */
     protected override _prepareDetectionModes(): void {
-        if (!(this.initialized && this.actor && this.rulesBasedVision)) {
+        if (!(this.constructed && this.actor && this.rulesBasedVision)) {
             return super._prepareDetectionModes();
         }
 
@@ -219,7 +218,7 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
 
     override prepareDerivedData(): void {
         super.prepareDerivedData();
-        if (!(this.initialized && this.actor && this.scene)) return;
+        if (!(this.constructed && this.actor && this.scene)) return;
 
         // Merge token overrides from REs into this document
         const { tokenOverrides } = this.actor.synthetics;


### PR DESCRIPTION
Eventually we'll need to flip on `useDefineForClassFields` in tsconfig.json, which will actually emit class fields in the transpile result. Using `declare` will prevent that, preserving the current behavior.