### PR TITLE
Migrate predicates that are not arrays

### DIFF
--- a/src/module/migration/migrations/840-array-wrap-predicates.ts
+++ b/src/module/migration/migrations/840-array-wrap-predicates.ts
@@ -1,0 +1,25 @@
+import { ItemSourcePF2e } from "@item/data/index.ts";
+import { MigrationBase } from "../base.ts";
+import { PredicatePF2e, RawPredicate } from "@system/predication.ts";
+
+/** Ensure predicates are wrapped in ensures following stricter validation */
+export class Migration840ArrayWrapPredicates extends MigrationBase {
+    static override version = 0.84;
+
+    #wrapPredicate(predicate: unknown): RawPredicate | undefined {
+        if (Array.isArray(predicate)) return predicate;
+        const arrayWrapped = [predicate];
+        return predicate && PredicatePF2e.isValid(arrayWrapped) ? arrayWrapped : undefined;
+    }
+
+    override async updateItem(source: ItemSourcePF2e): Promise<void> {
+        for (const rule of source.system.rules) {
+            if ("predicate" in rule) {
+                rule.predicate = this.#wrapPredicate(rule.predicate);
+            }
+            if ("definition" in rule) {
+                rule.definition = this.#wrapPredicate(rule.definition);
+            }
+        }
+    }
+}

--- a/src/module/migration/migrations/index.ts
+++ b/src/module/migration/migrations/index.ts
@@ -237,3 +237,4 @@ export { Migration836EnergizingConsolidation } from "./836-energizing-consolidat
 export { Migration837MoveHazardBookSources } from "./837-move-hazard-book-source.ts";
 export { Migration838StrikeAttackRollSelector } from "./838-strike-attack-roll-selector.ts";
 export { Migration839ActionCategories } from "./839-action-categories.ts";
+export { Migration840ArrayWrapPredicates } from "./840-array-wrap-predicates.ts";

--- a/src/module/migration/runner/base.ts
+++ b/src/module/migration/runner/base.ts
@@ -15,7 +15,7 @@ interface CollectionDiff<T extends foundry.documents.ActiveEffectSource | ItemSo
 export class MigrationRunnerBase {
     migrations: MigrationBase[];
 
-    static LATEST_SCHEMA_VERSION = 0.839;
+    static LATEST_SCHEMA_VERSION = 0.84;
 
     static MINIMUM_SAFE_VERSION = 0.618;
 

--- a/src/module/system/settings/index.ts
+++ b/src/module/system/settings/index.ts
@@ -315,5 +315,6 @@ function registerWorldSchemaVersion(): void {
         config: true,
         default: MigrationRunner.LATEST_SCHEMA_VERSION,
         type: Number,
+        requiresReload: true,
     });
 }


### PR DESCRIPTION
The system in part relied on Foundry's `ArrayField` for predicate validation, which is excessively loose: it will wrap anything that is not an array in one and declare it valid. The system is now stricter in its predicate validation, but some homebrew and modules had previously-coerced/validated predicates that are now invalid.