### PR TITLE
Add way to track partial boost in manual mode

### DIFF
--- a/src/module/actor/character/attribute-builder.ts
+++ b/src/module/actor/character/attribute-builder.ts
@@ -304,7 +304,7 @@ class AttributeBuilder extends Application {
         for (const input of htmlQueryAll<HTMLInputElement>(html, "input[type=text], input[type=number]")) {
             input.addEventListener("focus", () => {
                 if (input.type === "text" && input.dataset.dtype === "Number") {
-                    input.value = input.value.replace(/[+-]/g, "");
+                    input.value = input.value.replace(/[^-.0-9]/g, "");
                     input.type = "number";
                 }
                 input.select();

--- a/src/module/actor/character/attribute-builder.ts
+++ b/src/module/actor/character/attribute-builder.ts
@@ -1,10 +1,9 @@
 import { CharacterPF2e } from "@actor";
-import { Abilities } from "@actor/creature/data.ts";
 import { AttributeString } from "@actor/types.ts";
 import { ATTRIBUTE_ABBREVIATIONS } from "@actor/values.ts";
 import { AncestryPF2e, BackgroundPF2e, ClassPF2e } from "@item";
 import { maintainFocusInRender } from "@module/sheet/helpers.ts";
-import { ErrorPF2e, htmlClosest, htmlQuery, htmlQueryAll, setHasElement, signedInteger, tupleHasValue } from "@util";
+import { ErrorPF2e, addSign, htmlClosest, htmlQuery, htmlQueryAll, setHasElement, tupleHasValue } from "@util";
 import * as R from "remeda";
 
 class AttributeBuilder extends Application {
@@ -46,8 +45,15 @@ class AttributeBuilder extends Application {
             ancestry: actor.ancestry,
             background: actor.background,
             class: actor.class,
-            attributeModifiers: actor.abilities,
-            manualKeyAbility: actor.keyAttribute,
+            attributeModifiers: R.mapValues(actor.abilities, (value, attribute) => {
+                // Allow decimal values in manual mode (to track partial boosts)
+                const mod = build.manual ? actor._source.system.abilities?.[attribute].mod ?? 0 : value.base;
+                return {
+                    mod: addSign(Number(mod.toFixed(1))),
+                    label: CONFIG.PF2E.abilities[attribute],
+                };
+            }),
+            manualKeyAttribute: actor.keyAttribute,
             keyOptions: build.keyOptions,
             ...this.#calculateAncestryBoosts(),
             backgroundBoosts: this.#calculateBackgroundBoosts(),
@@ -294,10 +300,11 @@ class AttributeBuilder extends Application {
 
         $html.find("div.tooltip").tooltipster();
 
+        // Input handling for manual attribute score entry
         for (const input of htmlQueryAll<HTMLInputElement>(html, "input[type=text], input[type=number]")) {
             input.addEventListener("focus", () => {
                 if (input.type === "text" && input.dataset.dtype === "Number") {
-                    input.value = input.value.replace(/\D/g, "");
+                    input.value = input.value.replace(/[+-]/g, "");
                     input.type = "number";
                 }
                 input.select();
@@ -306,8 +313,8 @@ class AttributeBuilder extends Application {
             input.addEventListener("blur", () => {
                 if (input.type === "number" && input.dataset.dtype === "Number") {
                     input.type = "text";
-                    const newValue = Math.trunc(Math.clamped(Number(input.value) || 0, -5, 10));
-                    input.value = signedInteger(newValue);
+                    const newValue = Math.clamped(Number(input.value) || 0, -5, 10);
+                    input.value = addSign(newValue);
 
                     const propertyPath = input.dataset.property;
                     if (!propertyPath) throw ErrorPF2e("Empty property path");
@@ -499,8 +506,8 @@ class AttributeBuilder extends Application {
 
 interface AttributeBuilderSheetData {
     actor: CharacterPF2e;
-    attributeModifiers: Abilities;
-    manualKeyAbility: AttributeString;
+    attributeModifiers: Record<AttributeString, { label: string; mod: string }>;
+    manualKeyAttribute: AttributeString;
     attributes: Record<AttributeString, string>;
     ancestry: AncestryPF2e<CharacterPF2e> | null;
     background: BackgroundPF2e<CharacterPF2e> | null;

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -150,7 +150,6 @@
                     "Complete": "Complete",
                     "Flaw": "Flaw",
                     "Flaws": "Flaws",
-                    "HasPartial": "Has Partial Boost",
                     "Increase": "Increase",
                     "KeyIcon": "Key",
                     "LegacyFlaws": "Legacy Flaws",

--- a/static/templates/actors/character/attribute-builder.hbs
+++ b/static/templates/actors/character/attribute-builder.hbs
@@ -198,7 +198,7 @@
             </div>
             <div class="attributes">
                 {{#each attributeModifiers as |attribute key|}}
-                    <div class="row-column"{{#if attribute.partial}} title="{{localize "PF2E.Actor.Character.AttributeBuilder.HasPartial"}}"{{/if}}>
+                    <div class="row-column">
                         {{#if ../manual}}
                             <button type="button" data-action="class-key-attribute" data-key="{{lookup ../attributes key}}" data-attribute="{{key}}"
                                 class="boost{{#if (eq ../manualKeyAttribute key)}} selected{{/if}}"
@@ -207,12 +207,12 @@
                                 <i class="fa-solid fa-fw fa-key"></i>
                                 <span>{{localize "PF2E.Actor.Character.AttributeBuilder.KeyIcon"}}</span>
                             </button>
-                            <input type="text" data-property="system.abilities.{{key}}.mod" name="system.abilities.{{key}}.mod" value="{{numberFormat attribute.base sign=true}}" data-dtype="Number" placeholder="0">
+                            <input type="text" data-property="system.abilities.{{key}}.mod" name="system.abilities.{{key}}.mod" value="{{attribute.mod}}" data-dtype="Number" placeholder="0" step="0.5">
                         {{else}}
                             <button type="button" class="boost hidden"></button>
-                            <div class="value">{{numberFormat attribute.base sign=true}}{{#if attribute.partial}}*{{/if}}</div>
+                            <div class="value">{{attribute.mod}}</div>
                         {{/if}}
-                        <h4>{{localize (lookup ../attributes key)}}</h4>
+                        <h4>{{localize attribute.label}}</h4>
                     </div>
                 {{/each}}
                 <button class="complete" type="button" data-action="close">{{localize "PF2E.Actor.Character.AttributeBuilder.Complete"}}</button>


### PR DESCRIPTION
I noticed this when poking around, but its not possible to use manual ability boosts right now in any reasonable way without tracking your boosts elsewhere. This rectifies that.

This also fixes a bug where selected key score wasn't selected in manual.

![image](https://github.com/foundryvtt/pf2e/assets/1286721/b5197152-c1dd-4a81-a4c6-97f8dd070035)