### PR TITLE
Speed up `TextEditor._enrichContentLinks`

### DIFF
--- a/src/scripts/🐵🩹.ts
+++ b/src/scripts/🐵🩹.ts
@@ -2,6 +2,7 @@ import { TextEditorPF2e } from "@system/text-editor.ts";
 
 export function monkeyPatchFoundry(): void {
     TextEditor.enrichHTML = TextEditorPF2e.enrichHTML;
+    TextEditor._enrichContentLinks = TextEditorPF2e._enrichContentLinks;
     TextEditor._createInlineRoll = TextEditorPF2e._createInlineRoll;
     TextEditor._onClickInlineRoll = TextEditorPF2e._onClickInlineRoll;
 }

--- a/src/util/uuid.ts
+++ b/src/util/uuid.ts
@@ -27,6 +27,10 @@ class UUIDUtils {
         return typeof uuid === "string" && foundry.utils.parseUuid(uuid).documentType === "Item";
     }
 
+    static isCompendiumUUID(uuid: unknown): uuid is CompendiumUUID {
+        return typeof uuid === "string" && foundry.utils.parseUuid(uuid).collection instanceof CompendiumCollection;
+    }
+
     static isTokenUUID(uuid: unknown): uuid is TokenDocumentUUID {
         return typeof uuid === "string" && foundry.utils.parseUuid(uuid).documentType === "Token";
     }


### PR DESCRIPTION
Upstream retrieves documents from UUID links sequentially, which has a noticable load time with text containing many links: retrieve everything at once beforehand with the faster `UUIDUtils.fromUUIDs` system helper.