### PR TITLE
Increase all non-worn armor bulk

### DIFF
--- a/packs/equipment/ancestral-embrace.json
+++ b/packs/equipment/ancestral-embrace.json
@@ -93,7 +93,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "1"
+            "value": "2"
         }
     },
     "type": "armor"

--- a/packs/equipment/arachnid-harness-greater.json
+++ b/packs/equipment/arachnid-harness-greater.json
@@ -19,7 +19,7 @@
             "value": 4
         },
         "equippedBulk": {
-            "value": ""
+            "value": "1"
         },
         "group": "leather",
         "hardness": 0,
@@ -93,7 +93,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "1"
+            "value": "2"
         }
     },
     "type": "armor"

--- a/packs/equipment/arachnid-harness.json
+++ b/packs/equipment/arachnid-harness.json
@@ -19,7 +19,7 @@
             "value": 4
         },
         "equippedBulk": {
-            "value": ""
+            "value": "1"
         },
         "group": "leather",
         "hardness": 0,
@@ -93,7 +93,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "1"
+            "value": "2"
         }
     },
     "type": "armor"

--- a/packs/equipment/armored-cloak.json
+++ b/packs/equipment/armored-cloak.json
@@ -19,7 +19,7 @@
             "value": 3
         },
         "equippedBulk": {
-            "value": ""
+            "value": "L"
         },
         "group": null,
         "hardness": 0,
@@ -87,7 +87,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "L"
+            "value": "1"
         }
     },
     "type": "armor"

--- a/packs/equipment/armored-coat.json
+++ b/packs/equipment/armored-coat.json
@@ -19,7 +19,7 @@
             "value": 2
         },
         "equippedBulk": {
-            "value": ""
+            "value": "2"
         },
         "group": "leather",
         "hardness": 0,
@@ -87,7 +87,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "2"
+            "value": "3"
         }
     },
     "type": "armor"

--- a/packs/equipment/autumns-embrace.json
+++ b/packs/equipment/autumns-embrace.json
@@ -19,7 +19,7 @@
             "value": 4
         },
         "equippedBulk": {
-            "value": ""
+            "value": "1"
         },
         "group": "wood",
         "hardness": 0,
@@ -87,7 +87,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "1"
+            "value": "2"
         }
     },
     "type": "armor"

--- a/packs/equipment/bastion-of-the-inheritor.json
+++ b/packs/equipment/bastion-of-the-inheritor.json
@@ -19,7 +19,7 @@
             "value": 0
         },
         "equippedBulk": {
-            "value": ""
+            "value": "5"
         },
         "group": "plate",
         "hardness": 0,
@@ -99,7 +99,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "5"
+            "value": "6"
         }
     },
     "type": "armor"

--- a/packs/equipment/bastion-plate.json
+++ b/packs/equipment/bastion-plate.json
@@ -19,7 +19,7 @@
             "value": 0
         },
         "equippedBulk": {
-            "value": ""
+            "value": "5"
         },
         "group": "plate",
         "hardness": 0,
@@ -88,7 +88,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "5"
+            "value": "6"
         }
     },
     "type": "armor"

--- a/packs/equipment/black-hole-armor.json
+++ b/packs/equipment/black-hole-armor.json
@@ -19,7 +19,7 @@
             "value": 0
         },
         "equippedBulk": {
-            "value": ""
+            "value": "5"
         },
         "group": "plate",
         "hardness": 0,
@@ -88,7 +88,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "5"
+            "value": "6"
         }
     },
     "type": "armor"

--- a/packs/equipment/blade-byrnie-greater.json
+++ b/packs/equipment/blade-byrnie-greater.json
@@ -19,7 +19,7 @@
             "value": 3
         },
         "equippedBulk": {
-            "value": ""
+            "value": "1"
         },
         "group": "chain",
         "hardness": 0,
@@ -89,7 +89,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "1"
+            "value": "2"
         }
     },
     "type": "armor"

--- a/packs/equipment/blade-byrnie-major.json
+++ b/packs/equipment/blade-byrnie-major.json
@@ -19,7 +19,7 @@
             "value": 3
         },
         "equippedBulk": {
-            "value": ""
+            "value": "1"
         },
         "group": "chain",
         "hardness": 0,
@@ -89,7 +89,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "1"
+            "value": "2"
         }
     },
     "type": "armor"

--- a/packs/equipment/blade-byrnie.json
+++ b/packs/equipment/blade-byrnie.json
@@ -19,7 +19,7 @@
             "value": 3
         },
         "equippedBulk": {
-            "value": ""
+            "value": "1"
         },
         "group": "chain",
         "hardness": 0,
@@ -89,7 +89,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "1"
+            "value": "2"
         }
     },
     "type": "armor"

--- a/packs/equipment/blast-suit.json
+++ b/packs/equipment/blast-suit.json
@@ -19,7 +19,7 @@
             "value": 0
         },
         "equippedBulk": {
-            "value": ""
+            "value": "2"
         },
         "group": "plate",
         "hardness": 0,
@@ -89,7 +89,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "2"
+            "value": "3"
         }
     },
     "type": "armor"

--- a/packs/equipment/bone-dreadnought-plate.json
+++ b/packs/equipment/bone-dreadnought-plate.json
@@ -19,7 +19,7 @@
             "value": 0
         },
         "equippedBulk": {
-            "value": ""
+            "value": "5"
         },
         "group": "plate",
         "hardness": 0,
@@ -89,7 +89,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "5"
+            "value": "6"
         }
     },
     "type": "armor"

--- a/packs/equipment/breastplate-of-the-mountain.json
+++ b/packs/equipment/breastplate-of-the-mountain.json
@@ -19,7 +19,7 @@
             "value": 1
         },
         "equippedBulk": {
-            "value": ""
+            "value": "2"
         },
         "group": "plate",
         "hardness": 0,
@@ -102,7 +102,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "2"
+            "value": "3"
         }
     },
     "type": "armor"

--- a/packs/equipment/buckle-armor.json
+++ b/packs/equipment/buckle-armor.json
@@ -19,7 +19,7 @@
             "value": 3
         },
         "equippedBulk": {
-            "value": ""
+            "value": "1"
         },
         "group": "leather",
         "hardness": 0,
@@ -87,7 +87,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "1"
+            "value": "2"
         }
     },
     "type": "armor"

--- a/packs/equipment/ceramic-plate.json
+++ b/packs/equipment/ceramic-plate.json
@@ -19,7 +19,7 @@
             "value": 2
         },
         "equippedBulk": {
-            "value": ""
+            "value": "2"
         },
         "group": "plate",
         "hardness": 0,
@@ -87,7 +87,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "2"
+            "value": "3"
         }
     },
     "type": "armor"

--- a/packs/equipment/clockwork-disguise.json
+++ b/packs/equipment/clockwork-disguise.json
@@ -19,7 +19,7 @@
             "value": 3
         },
         "equippedBulk": {
-            "value": ""
+            "value": "2"
         },
         "group": "plate",
         "hardness": 0,
@@ -86,7 +86,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "2"
+            "value": "3"
         }
     },
     "type": "armor"

--- a/packs/equipment/clockwork-diving-suit.json
+++ b/packs/equipment/clockwork-diving-suit.json
@@ -19,7 +19,7 @@
             "value": 1
         },
         "equippedBulk": {
-            "value": ""
+            "value": "4"
         },
         "group": null,
         "hardness": 0,
@@ -84,7 +84,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "4"
+            "value": "5"
         }
     },
     "type": "armor"

--- a/packs/equipment/coral-armor.json
+++ b/packs/equipment/coral-armor.json
@@ -19,7 +19,7 @@
             "value": 2
         },
         "equippedBulk": {
-            "value": ""
+            "value": "2"
         },
         "group": "skeletal",
         "hardness": 0,
@@ -87,7 +87,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "2"
+            "value": "3"
         }
     },
     "type": "armor"

--- a/packs/equipment/devils-bargain.json
+++ b/packs/equipment/devils-bargain.json
@@ -19,7 +19,7 @@
             "value": 3
         },
         "equippedBulk": {
-            "value": ""
+            "value": "L"
         },
         "group": "leather",
         "hardness": 0,
@@ -109,7 +109,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "L"
+            "value": "1"
         }
     },
     "type": "armor"

--- a/packs/equipment/dragon-turtle-plate.json
+++ b/packs/equipment/dragon-turtle-plate.json
@@ -19,7 +19,7 @@
             "value": 1
         },
         "equippedBulk": {
-            "value": ""
+            "value": "3"
         },
         "group": "plate",
         "hardness": 0,
@@ -104,7 +104,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "3"
+            "value": "4"
         }
     },
     "type": "armor"

--- a/packs/equipment/elven-chain-high-grade.json
+++ b/packs/equipment/elven-chain-high-grade.json
@@ -19,7 +19,7 @@
             "value": 3
         },
         "equippedBulk": {
-            "value": "0"
+            "value": "L"
         },
         "group": "chain",
         "hardness": 0,
@@ -87,7 +87,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "L"
+            "value": "1"
         }
     },
     "type": "armor"

--- a/packs/equipment/elven-chain-standard-grade.json
+++ b/packs/equipment/elven-chain-standard-grade.json
@@ -19,7 +19,7 @@
             "value": 3
         },
         "equippedBulk": {
-            "value": "0"
+            "value": "L"
         },
         "group": "chain",
         "hardness": 0,
@@ -87,7 +87,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "L"
+            "value": "1"
         }
     },
     "type": "armor"

--- a/packs/equipment/energizing-lattice.json
+++ b/packs/equipment/energizing-lattice.json
@@ -19,7 +19,7 @@
             "value": 1
         },
         "equippedBulk": {
-            "value": ""
+            "value": "2"
         },
         "group": "chain",
         "hardness": 0,
@@ -87,7 +87,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "2"
+            "value": "3"
         }
     },
     "type": "armor"

--- a/packs/equipment/faerie-queens-bower.json
+++ b/packs/equipment/faerie-queens-bower.json
@@ -19,7 +19,7 @@
             "value": 4
         },
         "equippedBulk": {
-            "value": ""
+            "value": "1"
         },
         "group": "wood",
         "hardness": 0,
@@ -89,7 +89,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "1"
+            "value": "2"
         }
     },
     "type": "armor"

--- a/packs/equipment/fortress-plate.json
+++ b/packs/equipment/fortress-plate.json
@@ -19,7 +19,7 @@
             "value": 0
         },
         "equippedBulk": {
-            "value": ""
+            "value": "5"
         },
         "group": "plate",
         "hardness": 0,
@@ -88,7 +88,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "5"
+            "value": "6"
         }
     },
     "type": "armor"

--- a/packs/equipment/gi.json
+++ b/packs/equipment/gi.json
@@ -19,7 +19,7 @@
             "value": 5
         },
         "equippedBulk": {
-            "value": ""
+            "value": "L"
         },
         "group": "cloth",
         "hardness": 0,
@@ -86,7 +86,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "L"
+            "value": "1"
         }
     },
     "type": "armor"

--- a/packs/equipment/harmonic-hauberk.json
+++ b/packs/equipment/harmonic-hauberk.json
@@ -19,7 +19,7 @@
             "value": 3
         },
         "equippedBulk": {
-            "value": ""
+            "value": "1"
         },
         "group": "chain",
         "hardness": 0,
@@ -91,7 +91,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "1"
+            "value": "2"
         }
     },
     "type": "armor"

--- a/packs/equipment/heavy-barding-large.json
+++ b/packs/equipment/heavy-barding-large.json
@@ -19,7 +19,7 @@
             "value": 3
         },
         "equippedBulk": {
-            "value": ""
+            "value": "4"
         },
         "group": null,
         "hardness": 0,
@@ -87,7 +87,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "4"
+            "value": "5"
         }
     },
     "type": "armor"

--- a/packs/equipment/heavy-barding-small-or-medium.json
+++ b/packs/equipment/heavy-barding-small-or-medium.json
@@ -19,7 +19,7 @@
             "value": 3
         },
         "equippedBulk": {
-            "value": ""
+            "value": "4"
         },
         "group": null,
         "hardness": 0,
@@ -87,7 +87,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "4"
+            "value": "5"
         }
     },
     "type": "armor"

--- a/packs/equipment/hellknight-breastplate.json
+++ b/packs/equipment/hellknight-breastplate.json
@@ -19,7 +19,7 @@
             "value": 1
         },
         "equippedBulk": {
-            "value": ""
+            "value": "2"
         },
         "group": "plate",
         "hardness": 0,
@@ -84,7 +84,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "2"
+            "value": "3"
         }
     },
     "type": "armor"

--- a/packs/equipment/hellknight-half-plate.json
+++ b/packs/equipment/hellknight-half-plate.json
@@ -19,7 +19,7 @@
             "value": 1
         },
         "equippedBulk": {
-            "value": ""
+            "value": "3"
         },
         "group": "plate",
         "hardness": 0,
@@ -84,7 +84,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "3"
+            "value": "4"
         }
     },
     "type": "armor"

--- a/packs/equipment/immortal-bastion.json
+++ b/packs/equipment/immortal-bastion.json
@@ -19,7 +19,7 @@
             "value": 0
         },
         "equippedBulk": {
-            "value": ""
+            "value": "5"
         },
         "group": "plate",
         "hardness": 0,
@@ -88,7 +88,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "5"
+            "value": "6"
         }
     },
     "type": "armor"

--- a/packs/equipment/lamellar-breastplate.json
+++ b/packs/equipment/lamellar-breastplate.json
@@ -19,7 +19,7 @@
             "value": 1
         },
         "equippedBulk": {
-            "value": ""
+            "value": "2"
         },
         "group": "composite",
         "hardness": 0,
@@ -87,7 +87,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "2"
+            "value": "3"
         }
     },
     "type": "armor"

--- a/packs/equipment/lattice-armor.json
+++ b/packs/equipment/lattice-armor.json
@@ -19,7 +19,7 @@
             "value": 1
         },
         "equippedBulk": {
-            "value": ""
+            "value": "2"
         },
         "group": "chain",
         "hardness": 0,
@@ -84,7 +84,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "2"
+            "value": "3"
         }
     },
     "type": "armor"

--- a/packs/equipment/leaf-weave.json
+++ b/packs/equipment/leaf-weave.json
@@ -19,7 +19,7 @@
             "value": 4
         },
         "equippedBulk": {
-            "value": ""
+            "value": "1"
         },
         "group": "wood",
         "hardness": 0,
@@ -86,7 +86,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "1"
+            "value": "2"
         }
     },
     "type": "armor"

--- a/packs/equipment/leather-lamellar.json
+++ b/packs/equipment/leather-lamellar.json
@@ -19,7 +19,7 @@
             "value": 4
         },
         "equippedBulk": {
-            "value": ""
+            "value": "1"
         },
         "group": "composite",
         "hardness": 0,
@@ -86,7 +86,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "1"
+            "value": "2"
         }
     },
     "type": "armor"

--- a/packs/equipment/library-robes-greater.json
+++ b/packs/equipment/library-robes-greater.json
@@ -19,7 +19,7 @@
             "value": 5
         },
         "equippedBulk": {
-            "value": ""
+            "value": "L"
         },
         "group": "cloth",
         "hardness": 0,
@@ -87,7 +87,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "L"
+            "value": "1"
         }
     },
     "type": "armor"

--- a/packs/equipment/library-robes-major.json
+++ b/packs/equipment/library-robes-major.json
@@ -19,7 +19,7 @@
             "value": 5
         },
         "equippedBulk": {
-            "value": ""
+            "value": "L"
         },
         "group": "cloth",
         "hardness": 0,
@@ -87,7 +87,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "L"
+            "value": "1"
         }
     },
     "type": "armor"

--- a/packs/equipment/library-robes-true.json
+++ b/packs/equipment/library-robes-true.json
@@ -19,7 +19,7 @@
             "value": 5
         },
         "equippedBulk": {
-            "value": ""
+            "value": "L"
         },
         "group": "cloth",
         "hardness": 0,
@@ -87,7 +87,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "L"
+            "value": "1"
         }
     },
     "type": "armor"

--- a/packs/equipment/library-robes.json
+++ b/packs/equipment/library-robes.json
@@ -19,7 +19,7 @@
             "value": 5
         },
         "equippedBulk": {
-            "value": ""
+            "value": "L"
         },
         "group": "cloth",
         "hardness": 0,
@@ -87,7 +87,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "L"
+            "value": "1"
         }
     },
     "type": "armor"

--- a/packs/equipment/light-barding.json
+++ b/packs/equipment/light-barding.json
@@ -19,7 +19,7 @@
             "value": 5
         },
         "equippedBulk": {
-            "value": ""
+            "value": "2"
         },
         "group": null,
         "hardness": 0,
@@ -87,7 +87,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "2"
+            "value": "3"
         }
     },
     "type": "armor"

--- a/packs/equipment/linnorms-sankeit.json
+++ b/packs/equipment/linnorms-sankeit.json
@@ -19,7 +19,7 @@
             "value": 3
         },
         "equippedBulk": {
-            "value": ""
+            "value": "2"
         },
         "group": "wood",
         "hardness": 0,
@@ -87,7 +87,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "2"
+            "value": "3"
         }
     },
     "type": "armor"

--- a/packs/equipment/living-leaf-weave.json
+++ b/packs/equipment/living-leaf-weave.json
@@ -19,7 +19,7 @@
             "value": 4
         },
         "equippedBulk": {
-            "value": ""
+            "value": "1"
         },
         "group": "wood",
         "hardness": 0,
@@ -89,7 +89,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "1"
+            "value": "2"
         }
     },
     "type": "armor"

--- a/packs/equipment/mantis-shell.json
+++ b/packs/equipment/mantis-shell.json
@@ -19,7 +19,7 @@
             "value": 3
         },
         "equippedBulk": {
-            "value": ""
+            "value": "1"
         },
         "group": "skeletal",
         "hardness": 0,
@@ -86,7 +86,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "1"
+            "value": "2"
         }
     },
     "type": "armor"

--- a/packs/equipment/niyaháat.json
+++ b/packs/equipment/niyaháat.json
@@ -19,7 +19,7 @@
             "value": 2
         },
         "equippedBulk": {
-            "value": ""
+            "value": "2"
         },
         "group": "skeletal",
         "hardness": 0,
@@ -86,7 +86,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "2"
+            "value": "3"
         }
     },
     "type": "armor"

--- a/packs/equipment/o-yoroi.json
+++ b/packs/equipment/o-yoroi.json
@@ -19,7 +19,7 @@
             "value": 0
         },
         "equippedBulk": {
-            "value": ""
+            "value": "5"
         },
         "group": "composite",
         "hardness": 0,
@@ -87,7 +87,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "5"
+            "value": "6"
         }
     },
     "type": "armor"

--- a/packs/equipment/ouroboros-buckles.json
+++ b/packs/equipment/ouroboros-buckles.json
@@ -19,7 +19,7 @@
             "value": 3
         },
         "equippedBulk": {
-            "value": ""
+            "value": "1"
         },
         "group": "leather",
         "hardness": 0,
@@ -88,7 +88,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "1"
+            "value": "2"
         }
     },
     "type": "armor"

--- a/packs/equipment/power-suit.json
+++ b/packs/equipment/power-suit.json
@@ -19,7 +19,7 @@
             "value": 1
         },
         "equippedBulk": {
-            "value": ""
+            "value": "2"
         },
         "group": "composite",
         "hardness": 0,
@@ -96,7 +96,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "2"
+            "value": "3"
         }
     },
     "type": "armor"

--- a/packs/equipment/prismatic-plate.json
+++ b/packs/equipment/prismatic-plate.json
@@ -19,7 +19,7 @@
             "value": 1
         },
         "equippedBulk": {
-            "value": ""
+            "value": "1"
         },
         "group": "plate",
         "hardness": 0,
@@ -88,7 +88,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "1"
+            "value": "2"
         }
     },
     "type": "armor"

--- a/packs/equipment/quilted-armor.json
+++ b/packs/equipment/quilted-armor.json
@@ -19,7 +19,7 @@
             "value": 2
         },
         "equippedBulk": {
-            "value": ""
+            "value": "1"
         },
         "group": "cloth",
         "hardness": 0,
@@ -86,7 +86,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "1"
+            "value": "2"
         }
     },
     "type": "armor"

--- a/packs/equipment/reef-heart-greater.json
+++ b/packs/equipment/reef-heart-greater.json
@@ -19,7 +19,7 @@
             "value": 2
         },
         "equippedBulk": {
-            "value": ""
+            "value": "2"
         },
         "group": "skeletal",
         "hardness": 0,
@@ -93,7 +93,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "2"
+            "value": "3"
         }
     },
     "type": "armor"

--- a/packs/equipment/reef-heart.json
+++ b/packs/equipment/reef-heart.json
@@ -19,7 +19,7 @@
             "value": 2
         },
         "equippedBulk": {
-            "value": ""
+            "value": "2"
         },
         "group": "skeletal",
         "hardness": 0,
@@ -93,7 +93,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "2"
+            "value": "3"
         }
     },
     "type": "armor"

--- a/packs/equipment/remorhaz-armor.json
+++ b/packs/equipment/remorhaz-armor.json
@@ -19,7 +19,7 @@
             "value": 2
         },
         "equippedBulk": {
-            "value": ""
+            "value": "2"
         },
         "group": "skeletal",
         "hardness": 0,
@@ -88,7 +88,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "2"
+            "value": "3"
         }
     },
     "type": "armor"

--- a/packs/equipment/robe-of-the-archmagi-greater.json
+++ b/packs/equipment/robe-of-the-archmagi-greater.json
@@ -19,7 +19,7 @@
             "value": 5
         },
         "equippedBulk": {
-            "value": ""
+            "value": "1"
         },
         "group": null,
         "hardness": 0,
@@ -97,7 +97,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "1"
+            "value": "2"
         }
     },
     "type": "armor"

--- a/packs/equipment/robe-of-the-archmagi.json
+++ b/packs/equipment/robe-of-the-archmagi.json
@@ -19,7 +19,7 @@
             "value": 5
         },
         "equippedBulk": {
-            "value": ""
+            "value": "1"
         },
         "group": null,
         "hardness": 0,
@@ -97,7 +97,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "1"
+            "value": "2"
         }
     },
     "type": "armor"

--- a/packs/equipment/rusting-carapace.json
+++ b/packs/equipment/rusting-carapace.json
@@ -19,7 +19,7 @@
             "value": 4
         },
         "equippedBulk": {
-            "value": ""
+            "value": "1"
         },
         "group": "composite",
         "hardness": 0,
@@ -97,7 +97,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "1"
+            "value": "2"
         }
     },
     "type": "armor"

--- a/packs/equipment/sankeit.json
+++ b/packs/equipment/sankeit.json
@@ -19,7 +19,7 @@
             "value": 3
         },
         "equippedBulk": {
-            "value": ""
+            "value": "1"
         },
         "group": "wood",
         "hardness": 0,
@@ -86,7 +86,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "1"
+            "value": "2"
         }
     },
     "type": "armor"

--- a/packs/equipment/sarkorian-god-caller-garb.json
+++ b/packs/equipment/sarkorian-god-caller-garb.json
@@ -19,7 +19,7 @@
             "value": 5
         },
         "equippedBulk": {
-            "value": ""
+            "value": "L"
         },
         "group": "cloth",
         "hardness": 0,
@@ -89,7 +89,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "L"
+            "value": "1"
         }
     },
     "type": "armor"

--- a/packs/equipment/scarab-cuirass.json
+++ b/packs/equipment/scarab-cuirass.json
@@ -19,7 +19,7 @@
             "value": 4
         },
         "equippedBulk": {
-            "value": ""
+            "value": "1"
         },
         "group": "leather",
         "hardness": 0,
@@ -94,7 +94,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "1"
+            "value": "2"
         }
     },
     "type": "armor"

--- a/packs/equipment/scroll-robes.json
+++ b/packs/equipment/scroll-robes.json
@@ -19,7 +19,7 @@
             "value": 5
         },
         "equippedBulk": {
-            "value": ""
+            "value": "L"
         },
         "group": "cloth",
         "hardness": 0,
@@ -86,7 +86,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "L"
+            "value": "1"
         }
     },
     "type": "armor"

--- a/packs/equipment/shared-pain-sankeit.json
+++ b/packs/equipment/shared-pain-sankeit.json
@@ -19,7 +19,7 @@
             "value": 3
         },
         "equippedBulk": {
-            "value": ""
+            "value": "3"
         },
         "group": "wood",
         "hardness": 0,
@@ -90,7 +90,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "3"
+            "value": "4"
         }
     },
     "type": "armor"

--- a/packs/equipment/subterfuge-suit.json
+++ b/packs/equipment/subterfuge-suit.json
@@ -19,7 +19,7 @@
             "value": 4
         },
         "equippedBulk": {
-            "value": ""
+            "value": "1"
         },
         "group": "composite",
         "hardness": 0,
@@ -96,7 +96,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "1"
+            "value": "2"
         }
     },
     "type": "armor"

--- a/packs/equipment/suit-of-armoire.json
+++ b/packs/equipment/suit-of-armoire.json
@@ -19,7 +19,7 @@
             "value": 0
         },
         "equippedBulk": {
-            "value": ""
+            "value": "4"
         },
         "group": "plate",
         "hardness": 0,
@@ -84,7 +84,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "4"
+            "value": "5"
         }
     },
     "type": "armor"

--- a/packs/equipment/trollhound-vest.json
+++ b/packs/equipment/trollhound-vest.json
@@ -19,7 +19,7 @@
             "value": 2
         },
         "equippedBulk": {
-            "value": ""
+            "value": "2"
         },
         "group": "leather",
         "hardness": 0,
@@ -98,7 +98,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "2"
+            "value": "3"
         }
     },
     "type": "armor"

--- a/packs/equipment/wasp-guard.json
+++ b/packs/equipment/wasp-guard.json
@@ -19,7 +19,7 @@
             "value": 3
         },
         "equippedBulk": {
-            "value": ""
+            "value": "1"
         },
         "group": "leather",
         "hardness": 0,
@@ -102,7 +102,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "1"
+            "value": "2"
         }
     },
     "type": "armor"

--- a/packs/equipment/wolfjaw-armor.json
+++ b/packs/equipment/wolfjaw-armor.json
@@ -19,7 +19,7 @@
             "value": 2
         },
         "equippedBulk": {
-            "value": ""
+            "value": "2"
         },
         "group": "leather",
         "hardness": 0,
@@ -88,7 +88,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "2"
+            "value": "3"
         }
     },
     "type": "armor"

--- a/packs/equipment/wooden-breastplate.json
+++ b/packs/equipment/wooden-breastplate.json
@@ -19,7 +19,7 @@
             "value": 2
         },
         "equippedBulk": {
-            "value": ""
+            "value": "2"
         },
         "group": "wood",
         "hardness": 0,
@@ -84,7 +84,7 @@
             "value": "wornarmor"
         },
         "weight": {
-            "value": "2"
+            "value": "3"
         }
     },
     "type": "armor"


### PR DESCRIPTION
Currently a lot of new armors don't have their carried bulk set to one more than their worn bulk. Here I went through all armors and if their carried bulk wasn't one more than their worn bulk, and set it to it, setting their previous bulk to worn bulk in the process.