### PR TITLE
Remove token redraws in canvasReady hook

### DIFF
--- a/src/scripts/hooks/canvas-ready.ts
+++ b/src/scripts/hooks/canvas-ready.ts
@@ -22,23 +22,6 @@ export const CanvasReady = {
                 // Accomodate hex grid play with a usable default cone angle
                 CONFIG.MeasuredTemplate.defaults.angle = canvas.scene.hasHexGrid ? 60 : 90;
             }
-
-            // Redraw tokens
-            for (const token of canvas.tokens.placeables) {
-                const redrawTrigger = token.isVideo
-                    ? new Promise((resolve) => {
-                          // Wait until 50ms after the video starts playing to be safe - sometimes they'll still be
-                          // invisible if drawn immediately after they begin playing
-                          token.sourceElement.addEventListener("play", () => setTimeout(resolve, 50), { once: true });
-                      })
-                    : Promise.resolve();
-
-                redrawTrigger.then(async () => {
-                    const { visible } = token;
-                    await token.draw();
-                    token.visible = visible;
-                });
-            }
         });
     },
 };


### PR DESCRIPTION
It _seems_ this is no longer needed in V11.