### PR TITLE
Fix cast time of Thoughtful Gift

### DIFF
--- a/packs/spells/thoughtful-gift.json
+++ b/packs/spells/thoughtful-gift.json
@@ -83,7 +83,7 @@
             "value": "1 willing creature"
         },
         "time": {
-            "value": "1"
+            "value": "1 to 3"
         },
         "traditions": {
             "value": [

--- a/packs/spells/thoughtful-gift.json
+++ b/packs/spells/thoughtful-gift.json
@@ -83,7 +83,7 @@
             "value": "1 willing creature"
         },
         "time": {
-            "value": "1 (up to 3 if heightened)"
+            "value": "1"
         },
         "traditions": {
             "value": [


### PR DESCRIPTION
"Thoughtful Gift" gains the Exploration trait when cast, as its cast time of "1 (up to 3 if heightened)" is treated as unstructured.
~~Changed to 1 action to match the PDF.~~
Changed to "1 to 3".