### PR TITLE
Allow editing effects from effect panel tooltip

### DIFF
--- a/src/module/item/condition/persistent-damage-dialog.ts
+++ b/src/module/item/condition/persistent-damage-dialog.ts
@@ -6,8 +6,8 @@ import { DAMAGE_TYPE_ICONS } from "@system/damage/values.ts";
 import { htmlClosest, htmlQuery, htmlQueryAll, pick, sortBy } from "@util";
 import { PersistentDamagePF2e } from "./document.ts";
 
-class PersistentDamageDialog extends Application {
-    constructor(private actor: ActorPF2e, options: Partial<ApplicationOptions> = {}) {
+class PersistentDamageDialog extends Application<PersistentDamageDialogOptions> {
+    constructor(private actor: ActorPF2e, options: Partial<PersistentDamageDialogOptions> = {}) {
         super(options);
         actor.apps[this.appId] = this;
     }
@@ -132,10 +132,16 @@ class PersistentDamageDialog extends Application {
     /** Overriden to autofocus on first render behavior */
     protected override _injectHTML($html: JQuery<HTMLElement>): void {
         super._injectHTML($html);
+        const html = $html[0];
 
-        // Since this is an initial render, focus the roll button
-        htmlQuery($html[0], ".new .formula")?.focus();
+        // Since this is an initial render, focus the formula
+        const existing = this.options.editing ? htmlQuery(html, `[data-id=${this.options.editing}] .formula`) : null;
+        (existing ?? htmlQuery(html, ".new .formula"))?.focus();
     }
+}
+
+interface PersistentDamageDialogOptions extends ApplicationOptions {
+    editing?: string;
 }
 
 interface PersistentDialogData {

--- a/src/styles/system/_effects-panel.scss
+++ b/src/styles/system/_effects-panel.scss
@@ -50,6 +50,7 @@
             h1 {
                 @include p-reset;
                 border: none;
+                display: flex;
                 font-size: var(--font-size-14);
                 padding-top: 0.25em;
                 text-align: right;

--- a/static/templates/system/effects-panel.hbs
+++ b/static/templates/system/effects-panel.hbs
@@ -22,7 +22,10 @@
     <div class="effect-info">
         <h1>
             {{effect.name}}
-            <a data-action="send-to-chat" title="{{localize "PF2E.NPC.SendToChat"}}"><i class="fa-solid fa-comment-alt" ></i></a>
+            <a data-action="send-to-chat" data-tooltip="{{localize "PF2E.NPC.SendToChat"}}"><i class="fa-solid fa-fw fa-comment-alt" ></i></a>
+            {{#if (or (ne effect.type "condition") (eq effect.slug "persistent-damage"))}}
+                <a data-action="edit" data-tooltip="{{localize "PF2E.EditItemTitle"}}"><i class="fa-solid fa-fw fa-pencil" ></i></a>
+            {{/if}}
         </h1>
         {{#if (or (eq effect.type "effect") effect.breakdown)}}
             <div class="tags">


### PR DESCRIPTION
A certain module (and previous PR by someone) did it as shift+click, but an actual clickable button is hopefully less controversial. It doesn't show for conditions unless the condition is persistent damage (which opens up the persistent damage dialog and highlights the relevant formula).

![image](https://github.com/foundryvtt/pf2e/assets/1286721/25a6d1ec-4c8c-478a-9d3c-2d699c1062fc)