### PR TITLE
Add isDestroyed check to the raiseAShield action

### DIFF
--- a/src/scripts/macros/raise-a-shield.ts
+++ b/src/scripts/macros/raise-a-shield.ts
@@ -34,7 +34,10 @@ export async function raiseAShield(options: ActionDefaultOptions): Promise<void>
             return false;
         }
 
-        if (shield?.isBroken === false) {
+        if (shield?.isDestroyed) {
+            ui.notifications.warn(localize("ShieldIsDestroyed", { actor: speaker.alias, shield: shield.name }));
+            return false;
+        } else if (shield?.isBroken === false) {
             const effect = await fromUuid(ITEM_UUID);
             if (!(effect instanceof EffectPF2e)) {
                 throw ErrorPF2e("Raise a Shield effect not found");


### PR DESCRIPTION
While the `raiseAShield` action prevents the use of the shield when it is `broken`, it doesn't prevent it when it is `destroyed`, so i just added the condition and warning into the action.

The `isBroken` getter specifically avoid returning `true` when the shield is destroyed.