### PR TITLE
Refactor strike button lables and fix display of strike modifiers for strikes modified by rule elements

### DIFF
--- a/src/module/actor/data/base.ts
+++ b/src/module/actor/data/base.ts
@@ -234,12 +234,16 @@ interface StrikeData extends StatisticModifier {
     attack?: RollFunction<AttackRollParams>;
     /** Roll normal (non-critical) damage for this weapon. */
     damage?: DamageRollFunction;
+    /** The non-critical damage formula for this strike */
+    damageFormula?: string;
     /** Roll critical damage for this weapon. */
     critical?: DamageRollFunction;
+    /** The critical damage formula for this strike */
+    criticalDamageFormula?: string;
     /** Alternative usages of a strike weapon: thrown, combination-melee, etc. */
     altUsages?: StrikeData[];
     /** A list of attack variants which apply the Multiple Attack Penalty. */
-    variants: { label: string; roll: RollFunction<AttackRollParams> }[];
+    variants: { label?: string; roll: RollFunction<AttackRollParams> }[];
 
     /** Ammunition choices and selected ammo if this is a ammo consuming weapon. */
     ammunition?: {

--- a/src/module/actor/hazard/sheet.ts
+++ b/src/module/actor/hazard/sheet.ts
@@ -64,7 +64,7 @@ export class HazardSheetPF2e extends ActorSheetPF2e<HazardPF2e> {
             reset: await enrich(systemData.details.reset),
         });
 
-        const strikesWithDescriptions: (StrikeData & { damageFormula?: string })[] = systemData.actions;
+        const strikesWithDescriptions: StrikeData[] = systemData.actions;
         const actorRollData = actor.getRollData();
         for (const attack of strikesWithDescriptions) {
             const itemRollData = attack.item.getRollData();
@@ -74,7 +74,7 @@ export class HazardSheetPF2e extends ActorSheetPF2e<HazardPF2e> {
                     async: true,
                 });
             }
-            attack.damageFormula = String(await attack.damage?.({ getFormula: true }));
+            attack.damageFormula = String(await attack.damage?.({ getLabel: true }));
         }
 
         return {

--- a/src/module/actor/npc/sheet.ts
+++ b/src/module/actor/npc/sheet.ts
@@ -30,7 +30,6 @@ import {
     NPCSkillSheetData,
     NPCSpeedSheetData,
     NPCSpellcastingSheetData,
-    NPCStrikeSheetData,
     NPCSystemSheetData,
 } from "./types.ts";
 
@@ -393,7 +392,7 @@ class NPCSheetPF2e extends AbstractNPCSheet<NPCPF2e> {
      */
     async #prepareActions(sheetData: NPCSheetData): Promise<void> {
         // Enrich strike descriptions
-        const attacks: NPCStrikeSheetData[] = sheetData.data.actions;
+        const attacks = sheetData.data.actions;
         const actorRollData = this.actor.getRollData();
         for (const attack of attacks) {
             if (attack.description.length > 0) {
@@ -403,7 +402,7 @@ class NPCSheetPF2e extends AbstractNPCSheet<NPCPF2e> {
                     async: true,
                 });
             }
-            attack.damageFormula = String(await attack.damage?.({ getFormula: true }));
+            attack.damageFormula = String(await attack.damage?.({ getLabel: true }));
         }
 
         const actions: NPCActionSheetData = {

--- a/src/module/actor/npc/types.ts
+++ b/src/module/actor/npc/types.ts
@@ -42,7 +42,7 @@ type WithRank = { icon?: string; hover?: string; rank: ZeroToFour };
 type NPCSkillSheetData = NPCSkillData & WithAdjustments & WithRank;
 
 interface NPCSystemSheetData extends NPCSystemData {
-    actions: NPCStrikeSheetData[];
+    actions: NPCStrike[];
     attributes: NPCAttributes & {
         ac: ArmorClassTraceData & WithAdjustments;
         hp: HitPointsStatistic & WithAdjustments;
@@ -57,11 +57,6 @@ interface NPCSystemSheetData extends NPCSystemData {
     sortedSkills: Record<SkillAbbreviation, NPCSkillSheetData>;
     saves: Record<SaveType, NPCSaveData & WithAdjustments & WithRank & { labelShort?: string }>;
     skills: Record<SkillAbbreviation, NPCSkillSheetData>;
-}
-
-interface NPCStrikeSheetData extends NPCStrike {
-    /** The damage formula of the strike for display on sheets */
-    damageFormula?: string;
 }
 
 interface NPCSpellcastingSheetData extends SpellcastingSheetData {
@@ -138,7 +133,6 @@ export {
     NPCSkillSheetData,
     NPCSpeedSheetData,
     NPCSpellcastingSheetData,
-    NPCStrikeSheetData,
     NPCSystemSheetData,
     VariantCloneParams,
 };

--- a/src/module/system/rolls.ts
+++ b/src/module/system/rolls.ts
@@ -29,8 +29,8 @@ interface RollParameters {
 interface AttackRollParams extends RollParameters {
     /** A target token: pulled from `game.users.targets` if not provided */
     target?: TokenPF2e | null;
-    /** Retrieve the formula of the strike roll without following through to the end */
-    getFormula?: true;
+    /** Returns the fully evaluated attack modifier for strikes and the formula for damage. */
+    getLabel?: boolean;
     /** Should this strike consume ammunition, if applicable? */
     consumeAmmo?: boolean;
     /** The strike is involve throwing a thrown melee weapon or to use the melee usage of a combination weapon */

--- a/static/templates/actors/character/tabs/actions.hbs
+++ b/static/templates/actors/character/tabs/actions.hbs
@@ -230,9 +230,11 @@
         {{#if item.dealsDamage}}
             <button type="button" class="tag damage" data-action="strike-damage"
                 {{#if isAltUsage}}data-alt-usage="{{#if item.isThrown}}thrown{{else}}melee{{/if}}"{{/if}}
+                title="{{damageFormula}}"
                 >{{localize "PF2E.DamageLabel"}}</button>
             <button type="button" class="tag damage" data-action="strike-critical"
                 {{#if isAltUsage}}data-alt-usage="{{#if item.isThrown}}thrown{{else}}melee{{/if}}"{{/if}}
+                title="{{criticalDamageFormula}}"
             >{{localize "PF2E.CriticalDamageLabel"}}</button>
             {{#if (and versatileOptions (not (eq item.altUsageType "thrown")))}}
                 <div class="versatile-options">


### PR DESCRIPTION
Breaking (?) changes:
- Strike variant labels are no longer present in the actor data, only in sheet data. This could be changed to an async getter but that would be a breaking change too.
- The `getFormula` option is now `getLabel`. I could add a deprecation warning for `getFormula` if that is in use by modules at all.

Strikes from `Spell Effect: Dinosaur Form (Tyrannosaurus)` heightened to rank 8.
![image](https://github.com/foundryvtt/pf2e/assets/41452412/5e8f9115-1c4d-418c-bfe9-83910e204bd0)

NPC strikes:
![image](https://github.com/foundryvtt/pf2e/assets/41452412/d7973d5b-f704-4f2e-98e3-f669974f868b)

