### PR TITLE
Fix Advanced Undead Benefits

### DIFF
--- a/packs/data/ancestryfeatures.db/advanced-undead-benefits.json
+++ b/packs/data/ancestryfeatures.db/advanced-undead-benefits.json
@@ -53,6 +53,11 @@
                 "slug": "advanced-undead-paralyzed-sleep",
                 "type": "circumstance",
                 "value": 1
+            },
+            {
+                "key": "Resistance",
+                "type": "poison",
+                "value": "floor(@actor.level/2)"
             }
         ],
         "source": {

--- a/packs/data/feats.db/daywalker-vampire.json
+++ b/packs/data/feats.db/daywalker-vampire.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>Through a profane pledge or a bloodline quirk, you can tolerate the sun's light. You gain the advanced undead benefits and can't be destroyed by sunlight. This doesn't prevent you from becoming @UUID[Compendium.pf2e.conditionitems.Slowed]{Slowed} by exposure to the sun.</p>"
+            "value": "<p>Through a profane pledge or a bloodline quirk, you can tolerate the sun's light. You gain the @UUID[Compendium.pf2e.ancestryfeatures.Advanced Undead Benefits]{Advanced Undead Benefits} and can't be destroyed by sunlight. This doesn't prevent you from becoming @UUID[Compendium.pf2e.conditionitems.Slowed]{Slowed} by exposure to the sun.</p>"
         },
         "level": {
             "value": 6
@@ -23,7 +23,13 @@
                 }
             ]
         },
-        "rules": [],
+        "rules": [
+            {
+                "allowDuplicate": false,
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.ancestryfeatures.Advanced Undead Benefits"
+            }
+        ],
         "source": {
             "value": "Pathfinder Book of the Dead"
         },


### PR DESCRIPTION
This addresses #7556; the Daywalker feat from the Vampire dedication now grants the advanced undead benefits.
Additionally, the advanced undead benefits feature now grants poison resistance like it's supposed to.