### PR TITLE
Add variants to Magic Missile

### DIFF
--- a/packs/spells/magic-missile.json
+++ b/packs/spells/magic-missile.json
@@ -45,11 +45,75 @@
         "materials": {
             "value": ""
         },
-        "overlays": {},
-        "prepared": {
+        "overlays": {
+            "MqVPEdlq857SaX8o": {
+                "_id": "MqVPEdlq857SaX8o",
+                "overlayType": "override",
+                "sort":  1,
+                "system": {
+                    "time": {
+                        "value": "1"
+                    },
+                    "heightening": {
+                        "type": "interval",
+                        "interval": 2,
+                        "damage": {
+                            "0": "1d4+1"
+                        }
+                    }
+                }
+            },
+            "gNnCzsiv2MsOBkiZ": {
+                "_id": "gNnCzsiv2MsOBkiZ",
+                "overlayType": "override",
+                "sort": 2,
+                "system": {
+                    "time": {
+                        "value": "2"
+                    },
+                    "damage": {
+                        "value": {
+                            "0": {
+                                "value": "2d4+2"
+                            }
+                        }
+                    },
+                    "heightening": {
+                        "type": "interval",
+                        "interval": 2,
+                        "damage": {
+                            "0": "2d4+2"
+                        }
+                    }
+                }
+            },
+            "xIfLKkEENPM1clZv": {
+                "_id": "xIfLKkEENPM1clZv",
+                "system": {
+                    "time": {
+                        "value": "3"
+                    },
+                    "damage": {
+                        "value": {
+                            "0": {
+                                "value": "3d4+3"
+                            }
+                        }
+                    },
+                    "heightening": {
+                        "type": "interval",
+                        "interval": 2,
+                        "damage": {
+                            "0": "3d4+3"
+                        }
+                    }
+                }
+            }
+        },
+        "prepared": {  
             "value": ""
         },
-        "primarycheck": {
+        "primarycheck"{
             "value": ""
         },
         "range": {
@@ -64,7 +128,7 @@
             "value": ""
         },
         "secondarycheck": {
-            "value": ""
+             "value": ""
         },
         "source": {
             "value": "Pathfinder Core Rulebook"

--- a/packs/spells/magic-missile.json
+++ b/packs/spells/magic-missile.json
@@ -113,7 +113,7 @@
         "prepared": {  
             "value": ""
         },
-        "primarycheck"{
+        "primarycheck": {
             "value": ""
         },
         "range": {
@@ -128,7 +128,7 @@
             "value": ""
         },
         "secondarycheck": {
-             "value": ""
+            "value": ""
         },
         "source": {
             "value": "Pathfinder Core Rulebook"


### PR DESCRIPTION
Make it so Magic Missle spell allows you to choose 1,2 or 3-action variant rather than 1-action being the only one avaliable.
It also works with feats like dangerous sorcery or sorcer's blood magic
![Zrzut ekranu 2023-09-27 155725](https://github.com/foundryvtt/pf2e/assets/59914653/146b98eb-8cbb-485b-9ead-730ba40fbfe2)
