### PR TITLE
Update armor usage when category changed to shield

### DIFF
--- a/src/module/item/armor/document.ts
+++ b/src/module/item/armor/document.ts
@@ -3,10 +3,10 @@ import { AutomaticBonusProgression as ABP } from "@actor/character/automatic-bon
 import { ItemSummaryData } from "@item/data/index.ts";
 import { PhysicalItemHitPoints, PhysicalItemPF2e, getPropertySlots, getResilientBonus } from "@item/physical/index.ts";
 import { MAGIC_TRADITIONS } from "@item/spell/values.ts";
+import { UserPF2e } from "@module/user/index.ts";
 import { ErrorPF2e, addSign, setHasElement, sluggify } from "@util";
 import { ArmorSource, ArmorSystemData } from "./data.ts";
 import { ArmorCategory, ArmorGroup, BaseArmorType } from "./types.ts";
-import { UserPF2e } from "@module/user/index.ts";
 
 class ArmorPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends PhysicalItemPF2e<TParent> {
     override isStackableWith(item: PhysicalItemPF2e<TParent>): boolean {

--- a/src/module/item/armor/document.ts
+++ b/src/module/item/armor/document.ts
@@ -251,15 +251,19 @@ class ArmorPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Phy
         return typeOnly ? itemType : game.i18n.format("PF2E.identification.UnidentifiedItem", { item: itemType });
     }
 
+    /** Ensure correct shield/actual-armor usage */
     protected override async _preCreate(
         data: PreDocumentId<this["_source"]>,
         options: DocumentModificationContext<TParent>,
         user: UserPF2e
     ): Promise<boolean | void> {
-        this._source.system.usage.value = this.#usageForCategory(this._source.system.category);
+        const { category } = this._source.system;
+        this._source.system.usage.value = category === "shield" ? "held-in-one-hand" : "wornarmor";
+
         return super._preCreate(data, options, user);
     }
 
+    /** Ensure correct shield/actual-armor usage */
     protected override async _preUpdate(
         changed: DeepPartial<this["_source"]>,
         options: DocumentUpdateContext<TParent>,
@@ -267,13 +271,11 @@ class ArmorPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Phy
     ): Promise<boolean | void> {
         const category = changed.system?.category;
         if (changed.system && category) {
-            changed.system = mergeObject(changed.system, { usage: { value: this.#usageForCategory(category) } });
+            const usage = { value: category === "shield" ? "held-in-one-hand" : "wornarmor" };
+            changed.system = mergeObject(changed.system, { usage });
         }
-        return super._preUpdate(changed, options, user);
-    }
 
-    #usageForCategory(category: DeepPartial<ArmorCategory>): string {
-        return category === "shield" ? "held-in-one-hand" : "wornarmor";
+        return super._preUpdate(changed, options, user);
     }
 }
 

--- a/src/module/item/armor/sheet.ts
+++ b/src/module/item/armor/sheet.ts
@@ -49,6 +49,7 @@ class ArmorSheetPF2e extends PhysicalItemSheetPF2e<ArmorPF2e> {
         for (const slotNumber of [1, 2, 3, 4]) {
             formData[`system.propertyRune${slotNumber}.value`] ||= null;
         }
+        formData["system.usage.value"] = formData["system.category"] === "shield" ? "held-in-one-hand" : "wornarmor";
 
         return super._updateObject(event, formData);
     }

--- a/src/module/item/armor/sheet.ts
+++ b/src/module/item/armor/sheet.ts
@@ -49,7 +49,6 @@ class ArmorSheetPF2e extends PhysicalItemSheetPF2e<ArmorPF2e> {
         for (const slotNumber of [1, 2, 3, 4]) {
             formData[`system.propertyRune${slotNumber}.value`] ||= null;
         }
-        formData["system.usage.value"] = formData["system.category"] === "shield" ? "held-in-one-hand" : "wornarmor";
 
         return super._updateObject(event, formData);
     }


### PR DESCRIPTION
Shields don't function if they can't be held, and the armor UI has no affordances to change the usage.

The armor template defaults to "wornarmor": https://github.com/foundryvtt/pf2e/blob/e3889d815e906e3a840d6740111c9d9725fbb821/static/template.json#L724

An earlier migration fixed this for existing items, but does not address newly created items:
https://github.com/foundryvtt/pf2e/blob/e3889d815e906e3a840d6740111c9d9725fbb821/src/module/migration/migrations/718-carry-type.ts#L26