### PR TITLE
Fix more party sheet bugs

### DIFF
--- a/src/module/actor/party/document.ts
+++ b/src/module/actor/party/document.ts
@@ -208,6 +208,11 @@ class PartyPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
         }
 
         resetActors(removedCreatures);
+
+        // Update the actor directory if this included campaign changes
+        if (game.ready && !!changed.system?.campaign && game.actors.get(this.id) === (this as ActorPF2e)) {
+            ui.actors.render();
+        }
     }
 
     /** Overriden to inform creatures the party is defunct */

--- a/src/module/actor/party/sheet.ts
+++ b/src/module/actor/party/sheet.ts
@@ -354,6 +354,9 @@ class PartySheetPF2e extends ActorSheetPF2e<PartyPF2e> {
         return super._onDropItemCreate(itemData);
     }
 
+    /** Override to not auto-disable fields on a thing meant to be used by players */
+    protected override _disableFields(_form: HTMLElement): void {}
+
     /** Recursively performs a render and activation of all sub-regions */
     async #renderRegions(element: HTMLElement, data: object): Promise<void> {
         // Eventually this should cache results to compare if re-rendering

--- a/src/module/item/base.ts
+++ b/src/module/item/base.ts
@@ -704,7 +704,7 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
         userId: string
     ): void {
         super._onUpdate(data, options, userId);
-        if (!this.isOwned && game.ready && game.items.has(this.id)) {
+        if (game.ready && game.items.get(this.id) === this) {
             ui.items.render();
         }
     }

--- a/static/templates/actors/party/sheet.hbs
+++ b/static/templates/actors/party/sheet.hbs
@@ -7,7 +7,13 @@
         </div>
         <div class="details">
             <div class="title">
-                <input name="name" class="name" type="text" value="{{actor.name}}" placeholder="{{localize "PF2E.CharacterNamePlaceholder"}}"/>
+                <input
+                    name="name"
+                    class="name"
+                    type="text"
+                    value="{{actor.name}}"
+                    placeholder="{{localize "PF2E.CharacterNamePlaceholder"}}"
+                    {{disabled (not @root.options.editable)}}/>
                 <label>{{localize "TYPES.Actor.party"}}</label>
             </div>
         </div>

--- a/static/templates/sidebar/party-document-partial.hbs
+++ b/static/templates/sidebar/party-document-partial.hbs
@@ -1,11 +1,11 @@
 <ol class="party-list">
-{{#each parties}}
-    <li class="party flexcol {{#unless (lookup @root.extraFolders this.id)}}collapsed{{/unless}}" data-document-id="{{this.id}}">
-        <header class="directory-item party-header flexrow" data-entry-id="{{this.id}}" data-document-id="{{this.id}}">
+{{#each parties as |party|}}
+    <li class="party flexcol {{#unless (lookup @root.extraFolders party.id)}}collapsed{{/unless}}" data-entry-id="{{party.id}}" data-document-id="{{party.id}}">
+        <header class="directory-item party-header flexrow" data-entry-id="{{party.id}}" data-document-id="{{party.id}}">
             <!-- Drag Preview only -->
-            <img src="{{this.img}}" class="hidden">
+            <img src="{{party.img}}" class="hidden">
             <i class="fas fa-fw fa-users" data-action="open-sheet"></i>
-            <h3 class="noborder">{{this.name}}</h3>
+            <h3 class="noborder">{{party.name}}</h3>
             <div class="controls">
                 <a class="create-button" data-action="create-member">
                     <i class="fa-solid fa-user"></i>
@@ -15,7 +15,7 @@
         </header>
 
         <ol class="subdirectory">
-            {{#each this.members}}
+            {{#each party.members}}
             {{> (lookup @root "entryPartial")}}
             {{/each~}}
         </ol>


### PR DESCRIPTION
Fixes RK button not working for players, party folder closing when members are updated, and kingmaker stale folder bugs.

Casting `this` is a crime, but without that typescript complains that the type is infinitely recursive. 