### PR TITLE
Fix item summary / spell buttons firing when pressing enter elsewhere in the form

### DIFF
--- a/static/templates/actors/partials/item-summary.hbs
+++ b/static/templates/actors/partials/item-summary.hbs
@@ -34,15 +34,15 @@
 
         {{#unless item.hasVariants}}
             {{#if chatData.isAttack}}
-                <span><button class="spell_attack" data-action="spellAttack">{{localize "PF2E.AttackLabel"}}</button></span>
+                <span><button type="button" class="spell_attack" data-action="spellAttack">{{localize "PF2E.AttackLabel"}}</button></span>
             {{/if}}
             {{#if chatData.hasDamage}}
-                <span><button class="spell_damage" data-action="spellDamage">{{chatData.damageLabel}}: {{chatData.formula}}</button></span>
+                <span><button type="button" class="spell_damage" data-action="spellDamage">{{chatData.damageLabel}}: {{chatData.formula}}</button></span>
             {{/if}}
         {{/unless}}
 
         {{#if (and (eq item.type "consumable") item.uses.max)}}
-            <span><button class="consume" data-action="consume">{{localize "PF2E.ConsumableUseLabel"}} {{item.name}}</button></span>
+            <span><button type="button" class="consume" data-action="consume">{{localize "PF2E.ConsumableUseLabel"}} {{item.name}}</button></span>
         {{/if}}
     </div>
 {{/if}}

--- a/static/templates/items/spell-details.hbs
+++ b/static/templates/items/spell-details.hbs
@@ -211,7 +211,7 @@
 
 {{#unless data.heightening.type}}
     {{#if canHeighten}}
-        <button data-action="heightening-interval-create"><i class="fas fa-fw fa-plus"></i> {{localize "PF2E.SpellScalingInterval.Add"}}</button>
+        <button type="button" data-action="heightening-interval-create"><i class="fas fa-fw fa-plus"></i> {{localize "PF2E.SpellScalingInterval.Add"}}</button>
     {{/if}}
 {{/unless}}
 
@@ -250,7 +250,7 @@
         {{> systems/pf2e/templates/items/spell-overlay.hbs this=this}}
     {{/each}}
     {{#if canHeighten}}
-        <button data-action="heightening-fixed-create" data-overlay-type="heightening">
+        <button type="button" data-action="heightening-fixed-create" data-overlay-type="heightening">
             <i class="fas fa-fw fa-plus"></i> {{localize "PF2E.SpellScalingOverlay.Add"}}
         </button>
     {{/if}}

--- a/static/templates/items/spell-overlay.hbs
+++ b/static/templates/items/spell-overlay.hbs
@@ -29,7 +29,7 @@
 
     <div class="toggle-button-list">
         {{#each missing}}
-            <button data-action="overlay-add-property" data-property="{{key}}">
+            <button type="button" data-action="overlay-add-property" data-property="{{key}}">
                 <i class="fa fa-plus"></i>
                 {{localize label}}
             </button>


### PR DESCRIPTION
Several `<button>` elements in the Item Summary and Spell Details interfaces were not given a `type` attribute, defaulting them to type `submit`. Because these interfaces are included inside of `<form>` elements, it made them viable targets for _implicit submission_ of the form when certain actions are taken, most notably when the Enter key was pressed in another input. This creates a synthetic click event and triggers the button's corresponding handlers, that are seemingly unrelated to the field the user has focused.

These buttons were changed to `type="button"`:

- triggered from anywhere on the character sheet:
  - use consumable
  - item summary spell attack and spell damage
- triggered from anywhere in a spell details window:
  - add heightening (fixed & interval)
  - all of the add-absent-property buttons in the fixed heighten section

Closes #10007 