### PR TITLE
Fix migration - 702 

### DIFF
--- a/src/module/migration/migrations/702-re-formulas-at-instance-level.ts
+++ b/src/module/migration/migrations/702-re-formulas-at-instance-level.ts
@@ -9,7 +9,8 @@ export class Migration702REFormulasAtInstanceLevel extends MigrationBase {
 
     protected raiseToInstanceLevel(value: string): string {
         return value.replace(/@[a-z.]+/gi, (match) => {
-            if (["@mod", "@castLevel", "@heighten", "@item.badge.value"].includes(match)) return match;
+            if (["@weapon.system.damage.dice", "@mod", "@castLevel", "@heighten", "@item.badge.value"].includes(match))
+                return match;
             if (match.indexOf("@spell") >= 0) return match;
             if (match === "@details.level.value") return "@actor.level";
             if (match === "@actor.details.level.value") return "@actor.level";


### PR DESCRIPTION
Avoid situation when link to weapon is broken

Now ```@weapon.system.damage.dice``` convert to ```@actor.system.weapon.system.damage.dice```

actor.system.weapon — is invalid link