### PR TITLE
Restore wands to max charges when resting rather than 1

### DIFF
--- a/src/scripts/macros/rest-for-the-night.ts
+++ b/src/scripts/macros/rest-for-the-night.ts
@@ -88,7 +88,7 @@ export async function restForTheNight(options: ActionDefaultOptions): Promise<Ch
         // Restore wand charges
         const items = actor.itemTypes;
         const wands = items.consumable.filter((i) => i.category === "wand" && i.uses.value < i.uses.max);
-        itemUpdates.push(...wands.map((wand) => ({ _id: wand.id, "system.charges.value": 1 })));
+        itemUpdates.push(...wands.map((wand) => ({ _id: wand.id, "system.charges.value": wand.uses.max })));
         const wandRecharged = itemUpdates.length > 0;
 
         // Restore reagents


### PR DESCRIPTION
This is useful when you have multiple wands of the same type, allowing you to track them as a single item stack with multiple charges, or for homebrew wands with more than one charge.