### PR TITLE
Lower priority of fist shorthand strike to 99

### DIFF
--- a/src/module/rules/rule-element/strike.ts
+++ b/src/module/rules/rule-element/strike.ts
@@ -171,7 +171,7 @@ class StrikeRuleElement extends RuleElementPF2e<StrikeSchema> {
     protected override _initialize(options?: Record<string, unknown>): void {
         if (this._source.fist) {
             this.key = "Strike";
-            this.priority = 100;
+            this.priority = 99;
             this.slug = "fist";
             this.img = "systems/pf2e/icons/features/classes/powerful-fist.webp";
             this.category = "unarmed";


### PR DESCRIPTION
This is to allow other fist strikes (like from Ape animal instinct) to replace it.