### PR TITLE
Exclude ancestors curse flat-check notes from some rolls

### DIFF
--- a/packs/feat-effects/effect-curse-of-ancestral-meddling.json
+++ b/packs/feat-effects/effect-curse-of-ancestral-meddling.json
@@ -50,6 +50,13 @@
                             "ancestral-influence:martial",
                             "ancestral-influence:spellcasting"
                         ]
+                    },
+                    {
+                        "nor": [
+                            "check:type:initiative",
+                            "downtime",
+                            "exploration"
+                        ]
                     }
                 ],
                 "selector": "skill-check",
@@ -64,6 +71,13 @@
                         "or": [
                             "ancestral-influence:martial",
                             "ancestral-influence:spellcasting"
+                        ]
+                    },
+                    {
+                        "nor": [
+                            "check:type:initiative",
+                            "downtime",
+                            "exploration"
                         ]
                     }
                 ],
@@ -130,6 +144,13 @@
                             "ancestral-influence:martial",
                             "ancestral-influence:spellcasting"
                         ]
+                    },
+                    {
+                        "nor": [
+                            "check:type:initiative",
+                            "downtime",
+                            "exploration"
+                        ]
                     }
                 ],
                 "selector": "skill-check",
@@ -145,6 +166,13 @@
                         "or": [
                             "ancestral-influence:martial",
                             "ancestral-influence:spellcasting"
+                        ]
+                    },
+                    {
+                        "nor": [
+                            "check:type:initiative",
+                            "downtime",
+                            "exploration"
                         ]
                     }
                 ],
@@ -211,6 +239,13 @@
                             "ancestral-influence:martial",
                             "ancestral-influence:spellcasting"
                         ]
+                    },
+                    {
+                        "nor": [
+                            "check:type:initiative",
+                            "downtime",
+                            "exploration"
+                        ]
                     }
                 ],
                 "selector": "skill-check",
@@ -225,6 +260,13 @@
                         "or": [
                             "ancestral-influence:martial",
                             "ancestral-influence:spellcasting"
+                        ]
+                    },
+                    {
+                        "nor": [
+                            "check:type:initiative",
+                            "downtime",
+                            "exploration"
                         ]
                     }
                 ],


### PR DESCRIPTION
Specifically downtime & exploration actions, as well as initiative rolls (need to add roll option for that)