### PR TITLE
Remove global style overrides for chat log

### DIFF
--- a/src/styles/legacy/_chat.scss
+++ b/src/styles/legacy/_chat.scss
@@ -20,6 +20,7 @@
         }
 
         h3 {
+            border-bottom: none;
             flex: 1;
             margin: 0;
         }

--- a/src/styles/ui/sidebar/chat/_index.scss
+++ b/src/styles/ui/sidebar/chat/_index.scss
@@ -1,24 +1,7 @@
-#chat-log {
-    display: flex;
-    flex-direction: column;
-
-    > .message {
-        &:first-child {
-            margin-top: auto;
-        }
-    }
-}
-
 @import "chat-roll-details";
 
 .chat-message {
-    @import "../../../reset";
     @import "action", "check", "damage", "reroll";
-
-    > .message-header {
-        align-items: center;
-        margin-bottom: 0.33em;
-    }
 
     > .message-content {
         @import "conditions";


### PR DESCRIPTION
This has always been problematic and is no longer tenable with V11's "Jump to Bottom" feature