### PR TITLE
Fix improvised and kickback penalties not manifesting on PC sheet

### DIFF
--- a/packs/feats/weapon-improviser-dedication.json
+++ b/packs/feats/weapon-improviser-dedication.json
@@ -25,9 +25,12 @@
         },
         "rules": [
             {
-                "domain": "attack-roll",
-                "key": "RollOption",
-                "option": "self:ignore-improvised-penalty"
+                "key": "AdjustModifier",
+                "selectors": [
+                    "strike-attack-roll"
+                ],
+                "slug": "improvised",
+                "suppress": true
             }
         ],
         "source": {

--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -13,16 +13,7 @@ import {
     createAbilityModifier,
     createProficiencyModifier,
 } from "@actor/modifiers.ts";
-import {
-    AttackItem,
-    AttributeString,
-    CheckContext,
-    CheckContextParams,
-    MovementType,
-    RollContext,
-    RollContextParams,
-    SaveType,
-} from "@actor/types.ts";
+import { AttackItem, AttributeString, MovementType, RollContext, RollContextParams, SaveType } from "@actor/types.ts";
 import {
     ATTRIBUTE_ABBREVIATIONS,
     SAVE_TYPES,
@@ -1339,6 +1330,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
 
         // Everything from relevant synthetics
         modifiers.push(
+            ...PCStrikeAttackTraits.createAttackModifiers({ weapon, domains: selectors }),
             ...extractModifiers(synthetics, selectors, { injectables: { weapon }, resolvables: { weapon } })
         );
 
@@ -1723,23 +1715,6 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
         const context = await super.getRollContext(params);
         if (params.statistic instanceof StatisticModifier && context.self.item?.isOfType("weapon")) {
             PCStrikeAttackTraits.adjustWeapon(context.self.item);
-        }
-
-        return context;
-    }
-
-    /** Create attack-roll modifiers from weapon traits */
-    override getCheckContext<TStatistic extends StatisticCheck | StrikeData, TItem extends AttackItem | null>(
-        params: CheckContextParams<TStatistic, TItem>
-    ): Promise<CheckContext<this, TStatistic, TItem>>;
-    override async getCheckContext(params: CheckContextParams): Promise<CheckContext<this>> {
-        const context = await super.getCheckContext(params);
-        if (params.statistic instanceof StatisticModifier && context.self.item?.isOfType("weapon")) {
-            const fromTraits = PCStrikeAttackTraits.createAttackModifiers({
-                weapon: context.self.item,
-                domains: params.domains,
-            });
-            context.self.modifiers.push(...fromTraits);
         }
 
         return context;

--- a/src/module/actor/character/helpers.ts
+++ b/src/module/actor/character/helpers.ts
@@ -53,6 +53,7 @@ class PCStrikeAttackTraits extends StrikeAttackTraits {
             const unannotatedTrait = this.getUnannotatedTrait(trait);
             switch (unannotatedTrait) {
                 case "kickback": {
+                    // (pre-remaster language)
                     // "Firing a kickback weapon gives a –2 circumstance penalty to the attack roll, but characters with
                     // 14 or more Strength ignore the penalty."
                     return new ModifierPF2e({
@@ -60,7 +61,7 @@ class PCStrikeAttackTraits extends StrikeAttackTraits {
                         label: CONFIG.PF2E.weaponTraits.kickback,
                         modifier: -2,
                         type: "circumstance",
-                        predicate: new PredicatePF2e({ lt: ["ability:str:score", 14] }),
+                        predicate: new PredicatePF2e({ lt: ["attribute:str:mod", 2] }),
                         adjustments: extractModifierAdjustments(synthetics, domains, unannotatedTrait),
                     });
                 }


### PR DESCRIPTION
Retrieval of the penalties shouldn't have been in `getCheckRollContext`: it has all the context its needs during regular data preparation. Also updated kickback predicate for remaster refactors and used better RE on the Weapon Improviser Dedication feat.