### PR TITLE
Set `brokenThreshold` after altering physical-item max hit points

### DIFF
--- a/src/module/rules/rule-element/item-alteration/alteration.ts
+++ b/src/module/rules/rule-element/item-alteration/alteration.ts
@@ -149,6 +149,9 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
                         throw newValue.asError();
                     }
                     hp.max = Math.max(Math.trunc(newValue), 1);
+                    if ("brokenThreshold" in hp) {
+                        hp.brokenThreshold = Math.floor(hp.max / 2);
+                    }
                     this.#adjustCreatureShieldData(data.item);
                 }
                 return;


### PR DESCRIPTION
Closes #9274 