### PR TITLE
Set the ability on the NPCs casting statistic

### DIFF
--- a/src/module/actor/npc/document.ts
+++ b/src/module/actor/npc/document.ts
@@ -324,6 +324,7 @@ class NPCPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | nul
             // Assign statistic data to the spellcasting entry
             entry.statistic = new Statistic(this, {
                 slug: sluggify(`${entry.name}-spellcasting`),
+                ability: entry.attribute,
                 label: CONFIG.PF2E.magicTraditions[tradition ?? "arcane"],
                 domains: baseSelectors,
                 rollOptions: entry.getRollOptions("spellcasting"),


### PR DESCRIPTION
Without this change, in statistic/index.ts:147 this.ability is null, and so the casting modifier is not propagated to the drag handler.

For an example, cast "False Life" from an NPC and drag the effect onto them.