### PR TITLE
Add effect for Envenom Fangs

### DIFF
--- a/packs/feat-effects/effect-envenom-fangs.json
+++ b/packs/feat-effects/effect-envenom-fangs.json
@@ -1,0 +1,42 @@
+{
+    "_id": "yqCzUxrdLlk6Q9VW",
+    "img": "icons/creatures/abilities/fang-tooth-poison-green.webp",
+    "name": "Effect: Envenom Fangs",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Envenom Fangs]</p>\n<p>You envenom your fangs. If the next fangs Strike you make before the end of your next turn hits and deals damage, the Strike deals an additional 1d6 poison damage. On a critical failure, the poison is wasted as normal.</p>"
+        },
+        "duration": {
+            "expiry": "turn-end",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "level": {
+            "value": 5
+        },
+        "rules": [
+            {
+                "damageType": "poison",
+                "diceNumber": 1,
+                "dieSize": "d6",
+                "key": "DamageDice",
+                "selector": "fangs-damage"
+            }
+        ],
+        "source": {
+            "value": "Pathfinder Lost Omens: Character Guide"
+        },
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feats/envenom-fangs.json
+++ b/packs/feats/envenom-fangs.json
@@ -24,6 +24,10 @@
             ]
         },
         "rules": [],
+        "selfEffect": {
+            "name": "Effect: Envenom Fangs",
+            "uuid": "Compendium.pf2e.feat-effects.Item.Effect: Envenom Fangs"
+        },
         "source": {
             "value": "Pathfinder Lost Omens: Character Guide"
         },

--- a/packs/feats/fangs.json
+++ b/packs/feats/fangs.json
@@ -11,7 +11,7 @@
         },
         "category": "ancestry",
         "description": {
-            "value": "<p>Your incisors have grown into true fangs: long, sharp, and well-suited to drawing blood.</p>\n<p>You gain a fangs unarmed attack that deals @Damage[1d6[piercing]] damage. Your fangs are in the brawling group and have the grapple and unarmed traits.</p>"
+            "value": "<p>Your incisors have grown into true fangs: long, sharp, and well-suited to drawing blood.</p>\n<p>You gain a fangs unarmed attack that deals 1d6 piercing damage. Your fangs are in the brawling group and have the grapple and unarmed traits.</p>"
         },
         "level": {
             "value": 1
@@ -30,6 +30,7 @@
                     }
                 },
                 "group": "brawling",
+                "img": "systems/pf2e/icons/unarmed-attacks/fangs.webp",
                 "key": "Strike",
                 "label": "PF2E.BattleForm.Attack.Fangs",
                 "range": null,

--- a/packs/feats/sharp-fangs.json
+++ b/packs/feats/sharp-fangs.json
@@ -29,7 +29,7 @@
                         "die": "d8"
                     }
                 },
-                "group": "brawling",
+                "img": "systems/pf2e/icons/unarmed-attacks/fangs.webp",
                 "key": "Strike",
                 "label": "PF2E.BattleForm.Attack.Fangs",
                 "range": null,


### PR DESCRIPTION
Also add icons for fang strikes.

Closes https://github.com/foundryvtt/pf2e/issues/10051