### PR TITLE
Fix default ability action cost

### DIFF
--- a/src/module/item/action/sheet.ts
+++ b/src/module/item/action/sheet.ts
@@ -1,6 +1,5 @@
 import { ActionItemPF2e } from "@item/action/document.ts";
 import { ItemSheetDataPF2e } from "@item/sheet/data-types.ts";
-import { getActionIcon } from "@util/misc.ts";
 import { ItemSheetPF2e } from "../sheet/base.ts";
 import { FrequencySource } from "@item/data/base.ts";
 import { htmlQuery } from "@util";
@@ -8,9 +7,6 @@ import { htmlQuery } from "@util";
 export class ActionSheetPF2e extends ItemSheetPF2e<ActionItemPF2e> {
     override async getData(options?: Partial<DocumentSheetOptions>): Promise<ActionSheetData> {
         const data = await super.getData(options);
-
-        // Update icon based on the action cost
-        data.item.img = getActionIcon(this.item.actionCost);
 
         return {
             ...data,

--- a/static/template.json
+++ b/static/template.json
@@ -1005,7 +1005,7 @@
                 "traits"
             ],
             "actionType": {
-                "value": ""
+                "value": "passive"
             },
             "category": null,
             "actions": {


### PR DESCRIPTION
Also removed code that wasn't doing anything (since the sheet's image is the source item). Characters use the action cost as the action icon regardless of the action's item image.