### PR TITLE
Add tint and alpha overrides to TokenImage

### DIFF
--- a/src/module/rules/rule-element/token-image.ts
+++ b/src/module/rules/rule-element/token-image.ts
@@ -12,7 +12,7 @@ export class TokenImageRuleElement extends RuleElementPF2e {
 
     /** An optional scale, tint, and alpha adjustment */
     scale?: number;
-    tint?: string;
+    tint?: HexColorString;
     alpha?: number;
 
     constructor(data: TokenImageSource, item: ItemPF2e<ActorPF2e>, options?: RuleElementOptions) {
@@ -29,7 +29,7 @@ export class TokenImageRuleElement extends RuleElementPF2e {
         }
 
         if (typeof data.tint === "string") {
-            this.tint = data.tint;
+            this.tint = new Color(data.tint).toString();
         }
 
         if (typeof data.alpha === "number") {
@@ -43,7 +43,7 @@ export class TokenImageRuleElement extends RuleElementPF2e {
 
         if (!this.test()) return;
 
-        const texture: { src: VideoFilePath; scaleX?: number; scaleY?: number; tint?: string } = { src };
+        const texture: { src: VideoFilePath; scaleX?: number; scaleY?: number; tint?: HexColorString } = { src };
         if (this.scale) {
             texture.scaleX = this.scale;
             texture.scaleY = this.scale;

--- a/src/module/rules/rule-element/token-image.ts
+++ b/src/module/rules/rule-element/token-image.ts
@@ -53,7 +53,7 @@ export class TokenImageRuleElement extends RuleElementPF2e {
             texture.tint = this.tint;
         }
 
-        if (this.alpha) {
+        if (typeof this.alpha === "number") {
             this.actor.synthetics.tokenOverrides.alpha = this.alpha;
         }
 

--- a/src/module/rules/rule-element/token-image.ts
+++ b/src/module/rules/rule-element/token-image.ts
@@ -33,7 +33,7 @@ export class TokenImageRuleElement extends RuleElementPF2e {
         }
 
         if (typeof data.alpha === "number") {
-            this.alpha = data.alpha
+            this.alpha = data.alpha;
         }
     }
 

--- a/src/module/rules/rule-element/token-image.ts
+++ b/src/module/rules/rule-element/token-image.ts
@@ -31,6 +31,10 @@ export class TokenImageRuleElement extends RuleElementPF2e {
         if (typeof data.tint === "string") {
             this.tint = data.tint;
         }
+
+        if (typeof data.alpha === "number") {
+            this.alpha = data.alpha
+        }
     }
 
     override afterPrepareData(): void {

--- a/src/module/rules/rule-element/token-image.ts
+++ b/src/module/rules/rule-element/token-image.ts
@@ -10,8 +10,10 @@ export class TokenImageRuleElement extends RuleElementPF2e {
     /** An image or video path */
     value: string | BracketedValue | null;
 
-    /** An optional scale adjustment */
+    /** An optional scale, tint, and alpha adjustment */
     scale?: number;
+    tint?: string;
+    alpha?: number;
 
     constructor(data: TokenImageSource, item: ItemPF2e<ActorPF2e>, options?: RuleElementOptions) {
         super(data, item, options);
@@ -25,6 +27,10 @@ export class TokenImageRuleElement extends RuleElementPF2e {
         if (typeof data.scale === "number" && data.scale > 0) {
             this.scale = data.scale;
         }
+
+        if (typeof data.tint === "string") {
+            this.tint = data.tint
+        }
     }
 
     override afterPrepareData(): void {
@@ -33,10 +39,18 @@ export class TokenImageRuleElement extends RuleElementPF2e {
 
         if (!this.test()) return;
 
-        const texture: { src: VideoFilePath; scaleX?: number; scaleY?: number } = { src };
+        const texture: { src: VideoFilePath; scaleX?: number; scaleY?: number; tint?: string} = { src };
         if (this.scale) {
             texture.scaleX = this.scale;
             texture.scaleY = this.scale;
+        }
+
+        if (this.tint) {
+            texture.tint = this.tint
+        }
+
+        if (this.alpha) {
+            this.actor.synthetics.tokenOverrides.alpha = this.alpha
         }
 
         this.actor.synthetics.tokenOverrides.texture = texture;
@@ -52,4 +66,6 @@ export class TokenImageRuleElement extends RuleElementPF2e {
 interface TokenImageSource extends RuleElementSource {
     value?: unknown;
     scale?: unknown;
+    tint?: unknown;
+    alpha?: unknown;
 }

--- a/src/module/rules/rule-element/token-image.ts
+++ b/src/module/rules/rule-element/token-image.ts
@@ -29,7 +29,7 @@ export class TokenImageRuleElement extends RuleElementPF2e {
         }
 
         if (typeof data.tint === "string") {
-            this.tint = data.tint
+            this.tint = data.tint;
         }
     }
 
@@ -39,18 +39,18 @@ export class TokenImageRuleElement extends RuleElementPF2e {
 
         if (!this.test()) return;
 
-        const texture: { src: VideoFilePath; scaleX?: number; scaleY?: number; tint?: string} = { src };
+        const texture: { src: VideoFilePath; scaleX?: number; scaleY?: number; tint?: string } = { src };
         if (this.scale) {
             texture.scaleX = this.scale;
             texture.scaleY = this.scale;
         }
 
         if (this.tint) {
-            texture.tint = this.tint
+            texture.tint = this.tint;
         }
 
         if (this.alpha) {
-            this.actor.synthetics.tokenOverrides.alpha = this.alpha
+            this.actor.synthetics.tokenOverrides.alpha = this.alpha;
         }
 
         this.actor.synthetics.tokenOverrides.texture = texture;

--- a/src/module/rules/synthetics.ts
+++ b/src/module/rules/synthetics.ts
@@ -40,8 +40,12 @@ interface RuleElementSynthetics {
     striking: Record<string, StrikingSynthetic[]>;
     targetMarks: Map<TokenDocumentUUID, string>;
     toggles: RollOptionToggle[];
-    tokenOverrides: DeepPartial<Pick<foundry.documents.TokenSource, "light" | "name">> & {
-        texture?: { src: VideoFilePath } | { src: VideoFilePath; scaleX: number; scaleY: number };
+    tokenOverrides: DeepPartial<Pick<foundry.documents.TokenSource, "light" | "name" | "alpha">> & {
+        texture?:
+            | { src: VideoFilePath }
+            | { src: VideoFilePath; scaleX: number; scaleY: number }
+            | { src: VideoFilePath; scaleX: number; scaleY: number; tint: `#${string}` }
+            | { src: VideoFilePath; tint: `#${string}` };
     };
     weaponPotency: Record<string, PotencySynthetic[]>;
     preparationWarnings: {

--- a/src/module/rules/synthetics.ts
+++ b/src/module/rules/synthetics.ts
@@ -42,10 +42,8 @@ interface RuleElementSynthetics {
     toggles: RollOptionToggle[];
     tokenOverrides: DeepPartial<Pick<foundry.documents.TokenSource, "light" | "name" | "alpha">> & {
         texture?:
-            | { src: VideoFilePath }
-            | { src: VideoFilePath; scaleX: number; scaleY: number }
-            | { src: VideoFilePath; scaleX: number; scaleY: number; tint: `#${string}` }
-            | { src: VideoFilePath; tint: `#${string}` };
+            | { src: VideoFilePath; tint?: HexColorString }
+            | { src: VideoFilePath; tint?: HexColorString; scaleX: number; scaleY: number };
     };
     weaponPotency: Record<string, PotencySynthetic[]>;
     preparationWarnings: {

--- a/src/module/scene/token-document/document.ts
+++ b/src/module/scene/token-document/document.ts
@@ -239,14 +239,10 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
                 this.texture.scaleY = tokenOverrides.texture.scaleY;
                 this.flags.pf2e.autoscale = false;
             }
-            if ("tint" in tokenOverrides.texture) {
-                this.texture.tint = tokenOverrides.texture.tint;
-            }
+            this.texture.tint = tokenOverrides.texture.tint ?? this.texture.tint;
         }
 
-        if (tokenOverrides.alpha) {
-            this.alpha = tokenOverrides.alpha;
-        }
+        this.alpha = tokenOverrides.alpha ?? this.alpha;
 
         if (tokenOverrides.light) {
             this.light = new foundry.data.LightData(tokenOverrides.light, {

--- a/src/module/scene/token-document/document.ts
+++ b/src/module/scene/token-document/document.ts
@@ -239,6 +239,13 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
                 this.texture.scaleY = tokenOverrides.texture.scaleY;
                 this.flags.pf2e.autoscale = false;
             }
+            if (tokenOverrides.texture.tint) {
+                this.tint = tokenOverrides.texture.tint;
+            }
+        }
+
+        if (tokenOverrides.alpha) {
+            this.alpha = tokenOverrides.alpha;
         }
 
         if (tokenOverrides.light) {

--- a/src/module/scene/token-document/document.ts
+++ b/src/module/scene/token-document/document.ts
@@ -239,8 +239,8 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
                 this.texture.scaleY = tokenOverrides.texture.scaleY;
                 this.flags.pf2e.autoscale = false;
             }
-            if (tokenOverrides.texture.tint) {
-                this.tint = tokenOverrides.texture.tint;
+            if ("tint" in tokenOverrides.texture) {
+                this.texture.tint = tokenOverrides.texture.tint;
             }
         }
 

--- a/types/foundry/common/documents/token.d.ts
+++ b/types/foundry/common/documents/token.d.ts
@@ -10,8 +10,6 @@ import type { BaseScene, BaseUser } from "./module.d.ts";
 export default class BaseToken<TParent extends BaseScene | null = BaseScene | null> extends Document<TParent> {
     readonly actorLink: boolean;
 
-    alpha: number;
-
     displayName: TokenDisplayMode;
 
     disposition: TokenDisposition;
@@ -112,7 +110,6 @@ export interface TokenSource extends TokenLightData {
     actorId: string | null;
     actorLink: boolean;
     actorData: DeepPartial<ActorSource>;
-    alpha: number;
     mirrorX: boolean;
     mirrorY: boolean;
     height: number;

--- a/types/foundry/common/documents/token.d.ts
+++ b/types/foundry/common/documents/token.d.ts
@@ -10,6 +10,8 @@ import type { BaseScene, BaseUser } from "./module.d.ts";
 export default class BaseToken<TParent extends BaseScene | null = BaseScene | null> extends Document<TParent> {
     readonly actorLink: boolean;
 
+    alpha: number;
+
     displayName: TokenDisplayMode;
 
     disposition: TokenDisposition;
@@ -110,6 +112,7 @@ export interface TokenSource extends TokenLightData {
     actorId: string | null;
     actorLink: boolean;
     actorData: DeepPartial<ActorSource>;
+    alpha: number;
     mirrorX: boolean;
     mirrorY: boolean;
     height: number;


### PR DESCRIPTION
Before I fight typescript to resolve the errors is this something we'd be fine with adding in? It will help quite a bit with a third party thing I am working on and it's kind of a neat thing to be able to manage the tint/opacity of a token with a rule element.