### PR TITLE
Use action header in messages for some inline check vs defenses

### DIFF
--- a/src/module/system/action-macros/helpers.ts
+++ b/src/module/system/action-macros/helpers.ts
@@ -177,7 +177,7 @@ export class ActionMacroHelpers {
                     target: targetActor,
                 })!;
 
-                const header = await renderTemplate("./systems/pf2e/templates/chat/action/header.hbs", {
+                const header = await renderTemplate("systems/pf2e/templates/chat/action/header.hbs", {
                     glyph: options.actionGlyph,
                     subtitle,
                     title: options.title,

--- a/static/lang/action-en.json
+++ b/static/lang/action-en.json
@@ -741,10 +741,12 @@
             "performance": "Performance Check",
             "religion": "Religion Check",
             "society": "Society Check",
+            "spell": "{type} Spell Attack",
             "stealth": "Stealth Check",
             "survival": "Survival Check",
             "thievery": "Thievery Check",
-            "unarmed": "Unarmed Attack Roll"
+            "unarmed": "Unarmed Attack Roll",
+            "x": "{type} Check"
         },
         "ActionsWarning": {
             "NoActor": "Select at least one token before rolling, or assign a default character.",


### PR DESCRIPTION
The action header will be used if the check is against a defense and the originating item is an encounter action.

![image](https://github.com/foundryvtt/pf2e/assets/106829671/421b3380-468d-49ac-bc45-0861c990f69b)
