### PR TITLE
Remove obsolete sheath item from alchemist class kit

### DIFF
--- a/packs/data/equipment.db/class-kit-alchemist.json
+++ b/packs/data/equipment.db/class-kit-alchemist.json
@@ -47,14 +47,6 @@
                 "quantity": 1,
                 "uuid": "Compendium.pf2e.equipment-srd.2req0jGaxz8hScdB"
             },
-            "nn2p9": {
-                "img": "systems/pf2e/icons/equipment/adventuring-gear/sheath.webp",
-                "isContainer": false,
-                "items": {},
-                "name": "Sheath",
-                "quantity": 1,
-                "uuid": "Compendium.pf2e.equipment-srd.Zycu6zaGvDsqLH5g"
-            },
             "qsu8r": {
                 "img": "systems/pf2e/icons/equipment/weapons/sling-bullets.webp",
                 "isContainer": false,
@@ -84,6 +76,7 @@
             "value": {
                 "cp": 2,
                 "gp": 8,
+                "pp": 0,
                 "sp": 4
             }
         },


### PR DESCRIPTION
Previously, it was impossible to actually add the alchemist kit to a character due to the missing item.