### PR TITLE
Make death note abilities compute correct npc adjustments

### DIFF
--- a/src/module/item/action/document.ts
+++ b/src/module/item/action/document.ts
@@ -32,7 +32,7 @@ class ActionItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extend
 
     override getRollOptions(prefix = this.type): string[] {
         const options = super.getRollOptions(prefix);
-        if (this.frequency) {
+        if (this.frequency || this.system.deathNote) {
             options.push(`${prefix}:frequency:limited`);
         }
         return options;


### PR DESCRIPTION
Most people can only die once, which makes dying a limited and valuable resource.