### PR TITLE
Don't show sheet config in `TokenConfig` sheet

### DIFF
--- a/src/module/scene/token-document/sheet.ts
+++ b/src/module/scene/token-document/sheet.ts
@@ -8,6 +8,7 @@ class TokenConfigPF2e<TDocument extends TokenDocumentPF2e> extends TokenConfig<T
         return {
             ...super.defaultOptions,
             template: "systems/pf2e/templates/scene/token/sheet.hbs",
+            sheetConfig: false,
         };
     }
 


### PR DESCRIPTION
It's only possible to have a single sheet registered for token documents, so there's no reason to have a sheet config link.

Closes #10383 