### PR TITLE
Move cast level and spell variant info to origin flag

### DIFF
--- a/src/module/canvas/measured-template.ts
+++ b/src/module/canvas/measured-template.ts
@@ -2,6 +2,8 @@ import { MeasuredTemplateDocumentPF2e } from "@scene/measured-template-document.
 import { TemplateLayerPF2e } from "./index.ts";
 import { highlightGrid } from "./helpers.ts";
 import { ScenePF2e } from "@scene/index.ts";
+import { ItemPF2e } from "@item";
+import { ActorPF2e } from "@actor";
 
 class MeasuredTemplatePF2e<
     TDocument extends MeasuredTemplateDocumentPF2e<ScenePF2e | null> = MeasuredTemplateDocumentPF2e<ScenePF2e | null>
@@ -104,6 +106,10 @@ class MeasuredTemplatePF2e<
             this.refresh();
         }
     };
+
+    get item(): ItemPF2e<ActorPF2e> | null {
+        return this.document.item;
+    }
 }
 
 interface MeasuredTemplatePF2e<

--- a/src/module/chat-message/data.ts
+++ b/src/module/chat-message/data.ts
@@ -15,7 +15,7 @@ export interface ItemOriginFlag {
     type: ItemType;
     uuid: string;
     castLevel?: number;
-    spellVariantOverlayIds?: string[];
+    variant?: { overlays: string[] };
 }
 
 type ChatMessageFlagsPF2e = foundry.documents.ChatMessageFlags & {

--- a/src/module/chat-message/data.ts
+++ b/src/module/chat-message/data.ts
@@ -11,11 +11,18 @@ interface ChatMessageSourcePF2e extends foundry.documents.ChatMessageSource {
     flags: ChatMessageFlagsPF2e;
 }
 
+export interface ItemOriginFlag {
+    type: ItemType;
+    uuid: string;
+    castLevel?: number;
+    spellVariantOverlayIds?: string[];
+}
+
 type ChatMessageFlagsPF2e = foundry.documents.ChatMessageFlags & {
     pf2e: {
         damageRoll?: DamageRollFlag;
         context?: ChatContextFlag;
-        origin?: { type: ItemType; uuid: string; castLevel?: number; spellVariantOverlayIds?: string[] } | null;
+        origin?: ItemOriginFlag | null;
         casting?: { id: string; tradition: MagicTradition } | null;
         modifierName?: string;
         modifiers?: BaseRawModifier[];

--- a/src/module/chat-message/data.ts
+++ b/src/module/chat-message/data.ts
@@ -15,14 +15,13 @@ type ChatMessageFlagsPF2e = foundry.documents.ChatMessageFlags & {
     pf2e: {
         damageRoll?: DamageRollFlag;
         context?: ChatContextFlag;
-        origin?: { type: ItemType; uuid: string } | null;
-        casting?: { id: string; level: number; tradition: MagicTradition } | null;
+        origin?: { type: ItemType; uuid: string; castLevel?: number; spellVariantOverlayIds?: string[] } | null;
+        casting?: { id: string; tradition: MagicTradition } | null;
         modifierName?: string;
         modifiers?: BaseRawModifier[];
         preformatted?: "flavor" | "content" | "both";
         isFromConsumable?: boolean;
         journalEntry?: DocumentUUID;
-        spellVariant?: { overlayIds: string[] };
         strike?: StrikeLookupData | null;
         appliedDamage?: AppliedDamageFlag | null;
         [key: string]: unknown;

--- a/src/module/chat-message/document.ts
+++ b/src/module/chat-message/document.ts
@@ -120,7 +120,7 @@ class ChatMessagePF2e extends ChatMessage {
         }
 
         if (item?.isOfType("spell")) {
-            const overlayIds = this.flags.pf2e.origin?.spellVariantOverlayIds;
+            const overlayIds = this.flags.pf2e.origin?.variant?.overlays;
             const castLevel = this.flags.pf2e.origin?.castLevel ?? item.level;
             const modifiedSpell = item.loadVariant({ overlayIds, castLevel });
             return modifiedSpell ?? item;

--- a/src/module/chat-message/document.ts
+++ b/src/module/chat-message/document.ts
@@ -120,9 +120,9 @@ class ChatMessagePF2e extends ChatMessage {
         }
 
         if (item?.isOfType("spell")) {
-            const spellVariant = this.flags.pf2e.spellVariant;
-            const castLevel = this.flags.pf2e.casting?.level ?? item.level;
-            const modifiedSpell = item.loadVariant({ overlayIds: spellVariant?.overlayIds, castLevel });
+            const overlayIds = this.flags.pf2e.origin?.spellVariantOverlayIds;
+            const castLevel = this.flags.pf2e.origin?.castLevel ?? item.level;
+            const modifiedSpell = item.loadVariant({ overlayIds, castLevel });
             return modifiedSpell ?? item;
         }
 

--- a/src/module/item/base.ts
+++ b/src/module/item/base.ts
@@ -26,6 +26,7 @@ import { ItemSheetPF2e } from "./sheet/base.ts";
 import { ItemFlagsPF2e, ItemSystemData } from "./data/base.ts";
 import { ItemInstances } from "./types.ts";
 import { UUIDUtils } from "@util/uuid.ts";
+import { ItemOriginFlag } from "@module/chat-message/data.ts";
 
 /** Override and extend the basic :class:`Item` implementation */
 class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item<TParent> {
@@ -190,7 +191,7 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
                     canPopout: true,
                 },
                 pf2e: {
-                    origin: { uuid: this.uuid, type: this.type },
+                    origin: this.getOriginData(),
                 },
             },
             type: CONST.CHAT_MESSAGE_TYPES.OTHER,
@@ -310,6 +311,10 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
 
         await this.update(updates, { diff: false, recursive: false });
         ui.notifications.info(`Item "${this.name}" has been refreshed.`);
+    }
+
+    getOriginData(): ItemOriginFlag {
+        return { uuid: this.uuid, type: this.type as ItemType };
     }
 
     /* -------------------------------------------- */

--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -575,12 +575,14 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
         const flags = messageSource.flags.pf2e;
         const entry = this.trickMagicEntry ?? this.spellcasting;
 
+        flags.origin!.castLevel = Number(castData.castLevel) || this.level;
+        if (this.isVariant) flags.origin!.spellVariantOverlayIds = [...this.appliedOverlays!.values()];
+
         if (entry?.statistic) {
             // Eventually we need to figure out a way to request a tradition if the ability doesn't provide one
             const tradition = Array.from(this.traditions).at(0);
             flags.casting = {
                 id: entry.id,
-                level: Number(castData.castLevel) || this.level,
                 tradition: entry.tradition ?? tradition ?? "arcane",
             };
 
@@ -597,12 +599,6 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
         }
 
         flags.isFromConsumable = this.isFromConsumable;
-
-        if (this.isVariant) {
-            flags.spellVariant = {
-                overlayIds: [...this.appliedOverlays!.values()],
-            };
-        }
 
         if (!create) {
             message.updateSource(messageSource);

--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -449,6 +449,8 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
                     origin: {
                         type: this.type,
                         uuid: this.uuid,
+                        castLevel: this.level,
+                        spellVariantOverlayIds: this.isVariant ? [...this.appliedOverlays!.values()] : [],
                         name: this.name,
                         slug: this.slug,
                         traits: deepClone(this.system.traits.value),

--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -14,7 +14,7 @@ import { ItemSourcePF2e, ItemSummaryData } from "@item/data/index.ts";
 import { BaseSpellcastingEntry } from "@item/spellcasting-entry/types.ts";
 import { TrickMagicItemEntry } from "@item/spellcasting-entry/trick.ts";
 import { MeasuredTemplatePF2e } from "@module/canvas/index.ts";
-import { ChatMessagePF2e } from "@module/chat-message/index.ts";
+import { ChatMessagePF2e, ItemOriginFlag } from "@module/chat-message/index.ts";
 import { OneToTen, ZeroToTwo } from "@module/data.ts";
 import { extractDamageDice, extractDamageModifiers } from "@module/rules/helpers.ts";
 import { UserPF2e } from "@module/user/index.ts";
@@ -447,13 +447,10 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
             flags: {
                 pf2e: {
                     origin: {
-                        type: this.type,
-                        uuid: this.uuid,
-                        castLevel: this.level,
-                        spellVariantOverlayIds: this.isVariant ? [...this.appliedOverlays!.values()] : [],
                         name: this.name,
                         slug: this.slug,
                         traits: deepClone(this.system.traits.value),
+                        ...this.getOriginData(),
                     },
                 },
             },
@@ -576,9 +573,6 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
         const messageSource = message.toObject();
         const flags = messageSource.flags.pf2e;
         const entry = this.trickMagicEntry ?? this.spellcasting;
-
-        flags.origin!.castLevel = Number(castData.castLevel) || this.level;
-        if (this.isVariant) flags.origin!.spellVariantOverlayIds = [...this.appliedOverlays!.values()];
 
         if (entry?.statistic) {
             // Eventually we need to figure out a way to request a tradition if the ability doesn't provide one
@@ -856,6 +850,13 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
             },
             event
         );
+    }
+
+    override getOriginData(): ItemOriginFlag {
+        const flag = super.getOriginData();
+        flag.castLevel = this.level;
+        if (this.isVariant) flag.spellVariantOverlayIds = [...this.appliedOverlays!.values()];
+        return flag;
     }
 
     override async update(data: DocumentUpdateData<this>, options: DocumentUpdateContext<TParent> = {}): Promise<this> {

--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -855,7 +855,10 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
     override getOriginData(): ItemOriginFlag {
         const flag = super.getOriginData();
         flag.castLevel = this.level;
-        if (this.isVariant) flag.spellVariantOverlayIds = [...this.appliedOverlays!.values()];
+        if (this.isVariant && this.appliedOverlays) {
+            flag.variant = { overlays: [...this.appliedOverlays.values()] };
+        }
+
         return flag;
     }
 

--- a/src/module/scene/measured-template-document.ts
+++ b/src/module/scene/measured-template-document.ts
@@ -1,9 +1,28 @@
 import { MeasuredTemplatePF2e } from "@module/canvas/measured-template.ts";
 import { ScenePF2e } from "./document.ts";
+import { ItemPF2e } from "@item";
+import { ActorPF2e } from "@actor";
 
 export class MeasuredTemplateDocumentPF2e<
     TParent extends ScenePF2e | null = ScenePF2e | null
-> extends MeasuredTemplateDocument<TParent> {}
+> extends MeasuredTemplateDocument<TParent> {
+    get item(): ItemPF2e<ActorPF2e> | null {
+        const origin = this.flags.pf2e?.origin as Record<string, unknown>;
+        const uuid = origin?.uuid;
+        if (!uuid) return null;
+        const item = fromUuidSync(uuid as string);
+        if (!(item instanceof ItemPF2e)) return null;
+
+        if (item?.isOfType("spell")) {
+            const overlayIds = origin?.spellVariantOverlayIds as string[];
+            const castLevel = (origin?.castLevel ?? item.level) as number;
+            const modifiedSpell = item.loadVariant({ overlayIds, castLevel });
+            return modifiedSpell ?? item;
+        }
+
+        return item;
+    }
+}
 
 export interface MeasuredTemplateDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null>
     extends MeasuredTemplateDocument<TParent> {

--- a/src/module/scene/measured-template-document.ts
+++ b/src/module/scene/measured-template-document.ts
@@ -2,19 +2,20 @@ import { MeasuredTemplatePF2e } from "@module/canvas/measured-template.ts";
 import { ScenePF2e } from "./document.ts";
 import { ItemPF2e } from "@item";
 import { ActorPF2e } from "@actor";
+import { ItemOriginFlag } from "@module/chat-message/data.ts";
 
 export class MeasuredTemplateDocumentPF2e<
     TParent extends ScenePF2e | null = ScenePF2e | null
 > extends MeasuredTemplateDocument<TParent> {
     get item(): ItemPF2e<ActorPF2e> | null {
-        const origin = this.flags.pf2e?.origin as Record<string, unknown>;
+        const origin = this.flags.pf2e?.origin;
         const uuid = origin?.uuid;
         if (!uuid) return null;
         const item = fromUuidSync(uuid as string);
         if (!(item instanceof ItemPF2e)) return null;
 
         if (item?.isOfType("spell")) {
-            const overlayIds = origin?.spellVariantOverlayIds as string[];
+            const overlayIds = origin?.variant?.overlays;
             const castLevel = (origin?.castLevel ?? item.level) as number;
             const modifiedSpell = item.loadVariant({ overlayIds, castLevel });
             return modifiedSpell ?? item;
@@ -27,4 +28,10 @@ export class MeasuredTemplateDocumentPF2e<
 export interface MeasuredTemplateDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null>
     extends MeasuredTemplateDocument<TParent> {
     get object(): MeasuredTemplatePF2e<this> | null;
+
+    flags: DocumentFlags & {
+        pf2e?: {
+            origin?: ItemOriginFlag;
+        };
+    };
 }

--- a/src/module/system/check/check.ts
+++ b/src/module/system/check/check.ts
@@ -23,6 +23,7 @@ import { CheckModifiersDialog } from "./dialog.ts";
 import { CheckRoll, CheckRollDataPF2e } from "./roll.ts";
 import { StrikeAttackRoll } from "./strike/attack-roll.ts";
 import { CheckRollContext } from "./types.ts";
+import { ItemType } from "@item/data/index.ts";
 
 interface RerollOptions {
     heroPoint?: boolean;
@@ -232,7 +233,14 @@ class CheckPF2e {
 
         type MessagePromise = Promise<ChatMessagePF2e | ChatMessageSourcePF2e>;
         const message = await ((): MessagePromise => {
-            const origin = item && { uuid: item.uuid, type: item.type };
+            const origin: ChatMessageSourcePF2e["flags"]["pf2e"]["origin"] = item && {
+                uuid: item.uuid,
+                type: item.type as ItemType,
+            };
+            if (origin && item?.isOfType("spell")) {
+                origin.castLevel = item.level;
+                if (item.isVariant) origin.spellVariantOverlayIds = [...item.appliedOverlays!.values()];
+            }
             const coreFlags: Record<string, unknown> = { canPopout: true };
             if (context.type === "initiative") coreFlags.initiativeRoll = true;
             const flags = {

--- a/src/module/system/check/check.ts
+++ b/src/module/system/check/check.ts
@@ -23,7 +23,6 @@ import { CheckModifiersDialog } from "./dialog.ts";
 import { CheckRoll, CheckRollDataPF2e } from "./roll.ts";
 import { StrikeAttackRoll } from "./strike/attack-roll.ts";
 import { CheckRollContext } from "./types.ts";
-import { ItemType } from "@item/data/index.ts";
 
 interface RerollOptions {
     heroPoint?: boolean;
@@ -233,14 +232,6 @@ class CheckPF2e {
 
         type MessagePromise = Promise<ChatMessagePF2e | ChatMessageSourcePF2e>;
         const message = await ((): MessagePromise => {
-            const origin: ChatMessageSourcePF2e["flags"]["pf2e"]["origin"] = item && {
-                uuid: item.uuid,
-                type: item.type as ItemType,
-            };
-            if (origin && item?.isOfType("spell")) {
-                origin.castLevel = item.level;
-                if (item.isVariant) origin.spellVariantOverlayIds = [...item.appliedOverlays!.values()];
-            }
             const coreFlags: Record<string, unknown> = { canPopout: true };
             if (context.type === "initiative") coreFlags.initiativeRoll = true;
             const flags = {
@@ -250,7 +241,7 @@ class CheckPF2e {
                     unsafe: flavor,
                     modifierName: check.slug,
                     modifiers: check.modifiers.map((m) => m.toObject()),
-                    origin,
+                    origin: item?.getOriginData(),
                     strike,
                 },
             };

--- a/src/module/system/damage/damage.ts
+++ b/src/module/system/damage/damage.ts
@@ -1,7 +1,7 @@
 import { StrikeData } from "@actor/data/base.ts";
 import { ItemPF2e } from "@item";
 import { ItemType } from "@item/data/index.ts";
-import { ChatMessagePF2e, DamageRollContextFlag } from "@module/chat-message/index.ts";
+import { ChatMessageFlagsPF2e, ChatMessagePF2e, DamageRollContextFlag } from "@module/chat-message/index.ts";
 import { ZeroToThree } from "@module/data.ts";
 import { DEGREE_OF_SUCCESS_STRINGS } from "@system/degree-of-success.ts";
 import { DamageRoll, DamageRollDataPF2e } from "./roll.ts";
@@ -162,7 +162,14 @@ export class DamagePF2e {
 
         const { self, target } = context;
         const item = self?.item ?? null;
-        const origin = item ? { uuid: item.uuid, type: item.type as ItemType } : null;
+        const origin: ChatMessageFlagsPF2e["pf2e"]["origin"] = item && {
+            uuid: item.uuid,
+            type: item.type as ItemType,
+        };
+        if (origin && item?.isOfType("spell")) {
+            origin.castLevel = item.level;
+            if (item.isVariant) origin.spellVariantOverlayIds = [...item.appliedOverlays!.values()];
+        }
         const targetFlag = target ? { actor: target.actor.uuid, token: target.token.uuid } : null;
 
         // Retrieve strike flags. Strikes need refactoring to use ids before we can do better

--- a/src/module/system/damage/damage.ts
+++ b/src/module/system/damage/damage.ts
@@ -1,7 +1,6 @@
 import { StrikeData } from "@actor/data/base.ts";
 import { ItemPF2e } from "@item";
-import { ItemType } from "@item/data/index.ts";
-import { ChatMessageFlagsPF2e, ChatMessagePF2e, DamageRollContextFlag } from "@module/chat-message/index.ts";
+import { ChatMessagePF2e, DamageRollContextFlag } from "@module/chat-message/index.ts";
 import { ZeroToThree } from "@module/data.ts";
 import { DEGREE_OF_SUCCESS_STRINGS } from "@system/degree-of-success.ts";
 import { DamageRoll, DamageRollDataPF2e } from "./roll.ts";
@@ -162,14 +161,6 @@ export class DamagePF2e {
 
         const { self, target } = context;
         const item = self?.item ?? null;
-        const origin: ChatMessageFlagsPF2e["pf2e"]["origin"] = item && {
-            uuid: item.uuid,
-            type: item.type as ItemType,
-        };
-        if (origin && item?.isOfType("spell")) {
-            origin.castLevel = item.level;
-            if (item.isVariant) origin.spellVariantOverlayIds = [...item.appliedOverlays!.values()];
-        }
         const targetFlag = target ? { actor: target.actor.uuid, token: target.token.uuid } : null;
 
         // Retrieve strike flags. Strikes need refactoring to use ids before we can do better
@@ -225,7 +216,7 @@ export class DamagePF2e {
                         context: contextFlag,
                         target: targetFlag,
                         modifiers: data.modifiers?.map((m) => m.toObject()) ?? [],
-                        origin,
+                        origin: item?.getOriginData(),
                         strike,
                         preformatted: "both",
                     },


### PR DESCRIPTION
There are currently 3 different versions of `flags.pf2e.origin` for storing/retrieving an item:
- ChatMessage contains the full item data, correctly applying spell overlays (variant/heighten) when retrieving the item
- Check/Damage only stores the item uuid, making it impossible to fetch the full item with that message alone
- `SpellPF2e.createTemplate` has its own completely different format

This PR is my attempt at unifying the creation of (and retrieval from) `flags.pf2e.origin`. This would fix #2122 (to check another box in #4882).