### PR TITLE
Resolve roll note predicates

### DIFF
--- a/src/module/rules/rule-element/roll-note.ts
+++ b/src/module/rules/rule-element/roll-note.ts
@@ -53,7 +53,7 @@ class RollNoteRuleElement extends RuleElementPF2e<RollNoteSchema> {
                 selector,
                 title: title ? this.getReducedLabel(title) : null,
                 text,
-                predicate: this.predicate,
+                predicate: this.resolveInjectedProperties(this.predicate),
                 outcome: this.outcome,
                 visibility: this.visibility,
                 rule: this,


### PR DESCRIPTION
This allows {item|blah} and {actor|blah} stuff to work in roll note predicates like they do for modifiers and the like.