### PR TITLE
Add new kingdom building phase and pop open sheet

### DIFF
--- a/src/module/actor/party/kingdom/schema.ts
+++ b/src/module/actor/party/kingdom/schema.ts
@@ -10,7 +10,7 @@ import {
     KINGDOM_SKILLS,
 } from "./values.ts";
 import { RawModifier } from "@actor/modifiers.ts";
-import { RecordField } from "@system/schema-data-fields.ts";
+import { DataUnionField, RecordField, StrictBooleanField, StrictStringField } from "@system/schema-data-fields.ts";
 
 const { fields } = foundry.data;
 
@@ -200,8 +200,18 @@ const KINGDOM_SCHEMA = {
         nullable: false,
         initial: "kingmaker",
     }),
-    active: new fields.BooleanField<boolean, boolean, true, false>({ initial: false, required: true, nullable: false }),
-
+    active: new DataUnionField(
+        [
+            new StrictStringField<"building">({
+                required: false,
+                nullable: false,
+                choices: ["building"],
+                initial: undefined,
+            }),
+            new StrictBooleanField({ initial: false, required: false, nullable: false }),
+        ],
+        { required: false, nullable: false, initial: false }
+    ),
     name: new fields.StringField<string, string, true, false>({ required: true, nullable: false, initial: "" }),
     img: new fields.FilePathField<ImageFilePath, ImageFilePath, true, false>({
         categories: ["IMAGE"],

--- a/src/styles/ui/sidebar/_actor-directory.scss
+++ b/src/styles/ui/sidebar/_actor-directory.scss
@@ -55,11 +55,11 @@
                 position: relative;
                 text-align: center;
 
-                &:hover i.fa-plus {
+                &:hover i + i {
                     color: var(--color-text-hyperlink);
                 }
 
-                i.fa-plus {
+                i + i {
                     position: absolute;
                     top: -2px;
                     right: -2px;

--- a/static/lang/kingmaker-en.json
+++ b/static/lang/kingmaker-en.json
@@ -18,11 +18,13 @@
             "Random": "Random Event"
         },
         "KingdomBuilder": {
+            "ActivationMessage": "Begin the Kingdom Creation process? Make sure your players are ready before proceeding.",
             "Aspiration": "Aspiration",
             "AssignBoostsHeader": "Assign your boosts",
             "Boost": "Boost",
             "BoostsLabel": "Ability Boosts",
             "Builder": "Builder",
+            "CancelCreation": "Cancel Creation",
             "Complete": "Complete",
             "Feat": "Kingdom Feat",
             "FinalizeHeader": "Finalize Kingdom",


### PR DESCRIPTION
This adds a new phase of active, called "building", which allows players to open up the kingdom builder on their own without the GM needing to activate show sheets. 

![image](https://github.com/foundryvtt/pf2e/assets/1286721/af1ec5fe-1a28-4ce0-916d-011132c5116c)

When confirmed, the kingdom builder is opened to all players, and all players can now see the following on the party folder:
![image](https://github.com/foundryvtt/pf2e/assets/1286721/978d4d40-8602-4823-b95e-28d74fd19346)

The GM can reverse this (but it won't reset data) by clicking the new Cancel Creation button. This closes the sheet for all players resets the party crown icon back to crown+:
![image](https://github.com/foundryvtt/pf2e/assets/1286721/2008ebed-4633-4ea8-963c-59bbcd40a0ec)
