### PR TITLE
Add Glimpse Vulnerability Rules

### DIFF
--- a/packs/actions/glimpse-vulnerability.json
+++ b/packs/actions/glimpse-vulnerability.json
@@ -20,7 +20,22 @@
         "requirements": {
             "value": ""
         },
-        "rules": [],
+        "rules": [
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "option": "glimpse-vulnerability",
+                "toggleable": true
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "glimpse-vulnerability"
+                ],
+                "selector": "strike-damage",
+                "value": "2"
+            }
+        ],
         "source": {
             "value": "Pathfinder Dark Archive"
         },


### PR DESCRIPTION
If implemented this adds a roll option that grants you +2 to strike damage. This is similar to how it was implemented for Implement's Empowerment.