### PR TITLE
Refresh rule elements on copies of Mighty Bulwark

### DIFF
--- a/build/run-migration.ts
+++ b/build/run-migration.ts
@@ -10,7 +10,6 @@ import { getFilesRecursively } from "./lib/helpers.ts";
 import { MigrationBase } from "@module/migration/base.ts";
 import { MigrationRunnerBase } from "@module/migration/runner/base.ts";
 
-import { Migration849DeleteBrokenThreshold } from "@module/migration/migrations/849-delete-broken-threshold.ts";
 import { Migration850FlatFootedToOffGuard } from "@module/migration/migrations/850-flat-footed-to-off-guard.ts";
 import { Migration851JustInnovationId } from "@module/migration/migrations/851-just-innovation-id.ts";
 import { Migration852AbilityScoresToModifiers } from "@module/migration/migrations/852-ability-scores-to-modifiers.ts";
@@ -28,6 +27,7 @@ import { Migration864RemoveWeaponMAP } from "@module/migration/migrations/864-rm
 import { Migration865VitalityVoid } from "@module/migration/migrations/865-vitality-void.ts";
 import { Migration867DamageRollDomainFix } from "@module/migration/migrations/867-damage-roll-domain-fix.ts";
 import { Migration868StrikeRERange } from "@module/migration/migrations/868-strike-re-range.ts";
+import { Migration869RefreshMightyBulwark } from "@module/migration/migrations/869-refresh-mighty-bulwark.ts";
 
 // ^^^ don't let your IDE use the index in these imports. you need to specify the full path ^^^
 
@@ -38,7 +38,6 @@ globalThis.HTMLParagraphElement = window.HTMLParagraphElement;
 globalThis.Text = window.Text;
 
 const migrations: MigrationBase[] = [
-    new Migration849DeleteBrokenThreshold(),
     new Migration850FlatFootedToOffGuard(),
     new Migration851JustInnovationId(),
     new Migration852AbilityScoresToModifiers(),
@@ -56,6 +55,7 @@ const migrations: MigrationBase[] = [
     new Migration865VitalityVoid(),
     new Migration867DamageRollDomainFix(),
     new Migration868StrikeRERange(),
+    new Migration869RefreshMightyBulwark(),
 ];
 
 global.deepClone = <T>(original: T): T => {

--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -902,8 +902,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
             if (typeof strengthRequirement === "number" && this.system.abilities.str.mod >= strengthRequirement) {
                 for (const selector of ["skill-check", "initiative"]) {
                     const rollOptions = (this.rollOptions[selector] ??= {});
-                    // Nullish assign to not overwrite setting by rule element
-                    rollOptions["self:armor:strength-requirement-met"] ??= true;
+                    rollOptions["armor:strength-requirement-met"] = true;
                 }
             }
 
@@ -921,14 +920,14 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
                 armorCheckPenalty.predicate.push({ nor: ["attack", "armor:ignore-check-penalty"] });
                 if (["acrobatics", "athletics"].includes(longForm)) {
                     armorCheckPenalty.predicate.push({
-                        nor: ["self:armor:strength-requirement-met", "armor:trait:flexible"],
+                        nor: ["armor:strength-requirement-met", "armor:trait:flexible"],
                     });
                 } else if (longForm === "stealth" && wornArmor.traits.has("noisy")) {
                     armorCheckPenalty.predicate.push({
-                        nand: ["self:armor:strength-requirement-met", "armor:ignore-noisy-penalty"],
+                        nand: ["armor:strength-requirement-met", "armor:ignore-noisy-penalty"],
                     });
                 } else {
-                    armorCheckPenalty.predicate.push({ not: "self:armor:strength-requirement-met" });
+                    armorCheckPenalty.predicate.push({ not: "armor:strength-requirement-met" });
                 }
 
                 modifiers.push(armorCheckPenalty);

--- a/src/module/migration/migrations/869-refresh-mighty-bulwark.ts
+++ b/src/module/migration/migrations/869-refresh-mighty-bulwark.ts
@@ -1,0 +1,43 @@
+import type { ItemSourcePF2e } from "@item/data/index.ts";
+import { MigrationBase } from "../base.js";
+
+/** Refresh rule elements on mighty bulwark feat. */
+export class Migration869RefreshMightyBulwark extends MigrationBase {
+    static override version = 0.869;
+
+    get #mightyBulwarkRules() {
+        return [
+            {
+                key: "FlatModifier",
+                predicate: ["armor:trait:bulwark"],
+                selector: "reflex",
+                value: 4,
+            },
+            {
+                key: "AdjustModifier",
+                predicate: ["armor:trait:bulwark"],
+                selector: "reflex",
+                slug: "dex",
+                suppress: true,
+            },
+            {
+                key: "AdjustModifier",
+                selector: "reflex",
+                slug: "bulwark",
+                suppress: true,
+            },
+        ];
+    }
+
+    override async updateItem(source: ItemSourcePF2e): Promise<void> {
+        if (source.type === "feat" && source.system.slug === "mighty-bulwark") {
+            source.system.rules = this.#mightyBulwarkRules;
+        } else {
+            for (const rule of source.system.rules) {
+                if ("option" in rule && rule.option === "self:armor:strength-requirement-met") {
+                    rule.option = "armor:strength-requirement-met";
+                }
+            }
+        }
+    }
+}

--- a/src/module/migration/migrations/index.ts
+++ b/src/module/migration/migrations/index.ts
@@ -266,3 +266,4 @@ export { Migration865VitalityVoid } from "./865-vitality-void.ts";
 export { Migration866LinkToActorSizeAgain } from "./866-link-to-actor-size-again.ts";
 export { Migration867DamageRollDomainFix } from "./867-damage-roll-domain-fix.ts";
 export { Migration868StrikeRERange } from "./868-strike-re-range.ts";
+export { Migration869RefreshMightyBulwark } from "./869-refresh-mighty-bulwark.ts";

--- a/src/module/migration/runner/base.ts
+++ b/src/module/migration/runner/base.ts
@@ -2,8 +2,7 @@ import { ActorSourcePF2e } from "@actor/data/index.ts";
 import { ItemSourcePF2e } from "@item/data/index.ts";
 import { DocumentSchemaRecord } from "@module/data.ts";
 import { MigrationBase } from "@module/migration/base.ts";
-import { ScenePF2e } from "@scene/document.ts";
-import { TokenDocumentPF2e } from "@scene/token-document/document.ts";
+import type { ScenePF2e, TokenDocumentPF2e } from "@scene";
 
 interface CollectionDiff<T extends foundry.documents.ActiveEffectSource | ItemSourcePF2e> {
     inserted: T[];
@@ -14,7 +13,7 @@ interface CollectionDiff<T extends foundry.documents.ActiveEffectSource | ItemSo
 export class MigrationRunnerBase {
     migrations: MigrationBase[];
 
-    static LATEST_SCHEMA_VERSION = 0.868;
+    static LATEST_SCHEMA_VERSION = 0.869;
 
     static MINIMUM_SAFE_VERSION = 0.618;
 


### PR DESCRIPTION
Also remove the last internal "self:armor:*" roll option