### PR TITLE
Brush up rule elements on Crimson Fulcrum Lens

### DIFF
--- a/packs/equipment-effects/effect-crimson-fulcrum-lens.json
+++ b/packs/equipment-effects/effect-crimson-fulcrum-lens.json
@@ -27,20 +27,19 @@
             },
             {
                 "key": "FlatModifier",
-                "predicate": [
-                    "melee"
-                ],
-                "selector": "strike-damage",
+                "selector": "melee-strike-damage",
+                "slug": "crimson-fulcrum-lens",
                 "type": "item",
                 "value": 2
             },
             {
-                "key": "FlatModifier",
                 "predicate": [
-                    "melee"
+                    "item:base:jaws"
                 ],
-                "selector": "jaws-damage",
-                "type": "item",
+                "key": "AdjustModifier",
+                "mode": "upgrade",
+                "selector": "melee-strike-damage",
+                "slug": "crimson-fulcrum-lens",
                 "value": 4
             }
         ],

--- a/packs/equipment/crimson-fulcrum-lens.json
+++ b/packs/equipment/crimson-fulcrum-lens.json
@@ -6,7 +6,7 @@
         "baseItem": null,
         "containerId": null,
         "description": {
-            "value": "<p>This concave lens has a drifting crimson cloud resembling slowly swirling blood within it. While you have the Crimson Fulcrum Lens invested, you seethe with malevolent fury you can barely contain. You gain a +2 item bonus to saving throws against fear effects and a +2 item bonus to your melee Strike damage (this increases to a +4 item bonus to damage if the melee Strike is a jaws attack). You can also activate the lens in the following ways.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Crimson Fulcrum Lens]</p>\n<hr />\n<p><strong>Activate</strong> <span class=\"pf2-icon\">2</span> Interact</p>\n<p><strong>Frequency</strong> once per day</p>\n<hr />\n<p><strong>Effect</strong> You grasp the Crimson Fulcrum Lens in one hand and make a Strike that doesn't require that hand. The Strike deals an additional 1d8 precision damage (or 2d8 precision damage if you make a jaws Strike) and doesn't count toward your multiple attack penalty.</p>\n<p><strong>Activate</strong> <span class=\"pf2-icon\">2</span> Interact (attack, possession)</p>\n<hr />\n<p><strong>Effect</strong> While grasping the lens, make a melee spell attack roll with a modifier of +18. On a hit, you force the splinter of Nhimbaloth's essence from the lens to possess the target. You're no longer invested in the lens, and the target gains the benefits as though it had invested the lens but can't activate the lens's other abilities. This effect is permanent, but it can be ended by any effect that removes a possession effect. The lens doesn't have any magical abilities until the possession effect ends; when it does, the essence returns to the lens.</p>"
+            "value": "<p>This concave lens has a drifting crimson cloud resembling slowly swirling blood within it. While you have the Crimson Fulcrum Lens invested, you seethe with malevolent fury you can barely contain. You gain a +2 item bonus to saving throws against fear effects and a +2 item bonus to your melee Strike damage (this increases to a +4 item bonus to damage if the melee Strike is a jaws attack). You can also activate the lens in the following ways.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Crimson Fulcrum Lens]</p>\n<hr />\n<p><strong>Activate</strong> <span class=\"action-glyph\">2</span> Interact</p>\n<p><strong>Frequency</strong> once per day</p>\n<hr />\n<p><strong>Effect</strong> You grasp the Crimson Fulcrum Lens in one hand and make a Strike that doesn't require that hand. The Strike deals an additional 1d8 precision damage (or 2d8 precision damage if you make a jaws Strike) and doesn't count toward your multiple attack penalty.</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">2</span> Interact (attack, possession)</p>\n<hr />\n<p><strong>Effect</strong> While grasping the lens, make a melee spell attack roll with a modifier of +18. On a hit, you force the splinter of Nhimbaloth's essence from the lens to possess the target. You're no longer invested in the lens, and the target gains the benefits as though it had invested the lens but can't activate the lens's other abilities. This effect is permanent, but it can be ended by any effect that removes a possession effect. The lens doesn't have any magical abilities until the possession effect ends; when it does, the essence returns to the lens.</p>"
         },
         "equippedBulk": {
             "value": ""
@@ -32,7 +32,34 @@
             }
         },
         "quantity": 1,
-        "rules": [],
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "fear"
+                ],
+                "selector": "saving-throw",
+                "type": "item",
+                "value": 2
+            },
+            {
+                "key": "FlatModifier",
+                "selector": "melee-strike-damage",
+                "slug": "crimson-fulcrum-lens",
+                "type": "item",
+                "value": 2
+            },
+            {
+                "predicate": [
+                    "item:base:jaws"
+                ],
+                "key": "AdjustModifier",
+                "mode": "upgrade",
+                "selector": "melee-strike-damage",
+                "slug": "crimson-fulcrum-lens",
+                "value": 4
+            }
+        ],
         "size": "med",
         "source": {
             "value": "Pathfinder #165: Eyes of Empty Death"


### PR DESCRIPTION
Description update is just changing "pf2-icon" class to "action-glyph"