### PR TITLE
Refactor spells to use regular damage pipeline

### DIFF
--- a/src/module/item/melee/document.ts
+++ b/src/module/item/melee/document.ts
@@ -3,7 +3,7 @@ import { ActorPF2e } from "@actor";
 import { ItemSummaryData } from "@item/data/index.ts";
 import { ItemPF2e, WeaponPF2e } from "@item";
 import { BaseWeaponType, WeaponCategory, WeaponGroup, WeaponRangeIncrement } from "@item/weapon/types.ts";
-import { combineTerms } from "@scripts/dice.ts";
+import { simplifyFormula } from "@scripts/dice.ts";
 import { DamageCategorization } from "@system/damage/helpers.ts";
 import { ConvertedNPCDamage, WeaponDamagePF2e } from "@system/damage/weapon.ts";
 import { tupleHasValue } from "@util";
@@ -147,7 +147,7 @@ class MeleePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
             const { isElite, isWeak } = this.actor;
             if ((isElite || isWeak) && damageInstances.indexOf(instance) === 0) {
                 const adjustment = isElite ? 2 : -2;
-                instance.damage = combineTerms(`${instance.damage} + ${adjustment}`);
+                instance.damage = simplifyFormula(`${instance.damage} + ${adjustment}`);
             } else {
                 instance.damage = new Roll(instance.damage)._formula;
             }

--- a/src/module/item/spell/helpers.ts
+++ b/src/module/item/spell/helpers.ts
@@ -1,73 +1,28 @@
-import { DamageDicePF2e, ModifierPF2e } from "@actor/modifiers.ts";
-import { combineTerms } from "@scripts/dice.ts";
-import { DamageType } from "@system/damage/index.ts";
+import { DamageDicePF2e } from "@actor/modifiers.ts";
+import { DamagePartialTerm, DynamicBaseDamageData } from "@system/damage/index.ts";
 
-/** Contains the formula and all modifiers that apply to the instance */
-interface DamageInstancePartial {
-    formula: string;
-    damageType: DamageType;
-    damageCategory: string | null;
-
-    /** Additional damage tags such as silver or orichalcum */
-    tags: Set<string>;
-
-    /** Tracks which modifiers added to this instance */
-    modifiers: ModifierPF2e[];
-    dice: DamageDicePF2e[];
-}
+type RequiredNonNullable<T, K extends keyof T> = T & { [P in K]-?: NonNullable<T[P]> };
 
 /** Apply damage dice to a spell's damage formulas */
-function applyDamageDiceOverrides(formulas: DamageInstancePartial[], dice: DamageDicePF2e[]): void {
-    const activeAdjustments = dice.filter((d) => !d.ignored);
-    for (const data of formulas) {
-        const roll = new Roll(data.formula);
-        for (const adjustment of activeAdjustments) {
-            const die = roll.dice.shift();
-            if (!(die instanceof Die)) continue;
+function applyDamageDiceOverrides(base: DynamicBaseDamageData[], dice: DamageDicePF2e[]): void {
+    const overrideDice = dice.filter(
+        (d): d is RequiredNonNullable<DamageDicePF2e, "override"> => !d.ignored && !!d.override
+    );
 
-            if (adjustment.override) {
-                die.number = adjustment.override.diceNumber ?? die.number;
-                if (adjustment.override.dieSize) {
-                    const faces = Number(/\d{1,2}/.exec(adjustment.override.dieSize)?.shift());
-                    if (Number.isInteger(faces)) die.faces = faces;
-                }
+    if (!overrideDice.length) return;
+
+    for (const data of base) {
+        for (const adjustment of overrideDice) {
+            const die = data.terms.find((t): t is RequiredNonNullable<DamagePartialTerm, "dice"> => !!t.dice);
+            if (!die) continue;
+
+            die.dice.number = adjustment.override.diceNumber ?? die.dice.number;
+            if (adjustment.override.dieSize) {
+                const faces = Number(/\d{1,2}/.exec(adjustment.override.dieSize)?.shift());
+                if (Number.isInteger(faces)) die.dice.faces = faces;
             }
         }
-
-        data.formula = roll.formula;
     }
 }
 
-interface FormulaAndTags {
-    formula: string;
-    breakdownTags: string[];
-}
-
-/** Creates the formula and the breakdown tags for the instance partial data */
-function createFormulaAndTagsForPartial(data: DamageInstancePartial, typeLabel?: string | null): FormulaAndTags {
-    const nonAdjustingDice = data.dice.filter((dice) => !dice.override && !dice.ignored);
-    const formulaPartials = [
-        data.modifiers.map((m) => String(m.modifier)),
-        nonAdjustingDice.map((dice) => `${dice.diceNumber}${dice.dieSize}`),
-    ].flat();
-
-    const breakdownTags = [
-        data.modifiers.map((m) => `${m.label} ${m.modifier < 0 ? "" : "+"}${m.modifier}`),
-        nonAdjustingDice.map((d) => `${d.label} +${d.diceNumber}${d.dieSize}`),
-    ].flat();
-
-    if (data.formula !== "0" || !formulaPartials.length) {
-        formulaPartials.unshift(data.formula);
-        breakdownTags.unshift(data.formula);
-    }
-
-    // first breakdown gets the type label (damage type + category)
-    if (typeLabel) {
-        breakdownTags[0] = breakdownTags[0] + ` ${typeLabel}`;
-    }
-
-    const formula = combineTerms(formulaPartials.join(" + "));
-    return { formula, breakdownTags };
-}
-
-export { DamageInstancePartial, applyDamageDiceOverrides, createFormulaAndTagsForPartial };
+export { applyDamageDiceOverrides };

--- a/src/module/item/spell/index.ts
+++ b/src/module/item/spell/index.ts
@@ -1,6 +1,5 @@
 export * from "./data.ts";
 export * from "./document.ts";
-export * from "./helpers.ts";
 export * from "./overlay.ts";
 export * from "./sheet.ts";
 export * from "./types.ts";

--- a/src/module/system/damage/formula.ts
+++ b/src/module/system/damage/formula.ts
@@ -5,6 +5,7 @@ import {
     CriticalInclusion,
     DamageCategoryUnique,
     DamageFormulaData,
+    DamagePartialTerm,
     DamageType,
     MaterialDamageEffect,
 } from "./types.ts";
@@ -40,45 +41,57 @@ function createDamageFormula(
     }
 
     const critical = degree === DEGREE_OF_SUCCESS.CRITICAL_SUCCESS;
-    const { base } = damage;
+    const base = Array.isArray(damage.base) ? damage.base : [damage.base];
+    if (!base.length) {
+        return null;
+    }
 
     // Group dice by damage type
     const typeMap: DamageTypeMap = new Map();
-    if ((base.diceNumber && base.dieSize) || base.modifier) {
-        const label = (() => {
-            const diceSection = base.diceNumber ? `${base.diceNumber}${base.dieSize}` : null;
-            if (!diceSection) return String(base.modifier);
+    for (const baseEntry of base) {
+        const list = typeMap.get(baseEntry.damageType) ?? [];
+        typeMap.set(baseEntry.damageType, list);
 
-            const modifier = base.modifier ? Math.abs(base.modifier) : null;
-            const operator = base.modifier < 0 ? " - " : " + ";
-            return [diceSection, modifier].filter((p) => p !== null).join(operator);
-        })();
+        if ("terms" in baseEntry) {
+            list.push(...baseEntry.terms.map((t) => ({ ...baseEntry, ...t, label: null, critical: null })));
+        } else if ((baseEntry.diceNumber && baseEntry.dieSize) || baseEntry.modifier) {
+            const { diceNumber, dieSize, modifier, damageType } = baseEntry;
+            const label = (() => {
+                const diceSection = diceNumber ? `${diceNumber}${dieSize}` : null;
+                if (!diceSection) return String(modifier);
 
-        typeMap.set(base.damageType, [
-            {
+                const displayedModifier = modifier ? Math.abs(modifier) : null;
+                const operator = modifier < 0 ? " - " : " + ";
+                return [diceSection, displayedModifier].filter((p) => p !== null).join(operator);
+            })();
+
+            list.push({
                 label,
-                dice:
-                    base.diceNumber && base.dieSize
-                        ? { number: base.diceNumber, faces: Number(base.dieSize.replace("d", "")) }
-                        : null,
-                modifier: base.modifier ?? 0,
+                dice: diceNumber && dieSize ? { number: diceNumber, faces: Number(dieSize.replace("d", "")) } : null,
+                modifier: modifier ?? 0,
                 critical: null,
-                category: base.category,
-                materials: base.materials ?? [],
-            },
-        ]);
+                damageType,
+                category: baseEntry.category,
+                materials: baseEntry.materials ?? [],
+            });
+        }
     }
+
+    // Hold onto base terms for matching reasons (such as adding extra base dice)
+    const baseTerms = [...typeMap.values()].flat();
 
     // Dice always stack
     for (const dice of damage.dice.filter((d) => d.enabled)) {
-        const dieSize = dice.dieSize || base.dieSize || null;
-        if (dice.diceNumber > 0 && dieSize) {
-            const damageType = dice.damageType ?? base.damageType;
+        const damageType = dice.damageType ?? baseTerms[0].damageType;
+        const matchingBase = baseTerms.find((b) => b.damageType === dice.damageType) ?? baseTerms[0];
+        const faces = Number(dice.dieSize?.replace("d", "")) || matchingBase.dice?.faces || null;
+        if (dice.diceNumber > 0 && faces) {
             const list = typeMap.get(damageType) ?? [];
             list.push({
                 label: dice.label,
-                dice: { number: dice.diceNumber, faces: Number(dieSize.replace("d", "")) },
+                dice: { number: dice.diceNumber, faces },
                 modifier: 0,
+                damageType,
                 category: dice.category,
                 critical: dice.critical,
             });
@@ -92,17 +105,18 @@ function createDamageFormula(
     const modifiers = damage.modifiers
         .filter((m) => m.enabled)
         .flatMap((modifier): ModifierPF2e | never[] => {
-            modifier.damageType ??= base.damageType;
+            modifier.damageType ??= base[0].damageType;
             return outcomeMatches(modifier) ? modifier : [];
         });
 
     for (const modifier of modifiers) {
-        const damageType = modifier.damageType ?? base.damageType;
+        const damageType = modifier.damageType ?? base[0].damageType;
         const list = typeMap.get(damageType) ?? [];
         list.push({
             label: `${modifier.label} ${modifier.value < 0 ? "" : "+"}${modifier.value}`,
             dice: null,
             modifier: modifier.value,
+            damageType,
             category: modifier.damageCategory,
             critical: modifier.critical,
         });
@@ -167,8 +181,23 @@ function instancesFromTypeMap(
         })();
 
         const breakdown = (() => {
+            type DamagePartialWithLabel = DamagePartial & { label: string };
+
             const categories = [null, "persistent", "precision", "splash"] as const;
-            const flattenedDamage = categories.flatMap((c) => groups.get(c) ?? []);
+            const flattenedDamage = categories.flatMap((c) => {
+                const partials = groups.get(c) ?? [];
+                const breakdownDamage = partials.filter((e): e is DamagePartialWithLabel => e.label !== null);
+
+                // Null labels are assumed to be base damage. Combine them and create a single tag.
+                const unlabeled = partials.filter((e) => e.label === null);
+                if (unlabeled.length) {
+                    const append = c === "splash" ? ` ${game.i18n.localize("PF2E.Damage.RollFlavor.splash")}` : "";
+                    const label = createSimpleFormula(unlabeled) + append;
+                    breakdownDamage.splice(0, 0, { ...unlabeled[0], label });
+                }
+
+                return breakdownDamage;
+            });
             const breakdownDamage = flattenedDamage.filter((d) => d.critical !== true);
             if (degree === DEGREE_OF_SUCCESS.CRITICAL_SUCCESS) {
                 breakdownDamage.push(...flattenedDamage.filter((d) => d.critical === true));
@@ -176,6 +205,7 @@ function instancesFromTypeMap(
 
             if (!breakdownDamage.length) return [];
 
+            // Gather label values and assign a damage type string to the first label in the list
             const damageTypeLabel =
                 breakdownDamage[0].category === "persistent"
                     ? game.i18n.format("PF2E.Damage.PersistentTooltip", {
@@ -201,7 +231,7 @@ function createPartialFormulas(
     return categories.flatMap((category) => {
         const requestedPartials = (partials.get(category) ?? []).filter((p) => criticalInclusion.includes(p.critical));
         const term = ((): string => {
-            const expression = combinePartialTerms(requestedPartials, { doubleDice });
+            const expression = createSimpleFormula(requestedPartials, { doubleDice });
             return ["precision", "splash"].includes(category ?? "") && hasOperators(expression)
                 ? `(${expression})`
                 : expression;
@@ -212,22 +242,33 @@ function createPartialFormulas(
     });
 }
 
-/** Combines damage dice and modifiers into a single formula, ignoring the damage type and category. */
-function combinePartialTerms(terms: DamagePartialTerm[], { doubleDice }: { doubleDice?: boolean } = {}): string {
-    const constant = terms.reduce((total, p) => total + p.modifier, 0);
+/** Combines damage dice and modifiers into a simplified list of terms */
+function combinePartialTerms(terms: DamagePartialTerm[]): DamagePartialTerm[] {
+    const modifier = terms.reduce((total, p) => total + p.modifier, 0);
+    const constantTerm: DamagePartialTerm | null = modifier ? { dice: null, modifier } : null;
 
     // Group dice by number of faces
     const dice = terms
         .filter((p): p is DamagePartial & { dice: NonNullable<DamagePartial["dice"]> } => !!p.dice && p.dice.number > 0)
         .sort(sortBy((t) => -t.dice.faces));
 
-    // Combine dice into dice-expression strings
     const byFace = [...groupBy(dice, (t) => t.dice.faces).values()];
     const combinedDice = byFace.map((terms) => ({
-        ...terms[0],
+        modifier: 0,
         dice: { ...terms[0].dice, number: sum(terms.map((d) => d.dice.number)) },
     }));
-    const positiveDice = combinedDice.filter((t) => t.dice.number > 0);
+
+    return [...combinedDice, constantTerm].filter((t): t is DamagePartialTerm => !!t);
+}
+
+/** Combines damage dice and modifiers into a single formula, ignoring the damage type and category. */
+function createSimpleFormula(terms: DamagePartialTerm[], { doubleDice }: { doubleDice?: boolean } = {}): string {
+    terms = combinePartialTerms(terms);
+    const constant = terms.find((t) => !!t.modifier)?.modifier ?? 0;
+    const positiveDice = terms.filter(
+        (t): t is DamagePartial & { dice: NonNullable<DamagePartial["dice"]> } => !!t.dice && t.dice.number > 0
+    );
+
     const diceTerms = positiveDice.map((term) => {
         const number = doubleDice ? term.dice.number * 2 : term.dice.number;
         const faces = term.dice.faces;
@@ -245,8 +286,11 @@ function combinePartialTerms(terms: DamagePartialTerm[], { doubleDice }: { doubl
  * Given a simple flavor-less formula with only +/- operators, returns a list of damage partial terms.
  * All subtracted terms become negative terms.
  */
-function parseTermsFromSimpleFormula(formula: string | Roll): DamagePartialTerm[] {
-    const roll = formula instanceof Roll ? formula : new Roll(formula);
+function parseTermsFromSimpleFormula(
+    formula: string | Roll,
+    options?: { rollData: Record<string, unknown> }
+): DamagePartialTerm[] {
+    const roll = formula instanceof Roll ? formula : new Roll(formula, options?.rollData);
 
     // Parse from right to left so that when we hit an operator, we already have the term.
     return roll.terms.reduceRight((result, term) => {
@@ -304,19 +348,13 @@ function ensureValidFormulaHead(formula: string | null): string | null {
 /** A pool of damage dice & modifiers, grouped by damage type. */
 type DamageTypeMap = Map<DamageType, DamagePartial[]>;
 
-interface DamagePartialTerm {
-    /** The static amount of damage of the current damage type and category. */
-    modifier: number;
-    /** Maps the die face ("d4", "d6", "d8", "d10", "d12") to the number of dice of that type. */
-    dice: { number: number; faces: number } | null;
-}
-
 interface DamagePartial extends DamagePartialTerm {
-    /** Used to create the corresponding breakdown tag */
-    label: string;
+    /** Used to create the corresponding breakdown tag, if null it will be auto generated */
+    label: string | null;
+    damageType: DamageType;
     category: DamageCategoryUnique | null;
     critical: boolean | null;
     materials?: MaterialDamageEffect[];
 }
 
-export { AssembledFormula, DamagePartialTerm, combinePartialTerms, createDamageFormula, parseTermsFromSimpleFormula };
+export { AssembledFormula, combinePartialTerms, createSimpleFormula, createDamageFormula, parseTermsFromSimpleFormula };

--- a/src/module/system/damage/types.ts
+++ b/src/module/system/damage/types.ts
@@ -55,10 +55,14 @@ interface DamageRollContext extends BaseRollContext {
 }
 
 interface DamageFormulaData {
-    base: BasicDamageData;
+    base: BaseDamageData | BaseDamageData[];
     dice: DamageDicePF2e[];
     modifiers: ModifierPF2e[];
     ignoredResistances: { type: ResistanceType; max: number | null }[];
+}
+
+interface WeaponDamageFormulaData extends Omit<DamageFormulaData, "base"> {
+    base: WeaponBaseDamageData;
 }
 
 interface ResolvedDamageFormulaData extends DamageFormulaData {
@@ -66,7 +70,14 @@ interface ResolvedDamageFormulaData extends DamageFormulaData {
     breakdown: Record<DegreeOfSuccessString, string[]>;
 }
 
-interface BasicDamageData {
+interface DamagePartialTerm {
+    /** The static amount of damage of the current damage type and category. */
+    modifier: number;
+    /** Maps the die face ("d4", "d6", "d8", "d10", "d12") to the number of dice of that type. */
+    dice: { number: number; faces: number } | null;
+}
+
+interface WeaponBaseDamageData {
     damageType: DamageType;
     diceNumber: number;
     dieSize: DamageDieSize | null;
@@ -74,6 +85,15 @@ interface BasicDamageData {
     category: DamageCategoryUnique | null;
     materials?: MaterialDamageEffect[];
 }
+
+interface DynamicBaseDamageData {
+    terms: DamagePartialTerm[];
+    damageType: DamageType;
+    category: DamageCategoryUnique | null;
+    materials?: MaterialDamageEffect[];
+}
+
+type BaseDamageData = WeaponBaseDamageData | DynamicBaseDamageData;
 
 interface BaseDamageTemplate {
     name: string;
@@ -98,18 +118,22 @@ interface SpellDamageTemplate extends BaseDamageTemplate {
 type DamageTemplate = WeaponDamageTemplate | SpellDamageTemplate;
 
 export {
+    BaseDamageData,
     CriticalInclusion,
     DamageCategory,
     DamageCategoryRenderData,
     DamageCategoryUnique,
     DamageDieSize,
     DamageFormulaData,
+    DamagePartialTerm,
     DamageRollContext,
     DamageRollRenderData,
     DamageTemplate,
     DamageType,
     DamageTypeRenderData,
+    DynamicBaseDamageData,
     MaterialDamageEffect,
     SpellDamageTemplate,
+    WeaponDamageFormulaData,
     WeaponDamageTemplate,
 };

--- a/src/module/system/damage/weapon.ts
+++ b/src/module/system/damage/weapon.ts
@@ -31,9 +31,9 @@ import { DamageModifierDialog } from "./modifier-dialog.ts";
 import {
     DamageCategoryUnique,
     DamageDieSize,
-    DamageFormulaData,
     DamageRollContext,
     MaterialDamageEffect,
+    WeaponDamageFormulaData,
     WeaponDamageTemplate,
 } from "./types.ts";
 
@@ -492,7 +492,7 @@ class WeaponDamagePF2e {
             })
         );
 
-        const damage: DamageFormulaData = {
+        const damage: WeaponDamageFormulaData = {
             base: {
                 diceNumber: baseDamage.die ? baseDamage.dice : 0,
                 dieSize: baseDamage.die,
@@ -571,12 +571,12 @@ class WeaponDamagePF2e {
 
     /** Apply damage dice overrides and create a damage formula */
     static #finalizeDamage(
-        damage: DamageFormulaData,
+        damage: WeaponDamageFormulaData,
         degree: (typeof DEGREE_OF_SUCCESS)["SUCCESS" | "CRITICAL_SUCCESS"]
     ): AssembledFormula;
-    static #finalizeDamage(damage: DamageFormulaData, degree: typeof DEGREE_OF_SUCCESS.CRITICAL_FAILURE): null;
-    static #finalizeDamage(damage: DamageFormulaData, degree?: DegreeOfSuccessIndex): AssembledFormula | null;
-    static #finalizeDamage(damage: DamageFormulaData, degree: DegreeOfSuccessIndex): AssembledFormula | null {
+    static #finalizeDamage(damage: WeaponDamageFormulaData, degree: typeof DEGREE_OF_SUCCESS.CRITICAL_FAILURE): null;
+    static #finalizeDamage(damage: WeaponDamageFormulaData, degree?: DegreeOfSuccessIndex): AssembledFormula | null;
+    static #finalizeDamage(damage: WeaponDamageFormulaData, degree: DegreeOfSuccessIndex): AssembledFormula | null {
         damage = deepClone(damage);
         const { base } = damage;
         const critical = degree === DEGREE_OF_SUCCESS.CRITICAL_SUCCESS;

--- a/src/scripts/dice.ts
+++ b/src/scripts/dice.ts
@@ -1,6 +1,6 @@
 import { ActorPF2e } from "@actor";
 import { ItemPF2e } from "@item";
-import { combinePartialTerms, parseTermsFromSimpleFormula } from "@system/damage/formula.ts";
+import { createSimpleFormula, parseTermsFromSimpleFormula } from "@system/damage/formula.ts";
 import { ErrorPF2e } from "@util";
 
 /**
@@ -196,7 +196,7 @@ class DicePF2e {
  * Combines dice and flat values together in a condensed expression. Also repairs any + - and "- 3" errors.
  * For example, 3d4 + 2d4 + 3d6 + 5 + 2 is combined into 5d4 + 3d6 + 7. - 4 is corrected to -4.
  */
-function combineTerms(formula: string): string {
+function simplifyFormula(formula: string): string {
     if (formula === "0") return formula;
 
     const fixedFormula = formula.replace(/^\s*-\s+/, "-").replace(/\s*\+\s*-\s*/g, " - ");
@@ -209,7 +209,7 @@ function combineTerms(formula: string): string {
     }
 
     const terms = parseTermsFromSimpleFormula(roll);
-    return combinePartialTerms(terms);
+    return createSimpleFormula(terms);
 }
 
-export { DicePF2e, combineTerms };
+export { DicePF2e, simplifyFormula };


### PR DESCRIPTION
Enables the ability to add damage dice to spells. Also sneaky fix so that elite only applies to the first instance of damage.