### PR TITLE
Bump max domains settable from deity sheet to 6

### DIFF
--- a/src/module/item/deity/document.ts
+++ b/src/module/item/deity/document.ts
@@ -3,7 +3,7 @@ import { Alignment } from "@actor/creature/types.ts";
 import { ALIGNMENTS } from "@actor/creature/values.ts";
 import { ItemPF2e } from "@item";
 import { BaseWeaponType } from "@item/weapon/types.ts";
-import { sluggify } from "@util";
+import { objectHasKey, sluggify } from "@util";
 import { DeitySource, DeitySystemData } from "./data.ts";
 
 class DeityPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends ItemPF2e<TParent> {
@@ -52,6 +52,12 @@ class DeityPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
         for (const domain of this.system.domains.primary) {
             const label = CONFIG.PF2E.deityDomains[domain]?.label;
             deities.domains[domain] = label ?? domain;
+            // Add the apocryphal variant if there is one
+            const apocryphaKey = `${domain}-apocryphal`;
+            if (objectHasKey(CONFIG.PF2E.deityDomains, apocryphaKey)) {
+                const apocrypha = CONFIG.PF2E.deityDomains[apocryphaKey];
+                deities.domains[apocryphaKey] = apocrypha.label;
+            }
         }
 
         // Set some character roll options

--- a/src/module/item/deity/sheet.ts
+++ b/src/module/item/deity/sheet.ts
@@ -3,9 +3,10 @@ import { Alignment } from "@actor/creature/types.ts";
 import { DeityPF2e, ItemPF2e, SpellPF2e } from "@item";
 import { ItemSheetPF2e } from "@item/sheet/base.ts";
 import { ItemSheetDataPF2e } from "@item/sheet/data-types.ts";
-import { createSheetOptions, SheetOptions } from "@module/sheet/helpers.ts";
+import { SheetOptions, createSheetOptions } from "@module/sheet/helpers.ts";
 import { ErrorPF2e, htmlClosest, htmlQuery, htmlQueryAll, tagify } from "@util";
 import { UUIDUtils } from "@util/uuid.ts";
+import * as R from "remeda";
 
 export class DeitySheetPF2e extends ItemSheetPF2e<DeityPF2e> {
     static override get defaultOptions(): DocumentSheetOptions {
@@ -61,8 +62,10 @@ export class DeitySheetPF2e extends ItemSheetPF2e<DeityPF2e> {
         if (this.item.category === "philosophy") return;
 
         tagify(getInput("system.weapons"), { whitelist: CONFIG.PF2E.baseWeaponTypes, maxTags: 2 });
-        tagify(getInput("system.domains.primary"), { whitelist: CONFIG.PF2E.deityDomains, maxTags: 4 });
-        tagify(getInput("system.domains.alternate"), { whitelist: CONFIG.PF2E.deityDomains, maxTags: 4 });
+
+        const domainWhitelist = R.omitBy(CONFIG.PF2E.deityDomains, (_v, k) => k.endsWith("-apocryphal"));
+        tagify(getInput("system.domains.primary"), { whitelist: domainWhitelist, maxTags: 6 });
+        tagify(getInput("system.domains.alternate"), { whitelist: domainWhitelist, maxTags: 6 });
 
         const clericSpells = htmlQuery(html, ".cleric-spells");
         if (!clericSpells) return;


### PR DESCRIPTION
Also exclude apocryphal domains from list but then include as selectable for feats like Domain Initiate

![Screenshot from 2023-06-27 02-26-34](https://github.com/foundryvtt/pf2e/assets/106829671/fb6af30f-4c31-414d-a7cc-d50263c228e3)
