### PR TITLE
Don't attempt data cleaning in `PredicateField`

### DIFF
--- a/src/module/system/schema-data-fields.ts
+++ b/src/module/system/schema-data-fields.ts
@@ -55,7 +55,7 @@ class SlugField<
         value: Maybe<string>,
         options?: CleanFieldOptions
     ): MaybeSchemaProp<string, TRequired, TNullable, THasInitial>;
-    protected override _cleanType(value: Maybe<string>, options?: CleanFieldOptions): string | null | undefined {
+    protected override _cleanType(value: Maybe<string>, options?: CleanFieldOptions): unknown {
         const slug = super._cleanType(value, options);
         const camel = this.options.camel ?? null;
         return typeof slug === "string" ? sluggify(slug, { camel }) : slug;
@@ -111,7 +111,12 @@ class PredicateField<
     }
 
     /** Don't wrap a non-array in an array */
-    override _cast(value: unknown): unknown {
+    protected override _cast(value: unknown): unknown {
+        return value;
+    }
+
+    /** Parent method assumes array-wrapping: pass through unchanged */
+    protected override _cleanType(value: unknown): unknown {
         return value;
     }
 

--- a/types/foundry/common/data/fields.d.ts
+++ b/types/foundry/common/data/fields.d.ts
@@ -122,10 +122,7 @@ export abstract class DataField<
      * @param [options] Additional options for how the field is cleaned.
      * @returns The cleaned value.
      */
-    protected _cleanType(
-        value?: unknown,
-        options?: CleanFieldOptions
-    ): MaybeSchemaProp<TSourceProp, TRequired, TNullable, THasInitial>;
+    protected _cleanType(value: unknown, options?: CleanFieldOptions): unknown;
 
     /**
      * Cast a non-default value to ensure it is the correct type for the field
@@ -484,10 +481,7 @@ export class ArrayField<
 
     protected override _cast(value: unknown): unknown;
 
-    protected _cleanType(
-        value: unknown[] | Set<unknown>,
-        options?: CleanFieldOptions
-    ): MaybeSchemaProp<TSourceProp, TRequired, TNullable, THasInitial>;
+    protected _cleanType(value: unknown, options?: CleanFieldOptions): unknown;
 
     protected override _validateType(value: unknown, options?: Record<string, unknown>): void;
 


### PR DESCRIPTION
An upstream exception will still be thrown for invalid data, but it will at least be a handled one.