### PR TITLE
Include actor roll data in item roll data

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -1618,7 +1618,7 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
     /** This allows @actor.level and such to work for macros and inline rolls */
     override getRollData(): NonNullable<EnrichHTMLOptionsPF2e["rollData"]> {
         const rollData = { actor: this };
-        for (const prop of ["details", "attributes", "skills", "saves"] as const) {
+        for (const prop of ["abilities", "attributes", "details", "skills", "saves"] as const) {
             Object.defineProperty(rollData, prop, {
                 get: () => {
                     foundry.utils.logCompatibilityWarning(`@${prop} is deprecated`, {

--- a/src/module/actor/party/document.ts
+++ b/src/module/actor/party/document.ts
@@ -3,6 +3,7 @@ import { ItemType } from "@item/data/index.ts";
 import { UserPF2e } from "@module/documents.ts";
 import { CombatantPF2e, EncounterPF2e } from "@module/encounter/index.ts";
 import { TokenDocumentPF2e } from "@scene/index.ts";
+import { Statistic } from "@system/statistic/index.ts";
 import { sortBy, tupleHasValue } from "@util";
 import { DataModelValidationOptions } from "types/foundry/common/abstract/data.js";
 import { MemberData, PartySource, PartySystemData } from "./data.ts";
@@ -10,7 +11,6 @@ import { InvalidCampaign } from "./invalid-campaign.ts";
 import { Kingdom } from "./kingdom/index.ts";
 import { PartySheetRenderOptions } from "./sheet.ts";
 import { PartyCampaign, PartyUpdateContext } from "./types.ts";
-import { Statistic } from "@system/statistic/index.ts";
 
 class PartyPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | null> extends ActorPF2e<TParent> {
     override armorClass = null;
@@ -122,6 +122,10 @@ class PartyPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
         const promises = this.members.map((a) => CombatantPF2e.fromActor(a, true, { combat: options.combat }));
         const combatants = (await Promise.all(promises)).filter((c): c is CombatantPF2e<EncounterPF2e> => !!c);
         return combatants;
+    }
+
+    override getRollData(): Record<string, unknown> {
+        return mergeObject(super.getRollData(), this.campaign?.getRollData?.() ?? {});
     }
 
     /** Re-render the sheet if data preparation is called from the familiar's master */

--- a/src/module/actor/party/types.ts
+++ b/src/module/actor/party/types.ts
@@ -1,9 +1,9 @@
 import { ActorUpdateContext } from "@actor/base.ts";
 import { ItemType } from "@item/data/index.ts";
 import { TokenDocumentPF2e } from "@scene";
+import { Statistic } from "@system/statistic/index.ts";
 import type DataModel from "types/foundry/common/abstract/data.d.ts";
 import { PartyPF2e } from "./document.ts";
-import { Statistic } from "@system/statistic/index.ts";
 
 interface PartyUpdateContext<TParent extends TokenDocumentPF2e | null> extends ActorUpdateContext<TParent> {
     removedMembers?: string[];
@@ -19,6 +19,8 @@ interface PartyCampaign extends DataModel<PartyPF2e, {}> {
     createSidebarButtons?(): HTMLElement[];
     /** Returns any additional statistics that should be returned by the party */
     getStatistic?(slug: string): Statistic | null;
+    /** Additional data for inline rolls */
+    getRollData?(): Record<string, unknown>;
 }
 
 export { PartyCampaign, PartyUpdateContext };

--- a/src/module/item/base.ts
+++ b/src/module/item/base.ts
@@ -151,7 +151,8 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
     }
 
     override getRollData(): NonNullable<EnrichHTMLOptionsPF2e["rollData"]> {
-        return { actor: this.actor, item: this };
+        const actorRollData = this.actor?.getRollData() ?? { actor: null };
+        return { ...actorRollData, item: this };
     }
 
     /**


### PR DESCRIPTION
We could allow `@details` without deprecation warning if you think that'd be better.