### PR TITLE
Allow AdjustDegreeOfSuccess RE to adjust to a specific degree of success

### DIFF
--- a/src/module/rules/rule-element/adjust-degree-of-success.ts
+++ b/src/module/rules/rule-element/adjust-degree-of-success.ts
@@ -48,7 +48,12 @@ class AdjustDegreeOfSuccessRuleElement extends RuleElementPF2e {
             "one-degree-better": DEGREE_ADJUSTMENT_AMOUNTS.INCREASE,
             "one-degree-worse": DEGREE_ADJUSTMENT_AMOUNTS.LOWER,
             "two-degrees-worse": DEGREE_ADJUSTMENT_AMOUNTS.LOWER_BY_TWO,
+            "set-to-critical-failure": DEGREE_ADJUSTMENT_AMOUNTS.SET_TO_CRITICAL_FAILURE,
+            "set-to-failure": DEGREE_ADJUSTMENT_AMOUNTS.SET_TO_FAILURE,
+            "set-to-success": DEGREE_ADJUSTMENT_AMOUNTS.SET_TO_SUCCESS,
+            "set-to-critical-success": DEGREE_ADJUSTMENT_AMOUNTS.SET_TO_CRITICAL_SUCCESS,
         } as const;
+
         const record = (["all", ...DEGREE_OF_SUCCESS_STRINGS] as const).reduce((accumulated, outcome) => {
             const adjustment = adjustments[outcome];
             if (adjustment) {
@@ -83,6 +88,10 @@ const degreeAdjustmentAmountString = [
     "one-degree-worse",
     "two-degrees-better",
     "two-degrees-worse",
+    "set-to-critical-failure",
+    "set-to-failure",
+    "set-to-success",
+    "set-to-critical-success",
 ] as const;
 type DegreeAdjustmentAmountString = (typeof degreeAdjustmentAmountString)[number];
 

--- a/src/module/rules/rule-element/adjust-degree-of-success.ts
+++ b/src/module/rules/rule-element/adjust-degree-of-success.ts
@@ -48,10 +48,10 @@ class AdjustDegreeOfSuccessRuleElement extends RuleElementPF2e {
             "one-degree-better": DEGREE_ADJUSTMENT_AMOUNTS.INCREASE,
             "one-degree-worse": DEGREE_ADJUSTMENT_AMOUNTS.LOWER,
             "two-degrees-worse": DEGREE_ADJUSTMENT_AMOUNTS.LOWER_BY_TWO,
-            "set-to-critical-failure": DEGREE_ADJUSTMENT_AMOUNTS.SET_TO_CRITICAL_FAILURE,
-            "set-to-failure": DEGREE_ADJUSTMENT_AMOUNTS.SET_TO_FAILURE,
-            "set-to-success": DEGREE_ADJUSTMENT_AMOUNTS.SET_TO_SUCCESS,
-            "set-to-critical-success": DEGREE_ADJUSTMENT_AMOUNTS.SET_TO_CRITICAL_SUCCESS,
+            "to-critical-failure": DEGREE_ADJUSTMENT_AMOUNTS.SET_TO_CRITICAL_FAILURE,
+            "to-failure": DEGREE_ADJUSTMENT_AMOUNTS.SET_TO_FAILURE,
+            "to-success": DEGREE_ADJUSTMENT_AMOUNTS.SET_TO_SUCCESS,
+            "to-critical-success": DEGREE_ADJUSTMENT_AMOUNTS.SET_TO_CRITICAL_SUCCESS,
         } as const;
 
         const record = (["all", ...DEGREE_OF_SUCCESS_STRINGS] as const).reduce((accumulated, outcome) => {
@@ -88,10 +88,10 @@ const degreeAdjustmentAmountString = [
     "one-degree-worse",
     "two-degrees-better",
     "two-degrees-worse",
-    "set-to-critical-failure",
-    "set-to-failure",
-    "set-to-success",
-    "set-to-critical-success",
+    "to-critical-failure",
+    "to-failure",
+    "to-success",
+    "to-critical-success",
 ] as const;
 type DegreeAdjustmentAmountString = (typeof degreeAdjustmentAmountString)[number];
 

--- a/src/module/rules/rule-element/adjust-degree-of-success.ts
+++ b/src/module/rules/rule-element/adjust-degree-of-success.ts
@@ -48,10 +48,10 @@ class AdjustDegreeOfSuccessRuleElement extends RuleElementPF2e {
             "one-degree-better": DEGREE_ADJUSTMENT_AMOUNTS.INCREASE,
             "one-degree-worse": DEGREE_ADJUSTMENT_AMOUNTS.LOWER,
             "two-degrees-worse": DEGREE_ADJUSTMENT_AMOUNTS.LOWER_BY_TWO,
-            "to-critical-failure": DEGREE_ADJUSTMENT_AMOUNTS.SET_TO_CRITICAL_FAILURE,
-            "to-failure": DEGREE_ADJUSTMENT_AMOUNTS.SET_TO_FAILURE,
-            "to-success": DEGREE_ADJUSTMENT_AMOUNTS.SET_TO_SUCCESS,
-            "to-critical-success": DEGREE_ADJUSTMENT_AMOUNTS.SET_TO_CRITICAL_SUCCESS,
+            "to-critical-failure": DEGREE_ADJUSTMENT_AMOUNTS.TO_CRITICAL_FAILURE,
+            "to-failure": DEGREE_ADJUSTMENT_AMOUNTS.TO_FAILURE,
+            "to-success": DEGREE_ADJUSTMENT_AMOUNTS.TO_SUCCESS,
+            "to-critical-success": DEGREE_ADJUSTMENT_AMOUNTS.TO_CRITICAL_SUCCESS,
         } as const;
 
         const record = (["all", ...DEGREE_OF_SUCCESS_STRINGS] as const).reduce((accumulated, outcome) => {

--- a/src/module/rules/rule-element/adjust-degree-of-success.ts
+++ b/src/module/rules/rule-element/adjust-degree-of-success.ts
@@ -66,8 +66,9 @@ class AdjustDegreeOfSuccessRuleElement extends RuleElementPF2e {
 
     #isAdjustmentData(adjustment: DegreeAdjustmentsRuleRecord): boolean {
         const outcomes = ["all", ...DEGREE_OF_SUCCESS_STRINGS];
-        const amounts = ["one-degree-better", "one-degree-worse"];
-        return Object.entries(adjustment).every(([key, value]) => outcomes.includes(key) && amounts.includes(value));
+        return Object.entries(adjustment).every(
+            ([key, value]) => outcomes.includes(key) && degreeAdjustmentAmountString.includes(value)
+        );
     }
 }
 
@@ -77,11 +78,13 @@ interface AdjustDegreeOfSuccessRuleElement extends RuleElementPF2e {
     get actor(): CharacterPF2e | NPCPF2e;
 }
 
-type DegreeAdjustmentAmountString =
-    | "one-degree-better"
-    | "one-degree-worse"
-    | "two-degrees-better"
-    | "two-degrees-worse";
+const degreeAdjustmentAmountString = [
+    "one-degree-better",
+    "one-degree-worse",
+    "two-degrees-better",
+    "two-degrees-worse",
+] as const;
+type DegreeAdjustmentAmountString = (typeof degreeAdjustmentAmountString)[number];
 
 type DegreeAdjustmentsRuleRecord = {
     [key in "all" | DegreeOfSuccessString]?: DegreeAdjustmentAmountString;

--- a/src/module/system/degree-of-success.ts
+++ b/src/module/system/degree-of-success.ts
@@ -84,13 +84,13 @@ class DegreeOfSuccess {
     ): DegreeOfSuccessIndex {
         switch (amount) {
             case "criticalFailure":
-                return 0 as DegreeOfSuccessIndex;
+                return 0;
             case "failure":
-                return 1 as DegreeOfSuccessIndex;
+                return 1;
             case "success":
-                return 2 as DegreeOfSuccessIndex;
+                return 2;
             case "criticalSuccess":
-                return 3 as DegreeOfSuccessIndex;
+                return 3;
             default:
                 return Math.clamped(degreeOfSuccess + amount, 0, 3) as DegreeOfSuccessIndex;
         }

--- a/src/module/system/degree-of-success.ts
+++ b/src/module/system/degree-of-success.ts
@@ -82,7 +82,18 @@ class DegreeOfSuccess {
         amount: DegreeAdjustmentAmount,
         degreeOfSuccess: DegreeOfSuccessIndex
     ): DegreeOfSuccessIndex {
-        return Math.clamped(degreeOfSuccess + amount, 0, 3) as DegreeOfSuccessIndex;
+        switch (amount) {
+            case "criticalFailure":
+                return 0 as DegreeOfSuccessIndex;
+            case "failure":
+                return 1 as DegreeOfSuccessIndex;
+            case "success":
+                return 2 as DegreeOfSuccessIndex;
+            case "criticalSuccess":
+                return 3 as DegreeOfSuccessIndex;
+            default:
+                return Math.clamped(degreeOfSuccess + amount, 0, 3) as DegreeOfSuccessIndex;
+        }
     }
 
     /**
@@ -121,6 +132,10 @@ const DEGREE_ADJUSTMENT_AMOUNTS = {
     LOWER: -1,
     INCREASE: 1,
     INCREASE_BY_TWO: 2,
+    SET_TO_CRITICAL_FAILURE: "criticalFailure",
+    SET_TO_FAILURE: "failure",
+    SET_TO_SUCCESS: "success",
+    SET_TO_CRITICAL_SUCCESS: "criticalSuccess",
 } as const;
 
 type DegreeAdjustmentAmount = (typeof DEGREE_ADJUSTMENT_AMOUNTS)[keyof typeof DEGREE_ADJUSTMENT_AMOUNTS];

--- a/src/module/system/degree-of-success.ts
+++ b/src/module/system/degree-of-success.ts
@@ -132,10 +132,10 @@ const DEGREE_ADJUSTMENT_AMOUNTS = {
     LOWER: -1,
     INCREASE: 1,
     INCREASE_BY_TWO: 2,
-    SET_TO_CRITICAL_FAILURE: "criticalFailure",
-    SET_TO_FAILURE: "failure",
-    SET_TO_SUCCESS: "success",
-    SET_TO_CRITICAL_SUCCESS: "criticalSuccess",
+    TO_CRITICAL_FAILURE: "criticalFailure",
+    TO_FAILURE: "failure",
+    TO_SUCCESS: "success",
+    TO_CRITICAL_SUCCESS: "criticalSuccess",
 } as const;
 
 type DegreeAdjustmentAmount = (typeof DEGREE_ADJUSTMENT_AMOUNTS)[keyof typeof DEGREE_ADJUSTMENT_AMOUNTS];


### PR DESCRIPTION
As the title says, this PR adds 4 new options for DoS adjustment in the aforementioned RE.   
Additionally, this PR also fixes the issue where `two-degrees-XYZ` adjustments *theoretically* worked, but in practice the validator never let them through because they were missing from the list of valid amounts (this caused a whole single bug in the system with the Reckless Abandon Goblin feat).