### PR TITLE
Remove errant leftover setting of clear-template-buttons display style

### DIFF
--- a/src/module/chat-message/listeners/cards.ts
+++ b/src/module/chat-message/listeners/cards.ts
@@ -92,7 +92,6 @@ class ChatCards {
                     button.disabled = true;
                     await canvas.scene?.deleteEmbeddedDocuments("MeasuredTemplate", templateIds);
                     button.disabled = false;
-                    button.style.display = "none";
                     return;
                 }
                 case "spell-variant": {


### PR DESCRIPTION
This was part of the initial development and leftover after changing to use the "hidden" class.