### PR TITLE
Implement drawbacks to Cognitive Mutagens

### DIFF
--- a/packs/data/equipment-effects.db/effect-cognitive-mutagen-greater.json
+++ b/packs/data/equipment-effects.db/effect-cognitive-mutagen-greater.json
@@ -4,7 +4,7 @@
     "name": "Effect: Cognitive Mutagen (Greater)",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.equipment-srd.Cognitive Mutagen (Greater)]{Cognitive Mutagen (Greater)}</p>\n<p><strong>Implemented effects</strong></p>\n<ul>\n<li>+3 item bonus to Arcana, Crafting, Lore, Occultism and Society checks</li>\n<li>+3 item bonus to all Recall Knowledge checks</li>\n<li>-2 penalty to to Athletics and Acrobatics checks</li>\n<li>-2 penalty to weapon and unarmed attacks</li>\n<li>Treat Recall Knowledge critical failures as failures</li>\n</ul>\n<p><strong>Unimplemented effects</strong></p>\n<ul>\n<li>You can carry 2 less Bulk than normal before becoming encumbered</li>\n<li>The maximum Bulk you can carry is reduced by 4</li>\n</ul>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.equipment-srd.Cognitive Mutagen (Greater)]{Cognitive Mutagen (Greater)}</p>\n<p><strong>Implemented effects</strong></p>\n<ul>\n<li>+3 item bonus to Arcana, Crafting, Lore, Occultism and Society checks</li>\n<li>+3 item bonus to all Recall Knowledge checks</li>\n<li>-2 penalty to to Athletics and Acrobatics checks</li>\n<li>-2 penalty to weapon and unarmed attacks</li>\n<li>Treat Recall Knowledge critical failures as failures</li>\n<li>You can carry 2 less Bulk than normal before becoming encumbered</li>\n<li>The maximum Bulk you can carry is reduced by 4</li>\n</ul>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -56,6 +56,18 @@
                 ],
                 "selector": "skill-check",
                 "type": "skill"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "subtract",
+                "path": "system.attributes.bonusEncumbranceBulk",
+                "value": 2
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "subtract",
+                "path": "system.attributes.bonusLimitBulk",
+                "value": 4
             }
         ],
         "source": {

--- a/packs/data/equipment-effects.db/effect-cognitive-mutagen-lesser.json
+++ b/packs/data/equipment-effects.db/effect-cognitive-mutagen-lesser.json
@@ -4,7 +4,7 @@
     "name": "Effect: Cognitive Mutagen (Lesser)",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.equipment-srd.Cognitive Mutagen (Lesser)]{Cognitive Mutagen (Lesser)}</p>\n<p><strong>Implemented effects</strong></p>\n<ul>\n<li>+1 item bonus to Arcana, Crafting, Lore, Occultism and Society checks</li>\n<li>+1 item bonus to all Recall Knowledge checks</li>\n<li>-2 penalty to to Athletics and Acrobatics checks</li>\n<li>-2 penalty to weapon and unarmed attacks</li>\n<li>Treat Recall Knowledge critical failures as failures</li>\n</ul>\n<p><strong>Unimplemented effects</strong></p>\n<ul>\n<li>You can carry 2 less Bulk than normal before becoming encumbered</li>\n<li>The maximum Bulk you can carry is reduced by 4</li>\n</ul>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.equipment-srd.Cognitive Mutagen (Lesser)]{Cognitive Mutagen (Lesser)}</p>\n<p><strong>Implemented effects</strong></p>\n<ul>\n<li>+1 item bonus to Arcana, Crafting, Lore, Occultism and Society checks</li>\n<li>+1 item bonus to all Recall Knowledge checks</li>\n<li>-2 penalty to to Athletics and Acrobatics checks</li>\n<li>-2 penalty to weapon and unarmed attacks</li>\n<li>Treat Recall Knowledge critical failures as failures</li>\n<li>You can carry 2 less Bulk than normal before becoming encumbered</li>\n<li>The maximum Bulk you can carry is reduced by 4</li>\n</ul>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -56,6 +56,18 @@
                 ],
                 "selector": "skill-check",
                 "type": "skill"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "subtract",
+                "path": "system.attributes.bonusEncumbranceBulk",
+                "value": 2
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "subtract",
+                "path": "system.attributes.bonusLimitBulk",
+                "value": 4
             }
         ],
         "source": {

--- a/packs/data/equipment-effects.db/effect-cognitive-mutagen-major.json
+++ b/packs/data/equipment-effects.db/effect-cognitive-mutagen-major.json
@@ -4,7 +4,7 @@
     "name": "Effect: Cognitive Mutagen (Major)",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.equipment-srd.Cognitive Mutagen (Major)]{Cognitive Mutagen (Major)}</p>\n<p><strong>Implemented effects</strong></p>\n<ul>\n<li>+4 item bonus to Arcana, Crafting, Lore, Occultism and Society checks</li>\n<li>+4 item bonus to all Recall Knowledge checks</li>\n<li>-2 penalty to to Athletics and Acrobatics checks</li>\n<li>-2 penalty to weapon and unarmed attacks</li>\n<li>Treat Recall Knowledge critical failures as failures</li>\n</ul>\n<p><strong>Unimplemented effects</strong></p>\n<ul>\n<li>You can carry 2 less Bulk than normal before becoming encumbered</li>\n<li>The maximum Bulk you can carry is reduced by 4</li>\n</ul>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.equipment-srd.Cognitive Mutagen (Major)]{Cognitive Mutagen (Major)}</p>\n<p><strong>Implemented effects</strong></p>\n<ul>\n<li>+4 item bonus to Arcana, Crafting, Lore, Occultism and Society checks</li>\n<li>+4 item bonus to all Recall Knowledge checks</li>\n<li>-2 penalty to to Athletics and Acrobatics checks</li>\n<li>-2 penalty to weapon and unarmed attacks</li>\n<li>Treat Recall Knowledge critical failures as failures</li>\n<li>You can carry 2 less Bulk than normal before becoming encumbered</li>\n<li>The maximum Bulk you can carry is reduced by 4</li>\n</ul>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -56,6 +56,18 @@
                 ],
                 "selector": "skill-check",
                 "type": "skill"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "subtract",
+                "path": "system.attributes.bonusEncumbranceBulk",
+                "value": 2
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "subtract",
+                "path": "system.attributes.bonusEncumbranceBulk",
+                "value": 4
             }
         ],
         "source": {

--- a/packs/data/equipment-effects.db/effect-cognitive-mutagen-moderate.json
+++ b/packs/data/equipment-effects.db/effect-cognitive-mutagen-moderate.json
@@ -4,7 +4,7 @@
     "name": "Effect: Cognitive Mutagen (Moderate)",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.equipment-srd.Cognitive Mutagen (Moderate)]{Cognitive Mutagen (Moderate)}</p>\n<p><strong>Implemented effects</strong></p>\n<ul>\n<li>+2 item bonus to Arcana, Crafting, Lore, Occultism and Society checks</li>\n<li>+2 item bonus to all Recall Knowledge checks</li>\n<li>-2 penalty to to Athletics and Acrobatics checks</li>\n<li>-2 penalty to weapon and unarmed attacks</li>\n<li>Treat Recall Knowledge critical failures as failures</li>\n</ul>\n<p><strong>Unimplemented effects</strong></p>\n<ul>\n<li>You can carry 2 less Bulk than normal before becoming encumbered</li>\n<li>The maximum Bulk you can carry is reduced by 4</li>\n</ul>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.equipment-srd.Cognitive Mutagen (Moderate)]{Cognitive Mutagen (Moderate)}</p>\n<p><strong>Implemented effects</strong></p>\n<ul>\n<li>+2 item bonus to Arcana, Crafting, Lore, Occultism and Society checks</li>\n<li>+2 item bonus to all Recall Knowledge checks</li>\n<li>-2 penalty to to Athletics and Acrobatics checks</li>\n<li>-2 penalty to weapon and unarmed attacks</li>\n<li>Treat Recall Knowledge critical failures as failures</li>\n<li>You can carry 2 less Bulk than normal before becoming encumbered</li>\n<li>The maximum Bulk you can carry is reduced by 4</li>\n</ul>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -56,6 +56,18 @@
                 ],
                 "selector": "skill-check",
                 "type": "skill"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "subtract",
+                "path": "system.attributes.bonusEncumbranceBulk",
+                "value": 2
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "subtract",
+                "path": "system.attributes.bonusLimitBulk",
+                "value": 4
             }
         ],
         "source": {


### PR DESCRIPTION
This implements the drawbacks for all 4 versions of the Cognitive Mutagen. -2 to the encumbrance limit, and -4 to the max bulk.