### PR TITLE
Build out basic data structure of PC skill-increase management

### DIFF
--- a/src/module/actor/character/attribute-builder.ts
+++ b/src/module/actor/character/attribute-builder.ts
@@ -464,7 +464,7 @@ class AttributeBuilder extends Application {
                     return;
                 }
 
-                const buildSource = mergeObject(actor.toObject().system.build ?? {}, { attributes: { boosts: {} } });
+                const buildSource = actor.toObject().system.build;
                 const boosts = (buildSource.attributes.boosts[level] ??= []);
                 if (boosts.includes(attribute)) {
                     boosts.splice(boosts.indexOf(attribute), 1);

--- a/src/module/data.ts
+++ b/src/module/data.ts
@@ -46,6 +46,7 @@ type OneToThree = Exclude<ZeroToThree, 0>;
 type TwoToThree = Exclude<OneToThree, 1>;
 type ZeroToFour = ZeroToThree | 4;
 type OneToFour = Exclude<ZeroToFour, 0>;
+type TwoToFour = Exclude<OneToFour, 1>;
 type ZeroToFive = ZeroToFour | 5;
 type OneToFive = OneToThree | Extract<ZeroToFive, 4 | 5>;
 type ZeroToTen = ZeroToFive | 6 | 7 | 8 | 9 | 10;
@@ -151,6 +152,7 @@ export {
     SIZE_SLUGS,
     Size,
     TraitsWithRarity,
+    TwoToFour,
     TwoToThree,
     TypeAndValue,
     ValueAndMax,

--- a/src/module/item/background/document.ts
+++ b/src/module/item/background/document.ts
@@ -1,6 +1,6 @@
 import { ActorPF2e, CharacterPF2e } from "@actor";
+import { SKILL_DICTIONARY } from "@actor/values.ts";
 import { ABCItemPF2e, FeatPF2e } from "@item";
-import { OneToFour } from "@module/data.ts";
 import { BackgroundSource, BackgroundSystemData } from "./data.ts";
 
 class BackgroundPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends ABCItemPF2e<TParent> {
@@ -39,12 +39,12 @@ class BackgroundPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extend
             }
         }
 
-        const { trainedSkills } = this.system;
-        if (trainedSkills.value.length === 1) {
-            const key = trainedSkills.value[0];
-            const skill = this.actor.system.skills[key];
-            skill.rank = Math.max(skill.rank, 1) as OneToFour;
-        }
+        build.skills.increases.background = this.system.trainedSkills.value.map((s) => ({
+            item: this,
+            skill: SKILL_DICTIONARY[s],
+            rank: 1,
+            onConflict: "reallocate",
+        }));
     }
 }
 

--- a/src/module/item/class/data.ts
+++ b/src/module/item/class/data.ts
@@ -1,4 +1,4 @@
-import { AttributeString, SaveType } from "@actor/types.ts";
+import { AttributeString, SaveType, SkillAbbreviation } from "@actor/types.ts";
 import { ABCSystemSource } from "@item/abc/data.ts";
 import { BaseItemSourcePF2e, ItemTraits } from "@item/data/base.ts";
 import { ZeroToFour } from "@module/data.ts";
@@ -15,7 +15,7 @@ interface ClassSystemSource extends ABCSystemSource {
     attacks: ClassAttackProficiencies;
     defenses: ClassDefenseProficiencies;
     trainedSkills: {
-        value: string[];
+        value: SkillAbbreviation[];
         additional: number;
     };
     classDC: ZeroToFour;

--- a/src/module/item/class/document.ts
+++ b/src/module/item/class/document.ts
@@ -2,7 +2,7 @@ import { ActorPF2e, CharacterPF2e } from "@actor";
 import { ClassDCData } from "@actor/character/data.ts";
 import { FeatSlotLevel } from "@actor/character/feats.ts";
 import { SaveType } from "@actor/types.ts";
-import { SAVE_TYPES, SKILL_ABBREVIATIONS } from "@actor/values.ts";
+import { SAVE_TYPES, SKILL_ABBREVIATIONS, SKILL_DICTIONARY } from "@actor/values.ts";
 import { ABCItemPF2e, FeatPF2e } from "@item";
 import { ArmorCategory } from "@item/armor/index.ts";
 import { ARMOR_CATEGORIES } from "@item/armor/values.ts";
@@ -114,6 +114,26 @@ class ClassPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends ABC
 
         build.attributes.keyOptions = [...this.system.keyAbility.value];
         build.attributes.boosts.class = this.system.keyAbility.selected;
+        build.skills.increases.class.push(
+            ...this.system.trainedSkills.value.map(
+                (s) =>
+                    ({
+                        item: this,
+                        skill: SKILL_DICTIONARY[s],
+                        rank: 1,
+                        onConflict: "reallocate",
+                    } as const)
+            ),
+            ...[...Array(this.system.trainedSkills.additional)].map(
+                () =>
+                    ({
+                        item: this,
+                        skill: null,
+                        rank: 1,
+                        onConflict: "reallocate",
+                    } as const)
+            )
+        );
 
         attributes.classhp = this.hpPerLevel;
 

--- a/static/template.json
+++ b/static/template.json
@@ -68,7 +68,14 @@
             "templates": [
                 "common"
             ],
-            "exploration": [],
+            "build": {
+                "attributes": {
+                    "boosts": {}
+                },
+                "skills": {
+                    "selections": []
+                }
+            },
             "attributes": {
                 "bonusLimitBulk": 0,
                 "bonusEncumbranceBulk": 0,
@@ -123,7 +130,8 @@
                 },
                 "nationality": {
                     "value": ""
-                }
+                },
+                "exploration": []
             },
             "skills": {
                 "acr": {


### PR DESCRIPTION
This is overall inert, just setting up the skeleton of skill-training build data and having backgrounds and classes populate it.