### PR TITLE
Individual clear, activity drop for party exploration tab

### DIFF
--- a/src/module/actor/party/sheet.ts
+++ b/src/module/actor/party/sheet.ts
@@ -430,6 +430,17 @@ class PartySheetPF2e extends ActorSheetPF2e<PartyPF2e> {
             ui.notifications.info("PF2E.Actor.Party.ClearActivities.Complete", { localize: true });
         });
 
+        htmlQueryAll(html, "[data-action=clear-member-activity]").forEach((el) =>
+            el.addEventListener("click", async () => {
+                const toClear = this.actor.members.find((m) => m.id === el.dataset.actorId);
+                if (toClear) {
+                    await toClear.update({ "system.exploration": [] });
+                } else {
+                    console.error(`Could not clear activity for member ID ${el.dataset.actorId}`);
+                }
+            })
+        );
+
         htmlQuery(html, "[data-action=rest]")?.addEventListener("click", (event) => {
             game.pf2e.actions.restForTheNight({ event, actors: this.actor.members });
         });

--- a/src/module/scene/token-document/clown-car.ts
+++ b/src/module/scene/token-document/clown-car.ts
@@ -59,7 +59,13 @@ class PartyClownCar {
 
         const newTokens = (
             await Promise.all(this.party.members.map((m) => m.getTokenDocument({ x: token.x, y: token.y })))
-        ).map((t) => ({ ...t.toObject(), x: token.x, y: token.y }));
+        ).filter((t) => {
+            if (t.actor?.isToken) {
+                ui.notifications.warn(game.i18n.format("PF2E.Actor.Party.ClownCar.DepositUnlinkedToken", {actor: t.actor.name}))
+                return false;
+            }
+            return true;
+        }).map((t) => ({ ...t.toObject(), x: token.x, y: token.y }));
         const createdTokens = await this.scene.createEmbeddedDocuments("Token", newTokens);
 
         const freeSpaces = this.#getDepositSpaces();

--- a/src/module/scene/token-document/clown-car.ts
+++ b/src/module/scene/token-document/clown-car.ts
@@ -59,13 +59,17 @@ class PartyClownCar {
 
         const newTokens = (
             await Promise.all(this.party.members.map((m) => m.getTokenDocument({ x: token.x, y: token.y })))
-        ).filter((t) => {
-            if (t.actor?.isToken) {
-                ui.notifications.warn(game.i18n.format("PF2E.Actor.Party.ClownCar.DepositUnlinkedToken", {actor: t.actor.name}))
-                return false;
-            }
-            return true;
-        }).map((t) => ({ ...t.toObject(), x: token.x, y: token.y }));
+        )
+            .filter((t) => {
+                if (t.actor?.isToken) {
+                    ui.notifications.warn(
+                        game.i18n.format("PF2E.Actor.Party.ClownCar.DepositUnlinkedToken", { actor: t.actor.name })
+                    );
+                    return false;
+                }
+                return true;
+            })
+            .map((t) => ({ ...t.toObject(), x: token.x, y: token.y }));
         const createdTokens = await this.scene.createEmbeddedDocuments("Token", newTokens);
 
         const freeSpaces = this.#getDepositSpaces();

--- a/src/styles/actor/party/_exploration.scss
+++ b/src/styles/actor/party/_exploration.scss
@@ -112,6 +112,12 @@
             }
         }
 
+        .clear-activity {
+            margin-left: auto;
+            padding: 0.5rem;
+            font-size: var(--font-size-14);
+        }
+
         .empty {
             align-items: center;
             cursor: pointer;

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -337,6 +337,7 @@
                 },
                 "ClownCar": {
                     "Deposit": "Deposit PC Tokens",
+                    "DepositUnlinkedToken": "Skipping unlinked token for {actor}. Deposit and retrieve only work for party tokens with Link Actor Data enabled.",
                     "Retrieve": "Retrieve PC Tokens"
                 },
                 "DefaultName": "The Party",

--- a/static/templates/actors/party/regions/exploration.hbs
+++ b/static/templates/actors/party/regions/exploration.hbs
@@ -71,6 +71,9 @@
                                 </section>
                             {{/each}}
                         </div>
+                        <a class="clear-activity" data-action="clear-member-activity" data-actor-id="{{member.actor.id}}" title="{{localize "PF2E.Actor.Party.ClearActivities.Label"}}">
+                            <i class="fa-solid fa-trash fa-fw"></i>
+                        </a>
                     {{else}}
                         <div class="empty" data-action="open-sheet" data-tab="exploration">
                             <div class="icon"><i class="fa-solid fa-plus fa-fw"></i></div>


### PR DESCRIPTION
Two minor features and one bugfix for the party sheet and clown car:

- Adds trash-icon buttons to each party member in the exploration tab to clear solely their exploration activities (Closes #10211)
- Allows exploration activities to be dropped onto party members in the exploration tab to assign that activity
  - To prevent unnecessary activity duplication for common use cases (drag from compendium/other actors), this reuses any activities already on the actor that match `id` OR `sourceId`.
  - Holding `Shift` changes the drop behavior from "add" to "replace with"
- Prevents clown car deposit action from placing tokens that do not have Link Actor Data enabled. Such tokens can't be recognized as party members and cannot be retreived later, and likely represent a configuration mistake. Also displays a warning when this suppression occurs.

https://github.com/foundryvtt/pf2e/assets/1791252/735cd61b-af1c-4fbd-a7f3-cac1b5099e1a

