### PR TITLE
Fix party sheet speeds and update summary

### DIFF
--- a/src/module/actor/party/data.ts
+++ b/src/module/actor/party/data.ts
@@ -48,7 +48,7 @@ interface PartyAttributes
     immunities: never[];
     weaknesses: never[];
     resistances: never[];
-    speed: { value: number };
+    speed: { total: number };
 }
 
 interface PartyDetails extends PartyDetailsSource, ActorDetails {}

--- a/src/module/actor/party/document.ts
+++ b/src/module/actor/party/document.ts
@@ -108,8 +108,8 @@ class PartyPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
 
     override prepareDerivedData(): void {
         // Compute travel speed. Creature travel speed isn't implemented yet
-        const travelSpeed = Math.min(...this.members.map((m) => m.attributes.speed.value));
-        this.attributes.speed = { value: travelSpeed };
+        const travelSpeed = Math.min(...this.members.map((m) => m.attributes.speed.total));
+        this.attributes.speed = { total: travelSpeed };
     }
 
     async addMembers(...membersToAdd: CreaturePF2e[]): Promise<void> {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -343,6 +343,7 @@
                     "Content": "Remove member from party?"
                 },
                 "Rest": "Rest",
+                "Skills": "Party Skills",
                 "SlotAvailable": "Slot Available",
                 "Tabs": {
                     "Overview": "Overview",

--- a/static/templates/actors/party/regions/exploration.hbs
+++ b/static/templates/actors/party/regions/exploration.hbs
@@ -23,7 +23,7 @@
                     {{#unless member.restricted}}
                         <div class="sub-data">
                             <span>
-                                <i class="fas fa-person-running"></i> {{member.actor.attributes.speed.value}} {{localize "PF2E.TravelSpeed.FeetAcronym"}}
+                                <i class="fas fa-person-running"></i> {{member.actor.attributes.speed.total}} {{localize "PF2E.TravelSpeed.FeetAcronym"}}
                             </span>
                             <span>
                                 <i class="fas fa-eye"></i> {{member.actor.perception.dc.value}}

--- a/static/templates/actors/party/regions/overview.hbs
+++ b/static/templates/actors/party/regions/overview.hbs
@@ -5,11 +5,14 @@
         </div>
     {{/unless}}
 
-    {{#if members}}
+    {{#with overviewSummary}}
         <section class="summary">
             <nav>
                 <button type="button" data-action="change-view" data-view="languages">
                     {{localize "PF2E.Actor.Party.Languages"}}
+                </button>
+                <button type="button" data-action="change-view" data-view="skills">
+                    {{localize "PF2E.Actor.Party.Skills"}}
                 </button>
                 <button type="button" data-action="change-view" data-view="rk">
                     {{localize "PF2E.RecallKnowledge.Label"}}
@@ -25,15 +28,22 @@
                     </li>
                 {{/each}}
             </ul>
+            <div class="skills" data-view="skills">
+                {{#each skills as |skill|}}
+                    {{> skillTag skill=skill}}
+                {{/each}}
+            </div>
             <div class="skills" data-view="rk">
-                {{#each knowledge as |skill|}}
-                    <span class="tag-light" data-slug="{{skill.slug}}" {{#if skill.rank}}data-rank="{{skill.rank}}"{{/if}}>
-                        {{skill.label}} {{numberFormat skill.mod sign=true}}
-                    </span>
+                {{#each knowledge as |section|}}
+                    <div class="skills">
+                        {{#each section as |skill|}}
+                            {{> skillTag skill=skill}}
+                        {{/each}}
+                    </div>
                 {{/each}}
             </div>
         </section>
-    {{/if}}
+    {{/with}}
 
     {{#each members as |member|}}
         <section class="member {{#unless member.limited}}readonly{{/unless}}" data-actor-uuid="{{member.actor.uuid}}">
@@ -135,12 +145,16 @@
                         </button>
                     {{/with}}
                     {{#each member.bestSkills as |skill|}}
-                        <span class="tag-light" data-slug="{{skill.slug}}" {{#if skill.rank}}data-rank="{{skill.rank}}"{{/if}}>
-                            {{skill.label}} {{numberFormat skill.mod sign=true}}
-                        </span>
+                        {{> skillTag skill=skill}}
                     {{/each}}
                 </div>
             </div>
         </section>
     {{/each}}
 </div>
+
+{{#*inline "skillTag"}}
+    <span class="tag-light" data-slug="{{skill.slug}}" {{#if skill.rank}}data-rank="{{skill.rank}}"{{/if}}>
+        {{skill.label}} {{numberFormat skill.mod sign=true}}
+    </span>
+{{/inline}}


### PR DESCRIPTION
On request, this introduces a skills summary. Given a skills summary now exists, the number of "best skills" has been reduced to 4.

![image](https://github.com/foundryvtt/pf2e/assets/1286721/cdc5d4ad-df3f-40a8-b23b-cece376c5052)
