### PR TITLE
Implement Nanite Surge status bonus as a second self remove effect

### DIFF
--- a/packs/feat-effects/effect-nanite-surge-bonus.json
+++ b/packs/feat-effects/effect-nanite-surge-bonus.json
@@ -1,0 +1,42 @@
+{
+    "_id": "pFo9DVyaDb4LdURY",
+    "img": "icons/commodities/tech/tube-chamber-lightning.webp",
+    "name": "Effect: Nanite Surge (Bonus)",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Nanite Surge].</p>\n<p>You gain a +2 status bonus to the triggering skill check.</p>"
+        },
+        "duration": {
+            "expiry": null,
+            "sustained": false,
+            "unit": "unlimited",
+            "value": -1
+        },
+        "level": {
+            "value": 1
+        },
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "removeAfterRoll": "if-enabled",
+                "selector": "skill-check",
+                "type": "status",
+                "value": 2
+            }
+        ],
+        "source": {
+            "value": ""
+        },
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feat-effects/effect-nanite-surge.json
+++ b/packs/feat-effects/effect-nanite-surge.json
@@ -4,7 +4,7 @@
     "name": "Effect: Nanite Surge",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Nanite Surge].</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Nanite Surge].</p>\n<p>Your circuitry glows, lighting a <span class=\"with-repost\" data-pf2-effect-area=\"emanation\" data-pf2-distance=\"10\" data-pf2-traits=\"android,concentrate\">10-Foot Emanation</span> with dim light for 1 round.</p>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -24,6 +24,10 @@
                     "dim": 10,
                     "shadows": 0.2
                 }
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.feat-effects.Item.Effect: Nanite Surge (Bonus)"
             }
         ],
         "source": {

--- a/packs/feat-effects/effect-nanite-surge.json
+++ b/packs/feat-effects/effect-nanite-surge.json
@@ -4,7 +4,7 @@
     "name": "Effect: Nanite Surge",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Nanite Surge].</p>\n<p>Your circuitry glows, lighting a <span class=\"with-repost\" data-pf2-effect-area=\"emanation\" data-pf2-distance=\"10\" data-pf2-traits=\"android,concentrate\">10-Foot Emanation</span> with dim light for 1 round.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Nanite Surge].</p>\n<p>Your circuitry glows, lighting a @Template[type:emanation|distance:10] with dim light for 1 round.</p>"
         },
         "duration": {
             "expiry": "turn-start",

--- a/packs/feats/nanite-surge.json
+++ b/packs/feats/nanite-surge.json
@@ -23,24 +23,7 @@
         "prerequisites": {
             "value": []
         },
-        "rules": [
-            {
-                "domain": "all",
-                "key": "RollOption",
-                "label": "Activate Nanite Surge",
-                "option": "nanite-surge",
-                "toggleable": true
-            },
-            {
-                "key": "FlatModifier",
-                "predicate": [
-                    "nanite-surge"
-                ],
-                "selector": "skill-check",
-                "type": "status",
-                "value": 2
-            }
-        ],
+        "rules": [],
         "selfEffect": {
             "name": "Effect: Nanite Surge",
             "uuid": "Compendium.pf2e.feat-effects.Item.Effect: Nanite Surge"


### PR DESCRIPTION
Let me know if the templates (both in the effect and/or the feat) outta be removed.