### PR TITLE
Combine spellcasting entry dialog statistics in a single list

### DIFF
--- a/src/module/item/spellcasting-entry/data.ts
+++ b/src/module/item/spellcasting-entry/data.ts
@@ -48,7 +48,7 @@ interface SpellcastingEntrySystemSource extends ItemSystemSource {
         value: boolean;
     };
     proficiency: {
-        slug: string;
+        slug?: string;
         value: ZeroToFour;
     };
     slots: Record<SlotKey, SpellSlotData>;
@@ -67,6 +67,10 @@ interface SpellCollectionTypeSource {
 
 interface SpellcastingEntrySystemData extends SpellcastingEntrySystemSource, Omit<ItemSystemData, "level" | "traits"> {
     prepared: SpellCollectionTypeData;
+    proficiency: {
+        slug: string;
+        value: ZeroToFour;
+    };
 }
 
 interface SpellCollectionTypeData extends SpellCollectionTypeSource {

--- a/static/templates/actors/spellcasting-dialog.hbs
+++ b/static/templates/actors/spellcasting-dialog.hbs
@@ -31,35 +31,30 @@
 
         {{#unless object.isRitual}}
             <div class="form-group">
-                <label>{{localize "PF2E.MagicTraditionLabel"}}</label>
-                <select name="system.tradition.value">
-                    {{#select system.tradition.value}}
-                        {{#if (eq system.prepared.value "items")}}
-                            <option value="">{{localize "PF2E.MagicTraditionUseSpellLabel"}}</option>
-                        {{/if}}
-                        {{#each magicTraditions as |label mode|}}
-                            <option value="{{mode}}">{{localize label}}</option>
+                <label>{{localize "PF2E.ProficiencyLabel"}}</label>
+                <select name="system.proficiency.slug">
+                    {{#select system.proficiency.slug}}
+                        {{#each statistics as |statistic|}}
+                            <option value="{{statistic.slug}}">{{statistic.label}}</option>
                         {{/each}}
                     {{/select}}
                 </select>
             </div>
-            {{#if (eq actor.type "character")}}
+            {{#unless hasTradition}}
                 <div class="form-group">
-                    <label>{{localize "PF2E.ProficiencyLabel"}}</label>
-                    <select name="system.proficiency.slug">
-                        {{#select system.proficiency.slug}}
-                            {{#if system.tradition.value}}
-                                <option value="">
-                                    {{localize "PF2E.Actor.Creature.Spellcasting.TraditionSpellcasting" tradition=(localize (lookup @root.magicTraditions system.tradition.value))}}
-                                </option>
+                    <label>{{localize "PF2E.MagicTraditionLabel"}}</label>
+                    <select name="system.tradition.value">
+                        {{#select system.tradition.value}}
+                            {{#if (eq system.prepared.value "items")}}
+                                <option value="">{{localize "PF2E.MagicTraditionUseSpellLabel"}}</option>
                             {{/if}}
-                            {{#each statistics as |statistic|}}
-                                <option value="{{statistic.slug}}">{{statistic.label}}</option>
+                            {{#each magicTraditions as |label mode|}}
+                                <option value="{{mode}}">{{localize label}}</option>
                             {{/each}}
                         {{/select}}
                     </select>
                 </div>
-            {{/if}}
+            {{/unless}}
             <div class="form-group">
                 <label>{{localize "PF2E.SpellAbilityLabel"}}</label>
                 <select name="system.ability.value" {{disabled (not isAttributeConfigurable)}}>


### PR DESCRIPTION
This should hopefully make it less confusing
![image](https://github.com/foundryvtt/pf2e/assets/1286721/2021b1c1-b0c2-4298-9c94-ec52121c2dc8)
![image](https://github.com/foundryvtt/pf2e/assets/1286721/890d15b0-678f-4f0f-91dd-bc615707917b)
