### PR TITLE
Cache `CheckPF2e.roll` parameters and utilize the cache to reroll checks

### DIFF
--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -706,6 +706,11 @@
                 "Unspecific": "DC"
             },
             "Label": "Check",
+            "Reroll": {
+                "FailedCacheMessage": "The roll data is no longer cached. Please roll the check again.",
+                "FailedUserConnectionMessage": "Reroll failed. The message author is no longer connected to the server!",
+                "FailedSocketMessage": "Rerolling the message with id [{messageId}] for user {user} failed."
+            },
             "Result": {
                 "AdjustedLabel": "Result: <unadjusted>{unadjusted}</unadjusted> <adjusted>{adjusted}</adjusted> <offset>by {offset}</offset>",
                 "Degree": {


### PR DESCRIPTION
Just putting this up for discussion. The big caveat is that rerolls are no longer possible after a browser reload.
I would say that 99% of the time a reroll happens immediately after the original roll so I believe that we should at least consider doing it this way.

The pros:
- Rerolls are always rendered correctly.
- Target modifiers are captured when the original roll is made. If the target is, for example, no longer flanked the reroll would still include off-guard.

GMs automatically make a socket requests to the message author if they want to reroll a message.