### PR TITLE
Fix type errors in global.d.ts, rename to global.ts

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -1,40 +1,46 @@
 /// <reference types="vite/client" />
 
-import { AutomaticBonusProgression } from "@actor/character/automatic-bonus-progression.ts";
-import { FeatGroupOptions } from "@actor/character/feats.ts";
-import { CheckModifier, MODIFIER_TYPE, ModifierPF2e, StatisticModifier } from "@actor/modifiers.ts";
-import { ConditionSource } from "@item/condition/data.ts";
-import { CoinsPF2e } from "@item/physical/helpers.ts";
-import { ActiveEffectPF2e } from "@module/active-effect.ts";
-import { CompendiumBrowser, CompendiumBrowserSettings } from "@module/apps/compendium-browser/index.ts";
-import { EffectsPanel } from "@module/apps/effects-panel.ts";
-import { HotbarPF2e } from "@module/apps/hotbar.ts";
-import { LicenseViewer } from "@module/apps/license-viewer/app.ts";
-import {
+import type { AutomaticBonusProgression } from "@actor/character/automatic-bonus-progression.ts";
+import type { ElementalBlast } from "@actor/character/elemental-blast.ts";
+import type { FeatGroupOptions } from "@actor/character/feats.ts";
+import type { CheckModifier, ModifierPF2e, ModifierType, StatisticModifier } from "@actor/modifiers.ts";
+import type { ConditionSource } from "@item/condition/data.ts";
+import type { CoinsPF2e } from "@item/physical/helpers.ts";
+import type { ActiveEffectPF2e } from "@module/active-effect.ts";
+import type {
+    CompendiumBrowser,
+    CompendiumBrowserSettings,
+    CompendiumBrowserSources,
+} from "@module/apps/compendium-browser/index.ts";
+import type { EffectsPanel } from "@module/apps/effects-panel.ts";
+import type { HotbarPF2e } from "@module/apps/hotbar.ts";
+import type { LicenseViewer } from "@module/apps/license-viewer/app.ts";
+import type {
     ActorDirectoryPF2e,
     ChatLogPF2e,
     CompendiumDirectoryPF2e,
     EncounterTrackerPF2e,
 } from "@module/apps/sidebar/index.ts";
-import { WorldClock } from "@module/apps/world-clock/app.ts";
-import { CanvasPF2e, EffectsCanvasGroupPF2e } from "@module/canvas/index.ts";
-import { StatusEffects } from "@module/canvas/status-effects.ts";
-import { ChatMessagePF2e } from "@module/chat-message/index.ts";
-import { ActorsPF2e } from "@module/collection/actors.ts";
-import { ActorPF2e, ItemPF2e } from "@module/documents.ts";
-import { MacroPF2e } from "@module/macro.ts";
-import { RuleElementPF2e, RuleElements } from "@module/rules/index.ts";
-import { UserPF2e } from "@module/user/index.ts";
-import {
+import type { WorldClock } from "@module/apps/world-clock/app.ts";
+import type { CanvasPF2e, EffectsCanvasGroupPF2e } from "@module/canvas/index.ts";
+import type { StatusEffects } from "@module/canvas/status-effects.ts";
+import type { ChatMessagePF2e } from "@module/chat-message/index.ts";
+import type { ActorsPF2e } from "@module/collection/actors.ts";
+import type { ActorPF2e, ItemPF2e } from "@module/documents.ts";
+import type { MacroPF2e } from "@module/macro.ts";
+import type { RuleElementPF2e, RuleElements } from "@module/rules/index.ts";
+import type { UserPF2e } from "@module/user/index.ts";
+import type {
     AmbientLightDocumentPF2e,
     MeasuredTemplateDocumentPF2e,
     ScenePF2e,
     TileDocumentPF2e,
     TokenDocumentPF2e,
 } from "@scene/index.ts";
-import { PF2ECONFIG, StatusEffectIconTheme } from "@scripts/config/index.ts";
-import { DicePF2e } from "@scripts/dice.ts";
-import {
+import type { ActorDeltaPF2e } from "@scene/token-document/actor-delta.ts";
+import type { PF2ECONFIG, StatusEffectIconTheme } from "@scripts/config/index.ts";
+import type { DicePF2e } from "@scripts/dice.ts";
+import type {
     calculateXP,
     editPersistent,
     launchTravelSheet,
@@ -44,69 +50,93 @@ import {
     stealthForSelected,
     xpFromEncounter,
 } from "@scripts/macros/index.ts";
-import { remigrate } from "@scripts/system/remigrate.ts";
-import { CheckPF2e } from "@system/check/index.ts";
-import { EffectTracker } from "@system/effect-tracker.ts";
-import { ModuleArt } from "@system/module-art.ts";
-import { CustomDamageData, HomebrewTag, HomebrewTraitSettingsKey } from "@system/settings/homebrew/index.ts";
-import { TextEditorPF2e } from "@system/text-editor.ts";
-import { sluggify } from "@util";
-import Peggy from "peggy";
-import { CombatantPF2e, EncounterPF2e } from "./module/encounter/index.ts";
-import { ConditionManager } from "./module/system/conditions/index.ts";
+import type { remigrate } from "@scripts/system/remigrate.ts";
+import type { CheckPF2e } from "@system/check/index.ts";
+import type { EffectTracker } from "@system/effect-tracker.ts";
+import type { ModuleArt } from "@system/module-art.ts";
+import type { CustomDamageData, HomebrewTag, HomebrewTraitSettingsKey } from "@system/settings/homebrew/index.ts";
+import type { TextEditorPF2e } from "@system/text-editor.ts";
+import type { sluggify } from "@util";
+import type Peggy from "peggy";
+import type { CombatantPF2e, EncounterPF2e } from "./module/encounter/index.js";
+import type { ConditionManager } from "./module/system/conditions/index.js";
+
+interface GamePF2e
+    extends Game<
+        ActorPF2e<null>,
+        ActorsPF2e<ActorPF2e<null>>,
+        ChatMessagePF2e,
+        EncounterPF2e,
+        ItemPF2e<null>,
+        MacroPF2e,
+        ScenePF2e,
+        UserPF2e
+    > {
+    pf2e: {
+        actions: Record<string, Function>;
+        compendiumBrowser: CompendiumBrowser;
+        licenseViewer: LicenseViewer;
+        worldClock: WorldClock;
+        effectPanel: EffectsPanel;
+        effectTracker: EffectTracker;
+        rollActionMacro: typeof rollActionMacro;
+        rollItemMacro: typeof rollItemMacro;
+        gm: {
+            calculateXP: typeof calculateXP;
+            editPersistent: typeof editPersistent;
+            launchTravelSheet: typeof launchTravelSheet;
+            perceptionForSelected: typeof perceptionForSelected;
+            stealthForSelected: typeof stealthForSelected;
+            xpFromEncounter: typeof xpFromEncounter;
+        };
+        system: {
+            moduleArt: ModuleArt;
+            remigrate: typeof remigrate;
+            sluggify: typeof sluggify;
+        };
+        variantRules: {
+            AutomaticBonusProgression: typeof AutomaticBonusProgression;
+        };
+        Check: typeof CheckPF2e;
+        CheckModifier: typeof CheckModifier;
+        Coins: typeof CoinsPF2e;
+        ConditionManager: typeof ConditionManager;
+        Dice: typeof DicePF2e;
+        ElementalBlast: typeof ElementalBlast;
+        Modifier: typeof ModifierPF2e;
+        ModifierType: { [K in Uppercase<ModifierType>]: Lowercase<K> };
+        RuleElement: typeof RuleElementPF2e;
+        RuleElements: typeof RuleElements;
+        StatisticModifier: typeof StatisticModifier;
+        StatusEffects: typeof StatusEffects;
+        TextEditor: typeof TextEditorPF2e;
+    };
+}
+
+type ConfiguredConfig = Config<
+    AmbientLightDocumentPF2e<ScenePF2e | null>,
+    ActiveEffectPF2e<ActorPF2e | ItemPF2e | null>,
+    ActorPF2e,
+    ActorDeltaPF2e<TokenDocumentPF2e>,
+    ChatLogPF2e,
+    ChatMessagePF2e,
+    EncounterPF2e,
+    CombatantPF2e<EncounterPF2e | null, TokenDocumentPF2e>,
+    EncounterTrackerPF2e<EncounterPF2e | null>,
+    CompendiumDirectoryPF2e,
+    HotbarPF2e,
+    ItemPF2e,
+    MacroPF2e,
+    MeasuredTemplateDocumentPF2e,
+    TileDocumentPF2e,
+    TokenDocumentPF2e,
+    WallDocument<ScenePF2e | null>,
+    ScenePF2e,
+    UserPF2e,
+    EffectsCanvasGroupPF2e
+>;
 
 declare global {
-    interface Game<
-        TActor extends Actor<null>,
-        TActors extends Actors<TActor>,
-        TChatMessage extends ChatMessage,
-        TCombat extends Combat,
-        TItem extends Item<null>,
-        TMacro extends Macro,
-        TScene extends Scene,
-        TUser extends UserPF2e
-    > {
-        pf2e: {
-            actions: Record<string, Function>;
-            compendiumBrowser: CompendiumBrowser;
-            licenseViewer: LicenseViewer;
-            worldClock: WorldClock;
-            effectPanel: EffectsPanel;
-            effectTracker: EffectTracker;
-            rollActionMacro: typeof rollActionMacro;
-            rollItemMacro: typeof rollItemMacro;
-            gm: {
-                calculateXP: typeof calculateXP;
-                editPersistent: typeof editPersistent;
-                launchTravelSheet: typeof launchTravelSheet;
-                perceptionForSelected: typeof perceptionForSelected;
-                stealthForSelected: typeof stealthForSelected;
-                xpFromEncounter: typeof xpFromEncounter;
-            };
-            system: {
-                moduleArt: ModuleArt;
-                remigrate: typeof remigrate;
-                sluggify: typeof sluggify;
-            };
-            variantRules: {
-                AutomaticBonusProgression: typeof AutomaticBonusProgression;
-            };
-            Check: typeof CheckPF2e;
-            CheckModifier: typeof CheckModifier;
-            Coins: typeof CoinsPF2e;
-            ConditionManager: typeof ConditionManager;
-            Dice: typeof DicePF2e;
-            ElementalBlast: typeof ElementalBlast;
-            Modifier: typeof ModifierPF2e;
-            ModifierType: typeof MODIFIER_TYPE;
-            RuleElement: typeof RuleElementPF2e;
-            RuleElements: typeof RuleElements;
-            StatisticModifier: typeof StatisticModifier;
-            StatusEffects: typeof StatusEffects;
-            TextEditor: typeof TextEditorPF2e;
-        };
-    }
-
     interface ConfigPF2e extends ConfiguredConfig {
         debug: ConfiguredConfig["debug"] & {
             ruleElement: boolean;
@@ -122,22 +152,12 @@ declare global {
 
     namespace globalThis {
         // eslint-disable-next-line no-var
-        var game: Game<
-            ActorPF2e<null>,
-            ActorsPF2e<ActorPF2e<null>>,
-            ChatMessagePF2e,
-            EncounterPF2e,
-            ItemPF2e<null>,
-            MacroPF2e,
-            ScenePF2e,
-            UserPF2e
-        >;
+        var game: GamePF2e;
 
         // eslint-disable-next-line no-var
         var ui: FoundryUI<
-            ActorPF2e<null>,
-            ActorDirectoryPF2e<ActorPF2e<null>>,
-            ItemPF2e<null>,
+            ActorDirectoryPF2e,
+            ItemDirectory<ItemPF2e<null>>,
             ChatLogPF2e,
             CompendiumDirectoryPF2e,
             EncounterTrackerPF2e<EncounterPF2e | null>
@@ -246,26 +266,3 @@ declare global {
     const CONDITION_SOURCES: ConditionSource[];
     const ROLL_PARSER: Peggy.Parser;
 }
-
-type ConfiguredConfig = Config<
-    AmbientLightDocumentPF2e<ScenePF2e | null>,
-    ActiveEffectPF2e<ActorPF2e | ItemPF2e | null>,
-    ActorPF2e,
-    ActorDeltaPF2e,
-    ChatLogPF2e,
-    ChatMessagePF2e,
-    EncounterPF2e,
-    CombatantPF2e<EncounterPF2e | null, TokenDocumentPF2e>,
-    EncounterTrackerPF2e<EncounterPF2e | null>,
-    CompendiumDirectoryPF2e,
-    HotbarPF2e,
-    ItemPF2e,
-    MacroPF2e,
-    MeasuredTemplateDocumentPF2e,
-    TileDocumentPF2e,
-    TokenDocumentPF2e,
-    WallDocument<ScenePF2e | null>,
-    ScenePF2e,
-    UserPF2e,
-    EffectsCanvasGroupPF2e
->;

--- a/src/module/system/settings/index.ts
+++ b/src/module/system/settings/index.ts
@@ -338,7 +338,9 @@ function registerTrackingSettings(): void {
         config: false,
         type: String,
         default: "",
-        onChange: () => ui.actors.render(true),
+        onChange: () => {
+            ui.actors.render(true);
+        },
     });
 
     game.settings.register("pf2e", "worldSystemVersion", {

--- a/types/foundry/client/ui/index.d.ts
+++ b/types/foundry/client/ui/index.d.ts
@@ -10,9 +10,8 @@ import "./tour.d.ts";
 
 declare global {
     interface FoundryUI<
-        TActor extends Actor<null>,
-        TActorDirectory extends ActorDirectory<TActor>,
-        TItem extends Item<null>,
+        TActorDirectory extends ActorDirectory<Actor<null>>,
+        TItemDirectory extends ItemDirectory<Item<null>>,
         TChatLog extends ChatLog,
         TCompendiumDirectory extends CompendiumDirectory,
         TCombatTracker extends CombatTracker<Combat | null>
@@ -22,7 +21,7 @@ declare global {
         combat: TCombatTracker;
         compendium: TCompendiumDirectory;
         controls: SceneControls;
-        items: ItemDirectory<TItem>;
+        items: TItemDirectory;
         notifications: Notifications;
         settings: Settings;
         sidebar: Sidebar;


### PR DESCRIPTION
`skipLibCheck` means no .d.ts files will be type-checked