### PR TITLE
Automate Skinstitch Flay damage. Add Pest Haven effect.

### DIFF
--- a/packs/data/agents-of-edgewatch-bestiary.db/skitterstitch.json
+++ b/packs/data/agents-of-edgewatch-bestiary.db/skitterstitch.json
@@ -149,7 +149,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>The rotting hides and molding straw stuffing of skitterstitches are ideal nesting grounds for vermin and insect swarms.</p>\n<p>Any animal swarm sharing a space with a skitterstitch gains @UUID[Compendium.pf2e.bestiary-ability-glossary-srd.Fast Healing]{Fast Healing} 3.</p>\n<p>Additionally, if a creature deals at least 10 piercing or slashing damage to the skitterstitchstitch, the swarm can use its swarming bites Strike (or similar attack) against the attacker as a reaction.</p>"
+                    "value": "<p>The rotting hides and molding straw stuffing of skitterstitches are ideal nesting grounds for vermin and insect swarms. Any animal swarm sharing a space with a skitterstitch gains fast healing 3.</p>\n<p>Additionally, if a creature deals at least 10 piercing or slashing damage to the skitterstitchstitch, the swarm can use its swarming bites Strike (or similar attack) against the attacker as a reaction.</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Effect: Pest Haven]{Effect: Pest Haven}</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -230,12 +230,29 @@
                     "value": 2
                 },
                 "description": {
-                    "value": "<p>The skitterstitch makes a blade Strike against an animal or humanoid. On a success, the skitterstitch slices a long strip of flesh from the target; if the skitterstitch dealt damage, it deals an additional [[/r (1d6+4)[bleed]]] damage.</p>"
+                    "value": "<p>The skitterstitch makes a blade Strike against an animal or humanoid. On a success, the skitterstitch slices a long strip of flesh from the target; if the skitterstitch dealt damage, it deals an additional 1d6 persistent bleed damage.</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "domain": "strike-damage",
+                        "key": "RollOption",
+                        "option": "flay",
+                        "toggleable": true
+                    },
+                    {
+                        "damageType": "bleed",
+                        "diceNumber": 1,
+                        "dieSize": "d6",
+                        "key": "DamageDice",
+                        "predicate": [
+                            "flay"
+                        ],
+                        "selector": "blade-legs-damage"
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""
@@ -310,7 +327,7 @@
                     "value": 1
                 },
                 "description": {
-                    "value": "<p><strong>Requirements</strong> The skitterstitch hasn't used this ability since the last time it successfully used its Flay ability</p>\n<hr />\n<p><strong>Effect</strong> The skitterstitch sews flayed flesh to its body to seal tears and rents. The skitterstitch regains 8 Hit Points.</p>"
+                    "value": "<p><strong>Requirements</strong> The skitterstitch hasn't used this ability since the last time it successfully used its Flay ability</p>\n<hr />\n<p><strong>Effect</strong> The skitterstitch sews flayed flesh to its body to seal tears and rents. The skitterstitch regains [[/r 8[healing]]]{8 Hit Points}.</p>"
                 },
                 "requirements": {
                     "value": ""

--- a/packs/data/bestiary-effects.db/effect-pest-haven.json
+++ b/packs/data/bestiary-effects.db/effect-pest-haven.json
@@ -1,0 +1,40 @@
+{
+    "_id": "CM14G9kLI97aIC5h",
+    "img": "systems/pf2e/icons/spells/swarming-wasp-stings.webp",
+    "name": "Effect: Pest Haven",
+    "system": {
+        "description": {
+            "value": "<p>Any animal swarm sharing a space with a skinstitch gains fast healing 3.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "unlimited",
+            "value": -1
+        },
+        "level": {
+            "value": 1
+        },
+        "rules": [
+            {
+                "key": "FastHealing",
+                "value": 3
+            }
+        ],
+        "source": {
+            "value": "Pathfinder Bestiary 3"
+        },
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "target": null,
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/data/pathfinder-bestiary-3.db/skinstitch.json
+++ b/packs/data/pathfinder-bestiary-3.db/skinstitch.json
@@ -148,7 +148,7 @@
                     "value": null
                 },
                 "description": {
-                    "value": "<p>The rotting hides and molding straw stuffing of skinstitches are ideal nesting grounds for vermin and insect swarms. Any animal swarm sharing a space with a skinstitch gains @UUID[Compendium.pf2e.bestiary-ability-glossary-srd.Fast Healing]{Fast Healing 3}</p>\n<p>Additionally, if a creature deals at least 10 piercing or slashing damage to the skinstitch at once, the swarm can use its swarming bites Strike (or similar attack) against the attacker as a reaction.</p>"
+                    "value": "<p>The rotting hides and molding straw stuffing of skinstitches are ideal nesting grounds for vermin and insect swarms. Any animal swarm sharing a space with a skinstitch gains fast healing 3.</p>\n<p>Additionally, if a creature deals at least 10 piercing or slashing damage to the skinstitch at once, the swarm can use its swarming bites Strike (or similar attack) against the attacker as a reaction.</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Effect: Pest Haven]{Effect: Pest Haven}</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -187,7 +187,7 @@
                     "value": 2
                 },
                 "description": {
-                    "value": "<p>The skinstitch makes a blade Strike against an animal or humanoid. On a success, the skinstitch slices a long strip of flesh from the target; if the skinstitch dealt damage, it deals an additional [[/r 1d6[bleed]]].</p>"
+                    "value": "<p>The skinstitch makes a blade Strike against an animal or humanoid. On a success, the skinstitch slices a long strip of flesh from the target; if the skinstitch dealt damage, it deals an additional 1d6 persistent bleed damage.</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -200,18 +200,14 @@
                         "toggleable": true
                     },
                     {
-                        "key": "Note",
-                        "outcome": [
-                            "success",
-                            "criticalSuccess"
-                        ],
+                        "damageType": "bleed",
+                        "diceNumber": 1,
+                        "dieSize": "d6",
+                        "key": "DamageDice",
                         "predicate": [
                             "flay"
                         ],
-                        "selector": "blade-damage",
-                        "text": "{item|system.description.value}",
-                        "title": "{item|name}",
-                        "visibility": "owner"
+                        "selector": "blade-damage"
                     }
                 ],
                 "slug": null,


### PR DESCRIPTION
It's not clear whether the Skitterstitch should have the Flay and Stitch Skin actions ("These elite skinstitch variants have different attacks from the standard skinstitch, including a deadly poison."), so I've left the abilities in place for now.