### PR TITLE
Workaround upstream settings no longer being coerced

### DIFF
--- a/src/scripts/hooks/init.ts
+++ b/src/scripts/hooks/init.ts
@@ -23,6 +23,7 @@ import { registerFonts } from "@scripts/register-fonts.ts";
 import { registerKeybindings } from "@scripts/register-keybindings.ts";
 import { registerTemplates } from "@scripts/register-templates.ts";
 import { SetGamePF2e } from "@scripts/set-game-pf2e.ts";
+import { monkeyPatchSettings } from "@scripts/🐵🩹.ts";
 import { registerSettings } from "@system/settings/index.ts";
 import { htmlQueryAll } from "@util";
 
@@ -30,6 +31,7 @@ export const Init = {
     listen: (): void => {
         Hooks.once("init", () => {
             console.log("PF2e System | Initializing Pathfinder 2nd Edition System");
+            monkeyPatchSettings();
 
             CONFIG.PF2E = PF2ECONFIG;
             CONFIG.debug.ruleElement ??= false;

--- a/src/scripts/🐵🩹.ts
+++ b/src/scripts/🐵🩹.ts
@@ -1,7 +1,24 @@
 import { TextEditorPF2e } from "@system/text-editor.ts";
+import { tupleHasValue } from "@util";
 
 export function monkeyPatchFoundry(): void {
     TextEditor.enrichHTML = TextEditorPF2e.enrichHTML;
     TextEditor._createInlineRoll = TextEditorPF2e._createInlineRoll;
     TextEditor._onClickInlineRoll = TextEditorPF2e._onClickInlineRoll;
+}
+
+// Work around https://github.com/foundryvtt/foundryvtt/issues/9549
+export function monkeyPatchSettings(): void {
+    const PRIMITIVE_TYPES = [String, Number, Boolean, Array]; // v10 "primitive" config types
+    const originalGet = game.settings.get;
+    game.settings.get = function (namespace: string, key: string) {
+        const value = originalGet.call(game.settings, namespace, key);
+        const resolvedKey = `${namespace}.${key}`;
+        const config = game.settings.settings.get(resolvedKey);
+        if (config && tupleHasValue(PRIMITIVE_TYPES, config.type)) {
+            return config.type(value);
+        }
+
+        return value;
+    } as typeof originalGet;
 }

--- a/types/foundry/client/core/settings.d.ts
+++ b/types/foundry/client/core/settings.d.ts
@@ -128,6 +128,7 @@ declare global {
         get(key: "core.chatBubblesPan"): SettingConfig & { default: boolean };
         get(key: "core.defaultToken"): SettingConfig & { default: PreCreate<foundry.data.PrototypeTokenSource> };
         get(key: "core.notesDisplayToggle"): SettingConfig & { default: boolean };
+        get(key: string): SettingConfig | undefined;
     }
 
     /** A simple interface for World settings storage which imitates the API provided by localStorage */


### PR DESCRIPTION
Work around https://github.com/foundryvtt/foundryvtt/issues/9549

This doesn't recreate the full extent of coerce that v10 had, but it should handle numbers, which is our primary issue.
