### PR TITLE
Add resource points to kingdom header

### DIFF
--- a/src/module/actor/party/kingdom/schema.ts
+++ b/src/module/actor/party/kingdom/schema.ts
@@ -98,6 +98,12 @@ const KINGDOM_RESOURCES_SCHEMA = {
             return [type, schema];
         })
     ),
+    points: new fields.NumberField<number, number, false, false, true>({
+        min: 0,
+        required: false,
+        nullable: false,
+        initial: 0,
+    }),
     /** Worksites by commodity type, for the commodities that can have work sites */
     workSites: new fields.SchemaField(
         R.mapToObj(["lumber", "ore", "stone"], (type) => {

--- a/src/module/actor/party/kingdom/sheet.ts
+++ b/src/module/actor/party/kingdom/sheet.ts
@@ -181,7 +181,7 @@ class KingdomSheetPF2e extends ActorSheetPF2e<PartyPF2e> {
         }
 
         const { fame } = this.kingdom.resources;
-        const famePips = htmlQuery(html, "a[data-action=adjust-fame]");
+        const famePips = htmlQuery(html, "[data-action=adjust-fame]");
         famePips?.addEventListener("click", async () => {
             const newValue = Math.min(fame.value + 1, fame.max);
             await this.kingdom.update({ "resources.fame.value": newValue });

--- a/src/styles/actor/party/kingdom/_index.scss
+++ b/src/styles/actor/party/kingdom/_index.scss
@@ -60,10 +60,10 @@
 
         .details {
             display: grid;
-            grid-template-areas:
-                "title title title level"
-                "capital size fame level";
-            grid-template-columns: 1fr auto auto;
+            grid-template:
+                "title title title title level" auto
+                "capital size rp fame level" auto /
+                1fr auto auto auto auto;
             align-items: center;
             gap: 0 4px;
 
@@ -93,9 +93,10 @@
                 }
             }
 
-            .name {
+            .title {
+                display: flex;
                 grid-area: title;
-                flex: 1;
+                gap: 1rem;
                 font-size: var(--font-size-30);
             }
 
@@ -117,6 +118,15 @@
 
             .size {
                 grid-area: size;
+                margin-left: 0.5rem;
+                input {
+                    width: 3ch;
+                    text-align: center;
+                }
+            }
+
+            .resource-points {
+                grid-area: rp;
                 margin-left: 1rem;
                 input {
                     width: 3ch;
@@ -128,9 +138,9 @@
                 align-items: center;
                 display: flex;
                 grid-area: fame;
-                margin-left: 1rem;
+                margin-left: 0.25rem;
                 .pips {
-                    font-size: var(--font-size-14);
+                    font-size: var(--font-size-12);
                 }
             }
 

--- a/static/lang/kingmaker-en.json
+++ b/static/lang/kingmaker-en.json
@@ -87,7 +87,9 @@
                 "Collect": "Collect",
                 "Dice": "Resource Dice",
                 "Header": "Resources and Commodities",
+                "Points": "Resource Points",
                 "ResourceWorkSites": "Resource",
+                "RP": "RP",
                 "WorkSites": "Work Sites"
             },
             "Ruin": {

--- a/static/templates/actors/party/kingdom/sheet.hbs
+++ b/static/templates/actors/party/kingdom/sheet.hbs
@@ -6,7 +6,11 @@
             </div>
         </div>
         <div class="details">
-            <input name="name" class="name" type="text" value="{{kingdom.name}}" placeholder="{{localize "PF2E.Kingmaker.Kingdom.NamePlaceholder"}}"/>
+            <div class="title">
+                <input name="name" class="name" type="text" value="{{kingdom.name}}" placeholder="{{localize "PF2E.Kingmaker.Kingdom.NamePlaceholder"}}"/>
+                <div class="nation-type">{{nationTypeLabel}}</div>
+            </div>
+
             <label class="capital">
                 <span>{{localize "PF2E.Kingmaker.Kingdom.Capital"}}</span>
                 <input name="capital" type="text" value="{{kingdom.capital}}" placeholder="{{localize "PF2E.Kingmaker.Kingdom.CapitalPlaceholder"}}" />
@@ -15,12 +19,16 @@
             <label class="size">
                 <span>{{localize "PF2E.Kingmaker.Kingdom.Size"}}</span>
                 <input name="size" type="number" value="{{kingdom.size}}" />
-                <div>{{nationTypeLabel}}</div>
             </label>
 
-            <label class="fame">
+            <label class="resource-points">
+                <span data-tooltip="PF2E.Kingmaker.Kingdom.Resources.Points">{{localize "PF2E.Kingmaker.Kingdom.Resources.RP"}}</span>
+                <input name="resources.points" type="number" value="{{kingdom.resources.points}}" />
+            </label>
+
+            <label class="fame" data-action="adjust-fame">
                 <span>{{localize (concat "PF2E.Kingmaker.Kingdom.Aspiration." kingdom.aspiration)}}</span>
-                <a class="pips {{#unless member.owner}}readonly{{/unless}}" data-action="adjust-fame">
+                <a class="pips {{#unless member.owner}}readonly{{/unless}}">
                     {{#times kingdom.resources.fame.max}}
                         {{#if (gt @root.kingdom.resources.fame.value this)}}
                             <i class="fa-solid fa-circle"></i>


### PR DESCRIPTION
This is a resource that is omnipresent during the kingdom turn. Without an omnibar (nor the time to build one) the header is the current best place to put it.

![image](https://github.com/foundryvtt/pf2e/assets/1286721/706ec2ba-b5c3-4a7b-9d82-aa94b9ef794a)
