### PR TITLE
Refactor action rendering and maintain summary expanded state

### DIFF
--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -3,16 +3,7 @@ import { CreatureSheetData } from "@actor/creature/index.ts";
 import { MODIFIER_TYPES, createProficiencyModifier } from "@actor/modifiers.ts";
 import { ActorSheetDataPF2e } from "@actor/sheet/data-types.ts";
 import { SaveType } from "@actor/types.ts";
-import {
-    ActionItemPF2e,
-    AncestryPF2e,
-    BackgroundPF2e,
-    ClassPF2e,
-    DeityPF2e,
-    HeritagePF2e,
-    ItemPF2e,
-    LorePF2e,
-} from "@item";
+import { AncestryPF2e, BackgroundPF2e, ClassPF2e, DeityPF2e, FeatPF2e, HeritagePF2e, ItemPF2e, LorePF2e } from "@item";
 import { isSpellConsumable } from "@item/consumable/spell-consumables.ts";
 import { ItemSourcePF2e } from "@item/data/index.ts";
 import { MagicTradition } from "@item/spell/types.ts";
@@ -66,6 +57,9 @@ import { CharacterPF2e } from "./document.ts";
 import { FeatGroup } from "./feats.ts";
 import { PCSheetTabManager } from "./tab-manager.ts";
 import { CHARACTER_SHEET_TABS } from "./values.ts";
+import { ActionCost, Frequency } from "@item/data/base.ts";
+import { createSheetTags } from "@module/sheet/helpers.ts";
+import { SheetOptions } from "@module/sheet/helpers.ts";
 
 class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e<TActor> {
     protected readonly actorConfigClass = CharacterConfig;
@@ -196,7 +190,9 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
 
         // Is the stamina variant rule enabled?
         sheetData.hasStamina = game.settings.get("pf2e", "staminaVariant") > 0;
+
         sheetData.spellcastingEntries = await this.prepareSpellcasting();
+        sheetData.actions = this.#prepareActions();
         sheetData.feats = [...this.actor.feats, this.actor.feats.unorganized];
 
         const craftingFormulas = await this.actor.getCraftingFormulas();
@@ -298,36 +294,12 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
     override async prepareItems(sheetData: ActorSheetDataPF2e<CharacterPF2e>): Promise<void> {
         const actorData = sheetData.actor;
 
-        // Actions
-        type AnnotatedAction = ActionItemPF2e & {
-            encounter?: boolean;
-            exploration?: boolean;
-            downtime?: boolean;
-        };
-        const actions: Record<string, { label: string; actions: AnnotatedAction[] }> = {
-            action: { label: game.i18n.localize("PF2E.ActionsActionsHeader"), actions: [] },
-            reaction: { label: game.i18n.localize("PF2E.ActionsReactionsHeader"), actions: [] },
-            free: { label: game.i18n.localize("PF2E.ActionsFreeActionsHeader"), actions: [] },
-        };
-
         // Skills
         const lores: LorePF2e<TActor>[] = [];
 
         for (const itemData of sheetData.items) {
-            const item = this.actor.items.get(itemData._id, { strict: true });
-
-            // Feats (non-passive feats may show action icons)
-            if (item.isOfType("feat")) {
-                const actionType = item.actionCost?.type;
-                if (actionType) {
-                    itemData.feat = true;
-                    itemData.img = getActionIcon(item.actionCost);
-                    actions[actionType].actions.push(itemData);
-                }
-            }
-
             // Lore Skills
-            else if (itemData.type === "lore") {
+            if (itemData.type === "lore") {
                 itemData.system.icon = this.getProficiencyIcon((itemData.system.proficient || {}).value);
                 itemData.system.hover = CONFIG.PF2E.proficiencyLevels[(itemData.system.proficient || {}).value];
 
@@ -341,27 +313,53 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
 
                 lores.push(itemData);
             }
-
-            // Actions
-            else if (item.isOfType("action")) {
-                itemData.img = getActionIcon(item.actionCost);
-                const actionType = item.actionCost?.type ?? "free";
-                actions[actionType].actions.push(itemData);
-            }
-        }
-
-        // assign mode to actions
-        for (const action of Object.values(actions).flatMap((section) => section.actions)) {
-            action.downtime = action.system.traits.value.includes("downtime");
-            action.exploration = action.system.traits.value.includes("exploration");
-            action.encounter = !(action.downtime || action.exploration);
         }
 
         // Assign and return
         actorData.pfsBoons = this.actor.pfsBoons;
         actorData.deityBoonsCurses = this.actor.deityBoonsCurses;
-        actorData.actions = actions;
         actorData.lores = lores;
+    }
+
+    /** Prepares all ability type items that create an action in the sheet */
+    #prepareActions(): CharacterSheetData["actions"] {
+        const result: CharacterSheetData["actions"] = {
+            combat: {
+                action: { label: game.i18n.localize("PF2E.ActionsActionsHeader"), actions: [] },
+                reaction: { label: game.i18n.localize("PF2E.ActionsReactionsHeader"), actions: [] },
+                free: { label: game.i18n.localize("PF2E.ActionsFreeActionsHeader"), actions: [] },
+            },
+            exploration: [],
+            downtime: [],
+        };
+
+        for (const item of this.actor.items) {
+            if (!item.isOfType("action") && !(item.isOfType("feat") && item.actionCost)) {
+                continue;
+            }
+
+            const traitDescriptions = item.isOfType("feat") ? CONFIG.PF2E.featTraits : CONFIG.PF2E.actionTraits;
+            const action: ActionSheetData = {
+                ...R.pick(item, ["id", "name", "actionCost", "frequency"]),
+                img: getActionIcon(item.actionCost),
+                traits: createSheetTags(traitDescriptions, item.system.traits.value),
+            };
+
+            if (item.isOfType("feat")) {
+                action.feat = item;
+            }
+
+            if (item.system.traits.value.includes("exploration")) {
+                result.exploration.push(action);
+            } else if (item.system.traits.value.includes("downtime")) {
+                result.downtime.push(action);
+            } else {
+                const category = result.combat[item.actionCost?.type ?? "free"];
+                category?.actions.push(action);
+            }
+        }
+
+        return result;
     }
 
     async #prepareCraftingEntries(formulas: CraftingFormula[]): Promise<CraftingEntriesSheetData> {
@@ -1309,7 +1307,7 @@ interface CraftingSheetData {
 
 type CharacterSheetTabVisibility = Record<(typeof CHARACTER_SHEET_TABS)[number], boolean>;
 
-interface CharacterSheetData<TActor extends CharacterPF2e> extends CreatureSheetData<TActor> {
+interface CharacterSheetData<TActor extends CharacterPF2e = CharacterPF2e> extends CreatureSheetData<TActor> {
     abpEnabled: boolean;
     ancestry: AncestryPF2e<CharacterPF2e> | null;
     heritage: HeritagePF2e<CharacterPF2e> | null;
@@ -1336,7 +1334,22 @@ interface CharacterSheetData<TActor extends CharacterPF2e> extends CreatureSheet
     showPFSTab: boolean;
     spellcastingEntries: SpellcastingSheetData[];
     tabVisibility: CharacterSheetTabVisibility;
+    actions: {
+        combat: Record<"action" | "reaction" | "free", { label: string; actions: ActionSheetData[] }>;
+        exploration: ActionSheetData[];
+        downtime: ActionSheetData[];
+    };
     feats: FeatGroup[];
+}
+
+interface ActionSheetData {
+    id: string;
+    name: string;
+    img: string;
+    actionCost: ActionCost | null;
+    frequency: Frequency | null;
+    feat?: FeatPF2e;
+    traits: SheetOptions;
 }
 
 interface ClassDCSheetData extends ClassDCData {

--- a/static/templates/actors/character/tabs/actions.hbs
+++ b/static/templates/actors/character/tabs/actions.hbs
@@ -146,7 +146,7 @@
                         {{/each}}
                     </ol>
 
-                    {{#each actor.actions as |section sid|}}
+                    {{#each actions.combat as |section sid|}}
                         <h3 class="header">
                             {{section.label}}
                             {{#if @root.options.editable}}
@@ -163,9 +163,7 @@
 
                         <ol class="actions-list item-list directory-list">
                             {{#each section.actions as |action aid|}}
-                                {{#if action.encounter}}
-                                    {{> action action=action}}
-                                {{/if}}
+                                {{> action action=action}}
                             {{/each}}
                         </ol>
                     {{/each}}
@@ -187,10 +185,8 @@
                     </h3>
 
                     <ol class="actions-list item-list directory-list">
-                        {{#each actor.actions.free.actions as |action aid|}}
-                            {{#if action.exploration}}
-                                {{> action action=action}}
-                            {{/if}}
+                        {{#each actions.exploration as |action aid|}}
+                            {{> action action=action}}
                         {{/each}}
                     </ol>
                 </div>
@@ -211,10 +207,8 @@
                     </h3>
 
                     <ol class="actions-list item-list directory-list">
-                        {{#each actor.actions.free.actions as |action aid|}}
-                            {{#if action.downtime}}
-                                {{> action action=action}}
-                            {{/if}}
+                        {{#each actions.downtime as |action aid|}}
+                            {{> action action=action}}
                         {{/each}}
                     </ol>
                 </div>
@@ -260,20 +254,20 @@
 {{/inline}}
 
 {{#*inline "action"}}
-    <li class="action item" data-item-id="{{action._id}}">
+    <li class="action item" data-item-id="{{action.id}}" data-item-summary-id="action-{{action.id}}">
         <div class="item-name rollable">
             <div class="item-image">
                 <img src="{{action.img}}"/>
             </div>
             <h4>{{action.name}}</h4>
-            {{#if action.system.frequency}}
+            {{#if action.frequency}}
                 <div class="action-tracking">
-                    <input type="number" value="{{action.system.frequency.value}}" data-item-id="{{action._id}}" data-item-property="system.frequency.value"/>
+                    <input type="number" value="{{action.frequency.value}}" data-item-id="{{action.id}}" data-item-property="system.frequency.value"/>
                     <span>
                         /
-                        {{action.system.frequency.max}}
+                        {{action.frequency.max}}
                         {{localize "PF2E.Frequency.per"}}
-                        {{localize (lookup @root.frequencies action.system.frequency.per)}}
+                        {{localize (lookup @root.frequencies action.frequency.per)}}
                     </span>
                 </div>
             {{/if}}


### PR DESCRIPTION
The part that's a bugfix is data-item-summary-id. This bug occured when we converted item summaries from jquery. The rest is preparation for some work on exploration actions.

This does make it possible to have exploration activities with an action cost (where before it would always put under encounter) but if anyone does that they can have their sillyness.

Can wait for V11.