### PR TITLE
Add management of physical-item max HP alterations

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -744,6 +744,10 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
                 console.error(`PF2e | Failed to execute onBeforePrepareData on rule element ${rule}.`, error);
             }
         }
+
+        for (const item of this.items) {
+            item.onPrepareSynthetics?.();
+        }
     }
 
     /** Set traits as roll options */

--- a/src/module/actor/creature/data.ts
+++ b/src/module/actor/creature/data.ts
@@ -151,7 +151,7 @@ interface CreatureAttributes extends ActorAttributes {
     };
 
     senses: { value: string } | CreatureSensePF2e[];
-
+    shield?: HeldShieldData;
     speed: CreatureSpeeds;
 
     /** The current dying level (and maximum) for this creature. */

--- a/src/module/actor/creature/document.ts
+++ b/src/module/actor/creature/document.ts
@@ -317,7 +317,7 @@ abstract class CreaturePF2e<
         rollOptions.all["self:armored"] = !!this.wornArmor && this.wornArmor.category !== "unarmored";
 
         // Set whether the actor's shield is raised
-        if (attributes.shield?.raised && !attributes.shield.broken) {
+        if (attributes.shield?.raised && !attributes.shield.broken && !attributes.shield.destroyed) {
             this.rollOptions.all["self:shield:raised"] = true;
         }
 

--- a/src/module/item/base.ts
+++ b/src/module/item/base.ts
@@ -762,6 +762,8 @@ interface ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends 
 
     prepareSiblingData?(this: ItemPF2e<ActorPF2e>): void;
     prepareActorData?(this: ItemPF2e<ActorPF2e>): void;
+    /** Optional data-preparation callback executed after rule-element synthetics are prepared */
+    onPrepareSynthetics?(this: ItemPF2e<ActorPF2e>): void;
 
     /** Returns items that should also be added when this item is created */
     createGrantedItems(options?: object): Promise<ItemPF2e[]>;

--- a/src/module/item/physical/document.ts
+++ b/src/module/item/physical/document.ts
@@ -198,6 +198,11 @@ abstract class PhysicalItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | n
         systemData.baseItem ??= sluggify(systemData.stackGroup ?? "") || null;
         systemData.hp.brokenThreshold = Math.floor(systemData.hp.max / 2);
 
+        // An embedded item may have its maximum HP altered, but otherwise ensure current HP is no greater than max
+        if (!this.isEmbedded) {
+            systemData.hp.value = Math.min(systemData.hp.value, systemData.hp.max);
+        }
+
         // Temporary: prevent noise from items pre migration 746
         if (typeof systemData.price.value === "string") {
             systemData.price.value = CoinsPF2e.fromString(systemData.price.value);
@@ -304,6 +309,11 @@ abstract class PhysicalItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | n
         if (this._container && !this.actor.items.has(this._container.id)) {
             this._container = this.system.containerId = null;
         }
+    }
+
+    /** After item alterations have occurred, ensure that this item's hit points are no higher than its maximum */
+    override onPrepareSynthetics(this: PhysicalItemPF2e<ActorPF2e>): void {
+        this.system.hp.value = Math.min(this.system.hp.value, this.system.hp.max);
     }
 
     /** Can the provided item stack with this item? */

--- a/src/module/rules/rule-element/item-alteration/alteration.ts
+++ b/src/module/rules/rule-element/item-alteration/alteration.ts
@@ -1,5 +1,5 @@
 import type { ActorPF2e } from "@actor";
-import { ArmorPF2e, type ItemPF2e, type PhysicalItemPF2e } from "@item";
+import { type ItemPF2e, type PhysicalItemPF2e } from "@item";
 import { PersistentSourceData } from "@item/condition/data.ts";
 import { ItemSourcePF2e, PhysicalItemSource } from "@item/data/index.ts";
 import { itemIsOfType } from "@item/helpers.ts";
@@ -143,7 +143,8 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
                     if (newValue instanceof DataModelValidationFailure) {
                         throw newValue.asError();
                     }
-                    hp.max = Math.max(newValue, 1);
+                    hp.max = Math.max(Math.trunc(newValue), 1);
+                    this.#adjustCreatureShieldData(data.item);
                 }
                 return;
             }
@@ -184,7 +185,7 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
 
     /** Adjust creature shield data due it being set before item alterations occur */
     #adjustCreatureShieldData(item: PhysicalItemPF2e | PhysicalItemSource): void {
-        if (item instanceof ArmorPF2e && item.actor.isOfType("character", "npc") && item.isShield) {
+        if ("actor" in item && item.actor?.isOfType("character", "npc") && item.isOfType("armor") && item.isShield) {
             const { heldShield } = item.actor;
             if (item === heldShield) {
                 const shieldData = item.actor.attributes.shield;

--- a/src/module/rules/rule-element/item-alteration/rule-element.ts
+++ b/src/module/rules/rule-element/item-alteration/rule-element.ts
@@ -5,6 +5,8 @@ import type { StringField } from "types/foundry/common/data/fields.d.ts";
 import { AELikeRuleElement } from "../ae-like.ts";
 import { RuleElementOptions, RuleElementPF2e, RuleElementSchema, RuleElementSource } from "../index.ts";
 import { ItemAlteration, ItemAlterationSchema } from "./alteration.ts";
+import { ActorPF2e } from "@actor";
+import { ItemPF2e, PhysicalItemPF2e } from "@item";
 
 class ItemAlterationRuleElement extends RuleElementPF2e<ItemAlterationRuleSchema> {
     constructor(source: RuleElementSource, options: RuleElementOptions) {
@@ -46,6 +48,28 @@ class ItemAlterationRuleElement extends RuleElementPF2e<ItemAlterationRuleSchema
         } catch (error) {
             if (error instanceof Error) this.failValidation(error.message);
         }
+    }
+
+    /** If this RE alters max HP, proportionally adjust current HP of items it would match against */
+    override async preCreate(): Promise<void> {
+        if (this.ignored || this.property !== "hp-max") return;
+
+        const itemsOfType: ItemPF2e<ActorPF2e>[] = this.actor.itemTypes[this.itemType];
+        const actorRollOptions = this.actor.getRollOptions();
+        const itemsToAlter = itemsOfType.filter((i): i is PhysicalItemPF2e<ActorPF2e> =>
+            this.test([...actorRollOptions, ...i.getRollOptions("item")])
+        );
+        const updates = itemsToAlter.flatMap((item): { _id: string; "system.hp.value": number } | never[] => {
+            const source = item.toObject();
+            const alteration = new ItemAlteration(R.pick(this, ["mode", "property", "value"]), { parent: this });
+            alteration.applyTo(source);
+            alteration.applyTo(item);
+            const newHP = source.system.hp;
+            const oldHP = item._source.system.hp;
+            const newHPValue = Math.floor(oldHP.value * (newHP.max / oldHP.max));
+            return newHPValue === oldHP.value ? [] : { _id: item.id, "system.hp.value": newHPValue };
+        });
+        if (updates.length > 0) await this.actor.updateEmbeddedDocuments("Item", updates, { render: false });
     }
 }
 

--- a/src/module/rules/rule-element/item-alteration/schemas.ts
+++ b/src/module/rules/rule-element/item-alteration/schemas.ts
@@ -123,18 +123,20 @@ const ITEM_ALTERATION_VALIDATORS = {
     }),
     hardness: new ItemAlterationValidator({
         itemType: new fields.StringField({ required: true, choices: Array.from(PHYSICAL_ITEM_TYPES) }),
-        mode: new fields.StringField({ required: true, choices: ["add", "override"] }),
+        mode: new fields.StringField({
+            required: true,
+            choices: ["add", "downgrade", "override", "remove", "subtract", "upgrade"],
+        }),
         value: new fields.NumberField({ required: true, integer: true, nullable: false, positive: true } as const),
     }),
     "hp-max": new ItemAlterationValidator({
         itemType: new fields.StringField({ required: true, choices: Array.from(PHYSICAL_ITEM_TYPES) }),
         mode: new fields.StringField({
             required: true,
-            choices: ["add", "downgrade", "override", "remove", "subtract", "upgrade"],
+            choices: ["add", "downgrade", "multiply", "override", "remove", "subtract", "upgrade"],
         }),
         value: new fields.NumberField({
             required: true,
-            integer: true,
             nullable: false,
             positive: true,
             initial: undefined,

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2310,14 +2310,10 @@
             "reflex": "Master Reflex",
             "will": "Master Will"
         },
-        "MaxHPTitle": "Your maximum hit points. This field is automatically calculated.",
-        "MaxHPTitleNPC": "Maximum hit points.",
         "MaxHitPointsBaseLabel": "Base Max HP {base}",
-        "MaxHitPointsHeader": "Maximum Hit Points",
         "MaxHitPointsShortLabel": "Max HP",
         "MaxStaminaPointsShortLabel": "Max SP",
         "MaxStaminaTitle": "Your maximum stamina points",
-        "MetalStrikes": "Metal Strikes",
         "Migrations": {
             "Finished": "PF2E System Migration to version {version} completed!",
             "OnlyGMCanUse": "Only a gamemaster can use this tool.",

--- a/static/templates/items/armor-details.hbs
+++ b/static/templates/items/armor-details.hbs
@@ -163,19 +163,18 @@
 {{/if}}
 
 <div class="form-group">
-    <label>{{localize "PF2E.MaxHitPointsHeader"}}</label>
-    <input type="number"
-        {{#if (gt item.system.hp.max item._source.system.hp.max)}}
-            class="adjusted-higher"
-        {{else if (lt item.system.hp.max item._source.system.hp.max)}}
-            class="adjusted-lower"
-        {{/if}}
-        data-property="system.hp.max" data-value-base="{{item._source.system.hp.max}}" value="{{data.hp.max}}" />
-</div>
-
-<div class="form-group">
-    <label>{{localize "PF2E.HitPointsHeader"}}</label>
-    <input type="number" name="system.hp.value" value="{{data.hp.value}}" />
+    <label for="{{item.uuid}}-hp">{{localize "PF2E.HitPointsHeader"}}</label>
+    <div class="form-fields">
+        <input id="{{item.uuid}}-hp" type="number" name="system.hp.value" value="{{data.hp.value}}" />
+        /
+        <input type="number"
+            {{#if (gt item.system.hp.max item._source.system.hp.max)}}
+                class="adjusted-higher"
+            {{else if (lt item.system.hp.max item._source.system.hp.max)}}
+                class="adjusted-lower"
+            {{/if}}
+            data-property="system.hp.max" data-value-base="{{item._source.system.hp.max}}" value="{{data.hp.max}}" />
+    </div>
 </div>
 
 <div class="form-group">


### PR DESCRIPTION
It ended up being a tight-rope walk to generate the expected results: current HP must be proportionally adjusted but also reduced back down if a max-HP increase goes away for whatever reason.