### PR TITLE
send item to container from carry-type menu

### DIFF
--- a/src/module/actor/creature/sheet.ts
+++ b/src/module/actor/creature/sheet.ts
@@ -154,6 +154,29 @@ export abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends Act
             carryTypeMenu.addEventListener("click", carryMenuListener);
         }
 
+        // Send to container
+        for (const sendToContainer of htmlQueryAll(html, ".tab.inventory a[data-action=send-to-container]")) {
+            sendToContainer.addEventListener("click", (event) => {
+                if (!(event.currentTarget instanceof HTMLElement)) {
+                    throw ErrorPF2e("Unexpected error retrieving carry-type link");
+                }
+
+                const containerId = event.currentTarget.dataset.containerId;
+                if (!containerId || !this.actor.items.has(containerId)) {
+                    throw ErrorPF2e(`Unexpected error retrieving container with id: ${containerId}`);
+                }
+
+                const itemId = htmlClosest(event.currentTarget, "[data-item-id]")?.dataset.itemId;
+                const item = this.actor.inventory.get(itemId, { strict: true });
+                if (!item) {
+                    throw ErrorPF2e(`Unexpected error retrieving item with id: ${itemId}`);
+                }
+
+                if (item.system.containerId === containerId) return;
+                item.update({ "system.containerId": containerId });
+            });
+        }
+
         // General handler for embedded item updates
         const selectors = "input[data-item-id][data-item-property], select[data-item-id][data-item-property]";
         $html.find(selectors).on("change", (event) => {

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -134,6 +134,7 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
             totalWealthGold,
             inventory: this.prepareInventory(),
             enrichedContent: {},
+            availableContainers: this.actor.itemTypes.backpack.filter((container) => container.isIdentified),
         };
 
         await this.prepareItems?.(sheetData);

--- a/src/module/actor/sheet/data-types.ts
+++ b/src/module/actor/sheet/data-types.ts
@@ -1,7 +1,7 @@
 import { ActorPF2e } from "@actor/base.ts";
 import { ActorSizePF2e } from "@actor/data/size.ts";
 import { InventoryBulk } from "@actor/inventory/index.ts";
-import { PhysicalItemPF2e } from "@item";
+import { ContainerPF2e, PhysicalItemPF2e } from "@item";
 import { Coins } from "@item/physical/data.ts";
 import { PhysicalItemType } from "@item/physical/types.ts";
 import { RollOptionToggle } from "@module/rules/synthetics.ts";
@@ -52,4 +52,5 @@ export interface ActorSheetDataPF2e<TActor extends ActorPF2e> extends ActorSheet
     totalWealthGold: string;
     inventory: SheetInventory;
     enrichedContent: Record<string, string>;
+    availableContainers: ContainerPF2e<TActor>[];
 }

--- a/static/templates/actors/partials/carry-type.hbs
+++ b/static/templates/actors/partials/carry-type.hbs
@@ -43,5 +43,15 @@
             <a class="item-control item-location-option {{#if (eq item.system.equipped.carryType "dropped")}}selected{{/if}}"
                 data-carry-type="dropped"><i class="fas fa-grip-lines"></i>{{localize "PF2E.CarryType.dropped"}}</a>
         </li>
+        {{#each @root.availableContainers as |container|}}
+            {{#if (ne container ../item)}}
+                <li>
+                    <a class="item-control item-location-option {{#if (eq container ../item.container)}}selected{{/if}}" 
+                        data-container-id="{{container.id}}" data-action="send-to-container">
+                        <i class="fas fa-box"></i>{{container.name}}
+                    </a>
+                </li>
+            {{/if}}
+        {{/each}}
     </ul>
 </div>


### PR DESCRIPTION
Sometimes, the number of items on an actor can make drag & drop across the sheet's inventory a bit daunting.

I added the containers inside the carry-type menu making switching to different containers more convenient.

![send](https://github.com/foundryvtt/pf2e/assets/651462/943d2365-0269-4911-8113-a9c73ab69bbc)
