### PR TITLE
Add shorthand syntax for multiple rollable check buttons

### DIFF
--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -256,91 +256,6 @@ class TextEditorPF2e extends TextEditor {
         return null;
     }
 
-    static #createSingleCheck({
-        params,
-        allTraits,
-        item,
-        actor,
-        inlineLabel,
-    }: {
-        params: { type: string; dc: string } & Record<string, string>;
-        allTraits: string[];
-        item?: ItemPF2e | null;
-        actor?: ActorPF2e | null;
-        inlineLabel?: string;
-    }): HTMLSpanElement | null {
-        // Build the inline link
-        const html = document.createElement("span");
-        html.setAttribute("data-pf2-traits", `${allTraits}`);
-        const name = params.name ?? item?.name ?? params.type;
-        html.setAttribute("data-pf2-label", game.i18n.format("PF2E.InlineCheck.DCWithName", { name }));
-        html.setAttribute("data-pf2-repost-flavor", name);
-        const role = params.showDC ?? "owner";
-        html.setAttribute("data-pf2-show-dc", params.showDC ?? role);
-        html.setAttribute("data-pf2-adjustment", params.adjustment ?? "");
-
-        switch (params.type) {
-            case "flat":
-                html.innerHTML = inlineLabel ?? game.i18n.localize("PF2E.FlatCheck");
-                html.setAttribute("data-pf2-check", "flat");
-                break;
-            case "perception":
-                html.innerHTML = inlineLabel ?? game.i18n.localize("PF2E.PerceptionLabel");
-                html.setAttribute("data-pf2-check", "perception");
-                break;
-            case "fortitude":
-            case "reflex":
-            case "will": {
-                const saveName = game.i18n.localize(CONFIG.PF2E.saves[params.type]);
-                const saveLabel =
-                    params.basic === "true"
-                        ? game.i18n.format("PF2E.InlineCheck.BasicWithSave", { save: saveName })
-                        : saveName;
-                html.innerHTML = inlineLabel ?? saveLabel;
-                html.setAttribute("data-pf2-check", params.type);
-                break;
-            }
-            default: {
-                // Skill or Lore
-                const shortForm = (() => {
-                    if (objectHasKey(SKILL_EXPANDED, params.type)) {
-                        return SKILL_EXPANDED[params.type].shortform;
-                    } else if (objectHasKey(SKILL_DICTIONARY, params.type)) {
-                        return params.type;
-                    }
-                    return;
-                })();
-                const skillLabel = shortForm
-                    ? game.i18n.localize(CONFIG.PF2E.skills[shortForm])
-                    : params.type
-                          .split("-")
-                          .map((word) => {
-                              return word.slice(0, 1).toUpperCase() + word.slice(1);
-                          })
-                          .join(" ");
-                html.innerHTML = inlineLabel ?? skillLabel;
-                html.dataset.pf2Check = sluggify(params.type);
-            }
-        }
-
-        if (params.type && params.dc) {
-            // Let the inline roll function handle level base DCs
-            const checkDC = params.dc === "@self.level" ? params.dc : getCheckDC({ name, params, item, actor });
-            html.setAttribute("data-pf2-dc", checkDC);
-
-            let displayedDC = checkDC;
-            if (!isNaN(parseInt(params.dc))) {
-                // When using fixed DCs/adjustments, parse and add them to render the real DC
-                displayedDC = `${parseInt(params.dc) + parseInt(params.adjustment)}`;
-            }
-            const text = html.innerHTML;
-            if (checkDC !== "@self.level") {
-                html.innerHTML = game.i18n.format("PF2E.DCWithValueAndVisibility", { role, dc: displayedDC, text });
-            }
-        }
-        return html;
-    }
-
     static #createCheck({
         paramString,
         inlineLabel,
@@ -446,6 +361,90 @@ class TextEditorPF2e extends TextEditor {
             }
             return checkGroup;
         }
+    }
+
+    static #createSingleCheck({
+        params,
+        allTraits,
+        item,
+        actor,
+        inlineLabel,
+    }: {
+        params: { type: string; dc: string } & Record<string, string>;
+        allTraits: string[];
+        item?: ItemPF2e | null;
+        actor?: ActorPF2e | null;
+        inlineLabel?: string;
+    }): HTMLSpanElement | null {
+        // Build the inline link
+        const html = document.createElement("span");
+        html.setAttribute("data-pf2-traits", `${allTraits}`);
+        const name = params.name ?? item?.name ?? params.type;
+        html.setAttribute("data-pf2-label", game.i18n.format("PF2E.InlineCheck.DCWithName", { name }));
+        html.setAttribute("data-pf2-repost-flavor", name);
+        const role = params.showDC ?? "owner";
+        html.setAttribute("data-pf2-show-dc", params.showDC ?? role);
+        html.setAttribute("data-pf2-adjustment", params.adjustment ?? "");
+
+        switch (params.type) {
+            case "flat":
+                html.innerHTML = inlineLabel ?? game.i18n.localize("PF2E.FlatCheck");
+                html.setAttribute("data-pf2-check", "flat");
+                break;
+            case "perception":
+                html.innerHTML = inlineLabel ?? game.i18n.localize("PF2E.PerceptionLabel");
+                html.setAttribute("data-pf2-check", "perception");
+                break;
+            case "fortitude":
+            case "reflex":
+            case "will": {
+                const saveName = game.i18n.localize(CONFIG.PF2E.saves[params.type]);
+                const saveLabel =
+                    params.basic === "true"
+                        ? game.i18n.format("PF2E.InlineCheck.BasicWithSave", { save: saveName })
+                        : saveName;
+                html.innerHTML = inlineLabel ?? saveLabel;
+                html.setAttribute("data-pf2-check", params.type);
+                break;
+            }
+            default: {
+                // Skill or Lore
+                const shortForm = (() => {
+                    if (objectHasKey(SKILL_EXPANDED, params.type)) {
+                        return SKILL_EXPANDED[params.type].shortform;
+                    } else if (objectHasKey(SKILL_DICTIONARY, params.type)) {
+                        return params.type;
+                    }
+                    return;
+                })();
+                const skillLabel = shortForm
+                    ? game.i18n.localize(CONFIG.PF2E.skills[shortForm])
+                    : params.type
+                          .split("-")
+                          .map((word) => {
+                              return word.slice(0, 1).toUpperCase() + word.slice(1);
+                          })
+                          .join(" ");
+                html.innerHTML = inlineLabel ?? skillLabel;
+                html.dataset.pf2Check = sluggify(params.type);
+            }
+        }
+
+        if (params.type && params.dc) {
+            // Let the inline roll function handle level base DCs
+            const checkDC = params.dc === "@self.level" ? params.dc : getCheckDC({ name, params, item, actor });
+            html.setAttribute("data-pf2-dc", checkDC);
+
+            // When using fixed DCs/adjustments, parse and add them to render the real DC
+            const displayedDC = !isNaN(parseInt(params.dc))
+                ? `${parseInt(params.dc) + parseInt(params.adjustment)}`
+                : checkDC;
+            const text = html.innerHTML;
+            if (checkDC !== "@self.level") {
+                html.innerHTML = game.i18n.format("PF2E.DCWithValueAndVisibility", { role, dc: displayedDC, text });
+            }
+        }
+        return html;
     }
 }
 

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -97,10 +97,10 @@ class TextEditorPF2e extends TextEditor {
             app instanceof ActorSheetPF2e
                 ? [app.actor, app.actor.getRollData()]
                 : app instanceof ItemSheetPF2e
-                    ? [app.item.actor, app.item.getRollData()]
-                    : message?.actor
-                        ? [message.actor, message.getRollData()]
-                        : [null, {}];
+                ? [app.item.actor, app.item.getRollData()]
+                : message?.actor
+                ? [message.actor, message.getRollData()]
+                : [null, {}];
         const options = anchor.dataset.flavor ? { flavor: anchor.dataset.flavor } : {};
         const roll = new DamageRoll(anchor.dataset.formula, rollData, options);
 
@@ -256,12 +256,18 @@ class TextEditorPF2e extends TextEditor {
         return null;
     }
 
-    static #createSingleCheck({ params, allTraits, item, actor, inlineLabel }: {
-        params: { type: string, dc: string } & Record<string, string>,
-        allTraits: string[],
-        item?: ItemPF2e | null,
-        actor?: ActorPF2e | null,
-        inlineLabel?: string
+    static #createSingleCheck({
+        params,
+        allTraits,
+        item,
+        actor,
+        inlineLabel,
+    }: {
+        params: { type: string; dc: string } & Record<string, string>;
+        allTraits: string[];
+        item?: ItemPF2e | null;
+        actor?: ActorPF2e | null;
+        inlineLabel?: string;
     }): HTMLSpanElement | null {
         // Build the inline link
         const html = document.createElement("span");
@@ -307,11 +313,11 @@ class TextEditorPF2e extends TextEditor {
                 const skillLabel = shortForm
                     ? game.i18n.localize(CONFIG.PF2E.skills[shortForm])
                     : params.type
-                        .split("-")
-                        .map((word) => {
-                            return word.slice(0, 1).toUpperCase() + word.slice(1);
-                        })
-                        .join(" ");
+                          .split("-")
+                          .map((word) => {
+                              return word.slice(0, 1).toUpperCase() + word.slice(1);
+                          })
+                          .join(" ");
                 html.innerHTML = inlineLabel ?? skillLabel;
                 html.dataset.pf2Check = sluggify(params.type);
             }
@@ -324,7 +330,7 @@ class TextEditorPF2e extends TextEditor {
 
             let displayedDC = checkDC;
             if (!isNaN(parseInt(params.dc))) {
-                // When using fixed DCs/adjustments, parse and add them to render the actual DC
+                // When using fixed DCs/adjustments, parse and add them to render the real DC
                 displayedDC = `${parseInt(params.dc) + parseInt(params.adjustment)}`;
             }
             const text = html.innerHTML;
@@ -409,22 +415,27 @@ class TextEditorPF2e extends TextEditor {
             adjustments = new Array(types.length).fill(adjustments[0]);
         }
 
-        if (adjustments.some(adj => adj !== "" && isNaN(parseInt(adj)))) {
+        if (adjustments.some((adj) => adj !== "" && isNaN(parseInt(adj)))) {
             ui.notifications.warn(game.i18n.localize("PF2E.InlineCheck.Errors.NonIntegerAdjustment"));
             return null;
         }
 
-        const buttons = types.map((type, i) => this.#createSingleCheck({
-            allTraits, actor, item, inlineLabel,
-            params: { ...params, ...{ type, adjustment: adjustments[i] || "0" } }
-        }))
+        const buttons = types.map((type, i) =>
+            this.#createSingleCheck({
+                allTraits,
+                actor,
+                item,
+                inlineLabel,
+                params: { ...params, ...{ type, adjustment: adjustments[i] || "0" } },
+            })
+        );
         if (buttons.length === 1) {
             return buttons[0];
         } else {
             const checkGroup = document.createElement("div");
             checkGroup.setAttribute("data-pf2-checkgroup", "");
             for (const button of buttons) {
-                if (button == null) {
+                if (button === null) {
                     // Warning should have been displayed already by #createSingleCheck
                     return null;
                 }

--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -29,7 +29,8 @@ export const InlineRollLinks = {
             if (foundryDoc && !foundryDoc.isOwner) continue;
 
             const newButton = document.createElement("i");
-            const icon = link.parentElement?.dataset?.pf2Checkgroup != null ? "fa-comment-alt-dots" : "fa-comment-alt";
+            const icon =
+                link.parentElement?.dataset?.pf2Checkgroup !== undefined ? "fa-comment-alt-dots" : "fa-comment-alt";
             newButton.classList.add("fas", icon);
             newButton.setAttribute("data-pf2-repost", "");
             newButton.setAttribute("title", game.i18n.localize("PF2E.Repost"));
@@ -202,7 +203,7 @@ export const InlineRollLinks = {
         });
     },
 
-    makeRepostHtml: (target: HTMLElement, defaultVisibility: string) => {
+    makeRepostHtml: (target: HTMLElement, defaultVisibility: string): string => {
         const flavor = target.attributes.getNamedItem("data-pf2-repost-flavor")?.value ?? "";
         const showDC = target.attributes.getNamedItem("data-pf2-show-dc")?.value ?? defaultVisibility;
         return `<span data-visibility="${showDC}">${flavor}</span> ${target.outerHTML}`.trim();
@@ -216,11 +217,11 @@ export const InlineRollLinks = {
             return;
         }
 
-        const defaultVisibility = (document?.hasPlayerOwner ? "all" : "gm");
+        const defaultVisibility = document?.hasPlayerOwner ? "all" : "gm";
         let content;
-        if (target.parentElement?.dataset?.pf2Checkgroup != null) {
+        if (target.parentElement?.dataset?.pf2Checkgroup !== undefined) {
             content = htmlQueryAll(target.parentElement, inlineSelector)
-                .map(target => InlineRollLinks.makeRepostHtml(target, defaultVisibility))
+                .map((target) => InlineRollLinks.makeRepostHtml(target, defaultVisibility))
                 .join("<br>");
 
             content = `<div data-pf2-checkgroup>${content}</div>`;
@@ -231,9 +232,9 @@ export const InlineRollLinks = {
         const speaker =
             document instanceof ActorPF2e
                 ? ChatMessagePF2e.getSpeaker({
-                    actor: document,
-                    token: document.token ?? document.getActiveTokens(false, true).shift(),
-                })
+                      actor: document,
+                      token: document.token ?? document.getActiveTokens(false, true).shift(),
+                  })
                 : ChatMessagePF2e.getSpeaker();
 
         // If the originating document is a journal entry, include its UUID as a flag

--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -137,12 +137,11 @@ export const InlineRollLinks = {
                         const statistic = actor.getStatistic(pf2Check ?? "");
                         if (statistic) {
                             const dcValue = (() => {
+                                const adjustment = Number(pf2Adjustment) || 0;
                                 if (pf2Dc === "@self.level") {
-                                    const adjustment = Number(pf2Adjustment) || 0;
                                     return calculateDC(actor.level) + adjustment;
                                 }
-
-                                return Number(pf2Dc);
+                                return Number(pf2Dc) + adjustment;
                             })();
 
                             const dc = Number.isInteger(dcValue) ? { label: pf2Label, value: dcValue } : null;

--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -44,7 +44,6 @@ export const InlineRollLinks = {
 
         const links = htmlQueryAll(html, inlineSelector).filter((l) => l.nodeName === "SPAN");
         InlineRollLinks.injectRepostElement(links, foundryDoc);
-        // const $repostLinks = $html.find("i.fas.fa-comment-alt").filter(inlineSelector);
 
         InlineRollLinks.flavorDamageRolls(html, foundryDoc instanceof ActorPF2e ? foundryDoc : null);
 

--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -217,16 +217,17 @@ export const InlineRollLinks = {
         }
 
         const defaultVisibility = document?.hasPlayerOwner ? "all" : "gm";
-        let content;
-        if (target.parentElement?.dataset?.pf2Checkgroup !== undefined) {
-            content = htmlQueryAll(target.parentElement, inlineSelector)
-                .map((target) => InlineRollLinks.makeRepostHtml(target, defaultVisibility))
-                .join("<br>");
+        const content = (() => {
+            if (target.parentElement?.dataset?.pf2Checkgroup !== undefined) {
+                const content = htmlQueryAll(target.parentElement, inlineSelector)
+                    .map((target) => InlineRollLinks.makeRepostHtml(target, defaultVisibility))
+                    .join("<br>");
 
-            content = `<div data-pf2-checkgroup>${content}</div>`;
-        } else {
-            content = InlineRollLinks.makeRepostHtml(target, defaultVisibility);
-        }
+                return `<div data-pf2-checkgroup>${content}</div>`;
+            } else {
+                return InlineRollLinks.makeRepostHtml(target, defaultVisibility);
+            }
+        })();
 
         const speaker =
             document instanceof ActorPF2e

--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -40,7 +40,6 @@ export const InlineRollLinks = {
 
     listen: ($html: HTMLElement | JQuery, foundryDoc?: ClientDocument): void => {
         const html = $html instanceof HTMLElement ? $html : $html[0]!;
-        if ($html instanceof HTMLElement) $html = $($html);
 
         const links = htmlQueryAll(html, inlineSelector).filter((l) => l.nodeName === "SPAN");
         InlineRollLinks.injectRepostElement(links, foundryDoc);
@@ -67,13 +66,16 @@ export const InlineRollLinks = {
                 : null;
         };
 
-        $html.find("i[data-pf2-repost]").on("click", (event) => {
-            const target = event.currentTarget;
-            const parent = target.parentElement;
-            const document = documentFromDOM(target);
-            if (parent) InlineRollLinks.repostAction(parent, document);
-            event.stopPropagation();
-        });
+        htmlQueryAll(html, "i[data-pf2-repost]").forEach((btn) =>
+            btn.addEventListener("click", (event) => {
+                const target = event.target;
+                if (!(target instanceof HTMLElement)) return;
+                const parent = target?.parentElement;
+                const document = documentFromDOM(target);
+                if (parent) InlineRollLinks.repostAction(parent, document);
+                event.stopPropagation();
+            })
+        );
 
         const $links = $(links);
         $links.filter("[data-pf2-action]").on("click", (event) => {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1343,7 +1343,9 @@
             "BasicWithSave": "Basic {save}",
             "DCWithName": "{name} DC",
             "Errors": {
-                "TypeMissing": "Error in @Check: type parameter is mandatory"
+                "TypeMissing": "Error in @Check: type parameter is mandatory",
+                "AdjustmentLengthMismatch": "Error in @Check: mismatch between number of type: and adjustment: params",
+                "NonIntegerAdjustment": "Error in @Check: adjustments must be integers"
             }
         },
         "InlineTemplateErrors": {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -5491,3 +5491,4 @@
         "TabCombat": "Encounter Tracker"
     }
 }
+


### PR DESCRIPTION
(Per request of @TMunsie)

This allows using syntax like `@Check[type:athletics,acrobatics]` to create two rollable buttons at once. When this syntax is used, there are a few changes:

 - The rollable buttons are created in a new block of text (div) rather  than inline, with each button occupying a single line.
 - The rollable buttons are "grouped", and posting one to chat will post  all of the buttons to chat.
 - The post to chat button uses a different icon (`fa-comment-alt-dots`) to  indicate the buttons are grouped. 

Otherwise, everything else works the same. Parameters and display text are applied to all rollable buttons, with the exception of the `adjustment` parameter, which has also been enhanced in this PR. The `adjustment` parameter can now be applied to fixed DCs (rather than just `@self.level`), and if specified multiple times, allows adjusting each individual button when using the shorthand syntax for multiple buttons, like so:

`@Check[type:religion,fiend-lore,barbazu-lore|dc:20|adjustment:0,-2,-5]`

Here's a screenshot of what the new functionality looks like in practice. The checks from the journal entry have been posted to chat in the order they appear.

![Screenshot of new rollable check functionality](https://github.com/foundryvtt/pf2e/assets/5429337/cc75000c-3901-4b73-b4ae-d782beee2828)
