### PR TITLE
Automate advanced multiclass feats

### DIFF
--- a/packs/feats/advanced-arcana.json
+++ b/packs/feats/advanced-arcana.json
@@ -24,7 +24,35 @@
                 }
             ]
         },
-        "rules": [],
+        "rules": [
+            {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "parent:location:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
+                        "item:category:class",
+                        "item:trait:wizard"
+                    ],
+                    "itemType": "feat"
+                },
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.AdvancedMulticlassFeat"
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "{item|flags.pf2e.rulesSelections.advancedArcana}"
+            }
+        ],
         "source": {
             "value": "Pathfinder Core Rulebook"
         },

--- a/packs/feats/advanced-arcana.json
+++ b/packs/feats/advanced-arcana.json
@@ -40,6 +40,17 @@
                                 }
                             ]
                         },
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "self:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
                         "item:category:class",
                         "item:trait:wizard"
                     ],

--- a/packs/feats/advanced-blood-potency.json
+++ b/packs/feats/advanced-blood-potency.json
@@ -24,7 +24,35 @@
                 }
             ]
         },
-        "rules": [],
+        "rules": [
+            {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "parent:location:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
+                        "item:category:class",
+                        "item:trait:sorcerer"
+                    ],
+                    "itemType": "feat"
+                },
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.AdvancedMulticlassFeat"
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "{item|flags.pf2e.rulesSelections.advancedBloodPotency}"
+            }
+        ],
         "source": {
             "value": "Pathfinder Core Rulebook"
         },

--- a/packs/feats/advanced-blood-potency.json
+++ b/packs/feats/advanced-blood-potency.json
@@ -40,6 +40,17 @@
                                 }
                             ]
                         },
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "self:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
                         "item:category:class",
                         "item:trait:sorcerer"
                     ],

--- a/packs/feats/advanced-breakthrough.json
+++ b/packs/feats/advanced-breakthrough.json
@@ -24,7 +24,35 @@
                 }
             ]
         },
-        "rules": [],
+        "rules": [
+            {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "parent:location:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
+                        "item:category:class",
+                        "item:trait:inventor"
+                    ],
+                    "itemType": "feat"
+                },
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.AdvancedMulticlassFeat"
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "{item|flags.pf2e.rulesSelections.advancedBreakthrough}"
+            }
+        ],
         "source": {
             "value": "Pathfinder Guns & Gears"
         },

--- a/packs/feats/advanced-breakthrough.json
+++ b/packs/feats/advanced-breakthrough.json
@@ -40,6 +40,17 @@
                                 }
                             ]
                         },
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "self:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
                         "item:category:class",
                         "item:trait:inventor"
                     ],

--- a/packs/feats/advanced-concoction.json
+++ b/packs/feats/advanced-concoction.json
@@ -40,6 +40,17 @@
                                 }
                             ]
                         },
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "self:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
                         "item:category:class",
                         "item:trait:alchemist"
                     ],

--- a/packs/feats/advanced-concoction.json
+++ b/packs/feats/advanced-concoction.json
@@ -24,7 +24,35 @@
                 }
             ]
         },
-        "rules": [],
+        "rules": [
+            {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "parent:location:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
+                        "item:category:class",
+                        "item:trait:alchemist"
+                    ],
+                    "itemType": "feat"
+                },
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.AdvancedMulticlassFeat"
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "{item|flags.pf2e.rulesSelections.advancedConcoction}"
+            }
+        ],
         "source": {
             "value": "Pathfinder Core Rulebook"
         },

--- a/packs/feats/advanced-deduction.json
+++ b/packs/feats/advanced-deduction.json
@@ -40,6 +40,17 @@
                                 }
                             ]
                         },
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "self:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
                         "item:category:class",
                         "item:trait:investigator"
                     ],

--- a/packs/feats/advanced-deduction.json
+++ b/packs/feats/advanced-deduction.json
@@ -24,7 +24,35 @@
                 }
             ]
         },
-        "rules": [],
+        "rules": [
+            {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "parent:location:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
+                        "item:category:class",
+                        "item:trait:investigator"
+                    ],
+                    "itemType": "feat"
+                },
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.AdvancedMulticlassFeat"
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "{item|flags.pf2e.rulesSelections.advancedDeduction}"
+            }
+        ],
         "source": {
             "value": "Pathfinder Advanced Player's Guide"
         },

--- a/packs/feats/advanced-devotion.json
+++ b/packs/feats/advanced-devotion.json
@@ -30,6 +30,33 @@
                 "mode": "add",
                 "path": "system.custom.modifiers.champion-dedication-count",
                 "value": 1
+            },
+            {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "parent:location:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
+                        "item:category:class",
+                        "item:trait:champion"
+                    ],
+                    "itemType": "feat"
+                },
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.AdvancedMulticlassFeat"
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "{item|flags.pf2e.rulesSelections.advancedDevotion}"
             }
         ],
         "source": {

--- a/packs/feats/advanced-devotion.json
+++ b/packs/feats/advanced-devotion.json
@@ -46,6 +46,17 @@
                                 }
                             ]
                         },
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "self:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
                         "item:category:class",
                         "item:trait:champion"
                     ],

--- a/packs/feats/advanced-dogma.json
+++ b/packs/feats/advanced-dogma.json
@@ -24,7 +24,35 @@
                 }
             ]
         },
-        "rules": [],
+        "rules": [
+            {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "parent:location:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
+                        "item:category:class",
+                        "item:trait:cleric"
+                    ],
+                    "itemType": "feat"
+                },
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.AdvancedMulticlassFeat"
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "{item|flags.pf2e.rulesSelections.advancedDogma}"
+            }
+        ],
         "source": {
             "value": "Pathfinder Core Rulebook"
         },

--- a/packs/feats/advanced-dogma.json
+++ b/packs/feats/advanced-dogma.json
@@ -40,6 +40,17 @@
                                 }
                             ]
                         },
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "self:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
                         "item:category:class",
                         "item:trait:cleric"
                     ],

--- a/packs/feats/advanced-flair.json
+++ b/packs/feats/advanced-flair.json
@@ -40,6 +40,17 @@
                                 }
                             ]
                         },
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "self:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
                         "item:category:class",
                         "item:trait:swashbuckler"
                     ],

--- a/packs/feats/advanced-flair.json
+++ b/packs/feats/advanced-flair.json
@@ -24,7 +24,35 @@
                 }
             ]
         },
-        "rules": [],
+        "rules": [
+            {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "parent:location:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
+                        "item:category:class",
+                        "item:trait:swashbuckler"
+                    ],
+                    "itemType": "feat"
+                },
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.AdvancedMulticlassFeat"
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "{item|flags.pf2e.rulesSelections.advancedFlair}"
+            }
+        ],
         "source": {
             "value": "Pathfinder Advanced Player's Guide"
         },

--- a/packs/feats/advanced-fury.json
+++ b/packs/feats/advanced-fury.json
@@ -46,6 +46,17 @@
                                 }
                             ]
                         },
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "self:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
                         "item:category:class",
                         "item:trait:barbarian"
                     ],

--- a/packs/feats/advanced-fury.json
+++ b/packs/feats/advanced-fury.json
@@ -30,6 +30,33 @@
                 "mode": "add",
                 "path": "flags.pf2e.barbarian.archetypeFeatCount",
                 "value": 1
+            },
+            {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "parent:location:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
+                        "item:category:class",
+                        "item:trait:barbarian"
+                    ],
+                    "itemType": "feat"
+                },
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.AdvancedMulticlassFeat"
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "{item|flags.pf2e.rulesSelections.advancedFury}"
             }
         ],
         "source": {

--- a/packs/feats/advanced-hunters-trick.json
+++ b/packs/feats/advanced-hunters-trick.json
@@ -46,6 +46,17 @@
                                 }
                             ]
                         },
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "self:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
                         "item:category:class",
                         "item:trait:ranger"
                     ],

--- a/packs/feats/advanced-hunters-trick.json
+++ b/packs/feats/advanced-hunters-trick.json
@@ -30,6 +30,33 @@
                 "mode": "add",
                 "path": "system.custom.modifiers.ranger-dedication-count",
                 "value": 1
+            },
+            {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "parent:location:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
+                        "item:category:class",
+                        "item:trait:ranger"
+                    ],
+                    "itemType": "feat"
+                },
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.AdvancedMulticlassFeat"
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "{item|flags.pf2e.rulesSelections.advancedHuntersTrick}"
             }
         ],
         "source": {

--- a/packs/feats/advanced-kata.json
+++ b/packs/feats/advanced-kata.json
@@ -30,6 +30,33 @@
                 "mode": "add",
                 "path": "system.custom.modifiers.monk-dedication-count",
                 "value": 1
+            },
+            {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "parent:location:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
+                        "item:category:class",
+                        "item:trait:monk"
+                    ],
+                    "itemType": "feat"
+                },
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.AdvancedMulticlassFeat"
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "{item|flags.pf2e.rulesSelections.advancedKata}"
             }
         ],
         "source": {

--- a/packs/feats/advanced-kata.json
+++ b/packs/feats/advanced-kata.json
@@ -46,6 +46,17 @@
                                 }
                             ]
                         },
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "self:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
                         "item:category:class",
                         "item:trait:monk"
                     ],

--- a/packs/feats/advanced-maneuver.json
+++ b/packs/feats/advanced-maneuver.json
@@ -46,6 +46,17 @@
                                 }
                             ]
                         },
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "self:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
                         "item:category:class",
                         "item:trait:fighter"
                     ],

--- a/packs/feats/advanced-maneuver.json
+++ b/packs/feats/advanced-maneuver.json
@@ -30,6 +30,33 @@
                 "mode": "add",
                 "path": "system.custom.modifiers.fighter-dedication-count",
                 "value": 1
+            },
+            {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "parent:location:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
+                        "item:category:class",
+                        "item:trait:fighter"
+                    ],
+                    "itemType": "feat"
+                },
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.AdvancedMulticlassFeat"
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "{item|flags.pf2e.rulesSelections.advancedManeuver}"
             }
         ],
         "source": {

--- a/packs/feats/advanced-martial-magic.json
+++ b/packs/feats/advanced-martial-magic.json
@@ -24,7 +24,35 @@
                 }
             ]
         },
-        "rules": [],
+        "rules": [
+            {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "parent:location:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
+                        "item:category:class",
+                        "item:trait:magus"
+                    ],
+                    "itemType": "feat"
+                },
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.AdvancedMulticlassFeat"
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "{item|flags.pf2e.rulesSelections.advancedMartialMagic}"
+            }
+        ],
         "source": {
             "value": "Pathfinder Secrets of Magic"
         },

--- a/packs/feats/advanced-martial-magic.json
+++ b/packs/feats/advanced-martial-magic.json
@@ -40,6 +40,17 @@
                                 }
                             ]
                         },
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "self:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
                         "item:category:class",
                         "item:trait:magus"
                     ],

--- a/packs/feats/advanced-muses-whispers.json
+++ b/packs/feats/advanced-muses-whispers.json
@@ -24,7 +24,35 @@
                 }
             ]
         },
-        "rules": [],
+        "rules": [
+            {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "parent:location:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
+                        "item:category:class",
+                        "item:trait:bard"
+                    ],
+                    "itemType": "feat"
+                },
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.AdvancedMulticlassFeat"
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "{item|flags.pf2e.rulesSelections.advancedMusesWhispers}"
+            }
+        ],
         "source": {
             "value": "Pathfinder Core Rulebook"
         },

--- a/packs/feats/advanced-muses-whispers.json
+++ b/packs/feats/advanced-muses-whispers.json
@@ -40,6 +40,17 @@
                                 }
                             ]
                         },
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "self:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
                         "item:category:class",
                         "item:trait:bard"
                     ],

--- a/packs/feats/advanced-mysteries.json
+++ b/packs/feats/advanced-mysteries.json
@@ -40,6 +40,17 @@
                                 }
                             ]
                         },
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "self:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
                         "item:category:class",
                         "item:trait:oracle"
                     ],

--- a/packs/feats/advanced-mysteries.json
+++ b/packs/feats/advanced-mysteries.json
@@ -24,7 +24,35 @@
                 }
             ]
         },
-        "rules": [],
+        "rules": [
+            {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "parent:location:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
+                        "item:category:class",
+                        "item:trait:oracle"
+                    ],
+                    "itemType": "feat"
+                },
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.AdvancedMulticlassFeat"
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "{item|flags.pf2e.rulesSelections.advancedMysteries}"
+            }
+        ],
         "source": {
             "value": "Pathfinder Advanced Player's Guide"
         },

--- a/packs/feats/advanced-shooting.json
+++ b/packs/feats/advanced-shooting.json
@@ -40,6 +40,17 @@
                                 }
                             ]
                         },
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "self:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
                         "item:category:class",
                         "item:trait:gunslinger"
                     ],

--- a/packs/feats/advanced-shooting.json
+++ b/packs/feats/advanced-shooting.json
@@ -24,7 +24,35 @@
                 }
             ]
         },
-        "rules": [],
+        "rules": [
+            {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "parent:location:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
+                        "item:category:class",
+                        "item:trait:gunslinger"
+                    ],
+                    "itemType": "feat"
+                },
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.AdvancedMulticlassFeat"
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "{item|flags.pf2e.rulesSelections.advancedShooting}"
+            }
+        ],
         "source": {
             "value": "Pathfinder Guns & Gears"
         },

--- a/packs/feats/advanced-synergy.json
+++ b/packs/feats/advanced-synergy.json
@@ -40,6 +40,17 @@
                                 }
                             ]
                         },
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "self:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
                         "item:category:class",
                         "item:trait:summoner"
                     ],

--- a/packs/feats/advanced-synergy.json
+++ b/packs/feats/advanced-synergy.json
@@ -24,7 +24,35 @@
                 }
             ]
         },
-        "rules": [],
+        "rules": [
+            {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "parent:location:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
+                        "item:category:class",
+                        "item:trait:summoner"
+                    ],
+                    "itemType": "feat"
+                },
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.AdvancedMulticlassFeat"
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "{item|flags.pf2e.rulesSelections.advancedSynergy}"
+            }
+        ],
         "source": {
             "value": "Pathfinder Secrets of Magic"
         },

--- a/packs/feats/advanced-thaumaturgy.json
+++ b/packs/feats/advanced-thaumaturgy.json
@@ -24,7 +24,35 @@
                 }
             ]
         },
-        "rules": [],
+        "rules": [
+            {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "parent:location:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
+                        "item:category:class",
+                        "item:trait:thaumaturge"
+                    ],
+                    "itemType": "feat"
+                },
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.AdvancedMulticlassFeat"
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "{item|flags.pf2e.rulesSelections.advancedThaumaturgy}"
+            }
+        ],
         "source": {
             "value": "Pathfinder Dark Archive"
         },

--- a/packs/feats/advanced-thaumaturgy.json
+++ b/packs/feats/advanced-thaumaturgy.json
@@ -40,6 +40,17 @@
                                 }
                             ]
                         },
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "self:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
                         "item:category:class",
                         "item:trait:thaumaturge"
                     ],

--- a/packs/feats/advanced-thoughtform.json
+++ b/packs/feats/advanced-thoughtform.json
@@ -24,7 +24,35 @@
                 }
             ]
         },
-        "rules": [],
+        "rules": [
+            {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "parent:location:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
+                        "item:category:class",
+                        "item:trait:psychic"
+                    ],
+                    "itemType": "feat"
+                },
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.AdvancedMulticlassFeat"
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "{item|flags.pf2e.rulesSelections.advancedThoughtform}"
+            }
+        ],
         "source": {
             "value": "Pathfinder Dark Archive"
         },

--- a/packs/feats/advanced-thoughtform.json
+++ b/packs/feats/advanced-thoughtform.json
@@ -40,6 +40,17 @@
                                 }
                             ]
                         },
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "self:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
                         "item:category:class",
                         "item:trait:psychic"
                     ],

--- a/packs/feats/advanced-trickery.json
+++ b/packs/feats/advanced-trickery.json
@@ -40,6 +40,17 @@
                                 }
                             ]
                         },
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "self:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
                         "item:category:class",
                         "item:trait:rogue"
                     ],

--- a/packs/feats/advanced-trickery.json
+++ b/packs/feats/advanced-trickery.json
@@ -24,7 +24,35 @@
                 }
             ]
         },
-        "rules": [],
+        "rules": [
+            {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "parent:location:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
+                        "item:category:class",
+                        "item:trait:rogue"
+                    ],
+                    "itemType": "feat"
+                },
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.AdvancedMulticlassFeat"
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "{item|flags.pf2e.rulesSelections.advancedTrickery}"
+            }
+        ],
         "source": {
             "value": "Pathfinder Core Rulebook"
         },

--- a/packs/feats/advanced-wilding.json
+++ b/packs/feats/advanced-wilding.json
@@ -24,7 +24,35 @@
                 }
             ]
         },
-        "rules": [],
+        "rules": [
+            {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "parent:location:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
+                        "item:category:class",
+                        "item:trait:druid"
+                    ],
+                    "itemType": "feat"
+                },
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.AdvancedMulticlassFeat"
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "{item|flags.pf2e.rulesSelections.advancedWilding}"
+            }
+        ],
         "source": {
             "value": "Pathfinder Core Rulebook"
         },

--- a/packs/feats/advanced-wilding.json
+++ b/packs/feats/advanced-wilding.json
@@ -40,6 +40,17 @@
                                 }
                             ]
                         },
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "self:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
                         "item:category:class",
                         "item:trait:druid"
                     ],

--- a/packs/feats/advanced-witchcraft.json
+++ b/packs/feats/advanced-witchcraft.json
@@ -40,6 +40,17 @@
                                 }
                             ]
                         },
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "self:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
                         "item:category:class",
                         "item:trait:witch"
                     ],

--- a/packs/feats/advanced-witchcraft.json
+++ b/packs/feats/advanced-witchcraft.json
@@ -24,7 +24,35 @@
                 }
             ]
         },
-        "rules": [],
+        "rules": [
+            {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        {
+                            "lte": [
+                                "item:level",
+                                {
+                                    "div": [
+                                        "parent:location:level",
+                                        2
+                                    ]
+                                }
+                            ]
+                        },
+                        "item:category:class",
+                        "item:trait:witch"
+                    ],
+                    "itemType": "feat"
+                },
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.AdvancedMulticlassFeat"
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "{item|flags.pf2e.rulesSelections.advancedWitchcraft}"
+            }
+        ],
         "source": {
             "value": "Pathfinder Advanced Player's Guide"
         },

--- a/src/module/item/feat/document.ts
+++ b/src/module/item/feat/document.ts
@@ -153,10 +153,18 @@ class FeatPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
     /** Generate a list of strings for use in predication */
     override getRollOptions(prefix = "feat"): string[] {
         prefix = prefix === "feat" && this.isFeature ? "feature" : prefix;
-        return [
+        const rollOptions = [
             ...super.getRollOptions(prefix).filter((o) => !o.endsWith("level:0")),
             `${prefix}:category:${this.category}`,
         ];
+
+        const locationMatch = this.system.location?.match(/^([a-z-]*)-([0-9]*)$/);
+        if (locationMatch) {
+            rollOptions.push(`${prefix}:location:category:${locationMatch[1]}`);
+            rollOptions.push(`${prefix}:location:level:${locationMatch[2]}`);
+        }
+
+        return rollOptions;
     }
 
     /* -------------------------------------------- */

--- a/src/module/system/predication.ts
+++ b/src/module/system/predication.ts
@@ -63,37 +63,63 @@ class PredicatePF2e extends Array<PredicateStatement> {
     }
 
     #testBinaryOp(statement: BinaryOperation, domain: Set<string>): boolean {
-        if ("eq" in statement) {
-            return domain.has(`${statement.eq[0]}:${statement.eq[1]}`);
-        } else {
-            const operator = Object.keys(statement)[0];
+        const operator = Object.keys(statement)[0];
 
-            // Allow for tests of partial statements against numeric values
-            // E.g., `{ "gt": ["actor:level", 5] }` would match against "actor:level:6" and "actor:level:7"
-            const [left, right] = Object.values(statement)[0];
-            const domainArray = Array.from(domain);
-            const getValues = (operand: string | number): number[] => {
-                const maybeNumber = Number(operand);
-                if (!Number.isNaN(maybeNumber)) return [maybeNumber];
-                const pattern = new RegExp(String.raw`^${operand}:([^:]+)$`);
-                return domainArray.map((s) => Number(pattern.exec(s)?.[1] || NaN)).filter((v) => !Number.isNaN(v));
-            };
-            const leftValues = getValues(left);
-            const rightValues = getValues(right);
+        // Allow for tests of partial statements against numeric values
+        // E.g., `{ "gt": ["actor:level", 5] }` would match against "actor:level:6" and "actor:level:7"
+        const [left, right] = Object.values(statement)[0];
+        const domainArray = Array.from(domain);
+        const leftValues = StatementValidator.isMathOperation(left)
+            ? this.#resolveMathOperation(left, domain)
+            : typeof left === "number" || !Number.isNaN(Number(left))
+            ? [Number(left)]
+            : domainArray.flatMap((d) => (d.startsWith(left) ? Number(/:(-?\d+)$/.exec(d)?.[1]) : []));
+        const rightValues = StatementValidator.isMathOperation(right)
+            ? this.#resolveMathOperation(right, domain)
+            : typeof right === "number" || !Number.isNaN(Number(right))
+            ? [Number(right)]
+            : domainArray.flatMap((d) => (d.startsWith(right) ? Number(/:(-?\d+)$/.exec(d)?.[1]) : []));
 
-            switch (operator) {
-                case "gt":
-                    return leftValues.some((l) => rightValues.every((r) => l > r));
-                case "gte":
-                    return leftValues.some((l) => rightValues.every((r) => l >= r));
-                case "lt":
-                    return leftValues.some((l) => rightValues.every((r) => l < r));
-                case "lte":
-                    return leftValues.some((l) => rightValues.every((r) => l <= r));
-                default:
-                    console.warn("PF2e System | Malformed binary operation encountered");
-                    return false;
-            }
+        switch (operator) {
+            case "eq":
+                return leftValues.some((l) => rightValues.every((r) => l === r));
+            case "gt":
+                return leftValues.some((l) => rightValues.every((r) => l > r));
+            case "gte":
+                return leftValues.some((l) => rightValues.every((r) => l >= r));
+            case "lt":
+                return leftValues.some((l) => rightValues.every((r) => l < r));
+            case "lte":
+                return leftValues.some((l) => rightValues.every((r) => l <= r));
+            default:
+                console.warn("PF2e System | Malformed binary operation encountered");
+                return false;
+        }
+    }
+
+    #resolveMathOperation(statement: MathOperation, domain: Set<string>): number[] {
+        const operator = Object.keys(statement)[0];
+
+        const [left, right] = Object.values(statement)[0];
+        const domainArray = Array.from(domain);
+        const leftValues = domainArray.flatMap((d) => (d.startsWith(left) ? Number(/:(-?\d+)$/.exec(d)?.[1]) : []));
+        const rightValues =
+            typeof right === "number"
+                ? [right]
+                : domainArray.flatMap((d) => (d.startsWith(right) ? Number(/:(-?\d+)$/.exec(d)?.[1]) : []));
+
+        switch (operator) {
+            case "add":
+                return leftValues.flatMap((l) => rightValues.flatMap((r) => l + r));
+            case "sub":
+                return leftValues.flatMap((l) => rightValues.flatMap((r) => l - r));
+            case "mult":
+                return leftValues.flatMap((l) => rightValues.flatMap((r) => l * r));
+            case "div":
+                return leftValues.flatMap((l) => rightValues.flatMap((r) => l / r));
+            default:
+                console.warn("PF2e System | Malformed math operation encountered");
+                return [];
         }
     }
 
@@ -133,6 +159,22 @@ class StatementValidator {
         const [operator, operands]: [string, unknown] = entries[0];
         return (
             this.#binaryOperators.has(operator) &&
+            Array.isArray(operands) &&
+            operands.length === 2 &&
+            typeof operands[0] === "string" &&
+            (["string", "number"].includes(typeof operands[1]) || this.isMathOperation(operands[1]))
+        );
+    }
+
+    private static mathOperators = new Set(["add", "sub", "mult", "div"]);
+
+    static isMathOperation(statement: unknown): statement is MathOperation {
+        if (!isObject(statement)) return false;
+        const entries = Object.entries(statement);
+        if (entries.length > 1) return false;
+        const [operator, operands]: [string, unknown] = entries[0];
+        return (
+            this.mathOperators.has(operator) &&
             Array.isArray(operands) &&
             operands.length === 2 &&
             typeof operands[0] === "string" &&
@@ -204,11 +246,17 @@ class StatementValidator {
     }
 }
 
-type EqualTo = { eq: [string, string | number] };
-type GreaterThan = { gt: [string, string | number] };
-type GreaterThanEqualTo = { gte: [string, string | number] };
-type LessThan = { lt: [string, string | number] };
-type LessThanEqualTo = { lte: [string, string | number] };
+type Add = { add: [string, string | number] };
+type Subtract = { sub: [string, string | number] };
+type Multiply = { mult: [string, string | number] };
+type Divide = { div: [string, string | number] };
+type MathOperation = Add | Subtract | Multiply | Divide;
+
+type EqualTo = { eq: [string, string | number | MathOperation] };
+type GreaterThan = { gt: [string, string | number | MathOperation] };
+type GreaterThanEqualTo = { gte: [string, string | number | MathOperation] };
+type LessThan = { lt: [string, string | number | MathOperation] };
+type LessThanEqualTo = { lte: [string, string | number | MathOperation] };
 type BinaryOperation = EqualTo | GreaterThan | GreaterThanEqualTo | LessThan | LessThanEqualTo;
 type Atom = string | BinaryOperation;
 

--- a/tests/module/system/predication.test.ts
+++ b/tests/module/system/predication.test.ts
@@ -59,6 +59,36 @@ describe("Predication with numeric-comparison atomics returns correct results", 
     });
 });
 
+describe("Predication with numeric-comparison with mathematic operations returns correct results", () => {
+    test("add", () => {
+        const predicate = new PredicatePF2e({ eq: ["foo", { add: ["bar", 2] }] });
+        expect(predicate.test(["foo:1", "bar:1"])).toEqual(false);
+        expect(predicate.test(["foo:2", "bar:1"])).toEqual(false);
+        expect(predicate.test(["foo:3", "bar:1"])).toEqual(true);
+    });
+
+    test("subtract", () => {
+        const predicate = new PredicatePF2e({ eq: ["foo", { sub: ["bar", 2] }] });
+        expect(predicate.test(["foo:0", "bar:3"])).toEqual(false);
+        expect(predicate.test(["foo:1", "bar:3"])).toEqual(true);
+        expect(predicate.test(["foo:2", "bar:3"])).toEqual(false);
+    });
+
+    test("multiply", () => {
+        const predicate = new PredicatePF2e({ eq: ["foo", { mult: ["bar", 2] }] });
+        expect(predicate.test(["foo:1", "bar:1"])).toEqual(false);
+        expect(predicate.test(["foo:2", "bar:1"])).toEqual(true);
+        expect(predicate.test(["foo:3", "bar:1"])).toEqual(false);
+    });
+
+    test("divide", () => {
+        const predicate = new PredicatePF2e({ eq: ["foo", { div: ["bar", 2] }] });
+        expect(predicate.test(["foo:1", "bar:2"])).toEqual(true);
+        expect(predicate.test(["foo:2", "bar:2"])).toEqual(false);
+        expect(predicate.test(["foo:3", "bar:2"])).toEqual(false);
+    });
+});
+
 describe("Predication with conjunction and negation returns correct results", () => {
     test("conjunction operator", () => {
         const predicate = new PredicatePF2e({ and: ["foo", "bar", "baz"] });


### PR DESCRIPTION
(Resubmitted because of significant changes)

Contributes to completing #1956.

Automate advanced multiclass feats (e.g. Advanced Arcana, Advanced Maneuver etc) to allow a choice of feats from that class up to half your level (or rather, half the level of the feat slot being used).

## Supporting Changes

### New Feat Roll Options
I've introduced two new roll option for feats: `feat:location:category` and `feat:location:level`. These take their values from the feat's `location` field. So, for example, a feat with location `class-6` would have the roll options:
- `feat:location:category:class`
- `feat:location:level:6`

### Predication Mathematical Operations
I've added the ability to use mathematical operations within the `BinaryOperation` predicates. The available operations are `add` (addition), `sub` (subtraction), `mult` (multiplication), and `div` (division). They work similarly to the existing `BinaryOperation` elements, taking the form of an object which describes the operation to take place, and a two-length array where the first element is the "left" value and the second element is the "right" value.

For example, the following predicate will return true if the value of `item:level` is less than or equal to half the value of `self:level`:
```json
{
    "lte": [
        "item:level",
        {
            "div": [
                "self:level",
                2
            ]
        }
    ]
}
```

The implementation is fairly simple at the moment (no nested maths operations, only the right operator can be a maths operation) but the way I've written it should allow it to be easily extendable.

#### Bonus Fix
In the binary operation code, if the `right` value was a number, then the `left` value would be compared against this same number once for every roll option in the `domains` array. I've moved this check to outside the `flatMap` operation, so the comparison will only happen once.

## Feat Updates
Using the features introduced above, each of the "advanced" multiclass feats has had rule elements applied to give a choice of the feats, exactly like the "basic" multiclass feats, but replacing the `2` in the max level with a maths operation dividing the feat's slot by 2.

For example, taking `Advanced Dogma` in the 6th-level class feat slot will allow a choice of all the 1st- and 2nd-level cleric class feats, whereas taking it in the 8th-level class feat slot will allow a choice of all the 1st-4th-level cleric class feats.

For the case of unlevelled feat slots (e.g. bonus feats) the character's level is used to determine the level of feat that can be taken.