### PR TITLE
Preserve javascript identifiers in production builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
                 "typescript": "^5.0.4",
                 "vite": "^4.2.1",
                 "vite-plugin-checker": "^0.5.6",
-                "vite-tsconfig-paths": "^4.1.0",
+                "vite-tsconfig-paths": "^4.2.0",
                 "yargs": "^17.7.1"
             }
         },
@@ -8544,9 +8544,9 @@
             }
         },
         "node_modules/vite-tsconfig-paths": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-4.1.0.tgz",
-            "integrity": "sha512-Ps275He1fF6Wpm/3tvyokIfXd3lcmk4KsdCG4yduSTRVt+htaxIoEor88M1h3soOeXg5fn77ZiupVRwGeB/XNQ==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-4.2.0.tgz",
+            "integrity": "sha512-jGpus0eUy5qbbMVGiTxCL1iB9ZGN6Bd37VGLJU39kTDD6ZfULTTb1bcc5IeTWqWJKiWV5YihCaibeASPiGi8kw==",
             "dev": true,
             "dependencies": {
                 "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "typescript": "^5.0.4",
         "vite": "^4.2.1",
         "vite-plugin-checker": "^0.5.6",
-        "vite-tsconfig-paths": "^4.1.0",
+        "vite-tsconfig-paths": "^4.2.0",
         "yargs": "^17.7.1"
     },
     "dependencies": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,7 +24,12 @@ const config = Vite.defineConfig(({ command, mode }): Vite.UserConfig => {
                 order: "post",
                 async handler(code, chunk) {
                     return chunk.fileName.endsWith(".mjs")
-                        ? esbuild.transform(code, { minify: true, keepNames: true })
+                        ? esbuild.transform(code, {
+                              keepNames: true,
+                              minifyIdentifiers: false,
+                              minifySyntax: true,
+                              minifyWhitespace: true,
+                          })
                         : code;
                 },
             },
@@ -37,9 +42,7 @@ const config = Vite.defineConfig(({ command, mode }): Vite.UserConfig => {
                 apply: "build",
                 writeBundle: {
                     async handler() {
-                        if (buildMode === "development") {
-                            fs.closeSync(fs.openSync(path.resolve(outDir, "vendor.mjs"), "w"));
-                        }
+                        fs.closeSync(fs.openSync(path.resolve(outDir, "vendor.mjs"), "w"));
                     },
                 },
             },


### PR DESCRIPTION
The file-size savings isn't nothing (~500kb), but identifier minification would make investigating issue reports harder, and it's very unaccommodating to module authors