### PR TITLE
Adjust token-visibility testing to be more compliant with 2e rules

### DIFF
--- a/src/module/canvas/token/object.ts
+++ b/src/module/canvas/token/object.ts
@@ -21,9 +21,22 @@ class TokenPF2e<TDocument extends TokenDocumentPF2e = TokenDocumentPF2e> extends
         Object.defineProperty(this, "auras", { configurable: false, writable: false }); // It's ours, Kim!
     }
 
-    /** Guarantee boolean return */
+    /** Increase center-to-center point tolerance to be more compliant with 2e rules */
     override get isVisible(): boolean {
-        return super.isVisible ?? false;
+        // Clear the detection filter
+        this.detectionFilter = null;
+
+        // Only GM users can see hidden tokens
+        if (this.document.hidden && !game.user.isGM) return false;
+
+        // Some tokens are always visible
+        if (!canvas.effects.visibility.tokenVision) return true;
+        if (this.controlled) return true;
+
+        // Otherwise, test visibility against current sight polygons
+        if (canvas.effects.visionSources.get(this.sourceId)?.active) return true;
+        const tolerance = Math.floor(0.35 * Math.min(this.w, this.h));
+        return canvas.effects.visibility.testVisibility(this.center, { tolerance, object: this });
     }
 
     /** Is this token currently animating? */


### PR DESCRIPTION
A further improvement would be to make the LoS polygon a composite of circles at multiple origin points, but it'll be harder to get to the client code that creates the polygon.

This isn't in reference to an explicit vision rule but related to a diagram explaining cover rules: it is assumed that Kyra _can_ (barely) see the ogre.

Before:
![image](https://github.com/foundryvtt/pf2e/assets/106829671/d5b8ff76-cc71-4e49-af87-a10d43a0c2e7)

After:
![image](https://github.com/foundryvtt/pf2e/assets/106829671/2cd362f0-1361-4a01-aad0-b723e778dd94)

Reference: https://2e.aonprd.com/Images/Rules/Rules459.png
