### PR TITLE
Fix bugged description for Composite trait

### DIFF
--- a/src/scripts/config/traits.ts
+++ b/src/scripts/config/traits.ts
@@ -993,7 +993,7 @@ const traitDescriptions = {
     common: "PF2E.TraitDescriptionCommon",
     companion: "PF2E.TraitDescriptionCompanion",
     complex: "PF2E.TraitDescriptionComplex",
-    composite: "TraitDescriptionComposite",
+    composite: "PF2E.TraitDescriptionComposite",
     composition: "PF2E.TraitDescriptionComposition",
     concealable: "PF2E.TraitDescriptionConcealable",
     concentrate: "PF2E.TraitDescriptionConcentrate",


### PR DESCRIPTION
Fix the bug that caused "Composite" trait to not show a proper description.
Bug was caused by omission of "PF2E." in the map in traits.ts.

Fixes #9102