### PR TITLE
Post strike upon clicking NPC/hazard to-chat buttons

### DIFF
--- a/src/scripts/macros/hotbar.ts
+++ b/src/scripts/macros/hotbar.ts
@@ -47,11 +47,16 @@ export async function createActionMacro(actionIndex: number, slot: number): Prom
     game.user.assignHotbarMacro(actionMacro ?? null, slot);
 }
 
-export async function rollActionMacro(itemId: string, _actionIndex: number, actionSlug: string): Promise<void> {
+export async function rollActionMacro(
+    itemId: string,
+    _actionIndex: number,
+    actionSlug: string
+): Promise<ChatMessagePF2e | undefined> {
     const speaker = ChatMessage.getSpeaker();
     const actor = canvas.tokens.get(speaker.token ?? "")?.actor ?? game.actors.get(speaker.actor ?? "");
     if (!actor?.isOfType("character", "npc")) {
-        return ui.notifications.error("PF2E.MacroActionNoActorError", { localize: true });
+        ui.notifications.error("PF2E.MacroActionNoActorError", { localize: true });
+        return undefined;
     }
 
     const strikes: StrikeData[] = actor.system.actions;
@@ -59,7 +64,8 @@ export async function rollActionMacro(itemId: string, _actionIndex: number, acti
         strikes.find((s) => s.item.id === itemId && s.slug === actionSlug) ??
         strikes.find((s) => s.slug === actionSlug);
     if (!strike) {
-        return ui.notifications.error("PF2E.MacroActionNoActionError", { localize: true });
+        ui.notifications.error("PF2E.MacroActionNoActionError", { localize: true });
+        return undefined;
     }
 
     const templateData = {
@@ -84,7 +90,7 @@ export async function rollActionMacro(itemId: string, _actionIndex: number, acti
         chatData.whisper = ChatMessage.getWhisperRecipients("GM").map((u) => u.id);
     if (rollMode === "blindroll") chatData.blind = true;
 
-    ChatMessagePF2e.create(chatData);
+    return ChatMessagePF2e.create(chatData);
 }
 
 export async function createSkillMacro(

--- a/static/templates/actors/npc/partials/attack.hbs
+++ b/static/templates/actors/npc/partials/attack.hbs
@@ -22,7 +22,6 @@
     </h4>
 
     <div class="controls">
-        <a class="item-chat chat" title="{{localize "PF2E.NPC.SendToChat"}}"><i class="fa-solid fa-fw fa-comment-alt"></i></a>
         {{#if isEditable}}
             <a class="item-edit edit" title="{{localize "PF2E.NPC.Edit"}}"><i class="fa-solid fa-fw fa-edit"></i></a>
             <a class="item-delete delete" title="{{localize "PF2E.NPC.Remove"}}"><i class="fa-solid fa-fw fa-trash"></i></a>


### PR DESCRIPTION
The "chat data" and template of melee items aren't usable, so this is effectively a bugfix.