### PR TITLE
Show all property runes on ABP magic items embedded in loot actors

### DIFF
--- a/src/module/item/physical/runes.ts
+++ b/src/module/item/physical/runes.ts
@@ -18,8 +18,10 @@ import { isBlank } from "@util";
 
 function getPropertySlots(item: WeaponPF2e | ArmorPF2e): ZeroToFour {
     const fromMaterial = item.system.preciousMaterial?.value === "orichalcum" ? 1 : 0;
+
     const fromPotency = ABP.isEnabled(item.actor)
-        ? ABP.getAttackPotency(item.actor?.level ?? 20) // If the item is unowned, place no limit on slots
+        ? // If the item is unowned or on a loot actor, place no limit on slots
+          ABP.getAttackPotency(!item.actor || item.actor.isOfType("loot") ? 20 : item.actor.level)
         : item.system.runes.potency;
     return (fromMaterial + fromPotency) as ZeroToFour;
 }


### PR DESCRIPTION
Loot actors are always level 0, so currently they never show any property runes due to lack of attack potency