### PR TITLE
Fix strike label in `BattleFormRuleElement`

### DIFF
--- a/src/module/rules/rule-element/battle-form/rule-element.ts
+++ b/src/module/rules/rule-element/battle-form/rule-element.ts
@@ -350,7 +350,7 @@ class BattleFormRuleElement extends RuleElementPF2e<BattleFormRuleSchema> {
         const ruleData = Object.entries(strikes).map(([slug, strikeData]) => ({
             key: "Strike",
             label:
-                game.i18n.localize(strikeData.label ?? "") ??
+                game.i18n.localize(strikeData.label) ??
                 `PF2E.BattleForm.Attack.${sluggify(slug, { camel: "bactrian" })}`,
             slug,
             img: strikeData.img ?? BattleFormRuleElement.defaultIcons[slug] ?? this.item.img,


### PR DESCRIPTION
The label ended up as an empty string when `strikeData.label` is undefined. That was one of the last things I changed and I forgot to test it. 😭 