### PR TITLE
Add default filter to free archetype feat slots

### DIFF
--- a/src/module/actor/character/feats.ts
+++ b/src/module/actor/character/feats.ts
@@ -103,6 +103,8 @@ class CharacterFeats<TActor extends CharacterPF2e> extends Collection<FeatGroup<
                 label: "PF2E.FeatArchetypeHeader",
                 supported: ["class"],
                 slots: evenLevels,
+                featFilter: this.actor.itemTypes.feat.some((f) => f.traits.has("dedication"))
+                    ? ["traits-archetype"] : ["traits-dedication"],
             });
         }
 

--- a/src/module/actor/character/feats.ts
+++ b/src/module/actor/character/feats.ts
@@ -104,7 +104,8 @@ class CharacterFeats<TActor extends CharacterPF2e> extends Collection<FeatGroup<
                 supported: ["class"],
                 slots: evenLevels,
                 featFilter: this.actor.itemTypes.feat.some((f) => f.traits.has("dedication"))
-                    ? ["traits-archetype"] : ["traits-dedication"],
+                    ? ["traits-archetype"]
+                    : ["traits-dedication"],
             });
         }
 


### PR DESCRIPTION
Introduce a very simple default filter for free archetype feats. If you do not yet have a dedication, this filters by the `dedication` trait; if you DO have a dedication, this filters by the `archetype` trait.

More advanced logic (e.g. for specific archetypes) might be possible but seems overwrought and too likely to run into issues with how individual tables adjudicate gray areas and introduce house rules.

Closes #10006 