### PR TITLE
Copy trick item spellcasting entry to variant spell

### DIFF
--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -412,6 +412,7 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
             NonNullable<TParent>
         >;
         variant.original = this as SpellPF2e<NonNullable<TParent>>;
+        variant.trickMagicEntry = this.trickMagicEntry;
         variant.appliedOverlays = appliedOverlays;
         // Retrieve tradition since `#prepareSiblingData` isn't run:
         variant.system.traits.value = Array.from(new Set([...variant.traits, ...variant.traditions]));


### PR DESCRIPTION
Selecting a variant of a spell cast with trick magic item doesn't work, it just results in a message without buttons:
![image](https://github.com/foundryvtt/pf2e/assets/9253349/653279bd-7052-4134-8d3f-3f1a6884547f)
