### PR TITLE
Move most inventory functions to context menu

### DIFF
--- a/src/module/actor/npc/sheet.ts
+++ b/src/module/actor/npc/sheet.ts
@@ -486,34 +486,6 @@ class NPCSheetPF2e extends AbstractNPCSheet<NPCPF2e> {
         for (const element of htmlQueryAll<HTMLInputElement | HTMLSelectElement>(html, selector)) {
             element.addEventListener("change", (event) => this.#onChangeSpellcastingEntry(element, event));
         }
-
-        $html.find(".item-control[data-action=generate-attack]").on("click", async (event) => {
-            const { actor } = this;
-            const itemId = event.currentTarget.closest<HTMLElement>(".item")?.dataset.itemId ?? "";
-            const item = actor.items.get(itemId, { strict: true });
-            if (!item.isOfType("weapon")) return;
-
-            // Get confirmation from the user before replacing existing generated attacks
-            const existing = actor.itemTypes.melee.filter((m) => m.flags.pf2e.linkedWeapon === itemId).map((m) => m.id);
-            if (existing.length > 0) {
-                const proceed = await Dialog.confirm({
-                    title: game.i18n.localize("PF2E.Actor.NPC.GenerateAttack.Confirm.Title"),
-                    content: game.i18n.localize("PF2E.Actor.NPC.GenerateAttack.Confirm.Content"),
-                    defaultYes: false,
-                });
-                if (proceed) {
-                    await actor.deleteEmbeddedDocuments("Item", existing, { render: false });
-                } else {
-                    return;
-                }
-            }
-
-            const attacks = item.toNPCAttacks().map((a) => a.toObject());
-            await actor.createEmbeddedDocuments("Item", attacks);
-            ui.notifications.info(
-                game.i18n.format("PF2E.Actor.NPC.GenerateAttack.Notification", { attack: attacks.at(0)?.name ?? "" })
-            );
-        });
     }
 
     async #onChangeSpellcastingEntry(element: HTMLInputElement | HTMLSelectElement, event: Event): Promise<void> {

--- a/src/styles/actor/_inventory.scss
+++ b/src/styles/actor/_inventory.scss
@@ -19,6 +19,7 @@
         font-weight: 500;
         flex: 2;
         gap: 4px;
+        padding-right: 4px;
 
         h3,
         h4 {
@@ -136,11 +137,37 @@
         flex: 0 0 36px;
     }
 
+    #context-menu {
+        width: auto;
+        .context-item {
+            font-family: var(--font-primary);
+            font-size: var(--font-size-14);
+        }
+    }
+
     .item-controls {
-        flex: 0 0 90px;
+        flex: 0 0 5rem;
         font-size: var(--font-size-12);
         gap: 1px;
         justify-content: end;
+
+        [data-action="inventory-context-menu"] {
+            align-items: center;
+            border-left: 1px solid rgba(68, 55, 48, 0.4);
+            cursor: pointer;
+            display: flex;
+            height: 100%;
+            justify-content: center;
+            margin-left: 2px;
+
+            &:hover > i {
+                text-shadow: 0 0 8px var(--color-shadow-primary);
+            }
+            #context-menu {
+                left: unset;
+                right: 0;
+            }
+        }
     }
 
     .inventory-header {
@@ -197,6 +224,11 @@
     .inventory-items {
         border: 1px solid var(--border-color);
         border-top: none;
+        border-bottom: none;
+
+        &:last-child {
+            border-bottom: 1px solid var(--border-color);
+        }
     }
 
     .item {

--- a/src/styles/actor/character/_inventory.scss
+++ b/src/styles/actor/character/_inventory.scss
@@ -6,7 +6,7 @@
     }
 
     .item-controls {
-        flex: 0 0 100px;
+        flex: 0 0 6rem;
     }
 
     .wealth {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2752,7 +2752,7 @@
         },
         "RemoveModifierTitle": "Remove Modifier",
         "RemoveSpellcastingEntryTitle": "Remove Spellcasting Entry",
-        "RepairItemTitle": "Attempt to Repair Item",
+        "RepairItemTitle": "Repair Item",
         "Repost": "Post prompt to chat",
         "RerollMenu": {
             "ErrorCantDelete": "You are unable to delete the original roll.",

--- a/static/templates/actors/partials/item-line.hbs
+++ b/static/templates/actors/partials/item-line.hbs
@@ -52,28 +52,13 @@
                 {{#if (or (eq @root.actor.type "character") (eq @root.actor.type "npc"))}}
                     {{> "systems/pf2e/templates/actors/partials/carry-type.hbs" item=item}}
                 {{/if}}
-                {{#if item.isDamaged}}
-                    <a class="item-control" data-action="repair" title="{{localize "PF2E.RepairItemTitle"}}"><i class="fa-solid fa-hammer fa-fw"></i></a>
-                {{/if}}
-                {{#if @root.user.isGM}}
-                    {{#if item.isIdentified}}
-                        <a class="item-control" data-action="toggle-identified" title="{{localize "PF2E.identification.Mystify"}}"><i class="fa-regular fa-question-circle fa-fw"></i></a>
-                    {{else}}
-                        <a class="item-control" data-action="toggle-identified" title="{{localize "PF2E.identification.Identify"}}"><i class="fa-solid fa-question-circle fa-fw"></i></a>
-                    {{/if}}
-                {{/if}}
-                {{#if (and isSellable (ne @root.actor.type "loot"))}}
-                    <a class="item-control item-sell-treasure" data-action="sell-treasure" title="{{localize "PF2E.ui.sell"}}"><i class="fa-solid fa-coins fa-fw"></i></a>
-                {{/if}}
-                {{#if (and (eq item.type "weapon") (eq @root.actor.type "npc"))}}
-                    <a class="item-control" data-action="generate-attack" title="{{localize "PF2E.Actor.NPC.GenerateAttack.Label"}}"><i class="fa-solid fa-bolt fa-fw"></i></a>
-                {{/if}}
                 {{#if (or @root.user.isGM item.isIdentified)}}
                     <a class="item-control item-edit" title="{{localize "PF2E.EditItemTitle"}}"><i class="fa-solid fa-edit fa-fw"></i></a>
                 {{/if}}
                 {{#if (or owner (ne @root.actor.type "loot"))}}
                     <a class="item-control item-delete" title="{{localize "PF2E.DeleteItemTitle"}}"><i class="fa-solid fa-trash fa-fw"></i></a>
                 {{/if}}
+                <div class="item-control" data-action="inventory-context-menu"><i class="fa-solid fa-fw fa-ellipsis-v"></i></div>
             </div>
         {{/if}}
     </div>


### PR DESCRIPTION
Also moves the backpack toggle to the left of the item name. Note that Foundry context menus don't put themselves in the document body and thus do weird things to scrolling

![image](https://github.com/foundryvtt/pf2e/assets/1286721/5520cf72-7d4f-40e4-a3c9-86c44cef3d0e)

![image](https://github.com/foundryvtt/pf2e/assets/1286721/b4a28853-c9fe-4cb8-8ef9-1495186d974d)

