### PR TITLE
Add automation for Gallowdead's Charge Chain

### DIFF
--- a/packs/book-of-the-dead-bestiary/gallowdead.json
+++ b/packs/book-of-the-dead-bestiary/gallowdead.json
@@ -612,7 +612,34 @@
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "domain": "all",
+                        "key": "RollOption",
+                        "option": "charge-chain",
+                        "suboptions": [
+                            {
+                                "label": "PF2E.TraitNegative",
+                                "value": "damage"
+                            },
+                            {
+                                "label": "PF2E.TraitReach120",
+                                "value": "reach"
+                            }
+                        ],
+                        "toggleable": true
+                    },
+                    {
+                        "damageType": "negative",
+                        "diceNumber": 4,
+                        "dieSize": "d6",
+                        "key": "DamageDice",
+                        "predicate": [
+                            "charge-chain:damage"
+                        ],
+                        "selector": "spiked-chain-damage"
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""


### PR DESCRIPTION
I don't believe there's currently a way to apply "reach-120" to an NPC attack via REs. I've left the suboption in place to disambiguate the choice to the GM.