### PR TITLE
Add `TokenEffect#statuses` to fix rendering of combat tracker

### DIFF
--- a/src/module/actor/token-effect.ts
+++ b/src/module/actor/token-effect.ts
@@ -5,6 +5,8 @@ export class TokenEffect implements TemporaryEffect {
 
     tint?: string;
 
+    statuses: Set<string> = new Set();
+
     readonly isTemporary = true;
 
     readonly flags: Record<string, Record<string, string | boolean | undefined>> = {};

--- a/types/foundry/client/data/documents/active-effect.d.ts
+++ b/types/foundry/client/data/documents/active-effect.d.ts
@@ -162,6 +162,7 @@ declare global {
     > extends ClientBaseActiveEffect<TParent> {
         disabled: boolean;
         icon: ImageFilePath;
+        statuses: Set<string>;
         tint?: string;
     }
 
@@ -169,6 +170,7 @@ declare global {
         disabled: boolean;
         isTemporary: boolean;
         icon: ImageFilePath;
+        statuses: Set<string>;
         tint?: string;
     }
 }


### PR DESCRIPTION
`CombatTracker#getData` expects a `statuses` property on token effects.

```js
if ( combatant.actor ) {
  for ( const effect of combatant.actor.temporaryEffects ) {
    if ( effect.statuses.has(CONFIG.specialStatusEffects.DEFEATED) ) turn.defeated = true;
    else if ( effect.icon ) turn.effects.add(effect.icon);
  }
}
```