### PR TITLE
Handle NPC lootability without faking ownership level

### DIFF
--- a/src/module/actor/loot/document.ts
+++ b/src/module/actor/loot/document.ts
@@ -44,17 +44,17 @@ class LootPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | nu
         return false;
     }
 
+    /** A user can see a loot actor in the actor directory only if they have at least Observer permission */
+    override get visible(): boolean {
+        return this.permission >= CONST.DOCUMENT_OWNERSHIP_LEVELS.OBSERVER;
+    }
+
     /** Anyone with Limited permission can update a loot actor */
     override canUserModify(user: UserPF2e, action: UserAction): boolean {
         if (action === "update") {
             return this.permission >= CONST.DOCUMENT_OWNERSHIP_LEVELS.LIMITED;
         }
         return super.canUserModify(user, action);
-    }
-
-    /** A user can see a loot actor in the actor directory only if they have at least Observer permission */
-    override get visible(): boolean {
-        return this.permission >= CONST.DOCUMENT_OWNERSHIP_LEVELS.OBSERVER;
     }
 
     override async transferItemToActor(

--- a/src/module/actor/npc/sheet.ts
+++ b/src/module/actor/npc/sheet.ts
@@ -8,6 +8,7 @@ import { RecallKnowledgePopup } from "@actor/sheet/popups/recall-knowledge-popup
 import { AttributeString, MovementType } from "@actor/types.ts";
 import { ATTRIBUTE_ABBREVIATIONS, MOVEMENT_TYPES, SAVE_TYPES, SKILL_DICTIONARY } from "@actor/values.ts";
 import { createTagifyTraits } from "@module/sheet/helpers.ts";
+import { UserPF2e } from "@module/user/document.ts";
 import { DicePF2e } from "@scripts/dice.ts";
 import { eventToRollParams } from "@scripts/sheet-util.ts";
 import {
@@ -145,6 +146,11 @@ abstract class AbstractNPCSheet<TActor extends NPCPF2e> extends CreatureSheetPF2
             save.adjustedHigher = save.totalModifier > Number(save.base);
             save.adjustedLower = save.totalModifier < Number(save.base);
         }
+    }
+
+    /** Players can view the sheets of lootable NPCs. */
+    protected override _canUserView(user: UserPF2e): boolean {
+        return super._canUserView(user) || this.isLootSheet;
     }
 
     override activateListeners($html: JQuery<HTMLElement>): void {

--- a/src/module/canvas/token/object.ts
+++ b/src/module/canvas/token/object.ts
@@ -1,9 +1,10 @@
 import { EffectPF2e } from "@item";
+import { UserPF2e } from "@module/user/document.ts";
 import type { TokenDocumentPF2e } from "@scene/index.ts";
 import { htmlClosest } from "@util";
 import type { Renderer } from "pixi.js";
 import * as R from "remeda";
-import { CanvasPF2e, type TokenLayerPF2e, measureDistanceCuboid } from "../index.ts";
+import { CanvasPF2e, measureDistanceCuboid, type TokenLayerPF2e } from "../index.ts";
 import { HearingSource } from "../perception/hearing-source.ts";
 import { AuraRenderers } from "./aura/index.ts";
 
@@ -394,6 +395,11 @@ class TokenPF2e<TDocument extends TokenDocumentPF2e = TokenDocumentPF2e> extends
     /* -------------------------------------------- */
     /*  Event Handlers                              */
     /* -------------------------------------------- */
+
+    /** Players can view the sheets of lootable NPCs */
+    protected override _canView(user: UserPF2e, event: PIXI.FederatedPointerEvent): boolean {
+        return super._canView(user, event) || !!(this.actor?.isOfType("npc") && this.actor.isLootable);
+    }
 
     /** Refresh vision and the `EffectsPanel` */
     protected override _onControl(options: { releaseOthers?: boolean; pan?: boolean } = {}): void {

--- a/types/foundry/client/application/form-application/document-sheet/base.d.ts
+++ b/types/foundry/client/application/form-application/document-sheet/base.d.ts
@@ -36,6 +36,13 @@ declare global {
             options?: Partial<TOptions>
         ): DocumentSheetData<TDocument> | Promise<DocumentSheetData<TDocument>>;
 
+        /**
+         * Test whether a certain User has permission to view this Document Sheet.
+         * @param user The user requesting to render the sheet
+         * @returns Does the User have permission to view this sheet?
+         */
+        protected _canUserView(user: User): boolean;
+
         protected override _updateObject(event: Event, formData: Record<string, unknown>): Promise<void>;
     }
 }


### PR DESCRIPTION
This grants access to player NPC sheets via telling upstream what the player can specifically do at each check stage.