### PR TITLE
Add icon and secondary save link to Beheading Buzz Saw

### DIFF
--- a/packs/spells/beheading-buzz-saw.json
+++ b/packs/spells/beheading-buzz-saw.json
@@ -1,6 +1,6 @@
 {
     "_id": "dKWc83KKiXoIJkhp",
-    "img": "systems/pf2e/icons/default-icons/spell.svg",
+    "img": "icons/environment/traps/saw-steel-grey.webp",
     "name": "Beheading Buzz Saw",
     "system": {
         "area": {
@@ -19,16 +19,7 @@
         },
         "damage": {
             "value": {
-                "5TMsLf7oUmdkdVn2": {
-                    "applyMod": false,
-                    "type": {
-                        "categories": [],
-                        "subtype": "persistent",
-                        "value": "bleed"
-                    },
-                    "value": "4d6"
-                },
-                "pH4vCUB1fWo9gKml": {
+                "0": {
                     "applyMod": false,
                     "type": {
                         "categories": [],
@@ -36,11 +27,20 @@
                         "value": "slashing"
                     },
                     "value": "5d10"
+                },
+                "1": {
+                    "applyMod": false,
+                    "type": {
+                        "categories": [],
+                        "subtype": "persistent",
+                        "value": "bleed"
+                    },
+                    "value": "4d6"
                 }
             }
         },
         "description": {
-            "value": "<p>You compress molten scraps pulled from the Plane of Metal into a spinning disc with gruesome blades protruding from its edges. It wheels forward, slicing through anyone in its path. Each creature in the area takes @Damage[5d10[slashing]] damage and @Damage[4d6[persistent,bleed]] damage, with a Reflex save.</p>\n<hr />\n<p><strong>Success</strong> The creature is unaffected.</p>\n<p><strong>Failure</strong> The creature takes full damage.</p>\n<p><strong>Critical Failure</strong> The creature takes double damage. If the creature has a head, it must succeed at a Fortitude save or be decapitated; this kills any creature except ones that don't require a head to live. For creatures with multiple heads, this usually kills the creature only if you sever its last head. This second save has the death and incapacitation traits.</p>"
+            "value": "<p>You compress molten scraps pulled from the Plane of Metal into a spinning disc with gruesome blades protruding from its edges. It wheels forward, slicing through anyone in its path. Each creature in the area takes 5d10 slashing damage and 4d6 persistent bleed damage, with a Reflex save.</p>\n<p><strong>Success</strong> The creature is unaffected.</p>\n<p><strong>Failure</strong> The creature takes full damage.</p>\n<p><strong>Critical Failure</strong> The creature takes double damage. If the creature has a head, it must succeed at a @Check[type:fortitude|dc:resolve(@actor.system.attributes.spellDC.value)|traits:death,incapacitation] save or be decapitated; this kills any creature except ones that don't require a head to live. For creatures with multiple heads, this usually kills the creature only if you sever its last head. This second save has the death and incapacitation traits.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The slashing damage increases by 1d10, and the persistent bleed damage increases by 1d6.</p>"
         },
         "duration": {
             "value": ""
@@ -50,8 +50,8 @@
         },
         "heightening": {
             "damage": {
-                "5TMsLf7oUmdkdVn2": "1d6",
-                "pH4vCUB1fWo9gKml": "1d10"
+                "0": "1d10",
+                "1": "1d6"
             },
             "interval": 1,
             "type": "interval"


### PR DESCRIPTION
Also sorted damage entries and added Heightened info to description.