### PR TITLE
Remove MAP property from weapon system data, transferring to RE if set

### DIFF
--- a/build/run-migration.ts
+++ b/build/run-migration.ts
@@ -10,7 +10,6 @@ import { getFilesRecursively } from "./lib/helpers.ts";
 import { MigrationBase } from "@module/migration/base.ts";
 import { MigrationRunnerBase } from "@module/migration/runner/base.ts";
 
-import { Migration844DeityDomainUUIDs } from "@module/migration/migrations/844-deity-domains-uuids.ts";
 import { Migration846SpellSchoolOptional } from "@module/migration/migrations/846-spell-school-optional.ts";
 import { Migration847TempHPRuleEvents } from "@module/migration/migrations/847-temp-hp-rule-events.ts";
 import { Migration848NumericArmorProperties } from "@module/migration/migrations/848-numeric-armor-properties.ts";
@@ -28,6 +27,7 @@ import { Migration859MaterialTypeGrade } from "@module/migration/migrations/859-
 import { Migration860RMGroup } from "@module/migration/migrations/860-rm-group.ts";
 import { Migration862SpecificMagicArmor } from "@module/migration/migrations/862-specific-magic-armor.ts";
 import { Migration863FixMisspelledOrganaizationsProperty } from "@module/migration/migrations/863-fix-misspelled-organaizations-property.ts";
+import { Migration864RemoveWeaponMAP } from "@module/migration/migrations/864-rm-weapon-map.ts";
 
 // ^^^ don't let your IDE use the index in these imports. you need to specify the full path ^^^
 
@@ -38,7 +38,6 @@ globalThis.HTMLParagraphElement = window.HTMLParagraphElement;
 globalThis.Text = window.Text;
 
 const migrations: MigrationBase[] = [
-    new Migration844DeityDomainUUIDs(),
     new Migration846SpellSchoolOptional(),
     new Migration847TempHPRuleEvents(),
     new Migration848NumericArmorProperties(),
@@ -56,6 +55,7 @@ const migrations: MigrationBase[] = [
     new Migration860RMGroup(),
     new Migration862SpecificMagicArmor(),
     new Migration863FixMisspelledOrganaizationsProperty(),
+    new Migration864RemoveWeaponMAP(),
 ];
 
 global.deepClone = <T>(original: T): T => {

--- a/src/module/actor/data/base.ts
+++ b/src/module/actor/data/base.ts
@@ -236,7 +236,7 @@ interface StrikeData extends StatisticModifier {
     ready: boolean;
     /** Alias for `attack`. */
     roll?: RollFunction<AttackRollParams>;
-    /** Roll to attack with the given strike (with no MAP penalty; see `variants` for MAP penalties.) */
+    /** Roll to attack with the given strike (with no MAP; see `variants` for MAPs.) */
     attack?: RollFunction<AttackRollParams>;
     /** Roll normal (non-critical) damage for this weapon. */
     damage?: DamageRollFunction;

--- a/src/module/actor/helpers.ts
+++ b/src/module/actor/helpers.ts
@@ -146,8 +146,13 @@ function calculateMAPs(
     item: ItemPF2e,
     { domains, options }: { domains: string[]; options: Set<string> | string[] }
 ): MAPData {
+    const slugAndLabel = { slug: "multiple-attack-penalty", label: "PF2E.MultipleAttackPenalty" } as const;
+    const baseMap =
+        item.isOfType("action", "melee", "weapon") && item.traits.has("agile")
+            ? { ...slugAndLabel, map1: -4, map2: -8 }
+            : { ...slugAndLabel, map1: -5, map2: -10 };
+
     const optionSet = options instanceof Set ? options : new Set(options);
-    const baseMap = calculateBaseMAP(item);
     const maps = item.actor?.synthetics.multipleAttackPenalties ?? {};
     const fromSynthetics = domains
         .flatMap((d) => maps[d] ?? [])
@@ -156,34 +161,6 @@ function calculateMAPs(
 
     // Find lowest multiple attack penalty: penalties are negative, so actually looking for the highest value
     return [baseMap, ...fromSynthetics].reduce((lowest, p) => (p.map1 > lowest.map1 ? p : lowest));
-}
-
-function calculateBaseMAP(item: ItemPF2e): MAPData {
-    const slugAndLabel = { slug: "multiple-attack-penalty", label: "PF2E.MultipleAttackPenalty" } as const;
-
-    if (item.isOfType("action", "melee", "weapon")) {
-        // calculate multiple attack penalty tiers
-        const alternateMAP = item.isOfType("weapon") ? item.system.MAP.value : null;
-        switch (alternateMAP) {
-            case "1":
-                return { ...slugAndLabel, map1: -1, map2: -2 };
-            case "2":
-                return { ...slugAndLabel, map1: -2, map2: -4 };
-            case "3":
-                return { ...slugAndLabel, map1: -3, map2: -6 };
-            case "4":
-                return { ...slugAndLabel, map1: -4, map2: -8 };
-            case "5":
-                return { ...slugAndLabel, map1: -5, map2: -10 };
-            default: {
-                return item.traits.has("agile")
-                    ? { ...slugAndLabel, map1: -4, map2: -8 }
-                    : { ...slugAndLabel, map1: -5, map2: -10 };
-            }
-        }
-    }
-
-    return { ...slugAndLabel, map1: -5, map2: -10 };
 }
 
 /** Create roll options pertaining to the active encounter and the actor's participant */

--- a/src/module/item/weapon/data.ts
+++ b/src/module/item/weapon/data.ts
@@ -115,9 +115,6 @@ interface WeaponSystemSource extends Investable<PhysicalSystemSource> {
         canBeAmmo?: boolean;
         value: "worngloves" | "held-in-one-hand" | "held-in-one-plus-hands" | "held-in-two-hands";
     };
-    MAP: {
-        value: string;
-    };
     /** An optional override of the default ability modifier used in attack rolls with this weapon  */
     ability?: AttributeString | null;
     /** A combination weapon's melee usage */

--- a/src/module/migration/migrations/864-rm-weapon-map.ts
+++ b/src/module/migration/migrations/864-rm-weapon-map.ts
@@ -1,0 +1,33 @@
+import { ItemSourcePF2e } from "@item/data/index.ts";
+import { isObject } from "@util";
+import { MigrationBase } from "../base.ts";
+
+/** Remove MAP property from weapon system data, transferring to a rule element if set. */
+export class Migration864RemoveWeaponMAP extends MigrationBase {
+    static override version = 0.864;
+
+    override async updateItem(source: MaybeWithMAPProperty): Promise<void> {
+        if (source.type !== "weapon") return;
+
+        if (isObject<{ value: unknown }>(source.system.MAP)) {
+            const mapValue = -1 * Number(source.system.MAP.value);
+            if (mapValue < 0) {
+                const rule = { key: "MultipleAttackPenalty", selector: "{item|id}-attack", value: mapValue };
+                source.system.rules.push(rule);
+            }
+
+            if ("game" in globalThis) {
+                source.system["-=MAP"] = null;
+            } else {
+                delete source.system.MAP;
+            }
+        }
+    }
+}
+
+type MaybeWithMAPProperty = ItemSourcePF2e & {
+    system: {
+        MAP?: unknown;
+        "-=MAP"?: null;
+    };
+};

--- a/src/module/migration/migrations/index.ts
+++ b/src/module/migration/migrations/index.ts
@@ -261,3 +261,4 @@ export { Migration860RMGroup } from "./860-rm-group.ts";
 export { Migration861AuraColorsToAppearance } from "./861-aura-colors-to-appearance.ts";
 export { Migration862SpecificMagicArmor } from "./862-specific-magic-armor.ts";
 export { Migration863FixMisspelledOrganaizationsProperty } from "./863-fix-misspelled-organaizations-property.ts";
+export { Migration864RemoveWeaponMAP } from "./864-rm-weapon-map.ts";

--- a/src/module/migration/runner/base.ts
+++ b/src/module/migration/runner/base.ts
@@ -14,7 +14,7 @@ interface CollectionDiff<T extends foundry.documents.ActiveEffectSource | ItemSo
 export class MigrationRunnerBase {
     migrations: MigrationBase[];
 
-    static LATEST_SCHEMA_VERSION = 0.863;
+    static LATEST_SCHEMA_VERSION = 0.864;
 
     static MINIMUM_SAFE_VERSION = 0.618;
 

--- a/static/template.json
+++ b/static/template.json
@@ -644,10 +644,7 @@
             },
             "range": null,
             "reload": {
-                "value": ""
-            },
-            "MAP": {
-                "value": ""
+                "value": null
             },
             "potencyRune": {
                 "value": 0

--- a/static/templates/items/weapon-details.hbs
+++ b/static/templates/items/weapon-details.hbs
@@ -67,17 +67,6 @@
     </div>
 {{/if}}
 
-<div class="form-group">
-    <label>{{localize "PF2E.WeaponMAPLabel"}}</label>
-    <select name="system.MAP.value">
-        {{#select data.MAP.value}}
-            <option value="">{{localize "PF2E.WeaponMAPDefaultOption"}}</option>
-            {{#each weaponMAP as |name type|}}
-                <option value="{{type}}">{{name}}</option>
-            {{/each}}
-        {{/select}}
-    </select>
-</div>
 {{#unless isBomb}}
     <ol class="form-list">
         <h3>


### PR DESCRIPTION
After running the migration on a weapon with MAP set from the sheet:
![image](https://github.com/foundryvtt/pf2e/assets/106829671/c77e8946-07c7-400d-880a-0d0232eac8e2)
