### PR TITLE
Refactor note markup to use `createHTMLElement`

### DIFF
--- a/src/module/notes.ts
+++ b/src/module/notes.ts
@@ -1,15 +1,16 @@
 import { UserVisibility } from "@scripts/ui/user-visibility.ts";
 import { DegreeOfSuccessString } from "@system/degree-of-success.ts";
 import { PredicatePF2e, RawPredicate } from "@system/predication.ts";
+import { createHTMLElement } from "@util";
 import { RuleElementPF2e } from "./rules/index.ts";
 
 class RollNotePF2e {
     /** The selector used to determine on which rolls the note will be shown for. */
     selector: string;
     /** An optional title for the note */
-    #title: string | null;
+    title: string | null;
     /** The text content of this note. */
-    #text: string;
+    text: string;
     /** If true, these dice are user-provided/custom. */
     predicate: PredicatePF2e;
     /** List of outcomes to show this note for; or all outcomes if none are specified */
@@ -21,35 +22,42 @@ class RollNotePF2e {
 
     constructor(params: RollNoteParams) {
         this.selector = params.selector;
-        this.#title = params.title ?? null;
-        this.#text = params.text;
+        this.title = params.title ?? null;
+        this.text = params.text;
         this.predicate = new PredicatePF2e(params.predicate ?? []);
         this.outcome = [...(params.outcome ?? [])];
         this.visibility = params.visibility ?? null;
         this.rule = params.rule ?? null;
     }
 
-    get text(): string {
-        const section = document.createElement("section");
-        section.innerHTML = game.i18n.localize(this.#text);
+    static notesToHTML(notes: RollNotePF2e[]): HTMLUListElement {
+        return createHTMLElement("ul", {
+            classes: ["notes"],
+            children: notes.flatMap((n) => ["\n", n.toHTML()]).slice(1),
+        });
+    }
+
+    toHTML(): HTMLLIElement {
+        const element = createHTMLElement("li", {
+            classes: ["roll-note"],
+            dataset: {
+                itemId: this.rule?.item.id,
+                visibility: this.visibility,
+            },
+            innerHTML: game.i18n.localize(this.text),
+        });
+
         // Remove wrapping elements, such as from item descriptions
-        const { firstChild } = section;
-        if (section.childNodes.length === 1 && firstChild instanceof HTMLElement) {
-            section.innerHTML = firstChild.innerHTML;
-        }
-        section.classList.add("roll-note");
-
-        if (this.visibility) {
-            section.dataset.visibility = this.visibility;
+        if (element.childNodes.length === 1 && element.firstChild instanceof HTMLElement) {
+            element.innerHTML = element.firstChild.innerHTML;
         }
 
-        if (this.#title) {
-            const strong = document.createElement("strong");
-            strong.innerHTML = game.i18n.localize(this.#title);
-            section.prepend(strong, " ");
+        if (this.title) {
+            const strong = createHTMLElement("strong", { innerHTML: game.i18n.localize(this.title) });
+            element.prepend(strong, " ");
         }
 
-        return section.outerHTML;
+        return element;
     }
 
     clone(): RollNotePF2e {
@@ -59,9 +67,9 @@ class RollNotePF2e {
     toObject(): RollNoteSource {
         return {
             selector: this.selector,
-            title: this.#title,
-            text: this.#text,
-            predicate: this.predicate,
+            title: this.title,
+            text: this.text,
+            predicate: this.predicate.toObject(),
             outcome: this.outcome,
             visibility: this.visibility,
         };

--- a/src/module/system/check/check.ts
+++ b/src/module/system/check/check.ts
@@ -194,9 +194,9 @@ class CheckPF2e {
             roll.options.degreeOfSuccess = degree.value;
         }
 
-        const notes = context.notes?.map((n) => (n instanceof RollNotePF2e ? n : new RollNotePF2e(n))) ?? [];
-        const notesText =
-            notes
+        const notes =
+            context.notes
+                ?.map((n) => (n instanceof RollNotePF2e ? n : new RollNotePF2e(n)))
                 .filter((note) => {
                     if (!note.predicate.test([...rollOptions, ...(note.rule?.item.getRollOptions("parent") ?? [])])) {
                         return false;
@@ -207,9 +207,8 @@ class CheckPF2e {
                     }
                     const outcome = context.outcome ?? context.unadjustedOutcome;
                     return !!(outcome && note.outcome.includes(outcome));
-                })
-                .map((n) => n.text)
-                .join("\n") ?? "";
+                }) ?? [];
+        const notesList = RollNotePF2e.notesToHTML(notes);
 
         const item = context.item ?? null;
 
@@ -225,7 +224,7 @@ class CheckPF2e {
                       return createHTMLElement("h4", { classes: ["action"], children: [strong] });
                   })();
 
-            return [header, result ?? [], tags, notesText]
+            return [header, result ?? [], tags, notesList]
                 .flat()
                 .map((e) => (typeof e === "string" ? e : e.outerHTML))
                 .join("");
@@ -243,7 +242,7 @@ class CheckPF2e {
             domains: context.domains ?? [],
             target: context.target ? { actor: context.target.actor.uuid, token: context.target.token.uuid } : null,
             options: Array.from(rollOptions).sort(),
-            notes: notes.filter((n) => n.predicate.test(rollOptions)).map((n) => n.toObject()),
+            notes: notes.map((n) => n.toObject()),
             rollMode: context.rollMode,
             rollTwice: context.rollTwice ?? false,
             title: context.title ?? "PF2E.Check.Label",

--- a/src/scripts/ui/user-visibility.ts
+++ b/src/scripts/ui/user-visibility.ts
@@ -96,11 +96,12 @@ class UserVisibilityPF2e {
     }
 }
 
-type UserVisibility = "all" | "owner" | "gm" | "none";
+const USER_VISIBILITIES = new Set(["all", "owner", "gm", "none"] as const);
+type UserVisibility = SetElement<typeof USER_VISIBILITIES>;
 
 interface ProcessOptions {
     document?: ClientDocument | null;
     message?: ChatMessagePF2e;
 }
 
-export { UserVisibility, UserVisibilityPF2e };
+export { USER_VISIBILITIES, UserVisibility, UserVisibilityPF2e };

--- a/src/styles/ui/sidebar/chat/_index.scss
+++ b/src/styles/ui/sidebar/chat/_index.scss
@@ -3,6 +3,23 @@
 .chat-message {
     @import "action", "check", "damage", "reroll";
 
+    .message-header .flavor-text {
+        display: block;
+
+        ul.notes {
+            display: block;
+            line-height: 1.5em;
+            list-style: none;
+            margin: 0;
+            padding: 0;
+
+            li {
+                display: block;
+                line-height: 1.5em;
+            }
+        }
+    }
+
     > .message-content {
         @import "conditions";
     }


### PR DESCRIPTION
Also:
- Add itemId to note markup indicating which item the note came from
- Check metagame setting to determine default `showDC` for inline checks