### PR TITLE
Fix ephemeral effect transmitted by Holy Castigation feat

### DIFF
--- a/packs/feats/holy-castigation.json
+++ b/packs/feats/holy-castigation.json
@@ -32,9 +32,9 @@
                     "target:trait:fiend"
                 ],
                 "selectors": [
-                    "damage-application"
+                    "damage-received"
                 ],
-                "uuid": "Compendium.pf2e.conditionitems.Item.AJh5ex99aV6VTggg"
+                "uuid": "Compendium.pf2e.conditionitems.Item.U2Pgm6B4nmdQ2Gpd"
             }
         ],
         "source": {


### PR DESCRIPTION
I'll turn these into names on extract to prevent this in the future.