### PR TITLE
Create a toggleable button on character sheets to roll Recall Knowledge from proficiency tab skills

### DIFF
--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -921,7 +921,11 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
                 armorCheckPenalty.predicate.push({ nor: ["attack", "armor:ignore-check-penalty"] });
                 if (["acrobatics", "athletics"].includes(longForm)) {
                     armorCheckPenalty.predicate.push({
-                        nor: ["self:armor:strength-requirement-met", "self:armor:trait:flexible"],
+                        nor: [
+                            "self:armor:strength-requirement-met",
+                            "self:armor:trait:flexible",
+                            "action:recall-knowledge",
+                        ],
                     });
                 } else if (longForm === "stealth" && wornArmor.traits.has("noisy")) {
                     armorCheckPenalty.predicate.push({

--- a/src/module/system/check/check.ts
+++ b/src/module/system/check/check.ts
@@ -220,6 +220,7 @@ class CheckPF2e {
             target: context.target ? { actor: context.target.actor.uuid, token: context.target.token.uuid } : null,
             options: Array.from(rollOptions).sort(),
             notes: notes.map((n) => n.toObject()),
+            recallKnowledge: context.recallKnowledge ?? null,
             rollMode: context.rollMode,
             rollTwice: context.rollTwice ?? false,
             title: context.title ?? "PF2E.Check.Label",

--- a/src/module/system/check/types.ts
+++ b/src/module/system/check/types.ts
@@ -2,6 +2,7 @@ import { ActorPF2e } from "@actor";
 import { RollTarget } from "@actor/types.ts";
 import { ItemPF2e } from "@item";
 import { ZeroToTwo } from "@module/data.ts";
+import { RecallKnowledgeContextData } from "@module/recall-knowledge.ts";
 import { RollSubstitution } from "@module/rules/synthetics.ts";
 import { TokenDocumentPF2e } from "@scene/token-document/index.ts";
 import { CheckDC, DegreeOfSuccessAdjustment } from "@system/degree-of-success.ts";
@@ -16,6 +17,7 @@ type CheckType =
     | "flat-check"
     | "initiative"
     | "perception-check"
+    | "recall-knowledge-check"
     | "saving-throw"
     | "skill-check";
 
@@ -46,6 +48,8 @@ interface CheckRollContext extends BaseRollContext {
     damaging?: boolean;
     /** Is the roll a reroll? */
     isReroll?: boolean;
+    /** Whether the roll is a Recall Knowledge roll and associated data */
+    recallKnowledge?: RecallKnowledgeContextData | null;
     /** The number of MAP increases for this roll */
     mapIncreases?: Maybe<ZeroToTwo>;
     /** D20 results substituted for an actual roll */

--- a/src/module/system/statistic/statistic.ts
+++ b/src/module/system/statistic/statistic.ts
@@ -507,6 +507,7 @@ class StatisticCheck<TParent extends Statistic = Statistic> {
             damaging: args.damaging,
             rollMode,
             skipDialog,
+            recallKnowledge: args.recallKnowledge,
             rollTwice: args.rollTwice || extractRollTwice(actor.synthetics.rollTwice, domains, options),
             substitutions: extractRollSubstitutions(actor.synthetics.rollSubstitutions, domains, options),
             dosAdjustments,
@@ -576,6 +577,8 @@ interface StatisticRollParameters {
     rollMode?: RollMode | "roll";
     /** Should the dialog be skipped */
     skipDialog?: boolean;
+    /** */
+    recallKnowledge?: RecallKnowledgeContextData | null;
     /** Should this roll be rolled twice? If so, should it keep highest or lowest? */
     rollTwice?: RollTwiceOption;
     /** Any traits for the check */
@@ -591,6 +594,7 @@ interface StatisticRollParameters {
 }
 
 import { signedInteger } from "@util";
+import { RecallKnowledgeContextData } from "@module/recall-knowledge.ts";
 
 class StatisticDifficultyClass<TParent extends Statistic = Statistic> {
     parent: TParent;

--- a/src/scripts/handlebars.ts
+++ b/src/scripts/handlebars.ts
@@ -111,4 +111,11 @@ export function registerHandlebarsHelpers(): void {
     Handlebars.registerHelper("raw", function (this: unknown, options: Handlebars.HelperOptions): string {
         return options.fn(this);
     });
+
+    Handlebars.registerHelper("ifCond", function (this: unknown, v1: unknown, v2: unknown, options) {
+        if (v1 === v2) {
+            return options.fn(this);
+        }
+        return options.inverse(this);
+    });
 }

--- a/src/styles/actor/character/_proficiencies.scss
+++ b/src/styles/actor/character/_proficiencies.scss
@@ -1,4 +1,26 @@
 &.proficiencies {
+    .header {
+        display: flex;
+        justify-content: flex-start;
+        align-items: center;
+        h3 {
+            text-align: left;
+        }
+        .rk-toggle {
+            margin-left: auto;
+            margin-right: 0;
+            text-align: left;
+            height: 30px;
+            width: 30px;
+            border: none;
+            background-image: url(/systems/pf2e/icons/default-icons/lore.svg);
+            background-size: contain;
+            box-shadow: none;
+            &.selected {
+                @include requires-user-attention;
+            }
+        }
+    }
     .proficiencies-pane {
         @include p-reset;
     }

--- a/static/templates/actors/character/tabs/proficiencies.hbs
+++ b/static/templates/actors/character/tabs/proficiencies.hbs
@@ -1,5 +1,7 @@
 <div class="tab proficiencies" data-group="primary" data-tab="proficiencies">
-    <h3 class="header">{{localize "PF2E.CoreSkillsHeader"}}</h3>
+    <h3 class="header">{{localize "PF2E.CoreSkillsHeader"}}
+        <button data-visibility="gm" type="button" class="rk-toggle" title="Toggle Recall Knowledge"></button>
+    </h3>
     <ol class="overflow-list proficiencies-pane stroke-header">
         <ol class="skills-list">
             <!-- Core Skills -->

--- a/static/templates/chat/check-modifiers-dialog.hbs
+++ b/static/templates/chat/check-modifiers-dialog.hbs
@@ -56,8 +56,100 @@
         <input type="number" class="add-modifier-value" placeholder="+1">
         <button type="button" class="add-modifier">+{{localize "PF2E.Roll.Add"}}</button>
     </section>
+    {{#if recallKnowledge}}
     <hr/>
-
+    <div class="recall-knowledge-panel">
+        <span class="label">{{recallKnowledge.type}}</span>
+        {{#ifCond recallKnowledge.type "Recall Knowledge"}}
+            <div class="recall-knowledge-no-target">
+                <label>
+                    <input type="radio" name="recall-knowledge-manual-dc" value="simple-dc" checked/> Simple DC
+                </label>
+                <select name="simple-dcs" id="simple-dcs">
+                    {{#each simpleDCs}}
+                    <option value="{{this}}" {{#ifCond this "untrained"}}selected{{/ifCond}}>{{this}}</option>
+                    {{/each}}
+                </select>
+                <label>
+                    <input type="radio" name="recall-knowledge-manual-dc" value="level-based-dc"/> Level-Based DC
+                </label>
+                <select name="level-based-dcs" id="level-based-dcs">
+                    {{#each levelBasedDCs}}
+                    <option value="{{this}}" {{#ifCond this "0"}}selected{{/ifCond}}>{{this}}</option>
+                    {{/each}}
+                </select>
+            </div>
+        {{/ifCond}}
+        {{#if recallKnowledge.isLore}}
+        <div class="recall-knowledge-lore-panel">
+            <span class="label">Applicable Lore?: </span>
+            <label title="Normal">
+                <input type="radio" name="recall-knowledge-lore" value="normal" {{#ifCond recallKnowledge.applicableLore "normal"}}checked{{/ifCond}}/>
+                Normal
+            </label>
+            <label title="Easy Adjustment">
+                <input type="radio" name="recall-knowledge-lore" value="easy" {{#ifCond recallKnowledge.applicableLore "easy"}}checked{{/ifCond}}/>
+                Applicable
+            </label>
+            <label title="Very Easy Adjustment">
+                <input type="radio" name="recall-knowledge-lore" value="very-easy" {{#ifCond recallKnowledge.applicabaleLore "very-easy"}}checked{{/ifCond}}/>
+                Specific
+            </label>
+        </div>
+        {{/if}}
+        <div class="recall-knowledge-rarity-panel">
+            <span class="label">Rarity: </span>
+            <label title="Common">
+                <input type="radio" name="recall-knowledge-rarity" value="common" {{#ifCond recallKnowledge.rarity "common"}}checked{{/ifCond}}/>
+                Common
+            </label>
+            <label title="Hard Adjustment">
+                <input type="radio" name="recall-knowledge-rarity" value="uncommon" {{#ifCond recallKnowledge.rarity "uncommon"}}checked{{/ifCond}}/>
+                Uncommon
+            </label>
+            <label title="Very Hard Adjustment">
+                <input type="radio" name="recall-knowledge-rarity" value="rare" {{#ifCond recallKnowledge.rarity "rare"}}checked{{/ifCond}}/>
+                Rare
+            </label>
+            <label title="Incredibly Hard Adjustment">
+                <input type="radio" name="recall-knowledge-rarity" value="unique" {{#ifCond recallKnowledge.rarity "unique"}}checked{{/ifCond}}/>
+                Unique
+            </label>
+        </div>
+        <div class="recall-knowledge-difficulty-panel">
+            <span class="label">Difficulty: </span>
+            <label title="Incredibly Easy DC -10" >
+                <input type="radio" name="recall-knowledge-difficulty" value="incredibly-easy" {{#ifCond recallKnowledge.difficulty "incredibly-easy"}}checked{{/ifCond}}/>
+                IE
+            </label>
+            <label title="Very Easy DC -5" >
+                <input type="radio" name="recall-knowledge-difficulty" value="very-easy" {{#ifCond recallKnowledge.difficulty "very-easy"}}checked{{/ifCond}}/>
+                VE
+            </label>
+            <label title="Easy DC -2" >
+                <input type="radio" name="recall-knowledge-difficulty" value="easy" {{#ifCond recallKnowledge.difficulty "easy"}}checked{{/ifCond}}/>
+                E
+            </label>
+            <label title="Normal DC +0" >
+                <input type="radio" name="recall-knowledge-difficulty" value="normal" {{#ifCond recallKnowledge.difficulty "normal"}}checked{{/ifCond}}/>
+                N
+            </label>
+            <label title="Hard DC +2">
+                <input type="radio" name="recall-knowledge-difficulty" value="hard" {{#ifCond recallKnowledge.difficulty "hard"}}checked{{/ifCond}}/>
+                H
+            </label>
+            <label title="Very Hard DC +5">
+                <input type="radio" name="recall-knowledge-difficulty" value="very-hard" {{#ifCond recallKnowledge.difficulty "very-hard"}}checked{{/ifCond}}/>
+                VH
+            </label>
+            <label title="Incredibly Hard DC +10">
+                <input type="radio" name="recall-knowledge-difficulty" value="incredibly-hard" {{#ifCond recallKnowledge.difficulty "incredibly-hard"}}checked{{/ifCond}}/>
+                IH
+            </label>
+        </div>
+    </div>
+    {{/if}}
+    <hr/>
     <div class="fate">
         <label>
             <input type="radio" name="rollTwice" value="keep-higher" {{checked fortune}} />


### PR DESCRIPTION
This creates a toggleable button on player character sheets' proficiencies tab to roll Recall Knowledge from skills. This is not viewable by the player, only the GM.

- In the roll dialog:
- options to change simple or level-based DC is provided (if there is no user target)
- If a lore skill is rolled, an option to choose whether the lore is applicable or specific
- options to change the difficulty of the check and rarity of the creature on the fly

- When targeting a creature, it rolls a level-based check taking into account rarity of the creature
- When targeting a hazard, it rolls a level-based check taking into account rarity of the hazard
- When targeting nothing, defaults to DC 10 (the default setting in the roll dialog is an untrained simple check)

- If a skill with a physical attribute is rolled, the attribute is changed to int per CRB p 239