### PR TITLE
Remove "light overflow" from encumbrance bar on PC sheet

### DIFF
--- a/src/module/actor/inventory/bulk.ts
+++ b/src/module/actor/inventory/bulk.ts
@@ -60,7 +60,7 @@ export class InventoryBulk {
     }
 
     static computeTotalBulk(items: PhysicalItemPF2e[], actorSize: Size): Bulk {
-        items = this.flattenNonStowing(items);
+        items = this.#flattenNonStowing(items);
 
         // Figure out which items have stack groups and which don't
         const nonStackingItems = items.filter(
@@ -92,11 +92,11 @@ export class InventoryBulk {
     }
 
     /** Non-stowing containers are not "real" and thus shouldn't split stack groups */
-    private static flattenNonStowing(items: PhysicalItemPF2e[]): PhysicalItemPF2e[] {
+    static #flattenNonStowing(items: PhysicalItemPF2e[]): PhysicalItemPF2e[] {
         return items
             .map((item) => {
                 if (item.isOfType("backpack") && !item.stowsItems) {
-                    return this.flattenNonStowing(item.contents.contents);
+                    return this.#flattenNonStowing(item.contents.contents);
                 }
                 return item;
             })

--- a/src/module/item/physical/bulk.ts
+++ b/src/module/item/physical/bulk.ts
@@ -143,18 +143,18 @@ export class Bulk {
     toString(): string {
         const { light, normal } = this;
         if (normal === 0 && light === 0) {
-            return "-";
+            return game.i18n.localize("PF2E.Item.Physical.Bulk.Negligible");
         }
         if (normal > 0 && light === 0) {
-            return `${normal}`;
+            return normal.toString();
         }
         if (light === 1 && normal === 0) {
-            return `L`;
+            return game.i18n.localize("PF2E.Item.Physical.Bulk.Light");
         }
         if (light > 0 && normal === 0) {
-            return `${light}L`;
+            return game.i18n.format("PF2E.Item.Physical.Bulk.NLight", { light });
         }
-        return `${normal}; ${light}L`;
+        return game.i18n.format("PF2E.Item.Physical.Bulk.WithLight", { bulk: normal, light });
     }
 
     double(): Bulk {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1876,6 +1876,12 @@
             "NameLabel": "Name",
             "Physical": {
                 "Broken": "Broken",
+                "Bulk": {
+                    "Light": "L",
+                    "Negligible": "—",
+                    "NLight": "{light}L",
+                    "WithLight": "{bulk}, {light}L"
+                },
                 "Destroyed": "Destroyed",
                 "FromSpell": {
                     "CantripDeck5": "Cantrip Deck of {name} (5-pack)",

--- a/static/templates/actors/character/tabs/inventory.hbs
+++ b/static/templates/actors/character/tabs/inventory.hbs
@@ -2,15 +2,14 @@
     {{> "systems/pf2e/templates/actors/partials/coinage.hbs"}}
     {{> "systems/pf2e/templates/actors/partials/inventory.hbs"}}
 
-    {{#with inventory.bulk}}
-        <div class="encumbrance {{#if isEncumbered}}encumbered{{/if}} {{#if isOverMax}}over-limit{{/if}}">
+    {{#with inventory.bulk as |bulk|}}
+        <div class="encumbrance {{#if bulk.isEncumbered}}encumbered{{/if}} {{#if bulk.isOverMax}}over-limit{{/if}}">
             <img src="systems/pf2e/icons/equipment/adventuring-gear/backpack.webp" alt="Encumbrance">
-            <span class="encumbrance-bar" style="width:{{maxPercentageInteger}}%"></span>
+            <span class="encumbrance-bar" style="width:{{bulk.maxPercentageInteger}}%"></span>
             <div class="encumbrance-label">
-                <span>{{localize "PF2E.BulkLabel"}} {{value}} / {{localize "PF2E.ConditionTypeEncumbered"}}: {{encumberedAt}}</span>
-                <span>{{localize "PF2E.BulkMaxLabel"}}: {{max}}</span>
+                <span>{{localize "PF2E.BulkLabel"}}: {{bulk.value}} / {{localize "PF2E.ConditionTypeEncumbered"}}: {{bulk.encumberedAt}}</span>
+                <span>{{localize "PF2E.BulkMaxLabel"}}: {{bulk.max}}</span>
             </div>
-            <div class="encumbrance-light-bulk-overflow">+ ({{value.light}}/10) {{localize "PF2E.BulkTypeLight"}}</div>
             <span class="bar-bg"></span>
         </div>
     {{/with}}


### PR DESCRIPTION
Also improve localization

This information is redundant in the encumbrance display, and I've seen two users confused by it within a few days of each other.

Before:
![image](https://github.com/foundryvtt/pf2e/assets/106829671/927e7f46-b687-4d27-994f-10efa64c887c)

After:
![image](https://github.com/foundryvtt/pf2e/assets/106829671/aaf69822-eeb6-485f-9df2-7575af39515d)

