### PR TITLE
Open inventory tab for party members on inventory tab

### DIFF
--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -34,7 +34,13 @@ import {
     tupleHasValue,
 } from "@util";
 import { ActorSizePF2e } from "../data/size.ts";
-import { ActorSheetDataPF2e, CoinageSummary, InventoryItem, SheetInventory } from "./data-types.ts";
+import {
+    ActorSheetDataPF2e,
+    ActorSheetRenderOptionsPF2e,
+    CoinageSummary,
+    InventoryItem,
+    SheetInventory,
+} from "./data-types.ts";
 import { ItemSummaryRenderer } from "./item-summary-renderer.ts";
 import { MoveLootPopup } from "./loot/move-loot-popup.ts";
 import { AddCoinsPopup } from "./popups/add-coins-popup.ts";
@@ -1349,8 +1355,11 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
     }
 
     /** Overriden _render to maintain focus on tagify elements */
-    protected override async _render(force?: boolean, options?: RenderOptions): Promise<void> {
+    protected override async _render(force?: boolean, options?: ActorSheetRenderOptionsPF2e): Promise<void> {
         await maintainTagifyFocusInRender(this, () => super._render(force, options));
+        if (options?.tab) {
+            this._tabs[0].activate(options.tab);
+        }
     }
 
     /** Tagify sets an empty input field to "" instead of "[]", which later causes the JSON parse to throw an error */

--- a/src/module/actor/sheet/data-types.ts
+++ b/src/module/actor/sheet/data-types.ts
@@ -54,3 +54,8 @@ export interface ActorSheetDataPF2e<TActor extends ActorPF2e> extends ActorSheet
     inventory: SheetInventory;
     enrichedContent: Record<string, string>;
 }
+
+export interface ActorSheetRenderOptionsPF2e extends RenderOptions {
+    /** What tab to switch to when rendering the sheet */
+    tab?: string;
+}

--- a/src/styles/actor/_nav.scss
+++ b/src/styles/actor/_nav.scss
@@ -94,7 +94,7 @@ nav.sub-nav {
     background-color: var(--bg);
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.18);
     width: 100%;
-    flex: 0 0 44px;
+    flex: 0 0 2.5rem;
 
     &::before, &::after {
         content: "";

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -321,6 +321,10 @@
                 "Languages": "Party Languages",
                 "MembersLabel": "Members: ",
                 "NoSpecialSenses": "No Special Senses",
+                "RemoveMember": {
+                    "Title": "Remove Member",
+                    "Content": "Remove member from party?"
+                },
                 "Tabs": {
                     "Overview": "Overview",
                     "Inventory": "Inventory",

--- a/static/templates/actors/party/regions/inventory-members.hbs
+++ b/static/templates/actors/party/regions/inventory-members.hbs
@@ -18,7 +18,7 @@
         </li>
         {{#each members as |member|}}
             <li class="box">
-                <div class="actor-link content" data-actor-uuid="{{member.actor.uuid}}" data-action="open-sheet">
+                <div class="actor-link content" data-actor-uuid="{{member.actor.uuid}}" data-action="open-sheet" data-tab="inventory">
                     <img src="{{member.actor.img}}" />
                     <span class="name">{{member.actor.name}}</span>
                     <span class="value">


### PR DESCRIPTION
On the inventory tab of the party, open the inventory tab of the character.

I could move the implementation to an openTab() function on the character sheet that can be overriden to handle sub tabs (will be useful for exploration) but I'll get to that when it comes time to get to that.

render() is not an async function, so this isn't something we can do from the party sheet without resorting to hooks.