### PR TITLE
Loosen string format requirement of choice set flags

### DIFF
--- a/src/module/rules/rule-element/choice-set/rule-element.ts
+++ b/src/module/rules/rule-element/choice-set/rule-element.ts
@@ -166,10 +166,10 @@ class ChoiceSetRuleElement extends RuleElementPF2e<ChoiceSetSchema> {
     }
 
     #setDefaultFlag(source: ChoiceSetSource): string {
-        if (typeof source.flag === "string" && source.flag.length > 0) {
-            return sluggify(source.flag, { camel: "dromedary" });
-        }
-        return (source.flag = sluggify(this.item.slug ?? this.item.name, { camel: "dromedary" }));
+        return (source.flag =
+            typeof source.flag === "string" && source.flag.length > 0
+                ? source.flag.replace(/[^-a-z0-9]/gi, "")
+                : sluggify(this.item.slug ?? this.item.name, { camel: "dromedary" }));
     }
 
     /**


### PR DESCRIPTION
This isn't documented and trips up users writing their own choice sets. We can look at linting system usage of it.