### PR TITLE
Add support for spell damage dice type overrides

### DIFF
--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -17,9 +17,9 @@ import { MeasuredTemplateDocumentPF2e } from "@scene/index.ts";
 import { eventToRollParams } from "@scripts/sheet-util.ts";
 import { CheckRoll } from "@system/check/index.ts";
 import { DamagePF2e } from "@system/damage/damage.ts";
+import { DamageModifierDialog } from "@system/damage/dialog.ts";
 import { combinePartialTerms, createDamageFormula, parseTermsFromSimpleFormula } from "@system/damage/formula.ts";
 import { DamageCategorization, applyDamageDiceOverrides } from "@system/damage/helpers.ts";
-import { DamageModifierDialog } from "@system/damage/dialog.ts";
 import { DamageRoll } from "@system/damage/roll.ts";
 import {
     BaseDamageData,
@@ -331,12 +331,9 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
                         })
                 );
 
-            // Separate damage modifiers into persistent and all others for stacking rules processing
-            const resolvables = { spell: this };
-
             const extracted = extractDamageSynthetics(actor, base, domains, {
                 extraModifiers: attributeModifiers,
-                resolvables,
+                resolvables: { spell: this },
                 test: options,
             });
 

--- a/src/module/system/damage/helpers.ts
+++ b/src/module/system/damage/helpers.ts
@@ -71,6 +71,10 @@ function applyDamageDiceOverrides(base: BaseDamageData[], dice: DamageDicePF2e[]
                 const direction = adjustment.override.upgrade ? 1 : -1;
                 die.dice.faces = FACES[FACES.indexOf(die.dice.faces) + direction] ?? die.dice.faces;
             }
+
+            if (adjustment.override.damageType) {
+                data.damageType = adjustment.override.damageType;
+            }
         }
     }
 }


### PR DESCRIPTION
Also acquire adjustments for attribute modifiers in spell damage

It's a little awkward that attribute modifiers get their damage type set early. Maybe that can be refactored so that dice damage type overrides will propagate to them.