### PR TITLE
Move range increment/max data to single object in Strike RE

### DIFF
--- a/build/run-migration.ts
+++ b/build/run-migration.ts
@@ -10,9 +10,6 @@ import { getFilesRecursively } from "./lib/helpers.ts";
 import { MigrationBase } from "@module/migration/base.ts";
 import { MigrationRunnerBase } from "@module/migration/runner/base.ts";
 
-import { Migration846SpellSchoolOptional } from "@module/migration/migrations/846-spell-school-optional.ts";
-import { Migration847TempHPRuleEvents } from "@module/migration/migrations/847-temp-hp-rule-events.ts";
-import { Migration848NumericArmorProperties } from "@module/migration/migrations/848-numeric-armor-properties.ts";
 import { Migration849DeleteBrokenThreshold } from "@module/migration/migrations/849-delete-broken-threshold.ts";
 import { Migration850FlatFootedToOffGuard } from "@module/migration/migrations/850-flat-footed-to-off-guard.ts";
 import { Migration851JustInnovationId } from "@module/migration/migrations/851-just-innovation-id.ts";
@@ -30,6 +27,7 @@ import { Migration863FixMisspelledOrganaizationsProperty } from "@module/migrati
 import { Migration864RemoveWeaponMAP } from "@module/migration/migrations/864-rm-weapon-map.ts";
 import { Migration865VitalityVoid } from "@module/migration/migrations/865-vitality-void.ts";
 import { Migration867DamageRollDomainFix } from "@module/migration/migrations/867-damage-roll-domain-fix.ts";
+import { Migration868StrikeRERange } from "@module/migration/migrations/868-strike-re-range.ts";
 
 // ^^^ don't let your IDE use the index in these imports. you need to specify the full path ^^^
 
@@ -40,9 +38,6 @@ globalThis.HTMLParagraphElement = window.HTMLParagraphElement;
 globalThis.Text = window.Text;
 
 const migrations: MigrationBase[] = [
-    new Migration846SpellSchoolOptional(),
-    new Migration847TempHPRuleEvents(),
-    new Migration848NumericArmorProperties(),
     new Migration849DeleteBrokenThreshold(),
     new Migration850FlatFootedToOffGuard(),
     new Migration851JustInnovationId(),
@@ -60,6 +55,7 @@ const migrations: MigrationBase[] = [
     new Migration864RemoveWeaponMAP(),
     new Migration865VitalityVoid(),
     new Migration867DamageRollDomainFix(),
+    new Migration868StrikeRERange(),
 ];
 
 global.deepClone = <T>(original: T): T => {

--- a/packs/equipment/rod-of-razors.json
+++ b/packs/equipment/rod-of-razors.json
@@ -77,8 +77,9 @@
                 "group": "dart",
                 "key": "Strike",
                 "label": "Rod of Razors Flechette",
-                "maxRange": 100,
-                "range": 100,
+                "range": {
+                    "max": 100
+                },
                 "slug": "flechette",
                 "traits": [
                     "adamantine",

--- a/packs/equipment/throwing-shield.json
+++ b/packs/equipment/throwing-shield.json
@@ -44,7 +44,9 @@
                 },
                 "group": "shield",
                 "key": "Strike",
-                "range": 20,
+                "range": {
+                    "increment": 20
+                },
                 "traits": [
                     "thrown"
                 ]

--- a/packs/feat-effects/stance-vitality-manipulation-stance.json
+++ b/packs/feat-effects/stance-vitality-manipulation-stance.json
@@ -27,8 +27,9 @@
                 },
                 "key": "Strike",
                 "label": "PF2E.SpecificRule.VitalityManipulationStance.StrikeLabel",
-                "maxRange": 30,
-                "range": 30,
+                "range": {
+                    "max": 30
+                },
                 "traits": [
                     "unarmed",
                     "versatile-vitality"

--- a/packs/feat-effects/stance-wild-winds-stance.json
+++ b/packs/feat-effects/stance-wild-winds-stance.json
@@ -29,7 +29,9 @@
                 "img": "icons/magic/air/wind-tornado-funnel-blue-grey.webp",
                 "key": "Strike",
                 "label": "PF2E.SpecificRule.Stance.Attack.WindCrash",
-                "range": 30,
+                "range": {
+                    "increment": 30
+                },
                 "traits": [
                     "agile",
                     "propulsive",

--- a/packs/feats/core-cannon.json
+++ b/packs/feats/core-cannon.json
@@ -37,7 +37,9 @@
                 "predicate": [
                     "core-cannon"
                 ],
-                "range": 120,
+                "range": {
+                    "increment": 120
+                },
                 "traits": [
                     "unarmed"
                 ]

--- a/packs/feats/energy-beam.json
+++ b/packs/feats/energy-beam.json
@@ -31,7 +31,9 @@
                 },
                 "img": "icons/magic/light/projectile-beam-yellow.webp",
                 "key": "Strike",
-                "range": 20,
+                "range": {
+                    "increment": 20
+                },
                 "traits": [
                     "unarmed"
                 ]

--- a/packs/feats/foxfire.json
+++ b/packs/feats/foxfire.json
@@ -65,8 +65,9 @@
                 "group": "sling",
                 "img": "systems/pf2e/icons/spells/diamond-dust.webp",
                 "key": "Strike",
-                "maxRange": 20,
-                "range": 20,
+                "range": {
+                    "max": 20
+                },
                 "traits": [
                     "unarmed",
                     "magical"

--- a/packs/feats/scalding-spit.json
+++ b/packs/feats/scalding-spit.json
@@ -36,11 +36,12 @@
                 "img": "systems/pf2e/icons/unarmed-attacks/fire-mote.webp",
                 "key": "Strike",
                 "label": "PF2E.SpecificRule.Goblin.ScaldingSpit.BoilingSpit",
-                "maxRange": 30,
                 "predicate": [
                     "self:condition:persistent-damage:fire"
                 ],
-                "range": 30,
+                "range": {
+                    "max": 30
+                },
                 "slug": "boiling-spit",
                 "traits": [
                     "unarmed"

--- a/packs/feats/seedpod.json
+++ b/packs/feats/seedpod.json
@@ -31,7 +31,9 @@
                 },
                 "img": "icons/magic/nature/plant-poison-spit-green.webp",
                 "key": "Strike",
-                "range": 10,
+                "range": {
+                    "increment": 10
+                },
                 "traits": [
                     "unarmed"
                 ]

--- a/packs/feats/sprites-spark.json
+++ b/packs/feats/sprites-spark.json
@@ -32,11 +32,12 @@
                 "group": "sling",
                 "key": "Strike",
                 "label": "PF2E.SpecificRule.Sprite.SpritesSpark.Draxie",
-                "maxRange": 20,
                 "predicate": [
                     "self:heritage:draxie"
                 ],
-                "range": 20,
+                "range": {
+                    "max": 20
+                },
                 "traits": [
                     "unarmed"
                 ]
@@ -53,11 +54,12 @@
                 "group": "sling",
                 "key": "Strike",
                 "label": "PF2E.SpecificRule.Sprite.SpritesSpark.LuminousSprite",
-                "maxRange": 20,
                 "predicate": [
                     "self:heritage:luminous-sprite"
                 ],
-                "range": 20,
+                "range": {
+                    "max": 20
+                },
                 "traits": [
                     "unarmed"
                 ]
@@ -74,11 +76,12 @@
                 "group": "sling",
                 "key": "Strike",
                 "label": "PF2E.SpecificRule.Sprite.SpritesSpark.Grig",
-                "maxRange": 20,
                 "predicate": [
                     "self:heritage:grig"
                 ],
-                "range": 20,
+                "range": {
+                    "max": 20
+                },
                 "traits": [
                     "unarmed"
                 ]
@@ -95,11 +98,12 @@
                 "group": "sling",
                 "key": "Strike",
                 "label": "PF2E.SpecificRule.Sprite.SpritesSpark.Melixie",
-                "maxRange": 20,
                 "predicate": [
                     "self:heritage:melixie"
                 ],
-                "range": 20,
+                "range": {
+                    "max": 20
+                },
                 "traits": [
                     "unarmed"
                 ]
@@ -116,11 +120,12 @@
                 "group": "sling",
                 "key": "Strike",
                 "label": "PF2E.SpecificRule.Sprite.SpritesSpark.Nyktera",
-                "maxRange": 20,
                 "predicate": [
                     "self:heritage:nyktera"
                 ],
-                "range": 20,
+                "range": {
+                    "max": 20
+                },
                 "traits": [
                     "unarmed"
                 ]
@@ -137,11 +142,12 @@
                 "group": "sling",
                 "key": "Strike",
                 "label": "PF2E.SpecificRule.Sprite.SpritesSpark.Pixie",
-                "maxRange": 20,
                 "predicate": [
                     "self:heritage:pixie"
                 ],
-                "range": 20,
+                "range": {
+                    "max": 20
+                },
                 "traits": [
                     "unarmed"
                 ]

--- a/packs/feats/venom-spit.json
+++ b/packs/feats/venom-spit.json
@@ -32,7 +32,9 @@
                 "img": "systems/pf2e/icons/spells/diamond-dust.webp",
                 "key": "Strike",
                 "label": "PF2E.SpecificRule.Nagaji.VenomSpit.StrikeLabel",
-                "range": 10,
+                "range": {
+                    "increment": 10
+                },
                 "traits": [
                     "unarmed"
                 ]

--- a/packs/heritages/hooded-nagaji.json
+++ b/packs/heritages/hooded-nagaji.json
@@ -29,7 +29,9 @@
                         "not": "feat:venom-spit"
                     }
                 ],
-                "range": 10,
+                "range": {
+                    "increment": 10
+                },
                 "traits": [
                     "unarmed"
                 ]

--- a/packs/heritages/spined-azarketi.json
+++ b/packs/heritages/spined-azarketi.json
@@ -25,7 +25,9 @@
                 "img": "systems/pf2e/icons/unarmed-attacks/spine.webp",
                 "key": "Strike",
                 "label": "PF2E.BattleForm.Attack.Spine",
-                "range": 10,
+                "range": {
+                    "increment": 10
+                },
                 "traits": [
                     "unarmed"
                 ]

--- a/packs/kingmaker-bestiary/avatar-of-the-lantern-king.json
+++ b/packs/kingmaker-bestiary/avatar-of-the-lantern-king.json
@@ -3311,13 +3311,15 @@
                         },
                         "key": "Strike",
                         "label": "Blinding Beam (Fire)",
-                        "maxRange": 100,
                         "predicate": [
                             "fire-not-cold",
                             {
                                 "not": "change-shape"
                             }
                         ],
+                        "range": {
+                            "max": 100
+                        },
                         "traits": [
                             "fire",
                             "magical",
@@ -3337,7 +3339,6 @@
                         },
                         "key": "Strike",
                         "label": "Blinding Beam (Cold)",
-                        "maxRange": 100,
                         "predicate": [
                             {
                                 "nor": [
@@ -3346,6 +3347,9 @@
                                 ]
                             }
                         ],
+                        "range": {
+                            "max": 100
+                        },
                         "traits": [
                             "cold",
                             "magical",

--- a/packs/kingmaker-bestiary/castruccio-irovetti.json
+++ b/packs/kingmaker-bestiary/castruccio-irovetti.json
@@ -3932,8 +3932,9 @@
                         "group": "dart",
                         "key": "Strike",
                         "label": "Rod of Razors Flechette",
-                        "maxRange": 100,
-                        "range": 100,
+                        "range": {
+                            "max": 100
+                        },
                         "slug": "flechette",
                         "traits": [
                             "adamantine",

--- a/packs/paizo-pregens/takemiru.json
+++ b/packs/paizo-pregens/takemiru.json
@@ -1074,8 +1074,9 @@
                         "group": "sling",
                         "img": "systems/pf2e/icons/spells/diamond-dust.webp",
                         "key": "Strike",
-                        "maxRange": 20,
-                        "range": 20,
+                        "range": {
+                            "max": 20
+                        },
                         "traits": [
                             "unarmed",
                             "magical"

--- a/src/module/migration/migrations/868-strike-re-range.ts
+++ b/src/module/migration/migrations/868-strike-re-range.ts
@@ -1,0 +1,25 @@
+import type { ItemSourcePF2e } from "@item/data/index.ts";
+import { MigrationBase } from "../base.ts";
+import { RuleElementSource } from "@module/rules/index.ts";
+
+/** Convert `range` and `maxRange` properties of Strike rule elements to single `RangeData` object */
+export class Migration868StrikeRERange extends MigrationBase {
+    static override version = 0.868;
+
+    override async updateItem(source: ItemSourcePF2e): Promise<void> {
+        const strikeREs = source.system.rules.filter((r): r is OldStrikeSource => r.key === "Strike");
+        for (const rule of strikeREs) {
+            if (typeof rule.maxRange === "number" && rule.range !== rule.maxRange / 6) {
+                rule.range = { max: rule.maxRange };
+            } else if (typeof rule.range === "number") {
+                rule.range = { increment: rule.range };
+            }
+            delete rule.maxRange;
+        }
+    }
+}
+
+interface OldStrikeSource extends RuleElementSource {
+    range?: unknown;
+    maxRange?: unknown;
+}

--- a/src/module/migration/migrations/index.ts
+++ b/src/module/migration/migrations/index.ts
@@ -265,3 +265,4 @@ export { Migration864RemoveWeaponMAP } from "./864-rm-weapon-map.ts";
 export { Migration865VitalityVoid } from "./865-vitality-void.ts";
 export { Migration866LinkToActorSizeAgain } from "./866-link-to-actor-size-again.ts";
 export { Migration867DamageRollDomainFix } from "./867-damage-roll-domain-fix.ts";
+export { Migration868StrikeRERange } from "./868-strike-re-range.ts";

--- a/src/module/migration/runner/base.ts
+++ b/src/module/migration/runner/base.ts
@@ -14,7 +14,7 @@ interface CollectionDiff<T extends foundry.documents.ActiveEffectSource | ItemSo
 export class MigrationRunnerBase {
     migrations: MigrationBase[];
 
-    static LATEST_SCHEMA_VERSION = 0.867;
+    static LATEST_SCHEMA_VERSION = 0.868;
 
     static MINIMUM_SAFE_VERSION = 0.618;
 

--- a/src/module/rules/rule-element/strike.ts
+++ b/src/module/rules/rule-element/strike.ts
@@ -23,8 +23,8 @@ import type {
     SchemaField,
     StringField,
 } from "types/foundry/common/data/fields.d.ts";
-import { RuleElementOptions, RuleElementPF2e, RuleElementSchema, RuleElementSource } from "./index.ts";
 import { ResolvableValueField } from "./data.ts";
+import { RuleElementOptions, RuleElementPF2e, RuleElementSchema, RuleElementSource } from "./index.ts";
 
 /**
  * Create an ephemeral strike on an actor
@@ -103,10 +103,10 @@ class StrikeRuleElement extends RuleElementPF2e<StrikeSchema> {
             range: new fields.SchemaField(
                 {
                     increment: new fields.NumberField({
-                        required: true,
+                        required: false,
                         integer: true,
                         min: 5,
-                        nullable: false,
+                        nullable: true,
                         initial: 5,
                     }),
                     max: new fields.NumberField({
@@ -198,21 +198,6 @@ class StrikeRuleElement extends RuleElementPF2e<StrikeSchema> {
         } else {
             super._initialize(options);
         }
-    }
-
-    /** Temporary workaround until real migration */
-    static override migrateData<TSource extends { range?: unknown; maxRange?: unknown }>(source: TSource): TSource {
-        const premigrated = super.migrateData(source);
-
-        if (typeof premigrated.range === "number") {
-            const maxRange = typeof premigrated.maxRange === "number" ? premigrated.maxRange : null;
-            premigrated.range = { increment: premigrated.range, max: maxRange };
-        } else if ("maxRange" in premigrated && typeof premigrated.maxRange === "number") {
-            premigrated.range = { increment: premigrated.maxRange, max: premigrated.maxRange };
-        }
-        delete premigrated.maxRange;
-
-        return premigrated;
     }
 
     override beforePrepareData(): void {
@@ -369,11 +354,11 @@ type StrikeSchema = RuleElementSchema & {
     attackModifier: NumberField<number, number, false, true, true>;
     range: SchemaField<
         {
-            increment: NumberField<number, number, true, false, true>;
+            increment: NumberField<number, number, false, true, true>;
             max: NumberField<number, number, false, true, true>;
         },
-        { increment: number; max: number | null },
-        { increment: number; max: number | null } | null,
+        { increment: number | null; max: number | null },
+        { increment: number | null; max: number | null } | null,
         false,
         true,
         true


### PR DESCRIPTION
Retires a long-running in-place migration.