### PR TITLE
Remove options from strike attack roll passed to message damage buttons

### DIFF
--- a/src/module/chat-message/listeners/cards.ts
+++ b/src/module/chat-message/listeners/cards.ts
@@ -55,9 +55,8 @@ class ChatCards {
             const context = message.flags.pf2e.context;
             const mapIncreases = context && "mapIncreases" in context ? context.mapIncreases : null;
             const altUsage = context && "altUsage" in context ? context.altUsage : null;
-            const options = actor.getRollOptions(["all", "attack-roll"]);
             const target = message.target?.token?.object ?? null;
-            const rollArgs = { event, altUsage, mapIncreases, options, target };
+            const rollArgs = { event, altUsage, mapIncreases, target };
 
             switch (sluggify(action ?? "")) {
                 case "strike-attack":


### PR DESCRIPTION
Closes #10250 