### PR TITLE
Add automation for Weapon Siphon

### DIFF
--- a/packs/equipment-effects/effect-weapon-siphon.json
+++ b/packs/equipment-effects/effect-weapon-siphon.json
@@ -1,0 +1,108 @@
+{
+    "_id": "mPb9Bhq8T1nsyWug",
+    "img": "systems/pf2e/icons/default-icons/effect.svg",
+    "name": "Effect: Weapon Siphon",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.equipment-srd.Item.Weapon Siphon]</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "unlimited",
+            "value": -1
+        },
+        "level": {
+            "value": 1
+        },
+        "rules": [
+            {
+                "choices": {
+                    "ownedItems": true,
+                    "predicate": [
+                        "item:melee"
+                    ],
+                    "types": [
+                        "weapon"
+                    ]
+                },
+                "flag": "effectWeaponSiphonWeapon",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.Weapon"
+            },
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.WeaponSiphonDamage",
+                "option": "effect:weapon-siphon:damage",
+                "suboptions": [
+                    {
+                        "label": "PF2E.TraitAcid",
+                        "value": "acid"
+                    },
+                    {
+                        "label": "PF2E.TraitCold",
+                        "value": "cold"
+                    },
+                    {
+                        "label": "PF2E.TraitElectricity",
+                        "value": "electricity"
+                    },
+                    {
+                        "label": "PF2E.TraitFire",
+                        "value": "fire"
+                    },
+                    {
+                        "label": "PF2E.TraitForce",
+                        "value": "force"
+                    },
+                    {
+                        "label": "PF2E.TraitNegative",
+                        "value": "negative"
+                    },
+                    {
+                        "label": "PF2E.TraitPositive",
+                        "value": "positive"
+                    },
+                    {
+                        "label": "PF2E.TraitSonic",
+                        "value": "sonic"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "damageType": "{item|flags.pf2e.rulesSelections.effectweaponSiphondamage}",
+                "diceNumber": 1,
+                "dieSize": "d4",
+                "key": "DamageDice",
+                "predicate": [
+                    "effect:weapon-siphon:damage"
+                ],
+                "selector": "{item|flags.pf2e.rulesSelections.effectWeaponSiphonWeapon}-damage"
+            },
+            {
+                "key": "AdjustModifier",
+                "mode": "subtract",
+                "selectors": [
+                    "{item|flags.pf2e.rulesSelections.effectWeaponSiphonWeapon}-attack"
+                ],
+                "slug": "multiple-attack-penalty",
+                "value": 1
+            }
+        ],
+        "source": {
+            "value": ""
+        },
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/equipment-effects/effect-weapon-siphon.json
+++ b/packs/equipment-effects/effect-weapon-siphon.json
@@ -4,7 +4,7 @@
     "name": "Effect: Weapon Siphon",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.equipment-srd.Item.Weapon Siphon]</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.equipment-srd.Item.Weapon Siphon]</p>\n<p>You can load a lesser alchemical bomb into the attached weapon to deal an extra 1d4 energy damage for three attacks, but MAP is one greater than usual.</p>\n<hr />\n<p><em>Note: The checkbox and dropdown in the action tab control the extra damage, but the increased MAP is always enabled as long as this effect is applied. Use the checkbox to set whether a bomb is currently loaded, and only remove the effect itself if you detach the Weapon Siphon from the weapon.</em></p>"
         },
         "duration": {
             "expiry": "turn-start",

--- a/packs/equipment-effects/effect-weapon-siphon.json
+++ b/packs/equipment-effects/effect-weapon-siphon.json
@@ -91,7 +91,7 @@
             }
         ],
         "source": {
-            "value": ""
+            "value": "Pathfinder Treasure Vault"
         },
         "start": {
             "initiative": null,

--- a/packs/equipment/weapon-siphon.json
+++ b/packs/equipment/weapon-siphon.json
@@ -6,11 +6,12 @@
         "baseItem": null,
         "containerId": null,
         "description": {
-            "value": "<p><strong>Activate</strong> <span class=\"pf2-icon\">1</span> Interact</p>\n<p>This set of tubing snakes down the striking surface of a weapon to deliver alchemical explosives. A single lesser alchemical bomb can be fitted to the weapon siphon as an Interact action. The bomb must be one that deals energy damage, such as an acid flask, alchemist's fire, bottled lightning, frost vial, or thunderstone. The next three attacks made with the weapon deal 1d4 damage of the bomb's damage type in addition to the weapon's normal damage. If the second and third attacks aren't all made within 1 minute of the first attack, the bomb's energy is wasted. These attacks never deal splash damage or other special effects of the bomb and aren't modified by any abilities that add to or modify a bomb's effect.</p>\n<p>Adding a weapon siphon to a weapon throws off its balance, causing the multiple attack penalty with the weapon to be one greater than usual (usually –6 on a second attack and –11 on a third; or –5 and –10 with an agile weapon).</p>"
+            "value": "<p><strong>Activate</strong> <span class=\"pf2-icon\">1</span> Interact</p>\n<p>This set of tubing snakes down the striking surface of a weapon to deliver alchemical explosives. A single lesser alchemical bomb can be fitted to the weapon siphon as an Interact action. The bomb must be one that deals energy damage, such as an acid flask, alchemist's fire, bottled lightning, frost vial, or thunderstone. The next three attacks made with the weapon deal 1d4 damage of the bomb's damage type in addition to the weapon's normal damage. If the second and third attacks aren't all made within 1 minute of the first attack, the bomb's energy is wasted. These attacks never deal splash damage or other special effects of the bomb and aren't modified by any abilities that add to or modify a bomb's effect.</p>\n<p>Adding a weapon siphon to a weapon throws off its balance, causing the multiple attack penalty with the weapon to be one greater than usual (usually –6 on a second attack and –11 on a third; or –5 and –10 with an agile weapon).</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Weapon Siphon]</p>"
         },
         "equippedBulk": {
             "value": ""
         },
+        "group": null,
         "hardness": 0,
         "hp": {
             "max": 0,

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2767,6 +2767,7 @@
                 "Melee": "Melee Infusion",
                 "Ranged": "Ranged Infusion"
             },
+            "WeaponSiphonDamage": "Weapon Siphon Damage",
             "WellspringMage": {
                 "CriticalSuccess": "You temporarily recover an expended spell slot of any level of your choice. The temporary spell slot lasts for 1 minute, and if you don't use it by then, you experience an immediate @UUID[Compendium.pf2e.rollable-tables.RollTable.N0pDFNCffTe2Du39]{Wellspring Surge}.",
                 "Failure": "You generate a @UUID[Compendium.pf2e.rollable-tables.RollTable.N0pDFNCffTe2Du39]{Wellspring Surge}, with a spell level chosen randomly among your top three levels of spell slots (or all your levels if you have fewer than three)",


### PR DESCRIPTION
This PR adds an effect for the Weapon Siphon from treasure vault. The toggleable roll option can be used to select the energy damage type (or disable damage if no bomb is currently loaded), and the increased MAP applies as long as the effect is on the sheet since even an unloaded weapon siphon affects the weapon's balance.
![image](https://github.com/foundryvtt/pf2e/assets/5429337/4b3aab66-2896-45fc-aeaf-3c3b3a7c2f32)
