### PR TITLE
Fix Ancestral Paragon choice set and underlying data availability

### DIFF
--- a/packs/feats/adopted-ancestry.json
+++ b/packs/feats/adopted-ancestry.json
@@ -37,6 +37,12 @@
             },
             {
                 "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "system.details.ancestry.adopted",
+                "value": "{item|flags.pf2e.rulesSelections.ancestry}"
+            },
+            {
+                "key": "ActiveEffectLike",
                 "mode": "add",
                 "path": "system.details.ancestry.countsAs",
                 "value": "{item|flags.pf2e.rulesSelections.ancestry}"

--- a/packs/feats/ancestral-paragon.json
+++ b/packs/feats/ancestral-paragon.json
@@ -29,6 +29,8 @@
                         {
                             "or": [
                                 "item:trait:{actor|system.details.ancestry.trait}",
+                                "item:trait:{actor|system.details.ancestry.adopted}",
+                                "item:trait:{actor|system.details.ancestry.versatile}",
                                 "item:trait:{actor|system.details.heritage.trait}"
                             ]
                         },

--- a/packs/heritages/half-elf.json
+++ b/packs/heritages/half-elf.json
@@ -25,6 +25,12 @@
             },
             {
                 "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "system.details.ancestry.versatile",
+                "value": "elf"
+            },
+            {
+                "key": "ActiveEffectLike",
                 "mode": "add",
                 "path": "system.details.ancestry.countsAs",
                 "value": "elf"

--- a/packs/heritages/half-orc.json
+++ b/packs/heritages/half-orc.json
@@ -25,6 +25,12 @@
             },
             {
                 "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "system.details.ancestry.versatile",
+                "value": "orc"
+            },
+            {
+                "key": "ActiveEffectLike",
                 "mode": "add",
                 "path": "system.details.ancestry.countsAs",
                 "value": "half-orc"

--- a/src/module/actor/character/data.ts
+++ b/src/module/actor/character/data.ts
@@ -357,6 +357,10 @@ type CharacterDetails = Omit<CreatureDetails, "creature"> & {
     ancestry: {
         name: string;
         trait: string;
+        /** An "adopted" ancestry (typically gained through the Adopted Ancestry feat) */
+        adopted: string | null;
+        /** A versatile ancestry trait (such as "orc" for being a half-orc) */
+        versatile: string | null;
         /** All ancestries and versatile heritages the character "counts as" when selecting ancestry feats */
         countsAs: string[];
     } | null;

--- a/src/module/item/ancestry/document.ts
+++ b/src/module/item/ancestry/document.ts
@@ -138,6 +138,8 @@ class AncestryPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends 
         actor.system.details.ancestry = {
             name: this.name,
             trait: slug,
+            adopted: null,
+            versatile: null,
             countsAs: [slug],
         };
 


### PR DESCRIPTION
The `countsAs` array is no longer usable now that we're no longer able to make NeDB queries, so the additional traits fed into Ancestal Paragon need to be more statically defined.