### PR TITLE
Always show party coin distribute to gamemasters

### DIFF
--- a/src/module/actor/party/sheet.ts
+++ b/src/module/actor/party/sheet.ts
@@ -88,15 +88,9 @@ class PartySheetPF2e extends ActorSheetPF2e<PartyPF2e> {
         const base = await super.getData(options);
         const members = this.actor.members;
         const canDistributeCoins =
-            game.user.isGM &&
-            this.isEditable &&
-            this.actor.inventory.coins.copperValue > 0 &&
-            members.some(
-                (m) =>
-                    m.hasPlayerOwner &&
-                    m.isOfType("character") &&
-                    !m.system.traits.value.some((t) => ["minion", "eidolon"].includes(t))
-            );
+            game.user.isGM && this.isEditable
+                ? { enabled: this.actor.inventory.coins.copperValue > 0 && members.some(isReallyPC) }
+                : null;
 
         return {
             ...base,

--- a/src/module/actor/sheet/data-types.ts
+++ b/src/module/actor/sheet/data-types.ts
@@ -52,7 +52,7 @@ export interface ActorSheetDataPF2e<TActor extends ActorPF2e> extends ActorSheet
     totalCoinageGold: string;
     totalWealth: Coins;
     totalWealthGold: string;
-    canDistributeCoins?: boolean;
+    canDistributeCoins?: { enabled: boolean } | null;
     inventory: SheetInventory;
     enrichedContent: Record<string, string>;
 }

--- a/src/styles/actor/_coinage.scss
+++ b/src/styles/actor/_coinage.scss
@@ -95,6 +95,10 @@
             @include p-reset;
         }
 
+        &:disabled {
+            opacity: 0.6;
+        }
+
         &:hover:not(:disabled) {
             background-color: var(--primary);
             color: var(--color-text-light-0);

--- a/static/templates/actors/partials/coinage.hbs
+++ b/static/templates/actors/partials/coinage.hbs
@@ -3,23 +3,23 @@
         <li class="label">{{localize "PF2E.StackGroupCoins"}}</li>
         {{#each totalCoinage as |value denomination|}}
             <li class="denomination {{denomination}}">
-                <div class="currency-image" title="{{localize value.label}}"></div>
+                <div class="currency-image" data-tooltip="{{localize value.label}}"></div>
                 <span>{{value.value}}</span>
             </li>
         {{/each}}
         {{#if editable}}
             <li>
-                <button type="button" data-action="add-coins" title="{{localize "PF2E.AddCoinsTitle"}}">
+                <button type="button" data-action="add-coins" data-tooltip="{{localize "PF2E.AddCoinsTitle"}}">
                     <i class="fa-solid fa-plus fa-fw"></i>
                 </button>
             </li>
             <li>
-                <button type="button" data-action="remove-coins" title="{{localize "PF2E.RemoveCoinsTitle"}}">
+                <button type="button" data-action="remove-coins" data-tooltip="{{localize "PF2E.RemoveCoinsTitle"}}">
                     <i class="fa-solid fa-minus fa-fw"></i>
                 </button>
             </li>
             {{#if (or isLoot (eq @root.document.type "character"))}}
-                <li title="{{localize "PF2E.SellAllTreasureTitle"}}">
+                <li data-tooltip="{{localize "PF2E.SellAllTreasureTitle"}}">
                     <button type="button" data-action="sell-all-treasure">
                         <i class="fa-solid fa-coins fa-fw"></i>
                     </button>
@@ -27,7 +27,7 @@
             {{/if}}
             {{#if canDistributeCoins}}
                 <li>
-                    <button type="button" data-action="distribute-coins" title="{{localize "PF2E.Actor.Inventory.DistributeCoins"}}">
+                    <button type="button" data-action="distribute-coins" data-tooltip="{{localize "PF2E.Actor.Inventory.DistributeCoins"}}" {{disabled (not canDistributeCoins.enabled)}}>
                         <i class="fa-solid fa-share-all fa-fw"></i>
                     </button>
                 </li>


### PR DESCRIPTION
The button is now disabled instead if there are no players or coins to distribute.
![image](https://github.com/foundryvtt/pf2e/assets/1286721/bb091c2c-9bc7-483d-8343-813c4eb173bc)
