### PR TITLE
Fix missing extreme for Curse of Living Death and Curse of the Hero's Burden

### DIFF
--- a/packs/data/feat-effects.db/effect-curse-of-living-death.json
+++ b/packs/data/feat-effects.db/effect-curse-of-living-death.json
@@ -171,7 +171,8 @@
                     {
                         "or": [
                             "self:oracular-curse:stage:moderate",
-                            "self:oracular-curse:stage:major"
+                            "self:oracular-curse:stage:major",
+                            "self:oracular-curse:stage:extreme"
                         ]
                     }
                 ],

--- a/packs/data/feat-effects.db/effect-curse-of-the-heros-burden.json
+++ b/packs/data/feat-effects.db/effect-curse-of-the-heros-burden.json
@@ -178,7 +178,8 @@
                 "key": "FastHealing",
                 "predicate": [
                     "encounter:non-trivial",
-                    "self:oracular-curse:stage:major"
+                    "self:oracular-curse:stage:major",
+                    "self:oracular-curse:stage:extreme"
                 ],
                 "type": "fast-healing",
                 "value": "@actor.level"


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/8084