### PR TITLE
Indicate verified compatibility with 11.305

### DIFF
--- a/src/module/encounter/document.ts
+++ b/src/module/encounter/document.ts
@@ -265,11 +265,11 @@ class EncounterPF2e extends Combat {
     }
 
     /**
-     * Work around upstream issue present in version 11.304
+     * Work around upstream issue present in versions 11.304 and 11.305
      * https://github.com/foundryvtt/foundryvtt/issues/9718
      */
     protected override async _manageTurnEvents(adjustedTurn?: number): Promise<void> {
-        if (this.previous || game.version !== "11.304") {
+        if (this.previous || !["11.304", "11.305"].includes(game.version)) {
             return super._manageTurnEvents(adjustedTurn);
         }
     }

--- a/static/system.json
+++ b/static/system.json
@@ -6,7 +6,7 @@
     "version": "5.1.0",
     "compatibility": {
         "minimum": "11.304",
-        "verified": "11.304",
+        "verified": "11.305",
         "maximum": "11"
     },
     "authors": [


### PR DESCRIPTION
Also extend `Combat#_manageTurnEvents` workaround to 11.305