### PR TITLE
Allow Aura RE to include effect level

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -435,7 +435,7 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
                 };
 
                 const source = mergeObject(effect.toObject(), { flags });
-                source.system.level.value = data.level ?? aura.level ?? source.system.level.value;
+                source.system.level.value = aura.level ?? source.system.level.value;
                 source.system.duration.unit = "unlimited";
                 source.system.duration.expiry = null;
                 // Only transfer traits from the aura if the effect lacks its own

--- a/src/module/actor/types.ts
+++ b/src/module/actor/types.ts
@@ -67,7 +67,6 @@ interface AuraData {
 
 interface AuraEffectData {
     uuid: string;
-    level: number | null;
     affects: "allies" | "enemies" | "all";
     events: ("enter" | "turn-start" | "turn-end")[];
     save: {


### PR DESCRIPTION
A level set in an Aura RE will be propagated to the effects the aura transmits.