### PR TITLE
Add formula reevaluation on turn end

### DIFF
--- a/packs/feat-effects/effect-ancestral-influence.json
+++ b/packs/feat-effects/effect-ancestral-influence.json
@@ -11,7 +11,7 @@
                 "Spellcaster",
                 "Choice"
             ],
-            "reevaluate": "turn-start",
+            "reevaluate": "turn-end",
             "type": "formula",
             "value": "1d4"
         },

--- a/src/module/encounter/combatant.ts
+++ b/src/module/encounter/combatant.ts
@@ -116,13 +116,14 @@ class CombatantPF2e<
         if (Object.keys(actorUpdates).length > 0) {
             await actor.update(actorUpdates);
         }
+
+        // Effect changes on turn start/end
         for (const effect of actor.itemTypes.effect) {
-            await effect.onTurnStart();
+            await effect.onTurnStartEnd("start");
         }
-        // Don't forget about the little buddy
         if (actor.isOfType("character") && actor.familiar) {
             for (const effect of actor.familiar.itemTypes.effect) {
-                await effect.onTurnStart();
+                await effect.onTurnStartEnd("start");
             }
         }
 
@@ -138,6 +139,16 @@ class CombatantPF2e<
         const activeConditions = actor.conditions.active;
         for (const condition of activeConditions) {
             await condition.onEndTurn({ token: this.token });
+        }
+
+        // Effect changes on turn start/end
+        for (const effect of actor.itemTypes.effect) {
+            await effect.onTurnStartEnd("end");
+        }
+        if (actor.isOfType("character") && actor.familiar) {
+            for (const effect of actor.familiar.itemTypes.effect) {
+                await effect.onTurnStartEnd("end");
+            }
         }
 
         await this.update({ "flags.pf2e.roundOfLastTurnEnd": round });

--- a/src/module/item/abstract-effect/data.ts
+++ b/src/module/item/abstract-effect/data.ts
@@ -44,7 +44,7 @@ type EffectTrait = ActionTrait | SpellTrait;
 interface EffectBadgeValueSource extends EffectBadgeBaseSource {
     type: "value";
     value: number;
-    reevaluate?: { formula: string; event: "turn-start" } | null;
+    reevaluate?: { formula: string; event: "turn-start" | "turn-end" } | null;
 }
 
 interface EffectBadgeValue extends EffectBadgeValueSource, EffectBadgeBase {
@@ -55,7 +55,7 @@ interface EffectBadgeFormulaSource extends EffectBadgeBaseSource {
     type: "formula";
     value: string;
     evaluate?: boolean;
-    reevaluate?: "turn-start" | null;
+    reevaluate?: "turn-start" | "turn-end" | null;
 }
 
 interface EffectBadgeFormula extends EffectBadgeFormulaSource, EffectBadgeBase {}

--- a/src/module/item/effect/document.ts
+++ b/src/module/item/effect/document.ts
@@ -150,7 +150,7 @@ class EffectPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ab
         if (!actor) throw ErrorPF2e("A formula badge can only be evaluated if part of an embedded effect");
 
         const roll = await new Roll(badge.value, this.getRollData()).evaluate({ async: true });
-        const reevaluate = badge.reevaluate ? ({ formula: badge.value, event: "turn-start" } as const) : null;
+        const reevaluate = badge.reevaluate ? { formula: badge.value, event: badge.reevaluate } : null;
         const token = actor.getActiveTokens(false, true).shift();
         const speaker = ChatMessagePF2e.getSpeaker({ actor, token });
         roll.toMessage({ flavor: reduceItemName(this.name), speaker });
@@ -229,9 +229,10 @@ class EffectPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ab
     }
 
     /** If applicable, reevaluate this effect's badge */
-    async onTurnStart(): Promise<void> {
+    async onTurnStartEnd(event: "start" | "end"): Promise<void> {
         const { badge } = this;
-        if (badge?.type === "value" && badge.reevaluate) {
+
+        if (badge?.type === "value" && badge.reevaluate?.event === `turn-${event}`) {
             const newBadge = await this.evaluateFormulaBadge({
                 type: "formula",
                 value: badge.reevaluate.formula,

--- a/src/module/item/effect/sheet.ts
+++ b/src/module/item/effect/sheet.ts
@@ -64,11 +64,17 @@ export class EffectSheetPF2e extends ItemSheetPF2e<EffectPF2e> {
     }
 
     protected override async _updateObject(event: Event, formData: Record<string, unknown>): Promise<void> {
-        // Ensure badge labels remain an array
-        const expanded = expandObject(formData) as DeepPartial<EffectSource>;
+        const expanded = expandObject<DeepPartial<EffectSource>>(formData);
         const badge = expanded.system?.badge;
-        if (badge && "labels" in badge && typeof badge.labels === "object") {
-            badge.labels = Object.values(badge.labels);
+        if (badge) {
+            // Ensure badge labels remain an array
+            if ("labels" in badge && typeof badge.labels === "object") {
+                badge.labels = Object.values(badge.labels);
+            }
+            // Null out empty-string `badge.reevaluate`
+            if ("reevaluate" in badge) {
+                badge.reevaluate ||= null;
+            }
         }
 
         super._updateObject(event, flattenObject(expanded));

--- a/src/styles/item/_effect-sheet.scss
+++ b/src/styles/item/_effect-sheet.scss
@@ -1,10 +1,10 @@
-.sheet-sidebar .inventory-details .form-group.duration {
-    label {
+.sheet-content .sheet-sidebar .inventory-details .form-group {
+    select {
         max-width: fit-content;
-        padding-right: 0.1em;
     }
 
-    select {
-        max-width: 10em;
+     .form-group.duration label {
+        max-width: fit-content;
+        padding-right: 0.1em;
     }
 }

--- a/src/styles/item/_sidebar.scss
+++ b/src/styles/item/_sidebar.scss
@@ -1,4 +1,4 @@
-> section.sheet-sidebar {
+section.sheet-sidebar {
     flex: 0 0 220px;
     display: flex;
     flex-direction: column;

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1875,7 +1875,12 @@
                         "Hint": "The values of a badge can be given descriptive labels. They should be short enough to fit in the effects panel. Labels also serve as a natural maximum value for a badge.",
                         "Placeholder": "New Label"
                     },
-                    "ReevaluateFormula": "Reevaluate every turn?",
+                    "ReevaluateFormula": {
+                        "Label": "Reevaluate?",
+                        "Never": "Never",
+                        "TurnEnd": "On Turn End",
+                        "TurnStart": "On Turn Start"
+                    },
                     "Type": {
                         "counter": "Counter",
                         "formula": "Formula",

--- a/static/templates/items/effect-sidebar.hbs
+++ b/static/templates/items/effect-sidebar.hbs
@@ -51,9 +51,15 @@
                 </div>
             </div>
             <div class="form-group">
-                <label for="{{item.uuid}}-badge-reevaluate">{{localize "PF2E.Item.Effect.Badge.ReevaluateFormula"}}</label>
+                <label for="{{item.uuid}}-badge-reevaluate">{{localize "PF2E.Item.Effect.Badge.ReevaluateFormula.Label"}}</label>
                 <div class="form-fields">
-                    <input id="{{item.uuid}}-badge-reevaluate" type="checkbox" name="system.badge.reevaluate" value="turn-start" {{checked data.badge.reevaluate}} />
+                    <select id="{{item.uuid}}-badge-reevaluate" name="system.badge.reevaluate">
+                        {{#select data.badge.reevaluate}}
+                            <option value="">{{localize "PF2E.Item.Effect.Badge.ReevaluateFormula.Never"}}</option>
+                            <option value="turn-start">{{localize "PF2E.Item.Effect.Badge.ReevaluateFormula.TurnStart"}}</option>
+                            <option value="turn-end">{{localize "PF2E.Item.Effect.Badge.ReevaluateFormula.TurnEnd"}}</option>
+                        {{/select}}
+                    </select>
                 </div>
             </div>
         {{else}}


### PR DESCRIPTION
Oopsie'd the implementation of Ancestral Influence: it should reevaluate on turn end, not turn start.

This is going to need further expansion to handle reevaluation on rolling initiative, but that can come later.