### PR TITLE
Include compendia from modules beginning with `pf2e` in early migrations

### DIFF
--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -1067,7 +1067,7 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
         if (item.isOfType("feat")) {
             // Ensure feats from non-system compendiums are current before checking for appropriate feat slots
             const itemUUID = item.uuid;
-            if (itemUUID.startsWith("Compendium") && !itemUUID.startsWith("Compendium.pf2e")) {
+            if (itemUUID.startsWith("Compendium") && !itemUUID.startsWith("Compendium.pf2e.")) {
                 await MigrationRunner.ensureSchemaVersion(item, MigrationList.constructFromVersion(item.schemaVersion));
             }
             const featSlot = this.#getNearestFeatSlotId(event) ?? { categoryId: "" };


### PR DESCRIPTION
Took me slightly longer than I said, but, first PR (to anything, ever, so if I did a bad let me know): fixed the dot