### PR TITLE
Add more armor specialization automation

### DIFF
--- a/packs/classfeatures/armor-expertise.json
+++ b/packs/classfeatures/armor-expertise.json
@@ -97,6 +97,24 @@
                 ],
                 "type": "slashing",
                 "value": "2 + @armor.system.runes.potency"
+            },
+            {
+                "key": "Resistance",
+                "predicate": [
+                    "armor:category:medium",
+                    "armor:group:skeletal"
+                ],
+                "type": "precision",
+                "value": "3 + @armor.system.runes.potency"
+            },
+            {
+                "key": "Resistance",
+                "predicate": [
+                    "armor:category:heavy",
+                    "armor:group:skeletal"
+                ],
+                "type": "precision",
+                "value": "5 + @armor.system.runes.potency"
             }
         ],
         "source": {

--- a/packs/feats/acrobat-dedication.json
+++ b/packs/feats/acrobat-dedication.json
@@ -49,15 +49,15 @@
             },
             {
                 "key": "Note",
+                "outcome": [
+                    "criticalSuccess"
+                ],
                 "predicate": [
                     "action:tumble-through"
                 ],
                 "selector": "acrobatics",
                 "text": "As success, but you don't treat the enemy's space as difficult terrain.",
-                "title": "Critical Success",
-                "outcome": [
-                  "criticalSuccess"
-                ]
+                "title": "Critical Success"
             }
         ],
         "source": {

--- a/packs/feats/armor-specialist.json
+++ b/packs/feats/armor-specialist.json
@@ -77,6 +77,24 @@
                 ],
                 "type": "slashing",
                 "value": "2 + @armor.system.runes.potency"
+            },
+            {
+                "key": "Resistance",
+                "predicate": [
+                    "armor:category:medium",
+                    "armor:group:skeletal"
+                ],
+                "type": "precision",
+                "value": "3 + @armor.system.runes.potency"
+            },
+            {
+                "key": "Resistance",
+                "predicate": [
+                    "armor:category:heavy",
+                    "armor:group:skeletal"
+                ],
+                "type": "precision",
+                "value": "5 + @armor.system.runes.potency"
             }
         ],
         "source": {

--- a/packs/feats/hellknight-dedication.json
+++ b/packs/feats/hellknight-dedication.json
@@ -42,25 +42,16 @@
             {
                 "key": "FlatModifier",
                 "predicate": [
-                    "wearing-hellplate"
+                    "armor:slug:hellknight-plate"
                 ],
                 "selector": "intimidation",
                 "type": "circumstance",
                 "value": 1
             },
             {
-                "domain": "all",
-                "key": "RollOption",
-                "label": "PF2E.SpecificRule.ToggleProperty.WearingHellknightPlate",
-                "option": "wearing-hellplate",
-                "toggleable": true
-            },
-            {
                 "key": "Resistance",
                 "predicate": [
-                    "wearing-hellplate",
-                    "armor:category:heavy",
-                    "armor:group:plate"
+                    "armor:slug:hellknight-plate"
                 ],
                 "type": "slashing",
                 "value": "3 + @armor.system.runes.potency"

--- a/packs/feats/hellknight-dedication.json
+++ b/packs/feats/hellknight-dedication.json
@@ -47,6 +47,23 @@
                 "selector": "intimidation",
                 "type": "circumstance",
                 "value": 1
+            },
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.ToggleProperty.WearingHellknightPlate",
+                "option": "wearing-hellplate",
+                "toggleable": true
+            },
+            {
+                "key": "Resistance",
+                "predicate": [
+                    "wearing-hellplate",
+                    "armor:category:heavy",
+                    "armor:group:plate"
+                ],
+                "type": "slashing",
+                "value": "3 + @armor.system.runes.potency"
             }
         ],
         "source": {

--- a/packs/feats/tumble-behind-swashbuckler.json
+++ b/packs/feats/tumble-behind-swashbuckler.json
@@ -21,17 +21,17 @@
         },
         "rules": [
             {
-              "key": "Note",
-              "predicate": [
-                "action:tumble-through"
-              ],
-              "selector": "acrobatics",
-              "title": "{item|name}",
-              "text": "{item|system.description.value}",
-              "outcome": [
-                "success",
-                "criticalSuccess"
-              ]
+                "key": "Note",
+                "outcome": [
+                    "success",
+                    "criticalSuccess"
+                ],
+                "predicate": [
+                    "action:tumble-through"
+                ],
+                "selector": "acrobatics",
+                "text": "{item|system.description.value}",
+                "title": "{item|name}"
             }
         ],
         "source": {

--- a/packs/feats/unshaken-in-iron.json
+++ b/packs/feats/unshaken-in-iron.json
@@ -23,7 +23,128 @@
                 }
             ]
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "Resistance",
+                "predicate": [
+                    "armor:category:medium",
+                    "armor:group:composite",
+                    {
+                        "gte": [
+                            "defense:medium:rank",
+                            1
+                        ]
+                    }
+                ],
+                "type": "piercing",
+                "value": "1 + @armor.system.runes.potency"
+            },
+            {
+                "key": "Resistance",
+                "predicate": [
+                    "armor:category:medium",
+                    "armor:group:leather",
+                    {
+                        "gte": [
+                            "defense:medium:rank",
+                            1
+                        ]
+                    }
+                ],
+                "type": "bludgeoning",
+                "value": "1 + @armor.system.runes.potency"
+            },
+            {
+                "key": "Resistance",
+                "predicate": [
+                    "armor:category:medium",
+                    "armor:group:plate",
+                    {
+                        "gte": [
+                            "defense:medium:rank",
+                            1
+                        ]
+                    }
+                ],
+                "type": "slashing",
+                "value": "1 + @armor.system.runes.potency"
+            },
+            {
+                "key": "Resistance",
+                "predicate": [
+                    "armor:category:medium",
+                    "armor:group:skeletal",
+                    {
+                        "gte": [
+                            "defense:medium:rank",
+                            1
+                        ]
+                    }
+                ],
+                "type": "precision",
+                "value": "3 + @armor.system.runes.potency"
+            },
+            {
+                "key": "Resistance",
+                "predicate": [
+                    "armor:category:heavy",
+                    "armor:group:composite",
+                    {
+                        "gte": [
+                            "defense:heavy:rank",
+                            1
+                        ]
+                    }
+                ],
+                "type": "piercing",
+                "value": "2 + @armor.system.runes.potency"
+            },
+            {
+                "key": "Resistance",
+                "predicate": [
+                    "armor:category:heavy",
+                    "armor:group:leather",
+                    {
+                        "gte": [
+                            "defense:heavy:rank",
+                            1
+                        ]
+                    }
+                ],
+                "type": "bludgeoning",
+                "value": "2 + @armor.system.runes.potency"
+            },
+            {
+                "key": "Resistance",
+                "predicate": [
+                    "armor:category:heavy",
+                    "armor:group:plate",
+                    {
+                        "gte": [
+                            "defense:heavy:rank",
+                            1
+                        ]
+                    }
+                ],
+                "type": "slashing",
+                "value": "2 + @armor.system.runes.potency"
+            },
+            {
+                "key": "Resistance",
+                "predicate": [
+                    "armor:category:heavy",
+                    "armor:group:skeletal",
+                    {
+                        "gte": [
+                            "defense:heavy:rank",
+                            1
+                        ]
+                    }
+                ],
+                "type": "precision",
+                "value": "5 + @armor.system.runes.potency"
+            }
+        ],
         "source": {
             "value": "Pathfinder Lost Omens: Highhelm"
         },

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2700,8 +2700,7 @@
             "ToggleProperty": {
                 "GourdHead": "Gourd Head: Increase perception DC",
                 "TagTeam": "Flanking with another member of the Secret Society",
-                "Triangulate": "Spotter can see target",
-                "WearingHellknightPlate": "Wearing Hellknight Plate"
+                "Triangulate": "Spotter can see target"
             },
             "TrapFinder": {
                 "DefendingLabel": "Trap Finder (defending against traps)",

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2700,7 +2700,8 @@
             "ToggleProperty": {
                 "GourdHead": "Gourd Head: Increase perception DC",
                 "TagTeam": "Flanking with another member of the Secret Society",
-                "Triangulate": "Spotter can see target"
+                "Triangulate": "Spotter can see target",
+                "WearingHellknightPlate": "Wearing Hellknight Plate"
             },
             "TrapFinder": {
                 "DefendingLabel": "Trap Finder (defending against traps)",


### PR DESCRIPTION
- Skeletal group resistance applied on **Armor Expertise** and **Armor Specialist**
- **Hellknight Dedication** special resistance, triggered by
  - missing-but-implied toggle to indicate character is wearing hellknight plate
- Copied base armor specialization REs to **Unshaken in Iron** with extra predicates to detect armor proficiency. However this does _not_ attempt to handle the extra bonuses from Tenacious Stance yet.