### PR TITLE
Fix rolling initiatives for multiple combatants with common world actor

### DIFF
--- a/src/module/actor/initiative.ts
+++ b/src/module/actor/initiative.ts
@@ -12,6 +12,7 @@ interface InitiativeRollResult {
 }
 
 interface InitiativeRollParams extends StatisticRollParameters {
+    combatant?: CombatantPF2e<EncounterPF2e>;
     /** Whether the encounter tracker should be updated with the roll result */
     updateTracker?: boolean;
 }
@@ -21,8 +22,17 @@ class ActorInitiative {
     actor: ActorPF2e;
     statistic: Statistic;
 
-    get ability(): AbilityString | null {
+    get attribute(): AbilityString | null {
         return this.statistic.ability;
+    }
+
+    /** @deprecated */
+    get ability(): AbilityString | null {
+        foundry.utils.logCompatibilityWarning(
+            "`ActorInitiative#ability` is deprecated. Use `ActorInitiative#attribute` instead.",
+            { since: "5.3.0", until: "6.0.0" }
+        );
+        return this.attribute;
     }
 
     constructor(actor: ActorPF2e) {
@@ -52,7 +62,8 @@ class ActorInitiative {
 
     async roll(args: InitiativeRollParams = {}): Promise<InitiativeRollResult | null> {
         // Get or create the combatant
-        const combatant = await CombatantPF2e.fromActor(this.actor, false);
+        const combatant =
+            args.combatant?.actor === this.actor ? args.combatant : await CombatantPF2e.fromActor(this.actor, false);
         if (!combatant) return null;
 
         if (combatant.hidden) {

--- a/src/module/encounter/document.ts
+++ b/src/module/encounter/document.ts
@@ -1,4 +1,4 @@
-import { ActorPF2e, CharacterPF2e } from "@actor";
+import { CharacterPF2e } from "@actor";
 import { CharacterSheetPF2e } from "@actor/character/sheet.ts";
 import { RollInitiativeOptionsPF2e } from "@actor/data/index.ts";
 import { resetActors } from "@actor/helpers.ts";
@@ -81,15 +81,14 @@ class EncounterPF2e extends Combat {
         const rollMode = options.messageOptions?.rollMode ?? options.rollMode;
         if (options.secret) extraRollOptions.push("secret");
 
-        const combatants: { id: string; actor: ActorPF2e | null }[] = ids.flatMap(
-            (id) => this.combatants.get(id) ?? []
-        );
-        const fightyCombatants = combatants.filter((c): c is { id: string; actor: ActorPF2e } => !!c.actor?.initiative);
+        const combatants = ids.flatMap((id) => this.combatants.get(id) ?? []);
+        const fightyCombatants = combatants.filter((c) => !!c.actor?.initiative);
         const rollResults = await Promise.all(
             fightyCombatants.map(async (combatant): Promise<InitiativeRollResult | null> => {
                 return (
-                    combatant.actor.initiative?.roll({
+                    combatant.actor?.initiative?.roll({
                         ...options,
+                        combatant,
                         extraRollOptions,
                         updateTracker: false,
                         rollMode,


### PR DESCRIPTION
Currently if multiple combatants have the same world actor, initiative can only be rolled for the first in the list. I don't actually know of any use case for this scenario, but core allows it to function.