### PR TITLE
Set default aura texture alpha to 1

### DIFF
--- a/src/module/rules/rule-element/aura.ts
+++ b/src/module/rules/rule-element/aura.ts
@@ -127,7 +127,7 @@ class AuraRuleElement extends RuleElementPF2e<AuraSchema> {
             texture: new fields.SchemaField(
                 {
                     src: new StrictStringField({ required: true, nullable: false, initial: undefined }),
-                    alpha: new fields.AlphaField({ required: true, nullable: false, initial: 0.5 }),
+                    alpha: new fields.AlphaField({ required: true, nullable: false, initial: 1 }),
                     scale: new StrictNumberField({ required: true, nullable: false, positive: true, initial: 1 }),
                     loop: new StrictBooleanField({ required: false, nullable: false, initial: undefined }),
                     translation: new fields.SchemaField(xyPairSchema({ integer: true }), {


### PR DESCRIPTION
Following precedent set by core measure template textures

An opaque texture can be quite obstructing (see bottom example below), but I figure there ought to be a predictable default consistent with core measured templates.
![image](https://github.com/foundryvtt/pf2e/assets/106829671/b3479eda-0a80-45b7-a145-8aa4e3c449df)
