### PR TITLE
Fix base damagetype and diesize lookup for 0 base damage

### DIFF
--- a/src/module/item/affliction/document.ts
+++ b/src/module/item/affliction/document.ts
@@ -2,12 +2,7 @@ import { ActorPF2e } from "@actor";
 import { AbstractEffectPF2e, EffectBadge } from "@item/abstract-effect/index.ts";
 import { UserPF2e } from "@module/user/index.ts";
 import { AfflictionFlags, AfflictionSource, AfflictionSystemData } from "./data.ts";
-import {
-    AfflictionDamageTemplate,
-    DamagePF2e,
-    DamageRollContext,
-    DynamicBaseDamageData,
-} from "@system/damage/index.ts";
+import { AfflictionDamageTemplate, DamagePF2e, DamageRollContext, BaseDamageData } from "@system/damage/index.ts";
 import { createDamageFormula, parseTermsFromSimpleFormula } from "@system/damage/formula.ts";
 import { DamageRoll } from "@system/damage/roll.ts";
 
@@ -56,7 +51,7 @@ class AfflictionPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extend
     getStageDamage(stage: number): AfflictionDamage | null {
         const stageData = Object.values(this.system.stages).at(stage - 1);
 
-        const base: DynamicBaseDamageData[] = [];
+        const base: BaseDamageData[] = [];
         for (const data of Object.values(stageData?.damage ?? {})) {
             const { formula, type: damageType, category } = data;
             const terms = parseTermsFromSimpleFormula(formula);

--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -25,12 +25,7 @@ import { DamagePF2e } from "@system/damage/damage.ts";
 import { DamageCategorization } from "@system/damage/helpers.ts";
 import { DamageModifierDialog } from "@system/damage/modifier-dialog.ts";
 import { DamageRoll } from "@system/damage/roll.ts";
-import {
-    DamageFormulaData,
-    DamageRollContext,
-    DynamicBaseDamageData,
-    SpellDamageTemplate,
-} from "@system/damage/types.ts";
+import { DamageFormulaData, DamageRollContext, BaseDamageData, SpellDamageTemplate } from "@system/damage/types.ts";
 import { StatisticRollParameters } from "@system/statistic/index.ts";
 import { EnrichHTMLOptionsPF2e } from "@system/text-editor.ts";
 import { ErrorPF2e, getActionIcon, htmlClosest, ordinal, traitSlugToObject } from "@util";
@@ -208,7 +203,7 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
         const rollData = this.getRollData({ castLevel });
 
         // Loop over the user defined damage fields
-        const base: DynamicBaseDamageData[] = [];
+        const base: BaseDamageData[] = [];
         for (const [id, damage] of Object.entries(this.system.damage.value ?? {})) {
             if (!Roll.validate(damage.value)) {
                 console.error(`Failed to parse damage formula "${damage.value}"`);

--- a/src/module/item/spell/helpers.ts
+++ b/src/module/item/spell/helpers.ts
@@ -1,10 +1,10 @@
 import { DamageDicePF2e } from "@actor/modifiers.ts";
-import { DamagePartialTerm, DynamicBaseDamageData } from "@system/damage/index.ts";
+import { DamagePartialTerm, BaseDamageData } from "@system/damage/index.ts";
 
 type RequiredNonNullable<T, K extends keyof T> = T & { [P in K]-?: NonNullable<T[P]> };
 
-/** Apply damage dice to a spell's damage formulas */
-function applyDamageDiceOverrides(base: DynamicBaseDamageData[], dice: DamageDicePF2e[]): void {
+/** Apply damage dice to a spell's damage formulas (for now, terms only) */
+function applyDamageDiceOverrides(base: BaseDamageData[], dice: DamageDicePF2e[]): void {
     const overrideDice = dice.filter(
         (d): d is RequiredNonNullable<DamageDicePF2e, "override"> => !d.ignored && !!d.override
     );
@@ -13,7 +13,7 @@ function applyDamageDiceOverrides(base: DynamicBaseDamageData[], dice: DamageDic
 
     for (const data of base) {
         for (const adjustment of overrideDice) {
-            const die = data.terms.find((t): t is RequiredNonNullable<DamagePartialTerm, "dice"> => !!t.dice);
+            const die = data.terms?.find((t): t is RequiredNonNullable<DamagePartialTerm, "dice"> => !!t.dice);
             if (!die) continue;
 
             die.dice.number = adjustment.override.diceNumber ?? die.dice.number;

--- a/src/module/system/damage/types.ts
+++ b/src/module/system/damage/types.ts
@@ -77,23 +77,19 @@ interface DamagePartialTerm {
     dice: { number: number; faces: number } | null;
 }
 
-interface WeaponBaseDamageData {
+interface BaseDamageData {
+    terms?: DamagePartialTerm[];
     damageType: DamageType;
-    diceNumber: number;
-    dieSize: DamageDieSize | null;
-    modifier: number;
+    diceNumber?: number;
+    dieSize?: DamageDieSize | null;
+    modifier?: number;
     category: DamageCategoryUnique | null;
     materials?: MaterialDamageEffect[];
 }
 
-interface DynamicBaseDamageData {
-    terms: DamagePartialTerm[];
-    damageType: DamageType;
-    category: DamageCategoryUnique | null;
-    materials?: MaterialDamageEffect[];
+interface WeaponBaseDamageData extends BaseDamageData {
+    terms?: never;
 }
-
-type BaseDamageData = WeaponBaseDamageData | DynamicBaseDamageData;
 
 interface BaseDamageTemplate {
     name: string;
@@ -134,7 +130,6 @@ export {
     DamageTemplate,
     DamageType,
     DamageTypeRenderData,
-    DynamicBaseDamageData,
     MaterialDamageEffect,
     SpellDamageTemplate,
     WeaponBaseDamageData,


### PR DESCRIPTION
Theoretically we could make the base damage loop not an if/else but I'm a bit concerned about changing that at this time. 