### PR TITLE
Add schemas to `TokenEffectIconRuleElement`, `TokenImageRuleElement`, `TokenNameRuleElement`, `TokenLightRuleElement` and `WeaponPotencyRuleElement`

### DIFF
--- a/src/module/rules/rule-element/token-effect-icon.ts
+++ b/src/module/rules/rule-element/token-effect-icon.ts
@@ -1,19 +1,41 @@
 import { TokenEffect } from "@actor/token-effect.ts";
-import { RuleElementPF2e } from "./index.ts";
+import { RuleElementPF2e, RuleElementSchema } from "./index.ts";
 import { EffectPF2e } from "@item";
+import type { StringField } from "types/foundry/common/data/fields.d.ts";
+import { isImageFilePath } from "@util";
 
 /**
  * Add an effect icon to an actor's token
  * @category RuleElement
  */
-export class TokenEffectIconRuleElement extends RuleElementPF2e {
+class TokenEffectIconRuleElement extends RuleElementPF2e<TokenEffectIconSchema> {
+    static override defineSchema(): TokenEffectIconSchema {
+        const { fields } = foundry.data;
+        return {
+            ...super.defineSchema(),
+            value: new fields.StringField({ required: false, blank: false, initial: undefined }),
+        };
+    }
+
     override afterPrepareData(): void {
         if (!this.test()) return;
 
-        const path =
-            typeof this.data.value === "string" ? this.resolveInjectedProperties(this.data.value) : this.item.img;
+        const path = this.value ? this.resolveInjectedProperties(this.value).trim() : this.item.img;
+        if (!isImageFilePath(path)) {
+            return this.failValidation("value is not a valid image file path");
+        }
         this.actor.synthetics.tokenEffectIcons.push(
-            new TokenEffect(new EffectPF2e({ type: "effect", name: this.label, img: path.trim() as ImageFilePath }))
+            new TokenEffect(new EffectPF2e({ type: "effect", name: this.label, img: path }))
         );
     }
 }
+
+interface TokenEffectIconRuleElement
+    extends RuleElementPF2e<TokenEffectIconSchema>,
+        ModelPropsFromSchema<TokenEffectIconSchema> {}
+
+type TokenEffectIconSchema = RuleElementSchema & {
+    value: StringField<string, string, false, false, false>;
+};
+
+export { TokenEffectIconRuleElement };

--- a/src/module/rules/rule-element/token-image.ts
+++ b/src/module/rules/rule-element/token-image.ts
@@ -1,37 +1,28 @@
-import { BracketedValue, RuleElementOptions, RuleElementPF2e, RuleElementSource } from "./index.ts";
+import { ResolvableValueField } from "./data.ts";
+import { RuleElementOptions, RuleElementPF2e, RuleElementSchema, RuleElementSource } from "./index.ts";
+import type { ColorField, NumberField } from "types/foundry/common/data/fields.d.ts";
 
 /**
  * Change the image representing an actor's token
  * @category RuleElement
  */
-export class TokenImageRuleElement extends RuleElementPF2e {
-    /** An image or video path */
-    value: string | BracketedValue | null;
+class TokenImageRuleElement extends RuleElementPF2e<TokenImageRuleSchema> {
+    static override defineSchema(): TokenImageRuleSchema {
+        const { fields } = foundry.data;
+        return {
+            ...super.defineSchema(),
+            value: new ResolvableValueField({ required: true, nullable: false, initial: undefined }),
+            scale: new fields.NumberField({ required: false, nullable: false, positive: true, initial: undefined }),
+            tint: new fields.ColorField({ required: false, nullable: false, initial: undefined }),
+            alpha: new fields.NumberField({ required: false, nullable: false, initial: undefined }),
+        };
+    }
 
-    /** An optional scale, tint, and alpha adjustment */
-    scale?: number;
-    tint?: HexColorString;
-    alpha?: number;
-
-    constructor(data: TokenImageSource, options: RuleElementOptions) {
+    constructor(data: RuleElementSource, options: RuleElementOptions) {
         super(data, options);
 
-        if (typeof data.value === "string" || this.isBracketedValue(data.value)) {
-            this.value = data.value;
-        } else {
-            this.value = null;
-        }
-
-        if (typeof data.scale === "number" && data.scale > 0) {
-            this.scale = data.scale;
-        }
-
-        if (typeof data.tint === "string") {
-            this.tint = new Color(data.tint).toString();
-        }
-
-        if (typeof data.alpha === "number") {
-            this.alpha = data.alpha;
+        if (!(typeof this.value === "string" || this.isBracketedValue(this.value))) {
+            this.failValidation("value must be a string or a bracketed value");
         }
     }
 
@@ -51,7 +42,7 @@ export class TokenImageRuleElement extends RuleElementPF2e {
             texture.tint = this.tint;
         }
 
-        if (typeof this.alpha === "number") {
+        if (this.alpha) {
             this.actor.synthetics.tokenOverrides.alpha = this.alpha;
         }
 
@@ -65,9 +56,19 @@ export class TokenImageRuleElement extends RuleElementPF2e {
     }
 }
 
-interface TokenImageSource extends RuleElementSource {
-    value?: unknown;
-    scale?: unknown;
-    tint?: unknown;
-    alpha?: unknown;
-}
+interface TokenImageRuleElement
+    extends RuleElementPF2e<TokenImageRuleSchema>,
+        ModelPropsFromSchema<TokenImageRuleSchema> {}
+
+type TokenImageRuleSchema = RuleElementSchema & {
+    /** An image or video path */
+    value: ResolvableValueField<true, false, false>;
+    /** An optional scale adjustment */
+    scale: NumberField<number, number, false, false, false>;
+    /** An optional tint adjustment */
+    tint: ColorField<false, false, false>;
+    /** An optional alpha adjustment */
+    alpha: NumberField<number, number, false, false, false>;
+};
+
+export { TokenImageRuleElement };

--- a/src/module/rules/rule-element/token-name.ts
+++ b/src/module/rules/rule-element/token-name.ts
@@ -1,16 +1,34 @@
-import { RuleElementPF2e } from "./index.ts";
+import { ResolvableValueField } from "./data.ts";
+import { RuleElementPF2e, RuleElementSchema } from "./index.ts";
 
 /**
  * Change the name representing an actor's token
  * @category RuleElement
  */
-export class TokenNameRuleElement extends RuleElementPF2e {
+class TokenNameRuleElement extends RuleElementPF2e<TokenNameRuleSchema> {
+    static override defineSchema(): TokenNameRuleSchema {
+        return {
+            ...super.defineSchema(),
+            value: new ResolvableValueField({ required: true }),
+        };
+    }
+
     override afterPrepareData(): void {
-        const name = this.resolveValue();
-        if (typeof name !== "string") return this.failValidation("Missing value field");
+        const name = this.resolveValue(this.value);
+        if (typeof name !== "string") return this.failValidation("value must resolve to a string");
 
         if (!this.test()) return;
 
         this.actor.synthetics.tokenOverrides.name = name;
     }
 }
+
+interface TokenNameRuleElement
+    extends RuleElementPF2e<TokenNameRuleSchema>,
+        ModelPropsFromSchema<TokenNameRuleSchema> {}
+
+type TokenNameRuleSchema = RuleElementSchema & {
+    value: ResolvableValueField<true, false, false>;
+};
+
+export { TokenNameRuleElement };


### PR DESCRIPTION
The last batch. Tested with:
`TokenEffectIconRuleElement` -> `Torch`,
`TokenImageRuleElement` -> Manually (unused in the system),
`TokenNameRuleElement` -> Manually (unused in the system),
`TokenLightRuleElement` -> `Torch`,
`WeaponPotencyRuleElement` -> `Spell Effect: Magic Fang`