### PR TITLE
Update traits for Lethargy Poison to change conjuration to consumable

### DIFF
--- a/packs/equipment/lethargy-poison.json
+++ b/packs/equipment/lethargy-poison.json
@@ -58,7 +58,7 @@
             "rarity": "uncommon",
             "value": [
                 "alchemical",
-                "conjuration",
+                "consumable",
                 "incapacitation",
                 "injury",
                 "poison",


### PR DESCRIPTION
Fixed an incorrect trait of Lethargy Poison.