### PR TITLE
Allow divvying of party stash using inventory members sidebar

### DIFF
--- a/src/module/actor/party/sheet.ts
+++ b/src/module/actor/party/sheet.ts
@@ -451,7 +451,7 @@ class PartySheetPF2e extends ActorSheetPF2e<PartyPF2e> {
                 await this.moveItemBetweenActors(
                     event,
                     item.actor.id,
-                    item.actor?.token?.id ?? null,
+                    item.actor.token?.id ?? null,
                     actorUuid,
                     null,
                     item.id

--- a/src/module/actor/party/sheet.ts
+++ b/src/module/actor/party/sheet.ts
@@ -19,6 +19,7 @@ import type { Statistic } from "@system/statistic/index.ts";
 import { addSign, createHTMLElement, htmlClosest, htmlQuery, htmlQueryAll, sortBy, sum } from "@util";
 import * as R from "remeda";
 import { PartyPF2e } from "./document.ts";
+import { DropCanvasItemDataPF2e } from "@module/canvas/drop-canvas-data.ts";
 
 interface PartySheetRenderOptions extends ActorSheetRenderOptionsPF2e {
     actors?: boolean;
@@ -433,6 +434,32 @@ class PartySheetPF2e extends ActorSheetPF2e<PartyPF2e> {
         }
 
         return super._onDropItemCreate(itemData);
+    }
+
+    /** Override to allow divvying/outward transfer of items via party member blocks in inventory members sidebar. */
+    protected override async _onDropItem(
+        event: ElementDragEvent,
+        data: DropCanvasItemDataPF2e & { fromInventory?: boolean }
+    ): Promise<ItemPF2e<ActorPF2e | null>[]> {
+        const droppedRegion = event.target?.closest<HTMLElement>("[data-region]")?.dataset.region;
+        const targetActor = event.target?.closest<HTMLElement>("[data-actor-uuid]")?.dataset.actorUuid;
+        if (droppedRegion === "inventoryMembers" && targetActor) {
+            const item = await ItemPF2e.fromDropData(data);
+            if (!item) return [];
+            const actorUuid = foundry.utils.parseUuid(targetActor).documentId;
+            if (actorUuid && item.actor && item.isOfType("physical")) {
+                await this.moveItemBetweenActors(
+                    event,
+                    item.actor.id,
+                    item.actor?.token?.id ?? null,
+                    actorUuid,
+                    null,
+                    item.id
+                );
+                return [item];
+            }
+        }
+        return super._onDropItem(event, data);
     }
 
     /** Override to not auto-disable fields on a thing meant to be used by players */


### PR DESCRIPTION
To improve the usability of the stash screen for sorting loot, it seemed simpler to allow the party member blocks in the inventory sidebar to function as special drop targets for dragged items:

https://github.com/foundryvtt/pf2e/assets/1791252/c97af133-dfb1-4995-bd8c-ca859b2c65a4

This is a pretty simple reuse of `ActorSheetPF2e.moveItemBetweenActors` and thus has the standard restrictions of requiring a GM active for Player-initiated transfers.