### PR TITLE
Add `keepId` option (default `false`) to `WeaponPF2e#toNPCAttack`

### DIFF
--- a/src/module/actor/npc/document.ts
+++ b/src/module/actor/npc/document.ts
@@ -133,7 +133,7 @@ class NPCPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | nul
 
         // Extract as separate variables for easier use in this method.
         const { synthetics } = this;
-        const { modifierAdjustments, strikes } = synthetics;
+        const { modifierAdjustments } = synthetics;
         const baseLevel = this.system.details.level.base;
         this.synthetics.modifiers.hp ??= [];
 
@@ -249,7 +249,7 @@ class NPCPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | nul
         this.skills = this.prepareSkills();
 
         // process strikes.
-        const generatedMelee = Array.from(strikes.values()).flatMap((w) => w.toNPCAttacks());
+        const generatedMelee = Array.from(synthetics.strikes.values()).flatMap((w) => w.toNPCAttacks({ keepId: true }));
         for (const item of [...this.itemTypes.melee, ...generatedMelee]) {
             system.actions.push(strikeFromMeleeItem(item));
         }

--- a/src/module/item/weapon/document.ts
+++ b/src/module/item/weapon/document.ts
@@ -542,7 +542,7 @@ class WeaponPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
     }
 
     /** Generate a melee item from this weapon for use by NPCs */
-    toNPCAttacks(this: WeaponPF2e<ActorPF2e>): MeleePF2e<ActorPF2e>[] {
+    toNPCAttacks(this: WeaponPF2e<ActorPF2e>, { keepId = false } = {}): MeleePF2e<ActorPF2e>[] {
         const { actor } = this;
         if (!actor.isOfType("npc")) throw ErrorPF2e("Melee items can only be generated for NPCs");
 
@@ -669,6 +669,7 @@ class WeaponPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
             : [];
 
         const source: PreCreate<MeleeSource> = {
+            _id: keepId ? this.id : null,
             name: this._source.name,
             type: "melee",
             system: {

--- a/types/foundry/common/abstract/document.d.ts
+++ b/types/foundry/common/abstract/document.d.ts
@@ -610,7 +610,7 @@ type _Document = Document<_Document | null>;
 
 declare global {
     type PreCreate<T extends object> = T extends { name: string; type: string }
-        ? Omit<DeepPartial<T>, "name" | "type"> & { name: string; type: T["type"] }
+        ? Omit<DeepPartial<T>, "_id" | "name" | "type"> & { _id?: Maybe<string>; name: string; type: T["type"] }
         : DeepPartial<T>;
 
     type PreDocumentId<T extends object> = Omit<T, "_id"> & { _id: null };


### PR DESCRIPTION
This is to allow melee items generated from Strike synthetics to have IDs.