### PR TITLE
Trim down migration runner handling of synthetic actors & AEs

### DIFF
--- a/src/module/migration/runner/base.ts
+++ b/src/module/migration/runner/base.ts
@@ -29,23 +29,14 @@ export class MigrationRunnerBase {
         return currentVersion < (this.constructor as typeof MigrationRunnerBase).LATEST_SCHEMA_VERSION;
     }
 
-    diffCollection<T extends foundry.documents.ActiveEffectSource>(orig: T[], updated: T[]): CollectionDiff<T>;
-    diffCollection<T extends ItemSourcePF2e>(orig: T[], updated: T[]): CollectionDiff<T>;
-    diffCollection<T extends foundry.documents.ActiveEffectSource | ItemSourcePF2e>(
-        orig: T[],
-        updated: T[]
-    ): CollectionDiff<T>;
-    diffCollection<TSource extends foundry.documents.ActiveEffectSource | ItemSourcePF2e>(
-        orig: TSource[],
-        updated: TSource[]
-    ): CollectionDiff<TSource> {
-        const ret: CollectionDiff<TSource> = {
+    diffCollection(orig: ItemSourcePF2e[], updated: ItemSourcePF2e[]): CollectionDiff<ItemSourcePF2e> {
+        const diffs: CollectionDiff<ItemSourcePF2e> = {
             inserted: [],
             deleted: [],
             updated: [],
         };
 
-        const origSources: Map<string, TSource> = new Map();
+        const origSources: Map<string, ItemSourcePF2e> = new Map();
         for (const source of orig) {
             origSources.set(source._id!, source);
         }
@@ -55,21 +46,21 @@ export class MigrationRunnerBase {
             if (origSource) {
                 // check to see if anything changed
                 if (JSON.stringify(origSource) !== JSON.stringify(source)) {
-                    ret.updated.push(source);
+                    diffs.updated.push(source);
                 }
                 origSources.delete(source._id!);
             } else {
                 // it's new
-                ret.inserted.push(source);
+                diffs.inserted.push(source);
             }
         }
 
         // since we've been deleting them as we process, the ones remaining need to be deleted
         for (const source of origSources.values()) {
-            ret.deleted.push(source._id!);
+            diffs.deleted.push(source._id);
         }
 
-        return ret;
+        return diffs;
     }
 
     async getUpdatedActor(actor: ActorSourcePF2e, migrations: MigrationBase[]): Promise<ActorSourcePF2e> {

--- a/tests/mocks/actor.ts
+++ b/tests/mocks/actor.ts
@@ -68,17 +68,22 @@ export class MockActor {
         _context: DocumentModificationContext<TokenDocumentPF2e<ScenePF2e | null>> = {}
     ): Promise<ActorPF2e[]> {
         return updates.flatMap((update) => {
-            const actor = game.actors.find((actor) => actor.id === update._id);
+            const actor = game.actors.find((a) => a.id === update._id);
             if (!actor) throw Error("PANIC!");
 
             const itemUpdates = (update.items ?? []) as DeepPartial<ItemSourcePF2e>[];
             delete update.items;
             mergeObject(actor._source, update);
             for (const partial of itemUpdates) {
+                partial._id ??= "item1";
                 const source = actor._source.items.find(
                     (maybeSource: ItemSourcePF2e) => maybeSource._id === partial._id
                 );
-                if (source) mergeObject(source, partial);
+                if (source) {
+                    mergeObject(source, partial);
+                } else {
+                    actor.createEmbeddedDocuments("Item", [partial]);
+                }
             }
             actor.prepareData();
             return actor;

--- a/tests/module/migration.test.ts
+++ b/tests/module/migration.test.ts
@@ -301,8 +301,7 @@ describe("test migration runner", () => {
         static version = 14;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         async updateActor(actor: { items: any[] }) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            actor.system.sampleItemId = actor.items.find((x: any) => x.name === "sample item")._id;
+            actor.system.sampleItemId = actor.items.find((i: { name: string }) => i.name === "sample item")._id;
         }
     }
 


### PR DESCRIPTION
After some testing I was able to confirm that embedded items can be created and updated on synthetic actors in the same way as world actors.