### PR TITLE
Fix damage on Eidolon breath weapons

### DIFF
--- a/packs/data/actions.db/breath-weapon-acid-cone.json
+++ b/packs/data/actions.db/breath-weapon-acid-cone.json
@@ -13,7 +13,7 @@
             "value": 2
         },
         "description": {
-            "value": "<p>Your eidolon exhales a blast of destructive energy. Your eidolon deals [[/r 1d6[acid]]] damage to all creatures in a @Template[type:cone|distance:30], with a basic Reflex save against your spell DC.</p>\n<p>Your eidolon then can't use their Breath Weapon again for the next [[/r 1d4 #rounds]]{1d4 rounds}.</p>\n<p>At 3rd level and every 2 levels thereafter, the damage increases by 1d6. [[/r ((floor(@actor.level/2))d6)[acid]]]{Leveled Damage}</p>"
+            "value": "<p>Your eidolon exhales a blast of destructive energy. Your eidolon deals [[/r 1d6[acid]]] damage to all creatures in a @Template[type:cone|distance:30], with a basic Reflex save against your spell DC.</p>\n<p>Your eidolon then can't use their Breath Weapon again for the next [[/r 1d4 #rounds]]{1d4 rounds}.</p>\n<p>At 3rd level and every 2 levels thereafter, the damage increases by 1d6. [[/r ((ceil(@actor.level/2))d6)[acid]]]{Leveled Damage}</p>"
         },
         "requirements": {
             "value": ""

--- a/packs/data/actions.db/breath-weapon-acid-line.json
+++ b/packs/data/actions.db/breath-weapon-acid-line.json
@@ -13,7 +13,7 @@
             "value": 2
         },
         "description": {
-            "value": "<p>Your eidolon exhales a blast of destructive energy. Your eidolon deals [[/r 1d6[acid]]] damage to all creatures in a @Template[type:line|distance:60], with a basic Reflex save against your spell DC.</p>\n<p>Your eidolon then can't use their Breath Weapon again for the next [[/r 1d4 #rounds]]{1d4 rounds}.</p>\n<p>At 3rd level and every 2 levels thereafter, the damage increases by 1d6. [[/r ((floor(@actor.level/2))d6)[acid]]]{Leveled Damage}</p>"
+            "value": "<p>Your eidolon exhales a blast of destructive energy. Your eidolon deals [[/r 1d6[acid]]] damage to all creatures in a @Template[type:line|distance:60], with a basic Reflex save against your spell DC.</p>\n<p>Your eidolon then can't use their Breath Weapon again for the next [[/r 1d4 #rounds]]{1d4 rounds}.</p>\n<p>At 3rd level and every 2 levels thereafter, the damage increases by 1d6. [[/r ((ceil(@actor.level/2))d6)[acid]]]{Leveled Damage}</p>"
         },
         "requirements": {
             "value": ""

--- a/packs/data/actions.db/breath-weapon-cold-cone.json
+++ b/packs/data/actions.db/breath-weapon-cold-cone.json
@@ -13,7 +13,7 @@
             "value": 2
         },
         "description": {
-            "value": "<p>Your eidolon exhales a blast of destructive energy. Your eidolon deals [[/r 1d6[cold]]] damage to all creatures in a @Template[type:cone|distance:30], with a basic Reflex save against your spell DC.</p>\n<p>Your eidolon then can't use their Breath Weapon again for the next [[/r 1d4 #rounds]]{1d4 rounds}.</p>\n<p>At 3rd level and every 2 levels thereafter, the damage increases by 1d6. [[/r ((floor(@actor.level/2))d6)[cold]]]{Leveled Damage}</p>"
+            "value": "<p>Your eidolon exhales a blast of destructive energy. Your eidolon deals [[/r 1d6[cold]]] damage to all creatures in a @Template[type:cone|distance:30], with a basic Reflex save against your spell DC.</p>\n<p>Your eidolon then can't use their Breath Weapon again for the next [[/r 1d4 #rounds]]{1d4 rounds}.</p>\n<p>At 3rd level and every 2 levels thereafter, the damage increases by 1d6. [[/r ((ceil(@actor.level/2))d6)[cold]]]{Leveled Damage}</p>"
         },
         "requirements": {
             "value": ""

--- a/packs/data/actions.db/breath-weapon-cold-line.json
+++ b/packs/data/actions.db/breath-weapon-cold-line.json
@@ -13,7 +13,7 @@
             "value": 2
         },
         "description": {
-            "value": "<p>Your eidolon exhales a blast of destructive energy. Your eidolon deals [[/r 1d6[cold]]] damage to all creatures in a @Template[type:line|distance:60], with a basic Reflex save against your spell DC.</p>\n<p>Your eidolon then can't use their Breath Weapon again for the next [[/r 1d4 #rounds]]{1d4 rounds}.</p>\n<p>At 3rd level and every 2 levels thereafter, the damage increases by 1d6. [[/r ((floor(@actor.level/2))d6)[cold]]]{Leveled Damage}</p>"
+            "value": "<p>Your eidolon exhales a blast of destructive energy. Your eidolon deals [[/r 1d6[cold]]] damage to all creatures in a @Template[type:line|distance:60], with a basic Reflex save against your spell DC.</p>\n<p>Your eidolon then can't use their Breath Weapon again for the next [[/r 1d4 #rounds]]{1d4 rounds}.</p>\n<p>At 3rd level and every 2 levels thereafter, the damage increases by 1d6. [[/r ((ceil(@actor.level/2))d6)[cold]]]{Leveled Damage}</p>"
         },
         "requirements": {
             "value": ""

--- a/packs/data/actions.db/breath-weapon-electricity-cone.json
+++ b/packs/data/actions.db/breath-weapon-electricity-cone.json
@@ -13,7 +13,7 @@
             "value": 2
         },
         "description": {
-            "value": "<p>Your eidolon exhales a blast of destructive energy. Your eidolon deals [[/r 1d6[electricity]]] damage to all creatures in a @Template[type:cone|distance:30], with a basic Reflex save against your spell DC.</p>\n<p>Your eidolon then can't use their Breath Weapon again for the next [[/r 1d4 #rounds]]{1d4 rounds}.</p>\n<p>At 3rd level and every 2 levels thereafter, the damage increases by 1d6. [[/r ((floor(@actor.level/2))d6)[electricity]]]{Leveled Damage}</p>"
+            "value": "<p>Your eidolon exhales a blast of destructive energy. Your eidolon deals [[/r 1d6[electricity]]] damage to all creatures in a @Template[type:cone|distance:30], with a basic Reflex save against your spell DC.</p>\n<p>Your eidolon then can't use their Breath Weapon again for the next [[/r 1d4 #rounds]]{1d4 rounds}.</p>\n<p>At 3rd level and every 2 levels thereafter, the damage increases by 1d6. [[/r ((ceil(@actor.level/2))d6)[electricity]]]{Leveled Damage}</p>"
         },
         "requirements": {
             "value": ""

--- a/packs/data/actions.db/breath-weapon-electricity-line.json
+++ b/packs/data/actions.db/breath-weapon-electricity-line.json
@@ -13,7 +13,7 @@
             "value": 2
         },
         "description": {
-            "value": "<p>Your eidolon exhales a blast of destructive energy. Your eidolon deals [[/r 1d6[electricity]]] damage to all creatures in a @Template[type:line|distance:60], with a basic Reflex save against your spell DC.</p>\n<p>Your eidolon then can't use their Breath Weapon again for the next [[/r 1d4 #rounds]]{1d4 rounds}.</p>\n<p>At 3rd level and every 2 levels thereafter, the damage increases by 1d6. [[/r ((floor(@actor.level/2))d6)[electricity]]]{Leveled Damage}</p>"
+            "value": "<p>Your eidolon exhales a blast of destructive energy. Your eidolon deals [[/r 1d6[electricity]]] damage to all creatures in a @Template[type:line|distance:60], with a basic Reflex save against your spell DC.</p>\n<p>Your eidolon then can't use their Breath Weapon again for the next [[/r 1d4 #rounds]]{1d4 rounds}.</p>\n<p>At 3rd level and every 2 levels thereafter, the damage increases by 1d6. [[/r ((ceil(@actor.level/2))d6)[electricity]]]{Leveled Damage}</p>"
         },
         "requirements": {
             "value": ""

--- a/packs/data/actions.db/breath-weapon-fire-cone.json
+++ b/packs/data/actions.db/breath-weapon-fire-cone.json
@@ -13,7 +13,7 @@
             "value": 2
         },
         "description": {
-            "value": "<p>Your eidolon exhales a blast of destructive energy. Your eidolon deals [[/r 1d6[fire]]] damage to all creatures in a @Template[type:cone|distance:30], with a basic Reflex save against your spell DC.</p>\n<p>Your eidolon then can't use their Breath Weapon again for the next [[/r 1d4 #rounds]]{1d4 rounds}.</p>\n<p>At 3rd level and every 2 levels thereafter, the damage increases by 1d6. [[/r ((floor(@actor.level/2))d6)[fire]]]{Leveled Damage}</p>"
+            "value": "<p>Your eidolon exhales a blast of destructive energy. Your eidolon deals [[/r 1d6[fire]]] damage to all creatures in a @Template[type:cone|distance:30], with a basic Reflex save against your spell DC.</p>\n<p>Your eidolon then can't use their Breath Weapon again for the next [[/r 1d4 #rounds]]{1d4 rounds}.</p>\n<p>At 3rd level and every 2 levels thereafter, the damage increases by 1d6. [[/r ((ceil(@actor.level/2))d6)[fire]]]{Leveled Damage}</p>"
         },
         "requirements": {
             "value": ""

--- a/packs/data/actions.db/breath-weapon-fire-line.json
+++ b/packs/data/actions.db/breath-weapon-fire-line.json
@@ -13,7 +13,7 @@
             "value": 2
         },
         "description": {
-            "value": "<p>Your eidolon exhales a blast of destructive energy. Your eidolon deals [[/r 1d6[fire]]] damage to all creatures in a @Template[type:line|distance:60], with a basic Reflex save against your spell DC.</p>\n<p>Your eidolon then can't use their Breath Weapon again for the next [[/r 1d4 #rounds]]{1d4 rounds}.</p>\n<p>At 3rd level and every 2 levels thereafter, the damage increases by 1d6. [[/r ((floor(@actor.level/2))d6)[fire]]]{Leveled Damage}</p>"
+            "value": "<p>Your eidolon exhales a blast of destructive energy. Your eidolon deals [[/r 1d6[fire]]] damage to all creatures in a @Template[type:line|distance:60], with a basic Reflex save against your spell DC.</p>\n<p>Your eidolon then can't use their Breath Weapon again for the next [[/r 1d4 #rounds]]{1d4 rounds}.</p>\n<p>At 3rd level and every 2 levels thereafter, the damage increases by 1d6. [[/r ((ceil(@actor.level/2))d6)[fire]]]{Leveled Damage}</p>"
         },
         "requirements": {
             "value": ""

--- a/packs/data/actions.db/breath-weapon-negative-cone.json
+++ b/packs/data/actions.db/breath-weapon-negative-cone.json
@@ -13,7 +13,7 @@
             "value": 2
         },
         "description": {
-            "value": "<p>Your eidolon exhales a blast of destructive energy. Your eidolon deals [[/r 1d6[negative]]] damage to all creatures in a @Template[type:cone|distance:30], with a basic Reflex save against your spell DC.</p>\n<p>Your eidolon then can't use their Breath Weapon again for the next [[/r 1d4 #rounds]]{1d4 rounds}.</p>\n<p>At 3rd level and every 2 levels thereafter, the damage increases by 1d6. [[/r ((floor(@actor.level/2))d6)[negative]]]{Leveled Damage}</p>"
+            "value": "<p>Your eidolon exhales a blast of destructive energy. Your eidolon deals [[/r 1d6[negative]]] damage to all creatures in a @Template[type:cone|distance:30], with a basic Reflex save against your spell DC.</p>\n<p>Your eidolon then can't use their Breath Weapon again for the next [[/r 1d4 #rounds]]{1d4 rounds}.</p>\n<p>At 3rd level and every 2 levels thereafter, the damage increases by 1d6. [[/r ((ceil(@actor.level/2))d6)[negative]]]{Leveled Damage}</p>"
         },
         "requirements": {
             "value": ""

--- a/packs/data/actions.db/breath-weapon-negative-line.json
+++ b/packs/data/actions.db/breath-weapon-negative-line.json
@@ -13,7 +13,7 @@
             "value": 2
         },
         "description": {
-            "value": "<p>Your eidolon exhales a blast of destructive energy. Your eidolon deals [[/r 1d6[negative]]] damage to all creatures in a @Template[type:line|distance:60], with a basic Reflex save against your spell DC.</p>\n<p>Your eidolon then can't use their Breath Weapon again for the next [[/r 1d4 #rounds]]{1d4 rounds}.</p>\n<p>At 3rd level and every 2 levels thereafter, the damage increases by 1d6. [[/r ((floor(@actor.level/2))d6)[negative]]]{Leveled Damage}</p>"
+            "value": "<p>Your eidolon exhales a blast of destructive energy. Your eidolon deals [[/r 1d6[negative]]] damage to all creatures in a @Template[type:line|distance:60], with a basic Reflex save against your spell DC.</p>\n<p>Your eidolon then can't use their Breath Weapon again for the next [[/r 1d4 #rounds]]{1d4 rounds}.</p>\n<p>At 3rd level and every 2 levels thereafter, the damage increases by 1d6. [[/r ((ceil(@actor.level/2))d6)[negative]]]{Leveled Damage}</p>"
         },
         "requirements": {
             "value": ""

--- a/packs/data/actions.db/breath-weapon-piercing-cone.json
+++ b/packs/data/actions.db/breath-weapon-piercing-cone.json
@@ -13,7 +13,7 @@
             "value": 2
         },
         "description": {
-            "value": "<p>Your eidolon exhales a blast of destructive energy. Your eidolon deals [[/r 1d6[piercing]]] damage to all creatures in a @Template[type:cone|distance:30], with a basic Reflex save against your spell DC.</p>\n<p>Your eidolon then can't use their Breath Weapon again for the next [[/r 1d4 #rounds]]{1d4 rounds}.</p>\n<p>At 3rd level and every 2 levels thereafter, the damage increases by 1d6. [[/r ((floor(@actor.level/2))d6)[piercing]]]{Leveled Damage}</p>"
+            "value": "<p>Your eidolon exhales a blast of destructive energy. Your eidolon deals [[/r 1d6[piercing]]] damage to all creatures in a @Template[type:cone|distance:30], with a basic Reflex save against your spell DC.</p>\n<p>Your eidolon then can't use their Breath Weapon again for the next [[/r 1d4 #rounds]]{1d4 rounds}.</p>\n<p>At 3rd level and every 2 levels thereafter, the damage increases by 1d6. [[/r ((ceil(@actor.level/2))d6)[piercing]]]{Leveled Damage}</p>"
         },
         "requirements": {
             "value": ""

--- a/packs/data/actions.db/breath-weapon-piercing-line.json
+++ b/packs/data/actions.db/breath-weapon-piercing-line.json
@@ -13,7 +13,7 @@
             "value": 2
         },
         "description": {
-            "value": "<p>Your eidolon exhales a blast of destructive energy. Your eidolon deals [[/r 1d6[piercing]]] damage to all creatures in a @Template[type:line|distance:60], with a basic Reflex save against your spell DC.</p>\n<p>Your eidolon then can't use their Breath Weapon again for the next [[/r 1d4 #rounds]]{1d4 rounds}.</p>\n<p>At 3rd level and every 2 levels thereafter, the damage increases by 1d6. [[/r ((floor(@actor.level/2))d6)[piercing]]]{Leveled Damage}</p>"
+            "value": "<p>Your eidolon exhales a blast of destructive energy. Your eidolon deals [[/r 1d6[piercing]]] damage to all creatures in a @Template[type:line|distance:60], with a basic Reflex save against your spell DC.</p>\n<p>Your eidolon then can't use their Breath Weapon again for the next [[/r 1d4 #rounds]]{1d4 rounds}.</p>\n<p>At 3rd level and every 2 levels thereafter, the damage increases by 1d6. [[/r ((ceil(@actor.level/2))d6)[piercing]]]{Leveled Damage}</p>"
         },
         "requirements": {
             "value": ""

--- a/packs/data/actions.db/breath-weapon-poison-cone.json
+++ b/packs/data/actions.db/breath-weapon-poison-cone.json
@@ -13,7 +13,7 @@
             "value": 2
         },
         "description": {
-            "value": "<p>Your eidolon exhales a blast of destructive energy. Your eidolon deals [[/r 1d6[poison]]] damage to all creatures in a @Template[type:cone|distance:30], with a basic Reflex save against your spell DC.</p>\n<p>Your eidolon then can't use their Breath Weapon again for the next [[/r 1d4 #rounds]]{1d4 rounds}.</p>\n<p>At 3rd level and every 2 levels thereafter, the damage increases by 1d6. [[/r ((floor(@actor.level/2))d6)[poison]]]{Leveled Damage}</p>"
+            "value": "<p>Your eidolon exhales a blast of destructive energy. Your eidolon deals [[/r 1d6[poison]]] damage to all creatures in a @Template[type:cone|distance:30], with a basic Reflex save against your spell DC.</p>\n<p>Your eidolon then can't use their Breath Weapon again for the next [[/r 1d4 #rounds]]{1d4 rounds}.</p>\n<p>At 3rd level and every 2 levels thereafter, the damage increases by 1d6. [[/r ((ceil(@actor.level/2))d6)[poison]]]{Leveled Damage}</p>"
         },
         "requirements": {
             "value": ""

--- a/packs/data/actions.db/breath-weapon-poison-line.json
+++ b/packs/data/actions.db/breath-weapon-poison-line.json
@@ -13,7 +13,7 @@
             "value": 2
         },
         "description": {
-            "value": "<p>Your eidolon exhales a blast of destructive energy. Your eidolon deals [[/r 1d6[poison]]] damage to all creatures in a @Template[type:line|distance:60], with a basic Reflex save against your spell DC.</p>\n<p>Your eidolon then can't use their Breath Weapon again for the next [[/r 1d4 #rounds]]{1d4 rounds}.</p>\n<p>At 3rd level and every 2 levels thereafter, the damage increases by 1d6. [[/r ((floor(@actor.level/2))d6)[poison]]]{Leveled Damage}</p>"
+            "value": "<p>Your eidolon exhales a blast of destructive energy. Your eidolon deals [[/r 1d6[poison]]] damage to all creatures in a @Template[type:line|distance:60], with a basic Reflex save against your spell DC.</p>\n<p>Your eidolon then can't use their Breath Weapon again for the next [[/r 1d4 #rounds]]{1d4 rounds}.</p>\n<p>At 3rd level and every 2 levels thereafter, the damage increases by 1d6. [[/r ((ceil(@actor.level/2))d6)[poison]]]{Leveled Damage}</p>"
         },
         "requirements": {
             "value": ""


### PR DESCRIPTION
Fix the damage on the dragon eidolon's breath weapons by changing `floor` to `ceil` in the damage roll.