### PR TITLE
Add selectors: parameter for rollable checks

### DIFF
--- a/packs/actions/elemental-blast.json
+++ b/packs/actions/elemental-blast.json
@@ -11,7 +11,7 @@
         },
         "category": "offensive",
         "description": {
-            "value": "<p><span class=\"pf2-icon\">1</span> or <span class=\"pf2-icon\">2</span></p>\n<hr />\n<p>With a wave of your hand, you collect elemental matter from your aura and swing or hurl it. Choose one of your kinetic elements and a damage type listed for that element, then make a melee or ranged @Check[type:kineticist|defense:ac]{impulse attack} against the AC of one creature. Add your Strength modifier to the damage roll for a melee Elemental Blast. If you make a 2-action Elemental Blast, you gain a status bonus to the damage roll equal to your Constitution modifier. The element determines the damage die, damage type, and range (for a ranged blast). A damage type other than a physical damage type adds its trait to the blast.</p>\n<ul>\n<li><strong>Air</strong> 1d6 electricity or slashing, 60 feet</li>\n<li><strong>Earth</strong> 1d8 bludgeoning or piercing, 30 feet</li>\n<li><strong>Fire</strong> 1d6 fire, range 60 feet</li>\n<li><strong>Metal</strong> 1d8 piercing or slashing, 30 feet</li>\n<li><strong>Water</strong> 1d8 bludgeoning or cold, 30 feet</li>\n<li><strong>Wood</strong> 1d8 bludgeoning or vitality, 30 feet</li>\n</ul>\n<hr />\n<p><strong>Critical Success</strong> The target takes double damage.</p>\n<p><strong>Success</strong> The target takes full damage.</p>\n<hr />\n<p><strong>Level (+4)</strong> The damage increases by one die.</p>"
+            "value": "<p><span class=\"pf2-icon\">1</span> or <span class=\"pf2-icon\">2</span></p>\n<hr />\n<p>With a wave of your hand, you collect elemental matter from your aura and swing or hurl it. Choose one of your kinetic elements and a damage type listed for that element, then make a melee or ranged @Check[type:kineticist|defense:ac|selectors:attack,attack-roll,impulse-attack-roll]{impulse attack} against the AC of one creature. Add your Strength modifier to the damage roll for a melee Elemental Blast. If you make a 2-action Elemental Blast, you gain a status bonus to the damage roll equal to your Constitution modifier. The element determines the damage die, damage type, and range (for a ranged blast). A damage type other than a physical damage type adds its trait to the blast.</p>\n<ul>\n<li><strong>Air</strong> 1d6 electricity or slashing, 60 feet</li>\n<li><strong>Earth</strong> 1d8 bludgeoning or piercing, 30 feet</li>\n<li><strong>Fire</strong> 1d6 fire, range 60 feet</li>\n<li><strong>Metal</strong> 1d8 piercing or slashing, 30 feet</li>\n<li><strong>Water</strong> 1d8 bludgeoning or cold, 30 feet</li>\n<li><strong>Wood</strong> 1d8 bludgeoning or vitality, 30 feet</li>\n</ul>\n<hr />\n<p><strong>Critical Success</strong> The target takes double damage.</p>\n<p><strong>Success</strong> The target takes full damage.</p>\n<hr />\n<p><strong>Level (+4)</strong> The damage increases by one die.</p>"
         },
         "requirements": {
             "value": ""
@@ -21,12 +21,7 @@
             "value": "Pathfinder Rage of Elements"
         },
         "traits": {
-            "value": [
-                "attack",
-                "impulse",
-                "kineticist",
-                "primal"
-            ]
+            "value": ["attack", "impulse", "kineticist", "primal"]
         },
         "trigger": {
             "value": ""

--- a/packs/equipment/gate-attenuator-greater.json
+++ b/packs/equipment/gate-attenuator-greater.json
@@ -34,7 +34,14 @@
             }
         },
         "quantity": 1,
-        "rules": [],
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "selector": "impulse-attack-roll",
+                "type": "item",
+                "value": 2
+            }
+        ],
         "size": "med",
         "source": {
             "value": "Pathfinder Rage of Elements"

--- a/packs/equipment/gate-attenuator-major.json
+++ b/packs/equipment/gate-attenuator-major.json
@@ -34,7 +34,26 @@
             }
         },
         "quantity": 1,
-        "rules": [],
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "selector": "impulse-attack-roll",
+                "type": "item",
+                "value": 2
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "system.abilities.con.mod",
+                "value": 1
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "system.abilities.con.mod",
+                "value": 4
+            }
+        ],
         "size": "med",
         "source": {
             "value": "Pathfinder Rage of Elements"

--- a/packs/equipment/gate-attenuator.json
+++ b/packs/equipment/gate-attenuator.json
@@ -34,7 +34,14 @@
             }
         },
         "quantity": 1,
-        "rules": [],
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "selector": "impulse-attack-roll",
+                "type": "item",
+                "value": 1
+            }
+        ],
         "size": "med",
         "source": {
             "value": "Pathfinder Rage of Elements"

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -305,6 +305,7 @@ class TextEditorPF2e extends TextEditor {
             type: rawParams.type,
             basic: rawParams.basic !== undefined && ["true", ""].includes(rawParams.basic),
             showDC: rawParams.showDC === "" ? "all" : rawParams.showDC,
+            selectors: rawParams.selectors?.split(",").map((selector) => selector.trim()) ?? [],
             traits: (() => {
                 const traits: string[] = [];
                 // Set item traits
@@ -407,6 +408,7 @@ class TextEditorPF2e extends TextEditor {
         anchor.append(icon);
 
         anchor.dataset.pf2Traits = params.traits.toString();
+        if (params.selectors) anchor.dataset.pf2Selectors = params.selectors.toString();
         const name = params.name ?? item?.name ?? params.type;
         anchor.dataset.pf2RepostFlavor = name;
         const role = params.showDC ?? "owner";
@@ -431,6 +433,10 @@ class TextEditorPF2e extends TextEditor {
 
         switch (params.type) {
             case "flat":
+                if (params.selectors.length > 0) {
+                    anchor.dataset.tooltip = localize("Invalid", { message: localize("Errors.FlatCheckSelectors") });
+                    anchor.dataset.invalid = "true";
+                }
                 anchor.append(createLabel(inlineLabel ?? game.i18n.localize("PF2E.FlatCheck")));
                 anchor.dataset.pf2Check = "flat";
                 break;
@@ -723,6 +729,7 @@ interface CheckLinkParams {
     basic: boolean;
     adjustment?: string;
     traits: string[];
+    selectors: string[];
     name?: string;
     showDC?: string;
     immutable?: string;

--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -82,7 +82,8 @@ export const InlineRollLinks = {
         }
 
         for (const link of links.filter((l) => l.dataset.pf2Check && !l.dataset.invalid)) {
-            const { pf2Check, pf2Dc, pf2Traits, pf2Label, pf2Defense, pf2Adjustment, pf2Roller } = link.dataset;
+            const { pf2Check, pf2Dc, pf2Traits, pf2Selectors, pf2Label, pf2Defense, pf2Adjustment, pf2Roller } =
+                link.dataset;
             if (!pf2Check) return;
 
             link.addEventListener("click", async (event) => {
@@ -113,6 +114,11 @@ export const InlineRollLinks = {
                     ?.split(",")
                     .map((trait) => trait.trim())
                     .filter((trait) => !!trait);
+                const parsedSelectors =
+                    pf2Selectors
+                        ?.split(",")
+                        .map((selector) => selector.trim())
+                        .filter((selector) => !!selector) ?? [];
                 const eventRollParams = eventToRollParams(event);
 
                 switch (pf2Check) {
@@ -123,6 +129,7 @@ export const InlineRollLinks = {
                                 slug: "flat",
                                 modifiers: [],
                                 check: { type: "flat-check" },
+                                domains: parsedSelectors,
                             });
                             const dc = Number.isInteger(Number(pf2Dc))
                                 ? { label: pf2Label, value: Number(pf2Dc) }
@@ -144,7 +151,7 @@ export const InlineRollLinks = {
                                     if (bestSpellcasting) return bestSpellcasting;
                                 }
                                 return actor.getStatistic(pf2Check);
-                            })();
+                            })()?.extend({ domains: parsedSelectors });
                             if (!statistic) {
                                 console.warn(ErrorPF2e(`Skip rolling unknown statistic ${pf2Check}`).message);
                                 continue;

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1368,7 +1368,8 @@
                 "AdjustmentLengthMismatch": "mismatch between number of type and adjustment parameters",
                 "DCAndDefense": "cannot have both dc and defense arguments",
                 "NonIntegerAdjustment": "adjustments must be integers",
-                "TypeMissing": "type argment is mandatory"
+                "TypeMissing": "type argment is mandatory",
+                "FlatCheckSelectors": "flat checks cannot specify selectors"
             }
         },
         "InlineTemplateErrors": {


### PR DESCRIPTION
This works similarly to the `traits:` parameter, supporting multiple values. This PR also includes some minor data updates to take advantage of this functionality, adding the `attack`, `attack-roll`, and `impulse-attack-roll` selectors to the impulse attack roll button in Elemental Blast, and adding rule elements to Gate Attenuators to automate the item bonuses and constitution increase.