### PR TITLE
Remove Persistence of Memory ability from Shadow King's statblock

### DIFF
--- a/packs/stolen-fate-bestiary/the-shadow-prince.json
+++ b/packs/stolen-fate-bestiary/the-shadow-prince.json
@@ -892,48 +892,6 @@
             "type": "action"
         },
         {
-            "_id": "ia7nfgIs3ERJytZy",
-            "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Persistence of Memory",
-            "sort": 1200000,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "defensive",
-                "deathNote": true,
-                "description": {
-                    "value": "<p>When a brainchild is destroyed, it returns if anyone still fully believes it exists, re-forming within 100 feet of any believer after [[/br 2d4 #Persistance of Memory]]{2d4 days}.</p>"
-                },
-                "requirements": {
-                    "value": ""
-                },
-                "rules": [],
-                "slug": null,
-                "source": {
-                    "value": ""
-                },
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "illusion",
-                        "mental",
-                        "occult"
-                    ]
-                },
-                "trigger": {
-                    "value": ""
-                },
-                "weapon": {
-                    "value": ""
-                }
-            },
-            "type": "action"
-        },
-        {
             "_id": "XYbAi32NwuL6wFGa",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Deception",


### PR DESCRIPTION
Remove Persistence of Memory ability from Shadow King's statblock to match module: https://2e.aonprd.com/Monsters.aspx?ID=2559