### PR TITLE
Render parties like folders in sidebar

### DIFF
--- a/src/module/apps/sidebar/actor-directory.ts
+++ b/src/module/apps/sidebar/actor-directory.ts
@@ -1,25 +1,53 @@
+import { CharacterPF2e, CreaturePF2e, PartyPF2e } from "@actor";
 import { ActorPF2e } from "@actor/base.ts";
-import { fontAwesomeIcon, htmlQuery, htmlQueryAll } from "@util";
+import { fontAwesomeIcon, htmlClosest, htmlQuery, htmlQueryAll, sortBy } from "@util";
 
 /** Extend ActorDirectory to show more information */
-export class ActorDirectoryPF2e<TDocument extends ActorPF2e<null>> extends ActorDirectory<TDocument> {
+class ActorDirectoryPF2e extends ActorDirectory<ActorPF2e<null>> {
+    /** Any additional "folder like" elements (such as parties) that are maintained separately */
+    extraFolders: Record<string, boolean> = {};
+
+    /** If we are currently dragging a party. Needed because dragenter/dragover doesn't contain the drag source. */
+    draggingParty = false;
+
     static override get defaultOptions(): SidebarDirectoryOptions {
         const options = super.defaultOptions;
-        options.renderUpdateKeys.push("system.details.level.value", "system.attributes.adjustment");
+        options.renderUpdateKeys.push(
+            "system.details.level.value",
+            "system.attributes.adjustment",
+            "system.details.members"
+        );
         return options;
     }
 
     override async getData(): Promise<object> {
+        const parties = this.documents
+            .filter((a): a is PartyPF2e<null> => a instanceof PartyPF2e)
+            .sort(sortBy((p) => p.sort));
         return {
             ...(await super.getData()),
+            parties,
+            extraFolders: this.extraFolders,
             documentPartial: "systems/pf2e/templates/sidebar/actor-document-partial.hbs",
         };
+    }
+
+    /** Overriden to exclude parties and members from the directory tree */
+    static override setupFolders(
+        folders: Folder<EnfolderableDocument>[],
+        documents: ActorPF2e<null>[]
+    ): { root: boolean; content: WorldDocument[]; children: Folder<EnfolderableDocument>[] } {
+        const filteredDocuments: Actor<null>[] = documents.filter(
+            (a) => !a.isOfType("party", "creature") || (a.isOfType("creature") && !a.parties.size)
+        );
+        return super.setupFolders(folders, filteredDocuments);
     }
 
     override activateListeners($html: JQuery<HTMLElement>): void {
         super.activateListeners($html);
         const html = $html[0];
 
+        // Strip actor level from actors we lack proper observer permission for
         for (const element of htmlQueryAll(html, "li.directory-item.actor")) {
             const actor = game.actors.get(element.dataset.documentId ?? "");
             if (!actor?.testUserPermission(game.user, "OBSERVER")) {
@@ -27,7 +55,110 @@ export class ActorDirectoryPF2e<TDocument extends ActorPF2e<null>> extends Actor
             }
         }
 
+        // Implements folder-like collapse/expand functionality for parties.
+        for (const partyEl of htmlQueryAll(html, ".party-header")) {
+            partyEl.addEventListener("click", (event) => {
+                const folderEl = htmlClosest(event.target, ".party");
+                const documentId = htmlClosest(event.target, "[data-document-id]")?.dataset.documentId ?? "";
+                const party = game.actors.get(documentId);
+                if (party && folderEl) {
+                    this.extraFolders[documentId] = folderEl.classList.contains("collapsed");
+                    folderEl.classList.toggle("collapsed");
+                    if (this.popOut) this.setPosition();
+                }
+            });
+        }
+
+        // Alternative open sheet button (used by parties)
+        for (const openSheetEl of htmlQueryAll(html, "[data-action=open-sheet]")) {
+            openSheetEl.addEventListener("click", (event) => {
+                event.stopPropagation();
+                const documentId = htmlClosest(openSheetEl, "[data-document-id]")?.dataset.documentId;
+                const document = game.actors.get(documentId ?? "");
+                document?.sheet.render(true);
+            });
+        }
+
+        // Register event to create an actor as a new party member
+        for (const element of htmlQueryAll(html, "[data-action=create-member]")) {
+            element.addEventListener("click", async (event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                const documentId = htmlClosest(element, "[data-document-id]")?.dataset.documentId;
+                const party = game.actors.get(documentId ?? "");
+                if (!(party instanceof PartyPF2e)) return;
+
+                const button = event.currentTarget as HTMLElement;
+                const actor = await CharacterPF2e.createDialog(
+                    {},
+                    {
+                        width: 320,
+                        left: window.innerWidth - 630,
+                        top: button?.offsetTop ?? 0,
+                        types: ["creature"],
+                    }
+                );
+
+                // If the actor was created, add as a member and force the party folder open
+                if (actor) {
+                    this.extraFolders[party.id] = true;
+                    await party.addMembers(actor);
+                }
+            });
+        }
+
         this.#appendBrowseButton(html);
+    }
+
+    protected override _onDragStart(event: ElementDragEvent): void {
+        super._onDragStart(event);
+
+        // Add additional party metadata to the drag event
+        const fromParty = htmlClosest(event.target, ".party")?.dataset.documentId;
+        if (fromParty) {
+            const data: ActorSidebarDropData = JSON.parse(event.dataTransfer.getData("text/plain"));
+            data.fromParty = fromParty;
+            this.draggingParty = fromUuidSync(data.uuid as ActorUUID) instanceof PartyPF2e;
+            event.dataTransfer.setData("text/plain", JSON.stringify(data));
+        } else {
+            this.draggingParty = false;
+        }
+    }
+
+    /** Overriden to prevent highlighting of certain types of draggeed data (such as parties) */
+    protected override _onDragHighlight(event: DragEvent): void {
+        if (event.type === "dragenter" && this.draggingParty) {
+            event.stopPropagation();
+            return;
+        }
+
+        super._onDragHighlight(event);
+    }
+
+    protected override async _handleDroppedDocument(target: HTMLElement, data: ActorSidebarDropData): Promise<void> {
+        await super._handleDroppedDocument(target, data);
+
+        // Handle dragging members to and from parties (if relevant)
+        const toPartyId = htmlClosest(target, ".party")?.dataset.documentId;
+        if (toPartyId !== data.fromParty && data.uuid) {
+            const toParty = game.actors.get(toPartyId ?? "");
+            const fromParty = game.actors.get(data.fromParty ?? "");
+            const actor = fromUuidSync(data.uuid);
+            if (fromParty instanceof PartyPF2e) {
+                await fromParty.removeMembers(data.uuid as ActorUUID);
+            }
+            if (toParty instanceof PartyPF2e && actor instanceof CreaturePF2e) {
+                await toParty.addMembers(actor);
+            }
+        }
+    }
+
+    /** Inject parties without having to alter a core template */
+    protected override async _renderInner(data: object): Promise<JQuery> {
+        const $element = await super._renderInner(data);
+        const partyHTML = await renderTemplate("systems/pf2e/templates/sidebar/party-document-partial.hbs", data);
+        $element.find(".directory-list").prepend(partyHTML);
+        return $element;
     }
 
     /** Include flattened update data so parent method can read nested update keys */
@@ -40,6 +171,31 @@ export class ActorDirectoryPF2e<TDocument extends ActorPF2e<null>> extends Actor
         }
 
         return super._render(force, context);
+    }
+
+    protected override _contextMenu($html: JQuery<HTMLElement>): void {
+        super._contextMenu($html);
+        ContextMenu.create(this, $html, ".party .party-header", this._getEntryContextOptions());
+    }
+
+    protected override _getEntryContextOptions(): EntryContextOption[] {
+        const options = super._getEntryContextOptions();
+        options.push({
+            name: "Remove Member",
+            icon: '<i class="fas fa-bus"></i>',
+            condition: ($li) => $li.closest(".party").length > 0 && !$li.closest(".party-header").length,
+            callback: ($li) => {
+                const actorId = $li.data("document-id");
+                const partyId = $li.closest(".party").data("document-id");
+                const actor = game.actors.get(actorId ?? "");
+                const party = game.actors.get(partyId ?? "");
+                if (actor instanceof ActorPF2e && party instanceof PartyPF2e) {
+                    party.removeMembers(actor.uuid as ActorUUID);
+                }
+            },
+        });
+
+        return options;
     }
 
     /** Append a button to open the bestiary browser for GMs */
@@ -59,3 +215,9 @@ export class ActorDirectoryPF2e<TDocument extends ActorPF2e<null>> extends Actor
         htmlQuery(html, "footer.directory-footer")?.append(browseButton);
     }
 }
+
+interface ActorSidebarDropData extends DropCanvasData<"actor", ActorPF2e> {
+    fromParty?: string;
+}
+
+export { ActorDirectoryPF2e };

--- a/src/scripts/hooks/load.ts
+++ b/src/scripts/hooks/load.ts
@@ -80,7 +80,8 @@ export const Load = {
             import.meta.hot.on("template-update", async ({ path }: { path: string }): Promise<void> => {
                 delete _templateCache[path];
                 await getTemplate(path);
-                for (const app of Object.values(ui.windows)) {
+                const apps = [...Object.values(ui.windows), ui.sidebar];
+                for (const app of apps) {
                     app.render();
                 }
             });

--- a/src/styles/ui/sidebar/_actor-directory.scss
+++ b/src/styles/ui/sidebar/_actor-directory.scss
@@ -12,4 +12,56 @@
             color: var(--color-text-light-primary);
         }
     }
+
+    .party-list {
+        flex: 0 1 auto;
+        margin: 0;
+        padding: 0;
+    }
+
+    .party {
+        .party-header {
+            background: rgba(255, 255, 255, 0.2);
+            border-top: 1px solid var(--color-border-dark);
+            border-bottom: 1px solid var(--color-border-dark);
+            line-height: 1.5rem;
+            padding: 6px;
+
+            display: flex;
+            align-items: center;
+
+            .fa-fw {
+                cursor: pointer;
+                flex: 0 0 auto;
+                margin-right: 10px;
+                font-size: var(--font-size-16);
+            }
+
+            h3 {
+                flex: 1;
+                margin: 0;
+                overflow: hidden;
+                white-space: nowrap;
+                font-size: var(--font-size-16);
+            }
+
+            .controls {
+                flex: 0;
+                display: flex;
+                font-size: var(--font-size-14);
+            }
+        }
+
+        &.collapsed {
+            .party-header {
+                background: rgba(0, 0, 0, 0.5);
+            }
+
+            .subdirectory {
+                display: none;
+            }
+        }
+    }
+
+
 }

--- a/static/templates/sidebar/party-document-partial.hbs
+++ b/static/templates/sidebar/party-document-partial.hbs
@@ -1,0 +1,21 @@
+<ol class="party-list">
+{{#each parties}}
+    <li class="party flexcol {{#unless (lookup @root.extraFolders this.id)}}collapsed{{/unless}}" data-document-id="{{this.id}}">
+        <header class="directory-item party-header flexrow" data-document-id="{{this.id}}">
+            <i class="fas fa-fw fa-users" data-action="open-sheet"></i>
+            <h3 class="noborder">{{this.name}}</h3>
+            <div class="controls">
+                <a class="create-button" data-action="create-member">
+                    <i class="fas fa-user-plus"></i>
+                </a>
+            </div>
+        </header>
+
+        <ol class="subdirectory">
+            {{#each this.members}}
+            {{> (lookup @root "documentPartial")}}
+            {{/each~}}
+        </ol>
+    </li>
+{{/each}}
+</ol>

--- a/types/foundry/client/application/sidebar/sidebar-tab/sidebar-directory/base.d.ts
+++ b/types/foundry/client/application/sidebar/sidebar-tab/sidebar-directory/base.d.ts
@@ -62,6 +62,9 @@ declare global {
 
         protected override _onSearchFilter(event: KeyboardEvent, query: string, rgx: RegExp, html: HTMLElement): void;
 
+        /** Highlight folders as drop targets when a drag event enters or exits their area */
+        protected _onDragHighlight(event: DragEvent): void;
+
         /** Collapse all subfolders in this directory */
         collapseAll(): void;
 
@@ -71,6 +74,20 @@ declare global {
 
         /** Activate event listeners triggered within the Actor Directory HTML */
         override activateListeners(html: JQuery): void;
+
+        /**
+         * Handle Document data being dropped into the directory.
+         * @param target The target element
+         * @param data   The data being dropped
+         */
+        protected _handleDroppedDocument(target: HTMLElement, data: DropCanvasData): Promise<void>;
+
+        /**
+         * Handle Folder data being dropped into the directory.
+         * @param target The target element
+         * @param data   The data being dropped
+         */
+        protected _handleDroppedFolder(target: HTMLElement, data: DropCanvasData): Promise<void>;
 
         /**
          * Default folder context actions

--- a/types/foundry/client/ui/index.d.ts
+++ b/types/foundry/client/ui/index.d.ts
@@ -24,6 +24,7 @@ declare global {
         items: ItemDirectory<TItem>;
         notifications: Notifications;
         settings: Settings;
+        sidebar: Sidebar;
         tables: RollTableDirectory;
         windows: Record<number, Application>;
     }

--- a/types/foundry/common/documents/actor.d.ts
+++ b/types/foundry/common/documents/actor.d.ts
@@ -9,6 +9,8 @@ import type { BaseActiveEffect, BaseItem, BaseToken, BaseUser } from "./module.d
  * @property data The constructed data object for the document.
  */
 export default class BaseActor<TParent extends BaseToken | null = BaseToken | null> extends Document<TParent> {
+    sort: number;
+
     prototypeToken: foundry.data.PrototypeToken;
 
     /** The default icon used for newly created Actor documents */


### PR DESCRIPTION
Several ideas floated around for how to handle the case for where there exist multiple parties, but until we get more input from people who run such games this is currently the way I'd like to handle it.

So a new party list is created and injected during rendering into the actor list. This avoids us having to replace the sidebar template. The following scenarios are covered (unless I messed up somewhere):
1) Drag into party adds as member into party
2) Drag away from party removes as member
3) Party can be resorted (members are always alphabetical).
4) Right click party does what's intended
5) Right click a member of a party adds Remove Member to the options
6) Clicking on party icon opens the sheet. Clicking on the name collapses/hides the "folder".
7) Clicking on add actor on the party opens up an actor creation dialogue with reduced choices (creature types only)
8) Dragging the party's header into the scene creates a token for that party.

![image](https://user-images.githubusercontent.com/1286721/235284540-120c2057-4c8e-41fd-b7b4-845641488c47.png)

Eventually I would like a more distinct header for party, but I'd rather cross that bridge later.

