### PR TITLE
Add hooked rune, run damage roll strike adjustments set by property runes

### DIFF
--- a/src/module/item/physical/runes.ts
+++ b/src/module/item/physical/runes.ts
@@ -1652,17 +1652,19 @@ const WEAPON_PROPERTY_RUNES: { [T in WeaponPropertyRuneType]: WeaponPropertyRune
                 },
                 adjustDamageRoll: (weapon: WeaponPF2e | MeleePF2e, { notes }: { notes?: RollNotePF2e[] }): void => {
                     if (weapon._source.system.traits.value.includes("trip")) {
-                        notes?.push(new RollNotePF2e({
-                            selector: "strike-damage",
-                            outcome: ["criticalSuccess"],
-                            predicate: ["item:trait:trip"],
-                            title: "PF2E.WeaponPropertyRune.hooked.Name",
-                            text: "PF2E.WeaponPropertyRune.hooked.Note.criticalSuccess",
-                        }));
+                        notes?.push(
+                            new RollNotePF2e({
+                                selector: "strike-damage",
+                                outcome: ["criticalSuccess"],
+                                predicate: ["item:trait:trip"],
+                                title: "PF2E.WeaponPropertyRune.hooked.Name",
+                                text: "PF2E.WeaponPropertyRune.hooked.Note.criticalSuccess",
+                            })
+                        );
                     }
-                }
-            }
-        ]
+                },
+            },
+        ],
     },
     hopeful: {
         attack: {

--- a/src/module/item/physical/runes.ts
+++ b/src/module/item/physical/runes.ts
@@ -7,7 +7,7 @@ import { ArmorPropertyRuneType, ResilientRuneType } from "@item/armor/types.ts";
 import { SpellTrait } from "@item/spell/types.ts";
 import { StrikingRuneType, WeaponPropertyRuneType, WeaponRangeIncrement } from "@item/weapon/types.ts";
 import { OneToFour, Rarity, ZeroToFour, ZeroToThree } from "@module/data.ts";
-import { RollNoteSource } from "@module/notes.ts";
+import { RollNotePF2e, RollNoteSource } from "@module/notes.ts";
 import { StrikeAdjustment } from "@module/rules/synthetics.ts";
 import { PredicatePF2e } from "@system/predication.ts";
 
@@ -310,7 +310,7 @@ interface WeaponPropertyRuneData<TSlug extends WeaponPropertyRuneType> extends P
          */
         ignoredResistances?: { type: ResistanceType; max: number | null }[];
     };
-    strikeAdjustments?: StrikeAdjustment[];
+    strikeAdjustments?: Pick<StrikeAdjustment, "adjustDamageRoll" | "adjustWeapon">[];
 }
 
 /** Title and text are mandatory for these notes */
@@ -1635,6 +1635,34 @@ const WEAPON_PROPERTY_RUNES: { [T in WeaponPropertyRuneType]: WeaponPropertyRune
         rarity: "common",
         slug: "holy",
         traits: ["evocation", "good", "magical"],
+    },
+    hooked: {
+        level: 5,
+        name: "PF2E.WeaponPropertyRune.hooked.Name",
+        price: 140,
+        rarity: "rare",
+        slug: "hooked",
+        traits: ["conjuration", "magical"],
+        strikeAdjustments: [
+            {
+                adjustWeapon: (weapon: WeaponPF2e | MeleePF2e): void => {
+                    if (!weapon.system.traits.value.includes("trip")) {
+                        weapon.system.traits.value.push("trip");
+                    }
+                },
+                adjustDamageRoll: (weapon: WeaponPF2e | MeleePF2e, { notes }: { notes?: RollNotePF2e[] }): void => {
+                    if (weapon._source.system.traits.value.includes("trip")) {
+                        notes?.push(new RollNotePF2e({
+                            selector: "strike-damage",
+                            outcome: ["criticalSuccess"],
+                            predicate: ["item:trait:trip"],
+                            title: "PF2E.WeaponPropertyRune.hooked.Name",
+                            text: "PF2E.WeaponPropertyRune.hooked.Note.criticalSuccess",
+                        }));
+                    }
+                }
+            }
+        ]
     },
     hopeful: {
         attack: {

--- a/src/module/item/weapon/values.ts
+++ b/src/module/item/weapon/values.ts
@@ -71,6 +71,7 @@ const WEAPON_PROPERTY_RUNE_TYPES = new Set([
     "hauling",
     "holy",
     "hopeful",
+    "hooked",
     "impactful",
     "impossible",
     "keen",

--- a/src/module/rules/synthetics.ts
+++ b/src/module/rules/synthetics.ts
@@ -123,7 +123,7 @@ interface SenseSynthetic {
 interface StrikeAdjustment {
     adjustDamageRoll?: (
         weapon: WeaponPF2e | MeleePF2e,
-        { materials, notes }: { materials?: Set<MaterialDamageEffect>, notes?: RollNotePF2e[] }
+        { materials, notes }: { materials?: Set<MaterialDamageEffect>; notes?: RollNotePF2e[] }
     ) => void;
     adjustWeapon?: (weapon: WeaponPF2e | MeleePF2e) => void;
     adjustTraits?: (weapon: WeaponPF2e | MeleePF2e, traits: ActionTrait[]) => void;

--- a/src/module/rules/synthetics.ts
+++ b/src/module/rules/synthetics.ts
@@ -123,7 +123,7 @@ interface SenseSynthetic {
 interface StrikeAdjustment {
     adjustDamageRoll?: (
         weapon: WeaponPF2e | MeleePF2e,
-        { materials }: { materials?: Set<MaterialDamageEffect> }
+        { materials, notes }: { materials?: Set<MaterialDamageEffect>, notes?: RollNotePF2e[] }
     ) => void;
     adjustWeapon?: (weapon: WeaponPF2e | MeleePF2e) => void;
     adjustTraits?: (weapon: WeaponPF2e | MeleePF2e, traits: ActionTrait[]) => void;

--- a/src/module/system/damage/weapon.ts
+++ b/src/module/system/damage/weapon.ts
@@ -8,7 +8,7 @@ import {
     RUNE_DATA,
     getPropertyRuneDice,
     getPropertyRuneModifierAdjustments,
-    getPropertyRuneStrikeAdjustments
+    getPropertyRuneStrikeAdjustments,
 } from "@item/physical/runes.ts";
 import { WeaponDamage } from "@item/weapon/data.ts";
 import { RollNotePF2e } from "@module/notes.ts";

--- a/src/module/system/damage/weapon.ts
+++ b/src/module/system/damage/weapon.ts
@@ -4,7 +4,12 @@ import { DamageDiceOverride, DamageDicePF2e, ModifierPF2e, PROFICIENCY_RANK_OPTI
 import { AttributeString } from "@actor/types.ts";
 import { MeleePF2e, WeaponPF2e } from "@item";
 import { NPCAttackDamage } from "@item/melee/data.ts";
-import { RUNE_DATA, getPropertyRuneDice, getPropertyRuneModifierAdjustments, getPropertyRuneStrikeAdjustments } from "@item/physical/runes.ts";
+import {
+    RUNE_DATA,
+    getPropertyRuneDice,
+    getPropertyRuneModifierAdjustments,
+    getPropertyRuneStrikeAdjustments
+} from "@item/physical/runes.ts";
 import { WeaponDamage } from "@item/weapon/data.ts";
 import { RollNotePF2e } from "@module/notes.ts";
 import { extractDamageSynthetics, extractModifierAdjustments, extractModifiers } from "@module/rules/helpers.ts";

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -5210,6 +5210,12 @@
                     "criticalSuccess": "(<span class=\"pf2-icon\">R</span> command; once per day)<br /><strong>Trigger</strong> You critically succeed at an attack roll against an evil creature with the weapon<br /><strong>Effect</strong> You regain HP equal to double the evil creature's level. This is a good, positive, healing effect."
                 }
             },
+            "hooked": {
+                "Name": "Hooked",
+                "Note": {
+                    "criticalSuccess": "If a hooked weapon normally has the trip trait, you can attempt to Trip a foe as a reaction when you critically hit it with the hooked weapon."
+                }
+            },
             "hopeful": {
                 "Name": "Hopeful",
                 "Note": {


### PR DESCRIPTION
The goal here was to close #9519, but the challenge was that **Hooked** has different behaviors based on whether it added a trip trait and I couldn't identify a way for a static roll note to distinguish if a trait had been present on the source weapon or not. Certainly one might be able to abuse predicates, but even introducing a new roll option from a rune wasn't straightforward without uncomfortable levels of indirection.

So then I observed that strike adjustments have an `adjustDamageRoll` function -- _sure_ this currently only tweaks the damage _materials_, but it seemed by its name, placement, and 2nd-argument genericness that the intent was to provide a hook for any necessary data modifications. Thus this PR does as follows:

1. Updated `adjustDamageRoll` to also pass the current `RollNotePF2e` array
2. Fixed API omission where `adjustDamageRoll` on runes would never be called (it was only applied to adjustments from synthetics)
3. Updated typing on `WeaponPropertyRuneData.strikeAdjustments` to exclude `StrikeAdjustment.adjustTraits` and clarify that it is not currently supported
4. Introduced hooked weapon property rune, which adds the trip trait, and a critical damage note when the source weapon already had the trip trait

I'm sure it's very plausible I overlooked a better approach though.