### PR TITLE
Add some sanity checks to pair of migrations

### DIFF
--- a/src/module/migration/migrations/827-fix-tv-shield-traits.ts
+++ b/src/module/migration/migrations/827-fix-tv-shield-traits.ts
@@ -1,4 +1,5 @@
 import { ItemSourcePF2e } from "@item/data/index.ts";
+import { isObject } from "@util";
 import { MigrationBase } from "../base.ts";
 
 /** Fix unannotated shield traits added from Lost Omens: Treasure Vault */
@@ -6,6 +7,12 @@ export class Migration827FixTVShieldTraits extends MigrationBase {
     static override version = 0.827;
 
     override async updateItem(source: ItemSourcePF2e): Promise<void> {
+        // Sanity check
+        const traits: unknown = source.system.traits;
+        if (isObject(traits) && "value" in traits && !Array.isArray(traits.value)) {
+            traits.value = [];
+        }
+
         if (source.type !== "armor") return;
 
         switch (source.system.slug) {

--- a/src/module/migration/migrations/838-strike-attack-roll-selector.ts
+++ b/src/module/migration/migrations/838-strike-attack-roll-selector.ts
@@ -6,6 +6,11 @@ export class Migration838StrikeAttackRollSelector extends MigrationBase {
     static override version = 0.838;
 
     override async updateItem(source: ItemSourcePF2e): Promise<void> {
+        // Sanity check
+        if (!Array.isArray(source.system.rules)) {
+            source.system.rules = [];
+        }
+
         for (const rule of source.system.rules) {
             if (!("selector" in rule)) continue;
 


### PR DESCRIPTION
Noticing some bad data appearing in user issue reports--probably from modules?