### PR TITLE
Start process of referring to spell levels as ranks

### DIFF
--- a/src/module/actor/character/crafting/helpers.ts
+++ b/src/module/actor/character/crafting/helpers.ts
@@ -112,9 +112,9 @@ export async function craftSpellConsumable(
         consumableType === "wand" ? Math.ceil(item.level / 2) - 1 : Math.ceil(item.level / 2)
     ) as OneToTen;
     const validSpells = actor.itemTypes.spell
-        .filter((s) => s.baseLevel <= spellLevel && !s.isCantrip && !s.isFocusSpell && !s.isRitual)
+        .filter((s) => s.baseRank <= spellLevel && !s.isCantrip && !s.isFocusSpell && !s.isRitual)
         .reduce((result, spell) => {
-            result[spell.baseLevel] = [...(result[spell.baseLevel] || []), spell];
+            result[spell.baseRank] = [...(result[spell.baseRank] || []), spell];
             return result;
         }, {} as Record<number, SpellPF2e<ActorPF2e>[]>);
     const content = await renderTemplate("systems/pf2e/templates/actors/crafting-select-spell-dialog.hbs", {

--- a/src/module/actor/creature/sheet.ts
+++ b/src/module/actor/creature/sheet.ts
@@ -371,10 +371,10 @@ export abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends Act
                 return [spell ?? []].flat();
             } else if (dropItemEl.dataset.slotId) {
                 const dropId = Number(dropItemEl.dataset.slotId);
-                const slotLevel = Number(dropItemEl.dataset.slotLevel);
+                const slotRank = Number(dropItemEl.dataset.slotLevel);
 
-                if (Number.isInteger(dropId) && Number.isInteger(slotLevel)) {
-                    const allocated = await collection.prepareSpell(item, slotLevel, dropId);
+                if (Number.isInteger(dropId) && Number.isInteger(slotRank)) {
+                    const allocated = await collection.prepareSpell(item, slotRank, dropId);
                     if (allocated instanceof SpellcastingEntryPF2e) return [allocated];
                 }
             } else if (dropSlotType === "spell") {
@@ -388,7 +388,7 @@ export abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends Act
                         if (item.isCantrip !== test.isCantrip) return false;
                         if (item.isCantrip && test.isCantrip) return true;
                         if (item.isFocusSpell && test.isFocusSpell) return true;
-                        if (item.level === test.level) return true;
+                        if (item.rank === test.rank) return true;
                         return false;
                     };
 
@@ -397,7 +397,7 @@ export abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends Act
                         await item.sortRelative({ target, siblings });
                         return [target];
                     } else {
-                        const spell = await collection.addSpell(item, { slotLevel: target.level });
+                        const spell = await collection.addSpell(item, { slotLevel: target.rank });
                         this.openSpellPreparationSheet(collection.id);
                         return [spell ?? []].flat();
                     }
@@ -445,7 +445,7 @@ export abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends Act
             const collection = this.actor.spellcasting.collections.get(entryId, { strict: true });
             const slotLevel = Number(htmlClosest(event.target, "[data-slot-level]")?.dataset.slotLevel ?? 0);
             this.openSpellPreparationSheet(collection.id);
-            return [(await collection.addSpell(item, { slotLevel: Math.max(slotLevel, item.baseLevel) })) ?? []].flat();
+            return [(await collection.addSpell(item, { slotLevel: Math.max(slotLevel, item.baseRank) })) ?? []].flat();
         }
 
         return super._handleDroppedItem(event, item, data);

--- a/src/module/actor/sheet/helpers.ts
+++ b/src/module/actor/sheet/helpers.ts
@@ -9,23 +9,23 @@ function onClickCreateSpell(actor: ActorPF2e, data: Record<string, unknown>): vo
         throw ErrorPF2e("Unexpected missing spellcasting-entry location");
     }
 
-    const level = Number(data.level ?? 1) as ZeroToTen;
+    const rank = Number(data.level ?? 1) as ZeroToTen;
     const newLabel = game.i18n.localize("PF2E.NewLabel");
-    const [levelLabel, spellLabel] =
-        level > 0
+    const [rankLabel, spellLabel] =
+        rank > 0
             ? [
-                  game.i18n.localize(`PF2E.SpellLevel${data.level}`),
+                  game.i18n.localize(`PF2E.SpellLevel${rank}`),
                   game.i18n.localize(data.location === "rituals" ? "PF2E.SpellCategoryRitual" : "PF2E.SpellLabel"),
               ]
             : [null, game.i18n.localize("PF2E.TraitCantrip")];
     const source = {
         type: "spell",
-        name: R.compact([newLabel, levelLabel, spellLabel]).join(" "),
+        name: R.compact([newLabel, rankLabel, spellLabel]).join(" "),
         system: {
-            level: { value: level || 1 },
+            level: { value: rank || 1 },
             location: { value: String(data.location) },
             traits: {
-                value: level === 0 ? ["cantrip"] : [],
+                value: rank === 0 ? ["cantrip"] : [],
             },
         },
     } satisfies DeepPartial<SpellSource>;

--- a/src/module/actor/sheet/popups/casting-item-create-dialog.ts
+++ b/src/module/actor/sheet/popups/casting-item-create-dialog.ts
@@ -40,7 +40,7 @@ export class CastingItemCreateDialog extends FormApplication<ActorPF2e> {
         this.spell = spell;
         this.formDataCache = {
             itemType: this.spell.isCantrip ? "cantripDeck5" : "scroll",
-            level: spell.baseLevel,
+            level: spell.baseRank,
         };
         this.onSubmitCallback = callback;
     }
@@ -64,11 +64,11 @@ export class CastingItemCreateDialog extends FormApplication<ActorPF2e> {
         }
 
         const { cantripDeck5: cantripDeck5, ...nonCantripOptions } = itemTypeOptions;
-        const minimumLevel = this.spell.baseLevel;
-        const levels = Array.from(Array(11 - minimumLevel).keys()).map((index) => minimumLevel + index);
+        const minimumRank = this.spell.baseRank;
+        const ranks = Array.from(Array(11 - minimumRank).keys()).map((index) => minimumRank + index);
         return {
             ...(await super.getData()),
-            validLevels: levels,
+            validLevels: ranks,
             itemTypeOptions: this.spell.isCantrip ? { cantripDeck5: cantripDeck5 } : nonCantripOptions,
             itemType: this.formDataCache.itemType,
             level: this.formDataCache.level,

--- a/src/module/chat-message/document.ts
+++ b/src/module/chat-message/document.ts
@@ -121,7 +121,7 @@ class ChatMessagePF2e extends ChatMessage {
 
         if (item?.isOfType("spell")) {
             const overlayIds = this.flags.pf2e.origin?.variant?.overlays;
-            const castLevel = this.flags.pf2e.origin?.castLevel ?? item.level;
+            const castLevel = this.flags.pf2e.origin?.castLevel ?? item.rank;
             const modifiedSpell = item.loadVariant({ overlayIds, castLevel });
             return modifiedSpell ?? item;
         }

--- a/src/module/item/base.ts
+++ b/src/module/item/base.ts
@@ -137,7 +137,7 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
         ];
 
         // The heightened level of a spell is retrievable from its getter but not prepared level data
-        const level = this.isOfType("spell") ? this.level : this.system.level?.value ?? null;
+        const level = this.isOfType("spell") ? this.rank : this.system.level?.value ?? null;
         if (typeof level === "number") {
             options.push(`${prefix}:level:${level}`);
         }

--- a/src/module/item/consumable/spell-consumables.ts
+++ b/src/module/item/consumable/spell-consumables.ts
@@ -69,7 +69,7 @@ async function createConsumableFromSpell(
     spell: SpellPF2e,
     {
         type,
-        heightenedLevel = spell.baseLevel,
+        heightenedLevel = spell.baseRank,
         mystified = false,
     }: {
         type: SpellConsumableItemType;

--- a/src/module/item/deity/sheet.ts
+++ b/src/module/item/deity/sheet.ts
@@ -141,7 +141,7 @@ export class DeitySheetPF2e extends ItemSheetPF2e<DeityPF2e> {
             return;
         }
 
-        await this.item.update({ [`system.spells.${item.level}`]: item.uuid });
+        await this.item.update({ [`system.spells.${item.rank}`]: item.uuid });
     }
 
     /** Foundry inflexibly considers checkboxes to be booleans: set back to a string tuple for Divine Font */

--- a/src/module/item/spell/sheet.ts
+++ b/src/module/item/spell/sheet.ts
@@ -366,7 +366,7 @@ export class SpellSheetPF2e extends ItemSheetPF2e<SpellPF2e> {
     private getAvailableHeightenLevels() {
         const heightenLayers = this.item.getHeightenLayers();
         return [2, 3, 4, 5, 6, 7, 8, 9, 10].filter(
-            (level) => level > this.item.baseLevel && !heightenLayers.some((layer) => layer.level === level)
+            (level) => level > this.item.baseRank && !heightenLayers.some((layer) => layer.level === level)
         );
     }
 

--- a/src/module/item/spellcasting-entry/document.ts
+++ b/src/module/item/spellcasting-entry/document.ts
@@ -74,7 +74,7 @@ class SpellcastingEntryPF2e<TParent extends ActorPF2e | null = ActorPF2e | null>
     }
 
     get highestLevel(): number {
-        return this.spells?.highestLevel ?? 0;
+        return this.spells?.highestRank ?? 0;
     }
 
     get showSlotlessLevels(): boolean {
@@ -162,15 +162,15 @@ class SpellcastingEntryPF2e<TParent extends ActorPF2e | null = ActorPF2e | null>
     async cast(spell: SpellPF2e<ActorPF2e>, options: SpellcastingEntryPF2eCastOptions = {}): Promise<void> {
         const consume = options.consume ?? true;
         const message = options.message ?? true;
-        const slotLevel = options.level ?? spell.level;
-        const valid = !consume || spell.isCantrip || (await this.consume(spell, slotLevel, options.slot));
+        const slotRank = options.level ?? spell.rank;
+        const valid = !consume || spell.isCantrip || (await this.consume(spell, slotRank, options.slot));
         if (message && valid) {
-            const castLevel = spell.computeCastLevel(slotLevel);
-            await spell.toMessage(undefined, { rollMode: options.rollMode, data: { castLevel } });
+            const castRank = spell.computeCastRank(slotRank);
+            await spell.toMessage(undefined, { rollMode: options.rollMode, data: { castLevel: castRank } });
         }
     }
 
-    async consume(spell: SpellPF2e<ActorPF2e>, level: number, slot?: number): Promise<boolean> {
+    async consume(spell: SpellPF2e<ActorPF2e>, rank: number, slot?: number): Promise<boolean> {
         const actor = this.actor;
         if (!(actor instanceof CharacterPF2e || actor instanceof NPCPF2e)) {
             throw ErrorPF2e("Spellcasting entries require an actor");
@@ -192,8 +192,8 @@ class SpellcastingEntryPF2e<TParent extends ActorPF2e | null = ActorPF2e | null>
             }
         }
 
-        const levelLabel = game.i18n.localize(CONFIG.PF2E.spellLevels[level as OneToTen]);
-        const slotKey = goesToEleven(level) ? (`slot${level}` as const) : "slot0";
+        const rankLabel = game.i18n.localize(CONFIG.PF2E.spellLevels[rank as OneToTen]);
+        const slotKey = goesToEleven(rank) ? (`slot${rank}` as const) : "slot0";
         if (this.system.slots === null || !this.spells) {
             return false;
         }
@@ -217,7 +217,7 @@ class SpellcastingEntryPF2e<TParent extends ActorPF2e | null = ActorPF2e | null>
                 return false;
             }
 
-            await this.spells.setSlotExpendedState(level, slot, true);
+            await this.spells.setSlotExpendedState(rank, slot, true);
             return true;
         }
 
@@ -237,7 +237,7 @@ class SpellcastingEntryPF2e<TParent extends ActorPF2e | null = ActorPF2e | null>
             return true;
         } else {
             ui.notifications.warn(
-                game.i18n.format("PF2E.SpellSlotNotEnoughError", { name: spell.name, level: levelLabel })
+                game.i18n.format("PF2E.SpellSlotNotEnoughError", { name: spell.name, level: rankLabel })
             );
             return false;
         }
@@ -255,18 +255,18 @@ class SpellcastingEntryPF2e<TParent extends ActorPF2e | null = ActorPF2e | null>
     }
 
     /** Saves the prepared spell slot data to the spellcasting entry  */
-    async prepareSpell(spell: SpellPF2e, slotLevel: number, spellSlot: number): Promise<this | null> {
-        return this.spells?.prepareSpell(spell, slotLevel, spellSlot) ?? null;
+    async prepareSpell(spell: SpellPF2e, slotRank: number, spellSlot: number): Promise<this | null> {
+        return this.spells?.prepareSpell(spell, slotRank, spellSlot) ?? null;
     }
 
     /** Removes the spell slot and updates the spellcasting entry */
-    async unprepareSpell(spellLevel: number, slotLevel: number): Promise<this | null> {
-        return this.spells?.unprepareSpell(spellLevel, slotLevel) ?? null;
+    async unprepareSpell(spellLevel: number, slotRank: number): Promise<this | null> {
+        return this.spells?.unprepareSpell(spellLevel, slotRank) ?? null;
     }
 
     /** Sets the expended state of a spell slot and updates the spellcasting entry */
-    async setSlotExpendedState(slotLevel: number, spellSlot: number, isExpended: boolean): Promise<this | null> {
-        return this.spells?.setSlotExpendedState(slotLevel, spellSlot, isExpended) ?? null;
+    async setSlotExpendedState(slotRank: number, spellSlot: number, isExpended: boolean): Promise<this | null> {
+        return this.spells?.setSlotExpendedState(slotRank, spellSlot, isExpended) ?? null;
     }
 
     /** Returns rendering data to display the spellcasting entry in the sheet */

--- a/src/module/item/spellcasting-entry/trick.ts
+++ b/src/module/item/spellcasting-entry/trick.ts
@@ -142,7 +142,7 @@ class TrickMagicItemEntry<TActor extends ActorPF2e = ActorPF2e> implements Spell
 
     async cast(spell: SpellPF2e, options: CastOptions = {}): Promise<void> {
         const { rollMode, message } = options;
-        const castLevel = spell.computeCastLevel(spell.level);
+        const castLevel = spell.computeCastRank(spell.rank);
         if (message === false) return;
 
         try {

--- a/src/module/item/spellcasting-entry/types.ts
+++ b/src/module/item/spellcasting-entry/types.ts
@@ -61,7 +61,7 @@ interface SpellcastingSheetData
     statistic: StatisticChatData | null;
     hasCollection: boolean;
     flexibleAvailable?: { value: number; max: number } | null;
-    levels: SpellcastingSlotLevel[];
+    levels: SpellcastingSlotRank[];
     spellPrepList: Record<number, SpellPrepEntry[]> | null;
     isFlexible?: boolean;
     isFocusPool?: boolean;
@@ -72,7 +72,7 @@ interface SpellcastingSheetData
     showSlotlessLevels?: boolean;
 }
 
-interface SpellcastingSlotLevel {
+interface SpellcastingSlotRank {
     label: string;
     level: ZeroToTen;
     isCantrip: boolean;
@@ -115,5 +115,5 @@ export {
     SpellcastingEntry,
     SpellcastingEntryPF2eCastOptions,
     SpellcastingSheetData,
-    SpellcastingSlotLevel,
+    SpellcastingSlotRank,
 };

--- a/src/module/scene/measured-template-document.ts
+++ b/src/module/scene/measured-template-document.ts
@@ -16,8 +16,8 @@ export class MeasuredTemplateDocumentPF2e<
 
         if (item?.isOfType("spell")) {
             const overlayIds = origin?.variant?.overlays;
-            const castLevel = (origin?.castLevel ?? item.level) as number;
-            const modifiedSpell = item.loadVariant({ overlayIds, castLevel });
+            const castRank = (origin?.castLevel ?? item.rank) as number;
+            const modifiedSpell = item.loadVariant({ overlayIds, castLevel: castRank });
             return modifiedSpell ?? item;
         }
 

--- a/src/module/system/statistic/index.ts
+++ b/src/module/system/statistic/index.ts
@@ -396,7 +396,7 @@ class StatisticCheck<TParent extends Statistic = Statistic> {
         // Handle special case of incapacitation trait
         if ((options.has("incapacitation") || options.has("item:trait:incapacitation")) && dc) {
             const effectLevel = item?.isOfType("spell")
-                ? 2 * item.level
+                ? 2 * item.rank
                 : item?.isOfType("physical")
                 ? item.level
                 : origin?.level ?? actor.level;

--- a/static/templates/chat/spell-card.hbs
+++ b/static/templates/chat/spell-card.hbs
@@ -9,7 +9,7 @@
     <header class="card-header flexrow">
         <img src="{{item.img}}" title="{{item.name}}" width="36" height="36" />
         <h3>{{item.name}}</h3>
-        <h4>{{data.levelLabel}}</h4>
+        <h4>{{data.rankLabel}}</h4>
     </header>
 
     <section class="item-properties tags">


### PR DESCRIPTION
I took care to not yet rename anything that is a key in an object passed to a template.