### PR TITLE
Add tag styling for kingdom boosts and skills

### DIFF
--- a/src/styles/actor/party/kingdom/_builder.scss
+++ b/src/styles/actor/party/kingdom/_builder.scss
@@ -157,6 +157,13 @@
                     flex: 0;
                     white-space: nowrap;
                 }
+                .tag {
+                    border-radius: 4px;
+                    box-shadow: inset 0 0 0 1px rgb(0 0 0 / 30%);
+                    line-height: unset;
+                    padding: 0 0.15em;
+                    font-size: 0.9em;
+                }
             }
 
             a[disabled] {

--- a/src/styles/actor/party/kingdom/_features.scss
+++ b/src/styles/actor/party/kingdom/_features.scss
@@ -90,10 +90,18 @@
     }
 
     .build-entry-boosts {
+        font-family: var(--font-primary);
         margin-top: 1em;
         section {
             display: flex;
             gap: 4px;
+        }
+        .tag {
+            border-radius: 4px;
+            box-shadow: inset 0 0 0 1px rgb(0 0 0 / 30%);
+            line-height: unset;
+            padding: 0 0.15em;
+            font-size: 0.9em;
         }
     }
 

--- a/static/templates/actors/party/kingdom/partials/build-entry-boosts.hbs
+++ b/static/templates/actors/party/kingdom/partials/build-entry-boosts.hbs
@@ -3,9 +3,9 @@
     <div class="abilities">
         {{#each buildEntry.boosts as |boost|}}
             {{#if (eq boost "free")}}
-                <span>{{localize "PF2E.Kingmaker.KingdomBuilder.Free"}}</span>
+                <span class="tag">{{localize "PF2E.Kingmaker.KingdomBuilder.Free"}}</span>
             {{else}}
-                <span>{{localize (lookup @root.abilityLabels boost)}}</span>
+                <span class="tag">{{localize (lookup @root.abilityLabels boost)}}</span>
             {{/if}}
         {{/each}}
     </div>
@@ -13,7 +13,7 @@
 <section>
     <strong>{{localize "PF2E.Kingmaker.KingdomBuilder.FlawLabel"}}:</strong>
     {{#if buildEntry.flaw}}
-        <span>{{localize (lookup @root.abilityLabels buildEntry.flaw)}}</span>
+        <span class="tag">{{localize (lookup @root.abilityLabels buildEntry.flaw)}}</span>
     {{else}}
         <span>{{localize "PF2E.Kingmaker.KingdomBuilder.None"}}</span>
     {{/if}}
@@ -22,7 +22,7 @@
     <section>
         <strong>{{localize "PF2E.Kingmaker.KingdomBuilder.Skills"}}:</strong>
         {{#each buildEntry.skills as |skill|}}
-            <span>{{localize (lookup @root.skillLabels skill)}}</span>
+            <span class="tag">{{localize (lookup @root.skillLabels skill)}}</span>
         {{/each}}
     </section>
 {{/if}}


### PR DESCRIPTION
![image](https://github.com/foundryvtt/pf2e/assets/1286721/520803cf-4e8f-4547-9dc5-e9f1e0759c5d)
