### PR TITLE
Add light automation to Exorcist Dedication

### DIFF
--- a/packs/feats/exorcist-dedication.json
+++ b/packs/feats/exorcist-dedication.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>You've learned to attract, quell, and purify spirits, housing them in a special receptacle called a spirit dwelling until they're ready to move on. Through the power of prayers or ritual incantations, one mundane object in your possession becomes a spirit dwelling. Your spirit dwelling functions as a lure for lost spirits weakened by their time on the Material Plane. Each day during your daily preparations, your spirit dwelling attracts a spirit wisp who comes to dwell inside. If your spirit dwelling contains no wisps, you can spend 10 minutes in a minor ritual to cast your spirit dwelling around an area and attract another wisp. You can also capture stronger spirit remnants from vanquished undead spirits. As long as your spirit dwelling contains any spirits, it glows faintly, casting dim light in a 10-foot radius.</p>\n<p>As an exorcist, you do more than just collect spirits: you also help rid them of their burdens and lingering resentments, aiding their transition from the Material Plane. Every day, before your daily preparations, any spirit wisps and remnants remaining within your spirit dwelling from the previous day are purified and can join the River of Souls in their final journey to Pharasma's Boneyard.</p>\n<p>You can also learn abilities that let you purify a spirit in your spirit dwelling immediately in a cathartic surge, granting you a helpful effect as they depart for the afterlife. Any actions you gain from the exorcist archetype gain either the divine or occult trait, depending on whether you used Occultism or Religion to qualify for Exorcist Dedication. @UUID[Compendium.pf2e.actionspf2e.Item.Spirit's Mercy] is the simplest of the purifications.</p>\n<p><strong>Special</strong> You can't select another dedication feat until you have gained two other feats from the @UUID[Compendium.pf2e.journals.JournalEntry.vx5FGEG34AxI2dow.JournalEntryPage.WvleaXPfigawBvtN]{Exorcist} archetype.</p>"
+            "value": "<p>You've learned to attract, quell, and purify spirits, housing them in a special receptacle called a <em>spirit dwelling</em> until they're ready to move on. Through the power of prayers or ritual incantations, one mundane object in your possession becomes a <em>spirit dwelling</em>. Your <em>spirit dwelling</em> functions as a lure for lost spirits weakened by their time on the Material Plane. Each day during your daily preparations, your <em>spirit dwelling</em> attracts a spirit wisp who comes to dwell inside. If your <em>spirit dwelling</em> contains no wisps, you can spend 10 minutes in a minor ritual to cast your <em>spirit dwelling</em> around an area and attract another wisp. You can also capture stronger spirit remnants from vanquished undead spirits. As long as your <em>spirit dwelling</em> contains any spirits, it glows faintly, casting dim light in a 10-foot radius.</p>\n<p>As an exorcist, you do more than just collect spirits: you also help rid them of their burdens and lingering resentments, aiding their transition from the Material Plane. Every day, before your daily preparations, any spirit wisps and remnants remaining within your <em>spirit dwelling</em> from the previous day are purified and can join the River of Souls in their final journey to Pharasma's Boneyard.</p>\n<p>You can also learn abilities that let you purify a spirit in your <em>spirit dwelling</em> immediately in a cathartic surge, granting you a helpful effect as they depart for the afterlife. Any actions you gain from the exorcist archetype gain either the divine or occult trait, depending on whether you used Occultism or Religion to qualify for Exorcist Dedication. @UUID[Compendium.pf2e.actionspf2e.Item.Spirit's Mercy] is the simplest of the purifications.</p>\n<p><strong>Special</strong> You can't select another dedication feat until you have gained two other feats from the @UUID[Compendium.pf2e.journals.JournalEntry.vx5FGEG34AxI2dow.JournalEntryPage.WvleaXPfigawBvtN]{Exorcist} archetype.</p>"
         },
         "level": {
             "value": 4
@@ -31,6 +31,37 @@
             {
                 "key": "GrantItem",
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Collect Spirit Remnant"
+            },
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.ExorcistDedication.SpiritDwelling",
+                "option": "spirit-dwelling",
+                "toggleable": true
+            },
+            {
+                "key": "TokenLight",
+                "predicate": [
+                    "spirit-dwelling"
+                ],
+                "value": {
+                    "animation": {
+                        "intensity": 3,
+                        "speed": 3,
+                        "type": "fog"
+                    },
+                    "attenuation": 0.4,
+                    "color": "#90b4b4",
+                    "dim": 10,
+                    "shadows": 0.2
+                }
+            },
+            {
+                "key": "TokenEffectIcon",
+                "predicate": [
+                    "spirit-dwelling"
+                ],
+                "value": "icons/creatures/magical/spirit-mischief-fire-ice-blue.webp"
             }
         ],
         "source": {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -1881,6 +1881,9 @@
                 "Name": "Exemplary Finisher",
                 "Wit": "The foe takes a -2 circumstance penalty to attack rolls against you until the start of your next turn."
             },
+            "ExorcistDedication": {
+                "SpiritDwelling": "Spirit Dwelling"
+            },
             "FanesFourberie": {
                 "Prompt": "Treat Cards as darts or daggers?"
             },

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -1882,7 +1882,7 @@
                 "Wit": "The foe takes a -2 circumstance penalty to attack rolls against you until the start of your next turn."
             },
             "ExorcistDedication": {
-                "SpiritDwelling": "Spirit Dwelling"
+                "SpiritDwelling": "Your Spirit Dwelling contains a spirit"
             },
             "FanesFourberie": {
                 "Prompt": "Treat Cards as darts or daggers?"


### PR DESCRIPTION
Also emphasize "spirit dwelling" in description.

I just made a toggle on the feat, since that should avoids locking us into a migration path.

Considered making it an effect, but we don't really have a meaningful way to track spirit types so not sure how useful it would be. It could also be attached to a spirit dwelling item, but not sure how far we want to go down that rabbit hole.