### PR TITLE
Prevent partial statements from including NaN in the values

### DIFF
--- a/src/module/system/predication.ts
+++ b/src/module/system/predication.ts
@@ -102,7 +102,7 @@ class PredicatePF2e extends Array<PredicateStatement> {
                 case "lte":
                     return leftValues.some((l) => rightValues.every((r) => l <= r));
                 default:
-                    console.warn("PF2e System | Malformed binary operation encounter");
+                    console.warn("PF2e System | Malformed binary operation encountered");
                     return false;
             }
         }

--- a/src/module/system/predication.ts
+++ b/src/module/system/predication.ts
@@ -76,19 +76,12 @@ class PredicatePF2e extends Array<PredicateStatement> {
             // E.g., `{ "gt": ["actor:level", 5] }` would match against "actor:level:6" and "actor:level:7"
             const [left, right] = Object.values(statement)[0];
             const domainArray = Array.from(domain);
-
-            const getValues = (operand: string | number) => {
-                return typeof operand === "number" || !Number.isNaN(Number(operand))
-                    ? [Number(operand)]
-                    : domainArray.flatMap((d) => {
-                          if (d.startsWith(operand)) {
-                              const value = Number(/:(-?\d+)$/.exec(d)?.[1]);
-                              if (!Number.isNaN(value)) return value;
-                          }
-                          return [];
-                      });
+            const getValues = (operand: string | number): number[] => {
+                const maybeNumber = Number(operand);
+                if (!Number.isNaN(maybeNumber)) return [maybeNumber];
+                const pattern = new RegExp(String.raw`^${operand}:([^:]+)$`);
+                return domainArray.map((s) => Number(pattern.exec(s)?.[1] || NaN)).filter((v) => !Number.isNaN(v));
             };
-
             const leftValues = getValues(left);
             const rightValues = getValues(right);
 

--- a/src/module/system/predication.ts
+++ b/src/module/system/predication.ts
@@ -76,14 +76,21 @@ class PredicatePF2e extends Array<PredicateStatement> {
             // E.g., `{ "gt": ["actor:level", 5] }` would match against "actor:level:6" and "actor:level:7"
             const [left, right] = Object.values(statement)[0];
             const domainArray = Array.from(domain);
-            const leftValues =
-                typeof left === "number" || !Number.isNaN(Number(left))
-                    ? [Number(left)]
-                    : domainArray.flatMap((d) => (d.startsWith(left) ? Number(/:(-?\d+)$/.exec(d)?.[1]) : []));
-            const rightValues =
-                typeof right === "number" || !Number.isNaN(Number(right))
-                    ? [Number(right)]
-                    : domainArray.flatMap((d) => (d.startsWith(right) ? Number(/:(-?\d+)$/.exec(d)?.[1]) : []));
+
+            const getValues = (operand: string | number) => {
+                return typeof operand === "number" || !Number.isNaN(Number(operand))
+                    ? [Number(operand)]
+                    : domainArray.flatMap((d) => {
+                          if (d.startsWith(operand)) {
+                              const value = Number(/:(-?\d+)$/.exec(d)?.[1]);
+                              if (!Number.isNaN(value)) return value;
+                          }
+                          return [];
+                      });
+            };
+
+            const leftValues = getValues(left);
+            const rightValues = getValues(right);
 
             switch (operator) {
                 case "gt":


### PR DESCRIPTION
Without this fix, this predicate fails:
```
"predicate": [
	{
		"lt": [
			"self:size",
			"target:size"
		]
	}
]
```

This is because in testBinaryOp(), domains contains:
self:size:2, self:size:medium, target:size:4, target:size:huge
This results in values of:
self:size: (2,NaN)
target:size: (4,NaN)

After this fix, the values are:
self:size: (2)
target:size: (4)