### PR TITLE
Support extending statistic rule elements for spellcasting

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -667,6 +667,11 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
             rule.afterPrepareData?.();
         }
 
+        // Create Spellcasting entries, which may extend Statistic REs
+        for (const entry of this.itemTypes.spellcastingEntry) {
+            entry.prepareStatistic();
+        }
+
         // IWR rule elements were only just processed: set the actor to not off-guardable if immune to the condition
         if (this.attributes.flanking.offGuardable && this.isImmuneTo("off-guard")) {
             this.attributes.flanking.offGuardable = false;

--- a/src/module/actor/npc/data.ts
+++ b/src/module/actor/npc/data.ts
@@ -177,6 +177,8 @@ interface NPCAttributes
 
     /** A fake class DC (set to a level-based DC) for use with critical specialization effects that require it */
     classDC: { value: number };
+    /** The best spell DC */
+    spellDC: { value: number } | null;
     /** And a fake class-or-spell DC to go along with it */
     classOrSpellDC: { value: number };
 

--- a/static/templates/actors/spellcasting-dialog.hbs
+++ b/static/templates/actors/spellcasting-dialog.hbs
@@ -3,7 +3,7 @@
         <div class="form-group">
             <label>{{localize "PF2E.SpellcastingTypeLabel"}}</label>
             <select name="system.prepared.value" {{disabled object.id}}>
-                {{#select data.prepared.value}}
+                {{#select system.prepared.value}}
                     {{#each spellcastingTypes as |label mode|}}
                         <option value="{{mode}}">{{localize label}}</option>
                     {{/each}}
@@ -13,14 +13,14 @@
         {{#if object.isPrepared}}
             <div class="form-group">
                 <label>{{localize "PF2E.SpellFlexibleLabel"}}</label>
-                <input name="system.prepared.flexible" type="checkbox" {{checked data.prepared.flexible}}/>
+                <input name="system.prepared.flexible" type="checkbox" {{checked system.prepared.flexible}}/>
             </div>
         {{/if}}
-        {{#if (eq data.prepared.value "items")}}
+        {{#if (eq system.prepared.value "items")}}
             <div class="form-group">
                 <label>{{localize "PF2E.Actor.Creature.Spellcasting.MagicItemTypesLabel"}}</label>
                 <select name="system.prepared.validItems">
-                    {{#select data.prepared.validItems}}
+                    {{#select system.prepared.validItems}}
                         <option>{{localize "PF2E.Actor.Creature.Spellcasting.ValidItemTypes.All"}}</option>
                         <option value="scroll">{{localize "PF2E.Actor.Creature.Spellcasting.ValidItemTypes.Scroll"}}</option>
                     {{/select}}
@@ -33,8 +33,8 @@
             <div class="form-group">
                 <label>{{localize "PF2E.MagicTraditionLabel"}}</label>
                 <select name="system.tradition.value">
-                    {{#select data.tradition.value}}
-                        {{#if (eq data.prepared.value "items")}}
+                    {{#select system.tradition.value}}
+                        {{#if (eq system.prepared.value "items")}}
                             <option value="">{{localize "PF2E.MagicTraditionUseSpellLabel"}}</option>
                         {{/if}}
                         {{#each magicTraditions as |label mode|}}
@@ -47,36 +47,34 @@
                 <div class="form-group">
                     <label>{{localize "PF2E.ProficiencyLabel"}}</label>
                     <select name="system.proficiency.slug">
-                        {{#select data.proficiency.slug}}
-                            {{#if data.tradition.value}}
+                        {{#select system.proficiency.slug}}
+                            {{#if system.tradition.value}}
                                 <option value="">
-                                    {{localize "PF2E.Actor.Creature.Spellcasting.TraditionSpellcasting" tradition=(localize (lookup @root.magicTraditions data.tradition.value))}}
+                                    {{localize "PF2E.Actor.Creature.Spellcasting.TraditionSpellcasting" tradition=(localize (lookup @root.magicTraditions system.tradition.value))}}
                                 </option>
                             {{/if}}
-                            {{#each classDCs as |classDC|}}
-                                <option value="{{classDC.slug}}">{{localize "PF2E.Actor.Character.ClassDC.LabelSpecific" class=classDC.label}}</option>
+                            {{#each statistics as |statistic|}}
+                                <option value="{{statistic.slug}}">{{statistic.label}}</option>
                             {{/each}}
                         {{/select}}
                     </select>
                 </div>
             {{/if}}
-            {{#if hasAbility}}
-                <div class="form-group">
-                    <label>{{localize "PF2E.SpellAbilityLabel"}}</label>
-                    <select name="system.ability.value">
-                        {{#select data.ability.value}}
-                            {{#each abilities as |label key|}}
-                                <option value="{{key}}">{{localize label}}</option>
-                            {{/each}}
-                        {{/select}}
-                    </select>
-                </div>
-            {{/if}}
+            <div class="form-group">
+                <label>{{localize "PF2E.SpellAbilityLabel"}}</label>
+                <select name="system.ability.value" {{disabled (not isAttributeConfigurable)}}>
+                    {{#select selectedAttribute}}
+                        {{#each attributes as |label key|}}
+                            <option value="{{key}}">{{localize label}}</option>
+                        {{/each}}
+                    {{/select}}
+                </select>
+            </div>
             {{#if (eq actor.type "npc")}}
                 <div class="form-group">
                     <label>{{localize "PF2E.SpellcastingSettings.AutoHeightenLabel"}}</label>
                     <select name="system.autoHeightenLevel.value" data-dtype="Number">
-                        {{#select data.autoHeightenLevel.value}}
+                        {{#select system.autoHeightenLevel.value}}
                             <option>{{localize "PF2E.SpellcastingSettings.AutoHeightenDefault"}}</option>
                             {{#times 10}}
                                 <option value="{{add this 1}}">{{localize "PF2E.SpellLevel" level=(ordinal (add this 1))}}</option>


### PR DESCRIPTION
Main concern I have is if its ok to run spellcasting preparation after "afterPrepareData()".

After this the gate attenuator will work for kineticist item casting. And theoretically we can make extend statistics like "wizard spellcasting" if we choose to do that.