### PR TITLE
Fix issue with token light editor setting bright and dim to empty string

### DIFF
--- a/src/module/item/sheet/rule-element-form/token-light.ts
+++ b/src/module/item/sheet/rule-element-form/token-light.ts
@@ -43,6 +43,12 @@ class TokenLightForm extends RuleElementForm<TokenLightRuleSource, TokenLightRul
             lightAnimations: R.mapValues(CONFIG.Canvas.lightAnimations, (value) => value.label),
         };
     }
+
+    override updateObject(source: TokenLightRuleSource): void {
+        if (!source.value.bright) delete source.value.bright;
+        if (!source.value.dim) delete source.value.dim;
+        super.updateObject(source);
+    }
 }
 
 interface TokenLightSheetData extends RuleElementFormSheetData<TokenLightRuleSource, TokenLightRuleElement> {


### PR DESCRIPTION
The issue is that if you edit a TokenLight RE with the editor when the bright or dim is empty, it will set them to empty string, which causes an error:
`PF2e System | Token Light rules element on item Torch (Actor.cA9JfUbHgtBd9qg7.Item.Z9TZWS4OMrW3GrQi) failed to validate: bright must resolve to a number`