### PR TITLE
Don't apply bonus fire damage dice to Dehydrate

### DIFF
--- a/src/module/actor/character/elemental-blast.ts
+++ b/src/module/actor/character/elemental-blast.ts
@@ -369,9 +369,6 @@ class ElementalBlast {
             options: new Set([`action:${actionSlug}`, `action:cost:${actionCost}`, meleeOrRanged, ...item.traits]),
         });
 
-        const damageSynthetics = extractDamageSynthetics(this.actor, domains, { test: context.options });
-        const extraModifiers = R.compact([...damageSynthetics.modifiers, this.#strengthModToDamage(item, domains)]);
-        const modifiers = new StatisticModifier("", extraModifiers).modifiers;
         const baseDamage: BaseDamageData = {
             category: null,
             damageType: params.damageType,
@@ -382,6 +379,9 @@ class ElementalBlast {
                 },
             ],
         };
+        const damageSynthetics = extractDamageSynthetics(this.actor, [baseDamage], domains, { test: context.options });
+        const extraModifiers = R.compact([...damageSynthetics.modifiers, this.#strengthModToDamage(item, domains)]);
+        const modifiers = new StatisticModifier("", extraModifiers).modifiers;
         applyDamageDiceOverrides([baseDamage], damageSynthetics.dice);
 
         const damageData = createDamageFormula(

--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -334,7 +334,7 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
             // Separate damage modifiers into persistent and all others for stacking rules processing
             const resolvables = { spell: this };
 
-            const extracted = extractDamageSynthetics(actor, domains, {
+            const extracted = extractDamageSynthetics(actor, base, domains, {
                 extraModifiers: attributeModifiers,
                 resolvables,
                 test: options,

--- a/src/module/system/damage/weapon.ts
+++ b/src/module/system/damage/weapon.ts
@@ -460,7 +460,7 @@ class WeaponDamagePF2e {
         };
 
         // Extract damage modifiers and dice respecting stacking rules processing
-        const extracted = extractDamageSynthetics(actor, selectors, {
+        const extracted = extractDamageSynthetics(actor, [base], selectors, {
             resolvables,
             injectables,
             test: options,

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -739,7 +739,7 @@ async function augmentInlineDamageRoll(
 
         const { modifiers, dice } = (() => {
             if (!(actor instanceof ActorPF2e)) return { modifiers: [], dice: [] };
-            return extractDamageSynthetics(actor, domains, {
+            return extractDamageSynthetics(actor, base, domains, {
                 resolvables: rollData ?? {},
                 test: options,
             });


### PR DESCRIPTION
In general, prevents non-persistent damage dice and modifiers from applying to pure persistent damage.

I did it during the extractDamageSynthetics step so that the damage dice dialog continues to work as expected.

![image](https://github.com/foundryvtt/pf2e/assets/1286721/6e742dd6-830b-4967-84f4-ea91ae3d7320)

Doing it in createDamageFormula() led to enabled modifiers/dice in the dialog that were mysteriously ignored 🤣 