### PR TITLE
Wait for adjustCarryType to complete before considering execute complete

### DIFF
--- a/src/module/actor/character/helpers.ts
+++ b/src/module/actor/character/helpers.ts
@@ -167,7 +167,6 @@ class WeaponAuxiliaryAction {
 
     async execute({ selection = null }: { selection?: string | null } = {}): Promise<void> {
         const { actor, weapon } = this;
-
         if (typeof this.carryType === "string") {
             await actor.adjustCarryType(this.weapon, { carryType: this.carryType, handsHeld: this.hands ?? 0 });
         } else if (selection && tupleHasValue(weapon.system.traits.toggles.modular.options, selection)) {

--- a/src/module/actor/character/helpers.ts
+++ b/src/module/actor/character/helpers.ts
@@ -168,9 +168,8 @@ class WeaponAuxiliaryAction {
     async execute({ selection = null }: { selection?: string | null } = {}): Promise<void> {
         const { actor, weapon } = this;
 
-        let update: Promise<void> | undefined;
         if (typeof this.carryType === "string") {
-            update = actor.adjustCarryType(this.weapon, { carryType: this.carryType, handsHeld: this.hands ?? 0 });
+            await actor.adjustCarryType(this.weapon, { carryType: this.carryType, handsHeld: this.hands ?? 0 });
         } else if (selection && tupleHasValue(weapon.system.traits.toggles.modular.options, selection)) {
             const updated = await toggleWeaponTrait({ weapon, trait: "modular", selection });
             if (!updated) return;
@@ -216,10 +215,6 @@ class WeaponAuxiliaryAction {
             flavor,
             type: CONST.CHAT_MESSAGE_TYPES.EMOTE,
         });
-
-        if (update) {
-            await update;
-        }
     }
 }
 

--- a/src/module/actor/character/helpers.ts
+++ b/src/module/actor/character/helpers.ts
@@ -167,8 +167,10 @@ class WeaponAuxiliaryAction {
 
     async execute({ selection = null }: { selection?: string | null } = {}): Promise<void> {
         const { actor, weapon } = this;
+
+        let update: Promise<void> | undefined;
         if (typeof this.carryType === "string") {
-            actor.adjustCarryType(this.weapon, { carryType: this.carryType, handsHeld: this.hands ?? 0 });
+            update = actor.adjustCarryType(this.weapon, { carryType: this.carryType, handsHeld: this.hands ?? 0 });
         } else if (selection && tupleHasValue(weapon.system.traits.toggles.modular.options, selection)) {
             const updated = await toggleWeaponTrait({ weapon, trait: "modular", selection });
             if (!updated) return;
@@ -214,6 +216,10 @@ class WeaponAuxiliaryAction {
             flavor,
             type: CONST.CHAT_MESSAGE_TYPES.EMOTE,
         });
+
+        if (update) {
+            await update;
+        }
     }
 }
 


### PR DESCRIPTION
`WeaponAuxiliaryAction.execute` calls `Actor.adjustCarryType` (which is async) but doesn't wait for it to complete. This means that if we call `WeaponAuxiliaryAction.execute` programmatically, even with an `await`, then `Actor.adjustCarryType` will not have completed by the time `execute`'s returned Promise is resolved, and there is no way to determine when the `adjustCarryType` operation has actually completed.

This change makes `WeaponAuxiliaryAction.execute` await the completion of `Actor.adjustCarryType` before continuing.