### PR TITLE
More party sheet tweaks and fixes

### DIFF
--- a/src/module/actor/party/document.ts
+++ b/src/module/actor/party/document.ts
@@ -114,18 +114,18 @@ class PartyPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
 
     async addMembers(...membersToAdd: CreaturePF2e[]): Promise<void> {
         const existing = this.system.details.members.filter((d) => this.members.some((m) => m.uuid === d.uuid));
-
         const existingUUIDs = new Set(existing.map((data) => data.uuid));
         const newMembers = membersToAdd.filter((a) => !existingUUIDs.has(a.uuid));
-        const members: MemberData[] = [...existing, ...newMembers.map((m) => ({ uuid: m.uuid }))];
-        await this.update({ system: { details: { members } } });
 
-        // Remove all members from their original folder
+        // Remove all members from their original folder first
         for (const member of newMembers) {
             if (member.folder) {
                 await member.update({ folder: null });
             }
         }
+
+        const members: MemberData[] = [...existing, ...newMembers.map((m) => ({ uuid: m.uuid }))];
+        await this.update({ system: { details: { members } } });
 
         await resetActors(newMembers);
     }

--- a/src/module/system/settings/metagame.ts
+++ b/src/module/system/settings/metagame.ts
@@ -81,7 +81,7 @@ class MetagameSettings extends SettingsMenuPF2e {
     /** Hide "metagame_showPartyStats" setting in production builds until party actor is released */
     override async getData(): Promise<MenuTemplateData> {
         const data = await super.getData();
-        if (BUILD_MODE === "production") {
+        if (BUILD_MODE === "production" && !game.actors.some((a) => a.type === "party")) {
             delete data.settings.showPartyStats;
         }
         return data;

--- a/src/styles/actor/party/_index.scss
+++ b/src/styles/actor/party/_index.scss
@@ -94,6 +94,13 @@
         cursor: pointer;
     }
 
+    .readonly {
+        pointer-events: none;
+        a, button {
+            pointer-events: none;
+        }
+    }
+
     .container {
         height: 100%;
         overflow: hidden;

--- a/src/styles/actor/party/_overview.scss
+++ b/src/styles/actor/party/_overview.scss
@@ -1,4 +1,5 @@
 .content {
+    padding-top: 0.5rem;
     padding-bottom: 0.25rem;
 }
 
@@ -7,7 +8,7 @@
     display: flex;
     flex-direction: column;
     padding: 0.375rem 0.5rem;
-    margin: 12px 1rem 0.25rem 12px;
+    margin: 0.25rem 1rem 0.25rem 12px;
 
     nav {
         color: var(--alt-dark);
@@ -100,9 +101,9 @@
             color: white;
             font-size: var(--font-size-12);
             font-weight: 500;
+            height: 1.25rem;
             line-height: 1.25rem;
             position: absolute;
-            padding-left: 0.25rem;
             width: 100%;
 
             .bar {
@@ -121,6 +122,7 @@
             }
 
             span {
+                padding-left: 0.25rem;
                 position: relative; // lets it render over the bar
             }
         }

--- a/static/templates/actors/party/regions/exploration.hbs
+++ b/static/templates/actors/party/regions/exploration.hbs
@@ -15,7 +15,7 @@
                 </div>
             </li>
             {{#each members as |member|}}
-                <li class="box member">
+                <li class="box member {{#unless member.limited}}readonly{{/unless}}">
                     <div class="actor-link content" data-action="open-sheet" data-actor-uuid="{{member.actor.uuid}}">
                         <img src="{{member.actor.img}}" />
                         <span class="name">{{member.actor.name}}</span>
@@ -29,13 +29,13 @@
                                 <i class="fas fa-eye"></i> {{member.actor.perception.dc.value}}
                             </span>
                         </div>
-                            <footer class="health-bar">
-                                {{#with member.actor.attributes.hp as |hp|}}
-                                    <div class="bar" style="width: {{percentage hp.value hp.max}}%;"></div>
-                                    <span><i class="fas fa-heart"></i> {{hp.value}} / {{hp.max}}</span>
-                                {{/with}}
-                            </footer>
                     {{/unless}}
+                    <footer class="health-bar">
+                        <div class="bar" style="width: {{percentage member.hp.value member.hp.max}}%;"></div>
+                        {{#if member.hp.showValue}}
+                            <span><i class="fas fa-heart"></i> {{member.hp.value}} / {{member.hp.max}}</span>
+                        {{/if}}
+                    </footer>
                 </li>
             {{/each}}
         </ol>
@@ -53,35 +53,37 @@
         </header>
     {{/if}}
     <div class="activities">
-        {{#each explorationMembers as |member|}}
-            <section class="member-activity" data-actor-uuid="{{member.actor.uuid}}">
-                <div class="actor-image">
-                    <img class="actor-link" data-action="open-sheet" data-tab="exploration" src="{{member.actor.img}}">
-                </div>
+        {{#each members as |member|}}
+            {{#if (eq member.actor.type "character")}}
+                <section class="member-activity {{#unless member.observer}}readonly{{/unless}}" data-actor-uuid="{{member.actor.uuid}}">
+                    <div class="actor-image">
+                        <img class="actor-link" data-action="open-sheet" data-tab="exploration" src="{{member.actor.img}}">
+                    </div>
 
-                {{#if member.activities}}
-                    <div class="activity-entries">
-                        {{#each member.activities as |activity|}}
-                            <section class="activity {{#if (eq member.activities.length 1)}}single{{/if}}">
-                                <span class="name">{{activity.name}}</span>
-                                <span class="tags">
-                                    {{#each traits as |trait|}}
-                                        <span class="tag tag_transparent">{{trait.label}}</span>
-                                    {{/each}}
-                                </span>
-                            </section>
-                        {{/each}}
-                    </div>
-                {{else}}
-                    <div class="empty" data-action="open-sheet" data-tab="exploration">
-                        <div class="icon"><i class="fa-solid fa-plus fa-fw"></i></div>
-                        <div>
-                            <div class="name">{{localize "PF2E.Item.Action.Type.Activity"}}</div>
-                            <div class="hint">{{localize "PF2E.Actor.Party.SlotAvailable"}}</div>
+                    {{#if member.activities}}
+                        <div class="activity-entries">
+                            {{#each member.activities as |activity|}}
+                                <section class="activity {{#if (eq member.activities.length 1)}}single{{/if}}">
+                                    <span class="name">{{activity.name}}</span>
+                                    <span class="tags">
+                                        {{#each traits as |trait|}}
+                                            <span class="tag tag_transparent">{{trait.label}}</span>
+                                        {{/each}}
+                                    </span>
+                                </section>
+                            {{/each}}
                         </div>
-                    </div>
-                {{/if}}
-            </section>
+                    {{else}}
+                        <div class="empty" data-action="open-sheet" data-tab="exploration">
+                            <div class="icon"><i class="fa-solid fa-plus fa-fw"></i></div>
+                            <div>
+                                <div class="name">{{localize "PF2E.Item.Action.Type.Activity"}}</div>
+                                <div class="hint">{{localize "PF2E.Actor.Party.SlotAvailable"}}</div>
+                            </div>
+                        </div>
+                    {{/if}}
+                </section>
+            {{/if}}
         {{/each}}
     </div>
 </section>

--- a/static/templates/actors/party/regions/inventory-members.hbs
+++ b/static/templates/actors/party/regions/inventory-members.hbs
@@ -19,7 +19,7 @@
             </li>
         {{/unless}}
         {{#each members as |member|}}
-            <li class="box">
+            <li class="box {{#unless member.limited}}readonly{{/unless}}">
                 <div class="actor-link content" data-actor-uuid="{{member.actor.uuid}}" data-action="open-sheet" data-tab="inventory">
                     <img src="{{member.actor.img}}" />
                     <div class="sub-data">

--- a/static/templates/actors/party/regions/overview.hbs
+++ b/static/templates/actors/party/regions/overview.hbs
@@ -36,17 +36,19 @@
     {{/if}}
 
     {{#each members as |member|}}
-        <section class="member" data-actor-uuid="{{member.actor.uuid}}">
+        <section class="member {{#unless member.limited}}readonly{{/unless}}" data-actor-uuid="{{member.actor.uuid}}">
             <div class="portrait">
                 <a data-action="open-sheet"><img src="{{member.actor.img}}" /></a>
                 <div class="health-bar">
-                    {{#with member.actor.attributes.hp as |hp|}}
-                        {{#if hp.temp}}
-                            <div class="temp bar" style="width: {{percentage hp.temp hp.max}}%;"></div>
+                    <div class="health-bar">
+                        {{#if member.hp.temp}}
+                            <div class="temp bar" style="width: {{percentage member.hp.temp member.hp.max}}%;"></div>
                         {{/if}}
-                        <div class="bar" style="width: {{percentage hp.value hp.max}}%;"></div>
-                        <span><i class="fas fa-heart"></i> {{hp.value}} / {{hp.max}}</span>
-                    {{/with}}
+                        <div class="bar" style="width: {{percentage member.hp.value member.hp.max}}%;"></div>
+                        {{#if member.hp.showValue}}
+                            <span><i class="fas fa-heart"></i> {{member.hp.value}} / {{member.hp.max}}</span>
+                        {{/if}}
+                    </div>
                 </div>
             </div>
             <div class="data">
@@ -71,7 +73,7 @@
                         {{/if}}
                     {{/if}}
                     {{#if member.heroPoints}}
-                        <a class="hero-points" data-action="adjust-hero-points">
+                        <a class="hero-points {{#unless member.owner}}readonly{{/unless}}" data-action="adjust-hero-points">
                             {{#times member.heroPoints.max}}
                                 {{#if (gt member.heroPoints.value this)}}
                                     <img src="/systems/pf2e/dice/basic/heads.webp" />
@@ -120,7 +122,15 @@
 
                 <div class="skills">
                     {{#with member.actor.perception as |perception|}}
-                        <button type="button" class="perception tag-light rollable" {{#if perception.rank}}data-rank="{{perception.rank}}"{{/if}} {{#if @root.user.isGM}}data-action="roll" data-statistic="perception" data-secret="true"{{/if}}>
+                        <button
+                            type="button"
+                            class="perception tag-light rollable {{#unless @root.user.isGM}}readonly{{/unless}}"
+                            {{#if perception.rank}}data-rank="{{perception.rank}}"{{/if}}
+                            {{#if @root.user.isGM}}
+                                data-action="roll"
+                                data-statistic="perception"
+                                data-secret="true"
+                            {{/if}}>
                             {{perception.label}} {{numberFormat perception.mod sign=true}}
                         </button>
                     {{/with}}

--- a/static/templates/actors/party/sheet.hbs
+++ b/static/templates/actors/party/sheet.hbs
@@ -23,8 +23,8 @@
         {{#unless restricted}}
             <a data-tab="overview">{{localize "PF2E.Actor.Party.Tabs.Overview"}}</a>
         {{/unless}}
-        <a data-tab="inventory">{{localize "PF2E.Actor.Party.Tabs.Inventory"}}</a>
         <a data-tab="exploration">{{localize "PF2E.Actor.Party.Tabs.Exploration"}}</a>
+        <a data-tab="inventory">{{localize "PF2E.Actor.Party.Tabs.Inventory"}}</a>
         {{#if orphaned}}
             <a data-tab="orphaned">{{localize "PF2E.Actor.Party.Tabs.Orphaned"}}</a>
         {{/if}}
@@ -35,6 +35,9 @@
             <div class="tab" data-tab="overview" data-region="overview"></div>
         {{/unless}}
 
+        <div class="tab" data-tab="exploration" data-region="exploration">
+        </div>
+
         <div class="tab" data-tab="inventory">
             <aside class="sidebar">
                 <section data-region="inventoryMembers">
@@ -44,9 +47,6 @@
                 {{> "systems/pf2e/templates/actors/partials/coinage.hbs" owner=@root.owner}}
                 {{> "systems/pf2e/templates/actors/partials/inventory.hbs"}}
             </section>
-        </div>
-
-        <div class="tab" data-tab="exploration" data-region="exploration">
         </div>
 
         {{#if orphaned}}


### PR DESCRIPTION
* Swap exploration and inventory (so that exploration is the first tab if stats are disabled)
* Show health bar (without values) if stats (aka overview) is disabled
* Show an individual's stats regardless of setting if the user is an observer (instead of an owner)
* Show party stats setting is now visible in production worlds if a party actor exists (since its very near ready to release)
* Fix overview health bar alignment
* Fix pointer showing in places clicking would have no effect (due to permissions)
* Fix party members not properly getting removed from their original folder before transfer

![image](https://github.com/foundryvtt/pf2e/assets/1286721/00e27efd-11b8-4460-b432-d710c91e818e)
