### PR TITLE
Hide NPC names on Loot Sheets

### DIFF
--- a/src/module/actor/npc/sheet.ts
+++ b/src/module/actor/npc/sheet.ts
@@ -62,7 +62,10 @@ class NPCSheetPF2e<TActor extends NPCPF2e> extends CreatureSheetPF2e<TActor> {
     /** Use the token name as the title if showing a lootable NPC sheet */
     override get title(): string {
         if (this.isLootSheet || this.actor.limited) {
-            const actorName = this.token?.name ?? this.actor.name;
+            const tokenSetsNameVisibility = game.settings.get("pf2e", "metagame_tokenSetsNameVisibility");
+            const canSeeName = tokenSetsNameVisibility && !this.token?.playersCanSeeName;
+            const actorName = canSeeName ? "" : this.token?.name ?? this.actor.name;
+
             if (this.actor.isDead) {
                 return `${actorName} [${game.i18n.localize("PF2E.NPC.Dead")}]`;
             } else {

--- a/src/module/actor/npc/sheet.ts
+++ b/src/module/actor/npc/sheet.ts
@@ -63,8 +63,8 @@ class NPCSheetPF2e<TActor extends NPCPF2e> extends CreatureSheetPF2e<TActor> {
     override get title(): string {
         if (this.isLootSheet || this.actor.limited) {
             const tokenSetsNameVisibility = game.settings.get("pf2e", "metagame_tokenSetsNameVisibility");
-            const canSeeName = tokenSetsNameVisibility && !this.token?.playersCanSeeName;
-            const actorName = canSeeName ? "" : this.token?.name ?? this.actor.name;
+            const canSeeName = !tokenSetsNameVisibility || !this.token || this.token.playersCanSeeName;
+            const actorName = canSeeName ? this.token?.name ?? this.actor.name : "";
 
             if (this.actor.isDead) {
                 return `${actorName} [${game.i18n.localize("PF2E.NPC.Dead")}]`;


### PR DESCRIPTION
This PR addresses #7425. It removes the token name from the title of a loot sheet when the user cannot see the token's name.