### PR TITLE
Add schemas to `MultipleAttackPenaltyRuleElement`, `RollTwiceRuleElement` and `SenseRuleElement`

### DIFF
--- a/src/module/rules/rule-element/multiple-attack-penalty.ts
+++ b/src/module/rules/rule-element/multiple-attack-penalty.ts
@@ -1,42 +1,45 @@
 import { MAPSynthetic } from "../synthetics.ts";
-import { RuleElementSource } from "./data.ts";
-import { RuleElementOptions, RuleElementPF2e } from "./index.ts";
+import { ResolvableValueField, RuleElementSchema } from "./data.ts";
+import { RuleElementPF2e } from "./index.ts";
+import type { StringField } from "types/foundry/common/data/fields.d.ts";
 
 /**
  * @category RuleElement
  */
-export class MultipleAttackPenaltyRuleElement extends RuleElementPF2e {
-    private selector: string;
-
-    constructor(data: MAPSource, options: RuleElementOptions) {
-        super(data, options);
-
-        if (typeof data.selector === "string") {
-            this.selector = data.selector;
-        } else {
-            this.failValidation("Missing string selector property");
-            this.selector = "";
-        }
+class MultipleAttackPenaltyRuleElement extends RuleElementPF2e<MAPRuleSchema> {
+    static override defineSchema(): MAPRuleSchema {
+        const { fields } = foundry.data;
+        return {
+            ...super.defineSchema(),
+            selector: new fields.StringField({ required: true, blank: false }),
+            value: new ResolvableValueField({ required: true, initial: undefined }),
+        };
     }
 
     override beforePrepareData(): void {
         if (this.ignored) return;
 
         const selector = this.resolveInjectedProperties(this.selector);
-        const label = this.resolveInjectedProperties(this.label);
-        const value = Number(this.resolveValue(this.data.value)) || 0;
-        if (selector && label && value) {
-            const map: MAPSynthetic = { label, penalty: value, predicate: this.predicate };
+        const value = Number(this.resolveValue(this.value)) || 0;
+        if (selector && value) {
+            const map: MAPSynthetic = { label: this.label, penalty: value, predicate: this.predicate };
             const penalties = (this.actor.synthetics.multipleAttackPenalties[selector] ??= []);
             penalties.push(map);
         } else {
-            console.warn(
-                "PF2E | Multiple attack penalty requires at least a selector field and a non-empty value field"
+            this.failValidation(
+                "Multiple attack penalty requires at least a selector field and a non-empty value field"
             );
         }
     }
 }
 
-interface MAPSource extends RuleElementSource {
-    selector?: unknown;
-}
+interface MultipleAttackPenaltyRuleElement
+    extends RuleElementPF2e<MAPRuleSchema>,
+        ModelPropsFromSchema<MAPRuleSchema> {}
+
+type MAPRuleSchema = RuleElementSchema & {
+    selector: StringField<string, string, true, false, false>;
+    value: ResolvableValueField<true, false, false>;
+};
+
+export { MultipleAttackPenaltyRuleElement };

--- a/src/module/rules/rule-element/roll-twice.ts
+++ b/src/module/rules/rule-element/roll-twice.ts
@@ -1,45 +1,18 @@
 import { RollTwiceSynthetic } from "../synthetics.ts";
-import { RuleElementOptions, RuleElementPF2e } from "./base.ts";
-import { RuleElementSource } from "./index.ts";
+import { RuleElementPF2e } from "./base.ts";
+import { RuleElementSchema } from "./index.ts";
+import type { BooleanField, StringField } from "types/foundry/common/data/fields.d.ts";
 
 /** Roll Twice and keep either the higher or lower result */
-export class RollTwiceRuleElement extends RuleElementPF2e {
-    selector = "";
-
-    keep: "higher" | "lower" = "higher";
-
-    /** If the hosting item is an effect, remove or expire it after a matching roll is made */
-    removeAfterRoll = this.item.isOfType("effect");
-
-    constructor(data: RollTwiceSource, options: RuleElementOptions) {
-        super(data, options);
-
-        if (this.#isValid(data)) {
-            this.selector = this.resolveInjectedProperties(data.selector);
-            this.keep = data.keep;
-
-            const expireEffects = game.settings.get("pf2e", "automation.effectExpiration");
-            const removeExpired = game.settings.get("pf2e", "automation.removeExpiredEffects");
-
-            this.removeAfterRoll =
-                (expireEffects || removeExpired) && this.item.isOfType("effect")
-                    ? Boolean(data.removeAfterRoll ?? true)
-                    : false;
-        }
-    }
-
-    #isValid(data: RollTwiceSource): data is RollTwiceData {
-        if (!(typeof data.selector === "string" && data.selector)) {
-            this.failValidation("A Roll Twice rule element requires selector");
-            return false;
-        }
-
-        if (!(typeof data.keep === "string" && ["higher", "lower"].includes(data.keep))) {
-            this.failValidation('A Roll Twice rule element requires a "keep" property of either "higher" or "lower"');
-            return false;
-        }
-
-        return true;
+class RollTwiceRuleElement extends RuleElementPF2e<RollTwiceRuleSchema> {
+    static override defineSchema(): RollTwiceRuleSchema {
+        const { fields } = foundry.data;
+        return {
+            ...super.defineSchema(),
+            selector: new fields.StringField({ required: true, blank: false }),
+            keep: new fields.StringField({ required: true, choices: ["lower", "higher"] }),
+            removeAfterRoll: new fields.BooleanField({ required: false, initial: undefined }),
+        };
     }
 
     override beforePrepareData(): void {
@@ -57,8 +30,13 @@ export class RollTwiceRuleElement extends RuleElementPF2e {
             return;
         }
 
+        const expireEffects = game.settings.get("pf2e", "automation.effectExpiration");
+        const removeExpired = game.settings.get("pf2e", "automation.removeExpiredEffects");
+        const removeAfterRoll =
+            this.removeAfterRoll ?? ((expireEffects || removeExpired) && this.item.isOfType("effect"));
+
         const rolledTwice = roll?.dice.some((d) => ["kh", "kl"].some((m) => d.modifiers.includes(m))) ?? false;
-        if (!(rolledTwice && this.removeAfterRoll && selectors.includes(this.selector) && this.test(rollOptions))) {
+        if (!(rolledTwice && removeAfterRoll && selectors.includes(this.selector) && this.test(rollOptions))) {
             return;
         }
 
@@ -66,23 +44,23 @@ export class RollTwiceRuleElement extends RuleElementPF2e {
             rule.ignored = true;
         }
 
-        if (game.settings.get("pf2e", "automation.removeExpiredEffects")) {
+        if (removeExpired) {
             await this.item.delete();
-        } else if (game.settings.get("pf2e", "automation.effectExpiration")) {
+        } else if (expireEffects) {
             await this.item.update({ "system.duration.value": -1, "system.expired": true });
         }
     }
 }
 
-interface RollTwiceSource extends RuleElementSource {
-    selector?: unknown;
-    keep?: unknown;
-    removeAfterRoll?: unknown;
-}
+interface RollTwiceRuleElement
+    extends RuleElementPF2e<RollTwiceRuleSchema>,
+        ModelPropsFromSchema<RollTwiceRuleSchema> {}
 
-interface RollTwiceData {
-    key: "RollTwice";
-    selector: string;
-    keep: "higher" | "lower";
-    removeAfterRoll?: boolean;
-}
+type RollTwiceRuleSchema = RuleElementSchema & {
+    selector: StringField<string, string, true, false, false>;
+    keep: StringField<"higher" | "lower", "higher" | "lower", true, false, false>;
+    /** If the hosting item is an effect, remove or expire it after a matching roll is made */
+    removeAfterRoll: BooleanField<boolean, boolean, false, false, false>;
+};
+
+export { RollTwiceRuleElement };

--- a/src/module/rules/rule-element/sense.ts
+++ b/src/module/rules/rule-element/sense.ts
@@ -1,83 +1,71 @@
 import { CharacterPF2e, FamiliarPF2e } from "@actor";
 import { CreatureSensePF2e, SENSE_ACUITIES, SENSE_TYPES, SenseAcuity, SenseType } from "@actor/creature/sense.ts";
 import { ActorType } from "@actor/data/index.ts";
-import { setHasElement, tupleHasValue } from "@util";
 import { RuleElementOptions } from "./base.ts";
-import { RuleElementData, RuleElementPF2e, RuleElementSource } from "./index.ts";
+import { RuleElementPF2e, RuleElementSchema } from "./index.ts";
+import type { BooleanField, StringField } from "types/foundry/common/data/fields.d.ts";
+import { ResolvableValueField, RuleElementSource } from "./data.ts";
 
 /**
  * @category RuleElement
  */
-export class SenseRuleElement extends RuleElementPF2e {
+class SenseRuleElement extends RuleElementPF2e<SenseRuleSchema> {
     protected static override validActorTypes: ActorType[] = ["character", "familiar"];
 
-    private selector: SenseType;
-
-    private acuity: SenseAcuity;
+    static override defineSchema(): SenseRuleSchema {
+        const { fields } = foundry.data;
+        return {
+            ...super.defineSchema(),
+            selector: new fields.StringField({ required: true, nullable: false, choices: [...SENSE_TYPES] }),
+            force: new fields.BooleanField({ required: false, nullable: false, initial: false }),
+            acuity: new fields.StringField({
+                required: false,
+                nullable: false,
+                choices: SENSE_ACUITIES,
+                initial: undefined,
+            }),
+            range: new ResolvableValueField({ required: false, nullable: false, initial: undefined }),
+        };
+    }
 
     constructor(data: SenseRuleElementSource, options: RuleElementOptions) {
-        data.force ??= false;
-        data.range ??= "";
-        data.acuity ??= "precise";
-        const defaultLabels: Record<string, string | undefined> = CONFIG.PF2E.senses;
-        data.label ??= defaultLabels[String(data.selector)];
-
+        if (data.selector) {
+            data.label ??= CONFIG.PF2E.senses[data.selector];
+        }
         super(data, options);
-
-        if (setHasElement(SENSE_TYPES, data.selector)) {
-            this.selector = data.selector;
-        } else {
-            this.failValidation("Missing or unrecognized string selector property");
-            this.selector = "scent";
-        }
-
-        if (tupleHasValue(SENSE_ACUITIES, data.acuity)) {
-            this.acuity = data.acuity;
-        } else {
-            this.failValidation(
-                'Unrecognized acuity property: must be one of "precise", "imprecise", "vague", or omitted.'
-            );
-            this.acuity = "vague";
-        }
     }
 
     override beforePrepareData(): void {
         if (this.ignored) return;
 
-        const range = this.resolveValue(this.data.range, "");
-        if (this.selector) {
-            const newSense = new CreatureSensePF2e({
-                type: this.selector,
-                acuity: this.acuity,
-                value: String(range),
-                source: this.item.name,
-            });
-            this.actor.synthetics.senses.push({
-                sense: newSense,
-                predicate: this.predicate,
-                force: this.data.force,
-            });
-        } else {
-            this.failValidation("Sense requires at least a selector field and a label field or item name");
-        }
+        const range = this.resolveValue(this.range, "");
+        const newSense = new CreatureSensePF2e({
+            type: this.selector,
+            acuity: this.acuity,
+            value: String(range),
+            source: this.item.name,
+        });
+        this.actor.synthetics.senses.push({
+            sense: newSense,
+            predicate: this.predicate,
+            force: this.force,
+        });
     }
 }
 
-export interface SenseRuleElement {
+interface SenseRuleElement extends RuleElementPF2e<SenseRuleSchema>, ModelPropsFromSchema<SenseRuleSchema> {
     get actor(): CharacterPF2e | FamiliarPF2e;
-    data: SenseRuleElementData;
 }
 
-interface SenseRuleElementData extends RuleElementData {
-    label: string;
-    force: boolean;
-    acuity: SenseAcuity;
-    range: string | number;
-}
+type SenseRuleSchema = RuleElementSchema & {
+    selector: StringField<SenseType, SenseType, true, false, false>;
+    force: BooleanField<boolean, boolean, false, false, true>;
+    acuity: StringField<SenseAcuity, SenseAcuity, false, false, true>;
+    range: ResolvableValueField<false, false, false>;
+};
 
 interface SenseRuleElementSource extends RuleElementSource {
-    selector?: unknown;
-    acuity?: string;
-    range?: string | number | null;
-    force?: boolean;
+    selector?: SenseType;
 }
+
+export { SenseRuleElement };


### PR DESCRIPTION
Tested with:
`MultipleAttackPenaltyRuleElement` -> `Flurry` (Harsk Level 5),
`RollTwiceRuleElement` -> `Effect: Black Cat Curse` and `Spell Effect: True Strike`,
`SenseRuleElement` -> `Spell Effect: One With the Land` and `Dwarf` class (Harsk Level 5)