### PR TITLE
Update `Document#_pre(Create|Update|Delete)` return types for V11

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -1770,7 +1770,7 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
         data: PreDocumentId<this["_source"]>,
         options: DocumentModificationContext<TParent>,
         user: UserPF2e
-    ): Promise<void> {
+    ): Promise<boolean | void> {
         // Set default portrait and token images
         this._source.prototypeToken = mergeObject(this._source.prototypeToken ?? {}, { texture: {} });
         if (this._source.img === ActorPF2e.DEFAULT_ICON) {
@@ -1785,7 +1785,7 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
         changed: DeepPartial<this["_source"]>,
         options: ActorUpdateContext<TParent>,
         user: UserPF2e
-    ): Promise<void> {
+    ): Promise<boolean | void> {
         // Always announce HP changes for player-owned actors as floaty text (via `damageTaken` option)
         const changedHP = changed.system?.attributes?.hp;
         const currentHP = this.hitPoints;
@@ -1795,7 +1795,7 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
             if (damageTaken && !levelChanged) options.damageTaken = damageTaken;
         }
 
-        await super._preUpdate(changed, options, user);
+        return super._preUpdate(changed, options, user);
     }
 
     protected override _onUpdate(

--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -1828,7 +1828,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
         changed: DeepPartial<CharacterSource>,
         options: CreatureUpdateContext<TParent>,
         user: UserPF2e
-    ): Promise<void> {
+    ): Promise<boolean | void> {
         const systemData = this.system;
 
         // Clamp level, allowing for level-0 variant rule and enough room for homebrew "mythical" campaigns
@@ -1908,7 +1908,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
             }
         }
 
-        await super._preUpdate(changed, options, user);
+        return super._preUpdate(changed, options, user);
     }
 
     /** Toggle between boost-driven and manual management of ability scores */

--- a/src/module/actor/creature/document.ts
+++ b/src/module/actor/creature/document.ts
@@ -644,7 +644,7 @@ abstract class CreaturePF2e<
         changed: DeepPartial<this["_source"]>,
         options: CreatureUpdateContext<TParent>,
         user: UserPF2e
-    ): Promise<void> {
+    ): Promise<boolean | void> {
         // Clamp hit points
         const currentHP = this.hitPoints;
         const changedHP = changed.system?.attributes?.hp;
@@ -667,7 +667,7 @@ abstract class CreaturePF2e<
             if (this.isToken) options.diff = false; // Force an update and sheet re-render
         }
 
-        await super._preUpdate(changed, options, user);
+        return super._preUpdate(changed, options, user);
     }
 }
 

--- a/src/module/actor/party/document.ts
+++ b/src/module/actor/party/document.ts
@@ -168,8 +168,7 @@ class PartyPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
         changed: DeepPartial<PartySource>,
         options: PartyUpdateContext<TParent>,
         user: UserPF2e
-    ): Promise<void> {
-        await super._preUpdate(changed, options, user);
+    ): Promise<boolean | void> {
         const members = this.members;
         const newMemberUUIDs = changed?.system?.details?.members?.map((m) => m?.uuid);
         if (newMemberUUIDs) {
@@ -181,6 +180,8 @@ class PartyPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
         if (changed.system?.campaign && this.campaign && this.campaign.type !== "invalid") {
             changed.system.campaign.type = this.campaign.type;
         }
+
+        return super._preUpdate(changed, options, user);
     }
 
     /** Override to inform creatures when they were booted from a party */

--- a/src/module/actor/vehicle/document.ts
+++ b/src/module/actor/vehicle/document.ts
@@ -170,8 +170,10 @@ class VehiclePF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e |
         changed: DeepPartial<VehicleSource>,
         options: DocumentModificationContext<TParent>,
         user: UserPF2e
-    ): Promise<void> {
-        await super._preUpdate(changed, options, user);
+    ): Promise<boolean | void> {
+        const result = await super._preUpdate(changed, options, user);
+        if (result === false) return result;
+
         if (this.prototypeToken.flags?.pf2e?.linkToActorSize) {
             const { space } = this.system.details;
             const spaceUpdates = {
@@ -179,7 +181,7 @@ class VehiclePF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e |
                 length: changed.system?.details?.space?.long ?? space.long,
             };
             const tokenDimensions = this.getTokenDimensions(spaceUpdates);
-            mergeObject(changed, { token: tokenDimensions });
+            changed.prototypeToken = mergeObject(changed.prototypeToken ?? {}, tokenDimensions);
 
             if (canvas.scene) {
                 const updates = this.getActiveTokens()

--- a/src/module/item/action/document.ts
+++ b/src/module/item/action/document.ts
@@ -45,7 +45,7 @@ class ActionItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extend
         data: PreDocumentId<ActionItemSource>,
         options: DocumentModificationContext<TParent>,
         user: UserPF2e
-    ): Promise<void> {
+    ): Promise<boolean | void> {
         // In case this was copied from an actor, clear any active frequency value
         if (!this.parent) {
             if (this._source.system.frequency) {
@@ -60,7 +60,7 @@ class ActionItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extend
         changed: DeepPartial<this["_source"]>,
         options: DocumentModificationContext<TParent>,
         user: UserPF2e
-    ): Promise<void> {
+    ): Promise<boolean | void> {
         // Normalize action data
         if (changed.system && ("actionType" in changed.system || "actions" in changed.system)) {
             const actionType = changed.system?.actionType?.value ?? this.system.actionType.value;
@@ -71,7 +71,7 @@ class ActionItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extend
             });
         }
 
-        await super._preUpdate(changed, options, user);
+        return super._preUpdate(changed, options, user);
     }
 }
 

--- a/src/module/item/affliction/document.ts
+++ b/src/module/item/affliction/document.ts
@@ -115,7 +115,7 @@ class AfflictionPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extend
         changed: DeepPartial<this["_source"]>,
         options: DocumentModificationContext<TParent>,
         user: UserPF2e
-    ): Promise<void> {
+    ): Promise<boolean | void> {
         const duration = changed.system?.duration;
         if (typeof duration?.unit === "string" && !["unlimited", "encounter"].includes(duration.unit)) {
             if (duration.value === -1) duration.value = 1;

--- a/src/module/item/base.ts
+++ b/src/module/item/base.ts
@@ -612,7 +612,7 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
         data: PreDocumentId<this["_source"]>,
         options: DocumentModificationContext<TParent>,
         user: UserPF2e
-    ): Promise<void> {
+    ): Promise<boolean | void> {
         // Set default icon
         if (this._source.img === ItemPF2e.DEFAULT_ICON) {
             this._source.img = data.img = `systems/pf2e/icons/default-icons/${data.type}.svg`;
@@ -633,10 +633,10 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
             }
         }
 
-        await super._preCreate(data, options, user);
-
         // Remove any rule elements that request their own removal upon item creation
         this._source.system.rules = this._source.system.rules.filter((r) => !r.removeUponCreate);
+
+        return super._preCreate(data, options, user);
     }
 
     /** Keep `TextEditor` and anything else up to no good from setting this item's description to `null` */
@@ -644,7 +644,7 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
         changed: DeepPartial<this["_source"]>,
         options: DocumentUpdateContext<TParent>,
         user: UserPF2e
-    ): Promise<void> {
+    ): Promise<boolean | void> {
         if (changed.system?.description?.value === null) {
             changed.system.description.value = "";
         }
@@ -676,7 +676,7 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
             await rule.preUpdate?.(changed);
         }
 
-        await super._preUpdate(changed, options, user);
+        return super._preUpdate(changed, options, user);
     }
 
     /** Call onCreate rule-element hooks */

--- a/src/module/item/condition/document.ts
+++ b/src/module/item/condition/document.ts
@@ -95,7 +95,7 @@ class ConditionPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends
             const { damageType } = this.system.persistent;
             options.push(`damage:type:${damageType}`, `${prefix}:damage:type:${damageType}`);
             const category = DamageCategorization.fromDamageType(damageType);
-            if (category) options.push(`damage:category:${category}`, `item:damage:category:${category}`);
+            if (category) options.push(`damage:category:${category}`, `${prefix}:damage:category:${category}`);
         }
 
         return options.sort();
@@ -118,7 +118,7 @@ class ConditionPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends
             const roll = await this.system.persistent.damage.clone().evaluate({ async: true });
             roll.toMessage(
                 {
-                    speaker: ChatMessagePF2e.getSpeaker({ actor: actor, token }),
+                    speaker: ChatMessagePF2e.getSpeaker({ actor, token }),
                     flavor: `<strong>${this.name}</strong>`,
                 },
                 { rollMode: "roll" }
@@ -249,7 +249,7 @@ class ConditionPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends
         changed: DeepPartial<this["_source"]>,
         options: ConditionModificationContext<TParent>,
         user: UserPF2e
-    ): Promise<void> {
+    ): Promise<boolean | void> {
         options.conditionValue = this.value;
         return super._preUpdate(changed, options, user);
     }

--- a/src/module/item/effect/document.ts
+++ b/src/module/item/effect/document.ts
@@ -151,7 +151,7 @@ class EffectPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ab
         data: PreDocumentId<this["_source"]>,
         options: DocumentModificationContext<TParent>,
         user: UserPF2e
-    ): Promise<void> {
+    ): Promise<boolean | void> {
         if (this.isOwned) {
             const initiative = this.origin?.combatant?.initiative ?? game.combat?.combatant?.initiative ?? null;
             this.updateSource({
@@ -178,7 +178,7 @@ class EffectPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ab
         changed: DeepPartial<this["_source"]>,
         options: DocumentModificationContext<TParent>,
         user: UserPF2e
-    ): Promise<void> {
+    ): Promise<boolean | void> {
         const duration = changed.system?.duration;
         if (duration?.unit === "unlimited") {
             duration.expiry = null;

--- a/src/module/item/feat/document.ts
+++ b/src/module/item/feat/document.ts
@@ -167,7 +167,7 @@ class FeatPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
         data: PreDocumentId<FeatSource>,
         options: DocumentModificationContext<TParent>,
         user: UserPF2e
-    ): Promise<void> {
+    ): Promise<boolean | void> {
         // In case this was copied from an actor, clear the location if there's no parent.
         if (!this.parent) {
             this.updateSource({ "system.location": null });
@@ -183,7 +183,7 @@ class FeatPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
         changed: DeepPartial<this["_source"]>,
         options: DocumentModificationContext<TParent>,
         user: UserPF2e
-    ): Promise<void> {
+    ): Promise<boolean | void> {
         // Ensure an empty-string `location` property is null
         if (typeof changed.system?.location === "string") {
             changed.system.location ||= null;
@@ -218,7 +218,7 @@ class FeatPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
             mergeObject(changed, { system: { maxTakable: 1 } });
         }
 
-        await super._preUpdate(changed, options, user);
+        return super._preUpdate(changed, options, user);
     }
 
     /** Warn the owning user(s) if this feat was taken despite some restriction */

--- a/src/module/item/kit/document.ts
+++ b/src/module/item/kit/document.ts
@@ -69,11 +69,13 @@ class KitPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends ItemP
         changed: DeepPartial<this["_source"]>,
         options: DocumentModificationContext<TParent>,
         user: UserPF2e
-    ): Promise<void> {
-        if (!changed.system) return await super._preUpdate(changed, options, user);
+    ): Promise<boolean | void> {
+        if (!changed.system) {
+            return await super._preUpdate(changed, options, user);
+        }
 
         // Clear 0 price denominations
-        if (isObject<Record<string, unknown>>(changed.system?.price)) {
+        if (isObject<Record<string, unknown>>(changed.system.price)) {
             const price: Record<string, unknown> = changed.system.price;
             for (const denomination of DENOMINATIONS) {
                 if (price[denomination] === 0) {
@@ -82,7 +84,7 @@ class KitPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends ItemP
             }
         }
 
-        await super._preUpdate(changed, options, user);
+        return super._preUpdate(changed, options, user);
     }
 }
 

--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -895,7 +895,7 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
         data: PreDocumentId<this["_source"]>,
         options: DocumentModificationContext<TParent>,
         user: UserPF2e
-    ): Promise<void> {
+    ): Promise<boolean | void> {
         this._source.system.location.value ||= null;
         if (this._source.system.category.value === "ritual") {
             this._source.system.location.value = null;
@@ -908,8 +908,10 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
         changed: DeepPartial<SpellSource>,
         options: DocumentUpdateContext<TParent>,
         user: UserPF2e
-    ): Promise<void> {
-        await super._preUpdate(changed, options, user);
+    ): Promise<boolean | void> {
+        const result = await super._preUpdate(changed, options, user);
+        if (result === false) return result;
+
         const diff = (options.diff ??= true);
 
         const uses = changed.system?.location?.uses;

--- a/src/module/item/spellcasting-entry/document.ts
+++ b/src/module/item/spellcasting-entry/document.ts
@@ -309,7 +309,7 @@ class SpellcastingEntryPF2e<TParent extends ActorPF2e | null = ActorPF2e | null>
         changed: DeepPartial<this["_source"]>,
         options: DocumentModificationContext<TParent>,
         user: UserPF2e
-    ): Promise<void> {
+    ): Promise<boolean | void> {
         // Clamp slot updates
         if (changed.system?.slots) {
             for (const key of [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] as const) {
@@ -327,7 +327,7 @@ class SpellcastingEntryPF2e<TParent extends ActorPF2e | null = ActorPF2e | null>
             }
         }
 
-        await super._preUpdate(changed, options, user);
+        return super._preUpdate(changed, options, user);
     }
 
     /* -------------------------------------------- */

--- a/src/module/item/weapon/document.ts
+++ b/src/module/item/weapon/document.ts
@@ -816,7 +816,7 @@ class WeaponPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
         changed: DeepPartial<this["_source"]>,
         options: DocumentUpdateContext<TParent>,
         user: UserPF2e
-    ): Promise<void> {
+    ): Promise<boolean | void> {
         const traits = changed.system?.traits ?? {};
         if ("value" in traits && Array.isArray(traits.value)) {
             traits.value = traits.value.filter((t) => t in CONFIG.PF2E.weaponTraits);

--- a/types/foundry/client/data/documents/active-effect.d.ts
+++ b/types/foundry/client/data/documents/active-effect.d.ts
@@ -145,7 +145,7 @@ declare global {
             data: PreDocumentId<this["_source"]>,
             options: DocumentModificationContext<TParent>,
             user: User
-        ): Promise<void>;
+        ): Promise<boolean | void>;
     }
 
     interface ActiveEffect<

--- a/types/foundry/client/data/documents/actor.d.ts
+++ b/types/foundry/client/data/documents/actor.d.ts
@@ -156,7 +156,7 @@ declare global {
             data: PreDocumentId<this["_source"]>,
             options: DocumentModificationContext<TParent>,
             user: User
-        ): Promise<void>;
+        ): Promise<boolean | void>;
 
         protected override _onUpdate(
             changed: DeepPartial<this["_source"]>,

--- a/types/foundry/client/data/documents/chat-message.d.ts
+++ b/types/foundry/client/data/documents/chat-message.d.ts
@@ -153,7 +153,7 @@ declare global {
             changed: DeepPartial<this["_source"]>,
             options: DocumentModificationContext<null>,
             user: User
-        ): Promise<void>;
+        ): Promise<boolean | void>;
 
         protected override _onCreate(
             data: this["_source"],

--- a/types/foundry/client/data/documents/scene.d.ts
+++ b/types/foundry/client/data/documents/scene.d.ts
@@ -51,7 +51,7 @@ declare global {
             data: PreDocumentId<this["_source"]>,
             options: DocumentModificationContext<null>,
             user: User
-        ): Promise<void>;
+        ): Promise<boolean | void>;
 
         protected override _onCreate(
             data: this["_source"],
@@ -63,11 +63,11 @@ declare global {
             data: DocumentUpdateData<this>,
             options: SceneUpdateContext,
             user: User
-        ): Promise<void>;
+        ): Promise<boolean | void>;
 
         override _onUpdate(changed: DeepPartial<this["_source"]>, options: SceneUpdateContext, userId: string): void;
 
-        protected override _preDelete(options: DocumentModificationContext<null>, user: User): Promise<void>;
+        protected override _preDelete(options: DocumentModificationContext<null>, user: User): Promise<boolean | void>;
 
         protected override _onDelete(options: DocumentModificationContext<null>, userId: string): void;
 

--- a/types/foundry/client/data/documents/token-document.d.ts
+++ b/types/foundry/client/data/documents/token-document.d.ts
@@ -102,7 +102,7 @@ declare global {
             data: DocumentUpdateData<this>,
             options: TokenUpdateContext<TParent>,
             user: User
-        ): Promise<void>;
+        ): Promise<boolean | void>;
 
         protected override _onUpdate(
             changed: DeepPartial<this["_source"]>,

--- a/types/foundry/common/abstract/document.d.ts
+++ b/types/foundry/common/abstract/document.d.ts
@@ -462,15 +462,17 @@ export default abstract class Document<
     /**
      * Perform preliminary operations before a Document of this type is created.
      * Pre-creation operations only occur for the client which requested the operation.
+     * Modifications to the pending document before it is persisted should be performed with this.updateSource().
      * @param data    The initial data object provided to the document creation request
      * @param options Additional options which modify the creation request
      * @param user    The User requesting the document creation
+     * @returns A return value of false indicates the creation operation should be cancelled.
      */
     protected _preCreate(
         data: PreDocumentId<this["_source"]>,
         options: DocumentModificationContext<TParent>,
         user: BaseUser
-    ): Promise<void>;
+    ): Promise<boolean | void>;
 
     /**
      * Perform preliminary operations before a Document of this type is updated.
@@ -478,20 +480,22 @@ export default abstract class Document<
      * @param changed The differential data that is changed relative to the documents prior values
      * @param options Additional options which modify the update request
      * @param user    The User requesting the document update
+     * @returns A return value of false indicates the update operation should be cancelled.
      */
     protected _preUpdate(
         changed: DeepPartial<this["_source"]>,
         options: DocumentUpdateContext<TParent>,
         user: BaseUser
-    ): Promise<void>;
+    ): Promise<boolean | void>;
 
     /**
      * Perform preliminary operations before a Document of this type is deleted.
      * Pre-delete operations only occur for the client which requested the operation.
      * @param options Additional options which modify the deletion request
      * @param user    The User requesting the document deletion
+     * @returns A return value of false indicates the deletion operation should be cancelled.
      */
-    protected _preDelete(options: DocumentModificationContext<TParent>, user: BaseUser): Promise<void>;
+    protected _preDelete(options: DocumentModificationContext<TParent>, user: BaseUser): Promise<boolean | void>;
 
     /**
      * Perform follow-up operations after a Document of this type is created.

--- a/types/foundry/common/documents/active-effect.d.ts
+++ b/types/foundry/common/documents/active-effect.d.ts
@@ -39,7 +39,7 @@ export default class BaseActiveEffect<TParent extends BaseActor | BaseItem<BaseA
         data: PreDocumentId<this["_source"]>,
         options: DocumentModificationContext<TParent>,
         user: BaseUser
-    ): Promise<void>;
+    ): Promise<boolean | void>;
 }
 
 export default interface BaseActiveEffect<TParent extends BaseActor | BaseItem<BaseActor | null> | null>

--- a/types/foundry/common/documents/actor.d.ts
+++ b/types/foundry/common/documents/actor.d.ts
@@ -50,13 +50,13 @@ export default class BaseActor<TParent extends BaseToken | null = BaseToken | nu
         data: PreDocumentId<this["_source"]>,
         options: DocumentModificationContext<TParent>,
         user: BaseUser
-    ): Promise<void>;
+    ): Promise<boolean | void>;
 
     protected override _preUpdate(
         changed: DocumentUpdateData<this>,
         options: DocumentModificationContext<TParent>,
         user: BaseUser
-    ): Promise<void>;
+    ): Promise<boolean | void>;
 }
 
 export default interface BaseActor<TParent extends BaseToken | null = BaseToken | null>

--- a/types/foundry/common/documents/fog-exploration.d.ts
+++ b/types/foundry/common/documents/fog-exploration.d.ts
@@ -9,7 +9,7 @@ export default class BaseFogExploration extends Document<null> {
         changed: DocumentUpdateData<this>,
         options: DocumentModificationContext<null>,
         user: BaseUser
-    ): Promise<void>;
+    ): Promise<boolean | void>;
 
     /** Test whether a User can modify a FogExploration document. */
     protected static _canUserModify<T extends BaseFogExploration>(user: BaseUser, doc: T): boolean;

--- a/types/foundry/common/documents/macro.d.ts
+++ b/types/foundry/common/documents/macro.d.ts
@@ -25,7 +25,7 @@ export default class BaseMacro extends Document<null> {
         data: PreDocumentId<MacroSource>,
         options: DocumentModificationContext<null>,
         user: BaseUser
-    ): Promise<void>;
+    ): Promise<boolean | void>;
 
     /* -------------------------------------------- */
     /*  Deprecations and Compatibility              */


### PR DESCRIPTION
They can now return `Promise<boolean | void>`.