### PR TITLE
Restore navigation of PC actions

### DIFF
--- a/static/templates/actors/character/tabs/actions.hbs
+++ b/static/templates/actors/character/tabs/actions.hbs
@@ -8,7 +8,7 @@
     <div class="actions-container tab-content">
         <div class="actions-tabs-wrapper">
             <section class="actions-panels">
-                <div class="actions-panel" data-tab="encounter" data-group="actions-tabs">
+                <div class="actions-panel tab" data-tab="encounter" data-group="actions-tabs">
                     {{#if toggles}}
                         <div class="actions-options item-list">
                             {{#each toggles as |toggle idx|}}
@@ -169,7 +169,7 @@
                     {{/each}}
                 </div>
 
-                <div class="actions-panel" data-tab="exploration" data-group="actions-tabs">
+                <div class="actions-panel tab" data-tab="exploration" data-group="actions-tabs">
                     <h3 class="header">
                         {{localize "PF2E.ActionsActionsHeader"}}
                         {{#if @root.options.editable}}
@@ -191,7 +191,7 @@
                     </ol>
                 </div>
 
-                <div class="actions-panel" data-tab="downtime" data-group="actions-tabs">
+                <div class="actions-panel tab" data-tab="downtime" data-group="actions-tabs">
                     <h3 class="header">
                         {{localize "PF2E.ActionsActionsHeader"}}
                         {{#if @root.options.editable}}


### PR DESCRIPTION
In V11 the tab css class is required on all content divs.