### PR TITLE
Refactor rolling perception checks from the character sheet to remove deprecation warning

### DIFF
--- a/src/module/actor/creature/sheet.ts
+++ b/src/module/actor/creature/sheet.ts
@@ -263,6 +263,14 @@ export abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends Act
             this.actor.skills[key]?.check.roll(rollParams);
         });
 
+        // Roll perception checks
+        for (const element of htmlQueryAll<HTMLAnchorElement>(html, "a[data-action=perception-check]")) {
+            element.addEventListener("click", (event) => {
+                const extraRollOptions = element.dataset.secret ? ["secret"] : [];
+                this.actor.perception.roll({ ...eventToRollParams(event), extraRollOptions });
+            });
+        }
+
         // Add, edit, and remove spellcasting entries
         for (const section of htmlQueryAll(html, ".tab.spellcasting, .tab.spells") ?? []) {
             for (const element of htmlQueryAll(section, "[data-action=spellcasting-create]") ?? []) {

--- a/src/module/actor/creature/sheet.ts
+++ b/src/module/actor/creature/sheet.ts
@@ -264,7 +264,7 @@ export abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends Act
         });
 
         // Roll perception checks
-        for (const element of htmlQueryAll<HTMLAnchorElement>(html, "a[data-action=perception-check]")) {
+        for (const element of htmlQueryAll(html, "a[data-action=perception-check]")) {
             element.addEventListener("click", (event) => {
                 const extraRollOptions = element.dataset.secret ? ["secret"] : [];
                 this.actor.perception.roll({ ...eventToRollParams(event), extraRollOptions });

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -1,5 +1,5 @@
 import type { ActorPF2e } from "@actor";
-import { RollFunction, StrikeData } from "@actor/data/base.ts";
+import { StrikeData } from "@actor/data/base.ts";
 import { SAVE_TYPES } from "@actor/values.ts";
 import { AbstractEffectPF2e, ContainerPF2e, ItemPF2e, ItemProxyPF2e, PhysicalItemPF2e, SpellPF2e } from "@item";
 import { createConsumableFromSpell } from "@item/consumable/spell-consumables.ts";
@@ -314,24 +314,6 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
             const suboption = suboptionsSelect?.value ?? null;
             if (checkbox && domain && option) {
                 this.actor.toggleRollOption(domain, option, itemId ?? null, checkbox.checked, suboption);
-            }
-        });
-
-        // Roll Attribute Checks
-        $html.find(".attribute-name").on("click", (event) => {
-            event.preventDefault();
-            const key = event.currentTarget.parentElement?.getAttribute("data-attribute") || "";
-            const isSecret = event.currentTarget.getAttribute("data-secret");
-            const attributes: object = this.actor.system.attributes;
-            const attribute: unknown = objectHasKey(attributes, key) ? attributes[key] : null;
-            const isRollable = (property: unknown): property is { roll: RollFunction } =>
-                property instanceof Object && "roll" in property && typeof property["roll"] === "function";
-            if (isRollable(attribute)) {
-                const options = this.actor.getRollOptions(["all", key]);
-                if (isSecret) options.push("secret");
-                attribute.roll({ event, options });
-            } else {
-                this.actor.rollAttribute(event, key);
             }
         });
 

--- a/static/templates/actors/character/sidebar/initiative.hbs
+++ b/static/templates/actors/character/sidebar/initiative.hbs
@@ -4,8 +4,8 @@
         <i class="fas fa-eye"></i> {{localize "PF2E.ModifiersTitle"}}
     </button>
 </div>
-<div class="roll-data initiative-sidebar" data-attribute="initiative">
-    <a class="roll-icon roll-init">
+<div class="roll-data initiative-sidebar">
+    <a class="roll-icon roll-init" data-action="roll-initiative">
         {{> "systems/pf2e/templates/actors/character/icons/d20.hbs"}}
     </a>
     <h3>{{numberFormat data.attributes.initiative.totalModifier decimals=0 sign=true}}</h3>

--- a/static/templates/actors/character/sidebar/perception.hbs
+++ b/static/templates/actors/character/sidebar/perception.hbs
@@ -4,7 +4,7 @@
         <i class="fas fa-eye"></i> {{localize "PF2E.ModifiersTitle"}}
     </button>
 </div>
-<div class="roll-data perception-sidebar" data-attribute="perception">
+<div class="roll-data perception-sidebar">
     <a class="roll-icon attribute-name" data-action="perception-check" title="{{localize "PF2E.Check.Specific.Perception.Label"}}">
         {{> "systems/pf2e/templates/actors/character/icons/d20.hbs"}}
     </a>


### PR DESCRIPTION
The `.attribute-name` selector is only used for attribute checks in the NPC sheet now, and that has its own listener.