### PR TITLE
Tolerate TokenDocument instances having BaseScene parents in _onRelatedUpdate

### DIFF
--- a/src/module/scene/token-document/document.ts
+++ b/src/module/scene/token-document/document.ts
@@ -454,7 +454,7 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
         }
 
         if (aurasChanged || "width" in changes || "height" in changes) {
-            this.scene?.checkAuras();
+            this.scene?.checkAuras?.();
         }
     }
 


### PR DESCRIPTION
In our testing we noticed an issue when attempting to re-import AV. I had already spent the time to track down the issue so I thought I might submit a PR for it rather than simply log a report. Apologies if I've missed some additional process required.

### Steps to Reproduce
The repro steps for the issue are to attempt to re-import any adventure that contains Scenes and Actors over the already-imported adventure.

### Root Cause
The root cause is that foundry tracks all dependent TokenDocument instances for a given Actor, which in this case includes the TokenDocument instances that are created when the Adventure Document is initialised. I realise this is potentially surprising behaviour but there are good reasons that foundry tracks all dependents rather than just some of them.

These TokenDocuments have parents that are instances of `BaseScene` rather than `Scene`, and so do not have a `checkAuras` method. This is due to the way that Adventure Documents house their content in `EmbeddedDataField`s rather than `EmbeddedDocumentField`s. These TokenDocuments with `BaseScene` parents are a bit of an unexpected consequence of marrying the two behaviours, but it's not really clear what, if anything, we should change at this stage.