### PR TITLE
Convert Ancient Dust to non-text based persistent damage application

### DIFF
--- a/packs/spells/ancient-dust.json
+++ b/packs/spells/ancient-dust.json
@@ -24,6 +24,15 @@
         },
         "damage": {
             "value": {
+                "2voY0xl4sJrjuqKs": {
+                    "applyMod": false,
+                    "type": {
+                        "categories": [],
+                        "subtype": "persistent",
+                        "value": "negative"
+                    },
+                    "value": "1"
+                },
                 "bmKxkM6C7wpQlsxf": {
                     "applyMod": true,
                     "type": {
@@ -36,7 +45,7 @@
             }
         },
         "description": {
-            "value": "<p>You cough up a cloud of gray soil, echoing the dust in the graves of Kemnebi's many victims. Each creature in the area takes negative damage equal to your spellcasting modifier and 1 persistent negative damage depending on its Fortitude save.</p>\n<hr />\n<p><strong>Critical Success</strong> The creature is unaffected.</p>\n<p><strong>Success</strong> The creature takes half damage and no persistent damage.</p>\n<p><strong>Failure</strong> The creature takes full damage and persistent damage.</p>\n<p><strong>Critical Failure</strong> The creature takes double damage and double the persistent damage.</p>\n<hr />\n<p><strong>Heightened (+2)</strong> The initial negative damage increases by 1d6, and the persistent damage increases by 1.</p>\n<p>[[/r (ceil(@item.level/2))[persistent,negative]]]{Leveled Persistent Negative Damage}</p>"
+            "value": "<p>You cough up a cloud of gray soil, echoing the dust in the graves of Kemnebi's many victims. Each creature in the area takes negative damage equal to your spellcasting modifier and 1 persistent negative damage depending on its Fortitude save.</p>\n<hr />\n<p><strong>Critical Success</strong> The creature is unaffected.</p>\n<p><strong>Success</strong> The creature takes half damage and no persistent damage.</p>\n<p><strong>Failure</strong> The creature takes full damage and persistent damage.</p>\n<p><strong>Critical Failure</strong> The creature takes double damage and double the persistent damage.</p>\n<hr />\n<p><strong>Heightened (+2)</strong> The initial negative damage increases by 1d6, and the persistent damage increases by 1.</p>"
         },
         "duration": {
             "value": ""
@@ -46,6 +55,7 @@
         },
         "heightening": {
             "damage": {
+                "2voY0xl4sJrjuqKs": "1",
                 "bmKxkM6C7wpQlsxf": "1d6"
             },
             "interval": 2,
@@ -90,8 +100,8 @@
             "rarity": "uncommon",
             "value": [
                 "cantrip",
-                "negative",
-                "necromancy"
+                "necromancy",
+                "negative"
             ]
         }
     },


### PR DESCRIPTION
Does not account for no persistent damage on succeeded save. Previous version resulted in NaN persistent damage.