### PR TITLE
Fix rule element form reuse not working with quick consecutive updates

### DIFF
--- a/src/module/item/sheet/base.ts
+++ b/src/module/item/sheet/base.ts
@@ -29,7 +29,6 @@ import {
     tagify,
     tupleHasValue,
 } from "@util";
-import * as R from "remeda";
 import type * as TinyMCE from "tinymce";
 import { CodeMirror } from "./codemirror.ts";
 import { RULE_ELEMENT_FORMS, RuleElementForm } from "./rule-element-form/index.ts";
@@ -114,7 +113,9 @@ class ItemSheetPF2e<TItem extends ItemPF2e> extends ItemSheet<TItem> {
             : null;
 
         // Create and activate rule element sub forms
-        const previousForms = this.#ruleElementForms;
+        const previousForms = new Map<string, RuleElementForm>(
+            this.#ruleElementForms.map((f, index) => [`${f.rule.key}-${index}`, f])
+        );
         this.#ruleElementForms = rules.map((rule, index) => {
             const options = {
                 sheet: this,
@@ -126,10 +127,11 @@ class ItemSheetPF2e<TItem extends ItemPF2e> extends ItemSheet<TItem> {
             // If a form exists of the correct type with an exact match, reuse that one.
             // Reusing forms allow internal variables to persist between updates
             const FormClass = RULE_ELEMENT_FORMS[String(rule.key)] ?? RuleElementForm;
-            const existing = previousForms.find((f) => R.equals(f.rule, rule));
+            const id = `${rule.key}-${index}`;
+            const existing = previousForms.get(id);
             if (existing instanceof FormClass) {
                 // Prevent a form from getting reused twice
-                previousForms.splice(previousForms.indexOf(existing), 1);
+                previousForms.delete(id);
 
                 existing.initialize(options);
                 return existing;

--- a/src/module/item/sheet/rule-element-form/base.ts
+++ b/src/module/item/sheet/rule-element-form/base.ts
@@ -255,10 +255,6 @@ class RuleElementForm<
         if (this.schema) {
             cleanDataUsingSchema(this.schema.fields, source);
         }
-
-        // Update our reference so that equality matching works on the next data prep cycle
-        // This allows form reuse to occur
-        this.rule = source;
     }
 }
 


### PR DESCRIPTION
Comparing the source breaks when multiple updates are performed in quick succession. I assume there is a race condition somewhere down the line.
I think recording the rule element key and position in the index should be safe enough to identify if a form can be reused.
Unique ids in the rule elment source would be even better in this case but I don't think that is something we want to add.