### PR TITLE
Restore system placeholder for compendium search input

### DIFF
--- a/static/templates/sidebar/compendium-directory.hbs
+++ b/static/templates/sidebar/compendium-directory.hbs
@@ -3,7 +3,7 @@
     <header class="directory-header flexcol">
         <div class="header-actions action-buttons flexrow">
             {{#if canCreateEntry}}
-            <button class="create-entry"><i class="{{sidebarIcon}}"></i> {{localize 'SIDEBAR.Create' type=label}}</button>
+            <button class="create-entry"><i class="{{sidebarIcon}}"></i> {{localize "COMPENDIUM.Search"}}</button>
             {{/if}}
             {{#if canCreateFolder}}
             <button class="create-folder"><i class="{{folderIcon}}"></i> {{localize 'FOLDER.Create'}}</button>


### PR DESCRIPTION
Before (core placeholder):
![image](https://github.com/foundryvtt/pf2e/assets/106829671/43dc0eb0-26ba-40e5-982f-0574319edb3e)

After:
![image](https://github.com/foundryvtt/pf2e/assets/106829671/dad658bd-c354-4837-a9dd-9925c3264906)
