### PR TITLE
Add visual indication of token flanking position when targeting

### DIFF
--- a/src/module/canvas/token/object.ts
+++ b/src/module/canvas/token/object.ts
@@ -255,6 +255,23 @@ class TokenPF2e<TDocument extends TokenDocumentPF2e = TokenDocumentPF2e> extends
                         strokeThickness: 4,
                     },
                 ];
+            } else if (typeof params === "string") {
+                if (!params) return null;
+
+                const textStyle = this._getTextStyle();
+                const textStyleSubset = pick(textStyle, ["fontSize", "stroke", "strokeThickness"]);
+                const fill = this._getBorderColor() || this._getTextStyle().fill;
+
+                return [
+                    this.center,
+                    params,
+                    {
+                        ...textStyleSubset,
+                        anchor: CONST.TEXT_ANCHOR_POINTS.TOP,
+                        duration: 3000,
+                        fill: fill,
+                    },
+                ];
             } else {
                 const [change, details] = Object.entries(params)[0];
                 const isAdded = change === "create";
@@ -420,6 +437,7 @@ interface TokenImage extends PIXI.Sprite {
 type NumericFloatyEffect = { name: string; value?: number | null };
 type ShowFloatyEffectParams =
     | number
+    | string
     | { create: NumericFloatyEffect }
     | { update: NumericFloatyEffect }
     | { delete: NumericFloatyEffect };

--- a/src/module/canvas/token/object.ts
+++ b/src/module/canvas/token/object.ts
@@ -64,8 +64,8 @@ class TokenPF2e<TDocument extends TokenDocumentPF2e = TokenDocumentPF2e> extends
      * Determine whether this token can flank another—given that they have a flanking buddy on the opposite side
      * @param flankee                  The potentially flanked token
      * @param context.reach           An optional reach distance specific to this measurement
-     * @param context.ignoreFlankable Optionally ignore flankable (for targeting indicator) */
-    canFlank(flankee: TokenPF2e, context: { reach?: number, ignoreFlankable?: boolean } = {}): boolean {
+     * @param context.ignoreFlankable Optionally ignore flankable (for flanking position indicator) */
+    canFlank(flankee: TokenPF2e, context: { reach?: number; ignoreFlankable?: boolean } = {}): boolean {
         if (this === flankee || !game.settings.get("pf2e", "automation.flankingDetection")) {
             return false;
         }
@@ -73,7 +73,7 @@ class TokenPF2e<TDocument extends TokenDocumentPF2e = TokenDocumentPF2e> extends
         // Can actor flank and is flankee flankable (if we care about flankable)
         const flankable = context.ignoreFlankable || flankee.actor?.attributes.flanking.flankable;
         if (!(this.actor?.attributes.flanking.canFlank && flankable)) return false;
-        
+
         // Only PCs and NPCs can flank
         if (!this.actor.isOfType("character", "npc")) return false;
         // Only creatures can be flanked
@@ -91,8 +91,8 @@ class TokenPF2e<TDocument extends TokenDocumentPF2e = TokenDocumentPF2e> extends
      * Determine whether this token is in fact flanking another
      * @param flankee                  The potentially flanked token
      * @param context.reach           An optional reach distance specific to this measurement
-     * @param context.ignoreFlankable Optionally ignore flankable (for targeting indicator) */
-    isFlanking(flankee: TokenPF2e, context: { reach?: number, ignoreFlankable?: boolean } = {}): boolean {
+     * @param context.ignoreFlankable Optionally ignore flankable (for flanking position indicator) */
+    isFlanking(flankee: TokenPF2e, context: { reach?: number; ignoreFlankable?: boolean } = {}): boolean {
         if (!(this.actor && this.canFlank(flankee, context))) return false;
 
         // Return true if a flanking buddy is found
@@ -266,8 +266,7 @@ class TokenPF2e<TDocument extends TokenDocumentPF2e = TokenDocumentPF2e> extends
                 if (!params) return null;
 
                 const textStyle = this._getTextStyle();
-                const textStyleSubset = pick(textStyle, ["fontSize", "stroke", "strokeThickness"]);
-                const fill = this._getBorderColor() || this._getTextStyle().fill;
+                const textStyleSubset = pick(textStyle, ["fill", "fontSize", "stroke", "strokeThickness"]);
 
                 return [
                     this.center,
@@ -276,7 +275,6 @@ class TokenPF2e<TDocument extends TokenDocumentPF2e = TokenDocumentPF2e> extends
                         ...textStyleSubset,
                         anchor: CONST.TEXT_ANCHOR_POINTS.TOP,
                         duration: 3000,
-                        fill: fill,
                     },
                 ];
             } else {

--- a/src/scripts/hooks/target-token.ts
+++ b/src/scripts/hooks/target-token.ts
@@ -14,9 +14,12 @@ export const TargetToken = {
                 if (
                     targeted &&
                     user === game.user &&
-                    !!actorToken?.object?.isFlanking(tokenDocument.object, { reach: actor.getReach({}) })
+                    !!actorToken?.object?.isFlanking(
+                        tokenDocument.object, 
+                        { reach: actor.getReach({}), ignoreFlankable: true }
+                    )
                 ) {
-                    tokenDocument.object.showFloatyText("Flanked!");
+                    tokenDocument.object.showFloatyText("Flanking Position");
                 }
             }
 

--- a/src/scripts/hooks/target-token.ts
+++ b/src/scripts/hooks/target-token.ts
@@ -14,12 +14,12 @@ export const TargetToken = {
                 if (
                     targeted &&
                     user === game.user &&
-                    !!actorToken?.object?.isFlanking(
-                        tokenDocument.object, 
-                        { reach: actor.getReach({}), ignoreFlankable: true }
-                    )
+                    !!actorToken?.object?.isFlanking(tokenDocument.object, {
+                        reach: actor.getReach({}),
+                        ignoreFlankable: true,
+                    })
                 ) {
-                    tokenDocument.object.showFloatyText("Flanking Position");
+                    actorToken.object.showFloatyText("Flanking Position!");
                 }
             }
 

--- a/src/scripts/hooks/target-token.ts
+++ b/src/scripts/hooks/target-token.ts
@@ -1,9 +1,26 @@
 import { TokenDocumentPF2e } from "@scene/index.ts";
+import { getSelectedOrOwnActors } from "@util/token-actor-utils.ts";
 
 export const TargetToken = {
     listen: (): void => {
-        Hooks.on("targetToken", (_user, token): void => {
-            ui.combat.refreshTargetDisplay(token.document as TokenDocumentPF2e);
+        Hooks.on("targetToken", (user, token, targeted): void => {
+            const tokenDocument = token.document as TokenDocumentPF2e;
+            const actors = getSelectedOrOwnActors();
+
+            if (actors.length === 1 && tokenDocument.object) {
+                const actor = actors[0];
+                const actorToken = actor.getActiveTokens(false, true).shift();
+
+                if (
+                    targeted &&
+                    user === game.user &&
+                    !!actorToken?.object?.isFlanking(tokenDocument.object, { reach: actor.getReach({}) })
+                ) {
+                    tokenDocument.object.showFloatyText("Flanked!");
+                }
+            }
+
+            ui.combat.refreshTargetDisplay(tokenDocument);
         });
     },
 };

--- a/src/scripts/hooks/target-token.ts
+++ b/src/scripts/hooks/target-token.ts
@@ -14,10 +14,7 @@ export const TargetToken = {
                 if (
                     targeted &&
                     user === game.user &&
-                    !!actorToken?.object?.isFlanking(tokenDocument.object, {
-                        reach: actor.getReach({}),
-                        ignoreFlankable: true,
-                    })
+                    !!actorToken?.object?.isFlanking(tokenDocument.object, { ignoreFlankable: true })
                 ) {
                     actorToken.object.showFloatyText("Flanking Position!");
                 }


### PR DESCRIPTION
Addresses https://github.com/foundryvtt/pf2e/issues/4534.

This PR adds a scrolling floaty text "Flanking Position!" indicator on a token when that token targets another enemy token while possibly in flanking position. It's too big to embed, but I've uploaded a [video demonstrating this feature](https://imgur.com/a/cMrVIMZ). The indicator does not reveal whether or not the enemy token is actually flanked or is even flankable, in order to not give up possible metagame information (as discussed in the issue). Rather, this indicator shows that the targeting token _could_ be in flanking position, if it is possible to flank the enemy token. The indicator respects reach and ally/enemy relationships. 

The solution implemented is a bit different from that proposed in the issue. The issue suggested drawing a different target icon on the targeted token, with an additional hover-text note. Instead, this PR implements the indicator as temporary floating text on the targeting token. My thinking here is that while it's easy to figure out if a token is in a flanking position when the targeting is initiated, it's much more complicated to know whether that flanking position is maintained, since other tokens may move or die or experience conditions that prevent the original token from continuing to be in flanking position. Because of this, changing the targeting icon to represent flanking position either requires continually checking flanking position against many different changing circumstances or risking that the flanking-position targeting icon is displayed when no longer valid. Also, since it's the targeting token that is in position against the target, having the indicator appear over the targeting token seems to make more sense to me. 

For any questions or anything, I'm on discord as JellyfishJail#3956. 


