### PR TITLE
Fix double scrollbars on item sheet and make GM notes easier to edit

### DIFF
--- a/src/module/item/sheet/base.ts
+++ b/src/module/item/sheet/base.ts
@@ -20,6 +20,7 @@ import {
 import {
     ErrorPF2e,
     fontAwesomeIcon,
+    htmlClosest,
     htmlQuery,
     htmlQueryAll,
     objectHasKey,
@@ -253,9 +254,18 @@ class ItemSheetPF2e<TItem extends ItemPF2e> extends ItemSheet<TItem> {
         const sourceContent =
             name === "system.description.value" ? this.item._source.system.description.value : initialContent;
 
-        // Remove toolbar options that are unsuitable for a smaller notes field
-        if (name === "system.description.gm") {
-            options.toolbar = "styles bullist numlist image hr link removeformat code save";
+        const mutuallyExclusive = ["system.description.gm", "system.description.value"];
+        if (mutuallyExclusive.includes(name)) {
+            const html = this.element[0];
+            for (const elementName of mutuallyExclusive.filter((n) => n !== name)) {
+                const element = htmlQuery(html, `[data-edit="${elementName}"]`);
+                const section = htmlClosest(element, ".editor-container");
+                if (section) {
+                    section.style.display = "none";
+                }
+            }
+
+            htmlQuery(html, ".item-description")?.classList.add("editing");
         }
 
         return super.activateEditor(name, options, sourceContent);

--- a/src/styles/item/_index.scss
+++ b/src/styles/item/_index.scss
@@ -274,6 +274,14 @@
             }
 
             .item-description {
+                // Allow editor scrolling to take over when editing
+                &.editing {
+                    overflow: hidden;
+                    .descriptions > section {
+                        flex: 1;
+                    }
+                }
+
                 .descriptions {
                     display: flex;
                     flex-direction: column;
@@ -282,14 +290,18 @@
                     padding: 0 0.25em;
 
                     > * {
-                        display: inherit;
-                        flex-direction: inherit;
+                        display: flex;
+                        overflow: hidden;
+                        .editor {
+                            flex: 1;
+                        }
                     }
 
                     .gm-notes {
                         background-color: var(--visibility-gm-bg);
                         border: 1px dotted rgba(75, 74, 68, 0.5);
                         padding: 0 0.25em;
+                        flex: 0 0 auto;
 
                         &:not(.has-content) {
                             display: none;
@@ -305,10 +317,6 @@
                     }
 
                     .editor {
-                        display: inherit;
-                        flex-direction: inherit;
-                        flex-grow: inherit;
-
                         a.add-gm-notes,
                         a.editor-edit {
                             font-size: 1.33em;

--- a/static/templates/items/sheet.hbs
+++ b/static/templates/items/sheet.hbs
@@ -96,11 +96,11 @@
             <section class="tab item-description" data-tab="description">
                 <div class="descriptions">
                     {{#if user.isGM}}
-                        <section class="gm-notes{{#if enrichedContent.gmNotes}} has-content{{/if}}">
+                        <section class="editor-container gm-notes{{#if enrichedContent.gmNotes}} has-content{{/if}}">
                             {{editor enrichedContent.gmNotes target="system.description.gm" button=true owner=owner editable=editable}}
                         </section>
                     {{/if}}
-                    <section class="main">
+                    <section class="main editor-container">
                         {{#if (not isVariant)}}
                             {{editor enrichedContent.description target="system.description.value" button=true owner=owner editable=editable}}
                         {{else}}


### PR DESCRIPTION
https://github.com/foundryvtt/pf2e/assets/1286721/05589d73-d2c1-4b9e-abfe-ffedcd08dd81

Re-render sets it back, and currently there is no way to close the editor that doesn't also cause a re-render.

This is the bug I'm trying to fix:
![image](https://github.com/foundryvtt/pf2e/assets/1286721/4328197f-17b7-4236-93bc-922211f89996)
