### PR TITLE
Ensure inline type parameter is sluggified

### DIFF
--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -370,7 +370,7 @@ class TextEditorPF2e extends TextEditor {
                           })
                           .join(" ");
                 html.innerHTML = inlineLabel ?? skillLabel;
-                html.setAttribute("data-pf2-check", params.type);
+                html.setAttribute("data-pf2-check", sluggify(params.type));
             }
         }
 

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -370,7 +370,7 @@ class TextEditorPF2e extends TextEditor {
                           })
                           .join(" ");
                 html.innerHTML = inlineLabel ?? skillLabel;
-                html.setAttribute("data-pf2-check", sluggify(params.type));
+                html.dataset.pf2Check = sluggify(params.type);
             }
         }
 


### PR DESCRIPTION
This is not really a bugfix, more making it slightly more user friendly. It's expanding the system to accept `@Check[type:Athletics]` or `@Check[type:Engineering Lore]` without causing issues where the skill isn't found. This fixes some problems with the AV module journals as they have capitalized skill names, but enabling lore skills without needing an explicit label is actually useful for the system.