### PR TITLE
Add icons to some Kingmaker effects

### DIFF
--- a/packs/bestiary-effects/effect-bark-orders.json
+++ b/packs/bestiary-effects/effect-bark-orders.json
@@ -7,7 +7,7 @@
             "value": "<p>All kobold allies within 30 feet of him gain a +1 status bonus on attack rolls and saving throws against fear effects until the start of Chief Sootscale's next turn.</p>"
         },
         "duration": {
-            "expiry": "turn-end",
+            "expiry": "turn-start",
             "sustained": false,
             "unit": "rounds",
             "value": 1

--- a/packs/bestiary-effects/effect-bark-orders.json
+++ b/packs/bestiary-effects/effect-bark-orders.json
@@ -1,6 +1,6 @@
 {
     "_id": "Hv4NO0HADyAAdS4F",
-    "img": "systems/pf2e/icons/default-icons/effect.svg",
+    "img": "icons/skills/social/intimidation-impressing.webp",
     "name": "Effect: Bark Orders",
     "system": {
         "description": {

--- a/packs/bestiary-effects/effect-darivans-bloodline-magic.json
+++ b/packs/bestiary-effects/effect-darivans-bloodline-magic.json
@@ -1,6 +1,6 @@
 {
     "_id": "1toVzNVJZx0RwG1v",
-    "img": "systems/pf2e/icons/default-icons/effect.svg",
+    "img": "icons/magic/nature/mushrooms-fire-glow-blue.webp",
     "name": "Effect: Darivan's Bloodline Magic",
     "system": {
         "description": {

--- a/packs/bestiary-effects/effect-defensive-slice.json
+++ b/packs/bestiary-effects/effect-defensive-slice.json
@@ -1,6 +1,6 @@
 {
     "_id": "EwhWYPCNM8bIIYEI",
-    "img": "systems/pf2e/icons/default-icons/effect.svg",
+    "img": "icons/skills/melee/hand-grip-sword-red.webp",
     "name": "Effect: Defensive Slice",
     "system": {
         "description": {
@@ -17,24 +17,13 @@
         },
         "rules": [
             {
-                "domain": "all",
-                "key": "RollOption",
-                "option": "defensive-slice",
-                "toggleable": true
-            },
-            {
                 "key": "FlatModifier",
-                "predicate": [
-                    "defensive-slice"
-                ],
                 "selector": "ac",
+                "type": "status",
                 "value": 2
             },
             {
                 "key": "FlatModifier",
-                "predicate": [
-                    "defensive-slice"
-                ],
                 "selector": "attack",
                 "type": "status",
                 "value": -2

--- a/packs/bestiary-effects/effect-drain-luck.json
+++ b/packs/bestiary-effects/effect-drain-luck.json
@@ -1,6 +1,6 @@
 {
     "_id": "fGI77mVeCQKBAP0f",
-    "img": "systems/pf2e/icons/default-icons/effect.svg",
+    "img": "icons/magic/fire/orb-vortex.webp",
     "name": "Effect: Drain Luck",
     "system": {
         "badge": {
@@ -8,7 +8,7 @@
             "value": 1
         },
         "description": {
-            "value": "<p>The creature must succeed at a @Check[type:will|dc:48] save or gain a -1 status penalty to all checks; it is then temporarily immune to Drain Luck for 1 round. Further damage dealt by the Lantern King's searing rune Strikes increases the status penalty by 1 on a failed save to a maximum status penalty of -4. This status penalty is reduced by one every time the affected creature achieves a critical success on a die roll against a creature that is at least equal to them in level, but otherwise is permanent until removed.</p>"
+            "value": "<p>The creature gains a status penalty to all checks.</p>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -22,7 +22,11 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "selector": "skill-check",
+                "selector": [
+                    "perception",
+                    "saving-throw",
+                    "skill-check"
+                ],
                 "type": "status",
                 "value": "-1*min(4,@item.system.badge.value)"
             }

--- a/packs/bestiary-effects/effect-reminder-of-doom.json
+++ b/packs/bestiary-effects/effect-reminder-of-doom.json
@@ -1,6 +1,6 @@
 {
     "_id": "IrXb05caCTkP792e",
-    "img": "systems/pf2e/icons/default-icons/effect.svg",
+    "img": "icons/magic/unholy/silhouette-robe-evil-glow.webp",
     "name": "Effect: Reminder of Doom",
     "system": {
         "description": {

--- a/packs/kingmaker-bestiary/chief-sootscale.json
+++ b/packs/kingmaker-bestiary/chief-sootscale.json
@@ -253,7 +253,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>Chief Sootscale pushes other kobolds under his command to fight harder and more bravely. Until the start of his next turn, all kobold allies within 30 feet of him gain a +1 status bonus on attack rolls and saving throws against fear effects.</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Item.Effect: Bark Orders]</p>"
+                    "value": "<p>Chief Sootscale pushes other kobolds under his command to fight harder and more bravely. Until the start of his next turn, all kobold allies within @Template[type:emanation|distance:30]{30 feet} of him gain a +1 status bonus on attack rolls and saving throws against fear effects.</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Item.Effect: Bark Orders]</p>"
                 },
                 "requirements": {
                     "value": ""


### PR DESCRIPTION
Also remove RollOption from Effect: Defensive Slice and fix selector for Effect: Drain Luck.
Fix expiry for Effect: Bark Orders.