### PR TITLE
Reduce sheet-side logic in ability builder template

### DIFF
--- a/src/module/item/ancestry/document.ts
+++ b/src/module/item/ancestry/document.ts
@@ -33,6 +33,13 @@ class AncestryPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends 
             .filter((boost): boost is AbilityString => !!boost);
     }
 
+    /** Returns all flaws enforced by this ancestry normally */
+    get lockedFlaws(): AbilityString[] {
+        return Object.values(this.system.flaws)
+            .map((flaw) => flaw.selected)
+            .filter((flaw): flaw is AbilityString => !!flaw);
+    }
+
     /** Include all ancestry features in addition to any with the expected location ID */
     override getLinkedItems(): FeatPF2e<ActorPF2e>[] {
         if (!this.actor) return [];

--- a/src/styles/actor/character/_ability-builder.scss
+++ b/src/styles/actor/character/_ability-builder.scss
@@ -1,10 +1,4 @@
 .ability-builder-popup .window-content {
-    $boost-color: #316549;
-    $boost-locked-color: #1b3c2a;
-    $flaw-color: #5e0000;
-    $flaw-locked-color: #5e0000;
-    $neutral-color: var(--alt);
-
     background: url("/assets/sheet/background.webp");
     background-repeat: repeat-x, no-repeat;
     background-size: cover;
@@ -13,28 +7,28 @@
     padding: 10px 20px 10px 20px;
     position: relative;
 
+    h3 {
+        font: 400 var(--font-size-24) var(--serif-condensed);
+        line-height: var(--font-size-24);
+    }
+
+    h4 {
+        font: 400 var(--font-size-10) var(--sans-serif);
+        text-transform: uppercase;
+        color: #605856;
+    }
+
     button:focus:not(:focus-visible) {
         box-shadow: none;
     }
 
-    .background-stripes {
-        position: absolute;
-        left: 0;
-        top: 0;
-        bottom: 50px;
-        right: 0;
-        padding: 10px 20px 10px 20px;
-        pointer-events: none;
-
-        div:nth-child(even) {
-            background-color: rgba(68, 55, 48, 0.1);
-        }
-    }
-
     .row {
-        display: grid;
-        grid-template-columns: 220px repeat(6, 84px);
-        grid-template-rows: auto;
+        display: flex;
+        align-items: center;
+
+        .row-heading {
+            width: 220px;
+        }
 
         &.not-eligible {
             pointer-events: none;
@@ -45,17 +39,47 @@
                 visibility: hidden;
             }
         }
+
+        .abilities {
+            display: grid;
+            grid-template-columns: repeat(6, 84px);
+            grid-template-rows: auto;
+            flex: 0 0 auto;
+        }
+
+        .full-row {
+            display: flex;
+            flex: 1;
+            justify-content: center;
+        }
     }
 
-    .header-row {
+    header.row {
+        align-items: normal;
+        padding-top: 10px;
         height: 60px;
-
-        div {
-            padding-top: 10px;
-        }
 
         .row-column {
             display: block;
+        }
+
+        .abilities {
+            align-items: normal;
+        }
+    }
+
+    .background-stripes {
+        position: absolute;
+        left: 0;
+        top: 0;
+        bottom: 50px;
+        right: 0;
+        padding: 10px 20px 10px 20px;
+        pointer-events: none;
+        align-items: normal;
+
+        .abilities div:nth-child(odd) {
+            background-color: rgba(68, 55, 48, 0.1);
         }
     }
 
@@ -88,13 +112,6 @@
                 }
             }
         }
-    }
-
-    .full-row {
-        align-items: center;
-        display: flex;
-        grid-column: 2 / span 6;
-        justify-content: center;
     }
 
     .row-heading {
@@ -130,8 +147,8 @@
             grid-area: remaining;
             display: flex;
             margin-right: 10px;
-            width: 26px;
-            height: 26px;
+            width: 1.6rem;
+            height: 1.6rem;
             border-radius: 50%;
             background: rgba(68, 55, 48, 0.1);
             align-self: center;
@@ -163,19 +180,38 @@
 
         button {
             align-items: center;
+            border: 1px solid var(--button-color);
+            color: var(--button-color);
             display: flex;
             font-size: var(--font-size-12);
-            height: 1.5em;
             justify-content: space-around;
-            line-height: inherit;
-            margin: 4px 0;
             outline: none;
+            margin: 0;
             padding: 0.1em 0 0;
             position: relative;
             text-transform: uppercase;
+
             width: 6em;
+            height: 1.5em;
+
+            &.boost {
+                margin-top: auto; // line up with bottom
+                --button-color: #316549;
+                --button-locked-color: #1b3c2a;
+            }
+
+            &.flaw {
+                margin-bottom: auto; // line up with top
+                --button-color: #5e0000;
+                --button-locked-color: #5e0000;
+            }
+
+            &.selected {
+                background: var(--button-color);
+            }
 
             &:hover {
+                box-shadow: 0 0 5px var(--button-color);
                 cursor: pointer;
 
                 &.key-ability.selected {
@@ -204,6 +240,7 @@
 
             &:disabled {
                 background: rgba(0, 0, 0, 0.04);
+                opacity: 0.4;
 
                 &:active {
                     pointer-events: none;
@@ -211,103 +248,61 @@
             }
 
             &.locked {
+                background: var(--button-locked-color);
+                border-color: var(--button-locked-color);
                 pointer-events: none;
             }
 
-            &.boost {
-                border: 1px solid $boost-color;
-                color: $boost-color;
-
-                &.locked, &.selected {
-                    color: white;
-                }
-
-                &.selected {
-                    background: $boost-color;
-                }
-
-                &.locked {
-                    background: $boost-locked-color;
-                    border-color: $boost-locked-color;
-                }
-
-                &:hover {
-                    box-shadow: 0 0 5px $boost-color;
-                    &:disabled {
-                        box-shadow: none;
-                        color: rgba($boost-color, 0.4);
-                        border-color: rgba($boost-color, 0.4);
-                    }
-                }
-
-                &:disabled {
-                    color: rgba($boost-color, 0.4);
-                    border-color: rgba($boost-color, 0.4);
-                }
-            }
-
-            &.flaw {
-                border: 1px solid $flaw-color;
-                color: $flaw-color;
-
-                &.locked, &.selected {
-                    color: white;
-                }
-
-                &.selected {
-                    background: $flaw-color;
-                }
-
-                &.locked {
-                    background: $flaw-locked-color;
-                    border-color: $flaw-locked-color;
-                }
-
-                &:hover {
-                    box-shadow: 0 0 5px $flaw-color;
-                    &:disabled {
-                        box-shadow: none;
-                        color: rgba($flaw-color, 0.4);
-                        border-color: rgba($flaw-color, 0.4);
-                    }
-                }
-
-                &:disabled {
-                    color: rgba($flaw-color, 0.4);
-                    border-color: rgba($flaw-color, 0.4);
-                }
-            }
-
-            .flaw-indicator {
-                float: left;
-                margin: -1px -6px;
-                height: 14px;
-                width: 27px;
-                background: $flaw-color;
+            &.locked, &.selected {
                 color: white;
-                display: flex;
-                align-items: center;
-                justify-content: center;
             }
+        }
 
-            &.neutral {
-                border: 1px solid $neutral-color;
-                color: $neutral-color;
-
-                &.selected {
-                    border: none;
-                    background: $neutral-color;
-                    color: white;
-                }
-            }
+        div + .boost, button + .boost {
+            margin-top: 4px;
         }
     }
 
     .summary-row {
-        grid-template-rows: auto auto;
-
         .row-heading {
-            grid-row: 1 / 3;
+            display: block;
+        }
+
+        .hint-container {
+            background: rgba(211, 204, 188, 0.4);
+            padding: 12px;
+            margin-right: 10px;
+            border: 1px solid rgba(211, 204, 188, 1);
+            border-radius: 3px;
+            align-self: end;
+
+            h3 {
+                color: var(--primary);
+                font-variant: small-caps;
+                font-size: var(--font-size-20);
+                line-height: var(--font-size-16);
+                font-family: var(--sans-serif-condensed);
+                font-weight: 500;
+            }
+
+            p {
+                font-style: italic;
+                font-size: var(--font-size-12);
+                line-height: var(--font-size-14);
+                font-family: var(--sans-serif);
+                font-weight: 500;
+                margin-bottom: 3px;
+            }
+
+            label {
+                display: flex;
+                align-items: center;
+                margin-top: 10px;
+            }
+        }
+
+        .abilities {
+            grid-template-rows: auto auto;
         }
 
         .row-column {
@@ -347,54 +342,18 @@
         }
 
         .complete {
-            grid-row: 2 / 3;
-            grid-column: 2 / 9;
-
-            display: flex;
-            align-items: flex-end;
-            justify-content: flex-end;
+            grid-row: 2;
+            grid-column: 1 / 7;
             margin-top: 10px;
-
-            button {
-                color: white;
-                background: var(--secondary);
-                height: 35px;
-                width: 131px;
-                border: 1px solid var(--tertiary);
-            }
-        }
-    }
-
-    .hint-container {
-        background: rgba(211, 204, 188, 0.4);
-        padding: 12px;
-        margin-right: 10px;
-        border: 1px solid rgba(211, 204, 188, 1);
-        border-radius: 3px;
-        align-self: end;
-
-        h3 {
-            color: var(--primary);
-            font-variant: small-caps;
-            font-size: var(--font-size-20);
-            line-height: var(--font-size-16);
-            font-family: var(--sans-serif-condensed);
-            font-weight: 500;
+            margin-left: auto;
         }
 
-        p {
-            font-style: italic;
-            font-size: var(--font-size-12);
-            line-height: var(--font-size-14);
-            font-family: var(--sans-serif);
-            font-weight: 500;
-            margin-bottom: 3px;
-        }
-
-        label {
-            display: flex;
-            align-items: center;
-            margin-top: 10px;
+        button.complete {
+            color: white;
+            background: var(--secondary);
+            height: 35px;
+            width: 131px;
+            border: 1px solid var(--tertiary);
         }
     }
 
@@ -428,17 +387,6 @@
             height: var(--font-size-12);
             margin: 0;
         }
-    }
-
-    h3 {
-        font: 400 var(--font-size-24) var(--serif-condensed);
-        line-height: var(--font-size-24);
-    }
-
-    h4 {
-        font: 400 var(--font-size-10) var(--sans-serif);
-        text-transform: uppercase;
-        color: #605856;
     }
 }
 

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -174,6 +174,7 @@
                         "UseCustomLabel": "Use Custom"
                     },
                     "AncestryMissingHelp": "Choose an ancestry to select boosts.",
+                    "AlternateBoostsLabel": "Alternate Boosts",
                     "BackgroundBoostDescription": "Two boosts: one must be {a} or {b}.",
                     "BackgroundMissingHelp": "Choose a background to select boosts.",
                     "Boost": "Boost",

--- a/static/templates/actors/character/ability-builder.hbs
+++ b/static/templates/actors/character/ability-builder.hbs
@@ -1,57 +1,42 @@
 <form autocomplete="off" onsubmit="event.preventDefault();">
-    <div>
-        <div class="row header-row{{#if manual}} not-eligible{{/if}}">
+    <div class="ability-rows">
+        <header class="row{{#if manual}} not-eligible{{/if}}">
             <div class="row-heading">
                 <h3>{{localize "PF2E.Actor.Character.AbilityBuilder.Title"}}</h3>
             </div>
-            {{#each abilityScores as |ability key|}}
-                <div class="row-column">
-                    <h3>{{localize (concat "PF2E.AbilityId." key)}}</h3>
-                </div>
-            {{/each}}
-        </div>
+            <div class="abilities">
+                {{#each abilityScores as |ability key|}}
+                    <div class="row-column">
+                        <h3>{{localize (concat "PF2E.AbilityId." key)}}</h3>
+                    </div>
+                {{/each}}
+            </div>
+        </header>
 
         <!-- ancestry boosts -->
-        <div class="row{{#if manual}} not-eligible{{/if}}">
-            {{#if ancestry}}
+        <section class="row{{#if manual}} not-eligible{{/if}}" data-section="ancestry">
+            {{#if ancestryBoosts}}
                 <div class="row-heading">
-                    {{#unless (eq ancestryBoosts.remaining 0)}}<div class="remaining extra">{{ancestryBoosts.remaining}}</div>{{/unless}}
+                    {{#if ancestryBoosts.remaining}}<div class="remaining extra">{{ancestryBoosts.remaining}}</div>{{/if}}
                     <img class="" src="{{ancestry.img}}" title="{{ancestry.name}}" width="32" height="32" loading="lazy"/>
                     <div class="label">
                         <div class="title">{{localize "ITEM.TypeAncestry"}}</div>
                         <div class="description" data-tooltip-content="#{{actor.id}}-ancestry-tooltip">{{ancestry.name}}</div>
-                        <label class="extra">Alternate Boosts <input type="checkbox" {{checked alternateAncestryBoosts}} data-action="toggle-alternate-ancestry-boosts"></label>
+                        <label class="extra">
+                            {{localize "PF2E.Actor.Character.AbilityBuilder.AlternateBoostsLabel"}} <input type="checkbox" {{checked ancestryBoosts.alternate}} data-action="toggle-alternate-ancestry-boosts">
+                        </label>
                     </div>
                 </div>
-                {{#each ancestryBoosts.boosts as |boost ability|}}
-                    <div class="row-column">
-                        {{#if @root.ancestryBoosts.hasLockedFlaws}}
-                            <button type="button" data-action="voluntary-flaw" data-ability="{{ability}}" class="flaw locked selected{{#unless boost.lockedFlaw}} hidden{{/unless}}">
-                                {{#if boost.lockedFlaw}}<i class="fas fa-fw fa-lock"></i>{{/if}}
-                                {{localize "PF2E.Actor.Character.AbilityBuilder.Flaw"}}
-                            </button>
-                        {{/if}}
-
-                        <button type="button" data-action="ancestry-boost" data-ability="{{ability}}"
-                            class="boost {{#if boost.boosted}} selected{{/if}}{{#if boost.lockedBoost}} locked{{/if}}"
-                            {{disabled (not boost.available)}}
-                        >
-                            {{#if boost.lockedBoost}}<i class="fas fa-fw fa-lock"></i>{{/if}}
-                            {{localize "PF2E.Actor.Character.AbilityBuilder.Boost"}}
-                        </button>
-                    </div>
-                {{/each}}
-            {{else}}
+             {{else}}
                 <div class="row-heading">
                     <div class="label">
                         <div class="title">{{localize "ITEM.TypeAncestry"}}</div>
                         <div class="description">{{localize "PF2E.Actor.Character.AbilityBuilder.NotSelected"}}</div>
                     </div>
                 </div>
-                <div class="full-row">
-                    {{localize "PF2E.Actor.Character.AbilityBuilder.AncestryMissingHelp"}}
-                </div>
             {{/if}}
+
+            {{> abilityRow buttons=ancestryBoosts.buttons fallback="PF2E.Actor.Character.AbilityBuilder.AncestryMissingHelp"}}
 
             <div class="hover-content" id="{{actor.id}}-ancestry-tooltip">
                 <h2>{{localize "PF2E.Actor.Character.AbilityBuilder.Boosts"}}</h2>
@@ -67,13 +52,13 @@
                     {{/each}}
                 </ul>
             </div>
-        </div>
+        </section>
 
         <!-- ancestry voluntary flaw -->
-        <div class="row{{#if manual}} not-eligible{{/if}} voluntary-flaw-row">
+        <section class="row{{#if manual}} not-eligible{{/if}} voluntary-flaw-row" data-section="voluntary">
             {{#if ancestry}}
                 <div class="row-heading">
-                    {{#unless (eq ancestryBoosts.voluntaryBoostsRemaining 0)}}<div class="remaining extra">{{ancestryBoosts.voluntaryBoostsRemaining}}</div>{{/unless}}
+                    {{#if voluntaryFlaws.remaining}}<div class="remaining extra">{{voluntaryFlaws.remaining}}</div>{{/if}}
                     <div class="label">
                         <div class="description" data-tooltip-content="#{{actor.id}}-voluntary-flaw-tooltip">{{localize "PF2E.Actor.Character.AbilityBuilder.VoluntaryFlaw.Title"}}</div>
                         <label class="extra" data-tooltip-content="#{{actor.id}}-legacy-voluntary-flaw-tooltip">
@@ -82,64 +67,26 @@
                         </label>
                     </div>
                 </div>
-                {{#each ancestryBoosts.boosts as |boost ability|}}
-                    <div class="row-column">
-                        <div class="flaw-buttons">
-                            <button type="button" data-action="voluntary-flaw" data-ability="{{ability}}"
-                                class="flaw
-                                {{~#if boost.voluntary.canDoubleFlaw}} first{{/if}}
-                                {{~#if boost.voluntary.selected}} selected{{/if}}"
-                                {{disabled boost.voluntary.disabled}}
-                            >
-                                {{#if boost.lockedFlaw}}<i class="fas fa-lock"></i>{{/if}}
-                                {{localize "PF2E.Actor.Character.AbilityBuilder.Flaw"}}
-                            </button>
-                            {{#if boost.voluntary.canDoubleFlaw}}
-                                <button type="button" data-action="voluntary-flaw" data-ability="{{ability}}"
-                                    class="flaw second
-                                    {{~#if (eq boost.voluntary.selected 2)}} selected{{/if}}"
-                                    {{disabled boost.voluntary.secondFlawDisabled}}
-                                >x2</button>
-                            {{/if}}
-                        </div>
-
-                        {{#if @root.legacyFlaws}}
-                            <button type="button" data-action="voluntary-boost" data-ability="{{ability}}"
-                                class="tooltip boost{{#if boost.voluntary.boosted}} selected{{/if}}"
-                                {{disabled boost.voluntary.boostDisabled}}
-                            >
-                                {{localize "PF2E.Actor.Character.AbilityBuilder.Boost"}}
-                            </button>
-                        {{/if}}
-                    </div>
-                {{/each}}
+                {{> abilityRow buttons=voluntaryFlaws.buttons}}
             {{/if}}
 
             <div class="hover-content" id="{{actor.id}}-voluntary-flaw-tooltip">{{localize "PF2E.Actor.Character.AbilityBuilder.VoluntaryFlaw.Description"}}</div>
             <div class="hover-content" id="{{actor.id}}-legacy-voluntary-flaw-tooltip">{{localize "PF2E.Actor.Character.AbilityBuilder.VoluntaryFlaw.LegacyDescription"}}</div>
-        </div>
+        </section>
+
         <hr />
+
         <!-- background boosts -->
-        <div class="row{{#if manual}} not-eligible{{/if}}">
-            {{#if background}}
+        <section class="row{{#if manual}} not-eligible{{/if}}" data-section="background">
+            {{#if backgroundBoosts}}
                 <div class="row-heading" data-tooltip-content="#{{actor.id}}-background-tooltip">
-                    {{#unless (eq backgroundBoosts.remaining 0)}}<div class="remaining extra">{{backgroundBoosts.remaining}}</div>{{/unless}}
+                    {{#if backgroundBoosts.remaining}}<div class="remaining extra">{{backgroundBoosts.remaining}}</div>{{/if}}
                     <img class="" src="{{background.img}}" title="{{background.name}}" width="32" height="32" loading="lazy"/>
                     <div class="label">
                         <div class="title">{{localize "PF2E.Background"}}</div>
                         <div class="description">{{background.name}}</div>
                     </div>
                 </div>
-                {{#each backgroundBoosts.boosts as |boost ability|}}
-                    <div class="row-column">
-                        <button type="button" data-action="background-boost" data-ability="{{ability}}"
-                            class="boost{{#if boost.boosted}} selected{{/if}}"
-                            {{disabled (not boost.available)}}
-                        >
-                            {{localize "PF2E.Actor.Character.AbilityBuilder.Boost"}}
-                        </button>
-                    </div>
-                {{/each}}
             {{else}}
                 <div class="row-heading">
                     <div class="label">
@@ -147,8 +94,9 @@
                         <div class="description">{{localize "PF2E.Actor.Character.AbilityBuilder.NotSelected"}}</div>
                     </div>
                 </div>
-                <div class="full-row">{{localize "PF2E.Actor.Character.AbilityBuilder.BackgroundMissingHelp"}}</div>
             {{/if}}
+
+            {{> abilityRow buttons=backgroundBoosts.buttons fallback="PF2E.Actor.Character.AbilityBuilder.BackgroundMissingHelp"}}
 
             <div class="hover-content" id="{{actor.id}}-background-tooltip">
                 {{#if backgroundBoosts.tooltip}}
@@ -164,12 +112,12 @@
                     </ul>
                 {{/if}}
             </div>
-        </div>
+        </section>
 
         <hr />
 
         <!-- class boosts -->
-        <div class="row{{#if manual}} not-eligible{{/if}}">
+        <section class="row{{#if manual}} not-eligible{{/if}}">
             {{#if class}}
                 <div class="row-heading">
                     <img class="" src="{{class.img}}" title="{{ancestry.name}}" width="32" height="32" loading="lazy"/>
@@ -178,19 +126,21 @@
                         <div class="description">{{class.name}}</div>
                     </div>
                 </div>
-                {{#each abilities as |key ability|}}
-                    <div class="row-column">
-                        <button type="button" data-action="class-key-ability" data-key="{{key}}" data-ability="{{ability}}"
-                            class="boost key-ability
-                            {{~#if (not (contains ../keyOptions ability))}} hidden{{/if}}
-                            {{~#if (eq ../class.system.keyAbility.selected ability)}} selected{{/if}}
-                            {{~#if ../manual}} hidden{{/if}}"
-                        >
-                            <i class="fas fa-fw fa-key"></i>
-                            {{localize "PF2E.Actor.Character.AbilityBuilder.KeyIcon"}}
-                        </button>
-                    </div>
-                {{/each}}
+                <div class="abilities">
+                    {{#each abilities as |key ability|}}
+                        <div class="row-column">
+                            <button type="button" data-action="class-key-ability" data-key="{{key}}" data-ability="{{ability}}"
+                                class="boost key-ability
+                                {{~#if (not (contains ../keyOptions ability))}} hidden{{/if}}
+                                {{~#if (eq ../class.system.keyAbility.selected ability)}} selected{{/if}}
+                                {{~#if ../manual}} hidden{{/if}}"
+                            >
+                                <i class="fas fa-fw fa-key"></i>
+                                {{localize "PF2E.Actor.Character.AbilityBuilder.KeyIcon"}}
+                            </button>
+                        </div>
+                    {{/each}}
+                </div>
             {{else}}
                 <div class="row-heading">
                     <div class="label">
@@ -200,7 +150,7 @@
                 </div>
                 <div class="full-row">{{localize "PF2E.Actor.Character.AbilityBuilder.ClassMissingHelp"}}</div>
             {{/if}}
-        </div>
+        </section>
 
         <hr />
 
@@ -213,9 +163,9 @@
         </div>
 
         {{#each levelBoosts as |boosts|}}
-            <div class="row{{#if ../manual}} not-eligible{{/if}}{{#if (not boosts.eligible)}} not-eligible{{/if}}">
+            <section class="row{{#if ../manual}} not-eligible{{/if}}{{#if (not boosts.eligible)}} not-eligible{{/if}}" data-level="{{boosts.level}}">
                 <div class="row-heading">
-                    {{#unless (eq remaining 0)}}<div class="remaining extra">{{remaining}}</div>{{/unless}}
+                    {{#if remaining}}<div class="remaining extra">{{remaining}}</div>{{/if}}
                     <div class="label">
                         <div class="description">
                             {{#if (eq boosts.minLevel boosts.level)}}
@@ -226,61 +176,97 @@
                         </div>
                     </div>
                 </div>
-                {{#each boosts.boosts as |boost|}}
-                    <div class="row-column">
-                        <button type="button" data-action="level" data-level="{{boosts.level}}" data-ability="{{ability}}"
-                            class="boost {{#if boost.taken}} selected{{/if}}{{#if (not boosts.eligible)}} hidden{{/if}}"
-                            {{disabled (and boosts.full (not boost.taken))}}
-                        >
-                            {{localize "PF2E.Actor.Character.AbilityBuilder.Boost"}}
-                        </button>
-                    </div>
-                {{/each}}
-            </div>
+                {{> abilityRow buttons=boosts.buttons}}
+            </section>
         {{/each}}
 
-        <div class="row summary-row">
+        <section class="row summary-row">
             <div class="row-heading">
-                <div class="hint-container">
+                <aside class="hint-container">
                     <h3>{{localize "PF2E.Actor.Character.AbilityBuilder.AbilityScoreMethod.Title"}}</h3>
                     <p>{{localize "PF2E.Actor.Character.AbilityBuilder.AbilityScoreMethod.Description"}}</p>
                     <label>
                         <input type="checkbox" name="toggle-manual-mode"{{checked manual}}>
                         {{localize "PF2E.Actor.Character.AbilityBuilder.AbilityScoreMethod.UseCustomLabel"}}
                     </label>
-                </div>
+                </aside>
             </div>
-            {{#each abilityScores as |ability key|}}
-                <div class="row-column">
-                    {{#if ../manual}}
-                        <button type="button" data-action="class-key-ability" data-key="{{lookup ../abilities key}}" data-ability="{{key}}"
-                            class="boost{{#if (eq ../manualKeyAbility key)}} selected{{/if}}"
-                            tabindex="-1"
-                        >
-                            <i class="fas fa-fw fa-key"></i>
-                            {{localize "PF2E.Actor.Character.AbilityBuilder.KeyIcon"}}
-                        </button>
-                        <input type="number" data-property="system.abilities.{{key}}.value" name="system.abilities.{{key}}.value" value="{{ability.base}}" placeholder="10">
-                    {{else}}
-                        <button type="button" class="boost hidden"></button>
-                        <div class="value">{{ability.base}}</div>
-                    {{/if}}
-                    <h4>{{localize (lookup ../abilities key)}}</h4>
-                </div>
-            {{/each}}
-            <div class="complete">
-                <button type="button" data-action="close">{{localize "PF2E.Actor.Character.AbilityBuilder.Complete"}}</button>
+            <div class="abilities">
+                {{#each abilityScores as |ability key|}}
+                    <div class="row-column">
+                        {{#if ../manual}}
+                            <button type="button" data-action="class-key-ability" data-key="{{lookup ../abilities key}}" data-ability="{{key}}"
+                                class="boost{{#if (eq ../manualKeyAbility key)}} selected{{/if}}"
+                                tabindex="-1"
+                            >
+                                <i class="fas fa-fw fa-key"></i>
+                                {{localize "PF2E.Actor.Character.AbilityBuilder.KeyIcon"}}
+                            </button>
+                            <input type="number" data-property="system.abilities.{{key}}.value" name="system.abilities.{{key}}.value" value="{{ability.base}}" placeholder="10">
+                        {{else}}
+                            <button type="button" class="boost hidden"></button>
+                            <div class="value">{{ability.base}}</div>
+                        {{/if}}
+                        <h4>{{localize (lookup ../abilities key)}}</h4>
+                    </div>
+                {{/each}}
+                <button class="complete" type="button" data-action="close">{{localize "PF2E.Actor.Character.AbilityBuilder.Complete"}}</button>
             </div>
-        </div>
+        </section>
     </div>
 
     <div class="row background-stripes">
-        <div></div>
-        <div></div>
-        <div></div>
-        <div></div>
-        <div></div>
-        <div></div>
-        <div></div>
+        <div class="row-heading"></div>
+        <div class="abilities">
+            <div></div>
+            <div></div>
+            <div></div>
+            <div></div>
+            <div></div>
+            <div></div>
+        </div>
     </div>
 </form>
+
+{{#*inline "abilityRow"}}
+    {{#if buttons}}
+        <div class="abilities">
+            {{#each buttons as |state|}}
+                <div class="row-column" data-ability="{{state.ability}}" data-stat="{{state.stat}}">
+                    {{#if flaw}}
+                        {{> boostButton type="flaw" button=state.flaw}}
+                    {{/if}}
+                    {{#if boost}}
+                        {{> boostButton type="boost" button=state.boost}}
+                    {{/if}}
+                </div>
+            {{/each}}
+        </div>
+    {{else if fallback}}
+        <div class="full-row">{{localize fallback}}</div>
+    {{/if}}
+{{/inline}}
+
+{{#*inline "boostButton"}}
+    {{#if button.second}}
+        <div class="flaw-buttons">
+            {{> boostButtonSingle button=button type=type number="first"}}
+            {{> boostButtonSingle button=button.second type=type number="second"}}
+        </div>
+    {{else}}
+        {{> boostButtonSingle button=button type=type}}
+    {{/if}}
+
+    {{#*inline "boostButtonSingle"}}
+        <button type="button" data-action="{{type}}" class="tooltip boost-button {{type}} {{number}}{{#if button.selected}} selected{{/if}}{{#if button.locked}} locked{{/if}}" {{disabled (and button.disabled (not button.selected))}}>
+            {{#if button.locked}}<i class="fas fa-lock"></i>{{/if}}
+            {{#if (eq number "second")}}
+                x2
+            {{else if (eq type "flaw")}}
+                {{localize "PF2E.Actor.Character.AbilityBuilder.Flaw"}}
+            {{else}}
+                {{localize "PF2E.Actor.Character.AbilityBuilder.Boost"}}
+            {{/if}}
+        </button>
+    {{/inline}}
+{{/inline}}


### PR DESCRIPTION
Representing the data as a row of buttons reduces the amount of logic the template has to perform. Also converted some the divs to more fitting elements while I was at it.

This should wait until work on 5.0 starts. After this I'll do some tweaks for voluntary flaws and and try to remove the remaining invisible buttons.
![image](https://github.com/foundryvtt/pf2e/assets/1286721/126b06ec-55ef-42aa-a1d8-4bd940855864)
