### PR TITLE
Fix air gate junction granting incorrect bonus to stealth

### DIFF
--- a/packs/classfeatures/gate-junction.json
+++ b/packs/classfeatures/gate-junction.json
@@ -319,7 +319,7 @@
                 ],
                 "selector": "stealth",
                 "type": "status",
-                "value": "ternary(gte(@actor.level,7),3, ternary(gte(@actor.level,0),2,1))"
+                "value": "ternary(gte(@actor.level,17),3, ternary(gte(@actor.level,10),2,1))"
             },
             {
                 "key": "FlatModifier",


### PR DESCRIPTION
If implemented this fixes the issue with the air gate junction granting the incorrect bonus to stealth if you select skill junction.