### PR TITLE
Use item level as default actor level in @Damage

### DIFF
--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -629,8 +629,11 @@ async function augmentInlineDamageRoll(
     const { name, actor, item, traits, extraRollOptions } = args;
 
     try {
+        // Retrieve roll data. If there is no actor, determine a reasonable "min level" for formula display
         const rollData: Record<string, unknown> = item?.getRollData() ?? actor?.getRollData() ?? {};
-        rollData.actor ??= { level: 1 };
+        rollData.actor ??= { level: (item && "level" in item ? item.level : null) ?? 1 };
+
+        // Extract terms from formula
         const base = extractBaseDamage(new DamageRoll(baseFormula, rollData));
 
         const domains = R.compact([


### PR DESCRIPTION
Not correct for spells but actor level shouldn't be a param in spells anyways. This is mostly for action/feat/physical/campaignFeature