### PR TITLE
Add set-as-initiative button to new roll for rerolls

### DIFF
--- a/src/module/chat-message/listeners/set-as-initiative.ts
+++ b/src/module/chat-message/listeners/set-as-initiative.ts
@@ -29,9 +29,8 @@ export const SetAsInitiative = {
             setInitiativeButton.title = game.i18n.localize("PF2E.ClickToSetInitiative");
             setInitiativeButton.appendChild(fontAwesomeIcon("fa-swords", { style: "solid" }));
             btnContainer.appendChild(setInitiativeButton);
-            message.isReroll
-                ? li.querySelector(".pf2e-reroll-second .dice-total")?.appendChild(btnContainer)
-                : li.querySelector(".dice-total")?.appendChild(btnContainer);
+            const selector = message.isReroll ? ".pf2e-reroll-second .dice-total" : ".dice-total"; 
+            li.querySelector(selector)?.appendChild(btnContainer);
 
             setInitiativeButton.addEventListener("click", async (event): Promise<void> => {
                 event.stopPropagation();

--- a/src/module/chat-message/listeners/set-as-initiative.ts
+++ b/src/module/chat-message/listeners/set-as-initiative.ts
@@ -29,7 +29,7 @@ export const SetAsInitiative = {
             setInitiativeButton.title = game.i18n.localize("PF2E.ClickToSetInitiative");
             setInitiativeButton.appendChild(fontAwesomeIcon("fa-swords", { style: "solid" }));
             btnContainer.appendChild(setInitiativeButton);
-            const selector = message.isReroll ? ".pf2e-reroll-second .dice-total" : ".dice-total"; 
+            const selector = message.isReroll ? ".pf2e-reroll-second .dice-total" : ".dice-total";
             li.querySelector(selector)?.appendChild(btnContainer);
 
             setInitiativeButton.addEventListener("click", async (event): Promise<void> => {

--- a/src/module/chat-message/listeners/set-as-initiative.ts
+++ b/src/module/chat-message/listeners/set-as-initiative.ts
@@ -29,12 +29,9 @@ export const SetAsInitiative = {
             setInitiativeButton.title = game.i18n.localize("PF2E.ClickToSetInitiative");
             setInitiativeButton.appendChild(fontAwesomeIcon("fa-swords", { style: "solid" }));
             btnContainer.appendChild(setInitiativeButton);
-            if (message.isReroll) {
-                li.querySelector(".pf2e-reroll-discard .dmgBtn-container.dice-total-setInitiative-btn")?.remove();
-                li.querySelector(".pf2e-reroll-second .dice-total")?.appendChild(btnContainer);
-            } else {
-                li.querySelector(".dice-total")?.appendChild(btnContainer);
-            }
+            message.isReroll
+                ? li.querySelector(".pf2e-reroll-second .dice-total")?.appendChild(btnContainer)
+                : li.querySelector(".dice-total")?.appendChild(btnContainer);
 
             setInitiativeButton.addEventListener("click", async (event): Promise<void> => {
                 event.stopPropagation();

--- a/src/module/chat-message/listeners/set-as-initiative.ts
+++ b/src/module/chat-message/listeners/set-as-initiative.ts
@@ -29,7 +29,12 @@ export const SetAsInitiative = {
             setInitiativeButton.title = game.i18n.localize("PF2E.ClickToSetInitiative");
             setInitiativeButton.appendChild(fontAwesomeIcon("fa-swords", { style: "solid" }));
             btnContainer.appendChild(setInitiativeButton);
-            li.querySelector(".dice-total")?.appendChild(btnContainer);
+            if (message.isReroll) {
+                li.querySelector(".pf2e-reroll-discard .dmgBtn-container.dice-total-setInitiative-btn")?.remove();
+                li.querySelector(".pf2e-reroll-second .dice-total")?.appendChild(btnContainer);
+            } else {
+                li.querySelector(".dice-total")?.appendChild(btnContainer);
+            }
 
             setInitiativeButton.addEventListener("click", async (event): Promise<void> => {
                 event.stopPropagation();


### PR DESCRIPTION
When rerolling using a hero point, this removes the initiative button from the old roll and re-adds it to the new roll
Resolves #10357