### PR TITLE
Add "area-effect" to spell RollOptions

### DIFF
--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -639,10 +639,15 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
             }
         }
 
+        const areaEffect = !!this.system.area?.value;
+        if (areaEffect) {
+            options.add("area-effect");
+        }
+
         if (damageValues.length > 0 && this.system.spellType.value !== "heal") {
             options.add("damaging-effect");
 
-            if (this.system.area?.value) {
+            if (areaEffect) {
                 options.add("area-damage");
             }
         }

--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -639,17 +639,12 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
             }
         }
 
-        const areaEffect = !!this.system.area?.value;
-        if (areaEffect) {
-            options.add("area-effect");
-        }
+        const isAreaEffect = !!this.system.area?.value;
+        if (isAreaEffect) options.add("area-effect");
 
         if (damageValues.length > 0 && this.system.spellType.value !== "heal") {
             options.add("damaging-effect");
-
-            if (areaEffect) {
-                options.add("area-damage");
-            }
+            if (isAreaEffect) options.add("area-damage");
         }
 
         for (const trait of this.traits) {


### PR DESCRIPTION
For example, hobgoblin NPCs have a bonus to area effect saving throws when in formation, and the hobgoblin ancestry feat Formation Training provides a similar bonus. Also useful for items like Blast Suit. The rolloption "area-damage" isn't sufficient for spells like Entangle which don't do damage.