### PR TITLE
Remove determination of attack roll in `InlineRollLinks`

### DIFF
--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -151,18 +151,9 @@ export const InlineRollLinks = {
                                             .shift() ?? null;
                                     if (bestSpellcasting) return bestSpellcasting;
                                 }
-                                const bySlug = actor.getStatistic(pf2Check);
-                                // Frame the statistic as an attack-roll stat if the action includes the "attack" trait
-                                // and the check is otherwise unclassified.
-                                return bySlug?.check.type === "check" && traits.includes("attack")
-                                    ? bySlug.extend({
-                                          check: {
-                                              type: "attack-roll",
-                                              domains: ["attack", "attack-roll", `${pf2Check}-attack-roll`],
-                                          },
-                                      })
-                                    : bySlug;
+                                return actor.getStatistic(pf2Check);
                             })();
+
                             if (!statistic) {
                                 console.warn(ErrorPF2e(`Skip rolling unknown statistic ${pf2Check}`).message);
                                 continue;

--- a/static/templates/chat/action/header.hbs
+++ b/static/templates/chat/action/header.hbs
@@ -1,5 +1,5 @@
 <h4 class="action">
     <strong>{{localize title}}</strong>
-    {{#if subtitle}}<span class="subtitle">({{localize subtitle}})</span>{{/if}}
     {{#if glyph}}<span class="pf2-icon">{{glyph}}</span>{{/if}}
+    {{#if subtitle}}<span class="subtitle">({{localize subtitle}})</span>{{/if}}
 </h4>


### PR DESCRIPTION
This was a temporary solution until `SpecialStatistic` REs were added. Also tweak presentation of such rolls.