### PR TITLE
Use cached check data in `CheckPF2e.rerollFromMessage` instead of recreating the check from the message flag

### DIFF
--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -631,6 +631,7 @@
             "Title": "Roll Inspector"
         },
         "Check": {
+            "CacheExpired": "The reroll data for this check is no longer available. Please roll a new check instead.",
             "DC": {
                 "Label": {
                     "AdjustedTarget": "<target>Target: {target}</target> <dc>({dcType} <preadjusted>{preadjusted}</preadjusted> <adjusted>{adjusted}</adjusted>)</dc>",


### PR DESCRIPTION
Reroll by keeping an in-memory cache of the original `CheckModifier` and `CheckRollContext`. I'm not 100% that this is viable but it didn't take long to implement and actually fixes all the reroll problems.

Pros:
- No need to special case every additional `CheckPF2e` property.
- No need to make `Statistic`, `RollNotePF2e`, etc. fully serializeable.

Cons:
- Reloading wipes the cache.
- GMs can't reroll for players anymore.