### PR TITLE
Normalize weapon/armor group from `_preUpdate` methods, migrate away errant `group` property

### DIFF
--- a/build/run-migration.ts
+++ b/build/run-migration.ts
@@ -10,7 +10,6 @@ import { getFilesRecursively } from "./lib/helpers.ts";
 import { MigrationBase } from "@module/migration/base.ts";
 import { MigrationRunnerBase } from "@module/migration/runner/base.ts";
 
-import { Migration839ActionCategories } from "@module/migration/migrations/839-action-categories.ts";
 import { Migration841V11UUIDFormat } from "@module/migration/migrations/841-v11-uuid-format.ts";
 import { Migration844DeityDomainUUIDs } from "@module/migration/migrations/844-deity-domains-uuids.ts";
 import { Migration846SpellSchoolOptional } from "@module/migration/migrations/846-spell-school-optional.ts";
@@ -27,6 +26,7 @@ import { Migration856NoSystemDotCustom } from "@module/migration/migrations/856-
 import { Migration857WeaponSpecializationRE } from "@module/migration/migrations/857-weapon-spec-re.ts";
 import { Migration858FakeWeaponSpecialization } from "@module/migration/migrations/858-fake-weapon-specialization.ts";
 import { Migration859MaterialTypeGrade } from "@module/migration/migrations/859-material-type-grade.ts";
+import { Migration860RMGroup } from "@module/migration/migrations/860-rm-group.ts";
 
 // ^^^ don't let your IDE use the index in these imports. you need to specify the full path ^^^
 
@@ -37,7 +37,6 @@ globalThis.HTMLParagraphElement = window.HTMLParagraphElement;
 globalThis.Text = window.Text;
 
 const migrations: MigrationBase[] = [
-    new Migration839ActionCategories(),
     new Migration841V11UUIDFormat(),
     new Migration844DeityDomainUUIDs(),
     new Migration846SpellSchoolOptional(),
@@ -54,6 +53,7 @@ const migrations: MigrationBase[] = [
     new Migration857WeaponSpecializationRE(),
     new Migration858FakeWeaponSpecialization(),
     new Migration859MaterialTypeGrade(),
+    new Migration860RMGroup(),
 ];
 
 global.deepClone = <T>(original: T): T => {

--- a/packs/equipment/belt-of-good-health.json
+++ b/packs/equipment/belt-of-good-health.json
@@ -29,9 +29,6 @@
         "equippedBulk": {
             "value": ""
         },
-        "group": {
-            "value": ""
-        },
         "hardness": 0,
         "hp": {
             "max": 0,

--- a/packs/equipment/caverns-heart.json
+++ b/packs/equipment/caverns-heart.json
@@ -11,7 +11,6 @@
         "equippedBulk": {
             "value": ""
         },
-        "group": null,
         "hardness": 0,
         "hp": {
             "max": 0,

--- a/packs/equipment/demons-knot.json
+++ b/packs/equipment/demons-knot.json
@@ -12,7 +12,6 @@
         "equippedBulk": {
             "value": ""
         },
-        "group": null,
         "hardness": 0,
         "hp": {
             "max": 0,

--- a/packs/equipment/pyrite-rat.json
+++ b/packs/equipment/pyrite-rat.json
@@ -3,33 +3,12 @@
     "img": "systems/pf2e/icons/equipment/held-items/wondrous-figurine-golden-lion.webp",
     "name": "Pyrite Rat",
     "system": {
-        "MAP": {
-            "value": ""
-        },
-        "ability": {
-            "value": ""
-        },
         "baseItem": null,
-        "bonus": {
-            "value": 0
-        },
-        "bonusDamage": {
-            "value": 0
-        },
         "containerId": null,
-        "damage": {
-            "damageType": "slashing",
-            "dice": 1,
-            "die": "d6",
-            "value": ""
-        },
         "description": {
             "value": "<p>This lustrous, rat-shaped pyrite statuette is 1 inch tall. When activated, the statuette transforms into a flesh-and-blood giant rat. You can use the following action when you hold the <em>pyrite rat</em>. You can use this action only once per day, and the rat remains transformed for 1 hour.</p>\n<p><strong>Transform Statue</strong><span class=\"pf2-icon\">2</span> (concentrate, manipulate)</p>\n<hr />\n<p><strong>Effect</strong> You place the statue on solid ground and speak the rat's secret name, causing the statuette to transform into a living @UUID[Compendium.pf2e.pathfinder-bestiary.Actor.Giant Rat].</p>\n<p>In creature form, the giant rat acts on your turn. It gets 2 actions and can't use reactions. You have to spend an action each turn to tell it what to do; otherwise, it tries to run away from danger or cowers where it is.</p>\n<p>If the rat is slain while in animal form, it reverts to its statue shape and can't be transformed again until 1 week has passed. If the figurine is destroyed while in its statue form, it's shattered and its magical properties are lost forever.</p>"
         },
         "equippedBulk": {
-            "value": ""
-        },
-        "group": {
             "value": ""
         },
         "hardness": 0,
@@ -47,45 +26,18 @@
         "negateBulk": {
             "value": "0"
         },
-        "potencyRune": {
-            "value": ""
-        },
         "price": {
             "value": {
                 "gp": 32
             }
         },
-        "propertyRune1": {
-            "value": ""
-        },
-        "propertyRune2": {
-            "value": ""
-        },
-        "propertyRune3": {
-            "value": ""
-        },
-        "propertyRune4": {
-            "value": ""
-        },
         "quantity": 1,
-        "range": {
-            "value": ""
-        },
-        "reload": {
-            "value": ""
-        },
         "rules": [],
         "size": "med",
         "source": {
             "value": "Pathfinder Beginner Box"
         },
-        "splashDamage": {
-            "value": 0
-        },
         "stackGroup": null,
-        "strikingRune": {
-            "value": ""
-        },
         "traits": {
             "rarity": "common",
             "value": [
@@ -95,9 +47,6 @@
         },
         "usage": {
             "value": "held-in-one-hand"
-        },
-        "weaponType": {
-            "value": ""
         },
         "weight": {
             "value": "-"

--- a/packs/equipment/sentinel-horn.json
+++ b/packs/equipment/sentinel-horn.json
@@ -11,7 +11,6 @@
         "equippedBulk": {
             "value": ""
         },
-        "group": null,
         "hardness": 0,
         "hp": {
             "max": 0,

--- a/packs/equipment/sigil-of-the-first-clan.json
+++ b/packs/equipment/sigil-of-the-first-clan.json
@@ -11,7 +11,6 @@
         "equippedBulk": {
             "value": ""
         },
-        "group": null,
         "hardness": 0,
         "hp": {
             "max": 0,

--- a/packs/equipment/terror-spores.json
+++ b/packs/equipment/terror-spores.json
@@ -24,7 +24,6 @@
         "equippedBulk": {
             "value": ""
         },
-        "group": null,
         "hardness": 0,
         "hp": {
             "max": 0,

--- a/packs/equipment/tome-of-dripping-shadows.json
+++ b/packs/equipment/tome-of-dripping-shadows.json
@@ -11,7 +11,6 @@
         "equippedBulk": {
             "value": ""
         },
-        "group": null,
         "hardness": 0,
         "hp": {
             "max": 0,

--- a/packs/equipment/toxic-effluence.json
+++ b/packs/equipment/toxic-effluence.json
@@ -24,7 +24,6 @@
         "equippedBulk": {
             "value": ""
         },
-        "group": null,
         "hardness": 0,
         "hp": {
             "max": 0,

--- a/packs/equipment/volcanic-vigor-greater.json
+++ b/packs/equipment/volcanic-vigor-greater.json
@@ -11,7 +11,6 @@
         "equippedBulk": {
             "value": ""
         },
-        "group": null,
         "hardness": 0,
         "hp": {
             "max": 0,

--- a/packs/equipment/volcanic-vigor.json
+++ b/packs/equipment/volcanic-vigor.json
@@ -11,7 +11,6 @@
         "equippedBulk": {
             "value": ""
         },
-        "group": null,
         "hardness": 0,
         "hp": {
             "max": 0,

--- a/packs/sky-kings-tomb-bestiary/ashrin.json
+++ b/packs/sky-kings-tomb-bestiary/ashrin.json
@@ -531,7 +531,6 @@
                 "equippedBulk": {
                     "value": ""
                 },
-                "group": null,
                 "hardness": 0,
                 "hp": {
                     "max": 0,
@@ -652,7 +651,6 @@
                 "equippedBulk": {
                     "value": ""
                 },
-                "group": null,
                 "hardness": 0,
                 "hp": {
                     "max": 0,

--- a/packs/sky-kings-tomb-bestiary/hryngar-assassin.json
+++ b/packs/sky-kings-tomb-bestiary/hryngar-assassin.json
@@ -906,7 +906,6 @@
                 "equippedBulk": {
                     "value": ""
                 },
-                "group": null,
                 "hardness": 0,
                 "hp": {
                     "max": 0,

--- a/packs/sky-kings-tomb-bestiary/narseigus-wormcaller.json
+++ b/packs/sky-kings-tomb-bestiary/narseigus-wormcaller.json
@@ -3909,7 +3909,6 @@
                 "equippedBulk": {
                     "value": ""
                 },
-                "group": null,
                 "hardness": 0,
                 "hp": {
                     "max": 0,

--- a/src/module/item/armor/document.ts
+++ b/src/module/item/armor/document.ts
@@ -305,10 +305,12 @@ class ArmorPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Phy
         options: DocumentUpdateContext<TParent>,
         user: UserPF2e
     ): Promise<boolean | void> {
-        const category = changed.system?.category;
-        if (changed.system && category) {
-            const usage = { value: category === "shield" ? "held-in-one-hand" : "wornarmor" };
+        if (changed.system?.category) {
+            const usage = { value: changed.system.category === "shield" ? "held-in-one-hand" : "wornarmor" };
             changed.system = mergeObject(changed.system, { usage });
+        }
+        if (changed.system?.group !== undefined) {
+            changed.system.group ||= null;
         }
 
         return super._preUpdate(changed, options, user);

--- a/src/module/item/physical/sheet.ts
+++ b/src/module/item/physical/sheet.ts
@@ -228,12 +228,6 @@ class PhysicalItemSheetPF2e<TItem extends PhysicalItemPF2e> extends ItemSheetPF2
             formData["system.material.grade"] = null;
         }
 
-        // Normalize nullable fields to actual `null`s
-        const propertyPaths = ["system.baseItem", "system.group"];
-        for (const path of propertyPaths) {
-            formData[path] ||= null;
-        }
-
         // Convert price from a string to an actual object
         if ("system.price.value" in formData) {
             formData["system.price.value"] = CoinsPF2e.fromString(String(formData["system.price.value"]));

--- a/src/module/item/weapon/document.ts
+++ b/src/module/item/weapon/document.ts
@@ -778,6 +778,9 @@ class WeaponPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
         if ("value" in traits && Array.isArray(traits.value)) {
             traits.value = traits.value.filter((t) => t in CONFIG.PF2E.weaponTraits);
         }
+        if (changed.system?.group !== undefined) {
+            changed.system.group ||= null;
+        }
 
         return super._preUpdate(changed, options, user);
     }

--- a/src/module/migration/migrations/860-rm-group.ts
+++ b/src/module/migration/migrations/860-rm-group.ts
@@ -1,0 +1,26 @@
+import { ItemSourcePF2e } from "@item/data/index.ts";
+import { itemIsOfType } from "@item/helpers.ts";
+import { MigrationBase } from "../base.ts";
+
+/** Remove `group` property that got wrongly stored in some item system data */
+export class Migration860RMGroup extends MigrationBase {
+    static override version = 0.86;
+
+    override async updateItem(source: MaybeWithDeletableGroup): Promise<void> {
+        if (itemIsOfType(source, "armor", "condition", "weapon") || !("group" in source.system)) {
+            return;
+        }
+
+        if ("game" in globalThis) {
+            source.system["-=group"] = null;
+        } else {
+            delete source.system.group;
+        }
+    }
+}
+
+type MaybeWithDeletableGroup = ItemSourcePF2e & {
+    system: {
+        "-=group"?: unknown;
+    };
+};

--- a/src/module/migration/migrations/index.ts
+++ b/src/module/migration/migrations/index.ts
@@ -257,3 +257,4 @@ export { Migration856NoSystemDotCustom } from "./856-no-system-dot-custom.ts";
 export { Migration857WeaponSpecializationRE } from "./857-weapon-spec-re.ts";
 export { Migration858FakeWeaponSpecialization } from "./858-fake-weapon-specialization.ts";
 export { Migration859MaterialTypeGrade } from "./859-material-type-grade.ts";
+export { Migration860RMGroup } from "./860-rm-group.ts";

--- a/src/module/migration/runner/base.ts
+++ b/src/module/migration/runner/base.ts
@@ -14,7 +14,7 @@ interface CollectionDiff<T extends foundry.documents.ActiveEffectSource | ItemSo
 export class MigrationRunnerBase {
     migrations: MigrationBase[];
 
-    static LATEST_SCHEMA_VERSION = 0.859;
+    static LATEST_SCHEMA_VERSION = 0.86;
 
     static MINIMUM_SAFE_VERSION = 0.618;
 


### PR DESCRIPTION
`baseItem` is already being handled in `PhysicalItemPF2e#_preUpdate`