### PR TITLE
Revert "Add "bomb" trait to Blindpepper Bomb (#8027)"

### DIFF
--- a/packs/data/equipment.db/blindpepper-bomb.json
+++ b/packs/data/equipment.db/blindpepper-bomb.json
@@ -58,7 +58,6 @@
             "rarity": "uncommon",
             "value": [
                 "alchemical",
-                "bomb",
                 "consumable",
                 "visual"
             ]


### PR DESCRIPTION
This reverts commit 58f39957f9f4429beb4d9e80aa8f61c0b7fac450.

Blindpepper Bomb is a consumable.