### PR TITLE
Build config objects with Remeda functions and eliminate instances of accumulator spreading in reduces

### DIFF
--- a/src/scripts/config/index.ts
+++ b/src/scripts/config/index.ts
@@ -69,6 +69,7 @@ import {
     vehicleTraits,
     weaponTraits,
 } from "./traits.ts";
+import * as R from "remeda";
 
 export type StatusEffectIconTheme = "default" | "blackWhite";
 
@@ -172,21 +173,9 @@ const weaponCategories = {
     unarmed: "PF2E.WeaponTypeUnarmed",
 };
 
-const baseArmorTypes = Object.keys(enJSON.PF2E.Item.Armor.Base).reduce(
-    (map, slug) => ({
-        ...map,
-        [slug]: `PF2E.Item.Armor.Base.${slug}`,
-    }),
-    {} as Record<keyof typeof enJSON.PF2E.Item.Armor.Base, string>
-);
+const baseArmorTypes = R.mapValues(enJSON.PF2E.Item.Armor.Base, (_v, slug) => `PF2E.Item.Armor.Base.${slug}`);
 
-const baseWeaponTypes = Object.keys(enJSON.PF2E.Weapon.Base).reduce(
-    (map, slug) => ({
-        ...map,
-        [slug]: `PF2E.Weapon.Base.${slug}`,
-    }),
-    {} as Record<keyof typeof enJSON.PF2E.Weapon.Base, string>
-);
+const baseWeaponTypes = R.mapValues(enJSON.PF2E.Weapon.Base, (_v, slug) => `PF2E.Weapon.Base.${slug}`);
 
 /** Base weapon types that are considered equivalent for all rules purposes */
 const equivalentWeapons = {
@@ -260,17 +249,11 @@ const alignments: Record<Alignment, string> = {
     CE: "PF2E.AlignmentCE",
 };
 
-const deityDomains = Object.keys(enJSON.PF2E.Item.Deity.Domain).reduce((domains, key) => {
-    const slug = sluggify(key);
-    const casedKey = sluggify(key, { camel: "bactrian" });
-    return {
-        ...domains,
-        [slug]: {
-            label: `PF2E.Item.Deity.Domain.${casedKey}.Label`,
-            description: `PF2E.Item.Deity.Domain.${casedKey}.Description`,
-        },
-    };
-}, {} as Record<DeityDomain, { label: string; description: string }>);
+const deityDomains = R.mapToObj(Object.keys(enJSON.PF2E.Item.Deity.Domain), (key) => {
+    const label = `PF2E.Item.Deity.Domain.${key}.Label`;
+    const description = `PF2E.Item.Deity.Domain.${key}.Description`;
+    return [sluggify(key) as DeityDomain, { label, description }];
+});
 
 const weaponReload: Record<WeaponReloadTime, string> = {
     "-": "—", // Reload value for thrown weapons

--- a/src/scripts/config/traits.ts
+++ b/src/scripts/config/traits.ts
@@ -565,10 +565,7 @@ const otherWeaponTags: Record<OtherWeaponTag, string> = {
     shoddy: "PF2E.Item.Physical.OtherTag.Shoddy",
 };
 
-const rangeTraits = RANGE_TRAITS.reduce(
-    (descriptions, trait) => ({ ...descriptions, [trait]: `PF2E.Trait${sluggify(trait, { camel: "bactrian" })}` }),
-    {} as Record<(typeof RANGE_TRAITS)[number], string>
-);
+const rangeTraits = R.mapToObj(RANGE_TRAITS, (trait) => [trait, `PF2E.Trait${sluggify(trait, { camel: "bactrian" })}`]);
 
 const npcAttackTraits = {
     ...weaponTraits,
@@ -923,10 +920,7 @@ const armorTraits = {
     ponderous: "PF2E.TraitPonderous",
 };
 
-const rangeDescriptions = RANGE_TRAITS.reduce((descriptions, trait) => {
-    descriptions[trait] = "PF2E.TraitDescriptionRange";
-    return descriptions;
-}, {} as Record<(typeof RANGE_TRAITS)[number], string>);
+const rangeDescriptions = R.mapToObj(RANGE_TRAITS, (trait) => [trait, "PF2E.TraitDescriptionRange"]);
 
 const preciousMaterialDescriptions = {
     abysium: "PF2E.PreciousMaterialAbysiumDescription",

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -420,13 +420,11 @@ function configFromLocalization<T extends Record<string, TranslationDictionaryVa
     localization: T,
     prefix: string
 ): T {
-    return Object.entries(localization).reduce(
-        (map, [key, value]) => ({
-            ...map,
-            [key]: typeof value === "string" ? `${prefix}.${key}` : configFromLocalization(value, `${prefix}.${key}`),
-        }),
-        {} as T
-    );
+    return Object.entries(localization).reduce((result: Record<string, unknown>, [key, value]) => {
+        result[key] =
+            typeof value === "string" ? `${prefix}.${key}` : configFromLocalization(value, `${prefix}.${key}`);
+        return result;
+    }, {}) as T;
 }
 
 /** Does the parameter look like an image file path? */


### PR DESCRIPTION
`deityDomains` only works with `mapToObject` because we don't need to return the original key.