### PR TITLE
Remove `disableABP` flag from battle form effects

### DIFF
--- a/packs/data/spell-effects.db/spell-effect-elemental-form-air.json
+++ b/packs/data/spell-effects.db/spell-effect-elemental-form-air.json
@@ -130,13 +130,6 @@
                     ],
                     "field": "item|system.level.value"
                 }
-            },
-            {
-                "key": "ActiveEffectLike",
-                "mode": "override",
-                "path": "flags.pf2e.disableABP",
-                "priority": 10,
-                "value": true
             }
         ],
         "source": {

--- a/packs/data/spell-effects.db/spell-effect-elemental-form-earth.json
+++ b/packs/data/spell-effects.db/spell-effect-elemental-form-earth.json
@@ -134,13 +134,6 @@
                     ],
                     "field": "item|system.level.value"
                 }
-            },
-            {
-                "key": "ActiveEffectLike",
-                "mode": "override",
-                "path": "flags.pf2e.disableABP",
-                "priority": 10,
-                "value": true
             }
         ],
         "source": {

--- a/packs/data/spell-effects.db/spell-effect-elemental-form-fire.json
+++ b/packs/data/spell-effects.db/spell-effect-elemental-form-fire.json
@@ -153,13 +153,6 @@
                 "dieSize": "d4",
                 "key": "DamageDice",
                 "selector": "strike-damage"
-            },
-            {
-                "key": "ActiveEffectLike",
-                "mode": "override",
-                "path": "flags.pf2e.disableABP",
-                "priority": 10,
-                "value": true
             }
         ],
         "source": {

--- a/packs/data/spell-effects.db/spell-effect-elemental-form-water.json
+++ b/packs/data/spell-effects.db/spell-effect-elemental-form-water.json
@@ -142,13 +142,6 @@
                 "selector": "wave-damage",
                 "text": "PF2E.BattleForm.Note.Shove",
                 "title": "{item|name}"
-            },
-            {
-                "key": "ActiveEffectLike",
-                "mode": "override",
-                "path": "flags.pf2e.disableABP",
-                "priority": 10,
-                "value": true
             }
         ],
         "source": {

--- a/packs/data/spell-effects.db/spell-effect-fey-form-dryad.json
+++ b/packs/data/spell-effects.db/spell-effect-fey-form-dryad.json
@@ -65,13 +65,6 @@
                         }
                     ]
                 }
-            },
-            {
-                "key": "ActiveEffectLike",
-                "mode": "override",
-                "path": "flags.pf2e.disableABP",
-                "priority": 10,
-                "value": true
             }
         ],
         "source": {

--- a/packs/data/spell-effects.db/spell-effect-fey-form-elananx.json
+++ b/packs/data/spell-effects.db/spell-effect-fey-form-elananx.json
@@ -90,13 +90,6 @@
                 "dieSize": "d6",
                 "key": "DamageDice",
                 "selector": "jaws-damage"
-            },
-            {
-                "key": "ActiveEffectLike",
-                "mode": "override",
-                "path": "flags.pf2e.disableABP",
-                "priority": 10,
-                "value": true
             }
         ],
         "source": {

--- a/packs/data/spell-effects.db/spell-effect-fey-form-naiad.json
+++ b/packs/data/spell-effects.db/spell-effect-fey-form-naiad.json
@@ -70,13 +70,6 @@
                         }
                     ]
                 }
-            },
-            {
-                "key": "ActiveEffectLike",
-                "mode": "override",
-                "path": "flags.pf2e.disableABP",
-                "priority": 10,
-                "value": true
             }
         ],
         "source": {

--- a/packs/data/spell-effects.db/spell-effect-fey-form-redcap.json
+++ b/packs/data/spell-effects.db/spell-effect-fey-form-redcap.json
@@ -79,13 +79,6 @@
                         }
                     ]
                 }
-            },
-            {
-                "key": "ActiveEffectLike",
-                "mode": "override",
-                "path": "flags.pf2e.disableABP",
-                "priority": 10,
-                "value": true
             }
         ],
         "source": {

--- a/packs/data/spell-effects.db/spell-effect-fey-form-unicorn.json
+++ b/packs/data/spell-effects.db/spell-effect-fey-form-unicorn.json
@@ -94,13 +94,6 @@
                 "mode": "add",
                 "property": "property-runes",
                 "value": "ghost-touch"
-            },
-            {
-                "key": "ActiveEffectLike",
-                "mode": "override",
-                "path": "flags.pf2e.disableABP",
-                "priority": 10,
-                "value": true
             }
         ],
         "source": {

--- a/packs/data/spell-effects.db/spell-effect-insect-form-ant.json
+++ b/packs/data/spell-effects.db/spell-effect-insect-form-ant.json
@@ -129,12 +129,6 @@
                     ],
                     "field": "item|system.level.value"
                 }
-            },
-            {
-                "key": "ActiveEffectLike",
-                "mode": "override",
-                "path": "flags.pf2e.disableABP",
-                "value": true
             }
         ],
         "source": {

--- a/packs/data/spell-effects.db/spell-effect-insect-form-beetle.json
+++ b/packs/data/spell-effects.db/spell-effect-insect-form-beetle.json
@@ -128,12 +128,6 @@
                     ],
                     "field": "item|system.level.value"
                 }
-            },
-            {
-                "key": "ActiveEffectLike",
-                "mode": "override",
-                "path": "flags.pf2e.disableABP",
-                "value": true
             }
         ],
         "source": {

--- a/packs/data/spell-effects.db/spell-effect-insect-form-centipede.json
+++ b/packs/data/spell-effects.db/spell-effect-insect-form-centipede.json
@@ -138,12 +138,6 @@
                 "dieSize": "d4",
                 "key": "DamageDice",
                 "selector": "mandibles-damage"
-            },
-            {
-                "key": "ActiveEffectLike",
-                "mode": "override",
-                "path": "flags.pf2e.disableABP",
-                "value": true
             }
         ],
         "source": {

--- a/packs/data/spell-effects.db/spell-effect-insect-form-mantis.json
+++ b/packs/data/spell-effects.db/spell-effect-insect-form-mantis.json
@@ -132,12 +132,6 @@
                     ],
                     "field": "item|system.level.value"
                 }
-            },
-            {
-                "key": "ActiveEffectLike",
-                "mode": "override",
-                "path": "flags.pf2e.disableABP",
-                "value": true
             }
         ],
         "source": {

--- a/packs/data/spell-effects.db/spell-effect-insect-form-scorpion.json
+++ b/packs/data/spell-effects.db/spell-effect-insect-form-scorpion.json
@@ -183,12 +183,6 @@
                 "dieSize": "d4",
                 "key": "DamageDice",
                 "selector": "stinger-damage"
-            },
-            {
-                "key": "ActiveEffectLike",
-                "mode": "override",
-                "path": "flags.pf2e.disableABP",
-                "value": true
             }
         ],
         "source": {

--- a/packs/data/spell-effects.db/spell-effect-insect-form-spider.json
+++ b/packs/data/spell-effects.db/spell-effect-insect-form-spider.json
@@ -175,12 +175,6 @@
                 "selector": "web-attack",
                 "text": "PF2E.BattleForm.InsectForm.SpiderWebNote",
                 "title": "{item|name}"
-            },
-            {
-                "key": "ActiveEffectLike",
-                "mode": "override",
-                "path": "flags.pf2e.disableABP",
-                "value": true
             }
         ],
         "source": {

--- a/packs/data/spell-effects.db/spell-effect-monstrosity-form-phoenix.json
+++ b/packs/data/spell-effects.db/spell-effect-monstrosity-form-phoenix.json
@@ -164,12 +164,6 @@
                 "option": "shrouded",
                 "toggleable": true,
                 "value": true
-            },
-            {
-                "key": "ActiveEffectLike",
-                "mode": "override",
-                "path": "flags.pf2e.disableABP",
-                "value": true
             }
         ],
         "source": {

--- a/packs/data/spell-effects.db/spell-effect-monstrosity-form-purple-worm.json
+++ b/packs/data/spell-effects.db/spell-effect-monstrosity-form-purple-worm.json
@@ -164,12 +164,6 @@
                 "dieSize": "d6",
                 "key": "DamageDice",
                 "selector": "stinger-damage"
-            },
-            {
-                "key": "ActiveEffectLike",
-                "mode": "override",
-                "path": "flags.pf2e.disableABP",
-                "value": true
             }
         ],
         "source": {

--- a/packs/data/spell-effects.db/spell-effect-monstrosity-form-sea-serpent.json
+++ b/packs/data/spell-effects.db/spell-effect-monstrosity-form-sea-serpent.json
@@ -118,12 +118,6 @@
                     ],
                     "field": "item|system.level.value"
                 }
-            },
-            {
-                "key": "ActiveEffectLike",
-                "mode": "override",
-                "path": "flags.pf2e.disableABP",
-                "value": true
             }
         ],
         "source": {

--- a/packs/data/spell-effects.db/spell-effect-ooze-form-black-pudding.json
+++ b/packs/data/spell-effects.db/spell-effect-ooze-form-black-pudding.json
@@ -215,13 +215,6 @@
                 "dieSize": "d8",
                 "key": "DamageDice",
                 "selector": "strike-damage"
-            },
-            {
-                "key": "ActiveEffectLike",
-                "mode": "override",
-                "path": "flags.pf2e.disableABP",
-                "priority": 10,
-                "value": true
             }
         ],
         "source": {

--- a/packs/data/spell-effects.db/spell-effect-ooze-form-gelatinous-cube.json
+++ b/packs/data/spell-effects.db/spell-effect-ooze-form-gelatinous-cube.json
@@ -213,13 +213,6 @@
                 "selector": "strike-damage",
                 "text": "PF2E.BattleForm.OozeForm.GelatinousCubeNote",
                 "title": "{item|name}"
-            },
-            {
-                "key": "ActiveEffectLike",
-                "mode": "override",
-                "path": "flags.pf2e.disableABP",
-                "priority": 10,
-                "value": true
             }
         ],
         "source": {

--- a/packs/data/spell-effects.db/spell-effect-ooze-form-gray-ooze.json
+++ b/packs/data/spell-effects.db/spell-effect-ooze-form-gray-ooze.json
@@ -222,13 +222,6 @@
                 "selector": "strike-damage",
                 "text": "PF2E.BattleForm.Note.Grab",
                 "title": "{item|name}"
-            },
-            {
-                "key": "ActiveEffectLike",
-                "mode": "override",
-                "path": "flags.pf2e.disableABP",
-                "priority": 10,
-                "value": true
             }
         ],
         "source": {

--- a/packs/data/spell-effects.db/spell-effect-ooze-form-ochre-jelly.json
+++ b/packs/data/spell-effects.db/spell-effect-ooze-form-ochre-jelly.json
@@ -225,13 +225,6 @@
                 "selector": "strike-damage",
                 "text": "PF2E.BattleForm.Note.Grab",
                 "title": "{item|name}"
-            },
-            {
-                "key": "ActiveEffectLike",
-                "mode": "override",
-                "path": "flags.pf2e.disableABP",
-                "priority": 10,
-                "value": true
             }
         ],
         "source": {

--- a/packs/data/spell-effects.db/spell-effect-plant-form-arboreal.json
+++ b/packs/data/spell-effects.db/spell-effect-plant-form-arboreal.json
@@ -134,12 +134,6 @@
                     ],
                     "field": "item|system.level.value"
                 }
-            },
-            {
-                "key": "ActiveEffectLike",
-                "mode": "override",
-                "path": "flags.pf2e.disableABP",
-                "value": true
             }
         ],
         "source": {

--- a/packs/data/spell-effects.db/spell-effect-plant-form-flytrap.json
+++ b/packs/data/spell-effects.db/spell-effect-plant-form-flytrap.json
@@ -115,12 +115,6 @@
                 "selector": "leaf-damage",
                 "text": "PF2E.BattleForm.Note.Grab",
                 "title": "{item|name}"
-            },
-            {
-                "key": "ActiveEffectLike",
-                "mode": "override",
-                "path": "flags.pf2e.disableABP",
-                "value": true
             }
         ],
         "source": {

--- a/packs/data/spell-effects.db/spell-effect-plant-form-shambler.json
+++ b/packs/data/spell-effects.db/spell-effect-plant-form-shambler.json
@@ -110,12 +110,6 @@
                     ],
                     "field": "item|system.level.value"
                 }
-            },
-            {
-                "key": "ActiveEffectLike",
-                "mode": "override",
-                "path": "flags.pf2e.disableABP",
-                "value": true
             }
         ],
         "source": {


### PR DESCRIPTION
These are interfering with the comparison between the PC's own attack modifier and the form's, and they're already squelched as needed