### PR TITLE
Remove `LocalizePF2e` from `@module/apps`, `@module/canvas`, `@module/chat-message`, `@module/encounter`

### DIFF
--- a/src/module/apps/compendium-browser/index.ts
+++ b/src/module/apps/compendium-browser/index.ts
@@ -2,8 +2,7 @@ import { KitPF2e, PhysicalItemPF2e } from "@item";
 import { ActionTrait } from "@item/action/index.ts";
 import { ActionType } from "@item/data/base.ts";
 import { BaseSpellcastingEntry } from "@item/spellcasting-entry/index.ts";
-import { LocalizePF2e } from "@system/localize.ts";
-import { ErrorPF2e, htmlQueryAll, isObject, objectHasKey } from "@util";
+import { ErrorPF2e, htmlQueryAll, isObject, localizer, objectHasKey } from "@util";
 import { getSelectedOrOwnActors } from "@util/token-actor-utils.ts";
 import { UserPF2e } from "@module/user/document.ts";
 import Tagify from "@yaireo/tagify";
@@ -37,21 +36,21 @@ class PackLoader {
         indexFields: string[]
     ): AsyncGenerator<{ pack: CompendiumCollection<CompendiumDocument>; index: CompendiumIndex }, void, unknown> {
         this.loadedPacks[documentType] ??= {};
-        const translations = LocalizePF2e.translations.PF2E.CompendiumBrowser.ProgressBar;
+        const localize = localizer("PF2E.CompendiumBrowser.ProgressBar");
 
         const progress = new Progress({ steps: packs.length });
         for (const packId of packs) {
             let data = this.loadedPacks[documentType][packId];
             if (data) {
                 const { pack } = data;
-                progress.advance(game.i18n.format(translations.LoadingPack, { pack: pack?.metadata.label ?? "" }));
+                progress.advance(localize("LoadingPack", { pack: pack?.metadata.label ?? "" }));
             } else {
                 const pack = game.packs.get(packId);
                 if (!pack) {
                     progress.advance("");
                     continue;
                 }
-                progress.advance(game.i18n.format(translations.LoadingPack, { pack: pack.metadata.label }));
+                progress.advance(localize("LoadingPack", { pack: pack.metadata.label }));
                 if (pack.documentName === documentType) {
                     const index = await pack.getIndex({ fields: indexFields });
                     const firstResult: Partial<CompendiumIndexData> = index.contents.at(0) ?? {};
@@ -73,7 +72,7 @@ class PackLoader {
 
             yield data;
         }
-        progress.close(translations.LoadingComplete);
+        progress.close(localize("LoadingComplete"));
     }
 
     /** Set art provided by a module if any is available */

--- a/src/module/apps/compendium-browser/tabs/equipment.ts
+++ b/src/module/apps/compendium-browser/tabs/equipment.ts
@@ -1,6 +1,5 @@
 import { CoinsPF2e } from "@item/physical/helpers.ts";
-import { LocalizePF2e } from "@system/localize.ts";
-import { sluggify } from "@util";
+import { localizer, sluggify } from "@util";
 import { CompendiumBrowser } from "../index.ts";
 import { ContentTabName } from "../data.ts";
 import { CompendiumBrowserTab } from "./base.ts";
@@ -27,6 +26,8 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
         "rarity",
         "source",
     ];
+
+    #localizeCoins = localizer("PF2E.CurrencyAbbreviations");
 
     constructor(browser: CompendiumBrowser) {
         super(browser);
@@ -208,7 +209,12 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
 
     override parseRangeFilterInput(name: string, lower: string, upper: string): RangesData["values"] {
         if (name === "price") {
-            const coins = LocalizePF2e.translations.PF2E.CurrencyAbbreviations;
+            const coins = {
+                cp: this.#localizeCoins("cp"),
+                sp: this.#localizeCoins("sp"),
+                gp: this.#localizeCoins("gp"),
+                pp: this.#localizeCoins("pp"),
+            };
             for (const [english, translated] of Object.entries(coins)) {
                 lower = lower.replaceAll(translated, english);
                 upper = upper.replaceAll(translated, english);
@@ -225,7 +231,6 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
     }
 
     protected override prepareFilterData(): EquipmentFilters {
-        const coins = LocalizePF2e.translations.PF2E.CurrencyAbbreviations;
         return {
             checkboxes: {
                 itemtypes: {
@@ -284,8 +289,8 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
                     values: {
                         min: 0,
                         max: 20_000_000,
-                        inputMin: `0${coins.cp}`,
-                        inputMax: `200,000${coins.gp}`,
+                        inputMin: `0${this.#localizeCoins("cp")}`,
+                        inputMax: `200,000${this.#localizeCoins("gp")}`,
                     },
                 },
             },

--- a/src/module/apps/migration-summary.ts
+++ b/src/module/apps/migration-summary.ts
@@ -1,5 +1,4 @@
 import { MigrationRunner } from "@module/migration/index.ts";
-import { LocalizePF2e } from "@system/localize.ts";
 
 /** A summary window that opens after a system migration completes */
 export class MigrationSummary extends Application<MigrationSummaryOptions> {
@@ -49,7 +48,7 @@ export class MigrationSummary extends Application<MigrationSummaryOptions> {
             this.options.troubleshoot || actors.successful < actors.total || items.successful < items.total;
 
         const helpResourcesText = await TextEditor.enrichHTML(
-            LocalizePF2e.translations.PF2E.Migrations.Summary.HelpResources,
+            game.i18n.localize("PF2E.Migrations.Summary.HelpResources"),
             { async: true }
         );
 

--- a/src/module/apps/world-clock/app.ts
+++ b/src/module/apps/world-clock/app.ts
@@ -1,4 +1,3 @@
-import { LocalizePF2e } from "@system/localize.ts";
 import { ErrorPF2e, ordinal, tupleHasValue } from "@util";
 import { DateTime } from "luxon";
 import { animateDarkness } from "./animate-darkness.ts";
@@ -13,9 +12,6 @@ interface WorldClockData {
 }
 
 export class WorldClock extends Application {
-    /** Localization keys */
-    private readonly translations = LocalizePF2e.translations.PF2E.WorldClock;
-
     /** Is the ctrl key currently held down? */
     private ctrlKeyDown = false;
 
@@ -82,7 +78,7 @@ export class WorldClock extends Application {
     private get era(): string {
         switch (this.dateTheme) {
             case "AR": // Absalom Reckoning
-                return this.translations.AR.Era;
+                return game.i18n.localize(CONFIG.PF2E.worldClock.AR.Era);
             case "AD": // Earth on the Material Plane
                 return this.worldTime.toFormat("G");
             default:
@@ -111,9 +107,9 @@ export class WorldClock extends Application {
     private get month(): string {
         switch (this.dateTheme) {
             case "AR": {
-                const months = this.translations.AR.Months;
+                const months = CONFIG.PF2E.worldClock.AR.Months;
                 const month = this.worldTime.setLocale("en-US").monthLong as keyof typeof months;
-                return months[month];
+                return game.i18n.localize(months[month]);
             }
             default:
                 return this.worldTime.monthLong!;
@@ -124,9 +120,9 @@ export class WorldClock extends Application {
     private get weekday(): string {
         switch (this.dateTheme) {
             case "AR": {
-                const weekdays = this.translations.AR.Weekdays;
+                const weekdays = CONFIG.PF2E.worldClock.AR.Weekdays;
                 const weekday = this.worldTime.setLocale("en-US").weekdayLong as keyof typeof weekdays;
-                return weekdays[weekday];
+                return game.i18n.localize(weekdays[weekday]);
             }
             default:
                 return this.worldTime.weekdayLong!;
@@ -137,7 +133,7 @@ export class WorldClock extends Application {
         const date =
             this.dateTheme === "CE"
                 ? this.worldTime.toLocaleString(DateTime.DATE_HUGE)
-                : game.i18n.format(this.translations.Date, {
+                : game.i18n.format(CONFIG.PF2E.worldClock.Date, {
                       era: this.era,
                       year: this.year,
                       month: this.month,
@@ -223,7 +219,7 @@ export class WorldClock extends Application {
 
                 const retractTime = (this.ctrlKeyDown = event.type === "keydown");
 
-                const { Advance, Retract, TimeOfDay } = this.translations.Button;
+                const { Advance, Retract, TimeOfDay } = CONFIG.PF2E.worldClock.Button;
                 const advanceButtons = Array.from(
                     $html.get(0)?.querySelectorAll<HTMLButtonElement>("button[data-advance-time]") ?? []
                 );

--- a/src/module/canvas/status-effects.ts
+++ b/src/module/canvas/status-effects.ts
@@ -6,7 +6,7 @@ import { TokenPF2e } from "@module/canvas/token/index.ts";
 import { ChatMessagePF2e } from "@module/chat-message/index.ts";
 import { EncounterPF2e } from "@module/encounter/index.ts";
 import { StatusEffectIconTheme } from "@scripts/config/index.ts";
-import { LocalizePF2e } from "@system/localize.ts";
+import Translations from "static/lang/en.json";
 import { ErrorPF2e, fontAwesomeIcon, htmlQueryAll, objectHasKey, setHasElement } from "@util";
 
 const debouncedRender = foundry.utils.debounce(() => {
@@ -40,7 +40,7 @@ export class StatusEffects {
     }
 
     static get conditions(): Record<ConditionSlug, { name: string; rules: string; summary: string }> {
-        return LocalizePF2e.translations.PF2E.condition;
+        return Translations.PF2E.condition;
     }
 
     /**

--- a/src/module/chat-message/helpers.ts
+++ b/src/module/chat-message/helpers.ts
@@ -1,5 +1,4 @@
 import { DamageRoll } from "@system/damage/roll.ts";
-import { LocalizePF2e } from "@system/localize.ts";
 import { ErrorPF2e, htmlQuery, tupleHasValue } from "@util";
 import { ChatContextFlag, CheckRollContextFlag } from "./data.ts";
 import { ChatMessagePF2e } from "./document.ts";
@@ -24,8 +23,7 @@ async function applyDamageFromMessage({
             ? [message.token]
             : canvas.tokens.controlled.filter((t) => !!t.actor).map((t) => t.document);
     if (tokens.length === 0) {
-        const errorMsg = LocalizePF2e.translations.PF2E.UI.errorTargetToken;
-        return ui.notifications.error(errorMsg);
+        return ui.notifications.error("PF2E.UI.errorTargetToken", { localize: true });
     }
 
     const shieldBlockRequest = CONFIG.PF2E.chatDamageButtonShieldToggle;

--- a/src/module/chat-message/listeners/cards.ts
+++ b/src/module/chat-message/listeners/cards.ts
@@ -6,7 +6,6 @@ import { isSpellConsumable } from "@item/consumable/spell-consumables.ts";
 import { CoinsPF2e } from "@item/physical/helpers.ts";
 import { eventToRollParams } from "@scripts/sheet-util.ts";
 import { onRepairChatCardEvent } from "@system/action-macros/crafting/repair.ts";
-import { LocalizePF2e } from "@system/localize.ts";
 import { ErrorPF2e, sluggify, tupleHasValue } from "@util";
 import { ChatMessagePF2e } from "../index.ts";
 
@@ -107,15 +106,16 @@ export const ChatCards = {
                         const consumable = actor.items.get($button.attr("data-item") ?? "");
                         if (consumable?.isOfType("consumable")) {
                             const oldQuant = consumable.quantity;
-                            const toReplace = `${consumable.name} - ${LocalizePF2e.translations.ITEM.TypeConsumable} (${oldQuant})`;
+                            const consumableString = game.i18n.localize("ITEM.TypeConsumable");
+                            const toReplace = `${consumable.name} - ${consumableString} (${oldQuant})`;
                             await consumable.consume();
                             const currentQuant = oldQuant === 1 ? 0 : consumable.quantity;
                             let flavor = message.flavor.replace(
                                 toReplace,
-                                `${consumable.name} - ${LocalizePF2e.translations.ITEM.TypeConsumable} (${currentQuant})`
+                                `${consumable.name} - ${consumableString} (${currentQuant})`
                             );
                             if (currentQuant === 0) {
-                                const buttonStr = `>${LocalizePF2e.translations.PF2E.ConsumableUseLabel}</button>`;
+                                const buttonStr = `>${game.i18n.localize("PF2E.ConsumableUseLabel")}</button>`;
                                 flavor = flavor?.replace(buttonStr, " disabled" + buttonStr);
                             }
                             await message.update({ flavor });

--- a/src/module/encounter/document.ts
+++ b/src/module/encounter/document.ts
@@ -6,7 +6,6 @@ import { InitiativeRollResult } from "@actor/initiative.ts";
 import { SkillLongForm } from "@actor/types.ts";
 import { SKILL_DICTIONARY, SKILL_LONG_FORMS } from "@actor/values.ts";
 import { ScenePF2e, TokenDocumentPF2e } from "@scene/index.ts";
-import { LocalizePF2e } from "@system/localize.ts";
 import { setHasElement } from "@util";
 import { CombatantFlags, CombatantPF2e, RolledCombatant } from "./combatant.ts";
 
@@ -55,7 +54,6 @@ class EncounterPF2e extends Combat {
 
             const actorTraits = actor.traits;
             if (actor.type === "loot" || ["minion", "eidolon"].some((t) => actorTraits.has(t))) {
-                const translation = LocalizePF2e.translations.PF2E.Encounter.ExcludingFromInitiative;
                 const actorTypes: Record<string, string> = CONFIG.PF2E.actorTypes;
                 const type = game.i18n.localize(
                     actorTraits.has("minion")
@@ -64,7 +62,9 @@ class EncounterPF2e extends Combat {
                         ? CONFIG.PF2E.creatureTraits.eidolon
                         : actorTypes[actor.type]
                 );
-                ui.notifications.info(game.i18n.format(translation, { type, actor: actor.name }));
+                ui.notifications.info(
+                    game.i18n.format("PF2E.Encounter.ExcludingFromInitiative", { type, actor: actor.name })
+                );
                 return false;
             }
             return true;

--- a/src/scripts/config/index.ts
+++ b/src/scripts/config/index.ts
@@ -41,7 +41,7 @@ import {
 } from "@item/weapon/types.ts";
 import { Size } from "@module/data.ts";
 import { JournalSheetPF2e } from "@module/journal-entry/sheet.ts";
-import { sluggify } from "@util";
+import { configFromLocalization, sluggify } from "@util";
 import enJSON from "../../../static/lang/en.json";
 import { damageCategories, damageRollFlavors, damageTypes, materialDamageEffects } from "./damage.ts";
 import { immunityTypes, resistanceTypes, weaknessTypes } from "./iwr.ts";
@@ -1555,12 +1555,12 @@ export const PF2ECONFIG = {
     },
 
     // Year offsets relative to the current actual year
-    worldClock: {
+    worldClock: mergeObject(configFromLocalization(enJSON.PF2E.WorldClock, "PF2E.WorldClock"), {
         AR: { yearOffset: 2700 },
         IC: { yearOffset: 5200 },
         AD: { yearOffset: -95 },
         CE: { yearOffset: 0 },
-    },
+    }),
 
     runes: {
         weapon: {

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -431,6 +431,20 @@ function localizer(prefix: string): (...args: Parameters<Localization["format"]>
         formatArgs ? game.i18n.format(`${prefix}.${suffix}`, formatArgs) : game.i18n.localize(`${prefix}.${suffix}`);
 }
 
+/** Walk a localization object and recursively map the keys as localization strings starting with a given prefix */
+function configFromLocalization<T extends Record<string, TranslationDictionaryValue>>(
+    localization: T,
+    prefix: string
+): T {
+    return Object.entries(localization).reduce(
+        (map, [key, value]) => ({
+            ...map,
+            [key]: typeof value === "string" ? `${prefix}.${key}` : configFromLocalization(value, `${prefix}.${key}`),
+        }),
+        {} as T
+    );
+}
+
 /** Does the parameter look like an image file path? */
 function isImageFilePath(path: unknown): path is ImageFilePath {
     return typeof path === "string" && Object.keys(CONST.IMAGE_FILE_EXTENSIONS).some((e) => path.endsWith(`.${e}`));
@@ -446,6 +460,7 @@ function isImageOrVideoPath(path: unknown): path is ImageFilePath | VideoFilePat
 }
 
 export {
+    configFromLocalization,
     ErrorPF2e,
     Fraction,
     Optional,


### PR DESCRIPTION
I'm using an import of `en.json` for the world clock app.  Not sure if that's a bad idea. Seems to work as a drop in replacement for `LocalizePF2e` in that case though.