### PR TITLE
Invalidate AE-like paths containing /\bnull\b/

### DIFF
--- a/src/module/rules/rule-element/ae-like.ts
+++ b/src/module/rules/rule-element/ae-like.ts
@@ -85,6 +85,7 @@ class AELikeRuleElement<TSchema extends AELikeSchema> extends RuleElementPF2e<TS
         const actor = this.item.actor;
         return (
             path.length > 0 &&
+            !/\bnull\b/.test(path) &&
             (path.startsWith("flags.") ||
                 [path, path.replace(/\.[-\w]+$/, ""), path.replace(/\.?[-\w]+\.[-\w]+$/, "")].some(
                     (path) => getProperty(actor, path) !== undefined


### PR DESCRIPTION
This can happen if a choice set is dismissed without making a selection, with the selection being injected into an AE-like path.