### PR TITLE
Implement kingdom invested roles and Experienced Leadership

### DIFF
--- a/packs/kingmaker-features/kingdom-features/experienced-leadership.json
+++ b/packs/kingmaker-features/kingdom-features/experienced-leadership.json
@@ -22,7 +22,30 @@
         "prerequisites": {
             "value": []
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "AdjustModifier",
+                "mode": "upgrade",
+                "selector": "kingdom-check",
+                "slug": "invested",
+                "value": 2
+            },
+            {
+                "key": "AdjustModifier",
+                "mode": "upgrade",
+                "predicate": [
+                    {
+                        "gte": [
+                            "self:level",
+                            16
+                        ]
+                    }
+                ],
+                "selector": "kingdom-check",
+                "slug": "invested",
+                "value": 3
+            }
+        ],
         "source": {
             "value": "Pathfinder Kingmaker"
         },

--- a/src/module/actor/party/document.ts
+++ b/src/module/actor/party/document.ts
@@ -125,6 +125,7 @@ class PartyPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
         const travelSpeed = Math.min(...this.members.map((m) => m.attributes.speed.total));
         this.attributes.speed = { total: travelSpeed };
 
+        this.prepareSynthetics();
         this.campaign?.prepareDerivedData?.();
     }
 

--- a/src/module/actor/party/kingdom/sheet.ts
+++ b/src/module/actor/party/kingdom/sheet.ts
@@ -31,6 +31,7 @@ import {
     KINGDOM_ABILITY_LABELS,
     KINGDOM_COMMODITIES,
     KINGDOM_LEADERSHIP,
+    KINGDOM_LEADERSHIP_ABILITIES,
     KINGDOM_RUIN_LABELS,
 } from "./values.ts";
 
@@ -132,11 +133,16 @@ class KingdomSheetPF2e extends ActorSheetPF2e<PartyPF2e> {
             },
             leadership: KINGDOM_LEADERSHIP.map((slug) => {
                 const data = this.kingdom.leadership[slug];
-                const label = game.i18n.localize(`PF2E.Kingmaker.Kingdom.LeadershipRole.${slug}`);
                 const document = fromUuidSync(data.uuid ?? "");
                 const actor = document instanceof ActorPF2e ? document : null;
-                const img = actor?.prototypeToken.texture.src ?? actor?.img ?? ActorPF2e.DEFAULT_ICON;
-                return { ...data, actor, img, slug, label };
+                return {
+                    ...data,
+                    slug,
+                    label: game.i18n.localize(`PF2E.Kingmaker.Kingdom.LeadershipRole.${slug}`),
+                    actor,
+                    img: actor?.prototypeToken.texture.src ?? actor?.img ?? ActorPF2e.DEFAULT_ICON,
+                    abilityLabel: game.i18n.localize(KINGDOM_ABILITY_LABELS[KINGDOM_LEADERSHIP_ABILITIES[slug]]),
+                };
             }),
             actions: R.sortBy(kingdom.activities, (a) => a.name).map((item) => ({
                 item,
@@ -390,11 +396,19 @@ interface KingdomSheetData extends ActorSheetDataPF2e<PartyPF2e> {
     })[];
     commodities: CommoditySheetData[];
     resourceDice: KingdomData["resources"]["dice"] & { icon: string };
-    leadership: (KingdomLeadershipData & { actor: ActorPF2e | null; img: string; slug: string; label: string })[];
+    leadership: LeaderSheetData[];
     actions: { item: CampaignFeaturePF2e; traits: SheetOptions }[];
     skills: Statistic[];
     feats: FeatGroup<PartyPF2e, CampaignFeaturePF2e>[];
     actionFilterChoices: SheetOptions;
+}
+
+interface LeaderSheetData extends KingdomLeadershipData {
+    actor: ActorPF2e | null;
+    img: string;
+    slug: string;
+    label: string;
+    abilityLabel: string;
 }
 
 interface CommoditySheetData extends ValueAndMax {

--- a/src/module/actor/party/kingdom/values.ts
+++ b/src/module/actor/party/kingdom/values.ts
@@ -32,6 +32,17 @@ const KINGDOM_LEADERSHIP = [
     "warden",
 ] as const;
 
+const KINGDOM_LEADERSHIP_ABILITIES: Record<KingdomLeadershipRole, KingdomAbility> = {
+    ruler: "loyalty",
+    counselor: "culture",
+    general: "stability",
+    emissary: "loyalty",
+    magister: "culture",
+    treasurer: "economy",
+    viceroy: "economy",
+    warden: "stability",
+};
+
 const KINGDOM_COMMODITIES = ["food", "luxuries", "lumber", "ore", "stone"] as const;
 
 const KINGDOM_SKILLS = [
@@ -282,6 +293,7 @@ export {
     KINGDOM_SKILL_ABILITIES,
     KINGDOM_SKILL_LABELS,
     KINGDOM_LEADERSHIP,
+    KINGDOM_LEADERSHIP_ABILITIES,
     KINGDOM_RUIN_LABELS,
     VACANCY_PENALTIES,
     getKingdomABCData,

--- a/src/styles/actor/party/kingdom/_main.scss
+++ b/src/styles/actor/party/kingdom/_main.scss
@@ -23,7 +23,7 @@ input[type="text"], input[type="number"] {
             "img label";
         grid-template-columns: auto 1fr;
         grid-template-rows: 1fr auto;
-        margin-bottom: 4px;
+        margin-bottom: 6px;
 
         img {
             @include frame-icon;
@@ -41,6 +41,9 @@ input[type="text"], input[type="number"] {
             line-height: 1.5em;
             height: 1.5em;
             align-self: end;
+
+            display: flex;
+            justify-content: space-between;
         }
         .details {
             grid-area: label;
@@ -63,7 +66,7 @@ input[type="text"], input[type="number"] {
                 font-weight: 500;
             }
         }
-        .vacant {
+        .invested, .vacant {
             input {
                 margin: 0;
                 width: 1em;

--- a/static/lang/kingmaker-en.json
+++ b/static/lang/kingmaker-en.json
@@ -57,6 +57,8 @@
                 "stone": "Stone"
             },
             "ControlDC": "Control DC",
+            "Invested": "Invested",
+            "InvestedBonus": "Status Bonus to {ability}",
             "ImportDialog": {
                 "Title": "Import Activities",
                 "Content": "{added} activities will be added and {updated} activities will be updated: is this ok?"

--- a/static/templates/actors/party/kingdom/main.hbs
+++ b/static/templates/actors/party/kingdom/main.hbs
@@ -6,8 +6,16 @@
                 <img src="{{leader.img}}"/>
                 <div class="name">
                     {{#if leader.actor}}
-                        {{leader.actor.name}}
-                        <a data-action="remove-leader"><i class="fa-solid fa-times"></i></a>
+                        <span>
+                            {{leader.actor.name}}
+                            {{#if @root.options.editable}}
+                                <a data-action="remove-leader"><i class="fa-solid fa-times"></i></a>
+                            {{/if}}
+                        </span>
+                        <label class="invested" title="{{localize "PF2E.Kingmaker.Kingdom.InvestedBonus" ability=leader.abilityLabel}}">
+                            <input type="checkbox" name="leadership.{{leader.slug}}.invested" {{checked leader.invested}} />
+                            <span>{{localize "PF2E.Kingmaker.Kingdom.Invested"}}</span>
+                        </label>
                     {{else}}
                         {{localize "PF2E.Kingmaker.Kingdom.LeaderMissing"}}
                     {{/if}}
@@ -16,7 +24,7 @@
                     <span class="role">{{label}}</span>
                     {{#if leader.actor.hasPlayerOwner}}
                         <label class="vacant">
-                            <input type="checkbox" name="leadership.{{leader.slug}}.vacant" {{checked leader.vacant}}>
+                            <input type="checkbox" name="leadership.{{leader.slug}}.vacant" {{checked leader.vacant}} />
                             <span>{{localize "PF2E.Kingmaker.Kingdom.Vacant"}}</span>
                             <i class="fas fa-info-circle"></i>
                         </label>


### PR DESCRIPTION
For some reason, statistic.modifiers doesn't get modifier adjustments applied, but statistic.check.modifiers does. This means that the modifiers tooltip is not showing correct values. That doesn't seem to be a kingdom bug though, and more of a Statistic one.