### PR TITLE
Update rule elements on several AV actors

### DIFF
--- a/packs/abomination-vaults-bestiary/barcumbuk.json
+++ b/packs/abomination-vaults-bestiary/barcumbuk.json
@@ -1636,7 +1636,17 @@
                 "description": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "category": "persistent",
+                        "critical": true,
+                        "damageType": "fire",
+                        "diceNumber": 1,
+                        "dieSize": "d10",
+                        "key": "DamageDice",
+                        "selector": "{item|id}-damage"
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""
@@ -1694,7 +1704,17 @@
                 "description": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "category": "persistent",
+                        "critical": true,
+                        "damageType": "fire",
+                        "diceNumber": 1,
+                        "dieSize": "d10",
+                        "key": "DamageDice",
+                        "selector": "{item|id}-damage"
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""
@@ -2006,18 +2026,7 @@
                 "requirements": {
                     "value": ""
                 },
-                "rules": [
-                    {
-                        "key": "Note",
-                        "outcome": [
-                            "criticalSuccess"
-                        ],
-                        "selector": "attack",
-                        "text": "PF2E.WeaponPropertyRune.flaming.Note.criticalSuccess",
-                        "title": "{item|name}",
-                        "visibility": "gm"
-                    }
-                ],
+                "rules": [],
                 "slug": null,
                 "source": {
                     "value": ""

--- a/packs/abomination-vaults-bestiary/drill-field-barbazu.json
+++ b/packs/abomination-vaults-bestiary/drill-field-barbazu.json
@@ -653,7 +653,7 @@
                 "traits": {
                     "rarity": "common",
                     "value": [
-                        "deadly-d8",
+                        "deadly-d10",
                         "evil",
                         "forceful",
                         "magical",

--- a/packs/abomination-vaults-bestiary/hellforge-barbazu.json
+++ b/packs/abomination-vaults-bestiary/hellforge-barbazu.json
@@ -577,7 +577,17 @@
                 "description": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "category": "persistent",
+                        "critical": true,
+                        "damageType": "fire",
+                        "diceNumber": 1,
+                        "dieSize": "d10",
+                        "key": "DamageDice",
+                        "selector": "{item|id}-damage"
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""
@@ -586,7 +596,7 @@
                     "rarity": "common",
                     "value": [
                         "agile",
-                        "deadly-d8",
+                        "deadly-d10",
                         "evil",
                         "fire",
                         "forceful",

--- a/packs/abomination-vaults-bestiary/torture-chamber-barbazu.json
+++ b/packs/abomination-vaults-bestiary/torture-chamber-barbazu.json
@@ -582,7 +582,7 @@
                     "rarity": "common",
                     "value": [
                         "agile",
-                        "deadly-d8",
+                        "deadly-d10",
                         "evil",
                         "forceful",
                         "magical",

--- a/packs/pathfinder-bestiary/erinys.json
+++ b/packs/pathfinder-bestiary/erinys.json
@@ -1658,7 +1658,17 @@
                 "description": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "category": "persistent",
+                        "critical": true,
+                        "damageType": "fire",
+                        "diceNumber": 1,
+                        "dieSize": "d10",
+                        "key": "DamageDice",
+                        "selector": "{item|id}-damage"
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""
@@ -1716,7 +1726,17 @@
                 "description": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "category": "persistent",
+                        "critical": true,
+                        "damageType": "fire",
+                        "diceNumber": 1,
+                        "dieSize": "d10",
+                        "key": "DamageDice",
+                        "selector": "{item|id}-damage"
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""
@@ -2030,18 +2050,7 @@
                 "requirements": {
                     "value": ""
                 },
-                "rules": [
-                    {
-                        "key": "Note",
-                        "outcome": [
-                            "criticalSuccess"
-                        ],
-                        "selector": "attack",
-                        "text": "PF2E.WeaponPropertyRune.flaming.Note.criticalSuccess",
-                        "title": "{item|name}",
-                        "visibility": "gm"
-                    }
-                ],
+                "rules": [],
                 "slug": null,
                 "source": {
                     "value": ""


### PR DESCRIPTION
Adventure text makes it clear that the flaming rune is intended to be on the NPC strike.