### PR TITLE
Include roll options passed to strike methods when rolling

### DIFF
--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -1635,7 +1635,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
                     target: { token: targetToken },
                     domains,
                     outcome: method === "damage" ? "success" : "criticalSuccess",
-                    options: new Set([...params.options, ...baseOptions]),
+                    options: new Set([...baseOptions, ...params.options]),
                 });
 
                 if (!context.self.item.dealsDamage) {

--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -1545,7 +1545,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
                     statistic: action,
                     target: { token: game.user.targets.first() ?? null },
                     defense: "armor",
-                    options: baseOptions,
+                    options: new Set([...baseOptions, ...params.options]),
                     viewOnly: params.getFormula,
                 });
 
@@ -1635,7 +1635,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
                     target: { token: targetToken },
                     domains,
                     outcome: method === "damage" ? "success" : "criticalSuccess",
-                    options: baseOptions,
+                    options: new Set([...params.options, ...baseOptions]),
                 });
 
                 if (!context.self.item.dealsDamage) {

--- a/src/module/actor/helpers.ts
+++ b/src/module/actor/helpers.ts
@@ -360,7 +360,7 @@ function strikeFromMeleeItem(item: MeleePF2e<ActorPF2e>): NPCStrike {
                 target: { token: game.user.targets.first() ?? null },
                 defense: "armor",
                 domains,
-                options: baseOptions,
+                options: new Set([...baseOptions, ...params.options]),
             });
 
             // Check whether target is out of maximum range; abort early if so
@@ -433,7 +433,7 @@ function strikeFromMeleeItem(item: MeleePF2e<ActorPF2e>): NPCStrike {
                 viewOnly: params.getFormula ?? false,
                 domains,
                 outcome,
-                options: baseOptions,
+                options: new Set([...baseOptions, ...(params.options ?? [])]),
             });
 
             if (!context.self.item.dealsDamage && !params.getFormula) {


### PR DESCRIPTION
Possibility to add own option for damage/attack

`_token.actor.system.actions[0].roll({event, options: ['test']})`

`_token.actor.system.actions[0].damage({event, options: ['test']})`