### PR TITLE
Add effects for Flame Dancer and Phoenix Ward

### DIFF
--- a/packs/spell-effects/spell-effect-flame-dancer.json
+++ b/packs/spell-effects/spell-effect-flame-dancer.json
@@ -1,0 +1,57 @@
+{
+    "_id": "1cBl1gVcpzOqlluC",
+    "img": "icons/magic/fire/elemental-fire-humanoid.webp",
+    "name": "Spell Effect: Flame Dancer",
+    "system": {
+        "description": {
+            "value": "<p>Granted by <em>@UUID[Compendium.pf2e.spells-srd.Item.Flame Dancer]</em></p>\n<p>The target's unarmed Strikes deal additional fire damage. Critical hits with these Strikes also deal persistent fire damage.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "minutes",
+            "value": 1
+        },
+        "level": {
+            "value": 5
+        },
+        "rules": [
+            {
+                "damageType": "fire",
+                "diceNumber": "ternary(gte(@item.level,7),3,2)",
+                "dieSize": "d6",
+                "key": "DamageDice",
+                "predicate": [
+                    "unarmed"
+                ],
+                "selector": "strike-damage"
+            },
+            {
+                "category": "persistent",
+                "critical": true,
+                "damageType": "fire",
+                "diceNumber": "ternary(gte(@item.level,7),3,2)",
+                "dieSize": "d4",
+                "key": "DamageDice",
+                "predicate": [
+                    "unarmed"
+                ],
+                "selector": "strike-damage"
+            }
+        ],
+        "source": {
+            "value": "Pathfinder Rage of Elements"
+        },
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/spell-effects/spell-effect-phoenix-ward.json
+++ b/packs/spell-effects/spell-effect-phoenix-ward.json
@@ -1,0 +1,40 @@
+{
+    "_id": "0eP0JRBPwfRyu7gN",
+    "img": "icons/magic/fire/barrier-wall-flame-ring-yellow.webp",
+    "name": "Spell Effect: Phoenix Ward",
+    "system": {
+        "description": {
+            "value": "<p>Granted by <em>@UUID[Compendium.pf2e.spells-srd.Item.Phoenix Ward]</em></p>\n<p>You raise a fiery shield around yourself, gaining resistance 10 to fire.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "minutes",
+            "value": 1
+        },
+        "level": {
+            "value": 4
+        },
+        "rules": [
+            {
+                "key": "Resistance",
+                "type": "fire",
+                "value": 10
+            }
+        ],
+        "source": {
+            "value": "Pathfinder Rage of Elements"
+        },
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/spells/cave-fangs.json
+++ b/packs/spells/cave-fangs.json
@@ -1,6 +1,6 @@
 {
     "_id": "KEagmnwgsSbGmkme",
-    "img": "systems/pf2e/icons/default-icons/spell.svg",
+    "img": "icons/magic/earth/barrier-stone-explosion-spiked.webp",
     "name": "Cave Fangs",
     "system": {
         "area": {
@@ -31,7 +31,7 @@
             }
         },
         "description": {
-            "value": "<p>Sharp flowstone formations protrude from the ground and ceiling, dealing @Damage[6d6[piercing]] damage to creatures in the area with a basic Reflex save. Densely packed with protrusions, the area becomes difficult terrain for the duration. The protrusions turn to dust when the spell ends. You can Dismiss the spell.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by [[/r 2d6]].</p>"
+            "value": "<p>Sharp flowstone formations protrude from the ground and ceiling, dealing 6d6 piercing damage to creatures in the area with a basic Reflex save. Densely packed with protrusions, the area becomes difficult terrain for the duration. The protrusions turn to dust when the spell ends. You can Dismiss the spell.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
         },
         "duration": {
             "value": "1 minute"

--- a/packs/spells/dancing-fountain.json
+++ b/packs/spells/dancing-fountain.json
@@ -1,6 +1,6 @@
 {
     "_id": "smiVuoFMSgY2FTOO",
-    "img": "systems/pf2e/icons/default-icons/spell.svg",
+    "img": "icons/magic/water/wave-water-explosion.webp",
     "name": "Dancing Fountain",
     "system": {
         "area": {

--- a/packs/spells/flame-dancer.json
+++ b/packs/spells/flame-dancer.json
@@ -1,6 +1,6 @@
 {
     "_id": "p6ebe2PliRkGbmiV",
-    "img": "systems/pf2e/icons/default-icons/spell.svg",
+    "img": "icons/magic/fire/elemental-fire-humanoid.webp",
     "name": "Flame Dancer",
     "system": {
         "area": null,
@@ -18,7 +18,7 @@
             "value": {}
         },
         "description": {
-            "value": "<p>Fire encircles the target's hands and feet, and its eyes and hair catch ablaze. The target's unarmed Strikes deal an additional @Damage[2d6[fire]] damage. Critical hits with these Strikes also deal @Damage[2d4[persistent,fire]] damage. Additionally, when the target attempts to @UUID[Compendium.pf2e.actionspf2e.Item.Demoralize] a foe, they can use Performance instead of Intimidation; when using Performance to Demoralize, the action loses the auditory trait but gains the visual trait, and the target doesn't take a penalty when attempting to Demoralize a creature that doesn't understand its language.</p>\n<hr />\n<p><strong>Heightened (7th)</strong> The fire damage increases to 3d6, and the persistent fire damage increases to 3d4. If the target gets a critical success on a Demoralize check using Performance, the target of the Demoralize check becomes @UUID[Compendium.pf2e.conditionitems.Item.Fleeing] from the target of flame dancer for 1 round.</p>"
+            "value": "<p>Fire encircles the target's hands and feet, and its eyes and hair catch ablaze. The target's unarmed Strikes deal an additional 2d6 fire damage. Critical hits with these Strikes also deal 2d4 persistent fire damage. Additionally, when the target attempts to @UUID[Compendium.pf2e.actionspf2e.Item.Demoralize] a foe, they can use Performance instead of Intimidation; when using Performance to Demoralize, the action loses the auditory trait but gains the visual trait, and the target doesn't take a penalty when attempting to Demoralize a creature that doesn't understand its language.</p>\n<hr />\n<p><strong>Heightened (7th)</strong> The fire damage increases to 3d6, and the persistent fire damage increases to 3d4. If the target gets a critical success on a Demoralize check using Performance, the target of the Demoralize check becomes @UUID[Compendium.pf2e.conditionitems.Item.Fleeing] from the target of <em>flame dancer</em> for 1 round.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Flame Dancer]</p>"
         },
         "duration": {
             "value": "1 minute"

--- a/packs/spells/personal-ocean.json
+++ b/packs/spells/personal-ocean.json
@@ -1,6 +1,6 @@
 {
     "_id": "K2bTUhucPyhXlzjw",
-    "img": "systems/pf2e/icons/default-icons/spell.svg",
+    "img": "icons/magic/water/orb-water-transparent.webp",
     "name": "Personal Ocean",
     "system": {
         "area": null,

--- a/packs/spells/phoenix-ward.json
+++ b/packs/spells/phoenix-ward.json
@@ -1,6 +1,6 @@
 {
     "_id": "lJdAvY1sJyEmNDc6",
-    "img": "systems/pf2e/icons/default-icons/spell.svg",
+    "img": "icons/magic/fire/barrier-wall-flame-ring-yellow.webp",
     "name": "Phoenix Ward",
     "system": {
         "area": null,
@@ -25,7 +25,7 @@
             }
         },
         "description": {
-            "value": "<p>You raise a fiery shield around yourself, gaining resistance 10 to fire. If you take fire damage that would reduce you to 0 Hit Points, the phoenix ward absorbs any damage beyond the amount that would bring you to 1 Hit Point. The ward then heals you in a brilliant display of flames in the shape of a phoenix's wings and envelop you in light. You regain Hit Points equal to 4d8 + the absorbed damage; this is a healing vitality effect. The phoenix ward then ends, and you can't cast it again for 24 hours.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The healing increases by [[/r 1d8]].</p>"
+            "value": "<p>You raise a fiery shield around yourself, gaining resistance 10 to fire. If you take fire damage that would reduce you to 0 Hit Points, the <em>phoenix ward</em> absorbs any damage beyond the amount that would bring you to 1 Hit Point. The ward then heals you in a brilliant display of flames in the shape of a phoenix's wings and envelop you in light. You regain Hit Points equal to 4d8 + the absorbed damage; this is a healing vitality effect. The <em>phoenix ward</em> then ends, and you can't cast it again for 24 hours.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The healing increases by 1d8.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Phoenix Ward]</p>"
         },
         "duration": {
             "value": "1 minute"

--- a/packs/spells/wall-of-metal.json
+++ b/packs/spells/wall-of-metal.json
@@ -1,6 +1,6 @@
 {
     "_id": "CB5TlGv5ZghtMifi",
-    "img": "systems/pf2e/icons/default-icons/spell.svg",
+    "img": "icons/tools/smithing/plate-steel-grey.webp",
     "name": "Wall of Metal",
     "system": {
         "area": null,


### PR DESCRIPTION
Also add icons to Cave Fangs, Dancing Fountain, Flame Dancer, Personal Ocean, Phoenix Ward, Wall of Metal.