### PR TITLE
Save scroll position of Compendium Browser settings and show a message when the settings were saved

### DIFF
--- a/src/module/apps/compendium-browser/index.ts
+++ b/src/module/apps/compendium-browser/index.ts
@@ -258,7 +258,7 @@ class CompendiumBrowser extends Application {
                     initial: "landing-page",
                 },
             ],
-            scrollY: [".control-area", ".item-list"],
+            scrollY: [".control-area", ".item-list", ".settings-container"],
         };
     }
 
@@ -504,6 +504,7 @@ class CompendiumBrowser extends Application {
 
                     await this.#resetInitializedTabs();
                     this.render(true);
+                    ui.notifications.info("PF2E.BrowserSettingsSaved", { localize: true });
                 });
 
                 const sourceSearch = htmlQuery<HTMLInputElement>(form, "input[data-element=setting-sources-search]");

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -586,6 +586,7 @@
         "BrowserFilterWeaponFilters": "Weapon Filters",
         "BrowserSearchPlaceholder": "Search Text",
         "BrowserSearchTitle": "Right click for guide",
+        "BrowserSettingsSaved": "Settings have been saved",
         "BrowserSortyByLabel": "Sort by",
         "BrowserSortyByLevelLabel": "Level",
         "BrowserSortyByNameLabel": "Name",


### PR DESCRIPTION
This is needed with the length of the new source settings. I've added an info message because hitting save has no visible effect now.