### PR TITLE
Add metagame setting to restrict party ally visibility

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -186,6 +186,7 @@ declare global {
         get(module: "pf2e", setting: "metagame_secretDamage"): boolean;
         get(module: "pf2e", setting: "metagame_showDC"): boolean;
         get(module: "pf2e", setting: "metagame_showResults"): boolean;
+        get(module: "pf2e", setting: "metagame_showPartyStats"): boolean;
         get(module: "pf2e", setting: "metagame_tokenSetsNameVisibility"): boolean;
 
         get(module: "pf2e", setting: "tokens.autoscale"): boolean;

--- a/src/module/actor/party/document.ts
+++ b/src/module/actor/party/document.ts
@@ -146,7 +146,7 @@ class PartyPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
     private _resetAndRerenderDebounced = foundry.utils.debounce(() => {
         super.reset();
         this.sheet.render(false, { actor: true } as PartySheetRenderOptions);
-    }, 500);
+    }, 50);
 
     protected override async _preUpdate(
         changed: DeepPartial<PartySource>,

--- a/src/module/actor/party/types.ts
+++ b/src/module/actor/party/types.ts
@@ -1,47 +1,9 @@
-import { ActorPF2e } from "@actor";
 import { ActorUpdateContext } from "@actor/base.ts";
-import { ActorSheetDataPF2e } from "@actor/sheet/data-types.ts";
-import { ItemPF2e } from "@item";
 import { ItemType } from "@item/data/index.ts";
-import { Bulk } from "@item/physical/bulk.ts";
-import { ValueAndMax, ZeroToFour } from "@module/data.ts";
 import { TokenDocumentPF2e } from "@scene";
 import type DataModel from "types/foundry/common/abstract/data.d.ts";
 import { PartyPF2e } from "./document.ts";
 import { Statistic } from "@system/statistic/index.ts";
-
-interface PartySheetData extends ActorSheetDataPF2e<PartyPF2e> {
-    members: MemberBreakdown[];
-    languages: LanguageSheetData[];
-    inventorySummary: {
-        totalCoins: number;
-        totalWealth: number;
-        totalBulk: Bulk;
-    };
-    /** Unsupported items on the sheet, may occur due to disabled campaign data */
-    orphaned: ItemPF2e[];
-}
-
-interface SkillData {
-    slug: string;
-    label: string;
-    mod: number;
-    rank?: ZeroToFour | null;
-}
-
-interface MemberBreakdown {
-    actor: ActorPF2e;
-    heroPoints: ValueAndMax | null;
-    hasBulk: boolean;
-    bestSkills: SkillData[];
-    senses: { label: string | null; labelFull: string; acuity?: string }[];
-}
-
-interface LanguageSheetData {
-    slug: string;
-    label: string;
-    actors: ActorPF2e[];
-}
 
 interface PartyUpdateContext<TParent extends TokenDocumentPF2e | null> extends ActorUpdateContext<TParent> {
     removedMembers?: string[];
@@ -59,4 +21,4 @@ interface PartyCampaign extends DataModel<PartyPF2e, {}> {
     getStatistic?(slug: string): Statistic | null;
 }
 
-export { LanguageSheetData, MemberBreakdown, PartyCampaign, PartySheetData, PartyUpdateContext };
+export { PartyCampaign, PartyUpdateContext };

--- a/src/module/system/settings/metagame.ts
+++ b/src/module/system/settings/metagame.ts
@@ -1,3 +1,4 @@
+import { resetActors } from "@actor/helpers.ts";
 import { SettingsMenuPF2e } from "./menu.ts";
 
 const MetagameSettingsConfig = {
@@ -12,6 +13,16 @@ const MetagameSettingsConfig = {
         hint: "PF2E.SETTINGS.Metagame.ShowResults.Hint",
         default: true,
         type: Boolean,
+    },
+    showPartyStats: {
+        name: "PF2E.SETTINGS.Metagame.ShowPartyStats.Name",
+        hint: "PF2E.SETTINGS.Metagame.ShowPartyStats.Hint",
+        config: BUILD_MODE === "development" || game.actors.some((a) => a.isOfType("party")),
+        default: true,
+        type: Boolean,
+        onChange: () => {
+            resetActors(game.actors.filter((a) => a.isOfType("party")));
+        },
     },
     tokenSetsNameVisibility: {
         name: "PF2E.SETTINGS.Metagame.TokenSetsNameVisibility.Name",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2849,6 +2849,10 @@
                     "Hint": "If enabled, players will see the degree of success of checks made against NPCs and other non-player-owned sources.",
                     "Name": "Show results on attacks and saves"
                 },
+                "ShowPartyStats": {
+                    "Hint": "If enabled, players will see stats for their fellow party members in the party actor sheet",
+                    "Name": "Show Party Member Stats"
+                },
                 "TokenSetsNameVisibility": {
                     "Hint": "If enabled, then for any NPC token whose nameplate isn't visible to players, its name will also be hidden from them in the encounter tracker and chat messages.",
                     "Name": "Tokens determine NPC name visibility"

--- a/static/templates/actors/party/regions/inventory-members.hbs
+++ b/static/templates/actors/party/regions/inventory-members.hbs
@@ -1,34 +1,40 @@
 {{#if members}}
     <ol class="inventory-members">
-        <li class="box summary">
-            <header>{{localize "PF2E.Actor.Party.Total"}}</header>
-            <div class="summary-data">
-                <div>
-                    <label><i class="fa-solid fa-coins fa-fw"></i> {{localize "PF2E.Actor.Party.Coin"}}</label>
-                    <span class="value">{{numberFormat inventorySummary.totalCoins decimals=2}} gp</span>
+        {{#unless restricted}}
+            <li class="box summary">
+                <header>{{localize "PF2E.Actor.Party.Total"}}</header>
+                <div class="summary-data">
+                    <div>
+                        <label><i class="fa-solid fa-coins fa-fw"></i> {{localize "PF2E.Actor.Party.Coin"}}</label>
+                        <span class="value">{{numberFormat inventorySummary.totalCoins decimals=2}} gp</span>
+                    </div>
+                    <div>
+                        <label><i class="fa-solid fa-scale-unbalanced fa-fw"></i> {{localize "PF2E.Actor.Party.Wealth"}}</label>
+                        <span class="value">{{numberFormat inventorySummary.totalWealth decimals=2}} gp</span>
+                    </div>
                 </div>
-                <div>
-                    <label><i class="fa-solid fa-scale-unbalanced fa-fw"></i> {{localize "PF2E.Actor.Party.Wealth"}}</label>
-                    <span class="value">{{numberFormat inventorySummary.totalWealth decimals=2}} gp</span>
-                </div>
-            </div>
-            <footer>
-                <i class="fa-solid fa-weight-hanging"></i> {{localize "PF2E.BulkShortLabel"}} {{inventorySummary.totalBulk}}
-            </footer>
-        </li>
+                <footer>
+                    <i class="fa-solid fa-weight-hanging"></i> {{localize "PF2E.BulkShortLabel"}} {{inventorySummary.totalBulk}}
+                </footer>
+            </li>
+        {{/unless}}
         {{#each members as |member|}}
             <li class="box">
                 <div class="actor-link content" data-actor-uuid="{{member.actor.uuid}}" data-action="open-sheet" data-tab="inventory">
                     <img src="{{member.actor.img}}" />
                     <span class="name">{{member.actor.name}}</span>
-                    <span class="value">
-                        <i class="fa-solid fa-scale-unbalanced"></i>
-                        {{numberFormat member.actor.inventory.totalWealth.goldValue decimals=2}} gp
-                    </span>
+                    {{#unless member.restricted}}
+                        <span class="value">
+                            <i class="fa-solid fa-scale-unbalanced"></i>
+                            {{numberFormat member.actor.inventory.totalWealth.goldValue decimals=2}} gp
+                        </span>
+                    {{/unless}}
                 </div>
-                <footer>
-                    <i class="fa-solid fa-weight-hanging"></i> {{localize "PF2E.BulkShortLabel"}} {{member.actor.inventory.bulk.value}}
-                </footer>
+                {{#unless member.restricted}}
+                    <footer>
+                        <i class="fa-solid fa-weight-hanging"></i> {{localize "PF2E.BulkShortLabel"}} {{member.actor.inventory.bulk.value}}
+                    </footer>
+                {{/unless}}
             </li>
         {{/each}}
     </ol>

--- a/static/templates/actors/party/sheet.hbs
+++ b/static/templates/actors/party/sheet.hbs
@@ -14,7 +14,9 @@
     </header>
 
     <nav class="sub-nav">
+        {{#unless restricted}}
         <a data-tab="overview">{{localize "PF2E.Actor.Party.Tabs.Overview"}}</a>
+        {{/unless}}
         <a data-tab="inventory">{{localize "PF2E.Actor.Party.Tabs.Inventory"}}</a>
         {{#if orphaned}}
             <a data-tab="orphaned">{{localize "PF2E.Actor.Party.Tabs.Orphaned"}}</a>
@@ -22,8 +24,9 @@
     </nav>
 
     <section class="container">
-        <div class="tab" data-tab="overview" data-region="overview">
-        </div>
+        {{#unless restricted}}
+            <div class="tab" data-tab="overview" data-region="overview"></div>
+        {{/unless}}
 
         <div class="tab" data-tab="inventory">
             <aside class="sidebar">


### PR DESCRIPTION
I'll address the misalignment on the inventory boxes once exploration is in. The core styling is getting some tweaks and shuffling.

![image](https://github.com/foundryvtt/pf2e/assets/1286721/f9614443-f7a9-4bac-b1e9-f0735293f26a)
