### PR TITLE
Add a `RecordField` that handles `Record<string, DataField>` data

### DIFF
--- a/src/module/rules/rule-element/battle-form/rule-element.ts
+++ b/src/module/rules/rule-element/battle-form/rule-element.ts
@@ -1,7 +1,7 @@
 import { CharacterPF2e } from "@actor";
 import { CharacterStrike } from "@actor/character/data.ts";
 import { CharacterSkill } from "@actor/character/types.ts";
-import { SENSE_TYPES } from "@actor/creature/sense.ts";
+import { SENSE_ACUITIES, SENSE_TYPES } from "@actor/creature/sense.ts";
 import { ActorType } from "@actor/data/index.ts";
 import { ActorInitiative } from "@actor/initiative.ts";
 import { DiceModifierPF2e, ModifierPF2e, StatisticModifier } from "@actor/modifiers.ts";
@@ -21,6 +21,7 @@ import { StrikeRuleElement } from "../strike.ts";
 import { TempHPRuleElement } from "../temp-hp.ts";
 import { BattleFormSource, BattleFormStrike, BattleFormStrikeQuery } from "./types.ts";
 import { BattleFormRuleOverrideSchema, BattleFormRuleSchema } from "./schema.ts";
+import { RecordField } from "@system/schema-data-fields.ts";
 
 class BattleFormRuleElement extends RuleElementPF2e<BattleFormRuleSchema> {
     /** The label given to modifiers of AC, skills, and strikes */
@@ -57,7 +58,18 @@ class BattleFormRuleElement extends RuleElementPF2e<BattleFormRuleSchema> {
                         { required: false, initial: undefined }
                     ),
                     tempHP: new ResolvableValueField({ required: false, nullable: true, initial: null }),
-                    senses: new fields.ObjectField({ required: false, initial: undefined }),
+                    senses: new RecordField(
+                        new fields.SchemaField({
+                            acuity: new fields.StringField({
+                                choices: SENSE_ACUITIES,
+                                required: false,
+                                blank: false,
+                                initial: undefined,
+                            }),
+                            range: new fields.NumberField({ required: false, nullable: true, initial: undefined }),
+                        }),
+                        { required: false, initial: undefined }
+                    ),
                     size: new fields.StringField({ required: false, blank: false, initial: undefined }),
                     speeds: new fields.ObjectField({ required: false, initial: undefined }),
                     skills: new fields.ObjectField({ required: false, initial: undefined }),

--- a/src/module/rules/rule-element/battle-form/rule-element.ts
+++ b/src/module/rules/rule-element/battle-form/rule-element.ts
@@ -59,7 +59,7 @@ class BattleFormRuleElement extends RuleElementPF2e<BattleFormRuleSchema> {
                     ),
                     tempHP: new ResolvableValueField({ required: false, nullable: true, initial: null }),
                     senses: new RecordField(
-                        new fields.StringField({ required: true, blank: false }),
+                        new fields.StringField({ required: true, blank: false, choices: [...SENSE_TYPES] }),
                         new fields.SchemaField({
                             acuity: new fields.StringField({
                                 choices: SENSE_ACUITIES,

--- a/src/module/rules/rule-element/battle-form/rule-element.ts
+++ b/src/module/rules/rule-element/battle-form/rule-element.ts
@@ -59,6 +59,7 @@ class BattleFormRuleElement extends RuleElementPF2e<BattleFormRuleSchema> {
                     ),
                     tempHP: new ResolvableValueField({ required: false, nullable: true, initial: null }),
                     senses: new RecordField(
+                        new fields.StringField({ required: true, blank: false }),
                         new fields.SchemaField({
                             acuity: new fields.StringField({
                                 choices: SENSE_ACUITIES,

--- a/src/module/rules/rule-element/battle-form/schema.ts
+++ b/src/module/rules/rule-element/battle-form/schema.ts
@@ -38,6 +38,7 @@ type BattleFormRuleOverrideSchema = {
     >;
     tempHP: ResolvableValueField<false, true, true>;
     senses: RecordField<
+        StringField<string, string, true, false, false>,
         SchemaField<OverrideSenseSchema>,
         Record<string, SourcePropFromDataField<SchemaField<OverrideSenseSchema>>>,
         Record<string, ModelPropFromDataField<SchemaField<OverrideSenseSchema>>>,

--- a/src/module/rules/rule-element/battle-form/schema.ts
+++ b/src/module/rules/rule-element/battle-form/schema.ts
@@ -1,11 +1,9 @@
 import type {
     ArrayField,
     BooleanField,
-    ModelPropFromDataField,
     NumberField,
     ObjectField,
     SchemaField,
-    SourcePropFromDataField,
     StringField,
 } from "types/foundry/common/data/fields.d.ts";
 import { ResolvableValueField, RuleElementSchema } from "../data.ts";
@@ -13,7 +11,7 @@ import { RecordField } from "@system/schema-data-fields.ts";
 import { ImmunityRuleElement, ResistanceRuleElement, WeaknessRuleElement } from "../iwr/index.ts";
 import { BattleFormSkills, BattleFormSpeeds, BattleFormStrike } from "./types.ts";
 import { CreatureTrait } from "@actor/creature/index.ts";
-import { SenseAcuity } from "@actor/creature/sense.ts";
+import { SenseAcuity, SenseType } from "@actor/creature/sense.ts";
 
 type OverrideACSchema = {
     modifier: ResolvableValueField<false, false, true>;
@@ -38,10 +36,8 @@ type BattleFormRuleOverrideSchema = {
     >;
     tempHP: ResolvableValueField<false, true, true>;
     senses: RecordField<
-        StringField<string, string, true, false, false>,
+        StringField<SenseType, SenseType, true, false, false>,
         SchemaField<OverrideSenseSchema>,
-        Record<string, SourcePropFromDataField<SchemaField<OverrideSenseSchema>>>,
-        Record<string, ModelPropFromDataField<SchemaField<OverrideSenseSchema>>>,
         false,
         false,
         false

--- a/src/module/rules/rule-element/battle-form/schema.ts
+++ b/src/module/rules/rule-element/battle-form/schema.ts
@@ -1,19 +1,29 @@
 import type {
     ArrayField,
     BooleanField,
+    ModelPropFromDataField,
+    NumberField,
     ObjectField,
     SchemaField,
+    SourcePropFromDataField,
     StringField,
 } from "types/foundry/common/data/fields.d.ts";
 import { ResolvableValueField, RuleElementSchema } from "../data.ts";
+import { RecordField } from "@system/schema-data-fields.ts";
 import { ImmunityRuleElement, ResistanceRuleElement, WeaknessRuleElement } from "../iwr/index.ts";
-import { BattleFormSenses, BattleFormSkills, BattleFormSpeeds, BattleFormStrike } from "./types.ts";
+import { BattleFormSkills, BattleFormSpeeds, BattleFormStrike } from "./types.ts";
 import { CreatureTrait } from "@actor/creature/index.ts";
+import { SenseAcuity } from "@actor/creature/sense.ts";
 
 type OverrideACSchema = {
     modifier: ResolvableValueField<false, false, true>;
     ignoreCheckPenalty: BooleanField<boolean, boolean, false, false, true>;
     ignoreSpeedPenalty: BooleanField<boolean, boolean, false, false, true>;
+};
+
+type OverrideSenseSchema = {
+    acuity: StringField<SenseAcuity, SenseAcuity, false, false, false>;
+    range: NumberField<number, number, false, true, false>;
 };
 
 type BattleFormRuleOverrideSchema = {
@@ -27,7 +37,14 @@ type BattleFormRuleOverrideSchema = {
         false
     >;
     tempHP: ResolvableValueField<false, true, true>;
-    senses: ObjectField<BattleFormSenses, BattleFormSenses, false, false, false>;
+    senses: RecordField<
+        SchemaField<OverrideSenseSchema>,
+        Record<string, SourcePropFromDataField<SchemaField<OverrideSenseSchema>>>,
+        Record<string, ModelPropFromDataField<SchemaField<OverrideSenseSchema>>>,
+        false,
+        false,
+        false
+    >;
     size: StringField<string, string, false, true, false>;
     speeds: ObjectField<BattleFormSpeeds, BattleFormSpeeds, false, false, false>;
     skills: ObjectField<BattleFormSkills, BattleFormSkills, false, false, false>;

--- a/types/foundry/common/data/fields.d.ts
+++ b/types/foundry/common/data/fields.d.ts
@@ -462,11 +462,18 @@ export class ObjectField<
 
     protected override _cast(value: unknown): TSourceProp;
 
-    override initialize(value: unknown): MaybeSchemaProp<TModelProp, TRequired, TNullable, THasInitial>;
+    override initialize(
+        value: unknown,
+        model?: ConstructorOf<DataModel>,
+        options?: ObjectFieldOptions<TSourceProp, TRequired, TNullable, THasInitial>
+    ): MaybeSchemaProp<TModelProp, TRequired, TNullable, THasInitial>;
 
     override toObject(value: TModelProp): MaybeSchemaProp<TSourceProp, TRequired, TNullable, THasInitial>;
 
-    protected override _validateType(value: unknown): boolean | void;
+    protected override _validateType(
+        value: unknown,
+        options?: DataFieldValidationOptions
+    ): DataModelValidationFailure | boolean | void;
 }
 
 export type FlagField<

--- a/types/foundry/common/data/fields.d.ts
+++ b/types/foundry/common/data/fields.d.ts
@@ -208,6 +208,16 @@ export abstract class DataField<
         options?: DataFieldValidationOptions
     ): boolean | DataModelValidationFailure | void;
 
+    /**
+     * Certain fields may declare joint data validation criteria.
+     * This method will only be called if the field is designated as recursive.
+     * @param data       Candidate data for joint model validation
+     * @param options    Options which modify joint model validation
+     * @throws  An error if joint model validation fails
+     * @internal
+     */
+    _validateModel(data: Record<string, unknown>, options?: Record<string, unknown>): void;
+
     /* -------------------------------------------- */
     /*  Initialization and Serialization            */
     /* -------------------------------------------- */

--- a/types/foundry/common/data/fields.d.ts
+++ b/types/foundry/common/data/fields.d.ts
@@ -101,6 +101,16 @@ export abstract class DataField<
      */
     parent: DataSchema | undefined;
 
+    /** Whether this field defines part of a Document/Embedded Document hierarchy. */
+    static hierarchical: boolean;
+
+    /**
+     * Does this field type contain other fields in a recursive structure?
+     * Examples of recursive fields are SchemaField, ArrayField, or TypeDataField
+     * Examples of non-recursive fields are StringField, NumberField, or ObjectField
+     */
+    static recursive: boolean;
+
     /** Default parameters for this field type */
     protected static get _defaults(): DataFieldOptions<unknown, boolean, boolean, boolean>;
 
@@ -189,10 +199,14 @@ export abstract class DataField<
      * A default type-specific validator that can be overridden by child classes
      * @param value The candidate value
      * @param [options={}] Options which affect validation behavior
-     * @returns A boolean to indicate with certainty whether the value is valid. Otherwise, return void.
+     * @returns A boolean to indicate with certainty whether the value is valid, or specific DataModelValidationFailure
+     *          information, otherwise void.
      * @throws May throw a specific error if the value is not valid
      */
-    protected _validateType(value: unknown, options?: Record<string, unknown>): boolean | void;
+    protected _validateType(
+        value: unknown,
+        options?: DataFieldValidationOptions
+    ): boolean | DataModelValidationFailure | void;
 
     /* -------------------------------------------- */
     /*  Initialization and Serialization            */

--- a/types/foundry/common/data/validation-failure.d.ts
+++ b/types/foundry/common/data/validation-failure.d.ts
@@ -13,7 +13,7 @@ export class DataModelValidationFailure {
         dropped,
         message,
         unresolved,
-    }: {
+    }?: {
         invalidValue?: unknown;
         fallback?: unknown;
         dropped?: boolean;


### PR DESCRIPTION
Includes a sample implementation in the battle form rule element.

Validation error:

![validation-error](https://github.com/foundryvtt/pf2e/assets/41452412/69b149cc-b140-42df-8b31-81d1ec6688df)

`keys` option set to `["test"]`:

![key-error](https://github.com/foundryvtt/pf2e/assets/41452412/50c212be-01c3-4757-97ad-10788cff0931)
