### PR TITLE
Fix regression in feat tab trait filtering introduced by `#10044`

### DIFF
--- a/src/module/apps/compendium-browser/tabs/feat.ts
+++ b/src/module/apps/compendium-browser/tabs/feat.ts
@@ -142,12 +142,13 @@ export class CompendiumBrowserFeatTab extends CompendiumBrowserTab {
         selected: MultiselectData["selected"],
         condition: MultiselectData["conjunction"]
     ): boolean {
-        // Always return true for ancestry feats that have no ancestry trait
+        // Pre-filter the selected traits if the current ancestry item has no ancestry traits
         if (
             this.filterData.checkboxes.category.selected.includes("ancestry") &&
             !this.arrayIncludes(traits, this.#ancestryTraits)
         ) {
-            return true;
+            const withoutAncestryTraits = selected.filter((t) => !this.#ancestryTraits.includes(t.value));
+            return super.filterTraits(traits, withoutAncestryTraits, condition);
         }
         return super.filterTraits(traits, selected, condition);
     }

--- a/src/scripts/config/traits.ts
+++ b/src/scripts/config/traits.ts
@@ -53,6 +53,7 @@ const ancestryTraits = {
     oread: "PF2E.TraitOread",
     poppet: "PF2E.TraitPoppet",
     ratfolk: "PF2E.TraitRatfolk",
+    reflection: "PF2E.TraitReflection",
     shisk: "PF2E.TraitShisk",
     shoony: "PF2E.TraitShoony",
     skeleton: "PF2E.TraitSkeleton",


### PR DESCRIPTION
Fixes a regression pointed out by @tdhsmith in the last PR. The other selected traits are no longer dropped if an ancestry trait is present.
Also adds `Reflection` to the `ancestryTraits` config.