### PR TITLE
Tweak settlement/activities style and scroll filter summary into view

### DIFF
--- a/src/module/actor/party/kingdom/sheet.ts
+++ b/src/module/actor/party/kingdom/sheet.ts
@@ -499,6 +499,12 @@ class KingdomSheetPF2e extends ActorSheetPF2e<PartyPF2e> {
             const active = choice.dataset.slug ? choice.dataset.slug === trait : trait === null;
             choice.classList.toggle("active", active);
         }
+
+        // Scroll to top so that the Activity Phase summary is visible
+        const actionsList = htmlQuery(html, ".actions-list");
+        if (actionsList) {
+            actionsList.scrollTop = 0;
+        }
     }
 
     protected override async _onDropItem(

--- a/src/styles/actor/party/kingdom/_activities.scss
+++ b/src/styles/actor/party/kingdom/_activities.scss
@@ -133,6 +133,10 @@
         gap: 0.5rem;
         padding-right: 0.5rem;
 
+        &:not(:last-child) {
+            border-bottom: 1px solid var(--color-divider);
+        }
+
         .item-name {
             align-items: center;
             cursor: pointer;

--- a/src/styles/actor/party/kingdom/_world.scss
+++ b/src/styles/actor/party/kingdom/_world.scss
@@ -19,7 +19,7 @@ input[type="number"] {
     align-items: center;
     flex-wrap: wrap;
     gap: 0 1rem;
-    padding: 0.25rem 0;
+    padding: 0.25rem 0.25rem 0.25rem 0;
 
     &:not(:last-child) {
         border-bottom: 1px solid var(--color-divider);
@@ -67,14 +67,18 @@ input[type="number"] {
     }
 
     .settlement-data {
+        background: var(--paper-bg);
+        box-shadow: var(--drop-shadow);
         display: flex;
         justify-content: space-between;
-        margin: 0.5rem 0;
+        margin: 0.5rem 0.125rem 0.5rem 0;
 
         & > section {
-            background: var(--paper-bg);
-            box-shadow: var(--drop-shadow);
+            flex: 1 0 auto;
             padding: 0.5rem;
+            & + section {
+                border-left: 1px solid var(--color-divider);
+            }
         }
 
         input[type="number"] {

--- a/static/templates/actors/party/kingdom/tabs/world.hbs
+++ b/static/templates/actors/party/kingdom/tabs/world.hbs
@@ -5,7 +5,7 @@
             <i class="fa-solid fa-fw fa-plus"></i>{{localize "PF2E.AddShortLabel"}}
         </button>
     </h3>
-    <ol class="actions-list directory-list">
+    <ol class="directory-list">
         {{#each settlements as |settlement|}}
             {{> "systems/pf2e/templates/actors/party/kingdom/partials/settlement.hbs" settlement=settlement }}
         {{/each}}


### PR DESCRIPTION
Minor border/overflow stuff. Settlement tab still looks like sin, but a little less so. Plus a tiny bugfix.