### PR TITLE
fix use of old manifests to install old pf2e versions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,6 +33,15 @@ jobs:
           SYSTEM_VERSION=$(grep -oP '(?<="version": ")[^"]+' dist/system.json | tr -d '\n')
           echo "systemVersion=$SYSTEM_VERSION" >> $GITHUB_ENV
 
+      # Substitute the Manifest and Download URLs in the module.json
+      - name: Substitute Download Link For Versioned One
+        id: sub_manifest_link_version
+        uses: microsoft/variable-substitution@v1
+        with:
+          files: 'system.json'
+        env:
+          download: https://github.com/${{github.repository}}/releases/download/${{ env.systemVersion }}/module.zip
+
       - name: Zip Files
         working-directory: ./dist
         run: zip -r ./pf2e.zip ./*

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -38,7 +38,7 @@ jobs:
         id: sub_manifest_link_version
         uses: microsoft/variable-substitution@v1
         with:
-          files: 'system.json'
+          files: 'dist/system.json'
         env:
           download: https://github.com/${{github.repository}}/releases/download/${{ env.systemVersion }}/module.zip
 


### PR DESCRIPTION
In rare cases I have reason to not update Foundry to the latest version, this allows me to install and migrate the system with just a manifest link in those cases.