### PR TITLE
Update Bunyip Shift Form from effect to RollOption with suboptions

### DIFF
--- a/packs/pathfinder-bestiary/bunyip.json
+++ b/packs/pathfinder-bestiary/bunyip.json
@@ -420,7 +420,7 @@
                             "shift-form:snake-tail"
                         ],
                         "property": "weapon-traits",
-                        "value": "reach-10"
+                        "value": "reach"
                     },
                     {
                         "key": "Note",

--- a/packs/pathfinder-bestiary/bunyip.json
+++ b/packs/pathfinder-bestiary/bunyip.json
@@ -367,26 +367,69 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>A bunyip can alter its form slightly to gain an advantage and make it harder to recognize. When it does, its teeth shrink and its Jaws Strike doesn't deal the 1d6 persistent bleed damage. It can choose to gain either a long snake tail, granting its tail Strike reach 10 feet and Grab, or squat crocodile legs, increasing its land Speed to 20 feet. If it uses Shift Form again, the bunyip can return to normal or switch between a long tail or crocodile legs.</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Item.Effect: Crocodile Form]</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Item.Effect: Snake Form]</p>"
+                    "value": "<p>A bunyip can alter its form slightly to gain an advantage and make it harder to recognize. When it does, its teeth shrink and its Jaws Strike doesn't deal the 1d6 persistent bleed damage. It can choose to gain either a long snake tail, granting its tail Strike reach 10 feet and Grab, or squat crocodile legs, increasing its land Speed to 20 feet. If it uses Shift Form again, the bunyip can return to normal or switch between a long tail or crocodile legs.</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
                 "rules": [
                     {
+                        "domain": "all",
+                        "key": "RollOption",
+                        "option": "shift-form",
+                        "suboptions": [
+                            {
+                                "label": "PF2E.NPCAbility.Bunyip.SnakeTail",
+                                "value": "snake-tail"
+                            },
+                            {
+                                "label": "PF2E.NPCAbility.Bunyip.CrocodileLegs",
+                                "value": "crocodile-legs"
+                            }
+                        ],
+                        "toggleable": true
+                    },
+                    {
                         "damageType": "bleed",
                         "diceNumber": 1,
                         "dieSize": "d6",
                         "key": "DamageDice",
+                        "label": "PF2E.Weapon.Base.jaws",
                         "predicate": [
                             {
-                                "nor": [
-                                    "self:effect:crocodile-form",
-                                    "self:effect:snake-form"
-                                ]
+                                "not": "shift-form"
                             }
                         ],
                         "selector": "jaws-damage"
+                    },
+                    {
+                        "key": "BaseSpeed",
+                        "predicate": [
+                            "shift-form:crocodile-legs"
+                        ],
+                        "selector": "land-speed",
+                        "value": 20
+                    },
+                    {
+                        "definition": [
+                            "item:tail"
+                        ],
+                        "key": "AdjustStrike",
+                        "mode": "add",
+                        "predicate": [
+                            "shift-form:snake-tail"
+                        ],
+                        "property": "weapon-traits",
+                        "value": "reach-10"
+                    },
+                    {
+                        "key": "Note",
+                        "predicate": [
+                            "shift-form:snake-tail"
+                        ],
+                        "selector": "tail-attack",
+                        "text": "<p><strong><span class='pf2-icon'>1</span> @Localize[PF2E.AttackEffectGrab]</strong> ({item|name})</p>@Localize[PF2E.NPC.Abilities.Glossary.Grab]",
+                        "visibility": "owner"
                     }
                 ],
                 "slug": null,
@@ -396,6 +439,7 @@
                 "traits": {
                     "rarity": "common",
                     "value": [
+                        "morph",
                         "primal",
                         "transmutation"
                     ]

--- a/packs/pfs-season-2-bestiary/saddleback-bunyip.json
+++ b/packs/pfs-season-2-bestiary/saddleback-bunyip.json
@@ -21,10 +21,6 @@
                     "0": {
                         "damage": "1d10+4",
                         "damageType": "piercing"
-                    },
-                    "1": {
-                        "damage": "1d6",
-                        "damageType": "bleed"
                     }
                 },
                 "description": {
@@ -87,90 +83,6 @@
             "type": "melee"
         },
         {
-            "_id": "TfzCB1uBZW6VihRK",
-            "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "Jaws (Any Shifted Form)",
-            "sort": 300000,
-            "system": {
-                "attack": {
-                    "value": ""
-                },
-                "attackEffects": {
-                    "value": []
-                },
-                "bonus": {
-                    "value": 11
-                },
-                "damageRolls": {
-                    "bwit3qwgfivjf0d6551d": {
-                        "damage": "1d10+4",
-                        "damageType": "piercing"
-                    }
-                },
-                "description": {
-                    "value": ""
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "rarity": "common",
-                    "value": []
-                },
-                "weaponType": {
-                    "value": "melee"
-                }
-            },
-            "type": "melee"
-        },
-        {
-            "_id": "bsayxbcdQrY25nlv",
-            "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "Tail (Snake Tail Form)",
-            "sort": 400000,
-            "system": {
-                "attack": {
-                    "value": ""
-                },
-                "attackEffects": {
-                    "custom": "",
-                    "value": [
-                        "grab"
-                    ]
-                },
-                "bonus": {
-                    "value": 11
-                },
-                "damageRolls": {
-                    "a9kaiq8bdwu5fe0ly3br": {
-                        "damage": "1d8+4",
-                        "damageType": "bludgeoning"
-                    }
-                },
-                "description": {
-                    "value": ""
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "agile",
-                        "reach-10"
-                    ]
-                },
-                "weaponType": {
-                    "value": "melee"
-                }
-            },
-            "type": "melee"
-        },
-        {
             "_id": "0eV2k8OzTFtx9mhc",
             "flags": {
                 "core": {
@@ -179,7 +91,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Darkvision",
-            "sort": 500000,
+            "sort": 300000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -216,7 +128,7 @@
             "_id": "i8xGkDyTBirx7HaW",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Blood Scent",
-            "sort": 600000,
+            "sort": 400000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -250,40 +162,6 @@
             "type": "action"
         },
         {
-            "_id": "fQKe245E7FTwXsm4",
-            "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Crocodile Legs Form: Land Speed 20",
-            "sort": 700000,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "interaction",
-                "description": {
-                    "value": ""
-                },
-                "requirements": {
-                    "value": ""
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "rarity": "common",
-                    "value": []
-                },
-                "trigger": {
-                    "value": ""
-                }
-            },
-            "type": "action"
-        },
-        {
             "_id": "8jmLDBln04iAt8PU",
             "flags": {
                 "core": {
@@ -292,7 +170,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Scent (Imprecise) 100 feet",
-            "sort": 800000,
+            "sort": 500000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -329,7 +207,7 @@
             "_id": "4WwWjUOGDnJncjWj",
             "img": "systems/pf2e/icons/actions/Reaction.webp",
             "name": "Aquatic Opportunity",
-            "sort": 900000,
+            "sort": 600000,
             "system": {
                 "actionType": {
                     "value": "reaction"
@@ -366,7 +244,7 @@
             "_id": "4wMDNNrvnJFAi5UI",
             "img": "systems/pf2e/icons/actions/FreeAction.webp",
             "name": "Blood Frenzy",
-            "sort": 1000000,
+            "sort": 700000,
             "system": {
                 "actionType": {
                     "value": "free"
@@ -376,7 +254,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p><strong>Requirements</strong> The sea devil is not @UUID[Compendium.pf2e.conditionitems.Item.Fatigued] or already in a frenzy</p>\n<p><strong>Trigger</strong> The sea devil deals bleed damage to a living creature.</p>\n<hr />\n<p><strong>Effect</strong> The sea devil flies into a frenzy that lasts 1 minute. While frenzied, the sea devil gains a +1 status bonus to attack rolls with its claws and jaws, gains a +4 status bonus to damage rolls with its claws and jaws, gains 8 temporary HP until the end of the frenzy, and takes a -2 status penalty to AC. The sea devil can't voluntarily stop its frenzy. After its frenzy, the sea devil is @UUID[Compendium.pf2e.conditionitems.Item.Fatigued].</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Item.Effect: Blood Frenzy]</p>"
+                    "value": "<p><strong>Requirements</strong> The bunyip is not @UUID[Compendium.pf2e.conditionitems.Item.Fatigued] or already in a frenzy.</p>\n<p><strong>Trigger</strong> The bunyip deals bleed damage to a living creature.</p>\n<hr />\n<p><strong>Effect</strong> The bunyip flies into a frenzy that lasts 1 minute. While frenzied, the bunyip gains a +4 status bonus to damage rolls with its jaws, gains 8 temporary HP that go away at the end of the frenzy, and takes a -2 penalty to AC.</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Item.Effect: Blood Frenzy]</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -387,42 +265,9 @@
                         "predicate": [
                             "self:effect:blood-frenzy"
                         ],
-                        "selector": "claw-attack",
-                        "type": "status",
-                        "value": 1
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "predicate": [
-                            "self:effect:blood-frenzy"
-                        ],
-                        "selector": "jaws-attack",
-                        "type": "status",
-                        "value": 1
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "predicate": [
-                            "self:effect:blood-frenzy"
-                        ],
-                        "selector": "claw-damage",
-                        "type": "status",
-                        "value": 4
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "predicate": [
-                            "self:effect:blood-frenzy"
-                        ],
                         "selector": "jaws-damage",
                         "type": "status",
                         "value": 4
-                    },
-                    {
-                        "key": "ActiveEffectLike",
-                        "mode": "add",
-                        "path": "system.custom.modifiers.frenzyMod",
-                        "value": 1
                     },
                     {
                         "key": "FlatModifier",
@@ -430,8 +275,13 @@
                             "self:effect:blood-frenzy"
                         ],
                         "selector": "ac",
-                        "type": "status",
                         "value": -2
+                    },
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "add",
+                        "path": "system.custom.modifiers.frenzyMod",
+                        "value": 1
                     }
                 ],
                 "slug": null,
@@ -455,7 +305,7 @@
             "_id": "bdrrSnIH32ERMP25",
             "img": "systems/pf2e/icons/actions/OneAction.webp",
             "name": "Roar",
-            "sort": 1100000,
+            "sort": 800000,
             "system": {
                 "actionType": {
                     "value": "action"
@@ -500,7 +350,7 @@
             "_id": "yFqMLM1iygDqwiZC",
             "img": "systems/pf2e/icons/actions/OneAction.webp",
             "name": "Shift Form",
-            "sort": 1200000,
+            "sort": 900000,
             "system": {
                 "actionType": {
                     "value": "action"
@@ -515,7 +365,66 @@
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "domain": "all",
+                        "key": "RollOption",
+                        "option": "shift-form",
+                        "suboptions": [
+                            {
+                                "label": "PF2E.NPCAbility.Bunyip.SnakeTail",
+                                "value": "snake-tail"
+                            },
+                            {
+                                "label": "PF2E.NPCAbility.Bunyip.CrocodileLegs",
+                                "value": "crocodile-legs"
+                            }
+                        ],
+                        "toggleable": true
+                    },
+                    {
+                        "damageType": "bleed",
+                        "diceNumber": 1,
+                        "dieSize": "d6",
+                        "key": "DamageDice",
+                        "label": "PF2E.Weapon.Base.jaws",
+                        "predicate": [
+                            {
+                                "not": "shift-form"
+                            }
+                        ],
+                        "selector": "jaws-damage"
+                    },
+                    {
+                        "key": "BaseSpeed",
+                        "predicate": [
+                            "shift-form:crocodile-legs"
+                        ],
+                        "selector": "land-speed",
+                        "value": 20
+                    },
+                    {
+                        "definition": [
+                            "item:tail"
+                        ],
+                        "key": "AdjustStrike",
+                        "mode": "add",
+                        "predicate": [
+                            "shift-form:snake-tail"
+                        ],
+                        "property": "weapon-traits",
+                        "value": "reach-10"
+                    },
+                    {
+                        "key": "Note",
+                        "predicate": [
+                            "shift-form:snake-tail"
+                        ],
+                        "selector": "tail-attack",
+                        "text": "<p><strong><span class='pf2-icon'>1</span> @Localize[PF2E.AttackEffectGrab]</strong> ({item|name})</p>@Localize[PF2E.NPC.Abilities.Glossary.Grab]",
+                        "visibility": "owner"
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""
@@ -538,52 +447,10 @@
             "type": "action"
         },
         {
-            "_id": "dyL1ZAlRKdRcNUqz",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.bestiary-ability-glossary-srd.Item.Tkd8sH4pwFIPzqTr"
-                }
-            },
-            "img": "systems/pf2e/icons/actions/OneAction.webp",
-            "name": "Grab",
-            "sort": 1300000,
-            "system": {
-                "actionType": {
-                    "value": "action"
-                },
-                "actions": {
-                    "value": 1
-                },
-                "category": "offensive",
-                "description": {
-                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.Grab]</p>"
-                },
-                "requirements": {
-                    "value": ""
-                },
-                "rules": [],
-                "slug": "grab",
-                "source": {
-                    "value": "Pathfinder Bestiary"
-                },
-                "traits": {
-                    "rarity": "common",
-                    "value": []
-                },
-                "trigger": {
-                    "value": ""
-                },
-                "weapon": {
-                    "value": ""
-                }
-            },
-            "type": "action"
-        },
-        {
             "_id": "5S7tFHxSEP2DWfxo",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Athletics",
-            "sort": 1400000,
+            "sort": 1000000,
             "system": {
                 "description": {
                     "value": ""
@@ -606,7 +473,7 @@
             "_id": "zDy6hDQZdyxphtv7",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Stealth",
-            "sort": 1500000,
+            "sort": 1100000,
             "system": {
                 "description": {
                     "value": ""
@@ -629,7 +496,7 @@
             "_id": "X4HiSkCKkDAysjBE",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Survival",
-            "sort": 1600000,
+            "sort": 1200000,
             "system": {
                 "description": {
                     "value": ""

--- a/packs/pfs-season-2-bestiary/saddleback-bunyip.json
+++ b/packs/pfs-season-2-bestiary/saddleback-bunyip.json
@@ -413,7 +413,7 @@
                             "shift-form:snake-tail"
                         ],
                         "property": "weapon-traits",
-                        "value": "reach-10"
+                        "value": "reach"
                     },
                     {
                         "key": "Note",

--- a/src/scripts/config/traits.ts
+++ b/src/scripts/config/traits.ts
@@ -454,6 +454,7 @@ const weaponTraits = {
     "ranged-trip": "PF2E.TraitRangedTrip",
     razing: "PF2E.TraitRazing",
     reach: "PF2E.TraitReach",
+    "reach-10": "PF2E.TraitReach10",
     recovery: "PF2E.TraitRecovery",
     repeating: "PF2E.TraitRepeating",
     resonant: "PF2E.TraitResonant",

--- a/src/scripts/config/traits.ts
+++ b/src/scripts/config/traits.ts
@@ -454,7 +454,6 @@ const weaponTraits = {
     "ranged-trip": "PF2E.TraitRangedTrip",
     razing: "PF2E.TraitRazing",
     reach: "PF2E.TraitReach",
-    "reach-10": "PF2E.TraitReach10",
     recovery: "PF2E.TraitRecovery",
     repeating: "PF2E.TraitRepeating",
     resonant: "PF2E.TraitResonant",

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -543,6 +543,10 @@
                 "PinpointLight": "Pinpoint Light"
             },
             "BarghestFeed": "How many times has the Barghest fed?",
+            "Bunyip": {
+                "CrocodileLegs": "Crocodile Legs",
+                "SnakeTail": "Snake Tail"
+            },
             "Calikang": {
                 "SixfoldFlurry": "Strikes not taken?",
                 "SuspendedAnimationEnter": "Enter Suspended Animation",


### PR DESCRIPTION
Minor issue is that I couldn't use  GrantItem to grant Compendium.pf2e.bestiary-ability-glossary-srd.Item.Grab, even with "reevaluateOnUpdate": true. Not sure if it's an issue, given that the grab ability is emitted to chat when applicable anyway. If desired, we could just add the ability to the NPCs.

If accepted, "Effect: Crocodile Form" and "Effect: Snake Form" can be added to the migration/deletion list.