### PR TITLE
Fix attack roll result flavor showing `DC` instead of `AC`

### DIFF
--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -640,7 +640,7 @@
                     "WithTarget": "<target>Target: {target}</target> <dc>({dcType} {dc})</dc>"
                 },
                 "Specific": {
-                    "ac": "AC",
+                    "armor": "AC",
                     "athletics": "Athletics DC",
                     "deception": "Deception DC",
                     "fortitude": "Fortitude DC",


### PR DESCRIPTION
It's either this or change the `slug` in `@system/statistic/armor-class.ts` to `ac`.