### PR TITLE
Move token re-renders from actor updates to new designated location

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -1832,21 +1832,10 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
     }
 
     protected override _onEmbeddedDocumentChange(embeddedName: "Item" | "ActiveEffect"): void {
+        super._onEmbeddedDocumentChange(embeddedName);
+
         // Send any accrued warnings to the console
         this.synthetics.preparationWarnings.flush();
-
-        if (this.isToken) {
-            return super._onEmbeddedDocumentChange(embeddedName);
-        } else if (game.combat?.getCombatantByActor(this.id)) {
-            // Needs to be done since `super._onEmbeddedDocumentChange` isn't called
-            ui.combat.render();
-        }
-
-        // For linked tokens, replace parent method with alternative workflow to control canvas re-rendering
-        const tokenDocs = this.getActiveTokens(true, true);
-        for (const tokenDoc of tokenDocs) {
-            tokenDoc.onActorEmbeddedItemChange();
-        }
     }
 }
 

--- a/src/scripts/hooks/canvas-ready.ts
+++ b/src/scripts/hooks/canvas-ready.ts
@@ -21,6 +21,10 @@ export const CanvasReady = {
                 if (game.ready) canvas.scene.reset();
                 // Accomodate hex grid play with a usable default cone angle
                 CONFIG.MeasuredTemplate.defaults.angle = canvas.scene.hasHexGrid ? 60 : 90;
+
+                for (const token of canvas.tokens.placeables.filter((t) => t.visible)) {
+                    token.renderFlags.set({ redrawEffects: true });
+                }
             }
         });
     },

--- a/types/foundry/client/data/documents/token-document.d.ts
+++ b/types/foundry/client/data/documents/token-document.d.ts
@@ -110,8 +110,12 @@ declare global {
             userId: string
         ): void;
 
-        /** When the base Actor for a TokenDocument changes, we may need to update its Actor instance */
-        _onUpdateBaseActor(update?: Record<string, unknown>, options?: DocumentModificationContext<null>): void;
+        /**
+         * Whenever the token's actor delta changes, or the base actor changes, perform associated refreshes.
+         * @param [update]  The update delta.
+         * @param [options] The options provided to the update.
+         */
+        protected _onRelatedUpdate(update?: Record<string, unknown>, options?: DocumentModificationContext<null>): void;
 
         /** Get an Array of attribute choices which could be tracked for Actors in the Combat Tracker */
         static getTrackedAttributes(data?: object, _path?: string[]): TrackedAttributesDescription;


### PR DESCRIPTION
V11 made it possible to trim down and consolidate system handling of token re-renders from actor updates