### PR TITLE
Add `MeasuredTemplateDocumentPF2e#getTokens` to find all tokens inside a measured template

### DIFF
--- a/src/module/canvas/helpers.ts
+++ b/src/module/canvas/helpers.ts
@@ -14,10 +14,15 @@ function measureDistanceCuboid(
         reach = null,
         token = null,
         target = null,
+        source,
     }: {
         reach?: number | null;
         token?: TokenPF2e | null;
         target?: TokenPF2e | null;
+        source?: {
+            elevation: number;
+            height: number;
+        };
     } = {}
 ): number {
     if (!canvas.dimensions) return NaN;
@@ -61,17 +66,26 @@ function measureDistanceCuboid(
         distance.dx = Math.max(r0Snapped.left - r1Snapped.right, r1Snapped.left - r0Snapped.right, 0) + gridWidth;
         distance.dy = Math.max(r0Snapped.top - r1Snapped.bottom, r1Snapped.top - r0Snapped.bottom, 0) + gridWidth;
     }
-    if (token && target && token?.document?.elevation !== target?.document.elevation && token.actor && target.actor) {
-        const selfElevation = token.document.elevation;
-        const targetElevation = target.document.elevation;
 
-        const [selfDimensions, targetDimensions] = [token.actor.dimensions, target.actor.dimensions];
+    const elevationSource = source ?? {
+        elevation: token?.document.elevation ?? null,
+        height: token?.actor?.dimensions.height ?? null,
+    };
+    if (
+        elevationSource.elevation !== null &&
+        elevationSource.height !== null &&
+        target &&
+        elevationSource.elevation !== target?.document.elevation &&
+        target.actor
+    ) {
+        const targetElevation = target.document.elevation;
+        const targetDimensions = target.actor.dimensions;
 
         const gridSize = canvas.dimensions.size;
         const gridDistance = canvas.dimensions.distance;
 
-        const elevation0 = Math.floor((selfElevation / gridDistance) * gridSize);
-        const height0 = Math.floor((selfDimensions.height / gridDistance) * gridSize);
+        const elevation0 = Math.floor((elevationSource.elevation / gridDistance) * gridSize);
+        const height0 = Math.floor((elevationSource.height / gridDistance) * gridSize);
         const elevation1 = Math.floor((targetElevation / gridDistance) * gridSize);
         const height1 = Math.floor((targetDimensions.height / gridDistance) * gridSize);
 

--- a/src/module/scene/measured-template-document.ts
+++ b/src/module/scene/measured-template-document.ts
@@ -32,6 +32,10 @@ interface MeasuredTemplateDocumentPF2e<TParent extends ScenePF2e | null = SceneP
     flags: DocumentFlags & {
         pf2e?: {
             origin?: ItemOriginFlag;
+            elevation?: {
+                value: number;
+                zHeight: number;
+            };
         };
     };
 }

--- a/src/module/scene/measured-template-document.ts
+++ b/src/module/scene/measured-template-document.ts
@@ -4,7 +4,7 @@ import { ItemPF2e } from "@item";
 import { ActorPF2e } from "@actor";
 import { ItemOriginFlag } from "@module/chat-message/data.ts";
 
-export class MeasuredTemplateDocumentPF2e<
+class MeasuredTemplateDocumentPF2e<
     TParent extends ScenePF2e | null = ScenePF2e | null
 > extends MeasuredTemplateDocument<TParent> {
     get item(): ItemPF2e<ActorPF2e> | null {
@@ -25,7 +25,7 @@ export class MeasuredTemplateDocumentPF2e<
     }
 }
 
-export interface MeasuredTemplateDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null>
+interface MeasuredTemplateDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null>
     extends MeasuredTemplateDocument<TParent> {
     get object(): MeasuredTemplatePF2e<this> | null;
 
@@ -35,3 +35,5 @@ export interface MeasuredTemplateDocumentPF2e<TParent extends ScenePF2e | null =
         };
     };
 }
+
+export { MeasuredTemplateDocumentPF2e };

--- a/types/foundry/client/pixi/grid/base.d.ts
+++ b/types/foundry/client/pixi/grid/base.d.ts
@@ -71,7 +71,7 @@ declare global {
          *
          * @return  An object containing the coordinates of the snapped location
          */
-        getSnappedPosition(x: number, y: number, interval: number): { x: number; y: number };
+        getSnappedPosition(x: number, y: number, interval?: number): { x: number; y: number };
 
         /* -------------------------------------------- */
 


### PR DESCRIPTION
I'm not sure if this should live on the document or the object. Also the elevation calculation is probably wrong.

![Recording 2023-07-10 at 22 29 55](https://github.com/foundryvtt/pf2e/assets/41452412/ffa007a8-90ad-4029-a408-7104b42d4702)
