### PR TITLE
Fix npm run watch crashes when updates are made while a world is running

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ foundryconfig.json
 node_modules/
 package/
 packs-temp/
-static/packs/
 types/foundry/node_modules/
 types/foundry/package-lock.json
 

--- a/build/clean.ts
+++ b/build/clean.ts
@@ -1,0 +1,17 @@
+import fs from "fs";
+import path from "path";
+
+// Clean output directory, or create build directory
+const outDir = path.resolve(process.cwd(), "dist");
+if (fs.existsSync(outDir)) {
+    const filesToClean = fs.readdirSync(outDir).map((dirName) => path.resolve(outDir, dirName));
+    for (const file of filesToClean) {
+        fs.rmSync(file, { recursive: true });
+    }
+} else {
+    fs.mkdirSync(outDir);
+}
+
+// Delete static/packs dir to prevent overwrite during rebuilds (temporary backwards compatibility)
+const oldPacksDir = path.resolve(process.cwd(), "static/packs");
+fs.rmSync(oldPacksDir, { recursive: true, force: true });

--- a/build/lib/compendium-pack.ts
+++ b/build/lib/compendium-pack.ts
@@ -56,7 +56,7 @@ class CompendiumPack {
     data: PackEntry[];
     folders: DBFolder[];
 
-    static outDir = path.resolve(process.cwd(), "static/packs");
+    static outDir = path.resolve(process.cwd(), "dist/packs");
     static #namesToIds: {
         [K in Extract<CompendiumDocumentType, "Actor" | "Item" | "JournalEntry" | "Macro" | "RollTable">]: Map<
             string,

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
     "private": true,
     "type": "module",
     "scripts": {
-        "build": "npm run build:packs && vite build",
+        "build": "npm run clean && npm run build:packs && vite build",
         "build:packs": "esno ./build/build-packs.ts",
-        "watch": "npm run build:packs && vite build --watch --mode development",
+        "clean": "esno ./build/clean.ts",
+        "watch": "npm run clean && npm run build:packs && vite build --watch --mode development",
         "hot": "vite serve",
         "link": "esno ./build/link-foundry.ts",
         "extractPacks": "esno ./build/extract-packs.ts",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -97,7 +97,7 @@ const config = Vite.defineConfig(({ command, mode }): Vite.UserConfig => {
         esbuild: { keepNames: true },
         build: {
             outDir,
-            emptyOutDir: true,
+            emptyOutDir: false, // fails if world is running due to compendium locks. We do it in "npm run clean" instead.
             minify: false,
             sourcemap: buildMode === "development",
             lib: {


### PR DESCRIPTION
static/packs will need to be deleted from people's machines for builds to work properly after this. Perhaps I should delete it just in case?

After this static files are not deleted (only overwritten) between refreshes in npm run watch, but they are deleted when `npm run watch` or `npm run build` is ran. Perhaps that is fine.