### PR TITLE
Fix searching actions in Compendium Browser using text and type at the same time

### DIFF
--- a/src/module/apps/compendium-browser/tabs/action.ts
+++ b/src/module/apps/compendium-browser/tabs/action.ts
@@ -12,7 +12,7 @@ export class CompendiumBrowserActionTab extends CompendiumBrowserTab {
 
     /* MiniSearch */
     override searchFields = ["name"];
-    override storeFields = ["type", "name", "img", "uuid", "traits", "source"];
+    override storeFields = ["type", "name", "img", "uuid", "traits", "source", "actionType"];
 
     constructor(browser: CompendiumBrowser) {
         super(browser);


### PR DESCRIPTION
Issue related: https://github.com/foundryvtt/pf2e/issues/8699

Solution: add "actionType" to the storeFields.