### PR TITLE
Convert medicine skill actions

### DIFF
--- a/src/module/actor/actions/base.ts
+++ b/src/module/actor/actions/base.ts
@@ -141,7 +141,7 @@ abstract class BaseAction<TData extends BaseActionVariantData, TAction extends B
         return new Collection(variants);
     }
 
-    protected async getDefaultVariant(options?: { variant?: string }): Promise<ActionVariant | TAction> {
+    protected async getDefaultVariant(options?: { variant?: string }): Promise<TAction> {
         const variants = this.variants;
         if (options?.variant && !variants.size) {
             const reason = game.i18n.format("PF2E.ActionsWarning.Variants.None", {
@@ -168,7 +168,8 @@ abstract class BaseAction<TData extends BaseActionVariantData, TAction extends B
     }
 
     async toMessage(options?: Partial<ActionMessageOptions>): Promise<ChatMessagePF2e | undefined> {
-        const variant = await this.getDefaultVariant();
+        // use the data from the action to construct the message if no variant is specified
+        const variant = options?.variant ? await this.getDefaultVariant(options) : undefined;
         return (variant ?? this.toActionVariant()).toMessage(options);
     }
 

--- a/src/module/actor/actions/single-check.ts
+++ b/src/module/actor/actions/single-check.ts
@@ -13,7 +13,7 @@ import { Statistic } from "@system/statistic/index.ts";
 import { RollNotePF2e, RollNoteSource } from "@module/notes.ts";
 import { BaseAction, BaseActionData, BaseActionVariant, BaseActionVariantData } from "./base.ts";
 import { getActionGlyph } from "@util";
-import { ActorPF2e } from "@actor";
+import { ActorPF2e, CreaturePF2e } from "@actor";
 import { ItemPF2e } from "@item";
 
 type SingleCheckActionRollNoteData = Omit<RollNoteSource, "selector"> & { selector?: string };
@@ -123,7 +123,7 @@ class SingleCheckActionVariant extends BaseActionVariant {
             difficultyClass: isCheckDC(difficultyClass) ? difficultyClass : undefined,
             difficultyClassStatistic: isString(difficultyClass)
                 ? (target) => getProperty(target, difficultyClass) as Statistic
-                : undefined,
+                : this.difficultyClassWithTarget,
             event: options?.event,
             extraNotes: (selector) =>
                 notes.map((note) => {
@@ -140,6 +140,10 @@ class SingleCheckActionVariant extends BaseActionVariant {
         data: CheckContextData<ItemType>
     ): CheckContext<ItemType> | undefined {
         return ActionMacroHelpers.defaultCheckContext(opts, data);
+    }
+
+    protected difficultyClassWithTarget(_target: CreaturePF2e): Statistic | null {
+        return null;
     }
 }
 

--- a/src/module/actor/actions/types.ts
+++ b/src/module/actor/actions/types.ts
@@ -5,6 +5,7 @@ type ActionCost = (typeof ACTION_COST)[number];
 
 interface ActionMessageOptions {
     blind: boolean;
+    variant: string;
     whisper: string[];
 }
 

--- a/src/module/system/action-macros/index.ts
+++ b/src/module/system/action-macros/index.ts
@@ -45,7 +45,7 @@ import { subsist } from "./general/subsist.ts";
 import { coerce } from "./intimidation/coerce.ts";
 import { demoralize } from "./intimidation/demoralize.ts";
 import * as administerFirstAid from "./medicine/administer-first-aid.ts";
-import { treatDisease } from "./medicine/treat-disease.ts";
+import * as treatDisease from "./medicine/treat-disease.ts";
 import { treatPoison } from "./medicine/treat-poison.ts";
 import * as commandAnAnimal from "./nature/command-an-animal.ts";
 import { perform } from "./performance/perform.ts";
@@ -122,7 +122,7 @@ export const ActionMacros = {
 
     // Medicine
     administerFirstAid: administerFirstAid.legacy,
-    treatDisease,
+    treatDisease: treatDisease.legacy,
     treatPoison,
 
     // Nature
@@ -174,6 +174,7 @@ export const SystemActions: Action[] = [
     step,
     stride,
     takeCover,
+    treatDisease.action,
     trip.action,
     tumbleThrough.action,
 ];

--- a/src/module/system/action-macros/index.ts
+++ b/src/module/system/action-macros/index.ts
@@ -44,7 +44,7 @@ import { decipherWriting } from "./general/decipher-writing.ts";
 import { subsist } from "./general/subsist.ts";
 import { coerce } from "./intimidation/coerce.ts";
 import { demoralize } from "./intimidation/demoralize.ts";
-import { administerFirstAid } from "./medicine/administer-first-aid.ts";
+import * as administerFirstAid from "./medicine/administer-first-aid.ts";
 import { treatDisease } from "./medicine/treat-disease.ts";
 import { treatPoison } from "./medicine/treat-poison.ts";
 import * as commandAnAnimal from "./nature/command-an-animal.ts";
@@ -121,7 +121,7 @@ export const ActionMacros = {
     demoralize,
 
     // Medicine
-    administerFirstAid,
+    administerFirstAid: administerFirstAid.legacy,
     treatDisease,
     treatPoison,
 
@@ -147,6 +147,7 @@ export const ActionMacros = {
 };
 
 export const SystemActions: Action[] = [
+    administerFirstAid.action,
     balance.action,
     commandAnAnimal.action,
     concealAnObject.action,

--- a/src/module/system/action-macros/index.ts
+++ b/src/module/system/action-macros/index.ts
@@ -46,7 +46,7 @@ import { coerce } from "./intimidation/coerce.ts";
 import { demoralize } from "./intimidation/demoralize.ts";
 import * as administerFirstAid from "./medicine/administer-first-aid.ts";
 import * as treatDisease from "./medicine/treat-disease.ts";
-import { treatPoison } from "./medicine/treat-poison.ts";
+import * as treatPoison from "./medicine/treat-poison.ts";
 import * as commandAnAnimal from "./nature/command-an-animal.ts";
 import { perform } from "./performance/perform.ts";
 import * as createForgery from "./society/create-forgery.ts";
@@ -123,7 +123,7 @@ export const ActionMacros = {
     // Medicine
     administerFirstAid: administerFirstAid.legacy,
     treatDisease: treatDisease.legacy,
-    treatPoison,
+    treatPoison: treatPoison.legacy,
 
     // Nature
     commandAnAnimal: commandAnAnimal.legacy,
@@ -175,6 +175,7 @@ export const SystemActions: Action[] = [
     stride,
     takeCover,
     treatDisease.action,
+    treatPoison.action,
     trip.action,
     tumbleThrough.action,
 ];

--- a/src/module/system/action-macros/medicine/administer-first-aid.ts
+++ b/src/module/system/action-macros/medicine/administer-first-aid.ts
@@ -1,34 +1,52 @@
 import { ActionMacroHelpers, SkillActionOptions } from "../index.ts";
 import { Statistic } from "@system/statistic/index.ts";
+import { SingleCheckAction, SingleCheckActionVariant, SingleCheckActionVariantData } from "@actor/actions/index.ts";
+import { CreaturePF2e } from "@module/actor/index.ts";
+
+const PREFIX = "PF2E.Actions.AdministerFirstAid";
 
 const ADMINISTER_FIRST_AID_VARIANTS = ["stabilize", "stop-bleeding"] as const;
 type AdministerFirstAidVariant = (typeof ADMINISTER_FIRST_AID_VARIANTS)[number];
 
-export function administerFirstAid(options: { variant: AdministerFirstAidVariant } & SkillActionOptions): void {
+function stabilizeDifficultyClass(target: CreaturePF2e) {
+    const { dying } = target.attributes;
+    if (dying?.value) {
+        const dc = 5 + dying.recoveryDC + dying.value;
+        return new Statistic(target, {
+            slug: "administer-first-aid",
+            label: `${PREFIX}.Stabilize.Title`,
+            dc: { base: dc, label: `${PREFIX}.Stabilize.DifficultyClass.Label` },
+        });
+    }
+    throw new Error(game.i18n.localize(`${PREFIX}.Warning.TargetNotDying`));
+}
+
+function administerFirstAid(options: { variant: AdministerFirstAidVariant } & SkillActionOptions): void {
     const { notes, title, variant } = (() => {
+        const mainTitle = game.i18n.localize(`${PREFIX}.Title`);
         switch (options?.variant) {
             case "stabilize":
                 return {
                     notes: {
-                        criticalFailure: "PF2E.Actions.AdministerFirstAid.Stabilize.Notes.criticalFailure",
-                        success: "PF2E.Actions.AdministerFirstAid.Stabilize.Notes.success",
+                        criticalFailure: `${PREFIX}.Stabilize.Notes.criticalFailure`,
+                        success: `${PREFIX}.Stabilize.Notes.success`,
                     },
-                    title: "PF2E.Actions.AdministerFirstAid.Stabilize.Title",
+                    title: mainTitle + " - " + game.i18n.localize(`${PREFIX}.Stabilize.Title`),
                     variant: options.variant,
                 };
             case "stop-bleeding":
                 return {
                     notes: {
-                        criticalFailure: "PF2E.Actions.AdministerFirstAid.StopBleeding.Notes.criticalFailure",
-                        success: "PF2E.Actions.AdministerFirstAid.StopBleeding.Notes.success",
+                        criticalFailure: `${PREFIX}.StopBleeding.Notes.criticalFailure`,
+                        success: `${PREFIX}.StopBleeding.Notes.success`,
                     },
-                    title: "PF2E.Actions.AdministerFirstAid.StopBleeding.Title",
+                    title: mainTitle + " - " + game.i18n.localize(`${PREFIX}.StopBleeding.Title`),
                     variant: options.variant,
                 };
             default: {
                 const variant = options?.variant ? `'${options.variant}'` : "null";
                 const variants = ADMINISTER_FIRST_AID_VARIANTS.map((v) => `'${v}'`).join(", ");
-                const error = "PF2E.Actions.AdministerFirstAid.Warning.UnknownVariant";
+                const error = `${PREFIX}.Warning.UnknownVariant`;
                 ui.notifications.error(game.i18n.format(error, { variant, variants }));
                 throw new Error(`Unknown variant ${variant} for Administer First Aid, use one of ${variants}.`);
             }
@@ -48,16 +66,15 @@ export function administerFirstAid(options: { variant: AdministerFirstAidVariant
         difficultyClass: options.difficultyClass,
         difficultyClassStatistic: (target) => {
             if (variant === "stabilize" && target) {
-                const { dying } = target.attributes;
-                if (dying?.value) {
-                    const dc = 5 + dying.recoveryDC + dying.value;
-                    return new Statistic(target, {
-                        slug: "administer-first-aid",
-                        label: "PF2E.Actions.AdministerFirstAid.Stabilize.Title",
-                        dc: { base: dc, label: "PF2E.Actions.AdministerFirstAid.Stabilize.DifficultyClass.Label" },
-                    });
+                try {
+                    return stabilizeDifficultyClass(target);
+                } catch (error) {
+                    if (error instanceof Error) {
+                        ui.notifications.warn(error.message);
+                    } else {
+                        throw error;
+                    }
                 }
-                ui.notifications.warn(game.i18n.localize("PF2E.Actions.AdministerFirstAid.Warning.TargetNotDying"));
             }
             return null;
         },
@@ -70,3 +87,53 @@ export function administerFirstAid(options: { variant: AdministerFirstAidVariant
         throw error;
     });
 }
+
+class StabilizeActionVariant extends SingleCheckActionVariant {
+    protected override difficultyClassWithTarget(target: CreaturePF2e): Statistic | null {
+        return stabilizeDifficultyClass(target);
+    }
+}
+
+class AdministerFirstAidAction extends SingleCheckAction {
+    constructor() {
+        super({
+            cost: 2,
+            description: `${PREFIX}.Description`,
+            name: `${PREFIX}.Title`,
+            slug: "administer-first-aid",
+            statistic: "medicine",
+            traits: ["manipulate"],
+            variants: [
+                {
+                    description: `${PREFIX}.Stabilize.Description`,
+                    name: `${PREFIX}.Stabilize.Title`,
+                    notes: [
+                        { outcome: ["criticalSuccess", "success"], text: `${PREFIX}.Stabilize.Notes.success` },
+                        { outcome: ["criticalFailure"], text: `${PREFIX}.Stabilize.Notes.criticalFailure` },
+                    ],
+                    slug: "stabilize",
+                },
+                {
+                    description: `${PREFIX}.StopBleeding.Description`,
+                    name: `${PREFIX}.StopBleeding.Title`,
+                    notes: [
+                        { outcome: ["criticalSuccess", "success"], text: `${PREFIX}.StopBleeding.Notes.success` },
+                        { outcome: ["criticalFailure"], text: `${PREFIX}.StopBleeding.Notes.criticalFailure` },
+                    ],
+                    slug: "stop-bleeding",
+                },
+            ],
+        });
+    }
+
+    protected override toActionVariant(data?: SingleCheckActionVariantData): SingleCheckActionVariant {
+        if (data?.slug === "stabilize") {
+            return new StabilizeActionVariant(this, data);
+        }
+        return super.toActionVariant(data);
+    }
+}
+
+const action = new AdministerFirstAidAction();
+
+export { administerFirstAid as legacy, action };

--- a/src/module/system/action-macros/medicine/treat-disease.ts
+++ b/src/module/system/action-macros/medicine/treat-disease.ts
@@ -1,6 +1,7 @@
 import { ActionMacroHelpers, SkillActionOptions } from "../index.ts";
+import { SingleCheckAction } from "@actor/actions/index.ts";
 
-export function treatDisease(options: SkillActionOptions): void {
+function treatDisease(options: SkillActionOptions): void {
     const slug = options?.skill ?? "medicine";
     const rollOptions = ["action:treat-disease"];
     const modifiers = options?.modifiers;
@@ -23,3 +24,19 @@ export function treatDisease(options: SkillActionOptions): void {
         throw error;
     });
 }
+
+const action = new SingleCheckAction({
+    description: "PF2E.Actions.TreatDisease.Description",
+    name: "PF2E.Actions.TreatDisease.Title",
+    notes: [
+        { outcome: ["criticalSuccess"], text: "PF2E.Actions.TreatDisease.Notes.criticalSuccess" },
+        { outcome: ["success"], text: "PF2E.Actions.TreatDisease.Notes.success" },
+        { outcome: ["criticalFailure"], text: "PF2E.Actions.TreatDisease.Notes.criticalFailure" },
+    ],
+    rollOptions: ["action:treat-disease"],
+    slug: "treat-disease",
+    statistic: "medicine",
+    traits: ["downtime", "manipulate"],
+});
+
+export { treatDisease as legacy, action };

--- a/src/module/system/action-macros/medicine/treat-poison.ts
+++ b/src/module/system/action-macros/medicine/treat-poison.ts
@@ -1,6 +1,7 @@
 import { ActionMacroHelpers, SkillActionOptions } from "../index.ts";
+import { SingleCheckAction } from "@actor/actions/index.ts";
 
-export function treatPoison(options: SkillActionOptions): void {
+function treatPoison(options: SkillActionOptions): void {
     const slug = options?.skill ?? "medicine";
     const rollOptions = ["action:treat-poison"];
     const modifiers = options?.modifiers;
@@ -23,3 +24,20 @@ export function treatPoison(options: SkillActionOptions): void {
         throw error;
     });
 }
+
+const action = new SingleCheckAction({
+    cost: 1,
+    description: "PF2E.Actions.TreatPoison.Description",
+    name: "PF2E.Actions.TreatPoison.Title",
+    notes: [
+        { outcome: ["criticalSuccess"], text: "PF2E.Actions.TreatPoison.Notes.criticalSuccess" },
+        { outcome: ["success"], text: "PF2E.Actions.TreatPoison.Notes.success" },
+        { outcome: ["criticalFailure"], text: "PF2E.Actions.TreatPoison.Notes.criticalFailure" },
+    ],
+    rollOptions: ["action:treat-poison"],
+    slug: "treat-poison",
+    statistic: "medicine",
+    traits: ["manipulate"],
+});
+
+export { treatPoison as legacy, action };

--- a/static/lang/action-en.json
+++ b/static/lang/action-en.json
@@ -2,7 +2,9 @@
     "PF2E": {
         "Actions": {
             "AdministerFirstAid": {
+                "Description": "<p>You perform first aid on an adjacent creature that is dying or bleeding. If a creature is both dying and bleeding, choose which ailment you're trying to treat before you roll. You can Administer First Aid again to attempt to remedy the other effect.</p><ol><li><strong>Stabilize</strong> Attempt a Medicine check on a creature that has 0 Hit Points and the dying condition. The DC is equal to 5 + that creature's recovery roll DC (typically 15 + its dying value).</li><li><strong>Stop Bleeding</strong> Attempt a Medicine check on a creature that is taking persistent bleed damage, giving them a chance to make another flat check to remove the persistent damage. The DC is usually the DC of the effect that caused the bleed.</li></ol><p><strong>Success</strong> If you're trying to stabilize, the creature loses the dying condition (but remains unconscious). If you're trying to stop bleeding, the creature attempts a flat check to end the bleeding.<br><strong>Critical Failure</strong> If you were trying to stabilize, the creature's dying value increases by 1. If you were trying to stop bleeding, it immediately takes an amount of damage equal to its persistent bleed damage.</p>",
                 "Stabilize": {
+                    "Description": "<p>You perform first aid on an adjacent creature that is dying. Attempt a Medicine check on a creature that has 0 Hit Points and the dying condition. The DC is equal to 5 + that creature's recovery roll DC (typically 15 + its dying value).</p><p><strong>Success</strong> The creature loses the dying condition (but remains unconscious).<br><strong>Critical Failure</strong> The creature's dying value increases by 1.</p>",
                     "DifficultyClass": {
                         "Label": "Administer First Aid DC"
                     },
@@ -10,15 +12,17 @@
                         "criticalFailure": "<strong>Critical Failure</strong> The creature's dying value increases by 1.",
                         "success": "<strong>Success</strong> The creature loses the dying condition (but remains unconscious)."
                     },
-                    "Title": "Administer First Aid - Stabilize"
+                    "Title": "Stabilize"
                 },
                 "StopBleeding": {
+                    "Description": "<p>You perform first aid on an adjacent creature that is bleeding. Attempt a Medicine check on a creature that is taking persistent bleed damage, giving them a chance to make another flat check to remove the persistent damage. The DC is usually the DC of the effect that caused the bleed.</p><p><strong>Success</strong> The creature attempts a flat check to end the bleeding.<br><strong>Critical Failure</strong> The creature immediately takes an amount of damage equal to its persistent bleed damage.</p>",
                     "Notes": {
                         "criticalFailure": "<strong>Critical Failure</strong> The creature immediately takes an amount of damage equal to its persistent bleed damage.",
                         "success": "<strong>Success</strong> The creature attempts a flat check to end the bleeding."
                     },
-                    "Title": "Administer First Aid - Stop Bleeding"
+                    "Title": "Stop Bleeding"
                 },
+                "Title": "Administer First Aid",
                 "Warning": {
                     "TargetNotDying": "Targeted creature is not dying.",
                     "UnknownVariant": "Unknown variant {variant} used for Administer First Aid, use one of {variants}."

--- a/static/lang/action-en.json
+++ b/static/lang/action-en.json
@@ -637,6 +637,7 @@
                 "Title": "Track"
             },
             "TreatDisease": {
+                "Description": "<p>You spend at least 8 hours caring for a diseased creature. Attempt a Medicine check against the disease's DC. After you attempt to Treat a Disease for a creature, you can't try again until after that creature's next save against the disease.</p><p><strong>Critical Success</strong> You grant the creature a +4 circumstance bonus to its next saving throw against the disease.<br><strong>Success</strong> You grant the creature a +2 circumstance bonus to its next saving throw against the disease.<br><strong>Critical Failure</strong> Your efforts cause the creature to take a –2 circumstance penalty to its next save against the disease.</p>",
                 "Notes": {
                     "criticalFailure": "<strong>Critical Failure</strong> Your efforts cause the creature to take a -2 circumstance penalty to its next save against the disease.<br/>@UUID[Compendium.pf2e.equipment-effects.5oYKYXAexr0vhx84]{Effect: Treat Disease (Critical Failure)}",
                     "criticalSuccess": "<strong>Critical Success</strong> You grant the creature a +4 circumstance bonus to its next saving throw against the disease.<br/>@UUID[Compendium.pf2e.equipment-effects.id20P4pj7zDKeLmy]{Effect: Treat Disease (Critical Success)}",

--- a/static/lang/action-en.json
+++ b/static/lang/action-en.json
@@ -646,6 +646,7 @@
                 "Title": "Treat Disease"
             },
             "TreatPoison": {
+                "Description": "<p>You treat a patient to prevent the spread of poison. Attempt a Medicine check against the poison's DC. After you attempt to Treat a Poison for a creature, you can't try again until after the next time that creature attempts a save against the poison.</p><p><strong>Critical Success</strong> You grant the creature a +4 circumstance bonus to its next saving throw against the poison.<br><strong>Success</strong> You grant the creature a +2 circumstance bonus to its next saving throw against the poison.<br><strong>Critical Failure</strong> Your efforts cause the creature to take a –2 circumstance penalty to its next save against the poison.</p>",
                 "Notes": {
                     "criticalFailure": "<strong>Critical Failure</strong> Your efforts cause the creature to take a -2 circumstance penalty to its next save against the poison.<br/>@UUID[Compendium.pf2e.equipment-effects.ESuBosh3t1pXEcBj]{Effect: Treat Poison (Critical Failure)}",
                     "criticalSuccess": "<strong>Critical Success</strong> You grant the creature a +4 circumstance bonus to its next saving throw against the poison.<br/>@UUID[Compendium.pf2e.equipment-effects.XwCBalKJf3CiEiFa]{Effect: Treat Poison (Critical Success)}",


### PR DESCRIPTION
Administer First Aid, Treat Disease, and Treat Poison.

Add better support for description chat cards when action has variants, and also allow action variants to override difficult class calculation based on target