### PR TITLE
Refrain from recording timestamps on migration records

### DIFF
--- a/src/module/data.ts
+++ b/src/module/data.ts
@@ -73,7 +73,6 @@ interface NewDocumentSchemaRecord {
 interface MigratedDocumentSchemaRecord {
     version: number;
     lastMigration: {
-        datetime: string | null;
         version: {
             schema: number | null;
             system?: string;

--- a/src/module/migration/runner/base.ts
+++ b/src/module/migration/runner/base.ts
@@ -4,7 +4,6 @@ import { DocumentSchemaRecord } from "@module/data.ts";
 import { MigrationBase } from "@module/migration/base.ts";
 import { ScenePF2e } from "@scene/document.ts";
 import { TokenDocumentPF2e } from "@scene/token-document/document.ts";
-import { DateTime } from "luxon";
 
 interface CollectionDiff<T extends foundry.documents.ActiveEffectSource | ItemSourcePF2e> {
     inserted: T[];
@@ -209,7 +208,6 @@ export class MigrationRunnerBase {
         const fromVersion = typeof schema.version === "number" ? schema.version : null;
         schema.version = latestMigration.version;
         schema.lastMigration = {
-            datetime: DateTime.now().toISO(),
             version: {
                 schema: fromVersion,
                 foundry: "game" in globalThis ? game.version : undefined,

--- a/src/module/migration/runner/index.ts
+++ b/src/module/migration/runner/index.ts
@@ -300,10 +300,12 @@ export class MigrationRunner extends MigrationRunnerBase {
                 const wasSuccessful = !!(await this.#migrateSceneToken(token, migrations));
                 if (!wasSuccessful) continue;
 
-                // Only migrate if the synthetic actor has replaced migratable data
+                // Only migrate if the delta of the synthetic actor has migratable data
+                const deltaSource = token.delta?._source;
                 const hasMigratableData =
-                    !!token._source.delta?.flags?.pf2e ||
-                    Object.keys(token._source.delta ?? {}).some((k) => ["items", "system"].includes(k));
+                    (!!deltaSource && !!deltaSource.flags?.pf2e) ||
+                    ((deltaSource ?? {}).items ?? []).length > 0 ||
+                    Object.keys(deltaSource?.system ?? {}).length > 0;
 
                 if (actor.isToken) {
                     if (hasMigratableData) {
@@ -316,7 +318,7 @@ export class MigrationRunner extends MigrationRunnerBase {
                             }
                         }
                     }
-                    progress.advance({ by: 1 });
+                    progress.advance();
                 }
             }
         }


### PR DESCRIPTION
This is unfortunately causing deltas to bloat due to timestamps having differences of milliseconds