### PR TITLE
Add Tiger Claw slug

### DIFF
--- a/packs/data/feat-effects.db/stance-tiger-stance.json
+++ b/packs/data/feat-effects.db/stance-tiger-stance.json
@@ -30,6 +30,7 @@
                 "key": "Strike",
                 "label": "PF2E.SpecificRule.Stance.Attack.TigerClaw",
                 "range": null,
+                "slug": "tiger-claw",
                 "traits": [
                     "agile",
                     "finesse",


### PR DESCRIPTION
Added `slug` field to Tiger Claw strike (from the Tiger Stance).
The absence of `slug` caused bleed-on-crit and Tiger Slash to not apply when Tiger Claw strike name was translated. 