### PR TITLE
Add schemas to `FixedProficiencyRuleElement`, `LoseHitPointsRuleElement` and `MartialProficiencyRuleElement`

### DIFF
--- a/src/module/rules/rule-element/lose-hit-points.ts
+++ b/src/module/rules/rule-element/lose-hit-points.ts
@@ -1,39 +1,33 @@
 import { CreaturePF2e } from "@actor";
 import { ActorType } from "@actor/data/index.ts";
 import { ItemSourcePF2e } from "@item/data/index.ts";
-import { RuleElementOptions } from "./base.ts";
-import { RuleElementPF2e, RuleElementSource } from "./index.ts";
+import { RuleElementPF2e, RuleElementSchema } from "./index.ts";
+import type { BooleanField } from "types/foundry/common/data/fields.d.ts";
+import { ResolvableValueField } from "./data.ts";
 
 /** Reduce current hit points without applying damage */
-export class LoseHitPointsRuleElement extends RuleElementPF2e {
+class LoseHitPointsRuleElement extends RuleElementPF2e<LoseHitPointsRuleSchema> {
     static override validActorTypes: ActorType[] = ["character", "familiar", "npc"];
 
-    /**
-     * Lost hitpoints should reevaluate on item update, with the parent actor losing the difference in HP between the
-     * new and old values.
-     */
-    private reevaluateOnUpdate: boolean;
-
-    constructor(data: LoseHitPointsSource, options: RuleElementOptions) {
-        super(data, options);
-
-        const valueIsValid = typeof data.value === "number" || typeof data.value === "string";
-        if (!valueIsValid) {
-            this.failValidation("Missing numeric or string value");
-        }
-        this.reevaluateOnUpdate = !!data.reevaluateOnUpdate;
+    static override defineSchema(): LoseHitPointsRuleSchema {
+        const { fields } = foundry.data;
+        return {
+            ...super.defineSchema(),
+            value: new ResolvableValueField({ required: true, initial: undefined }),
+            reevaluateOnUpdate: new fields.BooleanField({ required: false, initial: false }),
+        };
     }
 
     override onCreate(actorUpdates: Record<string, unknown>): void {
         if (this.ignored) return;
-        const value = Math.abs(Number(this.resolveValue()) || 0);
+        const value = Math.abs(Number(this.resolveValue(this.value)) || 0);
         const currentHP = this.actor._source.system.attributes.hp.value;
         actorUpdates["system.attributes.hp.value"] = Math.max(currentHP - value, 0);
     }
 
     override async preUpdate(changes: DeepPartial<ItemSourcePF2e>): Promise<void> {
         if (!this.reevaluateOnUpdate || this.ignored) return;
-        const previousValue = Math.abs(Number(this.resolveValue()) || 0);
+        const previousValue = Math.abs(Number(this.resolveValue(this.value)) || 0);
         const newItem = this.item.clone(changes);
         const rule = newItem.system.rules.find((r): r is LoseHitPointsSource => r.key === this.key);
         const newValue = Math.abs(
@@ -50,11 +44,21 @@ export class LoseHitPointsRuleElement extends RuleElementPF2e {
     }
 }
 
-interface LoseHitPointsSource extends RuleElementSource {
-    value?: unknown;
-    reevaluateOnUpdate?: unknown;
-}
+type LoseHitPointsSource = SourceFromSchema<LoseHitPointsRuleSchema>;
 
-export interface LoseHitPointsRuleElement extends RuleElementPF2e {
+interface LoseHitPointsRuleElement
+    extends RuleElementPF2e<LoseHitPointsRuleSchema>,
+        ModelPropsFromSchema<LoseHitPointsRuleSchema> {
     get actor(): CreaturePF2e;
 }
+
+type LoseHitPointsRuleSchema = RuleElementSchema & {
+    value: ResolvableValueField<true, false, false>;
+    /**
+     * Lost hitpoints should reevaluate on item update, with the parent actor losing the difference in HP between the
+     * new and old values.
+     */
+    reevaluateOnUpdate: BooleanField<boolean, boolean, false, false, true>;
+};
+
+export { LoseHitPointsRuleElement };


### PR DESCRIPTION
Tested with:
`FixedProficiency` -> `Spell Effect: Object Memory (Weapon)`,
`LoseHitPoints` -> `Drained`,
`MartialProficiency` -> `Dwarven Weapon Familiarity` (Harsk lvl 5) and  `Gunslinger` Class