### PR TITLE
Add types for `Quadtree` and `CanvasQuadtree`

### DIFF
--- a/types/foundry/client/pixi/helpers/index.d.ts
+++ b/types/foundry/client/pixi/helpers/index.d.ts
@@ -5,5 +5,6 @@ import "./grid-highlight.d.ts";
 import "./object-hud.d.ts";
 import "./point-source/index.d.ts";
 import "./precise-text.d.ts";
+import "./quadtree.d.ts";
 import "./ray/index.d.ts";
 import "./resize-handle.d.ts";

--- a/types/foundry/client/pixi/helpers/quadtree.d.ts
+++ b/types/foundry/client/pixi/helpers/quadtree.d.ts
@@ -1,0 +1,155 @@
+export {};
+
+declare global {
+    interface QuadtreeObject<
+        TPlaceableObject extends PlaceableObject = PlaceableObject,
+        TQuadtree extends Quadtree<TPlaceableObject> = Quadtree<TPlaceableObject>
+    > {
+        r: Rectangle;
+        t: TPlaceableObject;
+        n: Set<TQuadtree>;
+    }
+
+    /**
+     * A Quadtree implementation that supports collision detection for rectangles.
+     *
+     * @param {Rectangle} bounds       The outer bounds of the region
+     * @param [options]                Additional options which configure the Quadtree
+     * @param [options.maxObjects=20]  The maximum number of objects per node
+     * @param [options.maxDepth=4]     The maximum number of levels within the root Quadtree
+     * @param [options._depth=0]       The depth level of the sub-tree. For internal use
+     * @param [options._root]          The root of the quadtree. For internal use
+     */
+    class Quadtree<TPlaceableObject extends PlaceableObject> {
+        /** The bounding rectangle of the region */
+        bounds: Rectangle;
+
+        /** The maximum number of objects allowed within this node before it must split */
+        maxObjects: number;
+
+        /** The maximum number of levels that the base quadtree is allowed */
+        maxDepth: number;
+
+        /** The depth of this node within the root Quadtree */
+        depth: number;
+
+        /** The objects contained at this level of the tree */
+        objects: QuadtreeObject<TPlaceableObject, this>[];
+
+        /** Children of this node */
+        nodes: this[];
+
+        /** The root Quadtree */
+        root: this;
+
+        constructor(
+            bounds: Rectangle,
+            options?: { maxObjects?: number; maxDepth?: number; _depth?: number; _root?: Quadtree<TPlaceableObject> }
+        );
+
+        /**
+         * A constant that enumerates the index order of the quadtree nodes from top-left to bottom-right.
+         * @enum {number}
+         */
+        static INDICES: { tl: number; tr: number; bl: number; br: number };
+
+        /**
+         * Return an array of all the objects in the Quadtree (recursive)
+         */
+        get all(): QuadtreeObject<TPlaceableObject, this>[];
+
+        /* -------------------------------------------- */
+        /*  Tree Management                             */
+        /* -------------------------------------------- */
+
+        /**
+         * Split this node into 4 sub-nodes.
+         * @returns The split Quadtree
+         */
+        split(): this;
+
+        /* -------------------------------------------- */
+        /*  Object Management                           */
+        /* -------------------------------------------- */
+
+        /**
+         * Clear the quadtree of all existing contents
+         * @returns The cleared Quadtree
+         */
+        clear(): this;
+
+        /**
+         * Add a rectangle object to the tree
+         * @param  obj  The object being inserted
+         * @returns     The Quadtree nodes the object was added to.
+         */
+        insert(obj: QuadtreeObject<TPlaceableObject, this>): this[];
+
+        /**
+         * Remove an object from the quadtree
+         * @param target     The quadtree target being removed
+         * @returns          The Quadtree for method chaining
+         */
+        remove(target: TPlaceableObject): this;
+
+        /**
+         * Remove an existing object from the quadtree and re-insert it with a new position
+         * @param obj  The object being inserted
+         * @returns    The Quadtree nodes the object was added to
+         */
+        update(obj: QuadtreeObject<TPlaceableObject, this>): this[];
+
+        /* -------------------------------------------- */
+        /*  Target Identification                       */
+        /* -------------------------------------------- */
+
+        /**
+         * Get all the objects which could collide with the provided rectangle
+         * @param rect    The normalized target rectangle
+         * @param [options]                    Options affecting the collision test.
+         * @param [options.collisionTest]    Function to further refine objects to return
+         *   after a potential collision is found. Parameters are the object and rect, and the
+         *   function should return true if the object should be added to the result set.
+         * @param [options._s]                    The existing result set, for internal use.
+         * @returns   The objects in the Quadtree which represent potential collisions
+         */
+        getObjects(
+            rect: Rectangle,
+            options?: {
+                collisionTest?: (obj: QuadtreeObject, rect: Rectangle) => boolean;
+                _s: Set<TPlaceableObject>;
+            }
+        ): Set<TPlaceableObject>;
+
+        /**
+         * Obtain the leaf nodes to which a target rectangle belongs.
+         * This traverses the quadtree recursively obtaining the final nodes which have no children.
+         * @param rect  The target rectangle.
+         * @returns     The Quadtree nodes to which the target rectangle belongs
+         */
+        getLeafNodes(rect: Rectangle): this[];
+
+        /**
+         * Obtain the child nodes within the current node which a rectangle belongs to.
+         * Note that this function is not recursive, it only returns nodes at the current or child level.
+         * @param rect  The target rectangle.
+         * @returns     The Quadtree nodes to which the target rectangle belongs
+         */
+        getChildNodes(rect: Rectangle): this[];
+
+        /** Identify all nodes which are adjacent to this one within the parent Quadtree. */
+        getAdjacentNodes(): this[];
+
+        /**
+         * Visualize the nodes and objects in the quadtree
+         * @param [options]
+         * @param [options.objects]    Visualize the rectangular bounds of objects in the Quadtree. Default is false.
+         */
+        private visualize(options?: { object?: boolean }): void;
+    }
+
+    /**
+     * A subclass of Quadtree specifically intended for classifying the location of objects on the game canvas.
+     */
+    class CanvasQuadtree<TPlaceableObject extends PlaceableObject> extends Quadtree<TPlaceableObject> {}
+}

--- a/types/foundry/client/pixi/placeables-layer/base.d.ts
+++ b/types/foundry/client/pixi/placeables-layer/base.d.ts
@@ -13,6 +13,8 @@ declare global {
         /** Keep track of history so that CTRL+Z can undo changes */
         history: CanvasHistory<TObject>[];
 
+        quadtree: CanvasQuadtree<TObject> | null;
+
         /** Track the PlaceableObject on this layer which is currently hovered upon. */
         get hover(): TObject | null;
 

--- a/types/foundry/client/pixi/placeables-layer/drawings-layer.d.ts
+++ b/types/foundry/client/pixi/placeables-layer/drawings-layer.d.ts
@@ -4,4 +4,6 @@
  * @category - Canvas
  * @todo: fill in
  */
-declare class DrawingsLayer<TDrawing extends Drawing = Drawing> extends PlaceablesLayer<TDrawing> {}
+declare class DrawingsLayer<TDrawing extends Drawing = Drawing> extends PlaceablesLayer<TDrawing> {
+    override quadtree: CanvasQuadtree<TDrawing>;
+}

--- a/types/foundry/client/pixi/placeables-layer/lighting-layer.d.ts
+++ b/types/foundry/client/pixi/placeables-layer/lighting-layer.d.ts
@@ -18,6 +18,8 @@ declare global {
     class LightingLayer<TAmbientLight extends AmbientLight = AmbientLight> extends PlaceablesLayer<TAmbientLight> {
         constructor();
 
+        override quadtree: CanvasQuadtree<TAmbientLight>;
+
         /** A mapping of light sources which are active within the rendered Scene */
         sources: Collection<LightSource<TAmbientLight | Token>>;
 

--- a/types/foundry/client/pixi/placeables-layer/notes-layer.d.ts
+++ b/types/foundry/client/pixi/placeables-layer/notes-layer.d.ts
@@ -1,1 +1,3 @@
-declare class NotesLayer<TNote extends Note = Note> extends PlaceablesLayer<TNote> {}
+declare class NotesLayer<TNote extends Note = Note> extends PlaceablesLayer<TNote> {
+    override quadtree: CanvasQuadtree<TNote>;
+}

--- a/types/foundry/client/pixi/placeables-layer/sounds-layer.d.ts
+++ b/types/foundry/client/pixi/placeables-layer/sounds-layer.d.ts
@@ -2,4 +2,6 @@
  * This Canvas Layer provides a container for AmbientSound objects.
  * @todo fill in
  */
-declare class SoundsLayer extends PlaceablesLayer<AmbientSound> {}
+declare class SoundsLayer extends PlaceablesLayer<AmbientSound> {
+    override quadtree: CanvasQuadtree<AmbientSound>;
+}

--- a/types/foundry/client/pixi/placeables-layer/template-layer.d.ts
+++ b/types/foundry/client/pixi/placeables-layer/template-layer.d.ts
@@ -6,6 +6,8 @@ declare global {
 
         static documentName: "MeasuredTemplate";
 
+        override quadtree: CanvasQuadtree<TTemplate>;
+
         /* -------------------------------------------- */
         /*  Methods                                     */
         /* -------------------------------------------- */

--- a/types/foundry/client/pixi/placeables-layer/tiles-layer.d.ts
+++ b/types/foundry/client/pixi/placeables-layer/tiles-layer.d.ts
@@ -6,4 +6,5 @@
 
 declare class TilesLayer<TTile extends Tile> extends PlaceablesLayer<TTile> {
     static override documentName: "Tile";
+    override quadtree: CanvasQuadtree<TTile>;
 }

--- a/types/foundry/client/pixi/placeables-layer/token-layer.d.ts
+++ b/types/foundry/client/pixi/placeables-layer/token-layer.d.ts
@@ -5,6 +5,8 @@ declare global {
     class TokenLayer<TToken extends Token = Token> extends PlaceablesLayer<TToken> {
         constructor();
 
+        override quadtree: CanvasQuadtree<TToken>;
+
         /** The current index position in the tab cycle */
         protected _tabIndex: number | null;
 

--- a/types/foundry/client/pixi/placeables-layer/walls-layer.d.ts
+++ b/types/foundry/client/pixi/placeables-layer/walls-layer.d.ts
@@ -7,6 +7,8 @@ declare global {
     > extends PlaceablesLayer<TObject> {
         constructor();
 
+        override quadtree: CanvasQuadtree<TObject>;
+
         /** A graphics layer used to display chained Wall selection */
         chain: PIXI.Graphics;
 


### PR DESCRIPTION
`CanvasQuadtree` is just a `Quadtree` that returns `canvas.dimensions.rect` as its `bounds`.