### PR TITLE
Brushup automation for Swashbuckler finishers

### DIFF
--- a/packs/classfeatures/precise-strike.json
+++ b/packs/classfeatures/precise-strike.json
@@ -29,8 +29,84 @@
                 "disabledValue": false,
                 "domain": "all",
                 "key": "RollOption",
-                "label": "PF2E.SpecificRule.PreciseStrike.Finisher",
+                "label": "PF2E.SpecificRule.Swashbuckler.Finisher.Label",
                 "option": "finisher",
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Swashbuckler.Finisher.Basic",
+                        "value": "basic"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Swashbuckler.Finisher.Bleeding",
+                        "predicate": [
+                            "feat:bleeding-finisher"
+                        ],
+                        "value": "bleeding"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Swashbuckler.Finisher.Confident",
+                        "predicate": [
+                            "feature:confident-finisher"
+                        ],
+                        "value": "confident"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Swashbuckler.Finisher.Dual",
+                        "predicate": [
+                            "feat:dual-finisher"
+                        ],
+                        "value": "dual"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Swashbuckler.Finisher.Impaling",
+                        "predicate": [
+                            "feat:impaling-finisher"
+                        ],
+                        "value": "impaling"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Swashbuckler.Finisher.Lethal",
+                        "predicate": [
+                            "feat:lethal-finisher"
+                        ],
+                        "value": "lethal"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Swashbuckler.Finisher.Mobile",
+                        "predicate": [
+                            "feat:mobile-finisher"
+                        ],
+                        "value": "mobile"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Swashbuckler.Finisher.Perfect",
+                        "predicate": [
+                            "feat:perfect-finisher"
+                        ],
+                        "value": "perfect"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Swashbuckler.Finisher.Stunning",
+                        "predicate": [
+                            "feat:stunning-finisher"
+                        ],
+                        "value": "stunning"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Swashbuckler.Finisher.Targeting",
+                        "predicate": [
+                            "feat:targeting-finisher"
+                        ],
+                        "value": "targeting"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Swashbuckler.Finisher.Unbalancing",
+                        "predicate": [
+                            "feat:unbalancing-finisher"
+                        ],
+                        "value": "unbalancing"
+                    }
+                ],
                 "toggleable": true
             },
             {

--- a/packs/feats/lethal-finisher.json
+++ b/packs/feats/lethal-finisher.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>You stab your foe in a vital organ, possibly killing them outright. Make a Strike. On a success, you forego your precise strike damage from the finisher.</p>\n<p>Instead, your target takes additional precision damage based on a Fortitude save against your class DC. If your Strike was a critical hit, the target's saving throw outcome is one degree worse.</p>\n<hr />\n<p><strong>Critical Success</strong> You deal 6 precision damage.</p>\n<p><strong>Success</strong> You deal 6d6 precision damage.</p>\n<p><strong>Failure</strong> You deal 12d6 precision damage.</p>\n<p><strong>Critical Failure</strong> You deal 18d6 precision damage.</p>"
+            "value": "<p>You stab your foe in a vital organ, possibly killing them outright. Make a Strike. On a success, you forego your precise strike damage from the finisher.</p>\n<p>Instead, your target takes additional precision damage based on a @Check[type:fortitude|dc:resolve(@actor.system.proficiencies.classDCs.swashbuckler.dc)] save against your class DC. If your Strike was a critical hit, the target's saving throw outcome is one degree worse.</p>\n<hr />\n<p><strong>Critical Success</strong> You deal 6 precision damage.</p>\n<p><strong>Success</strong> You deal 6d6 precision damage.</p>\n<p><strong>Failure</strong> You deal 12d6 precision damage.</p>\n<p><strong>Critical Failure</strong> You deal 18d6 precision damage.</p>"
         },
         "level": {
             "value": 18
@@ -23,7 +23,17 @@
                 }
             ]
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "Note",
+                "predicate": [
+                    "finisher:lethal"
+                ],
+                "selector": "strike-attack-roll",
+                "text": "{item|system.description.value}",
+                "title": "{item|name}"
+            }
+        ],
         "source": {
             "value": "Pathfinder Advanced Player's Guide"
         },

--- a/packs/feats/perfect-finisher.json
+++ b/packs/feats/perfect-finisher.json
@@ -19,7 +19,17 @@
         "prerequisites": {
             "value": []
         },
-        "rules": [],
+        "rules": [
+            {
+                "keep": "higher",
+                "key": "RollTwice",
+                "predicate": [
+                    "finisher:perfect"
+                ],
+                "removeAfterRoll": false,
+                "selector": "strike-attack-roll"
+            }
+        ],
         "source": {
             "value": "Pathfinder Advanced Player's Guide"
         },

--- a/packs/feats/stunning-finisher.json
+++ b/packs/feats/stunning-finisher.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>You attempt a dizzying blow. Make a melee Strike. If you hit, your foe must attempt a Fortitude save against your class DC with the following results; the save has the incapacitation trait.</p>\n<hr />\n<p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target can't use reactions until its next turn.</p>\n<p><strong>Failure</strong> The target is @UUID[Compendium.pf2e.conditionitems.Item.Stunned]{Stunned 1}.</p>\n<p><strong>Critical Failure</strong> The target is @UUID[Compendium.pf2e.conditionitems.Item.Stunned]{Stunned 3}.</p>"
+            "value": "<p>You attempt a dizzying blow. Make a melee Strike. If you hit, your foe must attempt a @Check[type:fortitude|dc:resolve(@actor.system.proficiencies.classDCs.swashbuckler.dc)|traits:incapacitation] save against your class DC with the following results; the save has the incapacitation trait.</p>\n<hr />\n<p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target can't use reactions until its next turn.</p>\n<p><strong>Failure</strong> The target is @UUID[Compendium.pf2e.conditionitems.Item.Stunned]{Stunned 1}.</p>\n<p><strong>Critical Failure</strong> The target is @UUID[Compendium.pf2e.conditionitems.Item.Stunned]{Stunned 3}.</p>"
         },
         "level": {
             "value": 8
@@ -19,7 +19,17 @@
         "prerequisites": {
             "value": []
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "Note",
+                "predicate": [
+                    "finisher:lethal"
+                ],
+                "selector": "strike-damage",
+                "text": "{item|system.description.value}",
+                "title": "{item|name}"
+            }
+        ],
         "source": {
             "value": "Pathfinder Advanced Player's Guide"
         },

--- a/packs/feats/targeting-finisher.json
+++ b/packs/feats/targeting-finisher.json
@@ -19,7 +19,17 @@
         "prerequisites": {
             "value": []
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "Note",
+                "predicate": [
+                    "finisher:targeting"
+                ],
+                "selector": "strike-damage",
+                "text": "{item|system.description.value}",
+                "title": "{item|name}"
+            }
+        ],
         "source": {
             "value": "Pathfinder Advanced Player's Guide"
         },

--- a/packs/feats/unbalancing-finisher.json
+++ b/packs/feats/unbalancing-finisher.json
@@ -19,7 +19,17 @@
         "prerequisites": {
             "value": []
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "Note",
+                "predicate": [
+                    "finisher:unbalancing"
+                ],
+                "selector": "strike-damage",
+                "text": "{item|system.description.value}",
+                "title": "{item|name}"
+            }
+        ],
         "source": {
             "value": "Pathfinder Advanced Player's Guide"
         },

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2553,6 +2553,20 @@
                 }
             },
             "Swashbuckler": {
+                "Finisher": {
+                    "Basic": "Basic",
+                    "Bleeding": "Bleeding",
+                    "Confident": "Confident",
+                    "Dual": "Dual",
+                    "Impaling": "Impaling",
+                    "Label": "Finisher",
+                    "Lethal": "Lethal",
+                    "Mobile": "Mobile",
+                    "Perfect": "Perfect",
+                    "Stunning": "Stunning",
+                    "Targeting": "Targeting",
+                    "Unbalancing": "Unbalancing"
+                },
                 "Panache": "You gain @UUID[Compendium.pf2e.feat-effects.Item.uBJsxCzNhje8m8jj]{Panache}.",
                 "Style": {
                     "Prompt": "Select a style."


### PR DESCRIPTION
Some rough edges still, bleeding finisher should be doable now but needs to dance around those rare level 16 multiclass swashbucklers maybe. That can be done as a follow up. Lethal finisher is going to be a problem, it's extra damage that depends on the target's save result which could be done through a toggle like this

```json
{
    "domain": "all",
    "key": "RollOption",
    "label": "PF2E.SpecificRule.Prompt.DegreeOfSuccessTarget",
    "option": "finisher:fatal:dice",
    "suboptions": [
        {
            "label": "PF2E.Check.Result.Degree.CheckcriticalSuccess",
            "value": "0"
        }, {
            "label": "PF2E.Check.Result.Degree.Checksuccess",
            "value": "6"
        }, {
            "label": "PF2E.Check.Result.Degree.Checkfailure",
            "value": "12"
        }, {
            "label": "PF2E.Check.Result.Degree.CheckcriticalFailure",
            "value": "18"
        }
    ],
    "toggleable": true,
    "disabledIf":[{"not":"finisher:lethal"}],
    "disabledValue":false
}
```

But the issue is that while the number of dice could be read in those dice don't double on a crit. Since it's precision damage we don't have a great way to do it inline. In theory we could do it with one note for each physical damage type and predicate on the strike being that damage type. But then we're missing some weird homebrew sword dealing mental damage or whatnot.