### PR TITLE
Automate Ofalth aura

### DIFF
--- a/packs/pathfinder-bestiary/ofalth.json
+++ b/packs/pathfinder-bestiary/ofalth.json
@@ -257,12 +257,19 @@
                 },
                 "rules": [
                     {
+                        "effects": [
+                            {
+                                "affects": "all",
+                                "events": [
+                                    "enter"
+                                ],
+                                "includesSelf": false,
+                                "uuid": "Compendium.pf2e.bestiary-effects.Item.Effect: Stench"
+                            }
+                        ],
                         "key": "Aura",
                         "radius": 30,
-                        "slug": "putrid-stench",
-                        "traits": [
-                            "aura"
-                        ]
+                        "slug": "putrid-stench"
                     }
                 ],
                 "slug": null,


### PR DESCRIPTION
The effect should apply to all creatures in the aura, also this thing is missing the olfactory trait and I'm tempted to correct that glaring Paizo omission.