### PR TITLE
Add separate `CharacterSystemSource` type

### DIFF
--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -83,7 +83,6 @@ import {
     CharacterAttributes,
     CharacterFlags,
     CharacterProficiency,
-    CharacterSaves,
     CharacterSource,
     CharacterStrike,
     CharacterSystemData,
@@ -269,10 +268,6 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
     /** Setup base ephemeral data to be modified by active effects and derived-data preparation */
     override prepareBaseData(): void {
         super.prepareBaseData();
-        const systemData: DeepPartial<CharacterSystemData> & { abilities: Abilities } = this.system;
-
-        // template.json may be stale, work around it until core is fixed
-        this.system.exploration ??= [];
 
         // If there are no parties, clear the exploration activities list
         if (!this.parties.size) {
@@ -309,6 +304,14 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
             result[level] = allowed;
             return result;
         }, {} as Record<(typeof boostLevels)[number], number>);
+
+        // Base ability scores
+        this.system.abilities = R.mapToObj(Array.from(ABILITY_ABBREVIATIONS), (a) => [
+            a,
+            mergeObject({ value: 10 }, this.system.abilities?.[a] ?? {}),
+        ]);
+
+        const systemData: DeepPartial<CharacterSystemData> & { abilities: Abilities } = this.system;
         const existingBoosts = systemData.build?.abilities?.boosts;
         systemData.build = {
             abilities: {
@@ -331,10 +334,11 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
             },
         };
 
-        // Base ability scores
-        for (const abbrev of ABILITY_ABBREVIATIONS) {
-            systemData.abilities[abbrev] = mergeObject({ value: 10 }, systemData.abilities[abbrev] ?? {});
-        }
+        // Base saves structure
+        systemData.saves = mergeObject(
+            R.mapToObj(SAVE_TYPES, (t) => [t, { rank: 0 }]),
+            systemData.saves ?? {}
+        );
 
         // Actor document and data properties from items
         const { details } = this.system;
@@ -377,24 +381,16 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
         attributes.ancestryhp = 0;
         attributes.classhp = 0;
 
-        // Familiar abilities
-        attributes.familiarAbilities = { value: 0 };
-
-        // Saves and skills
-        const saves: DeepPartial<CharacterSaves> = this.system.saves;
-        for (const save of SAVE_TYPES) {
-            saves[save] = {
-                ability: CONFIG.PF2E.savingThrowDefaultAbilities[save],
-                rank: saves[save]?.rank ?? 0,
-            };
-        }
-
-        const skills = this.system.skills;
+        // Skills
+        const { skills } = this.system;
         for (const key of SKILL_ABBREVIATIONS) {
             const skill = skills[key];
             skill.ability = SKILL_EXPANDED[SKILL_DICTIONARY[key]].ability;
             skill.armor = ["dex", "str"].includes(skill.ability);
         }
+
+        // Familiar abilities
+        attributes.familiarAbilities = { value: 0 };
 
         // Spellcasting-tradition proficiencies
         systemData.proficiencies = {
@@ -424,7 +420,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
         this.system.traits.size = new ActorSizePF2e({ value: "med" });
 
         // Weapon and Armor category proficiencies
-        const martial: DeepPartial<MartialProficiencies> = this.system.martial;
+        const martial: DeepPartial<MartialProficiencies> = (systemData.martial ??= {});
         for (const category of [...ARMOR_CATEGORIES, ...WEAPON_CATEGORIES]) {
             const proficiency: Partial<CharacterProficiency> = martial[category] ?? {};
             proficiency.rank = martial[category]?.rank ?? 0;
@@ -447,11 +443,10 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
         }
 
         // Indicate that crafting formulas stored directly on the actor are deletable
+        systemData.crafting = mergeObject({ formulas: [], entries: {} }, systemData.crafting ?? {});
         for (const formula of this.system.crafting.formulas) {
             formula.deletable = true;
         }
-
-        this.system.crafting.entries = {};
 
         // PC level is never a derived number, so it can be set early
         this.rollOptions.all[`self:level:${this.level}`] = true;
@@ -1927,7 +1922,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
 
     /** Toggle between boost-driven and manual management of ability scores */
     async toggleAbilityManagement(): Promise<void> {
-        if (Object.keys(this._source.system.abilities).length === 0) {
+        if (Object.keys(this._source.system.abilities ?? {}).length === 0) {
             // Add stored ability scores for manual management
             const baseAbilities = Array.from(ABILITY_ABBREVIATIONS).reduce(
                 (accumulated: Record<string, { value: 10 }>, abbrev) => ({

--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -801,7 +801,7 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
                 })}</p>`;
                 const title = game.i18n.localize("PF2E.CraftingTab.RemoveFormulaDialogTitle");
                 if (await Dialog.confirm({ title, content })) {
-                    const actorFormulas = this.actor.toObject().system.crafting.formulas ?? [];
+                    const actorFormulas = this.actor.toObject().system.crafting?.formulas ?? [];
                     actorFormulas.findSplice((f) => f.uuid === itemUuid);
                     this.actor.update({ "system.crafting.formulas": actorFormulas });
                 }
@@ -1225,7 +1225,7 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
             }
         }
         // Sort other formulas
-        const formulas = this.actor.toObject().system.crafting.formulas ?? [];
+        const formulas = this.actor.toObject().system.crafting?.formulas ?? [];
         const source = formulas.find((f) => f.uuid === sourceFormula.uuid);
         const target = formulas.find((f) => f.uuid === targetUuid);
         if (source && target) {

--- a/src/module/actor/creature/data.ts
+++ b/src/module/actor/creature/data.ts
@@ -19,7 +19,7 @@ import type {
     SkillLongForm,
 } from "@actor/types.ts";
 import type { CREATURE_ACTOR_TYPES } from "@actor/values.ts";
-import { LabeledNumber, Size, ValueAndMax, ValuesList, ZeroToThree } from "@module/data.ts";
+import { LabeledNumber, ValueAndMax, ValuesList, ZeroToThree } from "@module/data.ts";
 import { Statistic, StatisticTraceData } from "@system/statistic/index.ts";
 import { CreatureSensePF2e, SenseAcuity, SenseType } from "./sense.ts";
 import { Alignment, CreatureTrait } from "./types.ts";
@@ -47,7 +47,7 @@ interface CreatureSystemSource extends ActorSystemSource {
     customModifiers?: Record<string, RawModifier[]>;
 
     /** Saving throw data */
-    saves?: Record<SaveType, { value?: number; mod?: number }>;
+    saves?: Record<SaveType, object | undefined>;
 
     resources?: CreatureResourcesSource;
 }
@@ -65,7 +65,7 @@ interface CreatureTraitsSource extends ActorTraitsSource<CreatureTrait> {
     /** Languages which this actor knows and can speak. */
     languages: ValuesList<Language>;
 
-    size?: { value: Size };
+    senses?: { value: string } | SenseData[];
 }
 
 interface CreatureResourcesSource {
@@ -150,7 +150,6 @@ interface CreatureAttributes extends ActorAttributes {
         manipulate: number;
     };
 
-    senses: { value: string } | CreatureSensePF2e[];
     shield?: HeldShieldData;
     speed: CreatureSpeeds;
 
@@ -177,7 +176,7 @@ interface CreatureSpeeds extends StatisticModifier {
 }
 
 interface LabeledSpeed extends Omit<LabeledNumber, "exceptions"> {
-    type: MovementType;
+    type: Exclude<MovementType, "land">;
     source?: string;
     total?: number;
     derivedFromLand?: boolean;

--- a/src/module/actor/data/base.ts
+++ b/src/module/actor/data/base.ts
@@ -141,7 +141,7 @@ interface ActorTraitsSource<TTrait extends string> {
     value: TTrait[];
     /** The rarity of the actor (common, uncommon, etc.) */
     rarity?: Rarity;
-    /** The character size (such as 'med'). */
+    /** The actor size (such as 'med'). */
     size?: { value: Size };
 }
 

--- a/src/module/actor/sheet/popups/manage-attack-proficiencies.ts
+++ b/src/module/actor/sheet/popups/manage-attack-proficiencies.ts
@@ -61,7 +61,7 @@ function remove(actor: CharacterPF2e, event: MouseEvent): void {
         content: `<p>${message}</p>`,
         defaultYes: false,
         yes: () => {
-            if (!(key in actor._source.system.martial)) return;
+            if (!(key in (actor._source.system.martial ?? {}))) return;
             actor.update({ [`system.martial.-=${key}`]: null });
         },
     });

--- a/src/module/migration/migrations/605-catch-up-to-template-json.ts
+++ b/src/module/migration/migrations/605-catch-up-to-template-json.ts
@@ -18,7 +18,7 @@ export class Migration605CatchUpToTemplateJSON extends MigrationBase {
 
         if (actorData.type === "character" || actorData.type === "npc") {
             // Numeric HP max
-            if (typeof actorData.system.attributes.hp.max === "string") {
+            if ("max" in actorData.system.attributes.hp && typeof actorData.system.attributes.hp.max === "string") {
                 const newMax = parseInt(actorData.system.attributes.hp.max as string, 10);
                 if (Number.isInteger(newMax)) {
                     actorData.system.attributes.hp.max = newMax;

--- a/src/module/migration/migrations/612-normalize-rarities.ts
+++ b/src/module/migration/migrations/612-normalize-rarities.ts
@@ -4,11 +4,11 @@ import { ActorSourcePF2e } from "@actor/data/index.ts";
 export class Migration612NormalizeRarities extends MigrationBase {
     static override version = 0.612;
 
-    override async updateActor(actorData: ActorSourcePF2e): Promise<void> {
-        const traitsRaw = actorData.system.traits;
-        if (actorData.type === "familiar" || !traitsRaw) return;
+    override async updateActor(source: ActorSourcePF2e): Promise<void> {
+        const traitsRaw = source.system.traits;
+        if (source.type === "familiar" || !traitsRaw) return;
 
-        const traitsAndOtherMiscellany: { rarity?: unknown; traits?: { value: string[] } } = traitsRaw;
+        const traitsAndOtherMiscellany: { rarity?: unknown; traits?: { value: string[] }; value?: unknown } = traitsRaw;
         if (!("rarity" in traitsAndOtherMiscellany)) {
             traitsAndOtherMiscellany.rarity = { value: "common" };
         }

--- a/src/module/migration/migrations/620-rename-to-webp.ts
+++ b/src/module/migration/migrations/620-rename-to-webp.ts
@@ -1,4 +1,4 @@
-import { CharacterDetails } from "@actor/character/data.ts";
+import { CharacterDetailsSource } from "@actor/character/data.ts";
 import { ActorSourcePF2e } from "@actor/data/index.ts";
 import { ABCFeatureEntryData } from "@item/abc/data.ts";
 import { AncestrySource, BackgroundSource, ClassSource, ItemSourcePF2e, KitSource } from "@item/data/index.ts";
@@ -23,20 +23,20 @@ export class Migration620RenameToWebp extends MigrationBase {
         return ITEMS_WITH_ITEMS.includes(itemData.type);
     }
 
-    override async updateActor(actorData: ActorSourcePF2e): Promise<void> {
-        actorData.img = this.#renameToWebP(actorData.img);
+    override async updateActor(source: ActorSourcePF2e): Promise<void> {
+        source.img = this.#renameToWebP(source.img);
 
-        if (typeof actorData.prototypeToken?.texture.src === "string") {
-            actorData.prototypeToken.texture.src = this.#renameToWebP(actorData.prototypeToken.texture.src);
+        if (typeof source.prototypeToken?.texture.src === "string") {
+            source.prototypeToken.texture.src = this.#renameToWebP(source.prototypeToken.texture.src);
         }
 
         // Icons for active effects
-        for (const effect of actorData.effects ?? []) {
+        for (const effect of source.effects ?? []) {
             effect.icon = this.#renameToWebP(effect.icon);
         }
 
-        if (actorData.type === "character") {
-            const details: CharacterDetails & { deity?: { image: string } } = actorData.system.details;
+        if (source.type === "character") {
+            const details: CharacterDetailsSource & { deity?: { image: string } } = source.system.details;
             if (details.deity) {
                 details.deity.image = this.#renameToWebP(details.deity.image);
             }

--- a/src/module/migration/migrations/651-ephemeral-focus-pool.ts
+++ b/src/module/migration/migrations/651-ephemeral-focus-pool.ts
@@ -108,7 +108,7 @@ export class Migration651EphemeralFocusPool extends MigrationBase {
 
     override async updateActor(source: ActorSourcePF2e): Promise<void> {
         if (source.type !== "character") return;
-        const systemData: { resources: { focus?: { max?: number; "-=max"?: null } } } = source.system;
+        const systemData: { resources: { focus?: { max?: unknown; "-=max"?: null } } } = source.system;
         systemData.resources ??= {};
 
         const resources = systemData.resources;

--- a/src/module/migration/migrations/653-aes-to-res.ts
+++ b/src/module/migration/migrations/653-aes-to-res.ts
@@ -1,4 +1,3 @@
-import { CharacterProficiency } from "@actor/character/data.ts";
 import { ActorSourcePF2e } from "@actor/data/index.ts";
 import { AbilityString } from "@actor/types.ts";
 import { ClassSource, ItemSourcePF2e } from "@item/data/index.ts";
@@ -38,7 +37,7 @@ export class Migration653AEstoREs extends MigrationBase {
 
     override async updateActor(actorSource: ActorSourcePF2e): Promise<void> {
         if (actorSource.type !== "character") return;
-        const systemData: { martial: Record<string, CharacterProficiency> } = actorSource.system;
+        const systemData = actorSource.system;
         systemData.martial = {}; // Only remove on compendium JSON
 
         // Remove transferred ActiveEffects, some of which will be converted to RuleElements

--- a/src/module/migration/migrations/682-biography-fields.ts
+++ b/src/module/migration/migrations/682-biography-fields.ts
@@ -1,8 +1,8 @@
-import { CharacterSystemData } from "@actor/character/data.ts";
+import { CharacterSystemData, CharacterSystemSource } from "@actor/character/data.ts";
 import { ActorSourcePF2e } from "@actor/data/index.ts";
 import { MigrationBase } from "../base.ts";
 
-interface CharacterSystemDataOld extends CharacterSystemData {
+interface CharacterSystemDataOld extends CharacterSystemSource {
     details: CharacterSystemData["details"] & {
         biography: CharacterSystemData["details"]["biography"] & {
             public?: string | null;
@@ -48,8 +48,8 @@ export class Migration682BiographyFields extends MigrationBase {
         old.details.biography.organaizations ??= "";
     }
 
-    override async updateActor(actorSource: ActorSourcePF2e): Promise<void> {
-        if (actorSource.type !== "character") return;
-        this.replaceBiographyData(actorSource.system as CharacterSystemDataOld);
+    override async updateActor(source: ActorSourcePF2e): Promise<void> {
+        if (source.type !== "character") return;
+        this.replaceBiographyData(source.system as CharacterSystemDataOld);
     }
 }

--- a/src/module/migration/migrations/686-hero-points-to-resources.ts
+++ b/src/module/migration/migrations/686-hero-points-to-resources.ts
@@ -1,4 +1,4 @@
-import { CharacterSystemData } from "@actor/character/data.ts";
+import { CharacterSystemSource } from "@actor/character/data.ts";
 import { ActorSourcePF2e } from "@actor/data/index.ts";
 import { MigrationBase } from "../base.ts";
 
@@ -19,7 +19,7 @@ export class Migration686HeroPointsToResources extends MigrationBase {
     }
 }
 
-type MaybeWithOldHeroPoints = CharacterSystemData & {
+type MaybeWithOldHeroPoints = CharacterSystemSource & {
     attributes: {
         heroPoints?: { rank: number; max: number };
         "-=heroPoints"?: null;

--- a/src/module/migration/migrations/710-rarity-to-string.ts
+++ b/src/module/migration/migrations/710-rarity-to-string.ts
@@ -5,7 +5,7 @@ import { MigrationBase } from "../base.ts";
 export class Migration710RarityToString extends MigrationBase {
     static override version = 0.71;
 
-    private updateTraits(traits: { rarity?: string | { value: string } } | null): void {
+    private updateTraits(traits: { rarity?: string | { value: string }; value?: unknown } | null): void {
         if (typeof traits?.rarity === "object" && traits.rarity !== null) {
             traits.rarity = traits.rarity.value;
         }

--- a/src/module/migration/migrations/711-heritage-items.ts
+++ b/src/module/migration/migrations/711-heritage-items.ts
@@ -1,4 +1,4 @@
-import { CharacterDetails } from "@actor/character/data.ts";
+import { CharacterDetailsSource } from "@actor/character/data.ts";
 import { CreatureTrait } from "@actor/creature/types.ts";
 import { ActorSourcePF2e } from "@actor/data/index.ts";
 import { FeatSource, ItemSourcePF2e } from "@item/data/index.ts";
@@ -273,4 +273,4 @@ interface HeritageSystemSourceWithNoAncestrySlug extends Omit<HeritageSystemSour
     ancestry: { uuid: ItemUUID; name: string } | null;
 }
 
-type MaybeWithStoredHeritage = Omit<CharacterDetails, "heritage"> & { heritage?: unknown; "-=heritage"?: null };
+type MaybeWithStoredHeritage = CharacterDetailsSource & { heritage?: unknown; "-=heritage"?: null };

--- a/src/module/migration/migrations/712-actor-shield-structure.ts
+++ b/src/module/migration/migrations/712-actor-shield-structure.ts
@@ -1,4 +1,4 @@
-import { CharacterAttributes } from "@actor/character/data.ts";
+import { CharacterAttributesSource } from "@actor/character/data.ts";
 import { ActorSourcePF2e } from "@actor/data/index.ts";
 import { NPCAttributesSource } from "@actor/npc/data.ts";
 import { MigrationBase } from "../base.ts";
@@ -22,4 +22,4 @@ export class Migration712ActorShieldStructure extends MigrationBase {
     }
 }
 
-type WithDeletableShield = (NPCAttributesSource | CharacterAttributes) & { shield?: unknown; "-=shield"?: null };
+type WithDeletableShield = (NPCAttributesSource | CharacterAttributesSource) & { shield?: unknown; "-=shield"?: null };

--- a/src/module/migration/migrations/722-crafting-system-data.ts
+++ b/src/module/migration/migrations/722-crafting-system-data.ts
@@ -10,10 +10,11 @@ export class Migration722CraftingSystemData extends MigrationBase {
         if (source.type !== "character") return;
 
         if (!isObject(source.system.crafting)) {
-            source.system.crafting = { entries: {}, formulas: [] };
+            const filledCrafting = { entries: {}, formulas: [] };
+            source.system.crafting = filledCrafting;
         }
 
-        const { crafting } = source.system;
+        const crafting: Record<string, unknown> = source.system.crafting ?? {};
         if (!isObject(crafting.entries) || Array.isArray(crafting.entries)) {
             crafting.entries = {};
         }

--- a/src/module/migration/migrations/743-fix-weakness-structure.ts
+++ b/src/module/migration/migrations/743-fix-weakness-structure.ts
@@ -1,4 +1,4 @@
-import { CharacterTraitsData } from "@actor/character/data.ts";
+import { CharacterTraitsSource } from "@actor/character/data.ts";
 import { ActorSourcePF2e } from "@actor/data/index.ts";
 import { NPCTraitsSource } from "@actor/npc/data.ts";
 import { MigrationBase } from "../base.ts";
@@ -23,7 +23,7 @@ export class Migration743FixWeaknessStructure extends MigrationBase {
     }
 }
 
-type WithWRTraits = (CharacterTraitsData | NPCTraitsSource) & {
+type WithWRTraits = (CharacterTraitsSource | NPCTraitsSource) & {
     dv?: never[];
     dr?: never[];
 };

--- a/src/module/migration/migrations/774-unpersist-crafting-entries.ts
+++ b/src/module/migration/migrations/774-unpersist-crafting-entries.ts
@@ -17,7 +17,7 @@ export class Migration774UnpersistCraftingEntries extends MigrationBase {
 
     override async updateActor(source: ActorSourcePF2e): Promise<void> {
         if (source.type === "character") {
-            const craftingData: MaybeWithOldEntries = source.system.crafting;
+            const craftingData: MaybeWithOldEntries = source.system.crafting ?? {};
             const craftingEntries = craftingData.entries ?? {};
             const rules: MaybeWithRequiredTraits[] = source.items.flatMap((i) => i.system.rules);
             for (const rule of rules) {
@@ -36,8 +36,8 @@ export class Migration774UnpersistCraftingEntries extends MigrationBase {
         }
     }
 
-    override async updateItem(itemSource: ItemSourcePF2e): Promise<void> {
-        const rules = itemSource.system.rules;
+    override async updateItem(source: ItemSourcePF2e): Promise<void> {
+        const rules = source.system.rules;
         // Change requiredTraits property to craftableItems predicate
         const craftingEntryRules = rules.filter(
             (r: RuleElementSource & { requiredTraits?: unknown }): r is MaybeWithRequiredTraits =>

--- a/src/module/rules/synthetics.ts
+++ b/src/module/rules/synthetics.ts
@@ -70,7 +70,7 @@ type DeferredDamageDice = DeferredValue<DamageDicePF2e>;
 type DeferredMovementType = DeferredValue<BaseSpeedSynthetic | null>;
 type DeferredEphemeralEffect = DeferredPromise<EffectSource | ConditionSource | null>;
 
-interface BaseSpeedSynthetic extends Omit<LabeledSpeed, "label"> {
+interface BaseSpeedSynthetic extends Omit<LabeledSpeed, "label" | "type"> {
     type: MovementType;
     /**
      * Whether this speed is derived from a creature's land speed:

--- a/src/module/system/settings/homebrew/helpers.ts
+++ b/src/module/system/settings/homebrew/helpers.ts
@@ -3,7 +3,7 @@ import { ActorSourcePF2e } from "@actor/data/index.ts";
 import { ItemSourcePF2e, MeleeSource, WeaponSource } from "@item/data/index.ts";
 import { MigrationBase } from "@module/migration/base.ts";
 import { MigrationRunnerBase } from "@module/migration/runner/base.ts";
-import { isObject, objectHasKey } from "@util";
+import { isObject } from "@util";
 import { CustomDamageData, HomebrewTraitKey } from "./data.ts";
 
 /** User-defined type guard for checking that an object is a well-formed flag category of module-provided homebrew elements */
@@ -55,10 +55,11 @@ export function prepareCleanup(listKey: HomebrewTraitKey, deletions: string[]): 
                 }
                 case "weaponCategories": {
                     if (source.type === "character") {
+                        const martial = source.system.martial ?? {};
                         for (const key of deletions) {
-                            if (objectHasKey(source.system.martial, key)) {
-                                delete source.system.martial[key];
-                                (source.system.martial as unknown as Record<string, unknown>)[`-=${key}`] = null;
+                            if (martial[key]) {
+                                delete martial[key];
+                                (martial as unknown as Record<string, unknown>)[`-=${key}`] = null;
                             }
                         }
                     }
@@ -69,9 +70,10 @@ export function prepareCleanup(listKey: HomebrewTraitKey, deletions: string[]): 
                         const proficiencyKeys = deletions.map(
                             (deletion) => `weapon-group-${deletion}`
                         ) as WeaponGroupProficiencyKey[];
+                        const martial = source.system.martial ?? {};
                         for (const key of proficiencyKeys) {
-                            delete source.system.martial[key];
-                            (source.system.martial as unknown as Record<string, unknown>)[`-=${key}`] = null;
+                            delete martial[key];
+                            (martial as unknown as Record<string, unknown>)[`-=${key}`] = null;
                         }
                     }
                     break;
@@ -81,9 +83,10 @@ export function prepareCleanup(listKey: HomebrewTraitKey, deletions: string[]): 
                         const proficiencyKeys = deletions.map(
                             (deletion) => `weapon-base-${deletion}`
                         ) as BaseWeaponProficiencyKey[];
+                        const martial = source.system.martial ?? {};
                         for (const key of proficiencyKeys) {
-                            delete source.system.martial[key];
-                            (source.system.martial as unknown as Record<string, unknown>)[`-=${key}`] = null;
+                            delete martial[key];
+                            (martial as unknown as Record<string, unknown>)[`-=${key}`] = null;
                         }
                     }
                     break;

--- a/static/template.json
+++ b/static/template.json
@@ -37,7 +37,6 @@
                     "senses": [],
                     "languages": {
                         "value": [],
-                        "selected": [],
                         "custom": ""
                     }
                 },
@@ -69,8 +68,6 @@
             "templates": [
                 "common"
             ],
-            "abilities": {},
-            "saves": {},
             "exploration": [],
             "attributes": {
                 "bonusLimitBulk": 0,
@@ -177,10 +174,6 @@
                 "thi": {
                     "rank": 0
                 }
-            },
-            "martial": {},
-            "crafting": {
-                "formulas": []
             },
             "resources": {
                 "heroPoints": {


### PR DESCRIPTION
As part of the split from `CharacterSystemData`, refactor some runtime code (mostly old migrations) and prune some unneeded properties from template.json.