### PR TITLE
Fixed Weapon Infusion Properties

### DIFF
--- a/packs/feats/weapon-infusion.json
+++ b/packs/feats/weapon-infusion.json
@@ -78,161 +78,161 @@
                 ],
                 "toggleable": true
             },
-			 {
-        "key": "ActiveEffectLike",
-        "mode": "add",
-        "path": "flags.pf2e.kineticist.elementalBlast.air.damageTypes",
-        "predicate": [
-          {
-            "and": [
-              "kinetic-gate:air",
-              "self:effect:weapon-infusion"
-            ]
-          }
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.kineticist.elementalBlast.air.damageTypes",
+                "predicate": [
+                    {
+                        "and": [
+                            "kinetic-gate:air",
+                            "self:effect:weapon-infusion"
+                        ]
+                    }
+                ],
+                "value": "piercing"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.kineticist.elementalBlast.air.damageTypes",
+                "predicate": [
+                    {
+                        "and": [
+                            "kinetic-gate:air",
+                            "self:effect:weapon-infusion"
+                        ]
+                    }
+                ],
+                "value": "bludgeoning"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.kineticist.elementalBlast.earth.damageTypes",
+                "predicate": [
+                    {
+                        "and": [
+                            "kinetic-gate:earth",
+                            "self:effect:weapon-infusion"
+                        ]
+                    }
+                ],
+                "value": "slashing"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.kineticist.elementalBlast.fire.damageTypes",
+                "predicate": [
+                    {
+                        "and": [
+                            "kinetic-gate:fire",
+                            "self:effect:weapon-infusion"
+                        ]
+                    }
+                ],
+                "value": "bludgeoning"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.kineticist.elementalBlast.fire.damageTypes",
+                "predicate": [
+                    {
+                        "and": [
+                            "kinetic-gate:fire",
+                            "self:effect:weapon-infusion"
+                        ]
+                    }
+                ],
+                "value": "piercing"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.kineticist.elementalBlast.fire.damageTypes",
+                "predicate": [
+                    {
+                        "and": [
+                            "kinetic-gate:fire",
+                            "self:effect:weapon-infusion"
+                        ]
+                    }
+                ],
+                "value": "slashing"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.kineticist.elementalBlast.metal.damageTypes",
+                "predicate": [
+                    {
+                        "and": [
+                            "kinetic-gate:metal",
+                            "self:effect:weapon-infusion"
+                        ]
+                    }
+                ],
+                "value": "bludgeoning"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.kineticist.elementalBlast.water.damageTypes",
+                "predicate": [
+                    {
+                        "and": [
+                            "kinetic-gate:water",
+                            "self:effect:weapon-infusion"
+                        ]
+                    }
+                ],
+                "value": "piercing"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.kineticist.elementalBlast.water.damageTypes",
+                "predicate": [
+                    {
+                        "and": [
+                            "kinetic-gate:water",
+                            "self:effect:weapon-infusion"
+                        ]
+                    }
+                ],
+                "value": "slashing"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.kineticist.elementalBlast.wood.damageTypes",
+                "predicate": [
+                    {
+                        "and": [
+                            "kinetic-gate:wood",
+                            "self:effect:weapon-infusion"
+                        ]
+                    }
+                ],
+                "value": "piercing"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.kineticist.elementalBlast.wood.damageTypes",
+                "predicate": [
+                    {
+                        "and": [
+                            "kinetic-gate:wood",
+                            "self:effect:weapon-infusion"
+                        ]
+                    }
+                ],
+                "value": "slashing"
+            }
         ],
-        "value": "piercing"
-      },
-      {
-        "key": "ActiveEffectLike",
-        "mode": "add",
-        "path": "flags.pf2e.kineticist.elementalBlast.air.damageTypes",
-        "predicate": [
-          {
-            "and": [
-              "kinetic-gate:air",
-              "self:effect:weapon-infusion"
-            ]
-          }
-        ],
-        "value": "bludgeoning"
-      },
-      {
-        "key": "ActiveEffectLike",
-        "mode": "add",
-        "path": "flags.pf2e.kineticist.elementalBlast.earth.damageTypes",
-        "predicate": [
-          {
-            "and": [
-              "kinetic-gate:earth",
-              "self:effect:weapon-infusion"
-            ]
-          }
-        ],
-        "value": "slashing"
-      },
-      {
-        "key": "ActiveEffectLike",
-        "mode": "add",
-        "path": "flags.pf2e.kineticist.elementalBlast.fire.damageTypes",
-        "predicate": [
-          {
-            "and": [
-              "kinetic-gate:fire",
-              "self:effect:weapon-infusion"
-            ]
-          }
-        ],
-        "value": "bludgeoning"
-      },
-      {
-        "key": "ActiveEffectLike",
-        "mode": "add",
-        "path": "flags.pf2e.kineticist.elementalBlast.fire.damageTypes",
-        "predicate": [
-          {
-            "and": [
-              "kinetic-gate:fire",
-              "self:effect:weapon-infusion"
-            ]
-          }
-        ],
-        "value": "piercing"
-      },
-      {
-        "key": "ActiveEffectLike",
-        "mode": "add",
-        "path": "flags.pf2e.kineticist.elementalBlast.fire.damageTypes",
-        "predicate": [
-          {
-            "and": [
-              "kinetic-gate:fire",
-              "self:effect:weapon-infusion"
-            ]
-          }
-        ],
-        "value": "slashing"
-      },
-      {
-        "key": "ActiveEffectLike",
-        "mode": "add",
-        "path": "flags.pf2e.kineticist.elementalBlast.metal.damageTypes",
-        "predicate": [
-          {
-            "and": [
-              "kinetic-gate:metal",
-              "self:effect:weapon-infusion"
-            ]
-          }
-        ],
-        "value": "bludgeoning"
-      },
-      {
-        "key": "ActiveEffectLike",
-        "mode": "add",
-        "path": "flags.pf2e.kineticist.elementalBlast.water.damageTypes",
-        "predicate": [
-          {
-            "and": [
-              "kinetic-gate:water",
-              "self:effect:weapon-infusion"
-            ]
-          }
-        ],
-        "value": "piercing"
-      },
-      {
-        "key": "ActiveEffectLike",
-        "mode": "add",
-        "path": "flags.pf2e.kineticist.elementalBlast.water.damageTypes",
-        "predicate": [
-          {
-            "and": [
-              "kinetic-gate:water",
-              "self:effect:weapon-infusion"
-            ]
-          }
-        ],
-        "value": "slashing"
-      },
-      {
-        "key": "ActiveEffectLike",
-        "mode": "add",
-        "path": "flags.pf2e.kineticist.elementalBlast.wood.damageTypes",
-        "predicate": [
-          {
-            "and": [
-              "kinetic-gate:wood",
-              "self:effect:weapon-infusion"
-            ]
-          }
-        ],
-        "value": "piercing"
-      },
-      {
-        "key": "ActiveEffectLike",
-        "mode": "add",
-        "path": "flags.pf2e.kineticist.elementalBlast.wood.damageTypes",
-        "predicate": [
-          {
-            "and": [
-              "kinetic-gate:wood",
-              "self:effect:weapon-infusion"
-            ]
-          }
-        ],
-        "value": "slashing"
-      }
-	         ],
         "selfEffect": {
             "name": "Effect: Weapon Infusion",
             "uuid": "Compendium.pf2e.feat-effects.Item.Effect: Weapon Infusion"

--- a/packs/feats/weapon-infusion.json
+++ b/packs/feats/weapon-infusion.json
@@ -77,8 +77,162 @@
                     }
                 ],
                 "toggleable": true
-            }
+            },
+			 {
+        "key": "ActiveEffectLike",
+        "mode": "add",
+        "path": "flags.pf2e.kineticist.elementalBlast.air.damageTypes",
+        "predicate": [
+          {
+            "and": [
+              "kinetic-gate:air",
+              "self:effect:weapon-infusion"
+            ]
+          }
         ],
+        "value": "piercing"
+      },
+      {
+        "key": "ActiveEffectLike",
+        "mode": "add",
+        "path": "flags.pf2e.kineticist.elementalBlast.air.damageTypes",
+        "predicate": [
+          {
+            "and": [
+              "kinetic-gate:air",
+              "self:effect:weapon-infusion"
+            ]
+          }
+        ],
+        "value": "bludgeoning"
+      },
+      {
+        "key": "ActiveEffectLike",
+        "mode": "add",
+        "path": "flags.pf2e.kineticist.elementalBlast.earth.damageTypes",
+        "predicate": [
+          {
+            "and": [
+              "kinetic-gate:earth",
+              "self:effect:weapon-infusion"
+            ]
+          }
+        ],
+        "value": "slashing"
+      },
+      {
+        "key": "ActiveEffectLike",
+        "mode": "add",
+        "path": "flags.pf2e.kineticist.elementalBlast.fire.damageTypes",
+        "predicate": [
+          {
+            "and": [
+              "kinetic-gate:fire",
+              "self:effect:weapon-infusion"
+            ]
+          }
+        ],
+        "value": "bludgeoning"
+      },
+      {
+        "key": "ActiveEffectLike",
+        "mode": "add",
+        "path": "flags.pf2e.kineticist.elementalBlast.fire.damageTypes",
+        "predicate": [
+          {
+            "and": [
+              "kinetic-gate:fire",
+              "self:effect:weapon-infusion"
+            ]
+          }
+        ],
+        "value": "piercing"
+      },
+      {
+        "key": "ActiveEffectLike",
+        "mode": "add",
+        "path": "flags.pf2e.kineticist.elementalBlast.fire.damageTypes",
+        "predicate": [
+          {
+            "and": [
+              "kinetic-gate:fire",
+              "self:effect:weapon-infusion"
+            ]
+          }
+        ],
+        "value": "slashing"
+      },
+      {
+        "key": "ActiveEffectLike",
+        "mode": "add",
+        "path": "flags.pf2e.kineticist.elementalBlast.metal.damageTypes",
+        "predicate": [
+          {
+            "and": [
+              "kinetic-gate:metal",
+              "self:effect:weapon-infusion"
+            ]
+          }
+        ],
+        "value": "bludgeoning"
+      },
+      {
+        "key": "ActiveEffectLike",
+        "mode": "add",
+        "path": "flags.pf2e.kineticist.elementalBlast.water.damageTypes",
+        "predicate": [
+          {
+            "and": [
+              "kinetic-gate:water",
+              "self:effect:weapon-infusion"
+            ]
+          }
+        ],
+        "value": "piercing"
+      },
+      {
+        "key": "ActiveEffectLike",
+        "mode": "add",
+        "path": "flags.pf2e.kineticist.elementalBlast.water.damageTypes",
+        "predicate": [
+          {
+            "and": [
+              "kinetic-gate:water",
+              "self:effect:weapon-infusion"
+            ]
+          }
+        ],
+        "value": "slashing"
+      },
+      {
+        "key": "ActiveEffectLike",
+        "mode": "add",
+        "path": "flags.pf2e.kineticist.elementalBlast.wood.damageTypes",
+        "predicate": [
+          {
+            "and": [
+              "kinetic-gate:wood",
+              "self:effect:weapon-infusion"
+            ]
+          }
+        ],
+        "value": "piercing"
+      },
+      {
+        "key": "ActiveEffectLike",
+        "mode": "add",
+        "path": "flags.pf2e.kineticist.elementalBlast.wood.damageTypes",
+        "predicate": [
+          {
+            "and": [
+              "kinetic-gate:wood",
+              "self:effect:weapon-infusion"
+            ]
+          }
+        ],
+        "value": "slashing"
+      }
+	         ],
         "selfEffect": {
             "name": "Effect: Weapon Infusion",
             "uuid": "Compendium.pf2e.feat-effects.Item.Effect: Weapon Infusion"


### PR DESCRIPTION
Added missing Damage Types for Weapon Infusion, while the effect is on an actor
"You can choose to change the blast’s damage type to **bludgeoning, piercing, or slashing**—whichever suits the weapon shape"
 (RoE pg. 21)
