### PR TITLE
Add CritSpec for Thaumaturge Weapon Implement

### DIFF
--- a/packs/data/classfeatures.db/weapon.json
+++ b/packs/data/classfeatures.db/weapon.json
@@ -21,8 +21,33 @@
         },
         "rules": [
             {
+                "allowDuplicate": false,
                 "key": "GrantItem",
                 "uuid": "Compendium.pf2e.actionspf2e.Implement's Interruption"
+            },
+            {
+                "choices": {
+                    "includeHandwraps": true,
+                    "ownedItems": true,
+                    "types": [
+                        "weapon"
+                    ]
+                },
+                "flag": "weapon",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.Weapon"
+            },
+            {
+                "key": "CriticalSpecialization",
+                "predicate": [
+                    "feature:thaumaturge-weapon-expertise",
+                    {
+                        "or": [
+                            "item:category:{item|flags.pf2e.rulesSelections.weapon}",
+                            "item:id:{item|flags.pf2e.rulesSelections.weapon}"
+                        ]
+                    }
+                ]
             }
         ],
         "source": {


### PR DESCRIPTION
Users are prompted to choose a weapon after choosing the Weapon Implement. At level 5, that weapon will gain its critical specialization effect. Addresses #8064.