### PR TITLE
Remove `unsafe` property in system message flags

### DIFF
--- a/src/module/system/check/check.ts
+++ b/src/module/system/check/check.ts
@@ -262,7 +262,6 @@ class CheckPF2e {
                 core: context.type === "initiative" ? { initiativeRoll: true } : {},
                 pf2e: {
                     context: contextFlag,
-                    unsafe: flavor,
                     modifierName: check.slug,
                     modifiers: check.modifiers.map((m) => m.toObject()),
                     origin: item?.getOriginData(),


### PR DESCRIPTION
This was added during our brief attempt to use custom tags in flavor HTML.