### PR TITLE
Show encounter threat by participating combatants, XP for whole party

### DIFF
--- a/src/scripts/macros/xp/index.ts
+++ b/src/scripts/macros/xp/index.ts
@@ -95,7 +95,7 @@ function generateEncounterBudgets(partySize: number): EncounterBudgets {
 
 const rewardEncounterBudgets = generateEncounterBudgets(4);
 
-function calculateEncounterRating(challenge: number, budgets: EncounterBudgets): keyof EncounterBudgets {
+function calculateEncounterRating(challenge: number, budgets: EncounterBudgets): ThreatRating {
     if (challenge <= budgets.trivial) {
         return "trivial";
     } else if (challenge <= budgets.low) {


### PR DESCRIPTION
Still thinking of settings for this, but as a default: threat is relative to participating combatants, but XP is per player in the party, regardless of whether they were in the encounter.