### PR TITLE
Added workaround for Issue #8326

### DIFF
--- a/src/module/item/sheet/base.ts
+++ b/src/module/item/sheet/base.ts
@@ -92,7 +92,7 @@ export class ItemSheetPF2e<TItem extends ItemPF2e> extends ItemSheet<TItem> {
             rollData,
             async: true,
         });
-        enrichedContent.gmNotes = await TextEditor.enrichHTML(item.system.description.gm.trim(), {
+        enrichedContent.gmNotes = await TextEditor.enrichHTML(item.system.description.gm ? item.system.description.gm.trim() : "", {
             rollData,
             async: true,
         });


### PR DESCRIPTION
Items imported from earlier versions of this module do not have the item.system.description.gm property, causing errors when trying to open their respective item sheets.

Checking whether that item exists before calling .trim() should fix the issue.