### PR TITLE
Alert user on PC sheet when there are unallocated boosts

### DIFF
--- a/src/styles/actor/character/_attribute-builder.scss
+++ b/src/styles/actor/character/_attribute-builder.scss
@@ -160,7 +160,7 @@
             text-align: center;
 
             &.extra {
-                animation: glow 0.5s infinite alternate;
+                @include requires-user-attention;
             }
         }
 

--- a/src/styles/actor/character/_index.scss
+++ b/src/styles/actor/character/_index.scss
@@ -69,6 +69,7 @@ nav.sheet-navigation {
         .controls {
             display: flex;
         }
+
         button {
             background: transparent;
             border-radius: 2px 2px 0 0;
@@ -84,6 +85,10 @@ nav.sheet-navigation {
             outline: none;
             text-transform: uppercase;
             width: auto;
+
+            &.has-unallocated {
+                @include requires-user-attention;
+            }
         }
     }
 

--- a/src/styles/actor/party/kingdom/_builder.scss
+++ b/src/styles/actor/party/kingdom/_builder.scss
@@ -277,7 +277,7 @@
                 text-align: center;
 
                 &.extra {
-                    animation: glow 0.5s infinite alternate;
+                    @include requires-user-attention;
                 }
             }
 

--- a/src/styles/mixins/_animations.scss
+++ b/src/styles/mixins/_animations.scss
@@ -12,6 +12,10 @@
     animation-iteration-count: infinite;
 }
 
+@mixin requires-user-attention {
+    animation: glow 0.75s infinite alternate;
+}
+
 @mixin rotate {
     animation: rotation 2s infinite linear;
 }

--- a/static/templates/actors/character/tabs/general.hbs
+++ b/static/templates/actors/character/tabs/general.hbs
@@ -69,7 +69,9 @@
     </section>
 
     <h3 class="header">{{localize "PF2E.Actor.Creature.AttributeModifiers"}}
-        <button type="button" data-action="edit-attribute-modifiers"><i class="fa-solid fa-fw fa-edit"></i>{{localize "PF2E.Edit"}}</button>
+        <button type="button"{{#unless attributeBoostsAllocated}} class="has-unallocated"{{/unless}} data-action="edit-attribute-boosts">
+            <i class="fa-solid fa-fw fa-edit"></i>{{localize "PF2E.Edit"}}
+        </button>
     </h3>
     <section class="character-attributes">
         {{> "systems/pf2e/templates/actors/character/partials/attributes.hbs"}}


### PR DESCRIPTION
Shows the animated glowy thing like in the boost manager:
![image](https://github.com/foundryvtt/pf2e/assets/106829671/b08885aa-5c45-46c5-b74a-184a698e3753)
