### PR TITLE
Add slug to Anadi fangs

### DIFF
--- a/packs/data/ancestryfeatures.db/fangs.json
+++ b/packs/data/ancestryfeatures.db/fangs.json
@@ -33,6 +33,7 @@
                 "key": "Strike",
                 "label": "PF2E.BattleForm.Attack.Fangs",
                 "range": null,
+                "slug": "fangs",
                 "traits": [
                     "finesse",
                     "unarmed"


### PR DESCRIPTION
Add "slug" to Anadi fangs to trigger rule correctly.
If change language then "slug" for this item uses translated version and breaks other rules like effects