### PR TITLE
Add elemental ammunition variants

### DIFF
--- a/packs/equipment/elemental-ammunition-acid-greater.json
+++ b/packs/equipment/elemental-ammunition-acid-greater.json
@@ -1,0 +1,90 @@
+{
+    "_id": "bFghP17OWakSZWTU",
+    "img": "systems/pf2e/icons/default-icons/consumable.svg",
+    "name": "Elemental Ammunition (Acid, Greater)",
+    "system": {
+        "autoDestroy": {
+            "value": true
+        },
+        "baseItem": null,
+        "charges": {
+            "max": 0,
+            "value": 0
+        },
+        "consumableType": {
+            "value": "ammo"
+        },
+        "consume": {
+            "value": ""
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"pf2-icon\">1</span> Interact</p>\n<hr />\n<p>When activated, the reservoir of alchemical reagents in elemental ammunition atomizes on impact, dealing [[/r 3d4[persistent,acid]]] damage to the target and [[/r (3[splash])[acid]]]{3 splash damage} in addition to the damage the attack normally deals.</p>"
+        },
+        "equippedBulk": {
+            "value": ""
+        },
+        "hardness": 0,
+        "hp": {
+            "brokenThreshold": 0,
+            "max": 0,
+            "value": 0
+        },
+        "level": {
+            "value": 11
+        },
+        "negateBulk": {
+            "value": "0"
+        },
+        "preciousMaterial": {
+            "value": null
+        },
+        "preciousMaterialGrade": {
+            "value": null
+        },
+        "price": {
+            "value": {
+                "gp": 210
+            }
+        },
+        "quantity": 1,
+        "rules": [
+            {
+                "category": "persistent",
+                "damageType": "acid",
+                "diceNumber": 3,
+                "dieSize": "d4",
+                "key": "DamageDice",
+                "selector": "{item|id}-damage"
+            },
+            {
+                "damageCategory": "splash",
+                "damageType": "acid",
+                "key": "FlatModifier",
+                "selector": "{item|id}-damage",
+                "value": 3
+            }
+        ],
+        "size": "med",
+        "source": {
+            "value": "Pathfinder Treasure Vault"
+        },
+        "stackGroup": null,
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "acid",
+                "alchemical",
+                "consumable",
+                "splash"
+            ]
+        },
+        "usage": {
+            "value": "held-in-one-hand"
+        },
+        "weight": {
+            "value": "-"
+        }
+    },
+    "type": "consumable"
+}

--- a/packs/equipment/elemental-ammunition-acid-lesser.json
+++ b/packs/equipment/elemental-ammunition-acid-lesser.json
@@ -1,0 +1,89 @@
+{
+    "_id": "rx0aK5ubcV5Cb8yE",
+    "img": "systems/pf2e/icons/default-icons/consumable.svg",
+    "name": "Elemental Ammunition (Acid, Lesser)",
+    "system": {
+        "autoDestroy": {
+            "value": true
+        },
+        "baseItem": null,
+        "charges": {
+            "max": 0,
+            "value": 0
+        },
+        "consumableType": {
+            "value": "ammo"
+        },
+        "consume": {
+            "value": ""
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"pf2-icon\">1</span> Interact</p>\n<hr />\n<p>When activated, the reservoir of alchemical reagents in elemental ammunition atomizes on impact, dealing [[/r 1[persistent,acid]]] damage to the target and [[/r (1[splash])[acid]]]{1 splash damage} in addition to the damage the attack normally deals.</p>"
+        },
+        "equippedBulk": {
+            "value": ""
+        },
+        "hardness": 0,
+        "hp": {
+            "brokenThreshold": 0,
+            "max": 0,
+            "value": 0
+        },
+        "level": {
+            "value": 1
+        },
+        "negateBulk": {
+            "value": "0"
+        },
+        "preciousMaterial": {
+            "value": null
+        },
+        "preciousMaterialGrade": {
+            "value": null
+        },
+        "price": {
+            "value": {
+                "gp": 3
+            }
+        },
+        "quantity": 1,
+        "rules": [
+            {
+                "damageCategory": "persistent",
+                "damageType": "acid",
+                "key": "FlatModifier",
+                "selector": "{item|id}-damage",
+                "value": 1
+            },
+            {
+                "damageCategory": "splash",
+                "damageType": "acid",
+                "key": "FlatModifier",
+                "selector": "{item|id}-damage",
+                "value": 1
+            }
+        ],
+        "size": "med",
+        "source": {
+            "value": "Pathfinder Treasure Vault"
+        },
+        "stackGroup": null,
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "acid",
+                "alchemical",
+                "consumable",
+                "splash"
+            ]
+        },
+        "usage": {
+            "value": "held-in-one-hand"
+        },
+        "weight": {
+            "value": "-"
+        }
+    },
+    "type": "consumable"
+}

--- a/packs/equipment/elemental-ammunition-acid-moderate.json
+++ b/packs/equipment/elemental-ammunition-acid-moderate.json
@@ -1,0 +1,90 @@
+{
+    "_id": "OXWiI2UXL4vDh9z4",
+    "img": "systems/pf2e/icons/default-icons/consumable.svg",
+    "name": "Elemental Ammunition (Acid, Moderate)",
+    "system": {
+        "autoDestroy": {
+            "value": true
+        },
+        "baseItem": null,
+        "charges": {
+            "max": 0,
+            "value": 0
+        },
+        "consumableType": {
+            "value": "ammo"
+        },
+        "consume": {
+            "value": ""
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"pf2-icon\">1</span> Interact</p>\n<hr />\n<p>When activated, the reservoir of alchemical reagents in elemental ammunition atomizes on impact, dealing [[/r 2d4[persistent,acid]]] damage to the target and [[/r (2[splash])[acid]]]{2 splash damage} in addition to the damage the attack normally deals.</p>"
+        },
+        "equippedBulk": {
+            "value": ""
+        },
+        "hardness": 0,
+        "hp": {
+            "brokenThreshold": 0,
+            "max": 0,
+            "value": 0
+        },
+        "level": {
+            "value": 5
+        },
+        "negateBulk": {
+            "value": "0"
+        },
+        "preciousMaterial": {
+            "value": null
+        },
+        "preciousMaterialGrade": {
+            "value": null
+        },
+        "price": {
+            "value": {
+                "gp": 21
+            }
+        },
+        "quantity": 1,
+        "rules": [
+            {
+                "category": "persistent",
+                "damageType": "acid",
+                "diceNumber": 2,
+                "dieSize": "d4",
+                "key": "DamageDice",
+                "selector": "{item|id}-damage"
+            },
+            {
+                "damageCategory": "splash",
+                "damageType": "acid",
+                "key": "FlatModifier",
+                "selector": "{item|id}-damage",
+                "value": 2
+            }
+        ],
+        "size": "med",
+        "source": {
+            "value": "Pathfinder Treasure Vault"
+        },
+        "stackGroup": null,
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "acid",
+                "alchemical",
+                "consumable",
+                "splash"
+            ]
+        },
+        "usage": {
+            "value": "held-in-one-hand"
+        },
+        "weight": {
+            "value": "-"
+        }
+    },
+    "type": "consumable"
+}

--- a/packs/equipment/elemental-ammunition-cold-greater.json
+++ b/packs/equipment/elemental-ammunition-cold-greater.json
@@ -1,0 +1,90 @@
+{
+    "_id": "f8hbqhCIHkkxTMMQ",
+    "img": "systems/pf2e/icons/default-icons/consumable.svg",
+    "name": "Elemental Ammunition (Cold, Greater)",
+    "system": {
+        "autoDestroy": {
+            "value": true
+        },
+        "baseItem": null,
+        "charges": {
+            "max": 0,
+            "value": 0
+        },
+        "consumableType": {
+            "value": "ammo"
+        },
+        "consume": {
+            "value": ""
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"pf2-icon\">1</span> Interact</p>\n<hr />\n<p>When activated, the reservoir of alchemical reagents in elemental ammunition atomizes on impact, dealing [[/r 3d4[persistent,cold]]] damage to the target and [[/r (3[splash])[cold]]]{3 splash damage} in addition to the damage the attack normally deals.</p>"
+        },
+        "equippedBulk": {
+            "value": ""
+        },
+        "hardness": 0,
+        "hp": {
+            "brokenThreshold": 0,
+            "max": 0,
+            "value": 0
+        },
+        "level": {
+            "value": 11
+        },
+        "negateBulk": {
+            "value": "0"
+        },
+        "preciousMaterial": {
+            "value": null
+        },
+        "preciousMaterialGrade": {
+            "value": null
+        },
+        "price": {
+            "value": {
+                "gp": 210
+            }
+        },
+        "quantity": 1,
+        "rules": [
+            {
+                "category": "persistent",
+                "damageType": "cold",
+                "diceNumber": 3,
+                "dieSize": "d4",
+                "key": "DamageDice",
+                "selector": "{item|id}-damage"
+            },
+            {
+                "damageCategory": "splash",
+                "damageType": "cold",
+                "key": "FlatModifier",
+                "selector": "{item|id}-damage",
+                "value": 3
+            }
+        ],
+        "size": "med",
+        "source": {
+            "value": "Pathfinder Treasure Vault"
+        },
+        "stackGroup": null,
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "alchemical",
+                "cold",
+                "consumable",
+                "splash"
+            ]
+        },
+        "usage": {
+            "value": "held-in-one-hand"
+        },
+        "weight": {
+            "value": "-"
+        }
+    },
+    "type": "consumable"
+}

--- a/packs/equipment/elemental-ammunition-cold-lesser.json
+++ b/packs/equipment/elemental-ammunition-cold-lesser.json
@@ -1,0 +1,89 @@
+{
+    "_id": "Gh6TdsvMrynAtKZB",
+    "img": "systems/pf2e/icons/default-icons/consumable.svg",
+    "name": "Elemental Ammunition (Cold, Lesser)",
+    "system": {
+        "autoDestroy": {
+            "value": true
+        },
+        "baseItem": null,
+        "charges": {
+            "max": 0,
+            "value": 0
+        },
+        "consumableType": {
+            "value": "ammo"
+        },
+        "consume": {
+            "value": ""
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"pf2-icon\">1</span> Interact</p>\n<hr />\n<p>When activated, the reservoir of alchemical reagents in elemental ammunition atomizes on impact, dealing [[/r 1[persistent,cold]]] damage to the target and [[/r (1[splash])[cold]]]{1 splash damage} in addition to the damage the attack normally deals.</p>"
+        },
+        "equippedBulk": {
+            "value": ""
+        },
+        "hardness": 0,
+        "hp": {
+            "brokenThreshold": 0,
+            "max": 0,
+            "value": 0
+        },
+        "level": {
+            "value": 1
+        },
+        "negateBulk": {
+            "value": "0"
+        },
+        "preciousMaterial": {
+            "value": null
+        },
+        "preciousMaterialGrade": {
+            "value": null
+        },
+        "price": {
+            "value": {
+                "gp": 3
+            }
+        },
+        "quantity": 1,
+        "rules": [
+            {
+                "damageCategory": "persistent",
+                "damageType": "cold",
+                "key": "FlatModifier",
+                "selector": "{item|id}-damage",
+                "value": 1
+            },
+            {
+                "damageCategory": "splash",
+                "damageType": "cold",
+                "key": "FlatModifier",
+                "selector": "{item|id}-damage",
+                "value": 1
+            }
+        ],
+        "size": "med",
+        "source": {
+            "value": "Pathfinder Treasure Vault"
+        },
+        "stackGroup": null,
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "alchemical",
+                "cold",
+                "consumable",
+                "splash"
+            ]
+        },
+        "usage": {
+            "value": "held-in-one-hand"
+        },
+        "weight": {
+            "value": "-"
+        }
+    },
+    "type": "consumable"
+}

--- a/packs/equipment/elemental-ammunition-cold-moderate.json
+++ b/packs/equipment/elemental-ammunition-cold-moderate.json
@@ -1,0 +1,90 @@
+{
+    "_id": "jevmBnau7KBlALDw",
+    "img": "systems/pf2e/icons/default-icons/consumable.svg",
+    "name": "Elemental Ammunition (Cold, Moderate)",
+    "system": {
+        "autoDestroy": {
+            "value": true
+        },
+        "baseItem": null,
+        "charges": {
+            "max": 0,
+            "value": 0
+        },
+        "consumableType": {
+            "value": "ammo"
+        },
+        "consume": {
+            "value": ""
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"pf2-icon\">1</span> Interact</p>\n<hr />\n<p>When activated, the reservoir of alchemical reagents in elemental ammunition atomizes on impact, dealing [[/r 2d4[persistent,cold]]] damage to the target and [[/r (2[splash])[cold]]]{2 splash damage} in addition to the damage the attack normally deals.</p>"
+        },
+        "equippedBulk": {
+            "value": ""
+        },
+        "hardness": 0,
+        "hp": {
+            "brokenThreshold": 0,
+            "max": 0,
+            "value": 0
+        },
+        "level": {
+            "value": 5
+        },
+        "negateBulk": {
+            "value": "0"
+        },
+        "preciousMaterial": {
+            "value": null
+        },
+        "preciousMaterialGrade": {
+            "value": null
+        },
+        "price": {
+            "value": {
+                "gp": 21
+            }
+        },
+        "quantity": 1,
+        "rules": [
+            {
+                "category": "persistent",
+                "damageType": "cold",
+                "diceNumber": 2,
+                "dieSize": "d4",
+                "key": "DamageDice",
+                "selector": "{item|id}-damage"
+            },
+            {
+                "damageCategory": "splash",
+                "damageType": "cold",
+                "key": "FlatModifier",
+                "selector": "{item|id}-damage",
+                "value": 2
+            }
+        ],
+        "size": "med",
+        "source": {
+            "value": "Pathfinder Treasure Vault"
+        },
+        "stackGroup": null,
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "alchemical",
+                "cold",
+                "consumable",
+                "splash"
+            ]
+        },
+        "usage": {
+            "value": "held-in-one-hand"
+        },
+        "weight": {
+            "value": "-"
+        }
+    },
+    "type": "consumable"
+}

--- a/packs/equipment/elemental-ammunition-electricity-greater.json
+++ b/packs/equipment/elemental-ammunition-electricity-greater.json
@@ -1,0 +1,90 @@
+{
+    "_id": "XenMKy9o49tRl2Mn",
+    "img": "systems/pf2e/icons/default-icons/consumable.svg",
+    "name": "Elemental Ammunition (Electricity, Greater)",
+    "system": {
+        "autoDestroy": {
+            "value": true
+        },
+        "baseItem": null,
+        "charges": {
+            "max": 0,
+            "value": 0
+        },
+        "consumableType": {
+            "value": "ammo"
+        },
+        "consume": {
+            "value": ""
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"pf2-icon\">1</span> Interact</p>\n<hr />\n<p>When activated, the reservoir of alchemical reagents in elemental ammunition atomizes on impact, dealing [[/r 3d4[persistent,electricity]]] damage to the target and [[/r (3[splash])[electricity]]]{3 splash damage} in addition to the damage the attack normally deals.</p>"
+        },
+        "equippedBulk": {
+            "value": ""
+        },
+        "hardness": 0,
+        "hp": {
+            "brokenThreshold": 0,
+            "max": 0,
+            "value": 0
+        },
+        "level": {
+            "value": 11
+        },
+        "negateBulk": {
+            "value": "0"
+        },
+        "preciousMaterial": {
+            "value": null
+        },
+        "preciousMaterialGrade": {
+            "value": null
+        },
+        "price": {
+            "value": {
+                "gp": 210
+            }
+        },
+        "quantity": 1,
+        "rules": [
+            {
+                "category": "persistent",
+                "damageType": "electricity",
+                "diceNumber": 3,
+                "dieSize": "d4",
+                "key": "DamageDice",
+                "selector": "{item|id}-damage"
+            },
+            {
+                "damageCategory": "splash",
+                "damageType": "electricity",
+                "key": "FlatModifier",
+                "selector": "{item|id}-damage",
+                "value": 3
+            }
+        ],
+        "size": "med",
+        "source": {
+            "value": "Pathfinder Treasure Vault"
+        },
+        "stackGroup": null,
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "alchemical",
+                "consumable",
+                "electricity",
+                "splash"
+            ]
+        },
+        "usage": {
+            "value": "held-in-one-hand"
+        },
+        "weight": {
+            "value": "-"
+        }
+    },
+    "type": "consumable"
+}

--- a/packs/equipment/elemental-ammunition-electricity-lesser.json
+++ b/packs/equipment/elemental-ammunition-electricity-lesser.json
@@ -1,0 +1,89 @@
+{
+    "_id": "QFajBEtsV4ivChx9",
+    "img": "systems/pf2e/icons/default-icons/consumable.svg",
+    "name": "Elemental Ammunition (Electricity, Lesser)",
+    "system": {
+        "autoDestroy": {
+            "value": true
+        },
+        "baseItem": null,
+        "charges": {
+            "max": 0,
+            "value": 0
+        },
+        "consumableType": {
+            "value": "ammo"
+        },
+        "consume": {
+            "value": ""
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"pf2-icon\">1</span> Interact</p>\n<hr />\n<p>When activated, the reservoir of alchemical reagents in elemental ammunition atomizes on impact, dealing [[/r 1[persistent,electricity]]] damage to the target and [[/r (1[splash])[electricity]]]{1 splash damage} in addition to the damage the attack normally deals.</p>"
+        },
+        "equippedBulk": {
+            "value": ""
+        },
+        "hardness": 0,
+        "hp": {
+            "brokenThreshold": 0,
+            "max": 0,
+            "value": 0
+        },
+        "level": {
+            "value": 1
+        },
+        "negateBulk": {
+            "value": "0"
+        },
+        "preciousMaterial": {
+            "value": null
+        },
+        "preciousMaterialGrade": {
+            "value": null
+        },
+        "price": {
+            "value": {
+                "gp": 3
+            }
+        },
+        "quantity": 1,
+        "rules": [
+            {
+                "damageCategory": "persistent",
+                "damageType": "electricity",
+                "key": "FlatModifier",
+                "selector": "{item|id}-damage",
+                "value": 1
+            },
+            {
+                "damageCategory": "splash",
+                "damageType": "electricity",
+                "key": "FlatModifier",
+                "selector": "{item|id}-damage",
+                "value": 1
+            }
+        ],
+        "size": "med",
+        "source": {
+            "value": "Pathfinder Treasure Vault"
+        },
+        "stackGroup": null,
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "alchemical",
+                "consumable",
+                "electricity",
+                "splash"
+            ]
+        },
+        "usage": {
+            "value": "held-in-one-hand"
+        },
+        "weight": {
+            "value": "-"
+        }
+    },
+    "type": "consumable"
+}

--- a/packs/equipment/elemental-ammunition-electricity-moderate.json
+++ b/packs/equipment/elemental-ammunition-electricity-moderate.json
@@ -1,0 +1,90 @@
+{
+    "_id": "eCxl27P3nJkMPMLR",
+    "img": "systems/pf2e/icons/default-icons/consumable.svg",
+    "name": "Elemental Ammunition (Electricity, Moderate)",
+    "system": {
+        "autoDestroy": {
+            "value": true
+        },
+        "baseItem": null,
+        "charges": {
+            "max": 0,
+            "value": 0
+        },
+        "consumableType": {
+            "value": "ammo"
+        },
+        "consume": {
+            "value": ""
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"pf2-icon\">1</span> Interact</p>\n<hr />\n<p>When activated, the reservoir of alchemical reagents in elemental ammunition atomizes on impact, dealing [[/r 2d4[persistent,electricity]]] damage to the target and [[/r (2[splash])[electricity]]]{2 splash damage} in addition to the damage the attack normally deals.</p>"
+        },
+        "equippedBulk": {
+            "value": ""
+        },
+        "hardness": 0,
+        "hp": {
+            "brokenThreshold": 0,
+            "max": 0,
+            "value": 0
+        },
+        "level": {
+            "value": 5
+        },
+        "negateBulk": {
+            "value": "0"
+        },
+        "preciousMaterial": {
+            "value": null
+        },
+        "preciousMaterialGrade": {
+            "value": null
+        },
+        "price": {
+            "value": {
+                "gp": 21
+            }
+        },
+        "quantity": 1,
+        "rules": [
+            {
+                "category": "persistent",
+                "damageType": "electricity",
+                "diceNumber": 2,
+                "dieSize": "d4",
+                "key": "DamageDice",
+                "selector": "{item|id}-damage"
+            },
+            {
+                "damageCategory": "splash",
+                "damageType": "electricity",
+                "key": "FlatModifier",
+                "selector": "{item|id}-damage",
+                "value": 2
+            }
+        ],
+        "size": "med",
+        "source": {
+            "value": "Pathfinder Treasure Vault"
+        },
+        "stackGroup": null,
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "alchemical",
+                "consumable",
+                "electricity",
+                "splash"
+            ]
+        },
+        "usage": {
+            "value": "held-in-one-hand"
+        },
+        "weight": {
+            "value": "-"
+        }
+    },
+    "type": "consumable"
+}

--- a/packs/equipment/elemental-ammunition-fire-greater.json
+++ b/packs/equipment/elemental-ammunition-fire-greater.json
@@ -1,0 +1,90 @@
+{
+    "_id": "508EVxbGogVxjdQ0",
+    "img": "systems/pf2e/icons/default-icons/consumable.svg",
+    "name": "Elemental Ammunition (Fire, Greater)",
+    "system": {
+        "autoDestroy": {
+            "value": true
+        },
+        "baseItem": null,
+        "charges": {
+            "max": 0,
+            "value": 0
+        },
+        "consumableType": {
+            "value": "ammo"
+        },
+        "consume": {
+            "value": ""
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"pf2-icon\">1</span> Interact</p>\n<hr />\n<p>When activated, the reservoir of alchemical reagents in elemental ammunition atomizes on impact, dealing [[/r 3d4[persistent,fire]]] damage to the target and [[/r (3[splash])[fire]]]{3 splash damage} in addition to the damage the attack normally deals.</p>"
+        },
+        "equippedBulk": {
+            "value": ""
+        },
+        "hardness": 0,
+        "hp": {
+            "brokenThreshold": 0,
+            "max": 0,
+            "value": 0
+        },
+        "level": {
+            "value": 11
+        },
+        "negateBulk": {
+            "value": "0"
+        },
+        "preciousMaterial": {
+            "value": null
+        },
+        "preciousMaterialGrade": {
+            "value": null
+        },
+        "price": {
+            "value": {
+                "gp": 210
+            }
+        },
+        "quantity": 1,
+        "rules": [
+            {
+                "category": "persistent",
+                "damageType": "fire",
+                "diceNumber": 3,
+                "dieSize": "d4",
+                "key": "DamageDice",
+                "selector": "{item|id}-damage"
+            },
+            {
+                "damageCategory": "splash",
+                "damageType": "fire",
+                "key": "FlatModifier",
+                "selector": "{item|id}-damage",
+                "value": 3
+            }
+        ],
+        "size": "med",
+        "source": {
+            "value": "Pathfinder Treasure Vault"
+        },
+        "stackGroup": null,
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "alchemical",
+                "consumable",
+                "fire",
+                "splash"
+            ]
+        },
+        "usage": {
+            "value": "held-in-one-hand"
+        },
+        "weight": {
+            "value": "-"
+        }
+    },
+    "type": "consumable"
+}

--- a/packs/equipment/elemental-ammunition-fire-lesser.json
+++ b/packs/equipment/elemental-ammunition-fire-lesser.json
@@ -1,0 +1,89 @@
+{
+    "_id": "1QBXzOLpqU02LUtL",
+    "img": "systems/pf2e/icons/default-icons/consumable.svg",
+    "name": "Elemental Ammunition (Fire, Lesser)",
+    "system": {
+        "autoDestroy": {
+            "value": true
+        },
+        "baseItem": null,
+        "charges": {
+            "max": 0,
+            "value": 0
+        },
+        "consumableType": {
+            "value": "ammo"
+        },
+        "consume": {
+            "value": ""
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"pf2-icon\">1</span> Interact</p>\n<hr />\n<p>When activated, the reservoir of alchemical reagents in elemental ammunition atomizes on impact, dealing [[/r 1[persistent,fire]]] damage to the target and [[/r (1[splash])[fire]]]{1 splash damage} in addition to the damage the attack normally deals.</p>"
+        },
+        "equippedBulk": {
+            "value": ""
+        },
+        "hardness": 0,
+        "hp": {
+            "brokenThreshold": 0,
+            "max": 0,
+            "value": 0
+        },
+        "level": {
+            "value": 1
+        },
+        "negateBulk": {
+            "value": "0"
+        },
+        "preciousMaterial": {
+            "value": null
+        },
+        "preciousMaterialGrade": {
+            "value": null
+        },
+        "price": {
+            "value": {
+                "gp": 3
+            }
+        },
+        "quantity": 1,
+        "rules": [
+            {
+                "damageCategory": "persistent",
+                "damageType": "fire",
+                "key": "FlatModifier",
+                "selector": "{item|id}-damage",
+                "value": 1
+            },
+            {
+                "damageCategory": "splash",
+                "damageType": "fire",
+                "key": "FlatModifier",
+                "selector": "{item|id}-damage",
+                "value": 1
+            }
+        ],
+        "size": "med",
+        "source": {
+            "value": "Pathfinder Treasure Vault"
+        },
+        "stackGroup": null,
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "alchemical",
+                "consumable",
+                "fire",
+                "splash"
+            ]
+        },
+        "usage": {
+            "value": "held-in-one-hand"
+        },
+        "weight": {
+            "value": "-"
+        }
+    },
+    "type": "consumable"
+}

--- a/packs/equipment/elemental-ammunition-fire-moderate.json
+++ b/packs/equipment/elemental-ammunition-fire-moderate.json
@@ -1,0 +1,90 @@
+{
+    "_id": "hGNw3WFbO0troZvb",
+    "img": "systems/pf2e/icons/default-icons/consumable.svg",
+    "name": "Elemental Ammunition (Fire, Moderate)",
+    "system": {
+        "autoDestroy": {
+            "value": true
+        },
+        "baseItem": null,
+        "charges": {
+            "max": 0,
+            "value": 0
+        },
+        "consumableType": {
+            "value": "ammo"
+        },
+        "consume": {
+            "value": ""
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"pf2-icon\">1</span> Interact</p>\n<hr />\n<p>When activated, the reservoir of alchemical reagents in elemental ammunition atomizes on impact, dealing [[/r 2d4[persistent,fire]]] damage to the target and [[/r (2[splash])[fire]]]{2 splash damage} in addition to the damage the attack normally deals.</p>"
+        },
+        "equippedBulk": {
+            "value": ""
+        },
+        "hardness": 0,
+        "hp": {
+            "brokenThreshold": 0,
+            "max": 0,
+            "value": 0
+        },
+        "level": {
+            "value": 5
+        },
+        "negateBulk": {
+            "value": "0"
+        },
+        "preciousMaterial": {
+            "value": null
+        },
+        "preciousMaterialGrade": {
+            "value": null
+        },
+        "price": {
+            "value": {
+                "gp": 21
+            }
+        },
+        "quantity": 1,
+        "rules": [
+            {
+                "category": "persistent",
+                "damageType": "fire",
+                "diceNumber": 2,
+                "dieSize": "d4",
+                "key": "DamageDice",
+                "selector": "{item|id}-damage"
+            },
+            {
+                "damageCategory": "splash",
+                "damageType": "fire",
+                "key": "FlatModifier",
+                "selector": "{item|id}-damage",
+                "value": 2
+            }
+        ],
+        "size": "med",
+        "source": {
+            "value": "Pathfinder Treasure Vault"
+        },
+        "stackGroup": null,
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "alchemical",
+                "consumable",
+                "fire",
+                "splash"
+            ]
+        },
+        "usage": {
+            "value": "held-in-one-hand"
+        },
+        "weight": {
+            "value": "-"
+        }
+    },
+    "type": "consumable"
+}

--- a/packs/equipment/elemental-ammunition-poison-greater.json
+++ b/packs/equipment/elemental-ammunition-poison-greater.json
@@ -1,0 +1,90 @@
+{
+    "_id": "HBaqOphAbHKpVN0S",
+    "img": "systems/pf2e/icons/default-icons/consumable.svg",
+    "name": "Elemental Ammunition (Poison, Greater)",
+    "system": {
+        "autoDestroy": {
+            "value": true
+        },
+        "baseItem": null,
+        "charges": {
+            "max": 0,
+            "value": 0
+        },
+        "consumableType": {
+            "value": "ammo"
+        },
+        "consume": {
+            "value": ""
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"pf2-icon\">1</span> Interact</p>\n<hr />\n<p>When activated, the reservoir of alchemical reagents in elemental ammunition atomizes on impact, dealing [[/r 3d4[persistent,poison]]] damage to the target and [[/r (3[splash])[poison]]]{3 splash damage} in addition to the damage the attack normally deals.</p>"
+        },
+        "equippedBulk": {
+            "value": ""
+        },
+        "hardness": 0,
+        "hp": {
+            "brokenThreshold": 0,
+            "max": 0,
+            "value": 0
+        },
+        "level": {
+            "value": 11
+        },
+        "negateBulk": {
+            "value": "0"
+        },
+        "preciousMaterial": {
+            "value": null
+        },
+        "preciousMaterialGrade": {
+            "value": null
+        },
+        "price": {
+            "value": {
+                "gp": 210
+            }
+        },
+        "quantity": 1,
+        "rules": [
+            {
+                "category": "persistent",
+                "damageType": "poison",
+                "diceNumber": 3,
+                "dieSize": "d4",
+                "key": "DamageDice",
+                "selector": "{item|id}-damage"
+            },
+            {
+                "damageCategory": "splash",
+                "damageType": "poison",
+                "key": "FlatModifier",
+                "selector": "{item|id}-damage",
+                "value": 3
+            }
+        ],
+        "size": "med",
+        "source": {
+            "value": "Pathfinder Treasure Vault"
+        },
+        "stackGroup": null,
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "alchemical",
+                "consumable",
+                "poison",
+                "splash"
+            ]
+        },
+        "usage": {
+            "value": "held-in-one-hand"
+        },
+        "weight": {
+            "value": "-"
+        }
+    },
+    "type": "consumable"
+}

--- a/packs/equipment/elemental-ammunition-poison-lesser.json
+++ b/packs/equipment/elemental-ammunition-poison-lesser.json
@@ -1,0 +1,89 @@
+{
+    "_id": "A6hIsHoDH0V4mBYV",
+    "img": "systems/pf2e/icons/default-icons/consumable.svg",
+    "name": "Elemental Ammunition (Poison, Lesser)",
+    "system": {
+        "autoDestroy": {
+            "value": true
+        },
+        "baseItem": null,
+        "charges": {
+            "max": 0,
+            "value": 0
+        },
+        "consumableType": {
+            "value": "ammo"
+        },
+        "consume": {
+            "value": ""
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"pf2-icon\">1</span> Interact</p>\n<hr />\n<p>When activated, the reservoir of alchemical reagents in elemental ammunition atomizes on impact, dealing [[/r 1[persistent,poison]]] damage to the target and [[/r (1[splash])[poison]]]{1 splash damage} in addition to the damage the attack normally deals.</p>"
+        },
+        "equippedBulk": {
+            "value": ""
+        },
+        "hardness": 0,
+        "hp": {
+            "brokenThreshold": 0,
+            "max": 0,
+            "value": 0
+        },
+        "level": {
+            "value": 1
+        },
+        "negateBulk": {
+            "value": "0"
+        },
+        "preciousMaterial": {
+            "value": null
+        },
+        "preciousMaterialGrade": {
+            "value": null
+        },
+        "price": {
+            "value": {
+                "gp": 3
+            }
+        },
+        "quantity": 1,
+        "rules": [
+            {
+                "damageCategory": "persistent",
+                "damageType": "poison",
+                "key": "FlatModifier",
+                "selector": "{item|id}-damage",
+                "value": 1
+            },
+            {
+                "damageCategory": "splash",
+                "damageType": "poison",
+                "key": "FlatModifier",
+                "selector": "{item|id}-damage",
+                "value": 1
+            }
+        ],
+        "size": "med",
+        "source": {
+            "value": "Pathfinder Treasure Vault"
+        },
+        "stackGroup": null,
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "alchemical",
+                "consumable",
+                "poison",
+                "splash"
+            ]
+        },
+        "usage": {
+            "value": "held-in-one-hand"
+        },
+        "weight": {
+            "value": "-"
+        }
+    },
+    "type": "consumable"
+}

--- a/packs/equipment/elemental-ammunition-poison-moderate.json
+++ b/packs/equipment/elemental-ammunition-poison-moderate.json
@@ -1,0 +1,90 @@
+{
+    "_id": "BcUXqbAWje4Aj0WS",
+    "img": "systems/pf2e/icons/default-icons/consumable.svg",
+    "name": "Elemental Ammunition (Poison, Moderate)",
+    "system": {
+        "autoDestroy": {
+            "value": true
+        },
+        "baseItem": null,
+        "charges": {
+            "max": 0,
+            "value": 0
+        },
+        "consumableType": {
+            "value": "ammo"
+        },
+        "consume": {
+            "value": ""
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"pf2-icon\">1</span> Interact</p>\n<hr />\n<p>When activated, the reservoir of alchemical reagents in elemental ammunition atomizes on impact, dealing [[/r 2d4[persistent,poison]]] damage to the target and [[/r (2[splash])[poison]]]{2 splash damage} in addition to the damage the attack normally deals.</p>"
+        },
+        "equippedBulk": {
+            "value": ""
+        },
+        "hardness": 0,
+        "hp": {
+            "brokenThreshold": 0,
+            "max": 0,
+            "value": 0
+        },
+        "level": {
+            "value": 5
+        },
+        "negateBulk": {
+            "value": "0"
+        },
+        "preciousMaterial": {
+            "value": null
+        },
+        "preciousMaterialGrade": {
+            "value": null
+        },
+        "price": {
+            "value": {
+                "gp": 21
+            }
+        },
+        "quantity": 1,
+        "rules": [
+            {
+                "category": "persistent",
+                "damageType": "poison",
+                "diceNumber": 2,
+                "dieSize": "d4",
+                "key": "DamageDice",
+                "selector": "{item|id}-damage"
+            },
+            {
+                "damageCategory": "splash",
+                "damageType": "poison",
+                "key": "FlatModifier",
+                "selector": "{item|id}-damage",
+                "value": 2
+            }
+        ],
+        "size": "med",
+        "source": {
+            "value": "Pathfinder Treasure Vault"
+        },
+        "stackGroup": null,
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "alchemical",
+                "consumable",
+                "poison",
+                "splash"
+            ]
+        },
+        "usage": {
+            "value": "held-in-one-hand"
+        },
+        "weight": {
+            "value": "-"
+        }
+    },
+    "type": "consumable"
+}


### PR DESCRIPTION
Add variants for each of the damage types that elemental ammunition can deal, including rule elements which will pass to the firing weapon.