### PR TITLE
Fix for hazard sheet after migrated source data

### DIFF
--- a/static/templates/actors/hazard/sheet.hbs
+++ b/static/templates/actors/hazard/sheet.hbs
@@ -168,9 +168,9 @@
             <div class="source section-container headerless">
                 <div class="section-body flexrow">
                     <label>{{localize "PF2E.Source.Label"}}:</label>
-                    <input class="source-input" name="system.details.source.value" type="text" value="{{data.source.value}}" placeholder="{{localize "PF2E.Source.SourcePlaceholder"}}" />
+                    <input class="source-input" name="system.details.source.value" type="text" value="{{data.details.source.value}}" placeholder="{{localize "PF2E.Source.SourcePlaceholder"}}" />
                     <label>{{localize "PF2E.Source.AuthorLabel"}}:</label>
-                    <input name="system.details.source.author" type="text" value="{{data.source.author}}" placeholder="{{localize "PF2E.Source.AuthorPlaceholder"}}" />
+                    <input name="system.details.source.author" type="text" value="{{data.details.source.author}}" placeholder="{{localize "PF2E.Source.AuthorPlaceholder"}}" />
                 </div>
             </div>
         </section>


### PR DESCRIPTION
Hazard sheet did still use the old `system.source` instead of `system.details.source`for the value of the input fields. This results in empty values shown in the fields, and also can overwrite the existing data with those empty values.