### PR TITLE
Touch up oracular curses with stupid RE tricks

### DIFF
--- a/packs/feat-effects/effect-curse-of-ancestral-meddling.json
+++ b/packs/feat-effects/effect-curse-of-ancestral-meddling.json
@@ -309,6 +309,11 @@
                 ],
                 "property": "badge-max",
                 "value": 3
+            },
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "option": "oracular-curse:stage:{item|badge.value}"
             }
         ],
         "source": {

--- a/packs/feat-effects/effect-curse-of-creeping-ashes.json
+++ b/packs/feat-effects/effect-curse-of-creeping-ashes.json
@@ -43,6 +43,7 @@
                 ],
                 "key": "Aura",
                 "predicate": [
+                    "class:oracle",
                     {
                         "gt": [
                             "parent:badge:value",
@@ -62,13 +63,10 @@
                 "value": -10
             },
             {
-                "allowDuplicate": false,
                 "inMemoryOnly": true,
                 "key": "GrantItem",
-                "onDeleteActions": {
-                    "grantee": "restrict"
-                },
                 "predicate": [
+                    "class:oracle",
                     {
                         "gte": [
                             "parent:badge:value",
@@ -103,6 +101,11 @@
                 ],
                 "property": "badge-max",
                 "value": 3
+            },
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "option": "oracular-curse:stage:{item|badge.value}"
             }
         ],
         "source": {

--- a/packs/feat-effects/effect-curse-of-engulfing-flames.json
+++ b/packs/feat-effects/effect-curse-of-engulfing-flames.json
@@ -14,7 +14,7 @@
             "value": 1
         },
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.classfeatures.Item.Flames]</p>\n<h3>Curse of Engulfing Flames</h3>\n<p>You see flames and smoke wherever you look. These flames might be imagined, or they might be a preternatural glimpse of the metaphorical fires that empower the entire multiverse-but you always see them. Fires flare noticeably (though not dangerously) in your presence, you occasionally smoke slightly, and your body is almost painfully hot to the touch.</p>\n<h4>Minor Curse</h4>\n<p>The smoke, heat, and crackling flames of your curse fill your vision and all your other senses.</p>\n<p>Creatures further than 30 feet are @UUID[Compendium.pf2e.conditionitems.Item.Concealed] from you. You can't benefit from effects that would allow you to ignore or mitigate this concealment, as normal for effects of an oracular curse.</p>\n<h4>Moderate Curse</h4>\n<p>Smoke and flickering visions of flame fill your senses more completely, and harmless flickers of obscuring flames also fill your space.</p>\n<p>You are concealed from other creatures, though as the other creatures aren't cursed themselves, they can benefit from effects that would allow them to ignore or mitigate the concealed condition, as normal. All other creatures and objects are concealed from you regardless of distance; however, when casting a fire spell, you automatically succeed at the flat check for this concealed condition for targets within 30 feet.</p>\n<p>All your senses become imprecise beyond 30 feet, meaning everything past 30 feet that you'd normally be able to see is @UUID[Compendium.pf2e.conditionitems.Item.Hidden] from you.</p>\n<h4>Major Curse (11th)</h4>\n<p>The flames surrounding you are no longer simply visions.</p>\n<p>An aura of fire surrounds you in a @Template[type:emanation|distance:10], dealing [[/r 4d6[fire]]] damage (basic Reflex save) to all other creatures in the aura at the end of each of your turns. You lose [[/r 1d6]] Hit Points at the end of your turn each round, with no save; if you have a weakness to fire, increase the number of HP you lose by that weakness.</p>\n<p>You can suppress your aura until the start of your next turn by spending a single action, which has the concentrate trait, to diminish the flames, causing neither you nor anyone in the aura to take damage. While Refocusing to reduce your curse, you are continually diminishing the flames, so you don't lose HP. The flames subside if you fall @UUID[Compendium.pf2e.conditionitems.Item.Unconscious], but they resume when you wake up unless you rested for long enough to reset your curse. As usual for oracular curses, you can't mitigate or reduce the lost Hit Points in any way, though you can still heal the lost HP normally after the fact.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.classfeatures.Item.Flames]</p>\n<h3>Curse of Engulfing Flames</h3>\n<p>You see flames and smoke wherever you look. These flames might be imagined, or they might be a preternatural glimpse of the metaphorical fires that empower the entire multiverse-but you always see them. Fires flare noticeably (though not dangerously) in your presence, you occasionally smoke slightly, and your body is almost painfully hot to the touch.</p>\n<h4>Minor Curse</h4>\n<p>The smoke, heat, and crackling flames of your curse fill your vision and all your other senses.</p>\n<p>Creatures further than 30 feet are @UUID[Compendium.pf2e.conditionitems.Item.Concealed] from you. You can't benefit from effects that would allow you to ignore or mitigate this concealment, as normal for effects of an oracular curse.</p>\n<h4>Moderate Curse</h4>\n<p>Smoke and flickering visions of flame fill your senses more completely, and harmless flickers of obscuring flames also fill your space.</p>\n<p>You are concealed from other creatures, though as the other creatures aren't cursed themselves, they can benefit from effects that would allow them to ignore or mitigate the concealed condition, as normal. All other creatures and objects are concealed from you regardless of distance; however, when casting a fire spell, you automatically succeed at the flat check for this concealed condition for targets within 30 feet.</p>\n<p>All your senses become imprecise beyond 30 feet, meaning everything past 30 feet that you'd normally be able to see is @UUID[Compendium.pf2e.conditionitems.Item.Hidden] from you.</p>\n<h4>Major Curse (11th)</h4>\n<p>The flames surrounding you are no longer simply visions.</p>\n<p>An aura of fire surrounds you in a 10-foot emanation, dealing [[/r 4d6[fire]]] damage (basic Reflex save) to all other creatures in the aura at the end of each of your turns. You lose [[/r 1d6]] Hit Points at the end of your turn each round, with no save; if you have a weakness to fire, increase the number of HP you lose by that weakness.</p>\n<p>You can suppress your aura until the start of your next turn by spending a single action, which has the concentrate trait, to diminish the flames, causing neither you nor anyone in the aura to take damage. While Refocusing to reduce your curse, you are continually diminishing the flames, so you don't lose HP. The flames subside if you fall @UUID[Compendium.pf2e.conditionitems.Item.Unconscious], but they resume when you wake up unless you rested for long enough to reset your curse. As usual for oracular curses, you can't mitigate or reduce the lost Hit Points in any way, though you can still heal the lost HP normally after the fact.</p>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -27,12 +27,10 @@
         },
         "rules": [
             {
-                "allowDuplicate": false,
+                "inMemoryOnly": true,
                 "key": "GrantItem",
-                "onDeleteActions": {
-                    "grantee": "restrict"
-                },
                 "predicate": [
+                    "class:oracle",
                     {
                         "gte": [
                             "parent:badge:value",
@@ -83,6 +81,11 @@
                 ],
                 "property": "badge-max",
                 "value": 3
+            },
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "option": "oracular-curse:stage:{item|badge.value}"
             }
         ],
         "source": {

--- a/packs/feat-effects/effect-curse-of-living-death.json
+++ b/packs/feat-effects/effect-curse-of-living-death.json
@@ -209,6 +209,11 @@
                 ],
                 "property": "badge-max",
                 "value": 3
+            },
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "option": "oracular-curse:stage:{item|badge.value}"
             }
         ],
         "source": {

--- a/packs/feat-effects/effect-curse-of-outpouring-life.json
+++ b/packs/feat-effects/effect-curse-of-outpouring-life.json
@@ -83,6 +83,11 @@
                 ],
                 "property": "badge-max",
                 "value": 3
+            },
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "option": "oracular-curse:stage:{item|badge.value}"
             }
         ],
         "source": {

--- a/packs/feat-effects/effect-curse-of-the-heros-burden.json
+++ b/packs/feat-effects/effect-curse-of-the-heros-burden.json
@@ -229,6 +229,11 @@
                 ],
                 "slug": "battle-curse-penalty",
                 "value": 0
+            },
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "option": "oracular-curse:stage:{item|badge.value}"
             }
         ],
         "source": {

--- a/packs/feat-effects/effect-curse-of-the-perpetual-storm.json
+++ b/packs/feat-effects/effect-curse-of-the-perpetual-storm.json
@@ -125,16 +125,9 @@
                 "value": -2
             },
             {
-                "allowDuplicate": false,
-                "inMemoryOnly": true,
-                "key": "GrantItem",
-                "predicate": [
-                    {
-                        "not": "class:oracle"
-                    },
-                    "parent:badge:value:2"
-                ],
-                "uuid": "Compendium.pf2e.conditionitems.Item.Flat-Footed"
+                "domain": "all",
+                "key": "RollOption",
+                "option": "oracular-curse:stage:{item|badge.value}"
             }
         ],
         "source": {

--- a/packs/feat-effects/effect-curse-of-the-skys-call.json
+++ b/packs/feat-effects/effect-curse-of-the-skys-call.json
@@ -83,62 +83,27 @@
                 "value": 2
             },
             {
-                "allowDuplicate": false,
                 "inMemoryOnly": true,
                 "key": "GrantItem",
-                "onDeleteActions": {
-                    "grantee": "restrict"
-                },
-                "predicate": [
-                    "parent:badge:value:1"
-                ],
-                "reevaluateOnUpdate": true,
+                "priority": 39,
                 "uuid": "Compendium.pf2e.conditionitems.Item.Enfeebled"
             },
             {
-                "allowDuplicate": false,
-                "alterations": [
-                    {
-                        "mode": "override",
-                        "property": "badge-value",
-                        "value": 2
-                    }
-                ],
-                "inMemoryOnly": true,
-                "key": "GrantItem",
-                "onDeleteActions": {
-                    "grantee": "restrict"
-                },
+                "itemType": "condition",
+                "key": "ItemAlteration",
+                "mode": "upgrade",
                 "predicate": [
-                    "parent:badge:value:2"
-                ],
-                "reevaluateOnUpdate": true,
-                "uuid": "Compendium.pf2e.conditionitems.Item.Enfeebled"
-            },
-            {
-                "allowDuplicate": false,
-                "alterations": [
-                    {
-                        "mode": "override",
-                        "property": "badge-value",
-                        "value": 4
-                    }
-                ],
-                "inMemoryOnly": true,
-                "key": "GrantItem",
-                "onDeleteActions": {
-                    "grantee": "restrict"
-                },
-                "predicate": [
+                    "class:oracle",
+                    "item:slug:enfeebled",
                     {
                         "gte": [
                             "parent:badge:value",
-                            3
+                            2
                         ]
                     }
                 ],
-                "reevaluateOnUpdate": true,
-                "uuid": "Compendium.pf2e.conditionitems.Item.Enfeebled"
+                "property": "badge-value",
+                "value": "ternary(gt(@item.badge.value, 2), 4, 2)"
             },
             {
                 "itemType": "effect",
@@ -165,6 +130,11 @@
                 ],
                 "property": "badge-max",
                 "value": 3
+            },
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "option": "oracular-curse:stage:{item|badge.value}"
             }
         ],
         "source": {

--- a/packs/feat-effects/effect-curse-of-torrential-knowledge.json
+++ b/packs/feat-effects/effect-curse-of-torrential-knowledge.json
@@ -55,13 +55,10 @@
                 "value": 4
             },
             {
-                "allowDuplicate": false,
                 "inMemoryOnly": true,
                 "key": "GrantItem",
-                "onDeleteActions": {
-                    "grantee": "restrict"
-                },
                 "predicate": [
+                    "class:oracle",
                     {
                         "gte": [
                             "parent:badge:value",
@@ -69,7 +66,6 @@
                         ]
                     }
                 ],
-                "reevaluateOnUpdate": true,
                 "uuid": "Compendium.pf2e.conditionitems.Item.Flat-Footed"
             },
             {
@@ -97,6 +93,11 @@
                 ],
                 "property": "badge-max",
                 "value": 3
+            },
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "option": "oracular-curse:stage:{item|badge.value}"
             }
         ],
         "source": {

--- a/packs/feat-effects/effect-curse-of-turbulent-moments.json
+++ b/packs/feat-effects/effect-curse-of-turbulent-moments.json
@@ -44,6 +44,7 @@
                 "key": "AdjustModifier",
                 "mode": "override",
                 "predicate": [
+                    "class:oracle",
                     "parent:badge:value:2"
                 ],
                 "selector": "ac",
@@ -105,45 +106,32 @@
                 "value": -4
             },
             {
-                "allowDuplicate": false,
                 "inMemoryOnly": true,
                 "key": "GrantItem",
-                "onDeleteActions": {
-                    "grantee": "restrict"
-                },
-                "predicate": [
-                    "parent:badge:value:1"
-                ],
-                "reevaluateOnUpdate": true,
+                "priority": 39,
                 "uuid": "Compendium.pf2e.conditionitems.Item.Enfeebled"
             },
             {
-                "allowDuplicate": false,
-                "alterations": [
+                "itemType": "condition",
+                "key": "ItemAlteration",
+                "mode": "upgrade",
+                "predicate": [
+                    "class:oracle",
+                    "item:slug:enfeebled",
                     {
-                        "mode": "override",
-                        "property": "badge-value",
-                        "value": 2
+                        "gte": [
+                            "parent:badge:value",
+                            2
+                        ]
                     }
                 ],
-                "inMemoryOnly": true,
-                "key": "GrantItem",
-                "onDeleteActions": {
-                    "grantee": "restrict"
-                },
-                "predicate": [
-                    "parent:badge:value:2"
-                ],
-                "reevaluateOnUpdate": true,
-                "uuid": "Compendium.pf2e.conditionitems.Item.Enfeebled"
+                "property": "badge-value",
+                "value": "ternary(gt(@item.badge.value, 2), 3, 2)"
             },
             {
-                "allowDuplicate": false,
+                "allowDuplicate": true,
                 "inMemoryOnly": true,
                 "key": "GrantItem",
-                "onDeleteActions": {
-                    "grantee": "restrict"
-                },
                 "predicate": [
                     {
                         "gte": [
@@ -152,33 +140,7 @@
                         ]
                     }
                 ],
-                "reevaluateOnUpdate": true,
                 "uuid": "Compendium.pf2e.conditionitems.Item.Slowed"
-            },
-            {
-                "allowDuplicate": false,
-                "alterations": [
-                    {
-                        "mode": "override",
-                        "property": "badge-value",
-                        "value": 3
-                    }
-                ],
-                "inMemoryOnly": true,
-                "key": "GrantItem",
-                "onDeleteActions": {
-                    "grantee": "restrict"
-                },
-                "predicate": [
-                    {
-                        "gte": [
-                            "parent:badge:value",
-                            3
-                        ]
-                    }
-                ],
-                "reevaluateOnUpdate": true,
-                "uuid": "Compendium.pf2e.conditionitems.Item.Enfeebled"
             },
             {
                 "itemType": "effect",
@@ -205,6 +167,11 @@
                 ],
                 "property": "badge-max",
                 "value": 3
+            },
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "option": "oracular-curse:stage:{item|badge.value}"
             }
         ],
         "source": {

--- a/packs/feats/oracle-dedication.json
+++ b/packs/feats/oracle-dedication.json
@@ -39,6 +39,14 @@
             {
                 "key": "GrantItem",
                 "uuid": "Compendium.pf2e.classfeatures.Item.Mystery"
+            },
+            {
+                "inMemoryOnly": true,
+                "key": "GrantItem",
+                "predicate": [
+                    "oracular-curse:stage:2"
+                ],
+                "uuid": "Compendium.pf2e.conditionitems.Item.Flat-Footed"
             }
         ],
         "source": {


### PR DESCRIPTION
- Alter in-memory condition grants for Cosmos and Time curses
- Prevent effects of moderate-stage curses from applying to characters without the oracle class
- Have the Oracle Dedication feat impose flat-footed at the moderate curse stage