### PR TITLE
Add predicate to energizing lattice extra damage

### DIFF
--- a/packs/data/equipment-effects.db/effect-energizing-lattice.json
+++ b/packs/data/equipment-effects.db/effect-energizing-lattice.json
@@ -37,7 +37,8 @@
                 "diceNumber": 6,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "selector": "strike-damage"
+                "selector": "strike-damage",
+                "predicate":["unleash-energy"]
             }
         ],
         "source": {


### PR DESCRIPTION
Energizing lattice's additional damage should be predicated on the roll option being present