### PR TITLE
Remove override of no-longer-existing _onUpdateTokenActor

### DIFF
--- a/src/module/scene/token-document/document.ts
+++ b/src/module/scene/token-document/document.ts
@@ -411,25 +411,6 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
             this.object.release();
         }
 
-        // Handle ephemeral changes from synthetic actor
-        if (!this.actorLink && this.parent && changed.delta) {
-            const preUpdateIcon = this.texture.src;
-            const currentHeight = this.height;
-            // If the Actor data override changed, simulate updating the synthetic Actor
-            this._onUpdateTokenActor(changed.delta, options, userId);
-            this.reset();
-
-            // Fake some updates to trigger redraw
-            if (currentHeight !== this.height) changed.height = this.height;
-            changed.light = {} as foundry.data.LightSource;
-            if (preUpdateIcon !== this.texture.src) {
-                changed.texture = mergeObject(changed.texture ?? {}, {
-                    src: this.texture.src,
-                }) as foundry.documents.TokenSource["texture"];
-            }
-            delete changed.delta; // Prevent upstream from doing so a second time
-        }
-
         return super._onUpdate(changed, options, userId);
     }
 

--- a/types/foundry/client/data/documents/token-document.d.ts
+++ b/types/foundry/client/data/documents/token-document.d.ts
@@ -143,13 +143,6 @@ declare global {
             user: User
         ): Promise<void>;
 
-        /** When the Actor data overrides change for an un-linked Token Actor, simulate the pre-update process. */
-        protected _preUpdateTokenActor(
-            data: DocumentUpdateData<Actor<this>>,
-            options: TokenUpdateContext<TParent>,
-            userId: string
-        ): Promise<void>;
-
         protected override _onUpdate(
             changed: DeepPartial<this["_source"]>,
             options: DocumentModificationContext<TParent>,
@@ -158,13 +151,6 @@ declare global {
 
         /** When the base Actor for a TokenDocument changes, we may need to update its Actor instance */
         _onUpdateBaseActor(update?: Record<string, unknown>, options?: DocumentModificationContext<null>): void;
-
-        /** When the Actor data overrides change for an un-linked Token Actor, simulate the post-update process. */
-        protected _onUpdateTokenActor(
-            data: DeepPartial<this["_source"]["delta"]>,
-            options: DocumentModificationContext<TParent>,
-            userId: string
-        ): void;
 
         /** Get an Array of attribute choices which could be tracked for Actors in the Combat Tracker */
         static getTrackedAttributes(data?: Record<string, unknown>, _path?: string[]): TokenAttributes;

--- a/types/foundry/common/documents/token.d.ts
+++ b/types/foundry/common/documents/token.d.ts
@@ -20,6 +20,8 @@ export default class BaseToken<TParent extends BaseScene | null = BaseScene | nu
 
     alpha: number;
 
+    actorId: string | null;
+
     delta: BaseActorDelta<this> | null;
 
     texture: {


### PR DESCRIPTION
going to need to investigate how to restore this (assuming it's still necessary)