### PR TITLE
Move `PhysicalItemPF2e#generateModifiedName` to globally-exposed helper

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -5,7 +5,7 @@ import type { AutomaticBonusProgression } from "@actor/character/automatic-bonus
 import type { ElementalBlast } from "@actor/character/elemental-blast.ts";
 import type { FeatGroupOptions } from "@actor/character/feats.ts";
 import type { CheckModifier, ModifierPF2e, ModifierType, StatisticModifier } from "@actor/modifiers.ts";
-import type { ItemPF2e } from "@item";
+import type { ItemPF2e, PhysicalItemPF2e } from "@item";
 import type { ConditionSource } from "@item/condition/data.ts";
 import type { CoinsPF2e } from "@item/physical/helpers.ts";
 import type { ActiveEffectPF2e } from "@module/active-effect.ts";
@@ -94,6 +94,7 @@ interface GamePF2e
             moduleArt: ModuleArt;
             remigrate: typeof remigrate;
             sluggify: typeof sluggify;
+            generateItemName: (item: PhysicalItemPF2e) => string;
         };
         variantRules: {
             AutomaticBonusProgression: typeof AutomaticBonusProgression;

--- a/src/module/rules/rule-element/item-alteration/alteration.ts
+++ b/src/module/rules/rule-element/item-alteration/alteration.ts
@@ -174,9 +174,9 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
                 if (validator.isValid(data)) {
                     data.item.system.material.type = data.alteration.value;
                     data.item.system.material.grade = "standard";
-                    // Have the displayed name reflect the new material
-                    if ("generateModifiedName" in data.item) {
-                        data.item.name = data.item.generateModifiedName();
+                    // If this is a constructed item, have the displayed name reflect the new material
+                    if ("_source" in data.item) {
+                        data.item.name = game.pf2e.system.generateItemName(data.item);
                     }
                 }
                 return;

--- a/src/scripts/set-game-pf2e.ts
+++ b/src/scripts/set-game-pf2e.ts
@@ -2,7 +2,7 @@ import { Action } from "@actor/actions/index.ts";
 import { AutomaticBonusProgression } from "@actor/character/automatic-bonus-progression.ts";
 import { ElementalBlast } from "@actor/character/elemental-blast.ts";
 import { CheckModifier, ModifierPF2e, StatisticModifier } from "@actor/modifiers.ts";
-import { CoinsPF2e } from "@item/physical/helpers.ts";
+import { CoinsPF2e, generateItemName } from "@item/physical/helpers.ts";
 import { CompendiumBrowser } from "@module/apps/compendium-browser/index.ts";
 import { EffectsPanel } from "@module/apps/effects-panel.ts";
 import { LicenseViewer } from "@module/apps/license-viewer/app.ts";
@@ -93,7 +93,7 @@ export const SetGamePF2e = {
             licenseViewer: new LicenseViewer(),
             rollActionMacro,
             rollItemMacro,
-            system: { moduleArt: new ModuleArt(), remigrate, sluggify },
+            system: { generateItemName, moduleArt: new ModuleArt(), remigrate, sluggify },
             variantRules: { AutomaticBonusProgression },
         };
         game.pf2e = mergeObject(game.pf2e ?? {}, initSafe);


### PR DESCRIPTION
The name-generation method doesn't work very well (or at all) for some languages. This will allow localization-module authors to replace the function with their own.