### PR TITLE
Stack item quantities of items looted with the `LootNPCsPopup`

### DIFF
--- a/src/module/actor/sheet/loot/loot-npcs-popup.ts
+++ b/src/module/actor/sheet/loot/loot-npcs-popup.ts
@@ -1,5 +1,6 @@
 import { ActorPF2e } from "@actor/base.ts";
-import { PhysicalItemSource } from "@item/data/index.ts";
+import { PhysicalItemPF2e } from "@item";
+import { ScenePF2e, TokenDocumentPF2e } from "@scene";
 import { ErrorPF2e } from "@util";
 
 interface PopupData extends FormApplicationData<ActorPF2e> {
@@ -10,7 +11,7 @@ interface PopupData extends FormApplicationData<ActorPF2e> {
     }[];
 }
 
-export class LootNPCsPopup extends FormApplication<ActorPF2e> {
+class LootNPCsPopup extends FormApplication<ActorPF2e> {
     static override get defaultOptions(): FormApplicationOptions {
         const options = super.defaultOptions;
         options.id = "loot-NPCs";
@@ -25,8 +26,12 @@ export class LootNPCsPopup extends FormApplication<ActorPF2e> {
         _event: Event,
         formData: Record<string, unknown> & { selection?: boolean }
     ): Promise<void> {
-        const itemData: PhysicalItemSource[] = [];
+        const lootActor = this.object;
+        const newItems: PhysicalItemPF2e[] = [];
+        const itemUpdates = new Map<string, number>();
+        const itemsToDelete = new Map<ActorPF2e, string[]>();
         const selectionData = Array.isArray(formData.selection) ? formData.selection : [formData.selection];
+
         for (let i = 0; i < selectionData.length; i++) {
             const token = canvas.tokens.placeables.find((token) => token.actor && token.id === this.form[i]?.id);
             if (!token) {
@@ -34,14 +39,60 @@ export class LootNPCsPopup extends FormApplication<ActorPF2e> {
             }
             const currentSource = token.actor;
             if (selectionData[i] && currentSource) {
-                const currentSourceItemData = currentSource.inventory.map((item) => item.toObject());
-                itemData.push(...currentSourceItemData);
-                const idsToDelete = currentSourceItemData.map((item) => item._id);
-                currentSource.deleteEmbeddedDocuments("Item", idsToDelete);
+                for (const item of currentSource.inventory) {
+                    const stackableItem = lootActor.inventory.findStackableItem(item);
+                    if (stackableItem) {
+                        const currentQuantity = itemUpdates.get(stackableItem.id) ?? stackableItem.quantity;
+                        itemUpdates.set(stackableItem.id, currentQuantity + item.quantity);
+                        continue;
+                    }
+                    newItems.push(item);
+                }
+                // Deletions will be performed last in case of the other operations failing
+                itemsToDelete.set(
+                    currentSource,
+                    currentSource.inventory.map((item) => item.id)
+                );
             }
         }
-        if (itemData.length > 0) {
-            await this.object.createEmbeddedDocuments("Item", this.#combineStacks(itemData));
+        // Create new items in the loot actor
+        if (newItems.length > 0) {
+            // Try to stack incoming items
+            const stacked = newItems.reduce((result: PhysicalItemPF2e[], item) => {
+                const stackableItem = result.find((i) => i.isStackableWith(item));
+                if (stackableItem) {
+                    // Update existing item in the result list
+                    stackableItem.updateSource({
+                        system: {
+                            quantity: stackableItem.quantity + item.quantity,
+                        },
+                    });
+                    return result;
+                }
+                // Item is not stackable with an existing item in the result list; add it
+                result.push(item);
+                return result;
+            }, []);
+            const sources = stacked.map((i) => i.toObject());
+            await lootActor.createEmbeddedDocuments("Item", sources, {
+                render: itemUpdates.size === 0,
+            });
+        }
+        // Update exisiting items in the loot actor with new quantity
+        if (itemUpdates.size > 0) {
+            const updates = [...itemUpdates.entries()].map(([id, quantity]) => ({
+                _id: id,
+                system: {
+                    quantity,
+                },
+            }));
+            await lootActor.updateEmbeddedDocuments("Item", updates);
+        }
+        // Delete items from source actors
+        if (itemsToDelete.size > 0) {
+            for (const [actor, ids] of itemsToDelete) {
+                actor.deleteEmbeddedDocuments("Item", ids);
+            }
         }
     }
 
@@ -56,38 +107,10 @@ export class LootNPCsPopup extends FormApplication<ActorPF2e> {
         }));
         return { ...(await super.getData()), tokenInfo };
     }
-
-    /** Combine quantities of items */
-    #combineStacks(itemData: PhysicalItemSource[]): PhysicalItemSource[] {
-        const stacked: PhysicalItemSource[] = [];
-        for (const source of itemData) {
-            const stackableSource = stacked.find((s) => this.#isStackableWith(source, s));
-            if (stackableSource) {
-                stackableSource.system.quantity += source.system.quantity;
-                continue;
-            }
-            stacked.push(source);
-        }
-        return stacked;
-    }
-
-    /** Are the two provided items stackable? */
-    #isStackableWith(source: PhysicalItemSource, other: PhysicalItemSource): boolean {
-        const preCheck =
-            source !== other &&
-            source.type === other.type &&
-            source.name === other.name &&
-            source.system.identification.status === other.system.identification.status;
-        if (!preCheck) return false;
-
-        const sourceData = deepClone(source.system);
-        const otherData = deepClone(other.system);
-        sourceData.quantity = otherData.quantity;
-        sourceData.equipped = otherData.equipped;
-        sourceData.containerId = otherData.containerId;
-        sourceData.schema = otherData.schema;
-        sourceData.identification = otherData.identification;
-
-        return JSON.stringify(sourceData) === JSON.stringify(otherData);
-    }
 }
+
+interface LootNPCsPopup extends FormApplication<ActorPF2e> {
+    object: ActorPF2e<TokenDocumentPF2e<ScenePF2e> | null>;
+}
+
+export { LootNPCsPopup };

--- a/src/styles/actor/loot/_index.scss
+++ b/src/styles/actor/loot/_index.scss
@@ -180,9 +180,13 @@
 }
 
 .loot-actor-popup {
+    flex: unset;
+
     .confirm-button {
         @include button;
         width: calc(100% - 6px);
+        height: 2.5em;
+        margin-top: 1em;
         background-color: var(--tertiary);
     }
 

--- a/static/templates/actors/loot/loot-npcs-popup.hbs
+++ b/static/templates/actors/loot/loot-npcs-popup.hbs
@@ -2,15 +2,11 @@
     <div class="checkboxes">
         <h1>{{localize "PF2E.loot.LootNPCsPopupHeader"}}</h1>
         {{#each tokenInfo as |info|}}
-            <p>
                 <label class="selection" for="{{info.id}}">
                     <input type="checkbox" name="selection" id="{{info.id}}" {{checked info.checked}} />
                     <span>{{info.name}}</span>
                 </label>
-            </p>
         {{/each}}
     </div>
-    <p>
-        <button class="confirm-button" type="submit"><i class="far fa-save"></i>{{localize "PF2E.loot.LootNPCsLabel"}}
-    </p>
+    <button class="confirm-button" type="submit"><i class="far fa-save"></i>{{localize "PF2E.loot.LootNPCsLabel"}}
 </form>


### PR DESCRIPTION
This has the same logic as `PhysicalItemPF2e#isStackableWith`.

![Recording 2023-09-15 at 13 53 27](https://github.com/foundryvtt/pf2e/assets/41452412/6648b57e-d730-4083-bb81-112a44f158dc)

I've also fixed the popup UI after recording the video:

![image](https://github.com/foundryvtt/pf2e/assets/41452412/e7b8be99-0f7a-4b94-805e-047cdeb586fe)

Closes #8796
