### PR TITLE
Add effect for Conductive Weapon

### DIFF
--- a/packs/spell-effects/spell-effect-conductive-weapon.json
+++ b/packs/spell-effects/spell-effect-conductive-weapon.json
@@ -1,0 +1,60 @@
+{
+    "_id": "WdXLgPashH5in5eB",
+    "img": "icons/weapons/swords/sword-flanged-lightning.webp",
+    "name": "Spell Effect: Conductive Weapon",
+    "system": {
+        "description": {
+            "value": "<p>Granted by <em>@UUID[Compendium.pf2e.spells-srd.Item.Conductive Weapon]</em></p>\n<p>The target becomes a <em>+1 shock weapon</em>.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "minutes",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "rules": [
+            {
+                "choices": {
+                    "ownedItems": true,
+                    "types": [
+                        "weapon"
+                    ]
+                },
+                "flag": "weapon",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.Weapon"
+            },
+            {
+                "key": "WeaponPotency",
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-attack",
+                "value": 1
+            },
+            {
+                "definition": [
+                    "item:id:{item|flags.pf2e.rulesSelections.weapon}"
+                ],
+                "key": "AdjustStrike",
+                "mode": "add",
+                "property": "property-runes",
+                "value": "shock"
+            }
+        ],
+        "source": {
+            "value": "Pathfinder Rage of Elements"
+        },
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/spell-effects/spell-effect-conductive-weapon.json
+++ b/packs/spell-effects/spell-effect-conductive-weapon.json
@@ -4,7 +4,7 @@
     "name": "Spell Effect: Conductive Weapon",
     "system": {
         "description": {
-            "value": "<p>Granted by <em>@UUID[Compendium.pf2e.spells-srd.Item.Conductive Weapon]</em></p>\n<p>The target becomes a <em>+1 shock weapon</em>.</p>"
+            "value": "<p>Granted by <em>@UUID[Compendium.pf2e.spells-srd.Item.Conductive Weapon]</em></p>\n<p>The target becomes a <em>+1 shock weapon</em>. If any target of an attack with the weapon is wearing metal armor or is primarily made of metal, the electricity damage die from the <em>shock</em> rune is 1d12.</p>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -33,13 +33,47 @@
                 "value": 1
             },
             {
+                "domain": "all",
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Target.Metal",
+                "option": "target:metal",
+                "toggleable": true
+            },
+            {
                 "definition": [
                     "item:id:{item|flags.pf2e.rulesSelections.weapon}"
                 ],
                 "key": "AdjustStrike",
                 "mode": "add",
+                "predicate": [
+                    {
+                        "not": "target:metal"
+                    }
+                ],
                 "property": "property-runes",
                 "value": "shock"
+            },
+            {
+                "damageType": "electricity",
+                "diceNumber": 1,
+                "dieSize": "d12",
+                "key": "DamageDice",
+                "predicate": [
+                    "target:metal"
+                ],
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-damage"
+            },
+            {
+                "key": "Note",
+                "outcome": [
+                    "criticalSuccess"
+                ],
+                "predicate": [
+                    "target:metal"
+                ],
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-damage",
+                "text": "PF2E.WeaponPropertyRune.shock.Note.criticalSuccess",
+                "title": "PF2E.WeaponPropertyRune.shock.Name"
             }
         ],
         "source": {

--- a/packs/spells/conductive-weapon.json
+++ b/packs/spells/conductive-weapon.json
@@ -1,6 +1,6 @@
 {
     "_id": "fkUCvynklBGb4LaI",
-    "img": "systems/pf2e/icons/default-icons/spell.svg",
+    "img": "icons/weapons/swords/sword-flanged-lightning.webp",
     "name": "Conductive Weapon",
     "system": {
         "area": null,
@@ -18,7 +18,7 @@
             "value": {}
         },
         "description": {
-            "value": "<p>You channel powerful electric current through the metal of a weapon, zapping anyone the item hits. The target becomes a +1 shock weapon. If any target of an attack with the weapon is wearing metal armor or is primarily made of metal, the electricity damage die from the shock rune is [[/r 1d12]].</p>"
+            "value": "<p>You channel powerful electric current through the metal of a weapon, zapping anyone the item hits. The target becomes a <em>+1 shock weapon</em>. If any target of an attack with the weapon is wearing metal armor or is primarily made of metal, the electricity damage die from the shock rune is [[/r 1d12[electricity]]]{1d12}.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Conductive Weapon]</p>"
         },
         "duration": {
             "value": "1 minute"

--- a/packs/spells/conductive-weapon.json
+++ b/packs/spells/conductive-weapon.json
@@ -18,7 +18,7 @@
             "value": {}
         },
         "description": {
-            "value": "<p>You channel powerful electric current through the metal of a weapon, zapping anyone the item hits. The target becomes a <em>+1 shock weapon</em>. If any target of an attack with the weapon is wearing metal armor or is primarily made of metal, the electricity damage die from the shock rune is [[/r 1d12[electricity]]]{1d12}.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Conductive Weapon]</p>"
+            "value": "<p>You channel powerful electric current through the metal of a weapon, zapping anyone the item hits. The target becomes a <em>+1 shock weapon</em>. If any target of an attack with the weapon is wearing metal armor or is primarily made of metal, the electricity damage die from the <em>shock</em> rune is 1d12.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Conductive Weapon]</p>"
         },
         "duration": {
             "value": "1 minute"

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2620,7 +2620,8 @@
                 "AgainstDemons": "Against Demons",
                 "AgainstDevils": "Against Devils",
                 "AgainstHumanoids": "Against Humanoids",
-                "Necromancer": "Target is a necromancer"
+                "Necromancer": "Target is a necromancer",
+                "Metal": "Target is wearing metal armor or is made of metal"
             },
             "Tattoo": {
                 "WildwoodInk": {


### PR DESCRIPTION
~~I don't believe there's currently a way to modify a property rune's damage with an RE.~~

Faked the property rune for metal targets.