### PR TITLE
Remove numbers from party sheet sidebars

### DIFF
--- a/src/styles/actor/party/_index.scss
+++ b/src/styles/actor/party/_index.scss
@@ -181,6 +181,7 @@
             flex-direction: column;
             font-family: var(--sans-serif);
             gap: 0.5rem;
+            list-style-type: none;    
         }
 
         .box {


### PR DESCRIPTION
Before: barely visible numbers on edge of exploration/inventory sidebars
![image](https://github.com/foundryvtt/pf2e/assets/5429337/ef6581ab-b2cd-46cb-afce-6349552993be)

After: no more numbers
![image](https://github.com/foundryvtt/pf2e/assets/5429337/bf2fb0f6-0a7f-43a3-bfac-7f0066cdcab9)
