### PR TITLE
Simplify deterministic `RollTerm`s as soon as possible in damage rolls

### DIFF
--- a/src/module/system/damage/roll.ts
+++ b/src/module/system/damage/roll.ts
@@ -5,7 +5,7 @@ import { DegreeOfSuccessIndex } from "@system/degree-of-success.ts";
 import { RollDataPF2e } from "@system/rolls.ts";
 import { ErrorPF2e, fontAwesomeIcon, isObject, objectHasKey, tupleHasValue } from "@util";
 import type Peggy from "peggy";
-import { DamageCategorization, deepFindTerms, renderComponentDamage } from "./helpers.ts";
+import { DamageCategorization, deepFindTerms, renderComponentDamage, simplifyTerm } from "./helpers.ts";
 import { ArithmeticExpression, Grouping, GroupingData, InstancePool, IntermediateDie } from "./terms.ts";
 import { DamageCategory, DamageTemplate, DamageType, MaterialDamageEffect } from "./types.ts";
 import { DAMAGE_TYPE_ICONS } from "./values.ts";
@@ -353,8 +353,10 @@ class DamageInstance extends AbstractDamageRoll {
         for (const term of data.terms) {
             DamageRoll.classifyDice(term);
         }
+        const roll = super.fromData(data);
+        roll.terms = roll.terms.map((t) => simplifyTerm(t));
 
-        return super.fromData(data);
+        return roll;
     }
 
     /** Get the expected, minimum, or maximum value of a term */

--- a/src/module/system/damage/terms.ts
+++ b/src/module/system/damage/terms.ts
@@ -1,5 +1,5 @@
 import { isObject, tupleHasValue } from "@util";
-import { isSystemDamageTerm, markAsCrit, renderComponentDamage } from "./helpers.ts";
+import { isSystemDamageTerm, markAsCrit, renderComponentDamage, simplifyTerm } from "./helpers.ts";
 import { DamageInstance } from "./roll.ts";
 
 class ArithmeticExpression extends RollTerm<ArithmeticExpressionData> {
@@ -17,7 +17,7 @@ class ArithmeticExpression extends RollTerm<ArithmeticExpressionData> {
                 CONFIG.Dice.termTypes[datum.class ?? ""] ??
                 Object.values(CONFIG.Dice.terms).find((t) => t.name === datum.class) ??
                 Die;
-            return TermCls.fromData(datum);
+            return simplifyTerm(TermCls.fromData(datum));
         }) as [RollTerm, RollTerm];
 
         if (
@@ -210,7 +210,7 @@ class Grouping extends RollTerm<GroupingData> {
             CONFIG.Dice.termTypes[termData.term.class ?? ""] ??
             Object.values(CONFIG.Dice.terms).find((t) => t.name === termData.term.class) ??
             NumericTerm;
-        const childTerm = TermCls.fromData(termData.term);
+        const childTerm = simplifyTerm(TermCls.fromData(termData.term));
 
         // Remove redundant groupings
         if (childTerm instanceof Grouping) {
@@ -346,7 +346,7 @@ class IntermediateDie extends RollTerm<IntermediateDieData> {
             if (typeof termData === "number") return termData;
 
             const TermCls = CONFIG.Dice.termTypes[termData.class ?? "NumericTerm"];
-            const term = TermCls.fromData(termData);
+            const term = simplifyTerm(TermCls.fromData(termData));
             if (term instanceof NumericTerm) return term.number;
 
             // Immediately evaluate deterministic number or faces

--- a/types/foundry/client/roll.d.ts
+++ b/types/foundry/client/roll.d.ts
@@ -168,6 +168,9 @@ declare global {
          */
         static create(formula: string, data?: Record<string, unknown>, options?: RollOptions): Roll;
 
+        /** Get the default configured Roll class. */
+        static get defaultImplementation(): typeof Roll;
+
         /**
          * Transform an array of RollTerm objects into a cleaned string formula representation.
          * @param terms An array of terms to represent as a formula


### PR DESCRIPTION
Closes #7744

Before:
![image](https://github.com/foundryvtt/pf2e/assets/106829671/0c94d3e5-a67a-40c2-9df9-2dcc3c802b6d)

After:
![image](https://github.com/foundryvtt/pf2e/assets/106829671/f85694bc-aa30-4896-ad0e-4cea7b814fc8)
