### PR TITLE
Fix spell validation for spells with roll data

### DIFF
--- a/src/module/system/damage/roll.ts
+++ b/src/module/system/damage/roll.ts
@@ -107,7 +107,7 @@ class DamageRoll extends AbstractDamageRoll {
         formula = formula.trim();
         const wrapped = this.replaceFormulaData(formula.startsWith("{") ? formula : `{${formula}}`, {});
         try {
-            const result = this.parser.parse(wrapped);
+            const result = this.parser.parse(wrapped.replace(/@([a-z.0-9_-]+)/gi, "1"));
             return isObject(result) && "class" in result && ["PoolTerm", "InstancePool"].includes(String(result.class));
         } catch {
             return false;


### PR DESCRIPTION
This allows any `@` stuff to work in spells again. This is the same regex substitution foundry does in their own roll validation function.