### PR TITLE
Additional work on party sheet

### DIFF
--- a/src/styles/actor/party/_index.scss
+++ b/src/styles/actor/party/_index.scss
@@ -126,31 +126,6 @@
         }
     }
 
-    .content header {
-        align-items: center;
-        background-color: var(--sub);
-        color: white;
-        display: flex;
-        font-weight: 600;
-        margin-bottom: 0.5rem;
-        padding: 0 0.5rem;
-        line-height: 2.375rem;
-
-        .buttons {
-            align-items: center;
-            display: flex;
-            margin-left: auto;
-        }
-
-        button {
-            background-color: var(--tertiary);
-            border-color: 1px solid var(--alt-dark);
-            color: var(--alt-dark);
-            min-width: 1.875rem;
-            height: 1.875rem;
-        }
-    }
-
     .sidebar {
         @include scrollbar;
         border-right: 1px solid #888;
@@ -234,21 +209,67 @@
         }
     }
 
+    .content {
+        position: relative;
+        .blank-slate {
+            @include frame-elegant;
+            position: absolute;
+            left: 1rem;
+            top: 1rem;
+            right: 1rem;
+            padding: 1rem;
+        }
+
+        header {
+            align-items: center;
+            background-color: var(--sub);
+            color: white;
+            display: flex;
+            font-weight: 600;
+            margin-bottom: 0.5rem;
+            padding: 0 0.5rem;
+            line-height: 2.375rem;
+
+            .buttons {
+                align-items: center;
+                display: flex;
+                margin-left: auto;
+            }
+
+            button {
+                background-color: var(--tertiary);
+                border-color: 1px solid var(--alt-dark);
+                color: var(--alt-dark);
+                min-width: 1.875rem;
+                height: 1.875rem;
+            }
+        }
+    }
+
     .tag-light {
         --tag-color: #{$rank-untrained};
+
+        align-items: center;
         border: 1px solid var(--tag-color);
         border-radius: 2px;
         color: var(--tag-color);
+        display: flex;
+        line-height: unset;
+        gap: 0.125rem;
+        white-space: nowrap;
+        font-family: var(--sans-serif);
+        font-size: var(--font-size-13);
+        font-variant: all-small-caps;
+        font-weight: 700;
+
+        margin: 0;
         padding: 0 4px 0.1em 4px;
         width: auto;
         height: 1.25rem;
-        white-space: nowrap;
-        font-size: var(--font-size-13);
-        font-variant: all-small-caps;
-        font-weight: 500;
 
-        display: flex;
-        align-items: center;
+        .mod {
+            font-weight: 500;
+        }
     }
 
     [data-tab="inventory"] {

--- a/src/styles/actor/party/_overview.scss
+++ b/src/styles/actor/party/_overview.scss
@@ -1,15 +1,39 @@
+.content {
+    padding-bottom: 0.25rem;
+}
+
 .summary {
     @include frame-elegant;
-    padding: 0.5rem;
-    margin: 16px 16px 8px 16px;
+    display: flex;
+    flex-direction: column;
+    margin: 12px 1rem 0.25rem 12px;
+
+    & > * {
+        // Compensate for innate padding in svg, this makes the border fill the entire width
+        // Apply to all so text lines up
+        padding: 0 calc(0.625rem + 2px);
+        width: calc(100% + 4px);
+        margin-left: -2px;
+    }
+
     label {
+        border-bottom: 1px solid var(--color-border);
         color: var(--alt-dark);
         font-family: var(--serif);
+        font-size: var(--font-size-16);
         font-weight: 500;
-        line-height: 1em;
+        line-height: 1.25em;
+        padding-top: 0.25rem;
+
+        .total {
+            color: var(--alt);
+            font-size: var(--font-size-12);
+        }
     }
 
     .tags {
+        padding-top: 0.375rem;
+        padding-bottom: 0.375rem;
         margin: 0;
     }
 }
@@ -152,11 +176,10 @@
 
         & > div {
             border: 1px solid var(--color-border);
-            border-radius: 2px;
-            height: 2.6rem;
+            border-radius: 3px;
+            height: 2.875rem;
             display: flex;
             align-items: center;
-            justify-content: space-between;
             flex: 1 1 0;
         }
 
@@ -164,61 +187,113 @@
             display: flex;
             flex-direction: column;
             align-items: center;
-            justify-content: center;
             font-size: var(--font-size-18);
 
             label {
+                color: var(--alt-dark);
                 font-size: var(--font-size-10);
                 font-weight: 500;
+                margin-top: 0.25rem;
             }
-        }
-
-        .health-section {
-            flex: 1;
-            min-width: 9rem;
         }
 
         .health {
-            padding-right: 0.5rem;
-            margin-right: 0.125rem;
-            justify-content: center;
-            gap: 0.5rem;
+            position: relative;
+            flex: 0 0 8.25rem;
+            label {
+                text-transform: uppercase;
+            }
+            .health-value {
+                padding-right: 0.325rem;
+                justify-content: center;
+                gap: 0.5rem;
 
-            .max {
-                font-weight: 500;
+                .max {
+                    font-weight: 500;
+                }
+                .value, .max {
+                    display: inline-block;
+                    font-variant-numeric: tabular-nums;
+                }
+                .value {
+                    text-align: end;
+                }
             }
-            .value, .max {
-                display: inline-block;
-                font-variant-numeric: tabular-nums;
-            }
-            .value {
-                text-align: end;
+            .bar {
+                position: absolute;
+                left: 0;
+                bottom: 0;
+
+                background-color: var(--primary);
+                border-radius: 0 0 3px 3px;
+                height: 0.25rem;
             }
         }
 
         .saving-throws {
-            flex: 0.85;
-            min-width: 5.5rem;
+            flex: 0 0 8.625rem;
             .score {
                 flex: 1;
                 font-weight: 500;
+                height: 100%;
+
+                label {
+                    text-transform: uppercase;
+                }
+
+                &:not(:last-child) {
+                    border-right: 1px solid var(--border);
+                }
             }
         }
 
-        .senses {
-            flex: 1.4;
+        .senses-speeds {
+            flex: 1;
+            align-items: start;
+            padding: 0 0.5rem;
+            overflow: hidden;
+            label {
+                display: flex;
+                flex-direction: row;
+                width: 100%;
+                .abc {
+                    text-transform: uppercase;
+                    font-weight: 500;
+                    & + .abc {
+                        border-left: 1px solid var(--border);
+                        padding-left: 0.5rem;
+                        margin-left: 0.5rem;
+                    }
+                }
+                .size {
+                    border: 1px solid #{$rank-master};
+                    border-radius: 2px;
+                    color: #{$rank-master};
+                    float: right;
+                    font-weight: 600;
+                    margin-left: auto;
+                    margin-top: -1px;
+                    padding: 0 0.25rem;
+                }
+            }
             .value {
                 display: flex;
                 font-size: var(--font-size-12);
-                gap: 0.125rem;
-                align-items: center;
-                overflow: hidden;
-            }
-            [data-acuity="imprecise"], [data-acuity="vague"] {
-                border-style: dashed;
+                gap: 0.25rem;
+                overflow-x: auto;
+                width: 100%;
+
+                // if a scrollbar spawns, give it some space
+                padding-bottom: 6px;
+                margin-bottom: -6px;
+
+                [data-acuity="imprecise"], [data-acuity="vague"] {
+                    border-style: dashed;
+                }
             }
             .blank {
                 font-size: var(--font-size-14);
+                padding-top: 0.125rem;
             }
         }
 

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -327,6 +327,7 @@
                     "Complete": "Party exploration activities have been cleared"
                 },
                 "Languages": "Party Languages",
+                "LanguagesKnown": "{total} Total Known",
                 "MembersLabel": "Members: ",
                 "NoSpecialSenses": "No Special Senses",
                 "RemoveMember": {

--- a/static/templates/actors/party/regions/exploration.hbs
+++ b/static/templates/actors/party/regions/exploration.hbs
@@ -1,5 +1,9 @@
-<aside class="sidebar">
-    {{#if members}}
+{{#unless members}}
+    <section class="content">
+        <div class="blank-slate">{{localize "PF2E.Actor.Party.BlankSlate"}}</div>
+    </section>
+{{else}}
+    <aside class="sidebar">
         <ol class="box-list exploration-members">
             <li class="box summary">
                 <header>{{localize "PF2E.TravelSpeed.PartySpeed"}}</header>
@@ -39,49 +43,47 @@
                 </li>
             {{/each}}
         </ol>
-    {{else}}
-        {{localize "PF2E.Actor.Party.BlankSlate"}}
-    {{/if}}
-</aside>
-<section class="content">
-    {{#if @root.options.editable}}
-        <header>
-            <a data-action="clear-exploration">{{localize "PF2E.Actor.Party.ClearActivities.Label"}}</a>
-            <div class="buttons">
-                <button type="button" data-action="rest"><i class="fa-solid fa-fw fa-bed"></i> {{localize "PF2E.Actor.Party.Rest"}}</button>
-            </div>
-        </header>
-    {{/if}}
-    <div class="activities">
-        {{#each explorationMembers as |member|}}
-            <section class="member-activity" data-actor-uuid="{{member.actor.uuid}}">
-                <div class="actor-image">
-                    <img class="actor-link" data-action="open-sheet" data-tab="exploration" src="{{member.actor.img}}">
+    </aside>
+    <section class="content">
+        {{#if @root.options.editable}}
+            <header>
+                <a data-action="clear-exploration">{{localize "PF2E.Actor.Party.ClearActivities.Label"}}</a>
+                <div class="buttons">
+                    <button type="button" data-action="rest"><i class="fa-solid fa-fw fa-bed"></i> {{localize "PF2E.Actor.Party.Rest"}}</button>
                 </div>
+            </header>
+        {{/if}}
+        <div class="activities">
+            {{#each explorationMembers as |member|}}
+                <section class="member-activity" data-actor-uuid="{{member.actor.uuid}}">
+                    <div class="actor-image">
+                        <img class="actor-link" data-action="open-sheet" data-tab="exploration" src="{{member.actor.img}}">
+                    </div>
 
-                {{#if member.activities}}
-                    <div class="activity-entries">
-                        {{#each member.activities as |activity|}}
-                            <section class="activity {{#if (eq member.activities.length 1)}}single{{/if}}">
-                                <span class="name">{{activity.name}}</span>
-                                <span class="tags">
-                                    {{#each traits as |trait|}}
-                                        <span class="tag tag_transparent">{{trait.label}}</span>
-                                    {{/each}}
-                                </span>
-                            </section>
-                        {{/each}}
-                    </div>
-                {{else}}
-                    <div class="empty" data-action="open-sheet" data-tab="exploration">
-                        <div class="icon"><i class="fa-solid fa-plus fa-fw"></i></div>
-                        <div>
-                            <div class="name">{{localize "PF2E.Item.Action.Type.Activity"}}</div>
-                            <div class="hint">{{localize "PF2E.Actor.Party.SlotAvailable"}}</div>
+                    {{#if member.activities}}
+                        <div class="activity-entries">
+                            {{#each member.activities as |activity|}}
+                                <section class="activity {{#if (eq member.activities.length 1)}}single{{/if}}">
+                                    <span class="name">{{activity.name}}</span>
+                                    <span class="tags">
+                                        {{#each traits as |trait|}}
+                                            <span class="tag tag_transparent">{{trait.label}}</span>
+                                        {{/each}}
+                                    </span>
+                                </section>
+                            {{/each}}
                         </div>
-                    </div>
-                {{/if}}
-            </section>
-        {{/each}}
-    </div>
-</section>
+                    {{else}}
+                        <div class="empty" data-action="open-sheet" data-tab="exploration">
+                            <div class="icon"><i class="fa-solid fa-plus fa-fw"></i></div>
+                            <div>
+                                <div class="name">{{localize "PF2E.Item.Action.Type.Activity"}}</div>
+                                <div class="hint">{{localize "PF2E.Actor.Party.SlotAvailable"}}</div>
+                            </div>
+                        </div>
+                    {{/if}}
+                </section>
+            {{/each}}
+        </div>
+    </section>
+{{/unless}}

--- a/static/templates/actors/party/regions/overview.hbs
+++ b/static/templates/actors/party/regions/overview.hbs
@@ -1,14 +1,20 @@
-<div class="content">
+<section class="content">
     {{#unless members}}
-        <div class="summary">
+        <div class="blank-slate">
             {{localize "PF2E.Actor.Party.BlankSlate"}}
         </div>
     {{/unless}}
 
     {{#if members}}
         <div class="summary">
-            <label>{{localize "PF2E.Actor.Party.Languages"}}</label>
+            <label>
+                {{localize "PF2E.Actor.Party.Languages"}}
+                <span class="total">{{localize "PF2E.Actor.Party.LanguagesKnown" total=languages.length}}</span>
+            </label>
             <ul class="tags">
+                {{#unless languages}}
+                    {{localize "PF2E.NoneOption"}}
+                {{/unless}}
                 {{#each languages as |language|}}
                     <li class="tag tag_alt" data-language="{{language.slug}}">
                         {{language.label}}{{#if (gt language.actors.length 1)}} ({{language.actors.length}}){{/if}}
@@ -48,93 +54,76 @@
                 </div>
 
                 <div class="main-stats">
-                    <div class="score health-section">
-                        <label>{{localize "PF2E.HitPointsHeader"}}</label>
-                        <div class="health">
-                            <i class="fas fa-heart"></i>
-                            <span class="value">{{member.actor.attributes.hp.value}}</span>
-                            / <span class="max">{{member.actor.attributes.hp.max}}</span>
+                    {{#with member.actor.attributes.hp as |hp|}}
+                        <div class="score health">
+                            <label>{{localize "PF2E.HitPointsHeader"}}</label>
+                            <div class="health-value">
+                                <i class="fas fa-heart"></i>
+                                <span class="value">{{hp.value}}</span>
+                                / <span class="max">{{hp.max}}</span>
+                            </div>
+                            <div class="bar" style="width: {{percentage hp.value hp.max}}%;"></div>
                         </div>
-                    </div>
-                    {{#if member.actor.saves}}
-                        <div class="saving-throws">
-                            <span class="score">
-                                <label>{{localize "PF2E.SavesFortitudeShort"}}</label>
-                                {{member.actor.saves.fortitude.mod}}
-                            </span>
-                            <span class="score">
-                                <label>{{localize "PF2E.SavesReflexShort"}}</label>
-                                {{member.actor.saves.reflex.mod}}
-                            </span>
-                           <span class="score">
-                                <label>{{localize "PF2E.SavesWillShort"}}</label>
-                                {{member.actor.saves.will.mod}}
-                            </span>
-                        </div>
-                    {{/if}}
+                    {{/with}}
 
-                    <div class="score senses">
-                        <label>{{localize "PF2E.Senses"}}</label>
+                    <div class="saving-throws">
+                        <span class="score">
+                            <label>{{localize "PF2E.SavesFortitudeShort"}}</label>
+                            {{numberFormat member.actor.saves.fortitude.mod sign=true}}
+                        </span>
+                        <span class="score">
+                            <label>{{localize "PF2E.SavesReflexShort"}}</label>
+                            {{numberFormat member.actor.saves.reflex.mod sign=true}}
+                        </span>
+                        <span class="score">
+                            <label>{{localize "PF2E.SavesWillShort"}}</label>
+                            {{numberFormat member.actor.saves.will.mod sign=true}}
+                        </span>
+                    </div>
+
+                    <div class="score senses-speeds">
+                        <label>
+                            {{#if (eq member.actor.type "familiar")}}
+                                <span class="abc">{{localize "PF2E.Familiar.Familiar"}}</span>
+                                {{#if member.actor.master}}
+                                    <span class="abc">{{member.actor.master.name}}</span>
+                                {{/if}}
+                            {{else if member.actor.system.details.creatureType}}
+                                <span class="abc">{{member.actor.system.details.creatureType}}</span>
+                            {{else}}
+                                {{#if member.actor.ancestry}}
+                                    <span class="abc">{{member.actor.ancestry.name}}</span>
+                                {{/if}}
+                                {{#if member.actor.class}}
+                                    <span class="abc">{{member.actor.class.name}}</span>
+                                {{/if}}
+                            {{/if}}
+                            <span class="size">{{localize member.size.label}}</span>
+                        </label>
                         <div class="value">
+                            {{#each member.speeds as |speed|}}
+                                <span class="tag-light">{{localize speed.label}} {{speed.value}}</span>
+                            {{/each}}
                             {{#each member.senses as |sense|}}
                                 <span class="tag-light" data-acuity="{{sense.acuity}}" data-tooltip="{{sense.labelFull}}">{{localize sense.label}}</span>
                             {{/each}}
-                            {{#unless member.senses}}
-                                <span class="blank">{{localize "PF2E.Actor.Party.NoSpecialSenses"}}</span>
-                            {{/unless}}
                         </div>
                     </div>
-
-                    {{!-- {{#if member.actor.abilities}}
-                        <div class="ability-scores">
-                            <div class="ability-score-grid">
-                                <span class="score">
-                                    <label>STR</label>
-                                    {{numberFormat member.actor.abilities.str.mod sign=true}}
-                                </span>
-                                <span class="score">
-                                    <label>DEX</label>
-                                    {{numberFormat member.actor.abilities.dex.mod sign=true}}
-                                </span>
-                                <span class="score">
-                                    <label>CON</label>
-                                    {{numberFormat member.actor.abilities.con.mod sign=true}}
-                                </span>
-                                <span class="score">
-                                    <label>INT</label>
-                                    {{numberFormat member.actor.abilities.int.mod sign=true}}
-                                </span>
-                                <span class="score">
-                                    <label>WIS</label>
-                                    {{numberFormat member.actor.abilities.wis.mod sign=true}}
-                                </span>
-                                <span class="score">
-                                    <label>CHA</label>
-                                    {{numberFormat member.actor.abilities.cha.mod sign=true}}
-                                </span>
-                            </div>
-                        </div>
-                    {{else if member.actor.master}}
-                        <div class="score master">
-                            <label>{{localize "PF2E.Familiar.Master"}}</label>
-                            <div>{{member.actor.master.name}}</div>
-                        </div>
-                    {{/if}} --}}
                 </div>
 
                 <div class="skills">
                     {{#with member.actor.perception as |perception|}}
                         <button type="button" class="perception tag-light rollable" {{#if perception.rank}}data-rank="{{perception.rank}}"{{/if}} {{#if @root.user.isGM}}data-action="roll" data-statistic="perception" data-secret="true"{{/if}}>
-                            {{perception.label}} {{numberFormat perception.mod sign=true}}
+                            {{perception.label}} <span class="mod">{{numberFormat perception.mod sign=true}}</span>
                         </button>
                     {{/with}}
                     {{#each member.bestSkills as |skill|}}
                         <span class="tag-light" {{#if skill.rank}}data-rank="{{skill.rank}}"{{/if}}>
-                            {{skill.label}} {{numberFormat skill.mod sign=true}}
+                            {{skill.label}} <span class="mod">{{numberFormat skill.mod sign=true}}</span>
                         </span>
                     {{/each}}
                 </div>
             </div>
         </section>
     {{/each}}
-</div>
+</section>


### PR DESCRIPTION
* Adds ancestry, class, size, and speeds to overview
* Adds padding around inventory to line up with other elements
* Centers PC name label when wealth is missing (such as when viewing in a restricted mode)
* Add HP bar to overview
* Tweak styling of PC languages
* Increase default sheet height to fit 4 PCs
* Remove Lore from best skills. They'll come back later in an RK aggregate alternative view.

Adapted from Mats design

![image](https://github.com/foundryvtt/pf2e/assets/1286721/789b808d-98bf-4744-8f84-9bafb32e1d4a)
![image](https://github.com/foundryvtt/pf2e/assets/1286721/19894827-26ef-4933-9617-3612e3345224)
![image](https://github.com/foundryvtt/pf2e/assets/1286721/98010d80-1480-4dc1-a9bc-cb9845445715)
