### PR TITLE
Fix predication of Versatile Blast feat

### DIFF
--- a/packs/feats/versatile-blasts.json
+++ b/packs/feats/versatile-blasts.json
@@ -25,6 +25,7 @@
                 "mode": "add",
                 "path": "flags.pf2e.kineticist.elementalBlast.air.damageTypes",
                 "predicate": [
+                    "self:effect:kinetic-aura",
                     "kinetic-gate:air"
                 ],
                 "value": "cold"
@@ -34,6 +35,7 @@
                 "mode": "add",
                 "path": "flags.pf2e.kineticist.elementalBlast.earth.damageTypes",
                 "predicate": [
+                    "self:effect:kinetic-aura",
                     "kinetic-gate:earth"
                 ],
                 "value": "poison"
@@ -43,6 +45,7 @@
                 "mode": "add",
                 "path": "flags.pf2e.kineticist.elementalBlast.fire.damageTypes",
                 "predicate": [
+                    "self:effect:kinetic-aura",
                     "kinetic-gate:fire"
                 ],
                 "value": "cold"
@@ -52,6 +55,7 @@
                 "mode": "add",
                 "path": "flags.pf2e.kineticist.elementalBlast.metal.damageTypes",
                 "predicate": [
+                    "self:effect:kinetic-aura",
                     "kinetic-gate:metal"
                 ],
                 "value": "electricity"
@@ -61,6 +65,7 @@
                 "mode": "add",
                 "path": "flags.pf2e.kineticist.elementalBlast.water.damageTypes",
                 "predicate": [
+                    "self:effect:kinetic-aura",
                     "kinetic-gate:water"
                 ],
                 "value": "acid"
@@ -70,6 +75,7 @@
                 "mode": "add",
                 "path": "flags.pf2e.kineticist.elementalBlast.wood.damageTypes",
                 "predicate": [
+                    "self:effect:kinetic-aura",
                     "kinetic-gate:wood"
                 ],
                 "value": "poison"


### PR DESCRIPTION
Currently validation fails if no kinetic aura is active.