### PR TITLE
Fix spelling of Sussuran language

### DIFF
--- a/src/scripts/config/index.ts
+++ b/src/scripts/config/index.ts
@@ -1136,7 +1136,7 @@ export const PF2ECONFIG = {
         skald: "PF2E.LanguageSkald",
         sphinx: "PF2E.LanguageSphinx",
         strix: "PF2E.LanguageStrix",
-        susurran: "PF2E.LanguageSusurran",
+        sussuran: "PF2E.LanguageSussuran",
         taldane: "PF2E.LanguageTaldane",
         talican: "PF2E.LanguageTalican",
         tekritanin: "PF2E.LanguageTekritanin",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2227,7 +2227,7 @@
         "LanguageSkald": "Skald",
         "LanguageSphinx": "Sphinx",
         "LanguageStrix": "Strix",
-        "LanguageSusurran": "Susurran",
+        "LanguageSussuran": "Sussuran",
         "LanguageSylvan": "Sylvan",
         "LanguageTaldane": "Taldane",
         "LanguageTalican": "Talican",


### PR DESCRIPTION
Paizo used both spellings in the book, but the glossary uses this one so we should go with that.