### PR TITLE
Ensure predicates in custom modifiers are arrays

### DIFF
--- a/src/module/migration/migrations/793-make-predicates-arrays.ts
+++ b/src/module/migration/migrations/793-make-predicates-arrays.ts
@@ -1,3 +1,4 @@
+import { ActorSourcePF2e } from "@actor/data/index.ts";
 import { ItemSourcePF2e } from "@item/data/index.ts";
 import { RuleElementSource } from "@module/rules/index.ts";
 import { PredicateStatement, RawPredicate } from "@system/predication.ts";
@@ -29,6 +30,18 @@ export class Migration793MakePredicatesArrays extends MigrationBase {
                     : [],
             ].flat()
         );
+    }
+
+    /** Clear predicates in custom modifiers */
+    override async updateActor(source: ActorSourcePF2e): Promise<void> {
+        if ("customModifiers" in source.system) {
+            if (!isObject(source.system.customModifiers)) {
+                source.system.customModifiers = {};
+            }
+            for (const modifier of Object.values(source.system.customModifiers).flat()) {
+                modifier.predicate &&= [];
+            }
+        }
     }
 
     override async updateItem(source: ItemSourcePF2e): Promise<void> {


### PR DESCRIPTION
This needs to be added to a new migration, but popping it into 793 for now--where it should have been from the start.