### PR TITLE
Improved Gunslinger initial deeds

### DIFF
--- a/packs/actions/energy-shot.json
+++ b/packs/actions/energy-shot.json
@@ -20,7 +20,7 @@
             {
                 "key": "Note",
                 "selector": "initiative",
-                "text": "You can Interact to draw a ranged weapon. On your first three Strikes of this encounter with a firearm or crossbow, you deal an additional 1 acid, cold, fire or electricity damage. You choose which damage type to deal as part of making each Strike. @UUID[Compendium.pf2e.feat-effects.Item.Effect: Energy Shot]",
+                "text": "{item|system.description.value}",
                 "title": "<span class=\"pf2-icon\">F</span> {item|name}"
             }
         ],

--- a/packs/actions/energy-shot.json
+++ b/packs/actions/energy-shot.json
@@ -16,7 +16,14 @@
         "requirements": {
             "value": ""
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "Note",
+                "selector": "initiative",
+                "text": "You can Interact to draw a ranged weapon. On your first three Strikes of this encounter with a firearm or crossbow, you deal an additional 1 acid, cold, fire or electricity damage. You choose which damage type to deal as part of making each Strike. @UUID[Compendium.pf2e.feat-effects.Item.Effect: Energy Shot]",
+                "title": "<span class=\"pf2-icon\">F</span> {item|name}"
+            }
+        ],
         "source": {
             "value": "Pathfinder Guns & Gears"
         },

--- a/packs/actions/into-the-fray.json
+++ b/packs/actions/into-the-fray.json
@@ -20,7 +20,7 @@
             {
                 "key": "Note",
                 "selector": "initiative",
-                "text": "You can Interact to draw a one-handed ranged weapon and can then Interact to draw a one-handed melee weapon. As your first action on your first turn, you can Stride as a free action toward an enemy you can perceive.",
+                "text": "{item|system.description.value}",
                 "title": "<span class=\"pf2-icon\">F</span> {item|name}"
             }
         ],

--- a/packs/actions/into-the-fray.json
+++ b/packs/actions/into-the-fray.json
@@ -16,7 +16,14 @@
         "requirements": {
             "value": ""
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "Note",
+                "selector": "initiative",
+                "text": "You can Interact to draw a one-handed ranged weapon and can then Interact to draw a one-handed melee weapon. As your first action on your first turn, you can Stride as a free action toward an enemy you can perceive.",
+                "title": "<span class=\"pf2-icon\">F</span> {item|name}"
+            }
+        ],
         "source": {
             "value": "Pathfinder Guns & Gears"
         },

--- a/packs/actions/living-fortification.json
+++ b/packs/actions/living-fortification.json
@@ -11,41 +11,16 @@
         },
         "category": "offensive",
         "description": {
-            "value": "<p><strong>Trigger</strong> You roll initiative.</p>\n<hr />\n<p>You can posture defensively with firearms or crossbows, acting like a walking tower. Interact to draw a firearm or crossbow. You then position that weapon defensively, gaining a +1 circumstance bonus to AC until the start of your first turn, or a +2 circumstance bonus if the chosen weapon has the parry trait.</p>"
+            "value": "<p><strong>Trigger</strong> You roll initiative.</p>\n<hr />\n<p>You can posture defensively with firearms or crossbows, acting like a walking tower. Interact to draw a firearm or crossbow. You then position that weapon defensively, gaining a +1 circumstance bonus to AC until the start of your first turn, or a +2 circumstance bonus if the chosen weapon has the parry trait.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Living Fortification]</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Living Fortification (Parry Trait)]</p>"
         },
         "requirements": {
             "value": ""
         },
         "rules": [
             {
-                "domain": "ac",
-                "key": "RollOption",
-                "option": "living-fortification",
-                "suboptions": [
-                    {
-                        "label": "+1",
-                        "value": "1"
-                    },
-                    {
-                        "label": "+2",
-                        "value": "2"
-                    }
-                ],
-                "toggleable": true
-            },
-            {
-                "key": "FlatModifier",
-                "predicate": [
-                    "living-fortification"
-                ],
-                "selector": "ac",
-                "type": "circumstance",
-                "value": "{item|flags.pf2e.rulesSelections.livingFortification}"
-            },
-            {
                 "key": "Note",
                 "selector": "initiative",
-                "text": "Interact to draw a firearm or crossbow. You gain a +1 circumstance bonus to AC until the start of your first turn, or a +2 circumstance bonus if the chosen weapon has the parry trait.",
+                "text": "{item|system.description.value}",
                 "title": "<span class=\"pf2-icon\">F</span> {item|name}"
             }
         ],

--- a/packs/actions/living-fortification.json
+++ b/packs/actions/living-fortification.json
@@ -16,7 +16,39 @@
         "requirements": {
             "value": ""
         },
-        "rules": [],
+        "rules": [
+            {
+                "domain": "ac",
+                "key": "RollOption",
+                "option": "living-fortification",
+                "suboptions": [
+                    {
+                        "label": "+1",
+                        "value": "1"
+                    },
+                    {
+                        "label": "+2",
+                        "value": "2"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "living-fortification"
+                ],
+                "selector": "ac",
+                "type": "circumstance",
+                "value": "{item|flags.pf2e.rulesSelections.livingFortification}"
+            },
+            {
+                "key": "Note",
+                "selector": "initiative",
+                "text": "Interact to draw a firearm or crossbow. You gain a +1 circumstance bonus to AC until the start of your first turn, or a +2 circumstance bonus if the chosen weapon has the parry trait.",
+                "title": "<span class=\"pf2-icon\">F</span> {item|name}"
+            }
+        ],
         "source": {
             "value": "Pathfinder Guns & Gears"
         },

--- a/packs/actions/one-shot-one-kill.json
+++ b/packs/actions/one-shot-one-kill.json
@@ -67,7 +67,7 @@
                     "stealth"
                 ],
                 "selector": "initiative",
-                "text": "Interact to draw a firearm or crossbow. On your first turn, your first Strike with that weapon deals an additional 1d6 precision damage. This precision damage increases to 2d6 at 9th level and 3d6 at 15th level.",
+                "text": "{item|system.description.value}",
                 "title": "<span class=\"pf2-icon\">F</span> {item|name}"
             }
         ],

--- a/packs/actions/one-shot-one-kill.json
+++ b/packs/actions/one-shot-one-kill.json
@@ -60,6 +60,15 @@
                         }
                     ]
                 }
+            },
+            {
+                "key": "Note",
+                "predicate": [
+                    "stealth"
+                ],
+                "selector": "initiative",
+                "text": "Interact to draw a firearm or crossbow. On your first turn, your first Strike with that weapon deals an additional 1d6 precision damage. This precision damage increases to 2d6 at 9th level and 3d6 at 15th level.",
+                "title": "<span class=\"pf2-icon\">F</span> {item|name}"
             }
         ],
         "source": {

--- a/packs/actions/spring-the-trap.json
+++ b/packs/actions/spring-the-trap.json
@@ -20,7 +20,7 @@
             {
                 "key": "Note",
                 "selector": "initiative",
-                "text": "You can Interact to draw a combination weapon and set it to melee or ranged mode. On your first turn, your movement and ranged attacks don't trigger reactions that are normally triggered by movement or a ranged attack (such as Attack of Opportunity).",
+                "text": "{item|system.description.value}",
                 "title": "<span class=\"pf2-icon\">F</span> {item|name}"
             }
         ],

--- a/packs/actions/spring-the-trap.json
+++ b/packs/actions/spring-the-trap.json
@@ -16,7 +16,14 @@
         "requirements": {
             "value": ""
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "Note",
+                "selector": "initiative",
+                "text": "You can Interact to draw a combination weapon and set it to melee or ranged mode. On your first turn, your movement and ranged attacks don't trigger reactions that are normally triggered by movement or a ranged attack (such as Attack of Opportunity).",
+                "title": "<span class=\"pf2-icon\">F</span> {item|name}"
+            }
+        ],
         "source": {
             "value": "Pathfinder Lost Omens: Impossible Lands"
         },

--- a/packs/actions/ten-paces.json
+++ b/packs/actions/ten-paces.json
@@ -31,6 +31,12 @@
                 "key": "RollOption",
                 "option": "ten-paces",
                 "toggleable": true
+            },
+            {
+                "key": "Note",
+                "selector": "initiative",
+                "text": "You gain a +2 circumstance bonus to your initiative roll, and you can Interact to draw a one-handed firearm or one-handed crossbow. As your first action on your first turn, you can Step up to 10 feet as a free action."
+                "title": "<span class=\"pf2-icon\">F</span> {item|name}",
             }
         ],
         "source": {

--- a/packs/actions/ten-paces.json
+++ b/packs/actions/ten-paces.json
@@ -35,8 +35,8 @@
             {
                 "key": "Note",
                 "selector": "initiative",
-                "text": "You gain a +2 circumstance bonus to your initiative roll, and you can Interact to draw a one-handed firearm or one-handed crossbow. As your first action on your first turn, you can Step up to 10 feet as a free action."
-                "title": "<span class=\"pf2-icon\">F</span> {item|name}",
+                "text": "You gain a +2 circumstance bonus to your initiative roll, and you can Interact to draw a one-handed firearm or one-handed crossbow. As your first action on your first turn, you can Step up to 10 feet as a free action.",
+                "title": "<span class=\"pf2-icon\">F</span> {item|name}"
             }
         ],
         "source": {

--- a/packs/actions/ten-paces.json
+++ b/packs/actions/ten-paces.json
@@ -35,7 +35,7 @@
             {
                 "key": "Note",
                 "selector": "initiative",
-                "text": "You gain a +2 circumstance bonus to your initiative roll, and you can Interact to draw a one-handed firearm or one-handed crossbow. As your first action on your first turn, you can Step up to 10 feet as a free action.",
+                "text": "{item|system.description.value}",
                 "title": "<span class=\"pf2-icon\">F</span> {item|name}"
             }
         ],

--- a/packs/feat-effects/effect-living-fortification-parry-trait.json
+++ b/packs/feat-effects/effect-living-fortification-parry-trait.json
@@ -1,0 +1,44 @@
+{
+    "_id": "WxE5S3KY1DR5Nbxm",
+    "img": "systems/pf2e/icons/equipment/weapons/main-gauche.webp",
+    "name": "Effect: Living Fortification (Parry Trait)",
+    "system": {
+        "description": {
+            "value": "<p>You position your weapon defensively, gaining a +2 circumstance bonus to AC until the start of your next turn.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 0
+        },
+        "level": {
+            "value": 1
+        },
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "selector": "ac",
+                "type": "circumstance",
+                "value": 2
+            }
+        ],
+        "source": {
+            "value": "Pathfinder Guns & Gears"
+        },
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "gunslinger"
+            ]
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feat-effects/effect-living-fortification.json
+++ b/packs/feat-effects/effect-living-fortification.json
@@ -1,0 +1,44 @@
+{
+    "_id": "fRlvmul3LbLo2xvR",
+    "img": "systems/pf2e/icons/equipment/weapons/main-gauche.webp",
+    "name": "Effect: Living Fortification",
+    "system": {
+        "description": {
+            "value": "<p>You position your weapon defensively, gaining a +1 circumstance bonus to AC until the start of your next turn.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 0
+        },
+        "level": {
+            "value": 1
+        },
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "selector": "ac",
+                "type": "circumstance",
+                "value": 1
+            }
+        ],
+        "source": {
+            "value": "Pathfinder Guns & Gears"
+        },
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "gunslinger"
+            ]
+        }
+    },
+    "type": "effect"
+}


### PR DESCRIPTION
Added notes to the Gunslinger initiative rolls with the description of authorized actions.
![image](https://github.com/foundryvtt/pf2e/assets/63196064/cc3995ea-d761-4d13-97a4-93781833a506)
Added a toggle to provide Living Fortification AC buffs for the Vanguard.
![image](https://github.com/foundryvtt/pf2e/assets/63196064/5a41193e-1b06-490f-b41e-9349b02215d1)