### PR TITLE
Remove array-wrapping behavior (`_cast` method) in `PredicateField`

### DIFF
--- a/src/module/system/schema-data-fields.ts
+++ b/src/module/system/schema-data-fields.ts
@@ -110,6 +110,11 @@ class PredicateField<
         super(new PredicateStatementField(), options);
     }
 
+    /** Don't wrap a non-array in an array */
+    override _cast(value: unknown): unknown {
+        return value;
+    }
+
     /** Construct a `PredicatePF2e` from the initialized `PredicateStatement[]` */
     override initialize(
         value: RawPredicate,

--- a/types/foundry/common/data/fields.d.ts
+++ b/types/foundry/common/data/fields.d.ts
@@ -482,7 +482,7 @@ export class ArrayField<
 
     protected static override get _defaults(): ArrayFieldOptions<unknown[], boolean, boolean, boolean>;
 
-    protected override _cast(value: unknown): TSourceProp;
+    protected override _cast(value: unknown): unknown;
 
     protected _cleanType(
         value: unknown[] | Set<unknown>,


### PR DESCRIPTION
`ArrayField` will wrap any non-array in an array, which is too loose for data validation purposes.

Closes #7664