### PR TITLE
Fix declining a pick from a ChoiceSet defaulting to first item

### DIFF
--- a/src/module/apps/pick-a-thing-prompt.ts
+++ b/src/module/apps/pick-a-thing-prompt.ts
@@ -57,7 +57,7 @@ abstract class PickAThingPrompt<T> extends Application {
             event.currentTarget.closest(".content")?.querySelector<HTMLElement>("tag") ?? event.currentTarget;
         const selectedIndex = valueElement.getAttribute("value");
 
-        return selectedIndex === "" || !Number.isInteger(Number(selectedIndex))
+        return selectedIndex === null ||selectedIndex === "" || !Number.isInteger(Number(selectedIndex))
             ? null
             : this.choices.at(Number(selectedIndex)) ?? null;
     }

--- a/src/module/apps/pick-a-thing-prompt.ts
+++ b/src/module/apps/pick-a-thing-prompt.ts
@@ -57,7 +57,7 @@ abstract class PickAThingPrompt<T> extends Application {
             event.currentTarget.closest(".content")?.querySelector<HTMLElement>("tag") ?? event.currentTarget;
         const selectedIndex = valueElement.getAttribute("value");
 
-        return selectedIndex === null || selectedIndex === "" || !Number.isInteger(Number(selectedIndex))
+        return ["", null].includes(selectedIndex) || !Number.isInteger(Number(selectedIndex))
             ? null
             : this.choices.at(Number(selectedIndex)) ?? null;
     }

--- a/src/module/apps/pick-a-thing-prompt.ts
+++ b/src/module/apps/pick-a-thing-prompt.ts
@@ -57,7 +57,7 @@ abstract class PickAThingPrompt<T> extends Application {
             event.currentTarget.closest(".content")?.querySelector<HTMLElement>("tag") ?? event.currentTarget;
         const selectedIndex = valueElement.getAttribute("value");
 
-        return selectedIndex === null ||selectedIndex === "" || !Number.isInteger(Number(selectedIndex))
+        return selectedIndex === null || selectedIndex === "" || !Number.isInteger(Number(selectedIndex))
             ? null
             : this.choices.at(Number(selectedIndex)) ?? null;
     }


### PR DESCRIPTION
If the ChoiceSet is configured to "allowNoSelection": true, then clicking "Decline" results in a selectedIndex of null. The cast of Number(selectedIndex) evaluates to 0.