### PR TITLE
Consolidate action/feat duplicate code into helpers

### DIFF
--- a/src/module/item/action/document.ts
+++ b/src/module/item/action/document.ts
@@ -1,10 +1,11 @@
-import { ItemPF2e } from "@item/base.ts";
-import { ActionItemSource, ActionSystemData } from "./data.ts";
-import { UserPF2e } from "@module/user/index.ts";
+import { ActorPF2e } from "@actor";
+import { ItemPF2e } from "@item";
 import { ActionCost, Frequency } from "@item/data/base.ts";
 import { ItemSummaryData } from "@item/data/index.ts";
+import { UserPF2e } from "@module/user/index.ts";
 import { getActionTypeLabel } from "@util";
-import { ActorPF2e } from "@actor";
+import { ActionItemSource, ActionSystemData } from "./data.ts";
+import { normalizeActionChangeData } from "./helpers.ts";
 
 class ActionItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends ItemPF2e<TParent> {
     get actionCost(): ActionCost | null {
@@ -69,16 +70,7 @@ class ActionItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extend
         options: DocumentModificationContext<TParent>,
         user: UserPF2e
     ): Promise<boolean | void> {
-        // Normalize action data
-        if (changed.system && ("actionType" in changed.system || "actions" in changed.system)) {
-            const actionType = changed.system?.actionType?.value ?? this.system.actionType.value;
-            const actionCount = Number(changed.system?.actions?.value ?? this.system.actions.value);
-            changed.system = mergeObject(changed.system, {
-                actionType: { value: actionType },
-                actions: { value: actionType !== "action" ? null : Math.clamped(actionCount, 1, 3) },
-            });
-        }
-
+        normalizeActionChangeData(this, changed);
         return super._preUpdate(changed, options, user);
     }
 }

--- a/src/module/item/action/helpers.ts
+++ b/src/module/item/action/helpers.ts
@@ -1,0 +1,43 @@
+import { htmlQuery } from "@util";
+import { ActionSystemData } from "./data.ts";
+import { FrequencySource } from "@item/data/base.ts";
+import { ItemPF2e } from "@item";
+
+interface SourceWithActionData {
+    system: {
+        actionType: ActionSystemData["actionType"];
+        actions: ActionSystemData["actions"];
+    };
+}
+
+interface SourceWithFrequencyData {
+    system: {
+        frequency?: ActionSystemData["frequency"];
+    };
+}
+
+/** Pre-update helper to ensure actionType and actions are in sync with each other */
+function normalizeActionChangeData(document: SourceWithActionData, changed: DeepPartial<SourceWithActionData>): void {
+    if (changed.system && ("actionType" in changed.system || "actions" in changed.system)) {
+        const actionType = changed.system?.actionType?.value ?? document.system.actionType.value;
+        const actionCount = Number(changed.system?.actions?.value ?? document.system.actions.value);
+        changed.system = mergeObject(changed.system, {
+            actionType: { value: actionType },
+            actions: { value: actionType !== "action" ? null : Math.clamped(actionCount, 1, 3) },
+        });
+    }
+}
+
+/** Adds sheet listeners for modifying frequency */
+function addSheetFrequencyListeners(item: ItemPF2e & SourceWithFrequencyData, html: HTMLElement): void {
+    htmlQuery(html, "a[data-action=frequency-add]")?.addEventListener("click", () => {
+        const frequency: FrequencySource = { max: 1, per: "day" };
+        item.update({ system: { frequency } });
+    });
+
+    htmlQuery(html, "a[data-action=frequency-delete]")?.addEventListener("click", () => {
+        item.update({ "system.-=frequency": null });
+    });
+}
+
+export { addSheetFrequencyListeners, normalizeActionChangeData };

--- a/src/module/item/action/sheet.ts
+++ b/src/module/item/action/sheet.ts
@@ -1,8 +1,7 @@
 import { ActionItemPF2e } from "@item/action/document.ts";
 import { ItemSheetDataPF2e } from "@item/sheet/data-types.ts";
 import { ItemSheetPF2e } from "../sheet/base.ts";
-import { FrequencySource } from "@item/data/base.ts";
-import { htmlQuery } from "@util";
+import { addSheetFrequencyListeners } from "./helpers.ts";
 
 export class ActionSheetPF2e extends ItemSheetPF2e<ActionItemPF2e> {
     override async getData(options?: Partial<DocumentSheetOptions>): Promise<ActionSheetData> {
@@ -24,15 +23,7 @@ export class ActionSheetPF2e extends ItemSheetPF2e<ActionItemPF2e> {
     override activateListeners($html: JQuery<HTMLElement>): void {
         super.activateListeners($html);
         const html = $html[0];
-
-        htmlQuery(html, "a[data-action=frequency-add]")?.addEventListener("click", () => {
-            const frequency: FrequencySource = { max: 1, per: "day" };
-            this.item.update({ system: { frequency } });
-        });
-
-        htmlQuery(html, "a[data-action=frequency-delete]")?.addEventListener("click", () => {
-            this.item.update({ "system.-=frequency": null });
-        });
+        addSheetFrequencyListeners(this.item, html);
     }
 
     protected override _getSubmitData(updateData?: Record<string, unknown>): Record<string, unknown> {

--- a/src/module/item/campaign-feature/document.ts
+++ b/src/module/item/campaign-feature/document.ts
@@ -1,9 +1,10 @@
 import { ActorPF2e, PartyPF2e } from "@actor";
 import { FeatGroup } from "@actor/character/feats.ts";
+import { ItemPF2e } from "@item";
+import { normalizeActionChangeData } from "@item/action/helpers.ts";
 import { ActionCost, Frequency } from "@item/data/base.ts";
 import { UserPF2e } from "@module/user/index.ts";
 import { sluggify, tupleHasValue } from "@util";
-import { ItemPF2e } from "../index.ts";
 import { CampaignFeatureSource, CampaignFeatureSystemData, CampaignFeatureSystemSource } from "./data.ts";
 import { BehaviorType, KingmakerCategory, KingmakerTrait } from "./types.ts";
 import { CategoryData, KINGDOM_CATEGORY_DATA, KINGMAKER_CATEGORY_TYPES } from "./values.ts";
@@ -121,14 +122,7 @@ class CampaignFeaturePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> e
         }
 
         // Normalize action data
-        if (changed.system && ("actionType" in changed.system || "actions" in changed.system)) {
-            const actionType = changed.system?.actionType?.value ?? this.system.actionType.value;
-            const actionCount = Number(changed.system?.actions?.value ?? this.system.actions.value);
-            changed.system = mergeObject(changed.system, {
-                actionType: { value: actionType },
-                actions: { value: actionType !== "action" ? null : Math.clamped(actionCount, 1, 3) },
-            });
-        }
+        normalizeActionChangeData(this, changed);
 
         // Delete level if optional for the category type
         if (changed.system && changed.system.category) {

--- a/src/module/item/campaign-feature/sheet.ts
+++ b/src/module/item/campaign-feature/sheet.ts
@@ -1,7 +1,7 @@
+import { addSheetFrequencyListeners } from "@item/action/helpers.ts";
 import { ItemSheetDataPF2e, ItemSheetPF2e } from "@item/sheet/index.ts";
 import { htmlQuery } from "@util";
 import Tagify from "@yaireo/tagify";
-import { FrequencySource } from "@item/data/base.ts";
 import { CampaignFeaturePF2e } from "./document.ts";
 import { KINGMAKER_CATEGORIES } from "./values.ts";
 
@@ -30,6 +30,7 @@ class CampaignFeatureSheetPF2e extends ItemSheetPF2e<CampaignFeaturePF2e> {
     override activateListeners($html: JQuery<HTMLElement>): void {
         super.activateListeners($html);
         const html = $html[0];
+        addSheetFrequencyListeners(this.item, html);
 
         const prerequisites = htmlQuery<HTMLInputElement>(html, 'input[name="system.prerequisites.value"]');
         if (prerequisites) {
@@ -37,15 +38,6 @@ class CampaignFeatureSheetPF2e extends ItemSheetPF2e<CampaignFeaturePF2e> {
                 editTags: 1,
             });
         }
-
-        htmlQuery(html, "a[data-action=frequency-add]")?.addEventListener("click", () => {
-            const frequency: FrequencySource = { max: 1, per: "day" };
-            this.item.update({ system: { frequency } });
-        });
-
-        htmlQuery(html, "a[data-action=frequency-delete]")?.addEventListener("click", () => {
-            this.item.update({ "system.-=frequency": null });
-        });
     }
 
     protected override _updateObject(event: Event, formData: Record<string, unknown>): Promise<void> {

--- a/src/module/item/feat/document.ts
+++ b/src/module/item/feat/document.ts
@@ -1,12 +1,12 @@
 import { ActorPF2e } from "@actor";
 import { FeatGroup } from "@actor/character/feats.ts";
+import { HeritagePF2e, ItemPF2e } from "@item";
+import { normalizeActionChangeData } from "@item/action/helpers.ts";
 import { ActionCost, Frequency } from "@item/data/base.ts";
 import { ItemSummaryData } from "@item/data/index.ts";
-import { OneToThree } from "@module/data.ts";
 import { UserPF2e } from "@module/user/index.ts";
 import { getActionTypeLabel, sluggify } from "@util";
 import * as R from "remeda";
-import { HeritagePF2e, ItemPF2e } from "../index.ts";
 import { FeatSource, FeatSystemData } from "./data.ts";
 import { featCanHaveKeyOptions } from "./helpers.ts";
 import { FeatCategory, FeatTrait } from "./types.ts";
@@ -191,19 +191,7 @@ class FeatPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
         }
 
         // Normalize action data
-        if (changed.system && ("actionType" in changed.system || "actions" in changed.system)) {
-            const actionType = changed.system?.actionType?.value ?? this.system.actionType.value;
-            const actionCount = Number(changed.system?.actions?.value ?? this.system.actions.value);
-            changed.system = mergeObject(changed.system, {
-                actionType: { value: actionType },
-                actions: { value: actionType !== "action" ? null : Math.clamped(actionCount, 1, 3) },
-            });
-        }
-
-        const actionCount = changed.system?.actions;
-        if (actionCount) {
-            actionCount.value = (Math.clamped(Number(actionCount.value), 0, 3) || null) as OneToThree | null;
-        }
+        normalizeActionChangeData(this, changed);
 
         // Ensure onlyLevel1 and takeMultiple are consistent
         const traits = changed.system?.traits?.value;

--- a/src/module/item/feat/sheet.ts
+++ b/src/module/item/feat/sheet.ts
@@ -1,9 +1,9 @@
+import { addSheetFrequencyListeners } from "@item/action/helpers.ts";
 import { FeatPF2e } from "@item/feat/document.ts";
 import { ItemSheetDataPF2e, ItemSheetPF2e } from "@item/sheet/index.ts";
 import { htmlQuery, tagify } from "@util";
 import Tagify from "@yaireo/tagify";
 import { featCanHaveKeyOptions } from "./helpers.ts";
-import { FrequencySource } from "@item/data/base.ts";
 
 class FeatSheetPF2e extends ItemSheetPF2e<FeatPF2e> {
     override get validTraits(): Record<string, string> {
@@ -35,6 +35,7 @@ class FeatSheetPF2e extends ItemSheetPF2e<FeatPF2e> {
     override activateListeners($html: JQuery<HTMLElement>): void {
         super.activateListeners($html);
         const html = $html[0];
+        addSheetFrequencyListeners(this.item, html);
 
         const prerequisites = htmlQuery<HTMLInputElement>(html, 'input[name="system.prerequisites.value"]');
         if (prerequisites) {
@@ -42,15 +43,6 @@ class FeatSheetPF2e extends ItemSheetPF2e<FeatPF2e> {
                 editTags: 1,
             });
         }
-
-        htmlQuery(html, "a[data-action=frequency-add]")?.addEventListener("click", () => {
-            const frequency: FrequencySource = { max: 1, per: "day" };
-            this.item.update({ system: { frequency } });
-        });
-
-        htmlQuery(html, "a[data-action=frequency-delete]")?.addEventListener("click", () => {
-            this.item.update({ "system.-=frequency": null });
-        });
 
         const keyOptionsInput = htmlQuery<HTMLInputElement>(html, 'input[name="system.subfeatures.keyOptions"]');
         tagify(keyOptionsInput, { whitelist: CONFIG.PF2E.abilities, maxTags: 3 });


### PR DESCRIPTION
Feats embed actions (and so do campaign features) so its only right that they reach into actions to do the action stuff.

Eventually we can get spells also using action cost utilities, once we refactor actions/feats to both support variable action costs somehow.