### PR TITLE
Restore `effects` property of items and actors in the pack builder

### DIFF
--- a/build/lib/compendium-pack.ts
+++ b/build/lib/compendium-pack.ts
@@ -228,16 +228,19 @@ class CompendiumPack {
 
         docSource.flags ??= {};
         if (isActorSource(docSource)) {
+            docSource.effects = [];
             docSource.flags.core = { sourceId: this.#sourceIdOf(docSource._id, { docType: "Actor" }) };
             this.#assertSizeValid(docSource);
             docSource.system.schema = { version: MigrationRunnerBase.LATEST_SCHEMA_VERSION, lastMigration: null };
             for (const item of docSource.items) {
+                item.effects = [];
                 item.system.schema = { version: MigrationRunnerBase.LATEST_SCHEMA_VERSION, lastMigration: null };
                 CompendiumPack.convertRuleUUIDs(item, { to: "ids", map: CompendiumPack.#namesToIds.Item });
             }
         }
 
         if (isItemSource(docSource)) {
+            docSource.effects = [];
             docSource.flags.core = { sourceId: this.#sourceIdOf(docSource._id, { docType: "Item" }) };
             docSource.system.slug = sluggify(docSource.name);
             docSource.system.schema = { version: MigrationRunnerBase.LATEST_SCHEMA_VERSION, lastMigration: null };


### PR DESCRIPTION
See https://github.com/foundryvtt/foundryvtt/issues/9590