### PR TITLE
Include attack-damage for strikes and fix damage domains for roll context

### DIFF
--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -1625,7 +1625,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
 
         for (const method of ["damage", "critical"] as const) {
             action[method] = async (params: DamageRollParams = {}): Promise<string | Rolled<DamageRoll> | null> => {
-                const domains = ["all", `${weapon.id}-damage`, "attack-damage", "strike-damage", "damage-roll"];
+                const domains = ["all", `${weapon.id}-damage`, "attack-damage", "strike-damage", "damage"];
                 params.options ??= [];
                 const targetToken = params.target ?? game.user.targets.first() ?? null;
 

--- a/src/module/actor/helpers.ts
+++ b/src/module/actor/helpers.ts
@@ -414,7 +414,7 @@ function strikeFromMeleeItem(item: MeleePF2e<ActorPF2e>): NPCStrike {
     const damageRoll =
         (outcome: "success" | "criticalSuccess"): DamageRollFunction =>
         async (params: DamageRollParams = {}): Promise<Rolled<DamageRoll> | string | null> => {
-            const domains = ["all", `${item.id}-damage`, "attack-damage", "strike-damage", "damage-roll"];
+            const domains = ["all", `${item.id}-damage`, "attack-damage", "strike-damage", "damage"];
             const targetToken = params.target ?? game.user.targets.first() ?? null;
 
             const context = await actor.getDamageRollContext({

--- a/src/module/system/damage/weapon.ts
+++ b/src/module/system/damage/weapon.ts
@@ -589,6 +589,7 @@ class WeaponDamagePF2e {
             `${weapon.slug ?? sluggify(weapon.name)}-damage`,
             `${meleeOrRanged}-strike-damage`,
             `${meleeOrRanged}-damage`,
+            "attack-damage",
             "strike-damage",
             "damage",
         ];


### PR DESCRIPTION
I'm not sure about "all", and I think `WeaponDamagePF2e.#getSelectors()` should probably be utilized instead of this list somehow, but this should help currently. I'm not sure on what the effects would be of making that method public and calling it from the damage function.

