### PR TITLE
Make feat slots use `supported` to determine feat category when searching in the compendium browser

### DIFF
--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -849,9 +849,6 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
             .filter((s) => !!s)
             .map((s) => s.trim());
 
-        if (checkboxesFilterCodes.includes("category-general")) checkboxesFilterCodes.push("category-skill");
-        if (checkboxesFilterCodes.includes("category-class")) checkboxesFilterCodes.push("category-archetype");
-
         const featTab = game.pf2e.compendiumBrowser.tabs.feat;
         const filter = await featTab.getFilterData();
         const level = filter.sliders.level;

--- a/static/templates/actors/character/tabs/feats.hbs
+++ b/static/templates/actors/character/tabs/feats.hbs
@@ -45,7 +45,7 @@
                         </div>
                         <div class="item-controls">
                             {{#if @root.editable}}
-                                <a class="item-control feat-browse" data-filter="category-{{section.id}},{{section.featFilter}},conjunction-or" data-level="{{featSlot.level}}"><i class="fas fa-fw fa-search"></i></a>
+                                <a class="item-control feat-browse" data-filter="{{#each section.supported}}category-{{this}},{{/each}}{{section.featFilter}},conjunction-or" data-level="{{featSlot.level}}"><i class="fas fa-fw fa-search"></i></a>
                             {{/if}}
                         </div>
                     </li>


### PR DESCRIPTION
The previous implementation used the ID and a wacky workaround in `onClickBrowseFeats` to make the Compendium Browser behave.

The former probably happened because 99% of the time, ID and `supported` were actually equal for most feat categories, and the latter probably happened to cover that 1% where it didn't (i.e., archetypes before their removal as a category and general+skill feats).

The introduction of campaign feat categories increases that 1% significantly, because they have an issue where they cannot have pre-set, well, feat categories when you open the compendium browser by clicking on the search button of a feat slot unless you change their ID to the same as a default feat category (which makes them overwrite said category).