### PR TITLE
Fix adding mystified items when dropping on token

### DIFF
--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -1060,7 +1060,13 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
         const { actor } = this;
         const itemSource = item.toObject();
 
-        const mystified = game.user.isGM && event.altKey;
+        const mystified = ((): boolean => {
+            if (game.user.isGM) {
+                // If the item is dropped on the token, event.altKey is undefined
+                return event.altKey ?? game.keyboard.isModifierActive(KeyboardManager.MODIFIER_KEYS.ALT);
+            }
+            return false;
+        })();
 
         // Set effect to unidentified if alt key is held
         if (mystified && itemSource.type === "effect") {

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -1062,7 +1062,7 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
 
         const mystified = ((): boolean => {
             if (game.user.isGM) {
-                // If the item is dropped on the token, event.altKey is undefined
+                // If the item is dropped on a token, event.altKey is undefined
                 return event.altKey ?? game.keyboard.isModifierActive(KeyboardManager.MODIFIER_KEYS.ALT);
             }
             return false;


### PR DESCRIPTION
Without this fix, holding the alt key when dropping effect and items on PC and NPC tokens does not correctly create mystified items. This is because event.altKey is undefined when dropping on tokens.

The direct check of `game.keyboard.isModifierActive(KeyboardManager.MODIFIER_KEYS.ALT)` was removed by https://github.com/foundryvtt/pf2e/pull/8176