### PR TITLE
Fix revert damage button visibility

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -1335,7 +1335,6 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
                 applications: result.applications,
                 visibility: this.hasPlayerOwner ? "all" : "gm",
             },
-            canRevertDamage: this.canUserModify(game.user, "update"),
         });
 
         await ChatMessagePF2e.create({

--- a/src/module/chat-message/document.ts
+++ b/src/module/chat-message/document.ts
@@ -248,6 +248,14 @@ class ChatMessagePF2e extends ChatMessage {
             });
         }
 
+        // Remove revert damage button based on user permissions
+        const appliedDamageFlag = this.flags.pf2e.appliedDamage;
+        if (!appliedDamageFlag?.isReverted) {
+            if (!this.actor?.canUserModify(game.user, "update")) {
+                htmlQuery(html, "button[data-action=revert-damage]")?.remove();
+            }
+        }
+
         html.addEventListener("mouseenter", () => this.onHoverIn());
         html.addEventListener("mouseleave", () => this.onHoverOut());
 

--- a/static/templates/chat/damage/damage-taken.hbs
+++ b/static/templates/chat/damage/damage-taken.hbs
@@ -3,9 +3,7 @@
     {{#if iwr.applications}}
         <span class="iwr" data-visibility="{{iwr.visibility}}" data-applications="{{json iwr.applications}}"><i class="fas fa-info-circle small"></i></span>
     {{/if}}
-    {{#if canRevertDamage}}
-        <button type="button" class="revert-damage" data-action="revert-damage" data-tooltip="PF2E.RevertDamage.ButtonTooltip" data-tooltip-direction="UP"><i class="fa-solid fa-rotate-left"></i></button>
-    {{/if}}
+    <button type="button" class="revert-damage" data-action="revert-damage" data-tooltip="PF2E.RevertDamage.ButtonTooltip" data-tooltip-direction="UP"><i class="fa-solid fa-rotate-left"></i></button>
 
     {{#if persistent}}
         <section class="persistent">


### PR DESCRIPTION
This makes more sense than checking permissions on chat message creation as everyone else ends up with the same message.