### PR TITLE
Fix elite/weak adjustment for cantrips

### DIFF
--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -236,9 +236,10 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
                 }
             }
 
-            // Increase or decrease the first instance of damage by 4 if elite or weak
+            // Increase or decrease the first instance of damage by 2 or 4 if elite or weak
             if (terms.length > 0 && !base.length && this.actor.isOfType("npc") && this.actor.attributes.adjustment) {
-                terms.push({ dice: null, modifier: this.actor.isElite ? 4 : -4 });
+                const value = this.unlimited ? 2 : 4;
+                terms.push({ dice: null, modifier: this.actor.isElite ? value : -value });
             }
 
             const damageType = damage.type.value;


### PR DESCRIPTION
> Increase the damage of its Strikes and other offensive abilities by 2. If the creature has limits on how many times or how often it can use an ability (such as a spellcaster’s spells or a dragon’s Breath Weapon), increase the damage by 4 instead. 

While it says "spells" universally, the context is for limited use abilities.