### PR TITLE
Obscure token sprite if hearing/tremorsense detection filter is applied

### DIFF
--- a/src/module/canvas/token/object.ts
+++ b/src/module/canvas/token/object.ts
@@ -5,6 +5,7 @@ import { htmlClosest, pick } from "@util";
 import { CanvasPF2e, TokenLayerPF2e, measureDistanceCuboid } from "../index.ts";
 import { HearingSource } from "../perception/hearing-source.ts";
 import { AuraRenderers } from "./aura/index.ts";
+import { Renderer } from "pixi.js";
 
 class TokenPF2e<TDocument extends TokenDocumentPF2e = TokenDocumentPF2e> extends Token<TDocument> {
     /** Visual representation and proximity-detection facilities for auras */
@@ -346,6 +347,19 @@ class TokenPF2e<TDocument extends TokenDocumentPF2e = TokenDocumentPF2e> extends
         super.updateVisionSource({ defer, deleted });
         if (this._isVisionSource() && !deleted) {
             this.hearing.initialize();
+        }
+    }
+
+    /** Obscure the token's sprite if a hearing or tremorsense detection filter is applied to it */
+    override render(renderer: Renderer): void {
+        super.render(renderer);
+        if (!this.mesh) return;
+
+        const configuredTint = this.document.texture.tint ?? "#FFFFFF";
+        if (this.mesh.tint !== 0 && this.detectionFilter instanceof OutlineOverlayFilter) {
+            this.mesh.tint = 0;
+        } else if (this.mesh.tint === 0 && configuredTint !== "#000000" && !this.detectionFilter) {
+            this.mesh.tint = Number(Color.fromString(configuredTint));
         }
     }
 

--- a/types/foundry/client/pixi/placeables/token.d.ts
+++ b/types/foundry/client/pixi/placeables/token.d.ts
@@ -236,6 +236,14 @@ declare global {
         /* Rendering                                    */
         /* -------------------------------------------- */
 
+        override render(renderer: PIXI.Renderer): void;
+
+        /**
+         * Render the bound mesh detection filter.
+         * Note: this method does not verify that the detection filter exists.
+         */
+        protected _renderDetectionFilter(renderer: PIXI.Renderer): void;
+
         override clear(): this;
 
         protected _draw(): Promise<void>;

--- a/types/foundry/common/documents/token.d.ts
+++ b/types/foundry/common/documents/token.d.ts
@@ -33,7 +33,7 @@ export default class BaseToken<TParent extends BaseScene | null = BaseScene | nu
         offsetX: number;
         offsetY: number;
         rotation: number | null;
-        tint: HexColorString;
+        tint: HexColorString | undefined;
     };
 
     light: foundry.data.LightData;


### PR DESCRIPTION
Before:
![image](https://github.com/foundryvtt/pf2e/assets/106829671/191511ea-f3d6-4a20-afcc-ff7b33f8d2d7)

After:
![image](https://github.com/foundryvtt/pf2e/assets/106829671/c50a90a7-4258-4b1e-b18d-a3f718d89916)
