### PR TITLE
Add elite/weak adjustments for inline @Damage rolls

### DIFF
--- a/src/module/item/action/document.ts
+++ b/src/module/item/action/document.ts
@@ -30,6 +30,14 @@ class ActionItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extend
         }
     }
 
+    override getRollOptions(prefix = this.type): string[] {
+        const options = super.getRollOptions(prefix);
+        if (this.frequency) {
+            options.push(`${prefix}:frequency:limited`);
+        }
+        return options;
+    }
+
     override async getChatData(
         this: ActionItemPF2e<ActorPF2e>,
         htmlOptions: EnrichHTMLOptions = {}

--- a/src/module/item/feat/document.ts
+++ b/src/module/item/feat/document.ts
@@ -153,10 +153,11 @@ class FeatPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
     /** Generate a list of strings for use in predication */
     override getRollOptions(prefix = "feat"): string[] {
         prefix = prefix === "feat" && this.isFeature ? "feature" : prefix;
-        return [
+        return R.compact([
             ...super.getRollOptions(prefix).filter((o) => !o.endsWith("level:0")),
             `${prefix}:category:${this.category}`,
-        ];
+            this.frequency ? `${prefix}:frequency:limited` : null,
+        ]);
     }
 
     /* -------------------------------------------- */

--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -531,6 +531,10 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
             options.add(`${prefix}:duration:0`);
         }
 
+        if (!this.unlimited) {
+            options.add(`${prefix}:frequency:limited`);
+        }
+
         const damageValues = Object.values(this.system.damage.value);
         for (const damage of damageValues) {
             if (damage.type) {

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -626,6 +626,13 @@ async function augmentInlineDamageRoll(
             ...(traits ?? []),
         ]);
 
+        // Increase or decrease the first instance of damage by 2 or 4 if elite or weak
+        const firstBase = base.at(0);
+        if (firstBase && actor?.isOfType("npc") && (actor.isElite || actor.isWeak)) {
+            const value = options.has("item:frequency:limited") ? 4 : 2;
+            firstBase.terms?.push({ dice: null, modifier: actor.isElite ? value : -value });
+        }
+
         const { modifiers, dice } = (() => {
             if (!(actor instanceof ActorPF2e)) return { modifiers: [], dice: [] };
             return extractDamageSynthetics(actor, domains, {


### PR DESCRIPTION
Detection of limited use abilities is not perfect (certain special frequencies like 1d4 rounds cannot be represented), but for those gaps someone could theoretically commit crimes such as `@Damage[18d6[negative]|traits:item:frequency:limited]`