### PR TITLE
Fix various typos in en.json (#10178)

### DIFF
--- a/src/module/scene/token-document/document.ts
+++ b/src/module/scene/token-document/document.ts
@@ -383,7 +383,7 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
                     whisper: this.actor?.hasPlayerOwner
                         ? []
                         : game.users.contents.flatMap((user) => (user.isGM ? user.id : [])),
-                    content: game.i18n.format("PF2E.InitativeIsNow", { name: this.name, value: initiative }),
+                    content: game.i18n.format("PF2E.InitiativeIsNow", { name: this.name, value: initiative }),
                 },
             ]);
         }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1250,7 +1250,7 @@
             "ExcludingFromInitiative": "Excluding {type} {actor} from initiative.",
             "HasNoInitiativeScore": "{actor} has no initiative score.",
             "HideName": "Hide Name",
-            "InitiativeSet": "Inititative of {actor} was set to {initiative}.",
+            "InitiativeSet": "Initiative of {actor} was set to {initiative}.",
             "Metrics": {
                 "Award": {
                     "Label": "Award: {xp} XP",
@@ -1362,7 +1362,7 @@
         "FormulaListEmpty": "Empty (drag formula/item here)",
         "FormulaPlaceholder": "Formula",
         "FormulaSheet": {
-            "DescriptionUnknown": "This formula is completely filled with drawings of small stick men, stains from some unknown liquid, non-sensical rhymes written in children's letters, and other seemingly random markings. It must have been made by goblins, and makes no sense to you.<hr><strong>Note</strong> This formula is referencing a missing or invalid item.",
+            "DescriptionUnknown": "This formula is completely filled with drawings of small stick men, stains from some unknown liquid, nonsensical rhymes written in children's letters, and other seemingly random markings. It must have been made by goblins, and makes no sense to you.<hr><strong>Note</strong> This formula is referencing a missing or invalid item.",
             "NameEmpty": "Empty Formula",
             "NamePrefix": "Formula of {name}",
             "NameUnknown": "Unknown Formula"
@@ -1403,7 +1403,7 @@
         "ImageLabel": "Image",
         "ImmunitiesLabel": "Immunities",
         "IncrementEffectTitle": "Increase Effect Level",
-        "InitativeIsNow": "{name}'s Initiative is now {value}!",
+        "InitiativeIsNow": "{name}'s Initiative is now {value}!",
         "InitiativeHeader": "Initiative bonus",
         "InitiativeLabel": "Initiative",
         "InitiativeWithSkill": "Initiative: {skillName}",
@@ -2409,7 +2409,7 @@
         "MaxStaminaTitle": "Your maximum stamina points",
         "Migrations": {
             "Finished": "PF2E System Migration to version {version} completed!",
-            "OnlyGMCanUse": "Only a gamemaster can use this tool.",
+            "OnlyGMCanUse": "Only a Gamemaster can use this tool.",
             "OutsideSchemaRange": "The specified range is outside the system's schema version range (between {minimum} and {maximum}).",
             "Running": "Running system migration ...",
             "Starting": "Applying PF2E System Migration to version {version}. Please be patient and do not close your game or shut down your server.",
@@ -3753,7 +3753,7 @@
         "TraitDescriptionConcussive": "These weapons smash as much as puncture. When determining a creature's resistance or immunity to damage from this weapon, use the weaker of the target's resistance or immunity to piercing or to bludgeoning. For instance, if the creature were immune to piercing and had no resistance or immunity to bludgeoning damage, it would take full damage from a concussive weapon. Resistance or immunity to all physical damage, or all damage, applies as normal.",
         "TraitDescriptionConjuration": "Effects and magic items with this trait are associated with the conjuration school of magic, typically involving summoning, creation, teleportation, or moving things from place to place.",
         "TraitDescriptionConrasu": "A people that are made of cosmic force given consciousness and housed within unique exoskeletons.",
-        "TraitDescriptionConsecration": "A consecration spell enhances an area for an extended period of time. A given area can have only a single consecration effect at a time. The new effect attempts to counteract any existing one in areas of overlap.ation",
+        "TraitDescriptionConsecration": "A consecration spell enhances an area for an extended period of time. A given area can have only a single consecration effect at a time. The new effect attempts to counteract any existing one in areas of overlap.",
         "TraitDescriptionConstruct": "A construct is an artificial creature empowered by a force other than necromancy. Constructs are often mindless; they are immune to bleed damage, death effects, disease, healing, necromancy, nonlethal attacks, poison, and the doomed, drained, fatigued, paralyzed, sickened, and unconscious conditions; and they may have Hardness based on the materials used to construct their bodies. Constructs are not living creatures, nor are they undead. When reduced to 0 Hit Points, a construct creature is destroyed.",
         "TraitDescriptionConsumable": "An item with this trait can be used only once. Unless stated otherwise, it's destroyed after activation. Consumable items include alchemical items and magical consumables such as scrolls and talismans. When a character creates consumable items, they can make them in batches of four.",
         "TraitDescriptionContact": "This poison is delivered by contact with the skin.",
@@ -4656,7 +4656,7 @@
         },
         "UnitPriceLabel": "Unit price",
         "UnitedPaizoWorkers": {
-            "PFSNote": "Note for Pathfinder Society players: In support of UPW, merchandise purchased from the union store will count in the Online PFS region for the <span class=\"hover\" title=\"When you use a Hero Point to reroll a check, add a +1 cirumstance bonus to the reroll\">Promotional Vestments</a> boon.",
+            "PFSNote": "Note for Pathfinder Society players: In support of UPW, merchandise purchased from the union store will count in the Online PFS region for the <span class=\"hover\" title=\"When you use a Hero Point to reroll a check, add a +1 circumstance bonus to the reroll\">Promotional Vestments</a> boon.",
             "ReleaseIntro": "Redmond, WA (October 14th, 2021) — Today, the workers at Paizo, Inc - publisher of the Pathfinder and Starfinder roleplaying games - are announcing their formation of the United Paizo Workers union (UPW), with the Communication Workers of America's CODE-CWA project. This union is the first of its kind in the tabletop roleplaying games industry.",
             "Title": "Announcement: United Paizo Workers"
         },
@@ -5770,7 +5770,7 @@
             "NamePlaceholder": "Vehicle",
             "PassengersLabel": "Passengers",
             "PilotingCheckLabel": "Piloting Check",
-            "PropertyDescriptionCollisionDC": "The vehicles's DC for saving throws to mitigate damage.",
+            "PropertyDescriptionCollisionDC": "The vehicle's DC for saving throws to mitigate damage.",
             "PropertyDescriptionCollisionDamage": "The vehicle's collision damage. Unless otherwise stated, collisions deal bludgeoning damage.",
             "PropertyDescriptionCrew": "The crew members required to operate the vehicle.",
             "PropertyDescriptionPassengers": "The number of passengers the vehicle is typically configured to carry, if any.",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2409,7 +2409,7 @@
         "MaxStaminaTitle": "Your maximum stamina points",
         "Migrations": {
             "Finished": "PF2E System Migration to version {version} completed!",
-            "OnlyGMCanUse": "Only a Gamemaster can use this tool.",
+            "OnlyGMCanUse": "Only a gamemaster can use this tool.",
             "OutsideSchemaRange": "The specified range is outside the system's schema version range (between {minimum} and {maximum}).",
             "Running": "Running system migration ...",
             "Starting": "Applying PF2E System Migration to version {version}. Please be patient and do not close your game or shut down your server.",


### PR DESCRIPTION
Just a bunch of unrelated typos.

Found by looking through the thousand or so automatically-found dictionary warnings in my IDE (IntelliJ IDEA).