### PR TITLE
Assume actor is level 1 in @Damage instead of skipping

### DIFF
--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -613,13 +613,9 @@ async function augmentInlineDamageRoll(
 ): Promise<{ template: InlineDamageTemplate; context: DamageRollContext } | null> {
     const { name, actor, item, traits } = args;
 
-    // Special case: this is probably an unowned item. Show the normal formula in such cases.
-    if (!actor && baseFormula.includes("@actor")) {
-        return null;
-    }
-
     try {
-        const rollData = item?.getRollData() ?? actor?.getRollData();
+        const rollData: Record<string, unknown> = item?.getRollData() ?? actor?.getRollData() ?? {};
+        rollData.actor ??= { level: 1 };
         const base = extractBaseDamage(new DamageRoll(baseFormula, rollData));
 
         const domains = R.compact([


### PR DESCRIPTION
This avoids the need for the max(1, formula) hack and also makes most formulas prettier in unowned items.