### PR TITLE
Hide spell DCs when appropriate

### DIFF
--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -29,8 +29,17 @@ import {
 } from "@system/damage/types.ts";
 import { DEGREE_OF_SUCCESS_STRINGS } from "@system/degree-of-success.ts";
 import { StatisticRollParameters } from "@system/statistic/index.ts";
-import { EnrichmentOptionsPF2e } from "@system/text-editor.ts";
-import { ErrorPF2e, getActionIcon, htmlClosest, localizer, ordinal, setHasElement, traitSlugToObject } from "@util";
+import { EnrichmentOptionsPF2e, TextEditorPF2e } from "@system/text-editor.ts";
+import {
+    ErrorPF2e,
+    createHTMLElement,
+    getActionIcon,
+    htmlClosest,
+    localizer,
+    ordinal,
+    setHasElement,
+    traitSlugToObject,
+} from "@util";
 import * as R from "remeda";
 import { SpellHeightenLayer, SpellOverlayType, SpellSource, SpellSystemData, SpellSystemSource } from "./data.ts";
 import { SpellOverlayCollection } from "./overlay.ts";
@@ -720,7 +729,14 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
         // Spell save label
         const saveType = systemData.save.value ? game.i18n.localize(CONFIG.PF2E.saves[systemData.save.value]) : null;
         const saveKey = systemData.save.basic ? "PF2E.SaveDCLabelBasic" : "PF2E.SaveDCLabel";
-        const saveLabel = spellDC && saveType ? game.i18n.format(saveKey, { dc: spellDC, type: saveType }) : null;
+        const saveLabel = ((): string | null => {
+            if (!(spellDC && saveType)) return null;
+            const localized = game.i18n.format(saveKey, { dc: spellDC, type: saveType });
+            const tempElement = createHTMLElement("div", { innerHTML: localized });
+            const visibility = game.settings.get("pf2e", "metagame_showDC") ? "all" : "owner";
+            TextEditorPF2e.convertXMLNode(tempElement, "dc", { visibility, whose: null });
+            return tempElement.innerHTML;
+        })();
 
         // Spell attack labels
         const isHeal = systemData.spellType.value === "heal";

--- a/src/styles/legacy/_chat.scss
+++ b/src/styles/legacy/_chat.scss
@@ -51,13 +51,6 @@
         flex-direction: column;
         margin: 4px 0;
 
-        span {
-            display: block;
-            line-height: 28px;
-            text-align: center;
-            border: 1px solid var(--secondary-background);
-        }
-
         button {
             margin: 2px 0;
 

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -3172,8 +3172,8 @@
                 "name": "Condition Icon Set"
             }
         },
-        "SaveDCLabel": "Save DC {dc} {type}",
-        "SaveDCLabelBasic": "Save DC {dc} basic {type}",
+        "SaveDCLabel": "Save <dc>DC {dc}</dc> {type}",
+        "SaveDCLabelBasic": "Save <dc>DC {dc}</dc> basic {type}",
         "SavesFortitude": "Fortitude",
         "SavesFortitudeShort": "Fort",
         "SavesHeader": "Saves",

--- a/static/templates/chat/spell-card.hbs
+++ b/static/templates/chat/spell-card.hbs
@@ -39,7 +39,9 @@
             </button>
         {{else}}
             {{#if data.isSave}}
-                <button type="button" data-action="spell-save" data-save="{{data.save.type}}" data-dc="{{data.save.value}}" data-owner-title="{{data.save.breakdown}}">{{data.save.label}}</button>
+                <button type="button" data-action="spell-save" data-save="{{data.save.type}}" data-dc="{{data.save.value}}" data-owner-title="{{data.save.breakdown}}">
+                    {{{data.save.label}}}
+                </button>
             {{/if}}
             {{#if (or data.check data.hasDamage data.hasCounteractCheck.value data.area.type)}}
                 <section class="owner-buttons">


### PR DESCRIPTION
Before and after:
![image](https://github.com/foundryvtt/pf2e/assets/106829671/e83e3ebf-c8c4-4ab2-9fff-c607d1f5a093)
