### PR TITLE
Tweak style of item descriptions in effects panel

### DIFF
--- a/src/styles/system/_effects-panel.scss
+++ b/src/styles/system/_effects-panel.scss
@@ -44,7 +44,7 @@
             gap: 3px;
             height: min-content;
             margin-right: 0.5em;
-            max-width: 315px;
+            max-width: 350px;
             padding: 0.25em 0.5rem;
 
             h1 {
@@ -82,20 +82,21 @@
             }
 
             .instructions, .description {
-                font-size: 0.8em;
-                text-align: right;
+                font-size: var(--font-size-12);
             }
 
             .instructions {
                 display: flex;
                 flex-direction: column;
                 gap: 2px;
+                text-align: right;
             }
 
             .description {
                 background: rgba(black, 0.7);
                 max-height: 16em;
                 overflow-y: auto;
+                padding: 0 0.5em;
                 text-align: left;
 
                 a, span[data-pf2-effect-area] {


### PR DESCRIPTION
Further-enlarged font and widened total area

Before:
![image](https://github.com/foundryvtt/pf2e/assets/106829671/0df6e813-0cc2-46ce-842b-d03e3f981571)

After:
![image](https://github.com/foundryvtt/pf2e/assets/106829671/586c4586-c8f6-40a3-9da8-316bbfd543c6)
