### PR TITLE
Fix sheet body content cutting off/overlapping with navigation icons

### DIFF
--- a/src/styles/actor/_index.scss
+++ b/src/styles/actor/_index.scss
@@ -151,6 +151,7 @@ $header-height: 89px; /* Adjust height of the header */
         .sheet-body {
             grid-area: content;
             position: relative;
+            z-index: 0;
 
             ol {
                 list-style: none;


### PR DESCRIPTION
This creates a new stacking context on the actor sheet's "sheet-body" element, which prevents elements (mainly action-header) and text within from rendering above the navigation icons.

Before:
<img width="744" alt="Screenshot 2023-09-27 at 7 40 18 PM" src="https://github.com/foundryvtt/pf2e/assets/43155846/12e0d5e4-10d0-4fc5-b82d-87d9100fd1d7">
<img width="745" alt="Screenshot 2023-09-27 at 7 40 31 PM" src="https://github.com/foundryvtt/pf2e/assets/43155846/9fa8da48-456b-454a-86fc-1ac4b25a1ab2">
<img width="330" alt="Screenshot 2023-09-27 at 7 52 53 PM" src="https://github.com/foundryvtt/pf2e/assets/43155846/b78a7a9c-a4cc-4ea2-b657-ce2f22ca5abb">


After:
<img width="743" alt="Screenshot 2023-09-27 at 7 41 08 PM" src="https://github.com/foundryvtt/pf2e/assets/43155846/53ad615b-c11e-4495-8a2d-03e6abd7b646">
<img width="751" alt="Screenshot 2023-09-27 at 7 41 16 PM" src="https://github.com/foundryvtt/pf2e/assets/43155846/cd5d6f4a-a5b9-400e-b949-c408366bcfcb">
<img width="522" alt="Screenshot 2023-09-27 at 8 11 58 PM" src="https://github.com/foundryvtt/pf2e/assets/43155846/1fa6ac7c-49f3-4915-88a0-edbb10da8ba7">


