### PR TITLE
Fix `TemplateLayerPF2e#_onDragLeftMove`

### DIFF
--- a/src/module/canvas/layer/template.ts
+++ b/src/module/canvas/layer/template.ts
@@ -6,28 +6,26 @@ export class TemplateLayerPF2e<
     /** Originally by Furyspark for the PF1e system */
     protected override _onDragLeftMove(event: PlaceablesLayerEvent<TTemplate>): void {
         if (!canvas.scene || !canvas.dimensions) return;
+        const interaction = event.interactionData;
+        const { destination, layerDragState, preview: template, origin } = interaction;
 
-        // From PlaceablesLayer#_onDragLeftMove
-        const preview = event.interactionData.preview;
-        if (!preview || preview.destroyed) return;
-        if (preview.parent === null) {
+        if (!template || template.destroyed) return;
+        if (template.parent === null) {
             // In theory this should never happen, but rarely does
-            this.preview.addChild(preview);
+            this.preview.addChild(template);
         }
-        const createState = event.interactionData.createState ?? 0;
+        const dragState = layerDragState ?? 0;
 
-        if (createState >= 1) {
+        if (dragState >= 1) {
             // Snap the destination to the grid
-            const dest = event.interactionData.destination;
-            const { x, y } = canvas.grid.getSnappedPosition(dest.x, dest.y, 2);
-            dest.x = x;
-            dest.y = y;
+            const { x, y } = canvas.grid.getSnappedPosition(destination.x, destination.y, 2);
+            destination.x = x;
+            destination.y = y;
 
             // Compute the ray
-            const template = event.interactionData.preview;
             if (!template) return;
 
-            const ray = new Ray(event.interactionData.origin, event.interactionData.destination);
+            const ray = new Ray(origin, destination);
             const ratio = canvas.dimensions.size / canvas.dimensions.distance;
 
             // Update the shape data
@@ -47,7 +45,7 @@ export class TemplateLayerPF2e<
 
             // Draw the pending shape
             template.refresh();
-            event.interactionData.createState = 2;
+            event.interactionData.layerDragState = 2;
         }
     }
 

--- a/types/foundry/client/pixi/placeables-layer/base.d.ts
+++ b/types/foundry/client/pixi/placeables-layer/base.d.ts
@@ -320,13 +320,10 @@ declare global {
 }
 
 interface PlaceableInteractionData<TObject extends PlaceableObject> {
-    originalEvent: PlaceablesPointerEvent;
+    clearPreviewContainer: boolean;
     preview?: TObject | null;
-    createState?: number;
+    layerDragState?: number;
+    object: PIXI.Mesh;
     origin: Point;
     destination: Point;
 }
-
-type PlaceablesPointerEvent = {
-    isShift: boolean;
-};


### PR DESCRIPTION
This fixes manual drawing of `MeasuredTemplate`s

![template](https://github.com/foundryvtt/pf2e/assets/41452412/ba85736d-7879-4aa6-98a6-6f8e790374d8)
