### PR TITLE
Prevent premature data preparation in `TokenDocumentPF2e`

### DIFF
--- a/src/module/item/base.ts
+++ b/src/module/item/base.ts
@@ -227,8 +227,8 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
         super._initialize(options);
     }
 
+    /** If embedded, don't prepare data if the parent's data model hasn't initialized all its properties */
     override prepareData(): void {
-        // If embedded, don't prepare data if the parent's data model hasn't initialized all its properties
         if (this.parent && !this.parent.flags?.pf2e) return;
 
         super.prepareData();

--- a/src/module/scene/token-document/document.ts
+++ b/src/module/scene/token-document/document.ts
@@ -82,19 +82,6 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
         return this.parent;
     }
 
-    protected override _initialize(options?: Record<string, unknown>): void {
-        this.constructed ??= false;
-        this.auras = new Map();
-
-        this._source.flags.pf2e ??= {};
-        this._source.flags.pf2e.linkToActorSize ??= true;
-        this._source.flags.pf2e.autoscale = this._source.flags.pf2e.linkToActorSize
-            ? this._source.flags.pf2e.autoscale ?? game.settings.get("pf2e", "tokens.autoscale")
-            : false;
-
-        super._initialize(options);
-    }
-
     /** Is this token emitting light with a negative value */
     get emitsDarkness(): boolean {
         return this.light.bright < 0;
@@ -144,6 +131,26 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
             x: bounds.x + bounds.width / 2,
             y: bounds.y + bounds.height / 2,
         };
+    }
+
+    protected override _initialize(options?: Record<string, unknown>): void {
+        this.constructed ??= false;
+        this.auras = new Map();
+
+        this._source.flags.pf2e ??= {};
+        this._source.flags.pf2e.linkToActorSize ??= true;
+        this._source.flags.pf2e.autoscale = this._source.flags.pf2e.linkToActorSize
+            ? this._source.flags.pf2e.autoscale ?? game.settings.get("pf2e", "tokens.autoscale")
+            : false;
+
+        super._initialize(options);
+    }
+
+    /** If embedded, don't prepare data if the parent's data model hasn't initialized all its properties */
+    override prepareData(): void {
+        if (this.parent && !this.parent.flags?.pf2e) return;
+
+        super.prepareData();
     }
 
     /** If rules-based vision is enabled, disable manually configured vision radii */


### PR DESCRIPTION
Same measure as for `ItemPF2e`