### PR TITLE
Fix kingdom resource collection giving free commodities

### DIFF
--- a/packs/classfeatures/gate-junction.json
+++ b/packs/classfeatures/gate-junction.json
@@ -319,7 +319,7 @@
                 ],
                 "selector": "stealth",
                 "type": "status",
-                "value": "ternary(gte(@actor.level,17),3, ternary(gte(@actor.level,10),2,1))"
+                "value": "ternary(gte(@actor.level,7),3, ternary(gte(@actor.level,0),2,1))"
             },
             {
                 "key": "FlatModifier",


### PR DESCRIPTION
If implemented this fixes the issue with the resource collection on kingdom upkeep granting free commodities. Previously it was setting the commodities to the maximum allowed value.