### PR TITLE
Fill out check data to be usable by damaging actions

### DIFF
--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -1217,7 +1217,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
 
         const unarmedOrWeapon = weapon.category === "unarmed" ? "unarmed" : "weapon";
         const meleeOrRanged = weapon.isMelee ? "melee" : "ranged";
-        const slug = weapon.slug ?? sluggify(weapon.name);
+        const weaponSlug = weapon.slug ?? sluggify(weapon.name);
 
         const weaponSpecificSelectors = [
             weapon.baseType ? `${weapon.baseType}-base-attack-roll` : [],
@@ -1228,8 +1228,8 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
         const baseSelectors = [
             ...weaponSpecificSelectors,
             `${weapon.id}-attack`,
-            `${slug}-attack`,
-            `${slug}-attack-roll`,
+            `${weaponSlug}-attack`,
+            `${weaponSlug}-attack-roll`,
             `${unarmedOrWeapon}-attack-roll`,
             `${meleeOrRanged}-attack-roll`,
             "strike-attack-roll",
@@ -1403,7 +1403,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
 
         const flavor = this.getStrikeDescription(weapon);
         const rollOptions = [...this.getRollOptions(selectors), ...weaponRollOptions, ...weaponTraits, meleeOrRanged];
-        const strikeStat = new StatisticModifier(slug, modifiers, rollOptions);
+        const strikeStat = new StatisticModifier(weaponSlug, modifiers, rollOptions);
         const altUsages = weapon.getAltUsages().map((w) => this.prepareStrike(w, { categories }));
         const versatileLabel = (damageType: DamageType): string => {
             switch (damageType) {
@@ -1435,7 +1435,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
             item: weapon,
             type: "strike" as const,
             ...flavor,
-            options: weapon.system.options?.value ?? [],
+            options: R.compact([weapon.system.options?.value, "action:strike", "self:action:slug:strike"].flat()),
             traits: [],
             weaponTraits: Array.from(weaponTraits)
                 .map((t) => traitSlugToObject(t, CONFIG.PF2E.npcAttackTraits))
@@ -1579,6 +1579,8 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
 
                 const checkContext: CheckRollContext = {
                     type: "attack-roll",
+                    identifier: `${weapon.id}.${weaponSlug}.${meleeOrRanged}`,
+                    action: "strike",
                     actor: context.self.actor,
                     token: context.self.token,
                     target: context.target,

--- a/src/module/actor/helpers.ts
+++ b/src/module/actor/helpers.ts
@@ -389,6 +389,8 @@ function strikeFromMeleeItem(item: MeleePF2e<ActorPF2e>): NPCStrike {
                 new CheckModifier(checkName, context.self.statistic ?? strike, otherModifiers),
                 {
                     type: "attack-roll",
+                    identifier: item.id,
+                    action: "strike",
                     actor: context.self.actor,
                     token: context.self.token,
                     item: context.self.item,

--- a/src/module/chat-message/document.ts
+++ b/src/module/chat-message/document.ts
@@ -23,13 +23,6 @@ class ChatMessagePF2e extends ChatMessage {
             pf2e: {},
         });
         super(data, context);
-
-        // Backward compatibility for roll messages prior to `rollerId` (user ID) being stored with the roll
-        for (const roll of this.rolls) {
-            if (roll instanceof CheckRoll) {
-                roll.roller ??= this.user ?? null;
-            }
-        }
     }
 
     /** Is this a damage (or a manually-inputed non-D20) roll? */

--- a/src/module/system/check/check.ts
+++ b/src/module/system/check/check.ts
@@ -155,10 +155,16 @@ class CheckPF2e {
             return null;
         })();
 
+        const actionSlug = context.action ? sluggify(context.action) || null : null;
+
         const options: CheckRollDataPF2e = {
+            type: context.type,
+            identifier: context.identifier,
+            action: actionSlug,
             rollerId: game.userId,
             isReroll,
             totalModifier: check.totalModifier,
+            damaging: strike?.damaging ?? context.damaging ?? false,
             domains: context.domains,
         };
         if (strike) options.strike = strike;
@@ -226,6 +232,9 @@ class CheckPF2e {
 
         const contextFlag: CheckRollContextFlag = {
             ...context,
+            type: context.type ?? "check",
+            identifier: context.identifier ?? null,
+            action: actionSlug,
             item: undefined,
             dosAdjustments,
             actor: context.actor?.id ?? null,
@@ -237,11 +246,11 @@ class CheckPF2e {
             rollMode: context.rollMode,
             rollTwice: context.rollTwice ?? false,
             title: context.title ?? "PF2E.Check.Label",
-            type: context.type ?? "check",
             traits: context.traits ?? [],
             substitutions,
             dc: context.dc ? R.omit(context.dc, ["statistic"]) : null,
             skipDialog: context.skipDialog ?? !game.user.settings.showRollDialogs,
+            damaging: context.damaging ?? false,
             isReroll: context.isReroll ?? false,
             outcome: context.outcome ?? null,
             unadjustedOutcome: context.unadjustedOutcome ?? null,

--- a/src/module/system/check/index.ts
+++ b/src/module/system/check/index.ts
@@ -1,4 +1,4 @@
+export * from "./check.ts";
 export { CheckRoll } from "./roll.ts";
 export { StrikeAttackRoll } from "./strike/attack-roll.ts";
 export * from "./types.ts";
-export * from "./check.ts";

--- a/src/module/system/check/roll.ts
+++ b/src/module/system/check/roll.ts
@@ -3,25 +3,54 @@ import { ZeroToThree } from "@module/data.ts";
 import { UserPF2e } from "@module/user/index.ts";
 import { DegreeOfSuccessIndex } from "@system/degree-of-success.ts";
 import { RollDataPF2e } from "@system/rolls.ts";
+import { CheckType } from "./types.ts";
 
 class CheckRoll extends Roll {
-    roller: UserPF2e | null;
+    static override CHAT_TEMPLATE = "systems/pf2e/templates/chat/check/roll.hbs";
 
-    isReroll: boolean;
+    get roller(): UserPF2e | null {
+        return game.users.get(this.options.rollerId ?? "") ?? null;
+    }
 
-    isRerollable: boolean;
+    get type(): CheckType {
+        return this.options.type ?? "check";
+    }
 
-    constructor(formula: string, data = {}, options: CheckRollDataPF2e = {}) {
-        super(formula, data, options);
-
-        this.isReroll = options.isReroll ?? false;
-        this.isRerollable =
-            !this.isReroll && !this.dice.some((d) => d.modifiers.includes("kh") || d.modifiers.includes("kl"));
-        this.roller = game.users.get(this.options.rollerId ?? "") ?? null;
+    /** A string of some kind to help system API identify the roll */
+    get identifier(): string | null {
+        return this.options.identifier ?? null;
     }
 
     get degreeOfSuccess(): DegreeOfSuccessIndex | null {
         return this.options.degreeOfSuccess ?? null;
+    }
+
+    get isReroll(): boolean {
+        return this.options.isReroll ?? false;
+    }
+
+    get isRerollable(): boolean {
+        return !this.isReroll && !this.dice.some((d) => d.modifiers.includes("kh") || d.modifiers.includes("kl"));
+    }
+
+    override async render(this: Rolled<CheckRoll>, options: RollRenderOptions = {}): Promise<string> {
+        if (!this._evaluated) await this.evaluate({ async: true });
+        const { isPrivate, flavor, template } = options;
+
+        const chatData: Record<string, unknown> = {
+            formula: isPrivate ? "???" : this._formula,
+            flavor: isPrivate ? null : flavor,
+            user: game.user.id,
+            tooltip: isPrivate ? "" : await this.getTooltip(),
+            total: isPrivate ? "?" : Math.round(this.total * 100) / 100,
+            identifier: this.options.identifier,
+            action: this.options.action,
+            degree: this.degreeOfSuccess,
+            damaging: this.options.damaging,
+            canRollDamage: this.roller === game.user || game.user.isGM,
+        };
+
+        return renderTemplate(template ?? CheckRoll.CHAT_TEMPLATE, chatData);
     }
 }
 
@@ -30,6 +59,9 @@ interface CheckRoll extends Roll {
 }
 
 interface CheckRollDataPF2e extends RollDataPF2e {
+    type?: CheckType;
+    identifier?: Maybe<string>;
+    action?: Maybe<string>;
     isReroll?: boolean;
     degreeOfSuccess?: ZeroToThree;
     strike?: StrikeLookupData;

--- a/src/module/system/check/types.ts
+++ b/src/module/system/check/types.ts
@@ -22,6 +22,10 @@ type CheckType =
 interface CheckRollContext extends BaseRollContext {
     /** The type of this roll, like 'perception-check' or 'saving-throw'. */
     type?: CheckType;
+    /** A string of some kind to identify the roll: will be included in `CheckRoll#options` */
+    identifier?: Maybe<string>;
+    /** The slug of an action, of which this roll is a workflow component */
+    action?: Maybe<string>;
     /** Targeting data for the check, if applicable */
     target?: RollTarget | null;
     /** Should this roll be rolled twice? If so, should it keep highest or lowest? */
@@ -38,6 +42,8 @@ interface CheckRollContext extends BaseRollContext {
     dc?: CheckDC | null;
     /** The domains this roll had, for reporting purposes */
     domains?: string[];
+    /** Is this check part of an action that deals damage? */
+    damaging?: boolean;
     /** Is the roll a reroll? */
     isReroll?: boolean;
     /** The number of MAP increases for this roll */

--- a/src/module/system/statistic/index.ts
+++ b/src/module/system/statistic/index.ts
@@ -607,6 +607,8 @@ interface CheckDCReference {
 }
 
 interface StatisticRollParameters {
+    /** A string of some kind to identify the roll: will be included in `CheckRoll#options` */
+    identifier?: Maybe<string>;
     /** What token to use for the roll itself. Defaults to the actor's token */
     token?: TokenDocumentPF2e;
     /** Which attack this is (for the purposes of multiple attack penalty) */

--- a/src/styles/ui/sidebar/chat/_action.scss
+++ b/src/styles/ui/sidebar/chat/_action.scss
@@ -74,7 +74,7 @@
                 color: green;
                 position: absolute;
                 right: 4px;
-                top: 25%;
+                top: 26%;
             }
         }
     }

--- a/static/templates/chat/check/roll.hbs
+++ b/static/templates/chat/check/roll.hbs
@@ -1,0 +1,24 @@
+<div class="dice-roll {{type}}{{#if action}} {{action}}{{/if}}">
+    {{#if flavor~}}
+        <div class="dice-flavor">
+            {{flavor}}
+        </div>
+    {{~/if}}
+    <div class="dice-result">
+        <div class="dice-formula">{{formula}}</div>
+        {{{tooltip}}}
+        <h4 class="dice-total">{{total}}</h4>
+    </div>
+</div>
+{{#if (and action damaging canRollDamage)}}
+    <div class="message-buttons" data-identifier="{{identifier}}">
+        <button type="button" class="success" data-action="{{action}}-damage">
+            {{localize "PF2E.DamageLabel"}}
+            {{#if (eq degree 2)}}<i class="fa-solid fa-check fa-fw cue"></i>{{/if}}
+        </button>
+        <button type="button" class="critical-success" data-action="{{action}}-critical">
+            {{localize "PF2E.CriticalDamageLabel"}}
+            {{#if (eq degree 3)}}<i class="fa-solid fa-check fa-fw cue"></i>{{/if}}
+        </button>
+    </div>
+{{/if}}


### PR DESCRIPTION
This is a step towards being able to use the same roll class for strikes. It adds a dedicate template for `CheckRoll`s that includes action, damage, and other information.