### PR TITLE
Clean up styling on RE forms and minor tweaks

### DIFF
--- a/src/styles/item/_index.scss
+++ b/src/styles/item/_index.scss
@@ -193,7 +193,7 @@
             select {
                 &:hover:not(:disabled),
                 &:focus {
-                    border: 1px solid var(--color-border-dark-1);
+                    border-color: var(--color-border-dark-1);
                     box-shadow: 0 0 5px var(--secondary);
                 }
             }
@@ -490,14 +490,12 @@
         }
 
         .details-container-flex-row {
-            display: flex;
-            flex-direction: row;
             align-items: center;
+            display: flex;
             justify-content: space-between;
 
             & > label {
                 display: flex;
-                flex-direction: row;
                 align-items: center;
                 white-space: nowrap;
             }

--- a/src/styles/item/_rules.scss
+++ b/src/styles/item/_rules.scss
@@ -116,6 +116,8 @@
 
     // Style of a single rule editor form
     .rule-form {
+        --form-field-height: normal; // unset global styling
+
         border-bottom: 1px solid var(--color-border-light-primary);
         padding-bottom: 0.5rem;
         margin-bottom: 0.5rem;
@@ -126,6 +128,48 @@
 
         &.drag-gap {
             visibility: hidden;
+        }
+
+        label {
+            align-items: center;
+            display: flex;
+            gap: 4px;
+            font-weight: 500;
+            white-space: nowrap;
+            &:not(:first-child) {
+                padding-left: 2px;
+            }
+            input,
+            tags {
+                flex: 1;
+            }
+
+            input[type="checkbox"] {
+                width: 1rem;
+                height: 1rem;
+                flex-basis: auto;
+            }
+
+            input[type="checkbox"]:first-child:last-child {
+                margin-left: auto;
+                justify-self: flex-end;
+            }
+        }
+
+        select.short {
+            flex: 0 0 auto;
+        }
+
+        .content-link {
+            display: flex;
+            flex: 0 0 auto;
+            flex-direction: row;
+            align-items: center;
+            gap: 3px;
+            img {
+                width: 16px;
+                height: 16px;
+            }
         }
 
         .rule-element-header {
@@ -152,15 +196,9 @@
             }
         }
 
-        label,
-        .labelled-element {
-            display: flex;
-            align-items: center;
-            gap: 4px;
-            input,
-            tags {
-                flex: 1;
-            }
+        // Prevent certain buttons/links from resizing
+        .form-fields [data-action] {
+            flex: 0 0 auto;
         }
 
         .range {
@@ -219,24 +257,16 @@
             }
         }
 
-        // Main element for the value of a form group
-        // Flex row with gaps between items
-        .spaced-fields {
-            display: flex;
-            align-items: center;
-            gap: 4px;
-
-            label {
-                font-weight: 500;
-                padding-right: 2px;
-                &:not(:first-child) {
-                    padding-left: 2px;
-                }
-            }
-        }
-
         .brackets {
             margin-left: 9.5em;
+            .bracket {
+                align-items: center;
+                display: flex;
+                gap: 4px;
+                .value {
+                    flex: 1;
+                }
+            }
         }
 
         nav.rule-tabs {
@@ -467,42 +497,6 @@
                             margin: unset;
                         }
                     }
-                }
-            }
-        }
-
-        &[data-key="FastHealing"] {
-            select {
-                flex: 0;
-            }
-
-            .details,
-            tags {
-                flex: 1;
-            }
-
-            .resolvable {
-                flex: 1;
-                min-width: 120px;
-            }
-        }
-
-        &[data-key="FlatModifier"] {
-            .type-input {
-                flex: 0;
-            }
-        }
-
-        &[data-key="GrantItem"] {
-            a.granted {
-                display: flex;
-                flex: 0 0 auto;
-                flex-direction: row;
-                align-items: center;
-                gap: 3px;
-                img {
-                    width: 16px;
-                    height: 16px;
                 }
             }
         }

--- a/static/templates/items/rules/fast-healing.hbs
+++ b/static/templates/items/rules/fast-healing.hbs
@@ -1,30 +1,33 @@
 
-<div class="spaced-fields details-container-flex-row">
-    <select name="system.rules.{{index}}.type">
-        {{#select rule.type}}
-            {{#each types as |label key|}}
-                <option value="{{key}}">{{localize label}}</option>
-            {{/each}}
-        {{/select}}
-    </select>
-
-    {{{form.resolvableValue "value"}}}
-
-    {{#if (eq rule.type "regeneration")}}
-        <label>
-            {{localize "PF2E.RuleEditor.FastHealing.DeactivatedBy"}}
-            <input type="text" class="pf2e-tagify deactivated-by" name="system.rules.{{index}}.deactivatedBy" value="{{json rule.deactivatedBy}}" data-dtype="JSON"/>
-        </label>
-    {{else}}
-        <label>
-            {{localize "PF2E.DetailsHeading"}}
-            <input type="text" class="details" name="system.rules.{{index}}.details" value="{{rule.details}}"/>
-        </label>
-    {{/if}}
-    {{{form.resolvableAddBracket "value"}}}
+<div class="form-group">
+    <label class="short">{{localize "PF2E.RuleEditor.General.Value"}}</label>
+    <div class="form-fields">
+        {{{form.resolvableValue "value"}}}
+        <select name="system.rules.{{index}}.type" class="short">
+            {{#select rule.type}}
+                {{#each types as |label key|}}
+                    <option value="{{key}}">{{localize label}}</option>
+                {{/each}}
+            {{/select}}
+        </select>
+        {{{form.resolvableAddBracket "value"}}}
+    </div>
 </div>
 {{{form.resolvableBrackets "value"}}}
-<div class="spaced-fields">
-    <label>{{localize "PF2E.RuleEditor.General.Predicate"}}</label>
+<div class="form-group">
+    {{#if (eq rule.type "regeneration")}}
+        <div class="form-group">
+            <label class="short">{{localize "PF2E.RuleEditor.FastHealing.DeactivatedBy"}}</label>
+            <input type="text" class="pf2e-tagify deactivated-by" name="system.rules.{{index}}.deactivatedBy" value="{{json rule.deactivatedBy}}" data-dtype="JSON"/>
+        </div>
+    {{else}}
+        <div class="form-group">
+            <label class="short">{{localize "PF2E.DetailsHeading"}}</label>
+            <input type="text" class="details" name="system.rules.{{index}}.details" value="{{rule.details}}"/>
+        </div>
+    {{/if}}
+</div>
+<div class="form-group">
+    <label class="short">{{localize "PF2E.RuleEditor.General.Predicate"}}</label>
     <input type="text" name="system.rules.{{index}}.predicate" value="{{json rule.predicate}}" />
 </div>

--- a/static/templates/items/rules/flat-modifier.hbs
+++ b/static/templates/items/rules/flat-modifier.hbs
@@ -1,6 +1,6 @@
 <div class="form-group">
     <label class="short">{{localize "PF2E.RuleEditor.General.Label"}}</label>
-    <div class="spaced-fields details-container-flex-row">
+    <div class="form-fields">
         <input type="text" name="{{basePath}}.label" value="{{rule.label}}" placeholder="{{object.label}}" />
         <label>
             {{localize "PF2E.RuleEditor.FlatModifier.HideIfDisabled"}}
@@ -25,7 +25,7 @@
 
 <div class="form-group">
     <label class="short">{{localize "PF2E.RuleEditor.General.Value"}}</label>
-    <div class="spaced-fields details-container-flex-row">
+    <div class="form-fields">
         {{#if (eq rule.type "ability")}}
             <select name="{{basePath}}.ability">
                 {{#select rule.ability}}
@@ -37,7 +37,7 @@
         {{else}}
             {{{form.resolvableValue "value" hideButton=true}}}
         {{/if}}
-        <select name="{{basePath}}.type" class="type-input">
+        <select name="{{basePath}}.type" class="short">
             {{#select rule.type}}
                 {{#each types as |label slug|}}
                     <option value="{{slug}}">{{label}}</option>
@@ -54,9 +54,9 @@
 {{#if isDamage}}
 <div class="form-group">
     <label class="short">{{localize "PF2E.RuleEditor.General.DamageType"}}</label>
-    <div class="spaced-fields details-container-flex-row">
+    <div class="form-fields">
         <input type="text" class="pf2e-tagify damage-type" name="{{basePath}}.damageType" value="{{rule.damageType}}"/>
-        <select name="{{basePath}}.damageCategory">
+        <select name="{{basePath}}.damageCategory" class="short">
             {{#select rule.damageCategory}}
                 <option value=""></option>
                 {{#each damageCategories as |label key|}}
@@ -64,7 +64,7 @@
                 {{/each}}
             {{/select}}
         </select>
-        <select name="{{basePath}}.critical">
+        <select name="{{basePath}}.critical" class="short">
             {{#select rule.critical}}
                 <option value="">{{localize "PF2E.RuleEditor.General.CriticalBehavior.null"}}</option>
                 <option value="false">{{localize "PF2E.RuleEditor.General.CriticalBehavior.false"}}</option>

--- a/static/templates/items/rules/grant-item.hbs
+++ b/static/templates/items/rules/grant-item.hbs
@@ -14,12 +14,11 @@
 </div>
 <div class="form-group">
     <label class="short">{{localize "PF2E.UUID.Label"}}</label>
-    <div class="details-container-flex-row">
+    <div class="form-fields">
         <input type="text" name="system.rules.{{index}}.uuid" value="{{rule.uuid}}" />
         {{#if granted}}
-            <a class="granted content-link" data-uuid="{{granted.uuid}}">
-                <img src="{{granted.img}}"/>
-                {{granted.name}}
+            <a class="content-link" data-uuid="{{granted.uuid}}">
+                <img src="{{granted.img}}"/> {{granted.name}}
             </a>
         {{/if}}
     </div>

--- a/static/templates/items/rules/multiple-attack-penalty.hbs
+++ b/static/templates/items/rules/multiple-attack-penalty.hbs
@@ -20,7 +20,7 @@
 
 {{{form.resolvableBrackets "value"}}}
 
-<div class="spaced-fields">
-    <label for="{{fieldIdPrefix}}predicate">{{localize fields.predicate.label}}</label>
+<div class="form-group">
+    <label for="{{fieldIdPrefix}}predicate" class="short">{{localize fields.predicate.label}}</label>
     <input type="text" name="system.rules.{{index}}.predicate" id="{{fieldIdPrefix}}predicate" value="{{json rule.predicate}}" placeholder="[ ]" />
 </div>

--- a/static/templates/items/rules/note.hbs
+++ b/static/templates/items/rules/note.hbs
@@ -1,6 +1,6 @@
 <div class="form-group">
     <label class="short">{{localize "PF2E.RuleEditor.Note.Title"}}</label>
-    <div class="spaced-fields details-container-flex-row">
+    <div class="form-fields">
         <input type="text" name="system.rules.{{index}}.title" value="{{rule.title}}" />
         <label>
             {{localize "PF2E.RuleEditor.Note.Hidden"}}
@@ -26,11 +26,11 @@
 <textarea name="system.rules.{{index}}.text" spellcheck="false" placeholder="{{localize "PF2E.RuleEditor.Note.Text"}}">{{rule.text}}</textarea>
 
 <div class="form-group">
-    <label>{{localize "PF2E.RuleEditor.Note.Outcome"}}</label>
+    <label class="short">{{localize "PF2E.RuleEditor.Note.Outcome"}}</label>
     <input class="pf2e-tagify outcomes" name="system.rules.{{index}}.outcome" value="{{json rule.outcome}}" data-dtype="JSON" />
 </div>
 
 <div class="form-group">
-    <label>{{localize "PF2E.RuleEditor.General.Predicate"}}</label>
+    <label class="short">{{localize "PF2E.RuleEditor.General.Predicate"}}</label>
     <input type="text" name="system.rules.{{index}}.predicate" value="{{json rule.predicate}}" />
 </div>

--- a/static/templates/items/rules/partials/resolvable-brackets.hbs
+++ b/static/templates/items/rules/partials/resolvable-brackets.hbs
@@ -1,15 +1,17 @@
 {{#if (eq mode "brackets")}}
     <div class="brackets">
         {{#each value.brackets as |bracket idx|}}
-            <div class="bracket details-container-flex-row spaced-fields">
+            <div class="bracket">
                 <label>{{localize "PF2E.RuleEditor.General.Range"}}</label>
                 <div class="range">
                     <input type="number" name="{{@root.path}}.brackets.{{idx}}.start" value="{{bracket.start}}">
                     -
                     <input type="number" name="{{@root.path}}.brackets.{{idx}}.end" value="{{bracket.end}}">
                 </div>
-                <label>{{localize "PF2E.RuleEditor.General.Value"}}</label>
-                <input type="text" name="{{@root.path}}.brackets.{{idx}}.value" value="{{bracket.value}}"/>
+                <label class="value">
+                    {{localize "PF2E.RuleEditor.General.Value"}}
+                    <input type="text" name="{{@root.path}}.brackets.{{idx}}.value" value="{{bracket.value}}"/>
+                </label>
                 <a data-action="delete-bracket" data-idx="{{idx}}" data-property="{{@root.property}}"><i class="fa-solid fa-fw fa-trash"></i></a>
             </div>
         {{/each}}

--- a/static/templates/items/rules/token-image.hbs
+++ b/static/templates/items/rules/token-image.hbs
@@ -14,7 +14,7 @@
 </div>
 
 <div class="form-group scale">
-    <label for="{{fieldIdPrefix}}scale">
+    <label for="{{fieldIdPrefix}}scale" class="short">
         {{localize fields.scale.label}} <span class="units">({{localize "Ratio"}})</span>
     </label>
     <div class="form-fields">
@@ -25,13 +25,13 @@
 
 
 <div class="form-group">
-    <label for="{{fieldIdPrefix}}alpha">{{localize fields.alpha.label}}</label>
+    <label for="{{fieldIdPrefix}}alpha" class="short">{{localize fields.alpha.label}}</label>
     <div class="form-fields">
         {{rangePicker name=(concat "system.rules." index ".alpha") value=object.alpha min="0" max="1" step="0.05"}}
     </div>
 </div>
 
-<div class="spaced-fields">
-    <label for="{{fieldIdPrefix}}predicate">{{localize fields.predicate.label}}</label>
+<div class="form-group">
+    <label for="{{fieldIdPrefix}}predicate" class="short">{{localize fields.predicate.label}}</label>
     <input type="text" name="system.rules.{{index}}.predicate" id="{{fieldIdPrefix}}predicate" value="{{json rule.predicate}}" placeholder="[ ]" />
 </div>

--- a/static/templates/items/rules/token-light.hbs
+++ b/static/templates/items/rules/token-light.hbs
@@ -10,7 +10,7 @@
     <fieldset class="radii">
         <legend>{{localize "LIGHT.Radius"}}</legend>
         <div class="form-group">
-            <div class="spaced-fields details-container-flex-row">
+            <div class="form-fields">
                 <label class="short">{{localize "LIGHT.Dim"}}</label>
                 {{{form.resolvableValue "value.dim"}}}
                 {{{form.resolvableAddBracket "value.dim"}}}
@@ -19,7 +19,7 @@
             {{{form.resolvableBrackets "value.dim"}}}
 
         <div class="form-group">
-            <div class="spaced-fields details-container-flex-row">
+            <div class="form-fields">
                 <label class="short">{{localize "LIGHT.Bright"}}</label>
                 {{{form.resolvableValue "value.bright"}}}
                 {{{form.resolvableAddBracket "value.bright"}}}
@@ -49,7 +49,7 @@
         </div>
     </div>
 
-    <div class="spaced-fields column-span-two">
+    <div class="form-group column-span-two">
         <label>{{localize "PF2E.RuleEditor.General.Predicate"}}</label>
         <input type="text" class="predicate" name="system.rules.{{index}}.predicate" value="{{json rule.predicate}}" />
     </div>


### PR DESCRIPTION
This gets rid of the spaced-fields css, fixes the hover button layout twitching, and adds some of the styling we wanted as general styles. Also updates left side alignment of form elements (using label class short...) and redoes the fast healing form.

![image](https://github.com/foundryvtt/pf2e/assets/1286721/055decd9-cb66-4517-99ba-96422e36bbfd)
