### PR TITLE
Fix `Select Other Variant` button being show on heightened spell chat cards

### DIFF
--- a/static/templates/chat/spell-card.hbs
+++ b/static/templates/chat/spell-card.hbs
@@ -72,7 +72,7 @@
                             </button>
                         </div>
                     {{/if}}
-                    {{#if item.isVariant}}
+                    {{#if (gt item.appliedOverlays.size 0)}}
                         <button type="button" data-action="spell-variant" data-visibility="owner" data-original-id="{{item.original.id}}">{{localize "PF2E.Item.Spell.Variants.SelectOtherVariantLabel"}}</button>
                     {{/if}}
                 </section>


### PR DESCRIPTION
I'm not sure what exactly changed here but a heightened spell is technically a variant so it shoudn't have worked from the start.
Checking for applied overlays instead should only catch the correct instances.
The naming of Variant/Overlay/Override is a bit confusing.

![image](https://github.com/foundryvtt/pf2e/assets/41452412/a47fe843-44ca-4520-9678-5ea04d89a47a)
