### PR TITLE
Fix name for Blood-Pear Tree's Bloody Pear and remove Blight ability

### DIFF
--- a/packs/stolen-fate-bestiary/blood-pear-tree.json
+++ b/packs/stolen-fate-bestiary/blood-pear-tree.json
@@ -93,7 +93,7 @@
         {
             "_id": "fxc64qicfzi9l9lx",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "Rotten Fruit",
+            "name": "Bloody Pear",
             "sort": 300000,
             "system": {
                 "attack": {
@@ -264,61 +264,10 @@
             "type": "action"
         },
         {
-            "_id": "loe7wunkt2aw95fw",
-            "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Blight",
-            "sort": 700000,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "defensive",
-                "description": {
-                    "value": "<p>@Template[type:emanation|distance:30]{30 feet} @UUID[Compendium.pf2e.bestiary-ability-glossary-srd.Item.Aura]</p>\n<p>A plant entering or starting its turn in the corpseroot's aura begins to wither and must succeed at a @Check[type:fortitude|dc:27] save or become @UUID[Compendium.pf2e.conditionitems.Item.Sickened]{Sickened 2} (@UUID[Compendium.pf2e.conditionitems.Item.Sickened]{Sickened 4} on a critical failure). A plant that succeeds is temporarily immune for 1 minute.</p>\n<p>A plant that stays in the aura for 7 consecutive days must succeed at a @Check[type:fortitude|dc:27] save or die. If the plant was a creature or tree, it rises as a corpseroot. The newly risen corpseroot can't create more corpseroots but has all other corpseroot abilities. Plants that are neither magical nor creatures automatically fail saves against blight.</p>"
-                },
-                "requirements": {
-                    "value": ""
-                },
-                "rules": [
-                    {
-                        "key": "Aura",
-                        "radius": 30,
-                        "slug": "blight",
-                        "traits": [
-                            "aura",
-                            "necromancy",
-                            "poison",
-                            "primal"
-                        ]
-                    }
-                ],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "aura",
-                        "necromancy",
-                        "poison",
-                        "primal"
-                    ]
-                },
-                "trigger": {
-                    "value": ""
-                }
-            },
-            "type": "action"
-        },
-        {
             "_id": "t2vkqgxwqps1lc2c",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Plant",
-            "sort": 800000,
+            "sort": 700000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -352,7 +301,7 @@
             "_id": "u35onovz82ogkm7o",
             "img": "systems/pf2e/icons/actions/OneAction.webp",
             "name": "Take Root",
-            "sort": 900000,
+            "sort": 800000,
             "system": {
                 "actionType": {
                     "value": "action"
@@ -394,7 +343,7 @@
             },
             "img": "systems/pf2e/icons/actions/OneAction.webp",
             "name": "Grab",
-            "sort": 1000000,
+            "sort": 900000,
             "system": {
                 "actionType": {
                     "value": "action"
@@ -431,7 +380,7 @@
             "_id": "i47di6o0ykrbmr3p",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Athletics",
-            "sort": 1100000,
+            "sort": 1000000,
             "system": {
                 "description": {
                     "value": ""
@@ -454,7 +403,7 @@
             "_id": "utyqdxw6i6gyt6ik",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Stealth",
-            "sort": 1200000,
+            "sort": 1100000,
             "system": {
                 "description": {
                     "value": ""


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/8880