### PR TITLE
Add Godless Healing Feat to Treat Wounds macro

### DIFF
--- a/src/scripts/macros/treat-wounds.ts
+++ b/src/scripts/macros/treat-wounds.ts
@@ -110,8 +110,9 @@ async function treat(
     const rank = skill.rank ?? 1;
     const usedProf = requestedProf <= rank ? requestedProf : rank;
     const medicBonus = CheckFeat(actor, "medic-dedication") ? (usedProf - 1) * 5 : 0;
+    const godlessBonus = CheckFeat(actor, "godless-healing") ? 5 : 0;
     const dcValue = [15, 20, 30, 40][usedProf - 1] + mod;
-    const bonus = [0, 10, 30, 50][usedProf - 1] + medicBonus;
+    const bonus = [0, 10, 30, 50][usedProf - 1] + medicBonus + godlessBonus;
 
     const rollOptions = actor.getRollOptions(["all", "skill-check", "medicine"]);
     rollOptions.push("action:treat-wounds");


### PR DESCRIPTION
Godless Healing

You recover an additional 5 Hit Points from a successful attempt to Treat your Wounds or use Battle Medicine on you. After you or an ally use Battle Medicine on you, you become temporarily immune to that Battle Medicine for only 1 hour, instead of 1 day.

<img width="285" alt="Screenshot 2023-08-01 at 06 24 09" src="https://github.com/foundryvtt/pf2e/assets/6688366/e50a6678-1908-497d-a4e4-2242e08e0f33">
