### PR TITLE
Show action cost in feat chat card when available

### DIFF
--- a/static/templates/chat/feat-card.hbs
+++ b/static/templates/chat/feat-card.hbs
@@ -1,7 +1,10 @@
 <div class="pf2e chat-card item-card" data-actor-id="{{actor.id}}" data-item-id="{{item.id}}" {{#if tokenId}}data-token-id="{{tokenId}}"{{/if}}>
     <header class="card-header flexrow">
         <img src="{{item.img}}" title="{{item.name}}" width="36" height="36"/>
-        <h3>{{item.name}}</h3>
+        <h3>
+            {{item.name}}
+            {{{actionGlyph item.system.actions.value}}}
+        </h3>
     </header>
     <div class="tags">
         {{#each data.traits}}


### PR DESCRIPTION
The `actionGlyph` helper returns nothing if the passed value is invalid so no extra checks needed.

![image](https://github.com/foundryvtt/pf2e/assets/41452412/14b9deba-c4b3-4fae-bb74-eae236a7282b)
