### PR TITLE
Fix Hazard Source in Compendium Browser

### DIFF
--- a/src/module/apps/compendium-browser/tabs/hazard.ts
+++ b/src/module/apps/compendium-browser/tabs/hazard.ts
@@ -27,7 +27,7 @@ export class CompendiumBrowserHazardTab extends CompendiumBrowserTab {
 
         const hazardActors: CompendiumBrowserIndexData[] = [];
         const sources: Set<string> = new Set();
-        const indexFields = [...this.index, "system.details.alignment.value", "system.details.source.value"];
+        const indexFields = [...this.index, "system.details.alignment.value", "system.source.value"];
 
         for await (const { pack, index } of this.browser.packLoader.loadPacks(
             "Actor",
@@ -44,12 +44,12 @@ export class CompendiumBrowserHazardTab extends CompendiumBrowserTab {
                         continue;
                     }
                     // Prepare source
-                    const source = actorData.system.details.source?.value;
+                    const source = actorData.system.source?.value;
                     if (source) {
                         sources.add(source);
-                        actorData.system.details.source.value = sluggify(source);
+                        actorData.system.source.value = sluggify(source);
                     } else {
-                        actorData.system.details.source = { value: "" };
+                        actorData.system.source = { value: "" };
                     }
 
                     hazardActors.push({
@@ -61,7 +61,7 @@ export class CompendiumBrowserHazardTab extends CompendiumBrowserTab {
                         complexity: actorData.system.details.isComplex ? "complex" : "simple",
                         traits: actorData.system.traits.value,
                         rarity: actorData.system.traits.rarity,
-                        source: actorData.system.details.source.value,
+                        source: actorData.system.source.value,
                     });
                 }
             }


### PR DESCRIPTION
The field for the source filter of hazards in the compendium browser seemed to point to the wrong field, which resulted in the filter not being populated. It did use `system.details.source.value`, but it seems that the source is actually stored in `system.source.value`. 

Also mentioned in #6588