### PR TITLE
Treat 0 opacity auras as having null borders

### DIFF
--- a/src/module/item/sheet/rule-element-form/aura.ts
+++ b/src/module/item/sheet/rule-element-form/aura.ts
@@ -146,6 +146,11 @@ class AuraForm extends RuleElementForm<AuraRuleElementSource, AuraRuleElement> {
         // Clean up appearance data
         const appearance: DeepPartial<AuraRuleElementSource["appearance"]> = source.appearance;
 
+        // Treat 0 opacity as null
+        if (appearance?.border?.alpha === 0) {
+            appearance.border = null;
+        }
+
         if (appearance?.highlight?.color === game.user.color) {
             appearance.highlight.color = undefined;
         }

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -1041,6 +1041,7 @@
                         "Hint": "If the File is a video, whether to loop it",
                         "Label": "Loop"
                     },
+                    "NotApplicable": "Not Applicable",
                     "PlaybackRate": {
                         "Hint": "If the File is a video, the playback rate of the resulting <em>HTMLVideoElement</em>",
                         "Label": "Playback Rate"

--- a/static/templates/items/rules/aura.hbs
+++ b/static/templates/items/rules/aura.hbs
@@ -125,11 +125,15 @@
         <div class="stacked">
             <div class="two-items">
                 <label>{{localize fields.appearance.fields.border.fields.color.label}}</label>
-                {{colorPicker name=(concat "system.rules." index ".appearance.border.color") value=object.appearance.border.color}}
+                {{#if object.appearance.border}}
+                    {{colorPicker name=(concat "system.rules." index ".appearance.border.color") value=object.appearance.border.color}}
+                {{else}}
+                    <div>{{localize "PF2E.RuleEditor.Aura.Appearance.NotApplicable"}}</div>
+                {{/if}}
             </div>
             <div class="two-items">
                 <label>{{localize fields.appearance.fields.border.fields.alpha.label}}</label>
-                {{rangePicker name=(concat "system.rules." index ".appearance.border.alpha") value=object.appearance.border.alpha placeholder="0.75" min="0" max="1" step="0.05"}}
+                {{rangePicker name=(concat "system.rules." index ".appearance.border.alpha") value=(coalesce object.appearance.border.alpha 0) placeholder="0.75" min="0" max="1" step="0.05"}}
             </div>
         </div>
     </fieldset>


### PR DESCRIPTION
![image](https://github.com/foundryvtt/pf2e/assets/1286721/986a68a1-dbd0-4e5f-ac25-485f4d8806fa)
