### PR TITLE
Enable incapacitation trait for physical non-weapon items

### DIFF
--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -160,13 +160,14 @@ export const InlineRollLinks = {
                                 }
                                 return null;
                             })();
-                            // Retrieve the item if it is a spell and the check is a saving throw (for, e.g.,
-                            // incapacitation handling)
+
+                            // Retrieve the item if it is not a weapon and this is a saving throw
+                            // Exclude weapons so that roll notes on strikes from incapacitation abilities continue to work.
                             const item = (() => {
                                 if (!tupleHasValue(SAVE_TYPES, statistic.slug)) return null;
-                                return foundryDoc instanceof ItemPF2e && foundryDoc.isOfType("spell")
+                                return foundryDoc instanceof ItemPF2e && !foundryDoc.isOfType("weapon")
                                     ? foundryDoc
-                                    : foundryDoc instanceof ChatMessagePF2e && foundryDoc.item?.isOfType("spell")
+                                    : foundryDoc instanceof ChatMessagePF2e && !foundryDoc.item?.isOfType("weapon")
                                     ? foundryDoc.item
                                     : null;
                             })();


### PR DESCRIPTION
This *might* also have beneficial effects for ROE stuff, since it enables item retrieval and item roll options for everything. I don't know for sure though. I *think* this can be opened up to non-saves as well, but I want to be sure we need that first.

We can do weapons as well once roll notes can refer to their origin item (so stunning fist no breaky).

Feats use actor level for incapacitation (in StatisticCheck#roll()) so those continue to work just fine. 

I tested with the Drover's Band (beware AV spoilers).