### PR TITLE
Fix prefix of PC attribute roll options

### DIFF
--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -777,7 +777,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
 
         for (const key of ABILITY_ABBREVIATIONS) {
             const mod = this.abilities[key].mod;
-            rollOptionsAll[`ability:${key}:mod:${mod}`] = true;
+            rollOptionsAll[`attribute:${key}:mod:${mod}`] = true;
         }
 
         for (const key of SKILL_ABBREVIATIONS) {


### PR DESCRIPTION
This was already a breaking change with the removal of ability scores, so it might as well be right!