### PR TITLE
Add setting to control visibility of `refreshFromCompendium` buttons

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -194,6 +194,7 @@ declare global {
         get(module: "pf2e", setting: "compendiumBrowserPacks"): CompendiumBrowserSettings;
         get(module: "pf2e", setting: "critFumbleButtons"): boolean;
         get(module: "pf2e", setting: "critRule"): "doubledamage" | "doubledice";
+        get(module: "pf2e", setting: "dataTools"): boolean;
         get(module: "pf2e", setting: "deathIcon"): ImageFilePath;
         get(module: "pf2e", setting: "drawCritFumble"): boolean;
         get(module: "pf2e", setting: "enabledRulesUI"): boolean;

--- a/src/module/item/sheet/base.ts
+++ b/src/module/item/sheet/base.ts
@@ -495,7 +495,11 @@ export class ItemSheetPF2e<TItem extends ItemPF2e> extends ItemSheet<TItem> {
             buttons.splice(buttons.indexOf(sheetButton), 1);
         }
         // Convenenience utility for data entry; may make available to general users in the future
-        if (BUILD_MODE === "development" && this.item.isOwned && this.item.sourceId?.startsWith("Compendium.")) {
+        if (
+            game.settings.get("pf2e", "dataTools") &&
+            this.item.isOwned &&
+            this.item.sourceId?.startsWith("Compendium.")
+        ) {
             buttons.unshift({
                 label: "Refresh",
                 class: "refresh-from-compendium",

--- a/src/module/system/settings/index.ts
+++ b/src/module/system/settings/index.ts
@@ -135,14 +135,28 @@ export function registerSettings(): void {
     });
 
     game.settings.register("pf2e", "deathIcon", {
-        name: "PF2E.Settings.DeathIcon.Name",
-        hint: "PF2E.Settings.DeathIcon.Hint",
+        name: "PF2E.SETTINGS.DeathIcon.Name",
+        hint: "PF2E.SETTINGS.DeathIcon.Hint",
         scope: "world",
         config: false,
         default: "icons/svg/skull.svg",
         type: String,
         onChange: (choice?: string) => {
             if (isImageOrVideoPath(choice)) CONFIG.controlIcons.defeated = choice;
+        },
+    });
+
+    game.settings.register("pf2e", "dataTools", {
+        name: "PF2E.SETTINGS.DataTools.Name",
+        hint: "PF2E.SETTINGS.DataTools.Hint",
+        scope: "world",
+        config: false,
+        default: BUILD_MODE === "development",
+        type: Boolean,
+        onChange: () => {
+            for (const app of Object.values(ui.windows).filter((a) => a instanceof DocumentSheet)) {
+                app.render();
+            }
         },
     });
 


### PR DESCRIPTION
Data entry typically runs on production builds, so limiting it to dev build mode has it not reaching the target audience.