### PR TITLE
Fix Twisting Tree damage die upgrade

### DIFF
--- a/packs/classfeatures/twisting-tree.json
+++ b/packs/classfeatures/twisting-tree.json
@@ -23,10 +23,11 @@
             {
                 "key": "DamageDice",
                 "override": {
-                    "dieSize": "d6"
+                    "upgrade": true
                 },
                 "predicate": [
                     "item:base:staff",
+                    "item:damage:die:faces:d4",
                     "item:hands-held:1"
                 ],
                 "selector": "strike-damage"


### PR DESCRIPTION
Using an override has the system not consider it to be an upgrade, which allows for increase stacking