### PR TITLE
Add missing ability boosts for 4 Iconics.

### DIFF
--- a/packs/iconics/sajan-level-1.json
+++ b/packs/iconics/sajan-level-1.json
@@ -2372,12 +2372,14 @@
             "system": {
                 "boosts": {
                     "0": {
+                        "selected": "dex",
                         "value": [
                             "dex",
                             "str"
                         ]
                     },
                     "1": {
+                        "selected": "wis",
                         "value": [
                             "cha",
                             "con",
@@ -2729,6 +2731,7 @@
                 "value": 0
             }
         },
+        "exploration": [],
         "martial": {
             "martial": {
                 "rank": 0

--- a/packs/iconics/sajan-level-5.json
+++ b/packs/iconics/sajan-level-5.json
@@ -2847,12 +2847,14 @@
             "system": {
                 "boosts": {
                     "0": {
+                        "selected": "dex",
                         "value": [
                             "dex",
                             "str"
                         ]
                     },
                     "1": {
+                        "selected": "wis",
                         "value": [
                             "cha",
                             "con",
@@ -3637,6 +3639,7 @@
                 "value": 0
             }
         },
+        "exploration": [],
         "martial": {
             "martial": {
                 "rank": 1

--- a/packs/iconics/seelah-level-5.json
+++ b/packs/iconics/seelah-level-5.json
@@ -2637,6 +2637,7 @@
                     }
                 },
                 "keyAbility": {
+                    "selected": "str",
                     "value": [
                         "dex",
                         "str"

--- a/packs/iconics/valeros-level-5.json
+++ b/packs/iconics/valeros-level-5.json
@@ -2907,6 +2907,7 @@
                     }
                 },
                 "keyAbility": {
+                    "selected": "str",
                     "value": [
                         "dex",
                         "str"
@@ -3434,6 +3435,7 @@
                 "value": 0
             }
         },
+        "exploration": [],
         "martial": {},
         "pfs": {
             "characterNumber": null,


### PR DESCRIPTION
It appears there was a bad migration on these 4 Iconics and some of their ability boosts fell off at some point.