### PR TITLE
Remove kingdom builder unset button

### DIFF
--- a/src/module/actor/party/kingdom/builder.ts
+++ b/src/module/actor/party/kingdom/builder.ts
@@ -205,11 +205,6 @@ class KingdomBuilder extends FormApplication<Kingdom> {
                 });
             }
 
-            htmlQuery(categoryEl, "[data-action=unset]")?.addEventListener("click", () => {
-                this.selected[category] = null;
-                this.render();
-            });
-
             const saveCategory = async (): Promise<void> => {
                 const database = getKingdomABCData();
                 const selected = database[category][this.selected[category] ?? ""];

--- a/static/templates/actors/party/kingdom/builder.hbs
+++ b/static/templates/actors/party/kingdom/builder.hbs
@@ -148,7 +148,6 @@
                     {{buildEntry.name}}
                     {{#if @root.options.editable}}
                         <div class="item-controls">
-                            <a data-action="unset" {{disabled (not stale)}}><i class="fas fa-fw fa-redo"></i></a>
                             <a data-action="set" {{disabled (not stale)}}><i class="fas fa-fw fa-save"></i></a>
                         </div>
                     {{/if}}


### PR DESCRIPTION
This was originally conceived when I wanted to make it possible to edit the charter/government/etc. But now I think were I to do that, I'd add a "Custom" entry instead.