### PR TITLE
Remove tag line-height styling from NPC sheet

### DIFF
--- a/src/styles/actor/npc/_index.scss
+++ b/src/styles/actor/npc/_index.scss
@@ -550,10 +550,6 @@ $faded-color: #7a7971;
         }
     }
 
-    .tag {
-        line-height: 0.8rem;
-    }
-
     select {
         flex: auto 0 0;
         padding: 4px !important;


### PR DESCRIPTION
Before:
![image](https://github.com/foundryvtt/pf2e/assets/106829671/16886228-e564-451d-9428-4b9f9d9343d2)

After:
![image](https://github.com/foundryvtt/pf2e/assets/106829671/f40e072a-a06f-4b75-8ca4-cf22cb776dc5)
