### PR TITLE
Move IWR RE processing to `afterPrepareData` callback

### DIFF
--- a/src/module/rules/rule-element/battle-form/rule-element.ts
+++ b/src/module/rules/rule-element/battle-form/rule-element.ts
@@ -418,16 +418,16 @@ export class BattleFormRuleElement extends RuleElementPF2e {
     /** Immunity, weakness, and resistance */
     #prepareIWR(): void {
         for (const immunity of this.overrides.immunities) {
-            new ImmunityRuleElement({ key: "Immunity", ...immunity }, this.item).beforePrepareData();
+            new ImmunityRuleElement({ key: "Immunity", ...immunity }, this.item).afterPrepareData();
         }
         for (const weakness of this.overrides.weaknesses) {
-            new WeaknessRuleElement({ key: "Weakness", ...weakness, override: true }, this.item).beforePrepareData();
+            new WeaknessRuleElement({ key: "Weakness", ...weakness, override: true }, this.item).afterPrepareData();
         }
         for (const resistance of this.overrides.resistances) {
             new ResistanceRuleElement(
                 { key: "Resistance", ...resistance, override: true },
                 this.item
-            ).beforePrepareData();
+            ).afterPrepareData();
         }
     }
 

--- a/src/module/rules/rule-element/iwr/base.ts
+++ b/src/module/rules/rule-element/iwr/base.ts
@@ -80,7 +80,7 @@ abstract class IWRRuleElement<TSchema extends IWRRuleSchema> extends RuleElement
 
     abstract getIWR(value?: number): ImmunityData[] | WeaknessData[] | ResistanceData[];
 
-    override beforePrepareData(): void {
+    override afterPrepareData(): void {
         if (!this.test()) return;
 
         this.type = this.resolveInjectedProperties(this.type);


### PR DESCRIPTION
This is to allow predicates to include statements that are added later in derived data preparation