### PR TITLE
Ensure inventory icons are 24px wide on PC sheet

### DIFF
--- a/src/styles/actor/character/_index.scss
+++ b/src/styles/actor/character/_index.scss
@@ -89,11 +89,12 @@ nav.sheet-navigation {
 
     // general item-image properties
     .item-image {
-        display: flex;
         cursor: pointer;
-        position: relative;
+        display: flex;
         font-size: var(--font-size-16);
         height: 24px;
+        min-width: 24px;
+        position: relative;
         width: 24px;
 
         img {


### PR DESCRIPTION
Before:
![image](https://github.com/foundryvtt/pf2e/assets/106829671/7cd7bb12-aea7-4dba-ad3e-f84c7e9ddf3f)

After:
![image](https://github.com/foundryvtt/pf2e/assets/106829671/5c6794ae-d0f1-492b-b514-0527460529cf)
