### PR TITLE
Prevent action macros from creating duplicate h4 elements

### DIFF
--- a/src/module/system/check/check.ts
+++ b/src/module/system/check/check.ts
@@ -210,10 +210,15 @@ class CheckPF2e {
         const flavor = await (async (): Promise<string> => {
             const result = await this.#createResultFlavor({ degree, target: context.target ?? null });
             const tags = this.#createTagFlavor({ check, context, extraTags });
+            const header = check.slug.startsWith("<h4")
+                ? check.slug
+                : ((): HTMLElement => {
+                      const h4 = document.createElement("h4");
+                      h4.classList.add("action");
+                      h4.innerHTML = check.slug;
+                      return h4;
+                  })();
 
-            const header = document.createElement("h4");
-            header.classList.add("action");
-            header.innerHTML = check.slug;
             return [header, result ?? [], tags, notesText]
                 .flat()
                 .map((e) => (typeof e === "string" ? e : e.outerHTML))


### PR DESCRIPTION
Temporary measure until the macros can be further-gutted