### PR TITLE
Fix some Agents of Edgewatch NPCs

### DIFF
--- a/packs/agents-of-edgewatch-bestiary/clockwork-chopper.json
+++ b/packs/agents-of-edgewatch-bestiary/clockwork-chopper.json
@@ -647,6 +647,16 @@
             "perception": {
                 "value": 23
             },
+            "resistances": [
+                {
+                    "exceptions": [
+                        "adamantine",
+                        "orichalcum"
+                    ],
+                    "type": "physical",
+                    "value": 10
+                }
+            ],
             "speed": {
                 "otherSpeeds": [
                     {
@@ -655,7 +665,17 @@
                     }
                 ],
                 "value": 30
-            }
+            },
+            "weaknesses": [
+                {
+                    "type": "electricity",
+                    "value": 15
+                },
+                {
+                    "type": "orichalcum",
+                    "value": 15
+                }
+            ]
         },
         "details": {
             "alignment": {

--- a/packs/agents-of-edgewatch-bestiary/clockwork-injector.json
+++ b/packs/agents-of-edgewatch-bestiary/clockwork-injector.json
@@ -615,6 +615,16 @@
             "perception": {
                 "value": 23
             },
+            "resistances": [
+                {
+                    "exceptions": [
+                        "adamantine",
+                        "orichalcum"
+                    ],
+                    "type": "physical",
+                    "value": 10
+                }
+            ],
             "speed": {
                 "otherSpeeds": [
                     {
@@ -623,7 +633,17 @@
                     }
                 ],
                 "value": 30
-            }
+            },
+            "weaknesses": [
+                {
+                    "type": "electricity",
+                    "value": 15
+                },
+                {
+                    "type": "orichalcum",
+                    "value": 15
+                }
+            ]
         },
         "details": {
             "alignment": {

--- a/packs/agents-of-edgewatch-bestiary/daemonic-skinner.json
+++ b/packs/agents-of-edgewatch-bestiary/daemonic-skinner.json
@@ -1103,7 +1103,7 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p><strong>Trigger</strong> A creature taking @UUID[Compendium.pf2e.conditionitems.Item.Persistent Damage]{Persistent Bleed Damage} within 30 feet of the Daemonic Skinner Casts a Spell with a verbal component or speaks</p>\n<hr />\n<p><strong>Effect</strong> The Skinner wills the triggering creature's blood to gush from their mouth and constrict their throat. The target's spell is disrupted.</p>\n<p>The target must succeed at a @Check[type:fortitude|dc:20] save or become @UUID[Compendium.pf2e.conditionitems.Item.Sickened]{Sickened 2}.</p>"
+                    "value": "<p><strong>Trigger</strong> A creature taking @UUID[Compendium.pf2e.conditionitems.Item.Persistent Damage]{Persistent Bleed Damage} within 30 feet of the Daemonic Skinner Casts a Spell with a verbal component or speaks</p>\n<hr />\n<p><strong>Effect</strong> The Skinner wills the triggering creature's blood to gush from their mouth and constrict their throat. The target's spell is disrupted.</p>\n<p>The target must succeed at a @Check[type:fortitude|dc:47] save or become @UUID[Compendium.pf2e.conditionitems.Item.Sickened]{Sickened 2}.</p>"
                 },
                 "requirements": {
                     "value": ""

--- a/packs/agents-of-edgewatch-bestiary/gage-carlyle.json
+++ b/packs/agents-of-edgewatch-bestiary/gage-carlyle.json
@@ -646,7 +646,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>When Gage gets a critical success using the @UUID[Compendium.pf2e.action-macros.Macro.Lie: Deception]{Lie} action, the target's attitude toward him improves by one step, as though he'd succeeded at using Diplomacy to @UUID[Compendium.pf2e.actionspf2e.Item.Make an Impression].</p>\n<p>This works only once per conversation, and if he critically succeeds against multiple targets using the same result, he chooses one creature's attitude to improve.</p>\n<p>To use this ability, Gage must be lying to impart seemingly important information, inflate his status, or ingratiate himself, which trivial or irrelevant lies can't achieve.</p>"
+                    "value": "<p>When Gage gets a critical success using the @UUID[Compendium.pf2e.actionspf2e.Item.Lie] action, the target's attitude toward him improves by one step, as though he'd succeeded at using Diplomacy to @UUID[Compendium.pf2e.actionspf2e.Item.Make an Impression].</p>\n<p>This works only once per conversation, and if he critically succeeds against multiple targets using the same result, he chooses one creature's attitude to improve.</p>\n<p>To use this ability, Gage must be lying to impart seemingly important information, inflate his status, or ingratiate himself, which trivial or irrelevant lies can't achieve.</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -683,7 +683,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>When Gage meets a group of up to five people, he can immediately attempt a Diplomacy check to @UUID[Compendium.pf2e.action-macros.Macro.Make an Impression: Diplomacy]{Make an Impression}, comparing the result to the Will DC of each target.</p>\n<p>He takes a -3 penalty on this check, and it is possible to get different degrees of success for each target. If he fails or critically fails, he can engage in 1 minute of conversation and attempt a new check at the end of that time rather than accepting the failure or critical failure result.</p>"
+                    "value": "<p>When Gage meets a group of up to five people, he can immediately attempt a Diplomacy check to @UUID[Compendium.pf2e.actionspf2e.Item.Make an Impression], comparing the result to the Will DC of each target.</p>\n<p>He takes a -3 penalty on this check, and it is possible to get different degrees of success for each target. If he fails or critically fails, he can engage in 1 minute of conversation and attempt a new check at the end of that time rather than accepting the failure or critical failure result.</p>"
                 },
                 "requirements": {
                     "value": ""


### PR DESCRIPTION
Add resistances and weaknesses to Clockwork Chopper and Clockwork Injector. Fix Daemonic Skinner's Spell Choke DC.
Fix broken links in Gage Carlyle's Charming Liar and Smooth Operator.

Closes https://github.com/foundryvtt/pf2e/issues/8189