### PR TITLE
Add drag/drop reordering of rule elements

### DIFF
--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -27,6 +27,7 @@ import {
 } from "@system/tag-selector/index.ts";
 import {
     ErrorPF2e,
+    SORTABLE_DEFAULTS,
     fontAwesomeIcon,
     htmlClosest,
     htmlQuery,
@@ -64,12 +65,11 @@ import { RemoveCoinsPopup } from "./popups/remove-coins-popup.ts";
 abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActor, ItemPF2e> {
     static override get defaultOptions(): ActorSheetOptions {
         const options = super.defaultOptions;
-        options.dragDrop.push({ dragSelector: ".drag-handle" }, { dragSelector: ".item[draggable=true]" });
-        const itemDrag = options.dragDrop.find((d) => d.dragSelector === ".item-list .item");
-        if (itemDrag) {
-            // Inventory items are handled by Sortable
-            itemDrag.dragSelector = ".item-list .item:not(.inventory-list *)";
-        }
+        options.dragDrop = [
+            { dragSelector: "[data-foundry-list] .drag-handle" },
+            { dragSelector: ".item[draggable=true]" },
+            { dragSelector: ".item-list .item:not(.inventory-list *)" },
+        ];
         return mergeObject(options, {
             classes: ["default", "sheet", "actor"],
             scrollY: [".sheet-sidebar", ".tab.active", ".inventory-list"],
@@ -647,17 +647,10 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
         const inventoryList = htmlQuery(panel, "section.inventory-list, ol[data-container-type=actorInventory]");
         if (!inventoryList) return;
         const sortableOptions: Sortable.Options = {
-            animation: 200,
-            direction: "vertical",
-            dragClass: "drag-preview",
-            dragoverBubble: true,
+            ...SORTABLE_DEFAULTS,
             filter: "div.item-summary",
             preventOnFilter: false,
-            easing: "cubic-bezier(1, 0, 0, 1)",
-            ghostClass: "drag-gap",
             scroll: inventoryList,
-            scrollSensitivity: 30,
-            scrollSpeed: 15,
             setData: (dataTransfer, dragEl) => {
                 const item = this.actor.inventory.get(htmlQuery(dragEl, "div[data-item-id]")?.dataset.itemId, {
                     strict: true,

--- a/src/styles/item/_rules.scss
+++ b/src/styles/item/_rules.scss
@@ -11,6 +11,16 @@
         }
     }
 
+    fieldset {
+        border-radius: 5px;
+        border: 1px solid var(--secondary-background);
+        padding: 0.25em;
+
+        legend {
+            font-weight: 500;
+        }
+    }
+
     .nerd-details {
         margin-bottom: 10px;
 
@@ -36,23 +46,6 @@
     .rules {
         padding-top: 7px;
         padding-right: 7px;
-
-        .rule-element-header {
-            display: flex;
-            align-items: center;
-            margin-bottom: 0.25rem;
-
-            h3 {
-                margin: 0;
-                &.unrecognized {
-                    color: #880000;
-                }
-            }
-
-            .item-controls {
-                margin-left: auto;
-            }
-        }
 
         .add-rule-element {
             text-align: right;
@@ -121,8 +114,44 @@
         }
     }
 
-    // Styles for the rule editor forms
+    // Style of a single rule editor form
     .rule-form {
+        border-bottom: 1px solid var(--color-border-light-primary);
+        padding-bottom: 0.5rem;
+        margin-bottom: 0.5rem;
+
+        &.drag-preview {
+            background: url(../ui/parchment.jpg) repeat;
+        }
+
+        &.drag-gap {
+            visibility: hidden;
+        }
+
+        .rule-element-header {
+            display: flex;
+            align-items: center;
+            margin-bottom: 0.25rem;
+
+            .drag-handle {
+                cursor: grab;
+                font-weight: normal;
+                margin-right: 0.375rem;
+                padding: 0.125rem;
+            }
+
+            h3 {
+                margin: 0;
+                &.unrecognized {
+                    color: #880000;
+                }
+            }
+
+            .item-controls {
+                margin-left: auto;
+            }
+        }
+
         label,
         .labelled-element {
             display: flex;
@@ -224,16 +253,6 @@
             a.active {
                 font-weight: 600;
                 text-decoration: underline;
-            }
-        }
-
-        fieldset {
-            border-radius: 5px;
-            border: 1px solid var(--secondary-background);
-            padding: 0.25em;
-
-            legend {
-                font-weight: 500;
             }
         }
 

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -1,4 +1,5 @@
 import { ActionCost } from "@item/data/base.ts";
+import Sortable from "sortablejs";
 
 /**
  * Given an array and a key function, create a map where the key is the value that
@@ -441,10 +442,26 @@ function isImageOrVideoPath(path: unknown): path is ImageFilePath | VideoFilePat
     return isImageFilePath(path) || isVideoFilePath(path);
 }
 
+const SORTABLE_DEFAULTS: Sortable.Options = {
+    animation: 200,
+    direction: "vertical",
+    dragClass: "drag-preview",
+    dragoverBubble: true,
+    easing: "cubic-bezier(1, 0, 0, 1)",
+    ghostClass: "drag-gap",
+
+    // These options are from the Autoscroll plugin and serve as a fallback on mobile/safari/ie/edge
+    // Other browsers use the native implementation
+    scroll: true,
+    scrollSensitivity: 30,
+    scrollSpeed: 15,
+};
+
 export {
     ErrorPF2e,
     type Fraction,
     type SlugCamel,
+    SORTABLE_DEFAULTS,
     addSign,
     applyNTimes,
     configFromLocalization,

--- a/static/templates/actors/character/tabs/feats.hbs
+++ b/static/templates/actors/character/tabs/feats.hbs
@@ -12,7 +12,7 @@
                     <i class="fas fa-fw fa-search"></i>{{localize "PF2E.BrowseLabel"}}
                 </button>
             </h3>
-            <ol class="actions-list directory-list">
+            <ol class="actions-list directory-list" data-foundry-list>
                 {{#each section.feats as |featSlot|}}
                     {{> "systems/pf2e/templates/actors/character/partials/feat-slot.hbs" featSlot=featSlot featFilter=section.featFilter}}
                 {{/each}}

--- a/static/templates/actors/character/tabs/spellcasting.hbs
+++ b/static/templates/actors/character/tabs/spellcasting.hbs
@@ -1,5 +1,5 @@
 <div class="tab spellcasting spellbook-pane" data-group="primary" data-tab="spellcasting">
-    <ol class="spellcastingEntry-list directory-list">
+    <ol class="spellcastingEntry-list directory-list" data-foundry-list>
         {{#each spellcastingEntries as |entry eid|}}
             <li class="item item-container spellcasting-entry" data-item-id="{{entry.id}}" {{#if entry.hasCollection}}data-container-type="spellcastingEntry" data-container-id="{{entry.id}}"{{/if}}>
                 <div class="action-header">

--- a/static/templates/actors/npc/tabs/spells.hbs
+++ b/static/templates/actors/npc/tabs/spells.hbs
@@ -1,5 +1,5 @@
 <div class="tab spells" data-group="primary" data-tab="spells">
-    <ol class="entries-list">
+    <ol class="entries-list" data-foundry-list>
         {{#each spellcastingEntries as |entry eid|}}
             <li class="spellcasting-entry item item-container" data-item-id="{{entry.id}}" {{#if entry.hasCollection}}data-container-type="spellcastingEntry" data-container-id="{{entry.id}}"{{/if}}>
                 <div class="header">

--- a/static/templates/actors/party/kingdom/tabs/features.hbs
+++ b/static/templates/actors/party/kingdom/tabs/features.hbs
@@ -29,7 +29,7 @@
                     </button>
                 {{/if}}
             </h3>
-            <ol class="actions-list directory-list">
+            <ol class="actions-list directory-list" data-foundry-list>
                 {{#each section.feats as |featSlot|}}
                     {{> "systems/pf2e/templates/actors/character/partials/feat-slot.hbs" featSlot=featSlot featFilter=section.featFilter}}
                 {{/each}}

--- a/static/templates/actors/spellcasting-spell-list.hbs
+++ b/static/templates/actors/spellcasting-spell-list.hbs
@@ -1,5 +1,5 @@
 {{#with entry as |entry|}}
-    <ol class="directory-list spell-list" data-category="{{entry.category}}">
+    <ol class="directory-list spell-list" data-category="{{entry.category}}" data-foundry-list>
         {{!-- Add section for each level --}}
         {{#each entry.levels as |section|}}
             {{#if (or (gt section.active.length 0) entry.showSlotlessLevels)}}

--- a/static/templates/items/rules-panel.hbs
+++ b/static/templates/items/rules-panel.hbs
@@ -16,7 +16,7 @@
                 </label>
                 <input id="{{options.id}}-uuid" disabled value="{{item.uuid}}" />
                 <div class="item-controls">
-                    <a data-clipboard="{{item.uuid}}"><i class="fas fa-clipboard"></i></a>
+                    <a data-clipboard="{{item.uuid}}"><i class="fa-solid fa-fw fa-clipboard"></i></a>
                 </div>
             </div>
             {{#if item.sourceId}}
@@ -27,7 +27,7 @@
                     </label>
                     <input id="{{options.id}}-source-id" disabled value="{{item.sourceId}}" />
                     <div class="item-controls">
-                        <a data-clipboard="{{item.sourceId}}"><i class="fas fa-clipboard"></i></a>
+                        <a data-clipboard="{{item.sourceId}}"><i class="fa-solid fa-fw fa-clipboard"></i></a>
                     </div>
                 </div>
             {{/if}}
@@ -38,26 +38,24 @@
                 </label>
                 <input id="{{options.id}}-slug" type="text" name="system.slug" value="{{item.system.slug}}" />
                 <div class="item-controls">
-                    <a data-action="regenerate-slug" title="{{localize "PF2E.Item.Rules.RegenerateSlug"}}"><i class="fa-solid fa-sync-alt"></i></a>
+                    <a data-action="regenerate-slug" title="{{localize "PF2E.Item.Rules.RegenerateSlug"}}"><i class="fa-solid fa-fw fa-sync-alt"></i></a>
                 </div>
             </div>
         </div>
-
-        <div>
+        <div class="rule-element-forms">
             {{#each rules.elements}}
                 {{{template}}}
-                <hr/>
             {{/each}}
-            <div class="create-rule-element">
-                <select data-action="select-rule-element">
-                    {{#select rules.selection.selected}}
-                        {{#each rules.selection.types as |value key|}}
-                            <option value="{{key}}">{{value}}</option>
-                        {{/each}}
-                    {{/select}}
-                </select>
-                <a class="add-rule-element"><i class="fas fa-plus"></i> {{localize "PF2E.Item.Rules.New"}}</a>
-            </div>
+        </div>
+        <div class="create-rule-element">
+            <select data-action="select-rule-element">
+                {{#select rules.selection.selected}}
+                    {{#each rules.selection.types as |value key|}}
+                        <option value="{{key}}">{{value}}</option>
+                    {{/each}}
+                {{/select}}
+            </select>
+            <a class="add-rule-element"><i class="fas fa-plus"></i> {{localize "PF2E.Item.Rules.New"}}</a>
         </div>
     </div>
 {{/if}}

--- a/static/templates/items/rules/outer.hbs
+++ b/static/templates/items/rules/outer.hbs
@@ -1,5 +1,6 @@
 <section class="rule-form" data-key="{{rule.key}}" data-idx="{{index}}">
     <header class="rule-element-header">
+        <i class="fa-solid fa-bars drag-handle"></i>
         <h3{{#if (not recognized)}} class="unrecognized"{{/if}}>{{label}}</h3>
         <div class="item-controls">
             <a class="edit-rule-element" data-rule-index="{{index}}" data-tooltip="{{localize "PF2E.Item.Rules.Edit"}}"><i class="fa-solid fa-fw fa-edit"></i></a>


### PR DESCRIPTION
https://github.com/foundryvtt/pf2e/assets/1286721/11ab2e76-2756-4c7c-9fd6-c89d1477c41f

This also changes all existing drag-handles to need to be under a `data-foundry-list`. Reordering spells, npc/character spellcasting entries, and feats seem to continue to work.