### PR TITLE
Add pack's source package after its name in brackets on the Compendium Browser's Settings tab

### DIFF
--- a/src/module/apps/compendium-browser/data.ts
+++ b/src/module/apps/compendium-browser/data.ts
@@ -3,6 +3,7 @@ import * as browserTabs from "./tabs/index.ts";
 interface PackInfo {
     load: boolean;
     name: string;
+    package: string;
 }
 
 interface SourceInfo {

--- a/src/module/apps/compendium-browser/index.ts
+++ b/src/module/apps/compendium-browser/index.ts
@@ -316,6 +316,7 @@ class CompendiumBrowser extends Application {
                 settings.bestiary![pack.collection] = {
                     load,
                     name: pack.metadata.label,
+                    package: pack.metadata.packageName,
                 };
             }
             if (types.has("hazard")) {
@@ -323,6 +324,7 @@ class CompendiumBrowser extends Application {
                 settings.hazard![pack.collection] = {
                     load,
                     name: pack.metadata.label,
+                    package: pack.metadata.packageName,
                 };
             }
 
@@ -331,6 +333,7 @@ class CompendiumBrowser extends Application {
                 settings.action![pack.collection] = {
                     load,
                     name: pack.metadata.label,
+                    package: pack.metadata.packageName,
                 };
             } else if (
                 ["weapon", "armor", "equipment", "consumable", "treasure", "backpack", "kit"].some((type) =>
@@ -341,18 +344,21 @@ class CompendiumBrowser extends Application {
                 settings.equipment![pack.collection] = {
                     load,
                     name: pack.metadata.label,
+                    package: pack.metadata.packageName,
                 };
             } else if (types.has("feat")) {
                 const load = this.settings.feat?.[pack.collection]?.load ?? !!loadDefault[pack.collection];
                 settings.feat![pack.collection] = {
                     load,
                     name: pack.metadata.label,
+                    package: pack.metadata.packageName,
                 };
             } else if (types.has("spell")) {
                 const load = this.settings.spell?.[pack.collection]?.load ?? !!loadDefault[pack.collection];
                 settings.spell![pack.collection] = {
                     load,
                     name: pack.metadata.label,
+                    package: pack.metadata.packageName,
                 };
             }
         }

--- a/static/templates/compendium-browser/settings/pack-settings.hbs
+++ b/static/templates/compendium-browser/settings/pack-settings.hbs
@@ -3,7 +3,7 @@
     <h3>{{localize "PF2E.CompendiumBrowser.TabAction"}}</h3>
     <dl>
         {{#each settings.action as |conf pack|}}
-            <label><dt><input type="checkbox" name="action-{{pack}}" {{checked conf.load}}></dt><dd>{{conf.name}}</dd></label>
+            <label><dt><input type="checkbox" name="action-{{pack}}" {{checked conf.load}}></dt><dd>{{conf.name}} ({{conf.package}})</dd></label>
         {{/each}}
     </dl>
 </div>
@@ -12,7 +12,7 @@
     <h3>{{localize "PF2E.CompendiumBrowser.TabBestiary"}}</h3>
     <dl>
         {{#each settings.bestiary as |conf pack|}}
-            <label><dt><input type="checkbox" name="bestiary-{{pack}}" {{checked conf.load}}></dt><dd>{{conf.name}}</dd></label>
+            <label><dt><input type="checkbox" name="bestiary-{{pack}}" {{checked conf.load}}></dt><dd>{{conf.name}} ({{conf.package}})</dd></label>
         {{/each}}
     </dl>
 </div>
@@ -21,7 +21,7 @@
     <h3>{{localize "PF2E.CompendiumBrowser.TabEquipment"}}</h3>
     <dl>
         {{#each settings.equipment as |conf pack|}}
-            <label><dt><input type="checkbox" name="equipment-{{pack}}" {{checked conf.load}}></dt><dd>{{conf.name}}</dd></label>
+            <label><dt><input type="checkbox" name="equipment-{{pack}}" {{checked conf.load}}></dt><dd>{{conf.name}} ({{conf.package}})</dd></label>
         {{/each}}
     </dl>
 </div>
@@ -30,7 +30,7 @@
     <h3>{{localize "PF2E.CompendiumBrowser.TabFeat"}}</h3>
     <dl>
         {{#each settings.feat as |conf pack|}}
-            <label><dt><input type="checkbox" name="feat-{{pack}}" {{checked conf.load}}></dt><dd>{{conf.name}}</dd></label>
+            <label><dt><input type="checkbox" name="feat-{{pack}}" {{checked conf.load}}></dt><dd>{{conf.name}} ({{conf.package}})</dd></label>
         {{/each}}
     </dl>
 </div>
@@ -39,7 +39,7 @@
     <h3>{{localize "PF2E.CompendiumBrowser.TabHazard"}}</h3>
     <dl>
         {{#each settings.hazard as |conf pack|}}
-            <label><dt><input type="checkbox" name="hazard-{{pack}}" {{checked conf.load}}></dt><dd>{{conf.name}}</dd></label>
+            <label><dt><input type="checkbox" name="hazard-{{pack}}" {{checked conf.load}}></dt><dd>{{conf.name}} ({{conf.package}})</dd></label>
         {{/each}}
     </dl>
 </div>
@@ -48,7 +48,7 @@
     <h3>{{localize "PF2E.CompendiumBrowser.TabSpell"}}</h3>
     <dl>
         {{#each settings.spell as |conf pack|}}
-            <label><dt><input type="checkbox" name="spell-{{pack}}" {{checked conf.load}}></dt><dd>{{conf.name}}</dd></label>
+            <label><dt><input type="checkbox" name="spell-{{pack}}" {{checked conf.load}}></dt><dd>{{conf.name}} ({{conf.package}})</dd></label>
         {{/each}}
     </dl>
 </div>


### PR DESCRIPTION
![Screenshot_20230708_181501](https://github.com/foundryvtt/pf2e/assets/43446478/9ea60820-8679-4f53-aac7-8ae8b92b879c)

Because of the new ability to add folders for compendia, and to give each compendium a distinct banner, peeps have started to name their compendia simpler and more to-the-point.

This PR just makes it so that the origin package where the pack comes from is added  to the end of the checkbox label on the Settings tab, so you know which of the several dozen "Feats" you're actually toggling on.