### PR TITLE
Add a method to fully revert applied actor damage

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -1323,7 +1323,6 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
             persistentDamage.length > 0 ? await this.createEmbeddedDocuments("Item", persistentDamage) : []
         ) as ConditionPF2e<this>[];
 
-        const isHealing = hpDamage < 0;
         const content = await renderTemplate("systems/pf2e/templates/chat/damage/damage-taken.hbs", {
             statements,
             persistent: persistentCreated.map((p) => p.system.persistent!.damage.formula),
@@ -1332,7 +1331,6 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
                 visibility: this.hasPlayerOwner ? "all" : "gm",
             },
             canRevertDamage: this.canUserModify(game.user, "update"),
-            isHealing,
         });
 
         await ChatMessagePF2e.create({
@@ -1342,7 +1340,7 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
                 pf2e: {
                     appliedDamage: {
                         uuid: this.uuid,
-                        isHealing,
+                        isHealing: hpDamage < 0,
                         shield: shieldDamage !== 0 ? { id: actorShield?.itemId ?? "", damage: shieldDamage } : null,
                         persistent: persistentCreated.map((c) => c.id),
                         updates: Object.entries(hpUpdate.updates)

--- a/src/module/apps/sidebar/chat-log.ts
+++ b/src/module/apps/sidebar/chat-log.ts
@@ -74,7 +74,7 @@ export class ChatLogPF2e extends ChatLog<ChatMessagePF2e> {
                 }
             }
 
-            const revertDamageButton = htmlClosest<HTMLButtonElement>(target, "button.revert-damage");
+            const revertDamageButton = htmlClosest<HTMLButtonElement>(target, "button[data-action=revert-damage]");
             if (revertDamageButton) {
                 const appliedDamageFlag = message?.flags.pf2e.appliedDamage;
                 if (appliedDamageFlag) {

--- a/src/module/apps/sidebar/chat-log.ts
+++ b/src/module/apps/sidebar/chat-log.ts
@@ -246,20 +246,6 @@ export class ChatLogPF2e extends ChatLog<ChatMessagePF2e> {
         const canApplyTripleDamage: ContextOptionCondition = ($li: JQuery) =>
             canApplyDamage($li) && game.settings.get("pf2e", "critFumbleButtons");
 
-        const canRevertDamage: ContextOptionCondition = ($li: JQuery) => {
-            const message = game.messages.get($li[0].dataset.messageId, { strict: true });
-            const flag = message.flags.pf2e.appliedDamage;
-            if (!flag) return false;
-            const actorOrToken = fromUuidSync(flag.uuid);
-            const actor =
-                actorOrToken instanceof ActorPF2e
-                    ? actorOrToken
-                    : actorOrToken instanceof TokenDocumentPF2e
-                    ? actorOrToken.actor
-                    : null;
-            return !!actor && actor.canUserModify(game.user, "update");
-        };
-
         const canApplyInitiative: ContextOptionCondition = ($li: JQuery) => {
             const message = game.messages.get($li[0].dataset.messageId, { strict: true });
 
@@ -341,32 +327,6 @@ export class ChatLogPF2e extends ChatLog<ChatMessagePF2e> {
                 callback: ($li: JQuery) => {
                     const message = game.messages.get($li[0].dataset.messageId, { strict: true });
                     applyDamageFromMessage({ message, multiplier: -1 });
-                },
-            },
-            {
-                name: "PF2E.RevertDamage.Label",
-                icon: fontAwesomeIcon("trash-undo").outerHTML,
-                condition: canRevertDamage,
-                callback: async ($li: JQuery) => {
-                    const message = game.messages.get($li[0].dataset.messageId, { strict: true });
-                    const flag = message.flags.pf2e.appliedDamage;
-                    if (flag) {
-                        const actorOrToken = fromUuidSync(flag.uuid);
-                        const actor =
-                            actorOrToken instanceof ActorPF2e
-                                ? actorOrToken
-                                : actorOrToken instanceof TokenDocumentPF2e
-                                ? actorOrToken.actor
-                                : null;
-                        if (actor) {
-                            await actor.revertDamage(flag);
-                            const localization = flag.isHealing
-                                ? "PF2E.RevertDamage.HealingMessage"
-                                : "PF2E.RevertDamage.DamageMessage";
-                            ui.notifications.info(game.i18n.format(localization, { actor: actor.name }));
-                            message.delete();
-                        }
-                    }
                 },
             },
             {

--- a/src/module/apps/sidebar/chat-log.ts
+++ b/src/module/apps/sidebar/chat-log.ts
@@ -74,12 +74,18 @@ export class ChatLogPF2e extends ChatLog<ChatMessagePF2e> {
                 }
             }
 
-            if (htmlClosest(target, "span.revert-damage")) {
+            const revertDamageButton = htmlClosest<HTMLButtonElement>(target, "button.revert-damage");
+            if (revertDamageButton) {
                 const appliedDamageFlag = message?.flags.pf2e.appliedDamage;
                 if (appliedDamageFlag) {
                     const reverted = await this.#handleRevertDamageClick(appliedDamageFlag);
                     if (reverted) {
-                        message.delete();
+                        htmlQuery(messageEl, "span.statements")?.classList.add("reverted");
+                        revertDamageButton.remove();
+                        await message.update({
+                            "flags.pf2e.appliedDamage.isReverted": true,
+                            content: htmlQuery(messageEl, ".message-content")?.innerHTML ?? message.content,
+                        });
                     }
                 }
             }

--- a/src/module/apps/sidebar/chat-log.ts
+++ b/src/module/apps/sidebar/chat-log.ts
@@ -8,6 +8,7 @@ import { CheckPF2e } from "@system/check/index.ts";
 import { DamageRoll } from "@system/damage/roll.ts";
 import { fontAwesomeIcon, htmlClosest, htmlQuery, objectHasKey } from "@util";
 import { looksLikeDamageRoll } from "@system/damage/helpers.ts";
+import { TokenDocumentPF2e } from "@scene";
 
 export class ChatLogPF2e extends ChatLog<ChatMessagePF2e> {
     /** Replace parent method in order to use DamageRoll class as needed */
@@ -215,6 +216,20 @@ export class ChatLogPF2e extends ChatLog<ChatMessagePF2e> {
         const canApplyTripleDamage: ContextOptionCondition = ($li: JQuery) =>
             canApplyDamage($li) && game.settings.get("pf2e", "critFumbleButtons");
 
+        const canRevertDamage: ContextOptionCondition = ($li: JQuery) => {
+            const message = game.messages.get($li[0].dataset.messageId, { strict: true });
+            const flag = message.flags.pf2e.appliedDamage;
+            if (!flag) return false;
+            const actorOrToken = fromUuidSync(flag.uuid);
+            const actor =
+                actorOrToken instanceof ActorPF2e
+                    ? actorOrToken
+                    : actorOrToken instanceof TokenDocumentPF2e
+                    ? actorOrToken.actor
+                    : null;
+            return !!actor && actor.canUserModify(game.user, "update");
+        };
+
         const canApplyInitiative: ContextOptionCondition = ($li: JQuery) => {
             const message = game.messages.get($li[0].dataset.messageId, { strict: true });
 
@@ -296,6 +311,32 @@ export class ChatLogPF2e extends ChatLog<ChatMessagePF2e> {
                 callback: ($li: JQuery) => {
                     const message = game.messages.get($li[0].dataset.messageId, { strict: true });
                     applyDamageFromMessage({ message, multiplier: -1 });
+                },
+            },
+            {
+                name: "PF2E.RevertDamage.Label",
+                icon: fontAwesomeIcon("backward").outerHTML,
+                condition: canRevertDamage,
+                callback: async ($li: JQuery) => {
+                    const message = game.messages.get($li[0].dataset.messageId, { strict: true });
+                    const flag = message.flags.pf2e.appliedDamage;
+                    if (flag) {
+                        const actorOrToken = fromUuidSync(flag.uuid);
+                        const actor =
+                            actorOrToken instanceof ActorPF2e
+                                ? actorOrToken
+                                : actorOrToken instanceof TokenDocumentPF2e
+                                ? actorOrToken.actor
+                                : null;
+                        if (actor) {
+                            await actor.revertDamage(flag);
+                            const localization = flag.isHealing
+                                ? "PF2E.RevertDamage.HealingMessage"
+                                : "PF2E.RevertDamage.DamageMessage";
+                            ui.notifications.info(game.i18n.format(localization, { actor: actor.name }));
+                            message.delete();
+                        }
+                    }
                 },
             },
             {

--- a/src/module/chat-message/data.ts
+++ b/src/module/chat-message/data.ts
@@ -24,6 +24,7 @@ type ChatMessageFlagsPF2e = foundry.documents.ChatMessageFlags & {
         journalEntry?: DocumentUUID;
         spellVariant?: { overlayIds: string[] };
         strike?: StrikeLookupData | null;
+        appliedDamage?: AppliedDamageFlag;
         [key: string]: unknown;
     };
     core: NonNullable<foundry.documents.ChatMessageFlags["core"]>;
@@ -100,7 +101,19 @@ interface SpellCastContextFlag {
     rollMode?: RollMode;
 }
 
+interface AppliedDamageFlag {
+    uuid: ActorUUID | TokenDocumentUUID;
+    isHealing: boolean;
+    persistent: string[];
+    shield: {
+        id: string;
+        damage: number;
+    } | null;
+    updates: { path: string; value: number }[];
+}
+
 export {
+    AppliedDamageFlag,
     ChatContextFlag,
     ChatMessageSourcePF2e,
     ChatMessageFlagsPF2e,

--- a/src/module/chat-message/data.ts
+++ b/src/module/chat-message/data.ts
@@ -104,6 +104,7 @@ interface SpellCastContextFlag {
 interface AppliedDamageFlag {
     uuid: ActorUUID | TokenDocumentUUID;
     isHealing: boolean;
+    isReverted?: boolean;
     persistent: string[];
     shield: {
         id: string;

--- a/src/styles/ui/sidebar/chat/_damage.scss
+++ b/src/styles/ui/sidebar/chat/_damage.scss
@@ -429,5 +429,18 @@
                 max-width: fit-content;
             }
         }
+
+        button.revert-damage {
+            align-items: center;
+            background: var(--bg-dark);
+            display: inline-flex;
+            justify-content: center;
+            width: 3ch;
+            margin-left: 2px;
+        }
+
+        .reverted {
+            text-decoration: line-through;
+        }
     }
 }

--- a/src/styles/ui/sidebar/chat/_index.scss
+++ b/src/styles/ui/sidebar/chat/_index.scss
@@ -22,9 +22,5 @@
 
     > .message-content {
         @import "conditions";
-
-        .revert-damage {
-            cursor: pointer;
-        }
     }
 }

--- a/src/styles/ui/sidebar/chat/_index.scss
+++ b/src/styles/ui/sidebar/chat/_index.scss
@@ -22,5 +22,9 @@
 
     > .message-content {
         @import "conditions";
+
+        .revert-damage {
+            cursor: pointer;
+        }
     }
 }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2636,8 +2636,7 @@
         "ResolveTitle": "The amount of resolve points you have",
         "RestoreSpellTitle": "Restore Spell",
         "RevertDamage": {
-            "ButtonTooltipDamage": "Undo this damage",
-            "ButtonTooltipHealing": "Undo this damage",
+            "ButtonTooltip": "Undo",
             "DamageMessage": "Damage applied to {actor} was reverted",
             "HealingMessage": "Healing applied to {actor} was reverted"
         },

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2636,9 +2636,11 @@
         "ResolveTitle": "The amount of resolve points you have",
         "RestoreSpellTitle": "Restore Spell",
         "RevertDamage": {
-            "Label": "Revert",
+            "ButtonTooltipDamage": "Undo this damage",
+            "ButtonTooltipHealing": "Undo this damage",
             "DamageMessage": "Damage applied to {actor} was reverted",
-            "HealingMessage": "Healing applied to {actor} was reverted"
+            "HealingMessage": "Healing applied to {actor} was reverted",
+            "Label": "Revert"
         },
         "Roll": {
             "Add": "Add",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2639,8 +2639,7 @@
             "ButtonTooltipDamage": "Undo this damage",
             "ButtonTooltipHealing": "Undo this damage",
             "DamageMessage": "Damage applied to {actor} was reverted",
-            "HealingMessage": "Healing applied to {actor} was reverted",
-            "Label": "Revert"
+            "HealingMessage": "Healing applied to {actor} was reverted"
         },
         "Roll": {
             "Add": "Add",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2635,6 +2635,11 @@
         "ResolvePointsShortLabel": "Resolve",
         "ResolveTitle": "The amount of resolve points you have",
         "RestoreSpellTitle": "Restore Spell",
+        "RevertDamage": {
+            "Label": "Revert",
+            "DamageMessage": "Damage applied to {actor} was reverted",
+            "HealingMessage": "Healing applied to {actor} was reverted"
+        },
         "Roll": {
             "Add": "Add",
             "CriticalHit": "Critical Hit",

--- a/static/templates/chat/damage/damage-taken.hbs
+++ b/static/templates/chat/damage/damage-taken.hbs
@@ -4,7 +4,7 @@
         <span class="iwr" data-visibility="{{iwr.visibility}}" data-applications="{{json iwr.applications}}"><i class="fas fa-info-circle small"></i></span>
     {{/if}}
     {{#if canRevertDamage}}
-        <span class="revert-damage" data-tooltip="PF2E.RevertDamage.ButtonTooltip" data-tooltip-direction="UP"><i class="fa-solid fa-rotate-left"></i></span>
+        <button type="button" class="revert-damage" data-tooltip="PF2E.RevertDamage.ButtonTooltip" data-tooltip-direction="UP"><i class="fa-solid fa-rotate-left"></i></button>
     {{/if}}
 
     {{#if persistent}}

--- a/static/templates/chat/damage/damage-taken.hbs
+++ b/static/templates/chat/damage/damage-taken.hbs
@@ -3,6 +3,9 @@
     {{#if iwr.applications}}
         <span class="iwr" data-visibility="{{iwr.visibility}}" data-applications="{{json iwr.applications}}"><i class="fas fa-info-circle small"></i></span>
     {{/if}}
+    {{#if canRevertDamage}}
+        <span class="revert-damage" data-tooltip="PF2E.RevertDamage.ButtonTooltip{{#if isHealing}}Healing{{else}}Damage{{/if}}" data-tooltip-direction="UP"><i class="fas fa-trash-undo small"></i></span>
+    {{/if}}
 
     {{#if persistent}}
         <section class="persistent">

--- a/static/templates/chat/damage/damage-taken.hbs
+++ b/static/templates/chat/damage/damage-taken.hbs
@@ -4,7 +4,7 @@
         <span class="iwr" data-visibility="{{iwr.visibility}}" data-applications="{{json iwr.applications}}"><i class="fas fa-info-circle small"></i></span>
     {{/if}}
     {{#if canRevertDamage}}
-        <span class="revert-damage" data-tooltip="PF2E.RevertDamage.ButtonTooltip{{#if isHealing}}Healing{{else}}Damage{{/if}}" data-tooltip-direction="UP"><i class="fas fa-trash-undo small"></i></span>
+        <span class="revert-damage" data-tooltip="PF2E.RevertDamage.ButtonTooltip" data-tooltip-direction="UP"><i class="fa-solid fa-rotate-left"></i></span>
     {{/if}}
 
     {{#if persistent}}

--- a/static/templates/chat/damage/damage-taken.hbs
+++ b/static/templates/chat/damage/damage-taken.hbs
@@ -4,7 +4,7 @@
         <span class="iwr" data-visibility="{{iwr.visibility}}" data-applications="{{json iwr.applications}}"><i class="fas fa-info-circle small"></i></span>
     {{/if}}
     {{#if canRevertDamage}}
-        <button type="button" class="revert-damage" data-tooltip="PF2E.RevertDamage.ButtonTooltip" data-tooltip-direction="UP"><i class="fa-solid fa-rotate-left"></i></button>
+        <button type="button" class="revert-damage" data-action="revert-damage" data-tooltip="PF2E.RevertDamage.ButtonTooltip" data-tooltip-direction="UP"><i class="fa-solid fa-rotate-left"></i></button>
     {{/if}}
 
     {{#if persistent}}


### PR DESCRIPTION
The Crucible damage reversion looked neat so I implemented it for the system.
This records all applied updates in a flag on the damage chat message and adds a new context menu entry to revert everything stored in the flag.
It handles hp, temp hp, stamina, etc. and also shield hp and all persistent damage effects that were created.

[revert-damage.webm](https://github.com/foundryvtt/pf2e/assets/41452412/a0e072e5-4227-4fb4-857b-b21b313faabe)

[revert-healing.webm](https://github.com/foundryvtt/pf2e/assets/41452412/eeb9f80e-e6b4-458c-b78f-b682962ecc2f)
