### PR TITLE
Add party members to initiative instead of self

### DIFF
--- a/src/module/scene/token-document/document.ts
+++ b/src/module/scene/token-document/document.ts
@@ -15,6 +15,15 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
 
     declare auras: Map<string, TokenAura>;
 
+    /** Returns if the token is in combat, though some actors have different conditions */
+    override get inCombat(): boolean {
+        if (this.actor?.isOfType("party")) {
+            return this.actor.members.every((a) => game.combat?.getCombatantByActor(a.id));
+        }
+
+        return super.inCombat;
+    }
+
     /** Check actor for effects found in `CONFIG.specialStatusEffects` */
     override hasStatusEffect(statusId: string): boolean {
         if (statusId === "dead") return this.overlayEffect === CONFIG.controlIcons.defeated;


### PR DESCRIPTION
This does a few things
* The party is marked as in combat if *all* members are in combat
* Members with active tokens get added to combat (if they aren't already)
* Members without active tokens create a notification (same as if an actor rolls from the sheet without a token)

Later on we should dump all actors to the scene first (thus skipping the need for the notification) but I'd like to have the sidebar changes in place before we start doing that, just to have more info on what the overall flow will be.