### PR TITLE
Explicitly allow damage dice overrides of zero `diceNumber`

### DIFF
--- a/src/module/rules/rule-element/damage-dice.ts
+++ b/src/module/rules/rule-element/damage-dice.ts
@@ -4,8 +4,8 @@ import { ItemPF2e } from "@item";
 import { CriticalInclusion, DamageDieSize } from "@system/damage/types.ts";
 import { DAMAGE_DIE_FACES } from "@system/damage/values.ts";
 import { isObject, objectHasKey, setHasElement, sluggify, tupleHasValue } from "@util";
-import { RuleElementData, RuleElementPF2e } from "./index.ts";
 import { BracketedValue, RuleElementSource } from "./data.ts";
+import { RuleElementData, RuleElementPF2e } from "./index.ts";
 
 class DamageDiceRuleElement extends RuleElementPF2e {
     override slug: string;
@@ -79,7 +79,8 @@ class DamageDiceRuleElement extends RuleElementPF2e {
         } else {
             this.failValidation(
                 "The override property must be an object with one property of `upgrade` (boolean),",
-                "`downgrade (boolean)`, `dieSize` (d6-d12), or `damageType` (recognized damage type)"
+                "`downgrade (boolean)`, `diceNumber` (integer between 0 and 10), `dieSize` (d6-d12), or `damageType`",
+                "(recognized damage type)"
             );
             this.override = null;
         }
@@ -158,7 +159,7 @@ class DamageDiceRuleElement extends RuleElementPF2e {
                 typeof override.dieSize === "string" ||
                 (typeof override.diceNumber === "number" &&
                     Number.isInteger(override.diceNumber) &&
-                    override.diceNumber > 0 &&
+                    override.diceNumber >= 0 &&
                     override.diceNumber <= 10))
         );
     }

--- a/src/module/system/damage/formula.ts
+++ b/src/module/system/damage/formula.ts
@@ -1,7 +1,7 @@
-import * as R from "remeda";
 import { DamageDicePF2e } from "@actor/modifiers.ts";
-import { DegreeOfSuccessIndex, DEGREE_OF_SUCCESS } from "@system/degree-of-success.ts";
-import { groupBy, sum, sortBy, addSign } from "@util";
+import { DEGREE_OF_SUCCESS, DegreeOfSuccessIndex } from "@system/degree-of-success.ts";
+import { addSign, groupBy, sortBy, sum } from "@util";
+import * as R from "remeda";
 import {
     CriticalInclusion,
     DamageCategoryUnique,

--- a/src/module/system/damage/weapon.ts
+++ b/src/module/system/damage/weapon.ts
@@ -1,5 +1,5 @@
-import { TraitViewData } from "@actor/data/base.ts";
 import { ActorPF2e, CharacterPF2e, HazardPF2e, NPCPF2e } from "@actor";
+import { TraitViewData } from "@actor/data/base.ts";
 import {
     DamageDiceOverride,
     DamageDicePF2e,


### PR DESCRIPTION
The bugfix half of it is that a `diceNumber` override of zero _wasn't_ permitted but would slip through if a `dieSize` override was also present.