### PR TITLE
Automates cover

### DIFF
--- a/src/module/canvas/token/object.ts
+++ b/src/module/canvas/token/object.ts
@@ -149,11 +149,14 @@ class TokenPF2e<TDocument extends TokenDocumentPF2e = TokenDocumentPF2e> extends
         return flankingBuddies.some((b) => onOppositeSides(this, b, flankee));
     }
 
-    canCover() {
+    canCover(): boolean {
         return !!this.actor;
     }
 
-    getCreatureCover(fromToken: TokenPF2e, mode: "disabled" | "normal" | "small-margin" | "opposite-sides") {
+    getCreatureCover(
+        fromToken: TokenPF2e,
+        mode: "disabled" | "normal" | "small-margin" | "opposite-sides"
+    ): "lesser" | "standard" | undefined {
         if (mode === "disabled") return undefined;
 
         const origin = this.center;
@@ -203,7 +206,7 @@ class TokenPF2e<TDocument extends TokenDocumentPF2e = TokenDocumentPF2e> extends
             const sides = { top, right, bottom, left };
 
             if (intersectsWith(sides)) return extralarges ? "standard" : "lesser";
-            else if (isExtraLarge(token)) extralarges--;
+            else if (isExtraLarge(token)) extralarges -= 1;
         }
 
         return undefined;
@@ -213,7 +216,7 @@ class TokenPF2e<TDocument extends TokenDocumentPF2e = TokenDocumentPF2e> extends
         fromToken: TokenPF2e,
         mode: "disabled" | "center" | "spread",
         collisionType: WallRestrictionType = "move"
-    ) {
+    ): boolean {
         if (mode === "disabled") return false;
 
         if (mode === "center") {


### PR DESCRIPTION
This is a base implementation of cover automation, should it be added to the system and if so, should it be implemented like that ?

- how to handle the creature cover for diagonals ? right now i am forcing a minimum of 5 ft. between the attacker and the target
- there should probably be an easy way to ignore automated covers during a specific attack
- there need to be checks for feats/features that work with cover in pf2e
