### PR TITLE
Update party travel labels to adhere to mechanics

### DIFF
--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -370,6 +370,7 @@
                     "Stash": "Stash"
                 },
                 "Total": "Party Total",
+                "TravelHeader": "Party Travel and Hexploration",
                 "Visibility": {
                     "Restricted": "Restricted",
                     "Unrestricted": "Unrestricted"
@@ -4551,7 +4552,6 @@
         "TraitsLabel": "Traits",
         "Trap": "Trap",
         "TravelSpeed": {
-            "ActivitiesPerDay": "Activities per Day",
             "Days": "Days",
             "DetectBeforeRunningIntoIt": "Notice Everything in Advance",
             "DetectEverything": "Notice Everything",
@@ -4576,10 +4576,12 @@
             "Feet": "Feet",
             "FeetAcronym": "ft",
             "GreaterDifficultTerrain": "Greater Difficult Terrain Speed",
+            "HexplorationActivities": "Hexploration Activities",
             "Hours": "Hours",
             "HoursPerDay": "Hours Spent Traveling Per Day",
             "HustleMinutes": "Minutes Spent Hustling Per Day",
             "Journey": "Journey",
+            "Label": "Travel Speed",
             "Miles": "Miles",
             "Name": "Name",
             "None": "Full Speed",

--- a/static/templates/actors/party/regions/exploration.hbs
+++ b/static/templates/actors/party/regions/exploration.hbs
@@ -2,14 +2,14 @@
     {{#if members}}
         <ol class="box-list exploration-members">
             <li class="box summary">
-                <header>{{localize "PF2E.TravelSpeed.PartySpeed"}}</header>
+                <header>{{localize "PF2E.Actor.Party.TravelHeader"}}</header>
                 <div class="summary-data">
                     <div>
-                        <label>{{localize "PF2E.Speed"}}</label>
+                        <label>{{localize "PF2E.TravelSpeed.Label"}}</label>
                         <span class="value">{{explorationSummary.speed}} {{localize "PF2E.Feet"}}</span>
                     </div>
                     <div>
-                        <label>{{localize "PF2E.TravelSpeed.ActivitiesPerDay"}}</label>
+                        <label>{{localize "PF2E.TravelSpeed.HexplorationActivities"}}</label>
                         <span class="value">{{explorationSummary.activities}}</span>
                     </div>
                 </div>


### PR DESCRIPTION
![image](https://github.com/foundryvtt/pf2e/assets/1286721/ee5d1841-c655-4108-bef6-070544bb0ee7)

The Party Speed label is still in use by the Travel Duration macro, which we should probably wire into the active party if we're still interested in maintaining that. I don't even know why it exists (or that it existed).