### PR TITLE
Add initial kingdom model and extended campaign data support

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -186,6 +186,7 @@ declare global {
 
         get(module: "pf2e", setting: "campaignFeats"): boolean;
         get(module: "pf2e", setting: "campaignFeatSections"): FeatGroupOptions[];
+        get(module: "pf2e", setting: "campaignType"): string;
 
         get(module: "pf2e", setting: "homebrew.weaponCategories"): HomebrewTag<"weaponCategories">[];
         get(module: "pf2e", setting: HomebrewTraitSettingsKey): HomebrewTag[];

--- a/src/module/actor/party/data.ts
+++ b/src/module/actor/party/data.ts
@@ -13,6 +13,7 @@ interface PartySystemSource extends ActorSystemSource {
     attributes: PartyAttributesSource;
     details: PartyDetailsSource;
     traits?: never;
+    campaign?: PartyCampaignSource;
 }
 
 interface PartyAttributesSource extends ActorAttributesSource {
@@ -51,4 +52,6 @@ interface PartyAttributes
 
 interface PartyDetails extends PartyDetailsSource, ActorDetails {}
 
-export { MemberData, PartySource, PartySystemData };
+type PartyCampaignSource = { type: string } & Record<string, unknown>;
+
+export { MemberData, PartyCampaignSource, PartySource, PartySystemData };

--- a/src/module/actor/party/invalid-campaign.ts
+++ b/src/module/actor/party/invalid-campaign.ts
@@ -1,0 +1,56 @@
+import { createHTMLElement, fontAwesomeIcon } from "@util";
+import { PartyCampaign } from "./types.ts";
+import { PartyPF2e } from "./document.ts";
+
+/**
+ * Exists if the party's campaign type does not match the configured setting.
+ * Creates a warning and deletion dialog to give one last chance to back out.
+ */
+class InvalidCampaign implements PartyCampaign {
+    type = "invalid";
+
+    actor: PartyPF2e;
+    configuredType: string;
+
+    constructor(actor: PartyPF2e, currentType: string) {
+        this.actor = actor;
+        this.configuredType = currentType;
+    }
+
+    createSidebarButtons(): HTMLElement[] {
+        const icon = createHTMLElement("a", { children: [fontAwesomeIcon("warning", { fixedWidth: true })] });
+        icon.title = game.i18n.localize("PF2E.Actor.Party.InvalidCampaign.Hint");
+
+        if (game.user.isGM) {
+            icon.addEventListener("click", () => {
+                new Dialog({
+                    title: game.i18n.format("PF2E.Actor.Party.InvalidCampaign.Title", { party: this.actor.name }),
+                    content: game.i18n.format("PF2E.Actor.Party.InvalidCampaign.Message", {
+                        current: this.actor.system.campaign?.type ?? "",
+                        configured: this.configuredType,
+                    }),
+                    buttons: {
+                        yes: {
+                            icon: fontAwesomeIcon("trash").outerHTML,
+                            label: game.i18n.localize("Yes"),
+                            callback: async () => {
+                                await this.actor.update({ "system.-=campaign": null });
+                                ui.sidebar.render();
+                            },
+                        },
+                        cancel: {
+                            icon: fontAwesomeIcon("times").outerHTML,
+                            label: game.i18n.localize("Cancel"),
+                        },
+                    },
+                }).render(true);
+            });
+        } else {
+            icon.style.pointerEvents = "none";
+        }
+
+        return [icon];
+    }
+}
+
+export { InvalidCampaign };

--- a/src/module/actor/party/kingdom/data.ts
+++ b/src/module/actor/party/kingdom/data.ts
@@ -1,0 +1,35 @@
+import { ModelPropsFromSchema } from "types/foundry/common/data/fields.js";
+import { KINGDOM_SCHEMA } from "./schema.ts";
+import { KINGDOM_ABILITIES, KINGDOM_LEADERSHIP } from "./values.ts";
+
+interface KingdomCHG {
+    name: string;
+    img: ImageFilePath;
+    description: string;
+    boosts: (KingdomAbility | "free")[];
+    flaw: KingdomAbility | null;
+}
+
+interface KingdomGovernment extends KingdomCHG {
+    skills: string[];
+}
+
+type KingdomAbility = (typeof KINGDOM_ABILITIES)[number];
+type KingdomSchema = typeof KINGDOM_SCHEMA;
+type KingdomSource = SourceFromSchema<typeof KINGDOM_SCHEMA>;
+type KingdomData = ModelPropsFromSchema<typeof KINGDOM_SCHEMA>;
+type KingdomLeadershipData = KingdomData["leadership"][KingdomLeadershipRole];
+
+type FameType = "fame" | "infamy";
+type KingdomLeadershipRole = (typeof KINGDOM_LEADERSHIP)[number];
+
+export {
+    KingdomAbility,
+    KingdomCHG,
+    KingdomSchema,
+    KingdomData,
+    KingdomGovernment,
+    KingdomLeadershipData,
+    KingdomSource,
+    FameType,
+};

--- a/src/module/actor/party/kingdom/helpers.ts
+++ b/src/module/actor/party/kingdom/helpers.ts
@@ -1,0 +1,18 @@
+import * as R from "remeda";
+import { KingdomAbility, KingdomCHG } from "./data.ts";
+
+/** Resolves boosts using kingmaker rules. Free boosts cannot be the granted ability nor the flaw */
+export function resolveKingdomBoosts(entry: KingdomCHG, choices: KingdomAbility[]): KingdomAbility[] {
+    const notFreeBoosts = entry.boosts.filter((b): b is KingdomAbility => b !== "free");
+    return R.uniq([notFreeBoosts, choices].flat())
+        .filter((b) => b !== entry.flaw)
+        .slice(0, entry.boosts.length);
+}
+
+/** A less verbose version of R.map */
+export function mapValuesFromKeys<K extends string | number | symbol, V>(
+    keys: readonly K[],
+    mapping: (key: K) => V
+): Record<K, V> {
+    return R.mapToObj(keys, (key) => [key, mapping(key)]);
+}

--- a/src/module/actor/party/kingdom/index.ts
+++ b/src/module/actor/party/kingdom/index.ts
@@ -1,0 +1,2 @@
+export * from "./data.ts";
+export * from "./model.ts";

--- a/src/module/actor/party/kingdom/model.ts
+++ b/src/module/actor/party/kingdom/model.ts
@@ -1,0 +1,123 @@
+import { createHTMLElement, fontAwesomeIcon } from "@util";
+import { KingdomCHG, KingdomGovernment, KingdomSchema, KingdomSource } from "./data.ts";
+import { KINGDOM_SCHEMA } from "./schema.ts";
+import type { PartyPF2e } from "../document.ts";
+import { ModelPropsFromSchema } from "types/foundry/common/data/fields.js";
+import { PartyCampaign } from "../types.ts";
+import { ItemType } from "@item/data/index.ts";
+import { FeatGroup } from "@actor/character/feats.ts";
+import { KINGDOM_ABILITIES } from "./values.ts";
+import { resolveKingdomBoosts } from "./helpers.ts";
+import { PartyCampaignSource } from "../data.ts";
+
+const { DataModel } = foundry.abstract;
+
+/** Model for the Kingmaker campaign data type, which represents a Kingdom */
+class KingdomModel extends DataModel<null, KingdomSchema> implements PartyCampaign {
+    declare feats: FeatGroup<PartyPF2e>;
+    declare bonusFeats: FeatGroup<PartyPF2e>;
+
+    static override defineSchema(): KingdomSchema {
+        return KINGDOM_SCHEMA;
+    }
+
+    get extraItemTypes(): ItemType[] {
+        return ["action", "feat"];
+    }
+
+    get charter(): KingdomCHG | null {
+        return this.build.charter;
+    }
+
+    get heartland(): KingdomCHG | null {
+        return this.build.heartland;
+    }
+
+    get government(): KingdomGovernment | null {
+        return this.build.government;
+    }
+
+    constructor(private actor: PartyPF2e, source?: PartyCampaignSource) {
+        super(source);
+        this.#prepareAbilityScores();
+        this.#prepareFeats();
+    }
+
+    /** Creates sidebar buttons to inject into the chat message sidebar */
+    createSidebarButtons(): HTMLElement[] {
+        // Do not show kingdom to party members until it becomes activated.
+        if (!this.active && !game.user.isGM) return [];
+
+        const icon = createHTMLElement("a", { children: [fontAwesomeIcon("crown", { fixedWidth: true })] });
+        // todo: open sheet once clicked
+        return [icon];
+    }
+
+    async update(data: DeepPartial<KingdomSource> & Record<string, unknown>): Promise<void> {
+        await this.actor.update({ "system.campaign": data });
+    }
+
+    #prepareAbilityScores(): void {
+        for (const ability of KINGDOM_ABILITIES) {
+            this.abilities[ability].value = 10;
+        }
+
+        // Charter/Heartland/Government boosts
+        for (const category of ["charter", "heartland", "government"] as const) {
+            const data = this.build[category];
+            const chosen = this.build.boosts[category];
+            if (!data) continue;
+
+            if (data.flaw) {
+                this.abilities[data.flaw].value -= 2;
+            }
+
+            const activeBoosts = resolveKingdomBoosts(data, chosen);
+            for (const ability of activeBoosts) {
+                this.abilities[ability].value += this.abilities[ability].value >= 18 ? 1 : 2;
+            }
+        }
+
+        // Level boosts
+        const activeLevels = ([1, 5, 10, 15, 20] as const).filter((l) => this.level > l);
+        for (const level of activeLevels) {
+            const chosen = this.build.boosts[level].slice(0, 2);
+            for (const ability of chosen) {
+                this.abilities[ability].value += this.abilities[ability].value >= 18 ? 1 : 2;
+            }
+        }
+    }
+
+    #prepareFeats(): void {
+        const { actor } = this;
+
+        const evenLevels = new Array(actor.level)
+            .fill(0)
+            .map((_, idx) => idx + 1)
+            .filter((idx) => idx % 2 === 0);
+
+        this.feats = new FeatGroup(actor, {
+            id: "kingdom",
+            label: "Kingdom Feats",
+            slots: evenLevels,
+            featFilter: ["traits-kingdom"],
+        });
+
+        this.bonusFeats = new FeatGroup(actor, {
+            id: "bonus",
+            label: "PF2E.FeatBonusHeader",
+            featFilter: ["traits-kingdom"],
+        });
+
+        for (const feat of this.actor.itemTypes.feat) {
+            if (!this.feats.assignFeat(feat)) {
+                this.bonusFeats.assignFeat(feat);
+            }
+        }
+    }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface KingdomModel extends ModelPropsFromSchema<KingdomSchema> {}
+
+export { KingdomModel };

--- a/src/module/actor/party/kingdom/schema.ts
+++ b/src/module/actor/party/kingdom/schema.ts
@@ -1,0 +1,144 @@
+import { ActorPF2e } from "@actor";
+import { ArrayField, StringField } from "types/foundry/common/data/fields.js";
+import { KingdomAbility } from "./data.ts";
+import { mapValuesFromKeys } from "./helpers.ts";
+import { KINGDOM_ABILITIES, KINGDOM_COMMODITIES, KINGDOM_LEADERSHIP } from "./values.ts";
+
+const { fields } = foundry.data;
+
+function buildKingdomCHGSchema(): {
+    name: StringField<string, string, true, false>;
+    img: StringField<ImageFilePath, ImageFilePath, true, false>;
+    description: StringField<string, string, true, false>;
+    boosts: ArrayField<StringField<KingdomAbility | "free", KingdomAbility | "free", true, false>>;
+    flaw: StringField<KingdomAbility, KingdomAbility, true, true>;
+} {
+    return {
+        name: new fields.StringField({ blank: false, nullable: false }),
+        img: new fields.StringField({ required: true, nullable: false }),
+        description: new fields.StringField({ required: true, nullable: false }),
+        boosts: new fields.ArrayField(
+            new fields.StringField({ choices: [...KINGDOM_ABILITIES, "free"], nullable: false })
+        ),
+        flaw: new fields.StringField({ choices: KINGDOM_ABILITIES, required: true, nullable: true }),
+    };
+}
+
+const KINGDOM_BUILD_SCHEMA = {
+    charter: new fields.SchemaField(buildKingdomCHGSchema(), { nullable: true, initial: null }),
+    heartland: new fields.SchemaField(buildKingdomCHGSchema(), { nullable: true, initial: null }),
+    government: new fields.SchemaField(
+        {
+            ...buildKingdomCHGSchema(),
+            skills: new fields.ArrayField<StringField<string, string, true, false>>(
+                new fields.StringField({ required: true, nullable: false })
+            ),
+        },
+        { nullable: true, initial: null }
+    ),
+    boosts: new fields.SchemaField(
+        mapValuesFromKeys(["charter", "heartland", "government", "1", "5", "10", "15", "20"] as const, () => {
+            return new fields.ArrayField<StringField<KingdomAbility, KingdomAbility, true, false>>(
+                new fields.StringField<KingdomAbility, KingdomAbility, true, false>({
+                    choices: KINGDOM_ABILITIES,
+                    nullable: false,
+                })
+            );
+        })
+    ),
+};
+
+const KINGDOM_RESOURCES_SCHEMA = {
+    fame: new fields.SchemaField({
+        value: new fields.NumberField({ required: true, nullable: false, initial: 0 }),
+        max: new fields.NumberField({ required: true, nullable: false, initial: 3 }),
+    }),
+    commodities: new fields.SchemaField(
+        mapValuesFromKeys(KINGDOM_COMMODITIES, () => {
+            return new fields.SchemaField({
+                value: new fields.NumberField({ required: true, initial: 0 }),
+                max: new fields.NumberField({ required: true, initial: 0 }),
+                maxBase: new fields.NumberField({ required: false, nullable: true }),
+                maxExtra: new fields.NumberField({ required: true, initial: 0 }),
+            });
+        })
+    ),
+};
+
+const KINGDOM_SCHEMA = {
+    type: new fields.StringField({
+        initial: "kingmaker",
+        required: true,
+        nullable: false,
+    }),
+    capital: new fields.StringField({ initial: "", required: true }),
+    size: new fields.NumberField({ initial: 1, required: true, nullable: false }),
+    level: new fields.NumberField<number, number, true, false>({
+        required: true,
+        nullable: false,
+        min: 1,
+        max: 20,
+        initial: 1,
+    }),
+    xp: new fields.SchemaField({
+        value: new fields.NumberField({ required: true, nullable: false, initial: 0 }),
+        max: new fields.NumberField({
+            required: true,
+            nullable: false,
+            initial: 1000,
+        }),
+    }),
+    active: new fields.BooleanField<boolean, boolean, true, false>({ initial: false, required: true, nullable: false }),
+    abilities: new fields.SchemaField(
+        mapValuesFromKeys(KINGDOM_ABILITIES, () => {
+            return new fields.SchemaField({
+                value: new fields.NumberField<number, number, true, false>({
+                    initial: 10,
+                    required: true,
+                    nullable: false,
+                }),
+                ruin: new fields.SchemaField({
+                    value: new fields.NumberField<number, number, true, false>({
+                        required: true,
+                        nullable: false,
+                        initial: 0,
+                    }),
+                    max: new fields.NumberField<number, number, true, false>({
+                        required: true,
+                        nullable: false,
+                        initial: 10,
+                    }),
+                }),
+                // todo: see if this goes away once we wire it up
+                penalty: new fields.NumberField<number, number, true, false>({
+                    initial: 0,
+                    required: true,
+                    nullable: false,
+                }),
+            });
+        })
+    ),
+    leadership: new fields.SchemaField(
+        mapValuesFromKeys(KINGDOM_LEADERSHIP, () => {
+            return new fields.SchemaField({
+                img: new fields.FilePathField({ categories: ["IMAGE"], initial: () => ActorPF2e.DEFAULT_ICON }),
+                name: new fields.StringField<string, string, false>({
+                    required: false,
+                    nullable: true,
+                    blank: false,
+                    initial: null,
+                }),
+                vacant: new fields.BooleanField<boolean>({ initial: true }),
+                invested: new fields.BooleanField<boolean, boolean, false>({ required: false, initial: false }),
+            });
+        })
+    ),
+    attributes: new fields.SchemaField({
+        controlDC: new fields.SchemaField({}),
+        eventDC: new fields.SchemaField({}),
+    }),
+    build: new fields.SchemaField(KINGDOM_BUILD_SCHEMA),
+    resources: new fields.SchemaField(KINGDOM_RESOURCES_SCHEMA),
+};
+
+export { KINGDOM_SCHEMA };

--- a/src/module/actor/party/kingdom/values.ts
+++ b/src/module/actor/party/kingdom/values.ts
@@ -1,0 +1,147 @@
+import * as R from "remeda";
+import { localizer } from "@util";
+import { KingdomCHG, KingdomGovernment } from "./data.ts";
+
+const KINGDOM_ABILITIES = ["culture", "economy", "loyalty", "stability"] as const;
+const KINGDOM_LEADERSHIP = [
+    "ruler",
+    "counselor",
+    "general",
+    "emissary",
+    "magister",
+    "treasurer",
+    "viceroy",
+    "warden",
+] as const;
+const KINGDOM_COMMODITIES = ["food", "lumber", "luxuries", "ore", "stone"] as const;
+
+const KINGDOM_ABILITY_LABELS = R.mapToObj(KINGDOM_ABILITIES, (a) => [a, `PF2E.Kingmaker.Abilities.${a}`]);
+
+function getKingdomABCData(): {
+    charter: Record<string, KingdomCHG | undefined>;
+    heartland: Record<string, KingdomCHG | undefined>;
+    government: Record<string, KingdomGovernment | undefined>;
+} {
+    const localize = localizer("PF2E.Kingmaker");
+    return {
+        charter: {
+            conquest: {
+                name: localize("Charter.conquest.Name"),
+                description: localize("Charter.conquest.Description"),
+                img: "/icons/weapons/swords/sword-guard-steel-green.webp",
+                boosts: ["loyalty", "free"],
+                flaw: "culture",
+            },
+            expansion: {
+                name: localize("Charter.expansion.Name"),
+                description: localize("Charter.expansion.Description"),
+                img: "/icons/skills/trades/woodcutting-logging-axe-stump.webp",
+                boosts: ["culture", "free"],
+                flaw: "stability",
+            },
+            exploration: {
+                name: localize("Charter.exploration.Name"),
+                description: localize("Charter.exploration.Description"),
+                img: "/icons/tools/navigation/map-chart-tan.webp",
+                boosts: ["stability", "free"],
+                flaw: "economy",
+            },
+            grant: {
+                name: localize("Charter.grant.Name"),
+                description: localize("Charter.grant.Description"),
+                img: "/icons/skills/trades/academics-merchant-scribe.webp",
+                boosts: ["economy", "free"],
+                flaw: "loyalty",
+            },
+            open: {
+                name: localize("Charter.open.Name"),
+                description: localize("Charter.open.Description"),
+                img: "/icons/sundries/documents/document-sealed-brown-red.webp",
+                boosts: ["free"],
+                flaw: null,
+            },
+        },
+        heartland: {
+            forestOrSwamp: {
+                name: localize("Heartland.forestOrSwamp.Name"),
+                description: localize("Heartland.forestOrSwamp.Description"),
+                img: "/icons/environment/wilderness/tree-oak.webp",
+                boosts: ["culture"],
+                flaw: null,
+            },
+            hillOrPlain: {
+                name: localize("Heartland.hillOrPlain.Name"),
+                description: localize("Heartland.hillOrPlain.Description"),
+                img: "/icons/environment/creatures/horses.webp",
+                boosts: ["loyalty"],
+                flaw: null,
+            },
+            lakeOrRiver: {
+                name: localize("Heartland.lakeOrRiver.Name"),
+                description: localize("Heartland.lakeOrRiver.Description"),
+                img: "/icons/environment/settlement/bridge-stone.webp",
+                boosts: ["economy"],
+                flaw: null,
+            },
+            mountainOrRuins: {
+                name: localize("Heartland.mountainOrRuins.Name"),
+                description: localize("Heartland.mountainOrRuins.Description"),
+                img: "/icons/environment/wilderness/cave-entrance-mountain.webp",
+                boosts: ["stability"],
+                flaw: null,
+            },
+        },
+        government: {
+            despotism: {
+                name: localize("Government.despotism.Name"),
+                description: localize("Government.despotism.Description"),
+                img: "/icons/environment/settlement/pyramid.webp",
+                boosts: ["stability", "economy", "free"],
+                flaw: null,
+                skills: [],
+            },
+            feudalism: {
+                name: localize("Government.feudalism.Name"),
+                description: localize("Government.feudalism.Description"),
+                img: "/icons/environment/settlement/watchtower-cliff.webp",
+                boosts: ["stability", "culture", "free"],
+                flaw: null,
+                skills: [],
+            },
+            oligarchy: {
+                name: localize("Government.oligarchy.Name"),
+                description: localize("Government.oligarchy.Description"),
+                img: "/icons/environment/settlement/house-manor.webp",
+                boosts: ["loyalty", "economy", "free"],
+                flaw: null,
+                skills: [],
+            },
+            republic: {
+                name: localize("Government.republic.Name"),
+                description: localize("Government.republic.Description"),
+                img: "/icons/environment/settlement/gazebo.webp",
+                boosts: ["stability", "economy", "free"],
+                flaw: null,
+                skills: [],
+            },
+            thaumocracy: {
+                name: localize("Government.thaumocracy.Name"),
+                description: localize("Government.thaumocracy.Description"),
+                img: "/icons/environment/settlement/wizard-castle.webp",
+                boosts: ["economy", "culture", "free"],
+                flaw: null,
+                skills: [],
+            },
+            yeomanry: {
+                name: localize("Government.yeomanry.Name"),
+                description: localize("Government.yeomanry.Description"),
+                img: "/icons/environment/settlement/house-farmland-small.webp",
+                boosts: ["loyalty", "culture", "free"],
+                flaw: null,
+                skills: [],
+            },
+        },
+    };
+}
+
+export { KINGDOM_ABILITIES, KINGDOM_ABILITY_LABELS, KINGDOM_COMMODITIES, getKingdomABCData, KINGDOM_LEADERSHIP };

--- a/src/module/actor/party/types.ts
+++ b/src/module/actor/party/types.ts
@@ -50,8 +50,12 @@ interface PartyUpdateContext<TParent extends TokenDocumentPF2e | null> extends A
 
 /** Interface for a party campaign implementation, alternative data preparation used by parties for special campaigns */
 interface PartyCampaign {
+    type: string;
+    level?: number;
     /** Any additional item types supported by the campaign */
     extraItemTypes?: ItemType[];
+    /** Sidebar buttons to inject into the party header */
+    createSidebarButtons?(): HTMLElement[];
 }
 
 export { MemberBreakdown, PartyCampaign, PartySheetData, PartyUpdateContext, LanguageSheetData };

--- a/src/module/system/settings/index.ts
+++ b/src/module/system/settings/index.ts
@@ -266,7 +266,7 @@ export function registerSettings(): void {
         name: "PF2E.SETTINGS.CampaignType.Name",
         hint: "PF2E.SETTINGS.CampaignType.Hint",
         scope: "world",
-        config: BUILD_MODE === "development",
+        config: false, // 🤫
         default: "none",
         choices: R.mapToObj(["none", "kingmaker"], (key) => [key, `PF2E.SETTINGS.CampaignType.Choices.${key}`]),
         type: String,

--- a/src/module/system/settings/index.ts
+++ b/src/module/system/settings/index.ts
@@ -4,6 +4,7 @@ import { ItemPF2e, ItemSheetPF2e } from "@item";
 import { StatusEffects } from "@module/canvas/status-effects.ts";
 import { MigrationRunner } from "@module/migration/runner/index.ts";
 import { isImageOrVideoPath } from "@util";
+import * as R from "remeda";
 import { AutomationSettings } from "./automation.ts";
 import { HomebrewElements } from "./homebrew/menu.ts";
 import { MetagameSettings } from "./metagame.ts";
@@ -261,9 +262,23 @@ export function registerSettings(): void {
     });
     WorldClockSettings.registerSettings();
 
+    game.settings.register("pf2e", "campaignType", {
+        name: "PF2E.SETTINGS.CampaignType.Name",
+        hint: "PF2E.SETTINGS.CampaignType.Hint",
+        scope: "world",
+        config: BUILD_MODE === "development",
+        default: "none",
+        choices: R.mapToObj(["none", "kingmaker"], (key) => [key, `PF2E.SETTINGS.CampaignType.Choices.${key}`]),
+        type: String,
+        onChange: async () => {
+            await resetActors(game.actors.filter((a) => a.isOfType("party")));
+            ui.sidebar.render();
+        },
+    });
+
     game.settings.register("pf2e", "campaignFeats", {
-        name: CONFIG.PF2E.SETTINGS.CampaignFeats.name,
-        hint: CONFIG.PF2E.SETTINGS.CampaignFeats.hint,
+        name: "PF2E.SETTINGS.CampaignFeats.Name",
+        hint: "PF2E.SETTINGS.CampaignFeats.Hint",
         scope: "world",
         config: true,
         default: false,

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -328,6 +328,11 @@
                 }
             },
             "Party": {
+                "InvalidCampaign": {
+                    "Hint": "The campaign data is invalid",
+                    "Title": "Invalid Campaign ({party})",
+                    "Message": "This party has campaign data of type {current}, but the configured type is {configured}. Do you want to delete existing campaign data?"
+                },
                 "BlankSlate": "This party doesn't have any members. Drag a creature from the actor sidebar to get started. ",
                 "Coin": "Coin",
                 "Languages": "Party Languages",
@@ -2711,6 +2716,14 @@
             "CampaignFeats": {
                 "Hint": "Adds a section to all player sheets for campaign specific feats.",
                 "Name": "Campaign Feats"
+            },
+            "CampaignType": {
+                "Hint": "Extended campaign rule type for parties",
+                "Name": "Campaign Type",
+                "Choices": {
+                    "none": "None",
+                    "kingmaker": "Kingmaker"
+                }
             },
             "CompendiumBrowserPacks": {
                 "Hint": "Settings to exclude packs from loading",


### PR DESCRIPTION
This PR creates a method to define and initialize extended party campaign data. The idea is that when kingmaker is enabled, the party will initialize a data model during data preparation. This object can be used by the sidebar to inject additional buttons into the side.

![image](https://github.com/foundryvtt/pf2e/assets/1286721/4e56d3d2-3bb8-404f-843c-f8a075e414b3)

The campaign data is stored in system.campaign. This sort of structure makes it so that a party can only have a single campaign data extension. To prevent corruption, it checks for type mismatches during data preparation, and shows a warning (with an opportunity to delete data) if said corruption occurs.

![image](https://github.com/foundryvtt/pf2e/assets/1286721/971045cc-8ffc-48c4-8786-3201e7a3125e)
![image](https://github.com/foundryvtt/pf2e/assets/1286721/95e87635-e212-407f-b1a0-e0975cc057a9)

The ability to register additional campaign types will be done at a later date. I was more interested in solving the data structure than the needs for campaigns we may or may not eventually support. The crown party button will do something once the sheet is being merged in.

## Alternative

If we want to reserve the ability to have multiple party data extensions active simultaneously, we could store the data in `system.kingdom` or `system.campaign.kingdom` (though the nesting slay me). This also removes the need to check for data mismatches.
