### PR TITLE
Fix saddlebags bulk reduction

### DIFF
--- a/packs/equipment/saddlebags.json
+++ b/packs/equipment/saddlebags.json
@@ -28,7 +28,7 @@
             "type": null
         },
         "negateBulk": {
-            "value": "6"
+            "value": "2"
         },
         "price": {
             "value": {
@@ -42,7 +42,7 @@
             "value": "Pathfinder Core Rulebook"
         },
         "stackGroup": null,
-        "stowing": false,
+        "stowing": true,
         "traits": {
             "rarity": "common",
             "value": []


### PR DESCRIPTION
`Saddlebags come in a pair. Each can hold up to 3 Bulk of items, and the first 1 Bulk of items in each doesn't count against your mount's Bulk limit. The Bulk value given is for saddlebags worn by a mount. If you are carrying or stowing saddlebags, they count as 1 Bulk instead of light Bulk.`

It looks like saddlebags are setup so that the pair of bags are one item. This fixes it so that the first two bulk of items are negated properly.
