### PR TITLE
Implement damage reduction from hardness

### DIFF
--- a/src/module/actor/hazard/document.ts
+++ b/src/module/actor/hazard/document.ts
@@ -29,6 +29,10 @@ class HazardPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | 
         return this.system.details.isComplex;
     }
 
+    override get hardness(): number {
+        return Math.abs(this.system.attributes.hardness);
+    }
+
     /** Minimal check since the disabled status of a hazard isn't logged */
     override get canAttack(): boolean {
         return this.itemTypes.melee.length > 0;

--- a/src/module/actor/npc/document.ts
+++ b/src/module/actor/npc/document.ts
@@ -41,6 +41,10 @@ class NPCPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | nul
         return this.system.details.publicNotes;
     }
 
+    override get hardness(): number {
+        return Math.abs(this.system.attributes.hardness?.value ?? 0);
+    }
+
     /** Does this NPC have the Elite adjustment? */
     get isElite(): boolean {
         return this.attributes.adjustment === "elite";

--- a/src/module/actor/types.ts
+++ b/src/module/actor/types.ts
@@ -1,9 +1,9 @@
 import * as ActorInstance from "@actor";
-import { ActorPF2e } from "@actor/base.ts";
 import * as ItemInstance from "@item";
 import { EffectTrait } from "@item/abstract-effect/index.ts";
 import { ItemInstances } from "@item/types.ts";
 import { TokenPF2e } from "@module/canvas/index.ts";
+import { ActorPF2e, ItemPF2e } from "@module/documents.ts";
 import { TokenDocumentPF2e } from "@scene/index.ts";
 import { immunityTypes, resistanceTypes, weaknessTypes } from "@scripts/config/iwr.ts";
 import { DamageRoll } from "@system/damage/roll.ts";
@@ -164,6 +164,8 @@ interface CheckContext<
 interface ApplyDamageParams {
     damage: number | Rolled<DamageRoll>;
     token: TokenDocumentPF2e;
+    /** The item used in the damaging action */
+    item?: ItemPF2e<ActorPF2e> | null;
     skipIWR?: boolean;
     /** Predicate statements from the damage roll */
     rollOptions?: Set<string>;

--- a/src/module/chat-message/helpers.ts
+++ b/src/module/chat-message/helpers.ts
@@ -62,6 +62,7 @@ async function applyDamageFromMessage({
         await contextClone.applyDamage({
             damage,
             token,
+            item: message.item,
             skipIWR: multiplier <= 0,
             rollOptions: applicationRollOptions,
             shieldBlockRequest,

--- a/src/module/system/damage/iwr.ts
+++ b/src/module/system/damage/iwr.ts
@@ -203,7 +203,7 @@ interface IWRApplicationData {
     persistent: DamageInstance[];
 }
 
-interface UnafectedApplication {
+interface UnaffectedApplication {
     category: "unaffected";
     type: string;
     adjustment: number;
@@ -228,6 +228,18 @@ interface ResistanceApplication {
     ignored: boolean;
 }
 
-type IWRApplication = UnafectedApplication | ImmunityApplication | WeaknessApplication | ResistanceApplication;
+/** Post-IWR reductions from various sources (e.g., hardness) */
+interface DamageReductionApplication {
+    category: "reduction";
+    type: string;
+    adjustment: number;
+}
+
+type IWRApplication =
+    | UnaffectedApplication
+    | ImmunityApplication
+    | WeaknessApplication
+    | ResistanceApplication
+    | DamageReductionApplication;
 
 export { IWRApplication, IWRApplicationData, applyIWR };

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -887,7 +887,8 @@
                     "immunity": "Immune to {type}: {adjustment}",
                     "resistance": "Resistant to {type}: {adjustment}",
                     "unaffected": "Unaffected by {type}: {adjustment}",
-                    "weakness": "Weak to {type}: {adjustment}"
+                    "weakness": "Weak to {type}: {adjustment}",
+                    "reduction": "Reduced by {type}: {adjustment}"
                 },
                 "CompositeLabel": {
                     "Exceptions0DoubleVs0": "{type} {value}",
@@ -1011,6 +1012,10 @@
                     "weapons": "weapons",
                     "weapons-shedding-bright-light": "weapons shedding bright light"
                 }
+            },
+            "Hardness": {
+                "Full": "hardness",
+                "Half": "half hardness"
             },
             "IncreasedFrom": "Increased from {original} to minimum of 1",
             "NoDamageFormulaLabel": "No damage",


### PR DESCRIPTION
Closes #7634 

Adamantine dagger treating the animated armor's hardness as half its actual value:
![image](https://github.com/foundryvtt/pf2e/assets/106829671/22ce3370-8dac-41bb-872a-c96fc8c43ea8)
