### PR TITLE
Updates quantity of sacks purchased from 1 to 5 resolves #9394

### DIFF
--- a/packs/equipment/sack.json
+++ b/packs/equipment/sack.json
@@ -37,7 +37,7 @@
                 "cp": 1
             }
         },
-        "quantity": 1,
+        "quantity": 5,
         "rules": [],
         "size": "med",
         "source": {


### PR DESCRIPTION
Resolves issue #9394 

Changed quantity of sacks from 1 to 5.

Verified that the cost of sacks was indeed 5 for 1 cp. The SRD states that this is the price as well as the Core Rulebook printed and digital. Note - Archives of Nethys does NOT specify that sacks come in sets of 5. (https://2e.aonprd.com/Equipment.aspx?ID=45)