### PR TITLE
Handle item sheet resizing in description editing

### DIFF
--- a/src/styles/item/_index.scss
+++ b/src/styles/item/_index.scss
@@ -317,6 +317,8 @@
                     }
 
                     .editor {
+                        display: flex;
+                        flex-direction: column;
                         a.add-gm-notes,
                         a.editor-edit {
                             font-size: 1.33em;
@@ -341,6 +343,10 @@
 
                         &:hover a.add-gm-notes {
                             display: block;
+                        }
+
+                        .tox {
+                            flex: 1;
                         }
                     }
                 }


### PR DESCRIPTION
Missed a spot. I think this should probably be something we put in the sheet reset since it seems we need to work around this very often. The cause is that tinymce sets a inline height style. The journals get around it by removing the height property in activateEditor(). But flex seems to also solve the issue.