### PR TITLE
Make `Statistic` and `StatisticDifficultyClass` serializeable and reroll checks with a deserialized `StatisticDifficultyClas`

### DIFF
--- a/src/module/actor/modifiers.ts
+++ b/src/module/actor/modifiers.ts
@@ -253,7 +253,7 @@ class ModifierPF2e implements RawModifier {
     }
 
     toObject(): Required<RawModifier> {
-        return duplicate({ ...this, item: undefined });
+        return duplicate({ ...this });
     }
 
     toString(): string {

--- a/src/module/chat-message/data.ts
+++ b/src/module/chat-message/data.ts
@@ -5,7 +5,8 @@ import { ZeroToTwo } from "@module/data.ts";
 import { RollNoteSource } from "@module/notes.ts";
 import { CheckRollContext } from "@system/check/index.ts";
 import { DamageRollContext } from "@system/damage/types.ts";
-import { DegreeAdjustmentsRecord, DegreeOfSuccessString } from "@system/degree-of-success.ts";
+import { CheckDC, DegreeAdjustmentsRecord, DegreeOfSuccessString } from "@system/degree-of-success.ts";
+import { StatisticDCSource } from "@system/statistic/data.ts";
 import type { ChatMessageFlags } from "types/foundry/common/documents/chat-message.d.ts";
 
 interface ChatMessageSourcePF2e extends foundry.documents.ChatMessageSource {
@@ -73,6 +74,7 @@ type ContextFlagOmission =
     | "altUsage"
     | "createMessage"
     | "damaging"
+    | "dc"
     | "dosAdjustments"
     | "item"
     | "mapIncreases"
@@ -86,6 +88,11 @@ interface CheckRollContextFlag extends Required<Omit<CheckRollContext, ContextFl
     actor: string | null;
     token: string | null;
     item?: string;
+    dc?: Maybe<
+        Omit<CheckDC, "statistic"> & {
+            statistic?: StatisticDCSource;
+        }
+    >;
     dosAdjustments?: DegreeAdjustmentsRecord;
     target: TargetFlag | null;
     altUsage?: "thrown" | "melee" | null;

--- a/src/module/system/statistic/data.ts
+++ b/src/module/system/statistic/data.ts
@@ -83,12 +83,33 @@ interface StatisticTraceData extends BaseStatisticTraceData {
     dc: number;
 }
 
+interface StatisticSource {
+    actor: ActorUUID;
+    data: Omit<StatisticData, "filter" | "modifiers"> & {
+        modifiers: Required<RawModifier>[];
+    };
+    config: {
+        extraRollOptions?: string[];
+        item?: ItemUUID;
+        origin?: ActorUUID;
+        target?: ActorUUID;
+    };
+}
+
+interface StatisticDCSource {
+    parent: StatisticSource;
+    data: StatisticSource["data"];
+    config: StatisticSource["config"];
+}
+
 export type {
     BaseStatisticData,
     BaseStatisticTraceData,
     StatisticChatData,
     StatisticCheckData,
     StatisticData,
+    StatisticDCSource,
     StatisticDifficultyClassData,
+    StatisticSource,
     StatisticTraceData,
 };


### PR DESCRIPTION
![Recording 2023-09-11 at 20 53 56](https://github.com/foundryvtt/pf2e/assets/41452412/2afb9afa-f276-4ba2-b79b-fcf97d02a635)

I still think #9640 would be better 😛 