### PR TITLE
Fix breakdown tag for weapon persistent damage

### DIFF
--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -312,19 +312,6 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
                     resolvables: { spell: this },
                 })
             );
-
-            // Apply tweaks from base to damage dice labels. A similar thing is done in WeaponDamagePF2e#calculate().
-            // Eventually we need to consolidate the two.
-            for (const dice of damageDice) {
-                const matchingBase = base.find((t) => t.damageType === dice.damageType) || base.at(0);
-                const matchingFaces = matchingBase?.terms.find((t) => !!t.dice)?.dice?.faces;
-                const dieSize = dice.dieSize || (matchingFaces ? `d${matchingFaces}` : null);
-                if (dice.diceNumber > 0 && dieSize) {
-                    dice.label += ` +${dice.diceNumber}${dieSize}`;
-                } else if (dieSize) {
-                    dice.label += ` ${dice.dieSize}`;
-                }
-            }
         }
 
         const damage: DamageFormulaData = {

--- a/src/module/system/damage/formula.ts
+++ b/src/module/system/damage/formula.ts
@@ -1,6 +1,6 @@
-import { DamageDicePF2e, ModifierPF2e } from "@actor/modifiers.ts";
+import { DamageDicePF2e } from "@actor/modifiers.ts";
 import { DegreeOfSuccessIndex, DEGREE_OF_SUCCESS } from "@system/degree-of-success.ts";
-import { groupBy, sum, sortBy } from "@util";
+import { groupBy, sum, sortBy, addSign } from "@util";
 import {
     CriticalInclusion,
     DamageCategoryUnique,
@@ -79,15 +79,18 @@ function createDamageFormula(
     // Hold onto base terms for matching reasons (such as adding extra base dice)
     const baseTerms = [...typeMap.values()].flat();
 
-    // Dice always stack
+    // Sometimes a weapon may add base damage as bonus modifiers or dice. We need to auto-generate these
+    const BONUS_BASE_LABELS = ["PF2E.ConditionTypePersistent"].map((l) => game.i18n.localize(l));
+
+    // Add damage dice. Dice always stack
     for (const dice of damage.dice.filter((d) => d.enabled)) {
-        const damageType = dice.damageType ?? baseTerms[0].damageType;
         const matchingBase = baseTerms.find((b) => b.damageType === dice.damageType) ?? baseTerms[0];
-        const faces = Number(dice.dieSize?.replace("d", "")) || matchingBase.dice?.faces || null;
+        const faces = Number(dice.dieSize?.replace("d", "")) || matchingBase?.dice?.faces || null;
+        const damageType = dice.damageType ?? matchingBase.damageType;
         if (dice.diceNumber > 0 && faces) {
             const list = typeMap.get(damageType) ?? [];
             list.push({
-                label: dice.label,
+                label: BONUS_BASE_LABELS.includes(dice.label) ? null : `${dice.label} +${dice.diceNumber}d${faces}`,
                 dice: { number: dice.diceNumber, faces },
                 modifier: 0,
                 damageType,
@@ -101,18 +104,14 @@ function createDamageFormula(
     // Test that a damage modifier or dice partial is compatible with the prior check result
     const outcomeMatches = (m: { critical: boolean | null }): boolean => critical || m.critical !== true;
 
-    const modifiers = damage.modifiers
-        .filter((m) => m.enabled)
-        .flatMap((modifier): ModifierPF2e | never[] => {
-            modifier.damageType ??= damage.base[0].damageType;
-            return outcomeMatches(modifier) ? modifier : [];
-        });
+    // Add modifiers
+    for (const modifier of damage.modifiers.filter((m) => m.enabled && outcomeMatches(m))) {
+        const matchingBase = baseTerms.find((b) => b.damageType === modifier.damageType) ?? baseTerms[0];
+        const damageType = modifier.damageType ?? matchingBase.damageType;
 
-    for (const modifier of modifiers) {
-        const damageType = modifier.damageType ?? damage.base[0].damageType;
         const list = typeMap.get(damageType) ?? [];
         list.push({
-            label: `${modifier.label} ${modifier.value < 0 ? "" : "+"}${modifier.value}`,
+            label: BONUS_BASE_LABELS.includes(modifier.label) ? null : `${modifier.label} ${addSign(modifier.value)}`,
             dice: null,
             modifier: modifier.value,
             damageType,

--- a/src/module/system/damage/weapon.ts
+++ b/src/module/system/damage/weapon.ts
@@ -513,28 +513,6 @@ class WeaponDamagePF2e {
             ignoredResistances,
         };
 
-        // include dice number and size in damage tag
-        for (const dice of damage.dice) {
-            dice.label = game.i18n.localize(dice.label ?? dice.slug);
-            if (dice.diceNumber > 0 && dice.dieSize) {
-                dice.label += ` +${dice.diceNumber}${dice.dieSize}`;
-            } else if (base.dieSize && dice.diceNumber > 0) {
-                dice.label += ` +${dice.diceNumber}${base.dieSize}`;
-            } else if (dice.dieSize) {
-                dice.label += ` ${dice.dieSize}`;
-            }
-            if (
-                dice.category &&
-                dice.category !== "persistent" &&
-                (dice.diceNumber > 0 || dice.dieSize) &&
-                (!dice.damageType || (dice.damageType === base.damageType && dice.category !== base.category))
-            ) {
-                dice.label += ` ${dice.category}`;
-            }
-            dice.enabled = dice.predicate.test(options);
-            dice.ignored = !dice.enabled;
-        }
-
         const excludeFrom = weapon.isOfType("weapon") ? weapon : null;
         this.#excludeDamage({ actor, weapon: excludeFrom, modifiers: [...modifiers, ...damageDice], options });
 


### PR DESCRIPTION
I'm a bit disgusted I had to hardcode. I could hardcode against the weapon-persistent slug instead.

![image](https://user-images.githubusercontent.com/1286721/236963851-cfbcbc2a-74e3-49af-b451-21a3af11bc89.png)
