### PR TITLE
Add support for "carried" usage, disable rule elements for dropped items

### DIFF
--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -2045,7 +2045,8 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
 
         // If investing and unequipped, equip first
         if (!invested && !item.isEquipped) {
-            await this.adjustCarryType(item, item.system.usage.type, item.system.usage.hands, true);
+            const newCarryType = item.system.usage.type === "carried" ? "worn" : item.system.usage.type;
+            await this.adjustCarryType(item, newCarryType, item.system.usage.hands, true);
         }
 
         return !!(await item.update({ "system.equipped.invested": !invested }));

--- a/src/module/item/physical/document.ts
+++ b/src/module/item/physical/document.ts
@@ -536,6 +536,11 @@ abstract class PhysicalItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | n
             }
         }
 
+        // Uninvest if dropping
+        if (changed.system.equipped?.carryType === "dropped" && this.system.equipped.invested) {
+            changed.system.equipped.invested = false;
+        }
+
         // Remove equipped.handsHeld and equipped.inSlot if the item is held or worn anywhere
         const equipped: Record<string, unknown> = mergeObject(changed, { system: { equipped: {} } }).system.equipped;
         const newCarryType = String(equipped.carryType ?? this.system.equipped.carryType);

--- a/src/module/item/physical/usage.ts
+++ b/src/module/item/physical/usage.ts
@@ -13,12 +13,20 @@ interface WornUsage {
     hands?: 0;
 }
 
-export type UsageDetails = HeldUsage | WornUsage;
+interface CarriedUsage {
+    value: "carried";
+    type: "carried";
+    hands?: 0;
+}
 
-export function isEquipped(usage: UsageDetails, equipped: EquippedData): boolean {
-    if (usage.type !== equipped.carryType) {
-        return false;
-    }
+type UsageDetails = HeldUsage | WornUsage | CarriedUsage;
+
+type UsageType = UsageDetails["type"];
+
+function isEquipped(usage: UsageDetails, equipped: EquippedData): boolean {
+    if (equipped.carryType === "dropped") return false;
+    if (usage.type === "carried") return true;
+    if (usage.type !== equipped.carryType) return false;
 
     if (usage.type === "worn" && usage.where && !equipped.inSlot) {
         return false;
@@ -29,8 +37,11 @@ export function isEquipped(usage: UsageDetails, equipped: EquippedData): boolean
     return true;
 }
 
-export function getUsageDetails(usage: string): UsageDetails {
+function getUsageDetails(usage: string): UsageDetails {
     switch (usage) {
+        case "carried":
+            return { value: usage, type: usage };
+
         case "held-in-one-hand":
         case "held-in-one-plus-hands":
             return { value: usage, type: "held", hands: 1 };
@@ -129,3 +140,5 @@ export function getUsageDetails(usage: string): UsageDetails {
 
     return { value: usage, type: "worn", where: null };
 }
+
+export { UsageDetails, UsageType, getUsageDetails, isEquipped };

--- a/src/module/rules/rule-element/base.ts
+++ b/src/module/rules/rule-element/base.ts
@@ -72,7 +72,9 @@ abstract class RuleElementPF2e<TSchema extends RuleElementSchema = RuleElementSc
             // The DataModel schema defaulted `ignored` to `false`: only change to true if not already true
             if (this.ignored === false) {
                 this.ignored =
-                    (!!this.requiresEquipped && !item.isEquipped) || (!!this.requiresInvestment && !item.isInvested);
+                    (!!this.requiresEquipped && !item.isEquipped) ||
+                    item.system.equipped.carryType === "dropped" ||
+                    (!!this.requiresInvestment && !item.isInvested);
             }
         } else {
             this.requiresEquipped = null;

--- a/static/templates/actors/partials/carry-type.hbs
+++ b/static/templates/actors/partials/carry-type.hbs
@@ -6,46 +6,42 @@
     {{~else}}<i class="fas fa-tshirt fa-fw"></i>{{/if~}}
 </a>
 <div class="hover-content carry-hover-content" id="inventory-{{item.id}}-carryType" data-item-id="{{item.id}}">
-    <!-- {{item.system.usage.type}} / {{item.system.usage.where}} / {{item.system.usage.hands}} / {{item.system.usage.value}} -->
     <ul>
-        {{#if (eq item.system.usage.type "held")}}
+        <li>
+            <a class="item-control item-location-option{{#if (and (eq item.system.equipped.carryType "held") (eq item.system.equipped.handsHeld 1))}} selected{{/if}}"
+                data-carry-type="held"
+                data-hands-held="1">
+                <i class="fas fa-hand-rock"></i>{{localize "PF2E.CarryType.held1"}}
+            </a>
+        </li>
+        <li>
+            <a class="item-control item-location-option{{#if (and (eq item.system.equipped.carryType "held") (eq item.system.equipped.handsHeld 2))}} selected{{/if}}"
+                data-carry-type="held"
+                data-hands-held="2">
+                <i class="fas fa-hand-rock"></i>{{localize "PF2E.CarryType.held2"}}
+            </a>
+        </li>
+        {{#if (and (eq item.system.usage.type "worn") item.system.usage.where)}}
             <li>
-                <a class="item-control item-location-option{{#if (and (eq item.system.equipped.carryType "held") (eq item.system.equipped.handsHeld 1))}} selected{{/if}}"
-                    data-carry-type="held"
-                    data-hands-held="1">
-                    <i class="fas fa-hand-rock"></i>{{localize "PF2E.CarryType.held1"}}
+                <a class="item-control item-location-option{{#if item.system.equipped.inSlot}} selected{{/if}}" data-carry-type="worn" data-in-slot="true">
+                    <i class="fas fa-tshirt"></i>{{localize "PF2E.Item.Physical.Usage.WornParenthetical" where=(localize (concat "PF2E.Item.Physical.Usage.WornSlot." item.system.usage.where))}}
                 </a>
             </li>
         {{/if}}
-    <li>
-        <a class="item-control item-location-option{{#if (and (eq item.system.equipped.carryType "held") (eq item.system.equipped.handsHeld 2))}} selected{{/if}}"
-            data-carry-type="held"
-            data-hands-held="2">
-            <i class="fas fa-hand-rock"></i>{{localize "PF2E.CarryType.held2"}}
-        </a>
-    </li>
-    {{#if (and (eq item.system.usage.type "worn") item.system.usage.where)}}
         <li>
-            <a class="item-control item-location-option{{#if item.system.equipped.inSlot}} selected{{/if}}" data-carry-type="worn" data-in-slot="true">
-                <i class="fas fa-tshirt"></i>{{localize "PF2E.Item.Physical.Usage.WornParenthetical" where=(localize (concat "PF2E.Item.Physical.Usage.WornSlot." item.system.usage.where))}}
-            </a>
+            <a class="item-control item-location-option{{#if (and (eq item.system.equipped.carryType "worn") (or (not item.system.usage.where) (eq item.system.equipped.inSlot false)))}} selected{{/if}}"
+                data-carry-type="worn"
+                data-in-slot="false"><i class="fas fa-tshirt"></i>{{localize "PF2E.CarryType.worn"}}</a>
         </li>
-    {{/if}}
-    <li>
-        <a class="item-control item-location-option{{#if (and (eq item.system.equipped.carryType "worn") (or (not item.system.usage.where) (eq item.system.equipped.inSlot false)))}} selected{{/if}}"
-            data-carry-type="worn"
-            data-in-slot="false"><i class="fas fa-tshirt"></i>{{localize "PF2E.CarryType.worn"}}</a>
-    </li>
-
-    {{#if @root.inventory.hasStowingContainers}}
+        {{#if @root.inventory.hasStowingContainers}}
+            <li>
+                <a class="item-control item-location-option{{#if (eq item.system.equipped.carryType "stowed")}} selected{{/if}}"
+                    data-carry-type="stowed"><i class="fas fa-box"></i>{{localize "PF2E.CarryType.stowed"}}</a>
+            </li>
+        {{/if}}
         <li>
-            <a class="item-control item-location-option{{#if (eq item.system.equipped.carryType "stowed")}} selected{{/if}}"
-                data-carry-type="stowed"><i class="fas fa-box"></i>{{localize "PF2E.CarryType.stowed"}}</a>
+            <a class="item-control item-location-option {{#if (eq item.system.equipped.carryType "dropped")}}selected{{/if}}"
+                data-carry-type="dropped"><i class="fas fa-grip-lines"></i>{{localize "PF2E.CarryType.dropped"}}</a>
         </li>
-    {{/if}}
-    <li>
-        <a class="item-control item-location-option {{#if (eq item.system.equipped.carryType "dropped")}}selected{{/if}}"
-            data-carry-type="dropped"><i class="fas fa-grip-lines"></i>{{localize "PF2E.CarryType.dropped"}}</a>
-    </li>
-</ul>
+    </ul>
 </div>


### PR DESCRIPTION
- An item with a "carried" usage is considered equipped so long as it's not dropped
- A dropped item is never counted as equipped or invested
- All REs are disabled for dropped items, even if they don't require equipping