### PR TITLE
Include spellcasting roll options in damage rolls

### DIFF
--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -579,6 +579,12 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
             options.add(trait);
         }
 
+        // Include spellcasting roll options (if available)
+        const spellcastingOptions = this.spellcasting?.getRollOptions?.("spellcasting") ?? [];
+        for (const option of spellcastingOptions) {
+            options.add(option);
+        }
+
         return super.getRollOptions(prefix).concat([...options]);
     }
 

--- a/src/module/item/spellcasting-entry/types.ts
+++ b/src/module/item/spellcasting-entry/types.ts
@@ -27,6 +27,7 @@ interface BaseSpellcastingEntry<TActor extends ActorPF2e | null = ActorPF2e | nu
     system?: SpellcastingEntrySystemData;
 
     getSheetData(): Promise<SpellcastingSheetData>;
+    getRollOptions?(prefix: "spellcasting"): string[];
 
     canCast(spell: SpellPF2e, options?: { origin?: PhysicalItemPF2e }): boolean;
 


### PR DESCRIPTION
They were already there for the statistic itself (and therefore attack rolls), but they weren't there for damage rolls.