### PR TITLE
Fix kingdom resource collection giving free commodities

### DIFF
--- a/src/module/actor/party/kingdom/model.ts
+++ b/src/module/actor/party/kingdom/model.ts
@@ -120,7 +120,7 @@ class Kingdom extends DataModel<PartyPF2e, KingdomSchema> implements PartyCampai
                 points: roll.total,
                 commodities: R.mapValues(commodities, (incoming, type) => {
                     const current = this.resources.commodities[type];
-                    return { value: Math.max(current.value + incoming, current.max) };
+                    return { value: Math.min(current.value + incoming, current.max) };
                 }),
             },
         });


### PR DESCRIPTION
If implemented this fixes the issue with the resource collection on kingdom upkeep granting free commodities. Previously it was setting the commodities to the maximum allowed value.