### PR TITLE
Fix detection of selected republic/thaumocracy in kingdom builder

### DIFF
--- a/src/module/actor/party/kingdom/schema.ts
+++ b/src/module/actor/party/kingdom/schema.ts
@@ -15,13 +15,15 @@ import { DataUnionField, RecordField, StrictBooleanField, StrictStringField } fr
 const { fields } = foundry.data;
 
 function buildKingdomCHGSchema(): {
+    id: StringField<string, string, false, false>;
     name: StringField<string, string, true, false>;
     img: StringField<ImageFilePath, ImageFilePath, true, false>;
     description: StringField<string, string, true, false>;
     boosts: ArrayField<StringField<KingdomAbility | "free", KingdomAbility | "free", true, false>>;
 } {
     return {
-        name: new fields.StringField({ blank: false, nullable: false }),
+        id: new fields.StringField({ required: false, initial: undefined, blank: false }),
+        name: new fields.StringField({ required: true, nullable: false, blank: false }),
         img: new fields.StringField({ required: true, nullable: false }),
         description: new fields.StringField({ required: true, nullable: false }),
         boosts: new fields.ArrayField(

--- a/static/lang/kingmaker-en.json
+++ b/static/lang/kingmaker-en.json
@@ -289,11 +289,11 @@
             },
             "republic": {
                 "Name": "Republic",
-                "Description": "Your nation draws its leadership from its own citizens. Elected representatives meet in parliamentary bodies to guide the nation. "
+                "Description": "Your nation draws its leadership from its own citizens. Elected representatives meet in parliamentary bodies to guide the nation."
             },
             "thaumocracy": {
                 "Name": "Thaumocracy",
-                "Description": "Your nation is governed by those most skilled in magic, using their knowledge and power to determine the best ways to rule. While the type of magic wielded by the nation's rulers can adjust its themes (or even its name—a thaumocracy run by divine spellcasters would be a theocracy, for example), the details below remain the same whether it's arcane, divine, occult, primal, or any combination of the four. "
+                "Description": "Your nation is governed by those most skilled in magic, using their knowledge and power to determine the best ways to rule. While the type of magic wielded by the nation's rulers can adjust its themes (or even its name—a thaumocracy run by divine spellcasters would be a theocracy, for example), the details below remain the same whether it's arcane, divine, occult, primal, or any combination of the four."
             },
             "yeomanry": {
                 "Name": "Yeomanry",


### PR DESCRIPTION
Explicit check is from the days when it was an ObjectField and editing ABC entries was on the table. It was converted to SchemaField and the feature was descoped.