### PR TITLE
Set missed slug for NPC reactions

### DIFF
--- a/packs/data/blood-lords-bestiary.db/ghoul-antipaladin.json
+++ b/packs/data/blood-lords-bestiary.db/ghoul-antipaladin.json
@@ -1139,7 +1139,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "destructive-vengeance",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/blood-lords-bestiary.db/seldeg-bheldis.json
+++ b/packs/data/blood-lords-bestiary.db/seldeg-bheldis.json
@@ -961,7 +961,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "iron-command",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/fists-of-the-ruby-phoenix-bestiary.db/tino-tung-level-13.json
+++ b/packs/data/fists-of-the-ruby-phoenix-bestiary.db/tino-tung-level-13.json
@@ -1104,7 +1104,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "retributive-strike",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/fists-of-the-ruby-phoenix-bestiary.db/tino-tung-level-9.json
+++ b/packs/data/fists-of-the-ruby-phoenix-bestiary.db/tino-tung-level-9.json
@@ -862,7 +862,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "retributive-strike",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/npc-gallery.db/antipaladin.json
+++ b/packs/data/npc-gallery.db/antipaladin.json
@@ -740,7 +740,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "destructive-vengeance",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/horned-archon.json
+++ b/packs/data/pathfinder-bestiary.db/horned-archon.json
@@ -1275,7 +1275,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "retributive-strike",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/lantern-archon-gestalt.json
+++ b/packs/data/pathfinder-bestiary.db/lantern-archon-gestalt.json
@@ -951,7 +951,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "retributive-strike",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/lantern-archon.json
+++ b/packs/data/pathfinder-bestiary.db/lantern-archon.json
@@ -796,7 +796,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "retributive-strike",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/legion-archon.json
+++ b/packs/data/pathfinder-bestiary.db/legion-archon.json
@@ -1108,7 +1108,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "retributive-strike",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pathfinder-bestiary.db/shield-archon.json
+++ b/packs/data/pathfinder-bestiary.db/shield-archon.json
@@ -1422,7 +1422,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "retributive-strike",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/pfs-season-3-bestiary.db/tyrannical-interrogator.json
+++ b/packs/data/pfs-season-3-bestiary.db/tyrannical-interrogator.json
@@ -799,7 +799,7 @@
                         "value": 1
                     }
                 ],
-                "slug": null,
+                "slug": "iron-command",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/quest-for-the-frozen-flame-bestiary.db/lomok.json
+++ b/packs/data/quest-for-the-frozen-flame-bestiary.db/lomok.json
@@ -1155,7 +1155,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "retributive-strike",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/stolen-fate-bestiary.db/drustan.json
+++ b/packs/data/stolen-fate-bestiary.db/drustan.json
@@ -1423,7 +1423,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "iron-command",
                 "source": {
                     "value": ""
                 },

--- a/packs/data/strength-of-thousands-bestiary.db/wereant-sentinel.json
+++ b/packs/data/strength-of-thousands-bestiary.db/wereant-sentinel.json
@@ -565,7 +565,7 @@
                     "value": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "retributive-strike",
                 "source": {
                     "value": ""
                 },


### PR DESCRIPTION
Set missed slug for NPC reactions
Retributive Strike, Glimpse of Redemption, Liberating Step, Iron Command, Selfish Shield, Destructive Vengeance

It's need to trigger these reactions with [module](https://github.com/reyzor1991/foundry-vtt-pf2e-reaction) 

