### PR TITLE
Add Change Shape Strike automation for Pukwudgie, Harmony In Agony, Weeping Jack

### DIFF
--- a/packs/blood-lords-bestiary/harmony-in-agony.json
+++ b/packs/blood-lords-bestiary/harmony-in-agony.json
@@ -4182,12 +4182,37 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<ul>\n<li><strong>Bat</strong> Harmony changes into a @UUID[Compendium.pf2e.pathfinder-bestiary.Actor.Giant Bat]. She gains echolocation 40 feet, a land Speed of 20 feet and a fly Speed of 30 feet, and a fangs Strike ([[/r 1d20+26]]{+26}, [[/r 1d20+21]]{+21}, [[/r 1d20+16]]{+16}) @Damage[(3d8+10)[piercing]].</li>\n</ul>\n<hr />\n<p>@Localize[PF2E.NPC.Abilities.Glossary.ChangeShape]</p>"
+                    "value": "<ul>\n<li><strong>Bat</strong> Harmony changes into a @UUID[Compendium.pf2e.pathfinder-bestiary.Actor.Giant Bat]. She gains echolocation 40 feet, a land Speed of 20 feet and a fly Speed of 30 feet, and a fangs Strike +26 for 3d8+10 piercing</li>\n</ul>\n<hr />\n<p>@Localize[PF2E.NPC.Abilities.Glossary.ChangeShape]</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "domain": "all",
+                        "key": "RollOption",
+                        "option": "change-shape",
+                        "toggleable": true
+                    },
+                    {
+                        "attackModifier": 26,
+                        "damage": {
+                            "base": {
+                                "damageType": "piercing",
+                                "dice": 3,
+                                "die": "d8",
+                                "modifier": 10
+                            }
+                        },
+                        "key": "Strike",
+                        "label": "PF2E.BattleForm.Attack.Fangs",
+                        "predicate": [
+                            "change-shape"
+                        ],
+                        "slug": "fangs",
+                        "traits": []
+                    }
+                ],
                 "slug": "vampire-true-change-shape",
                 "source": {
                     "value": "Pathfinder Bestiary"

--- a/packs/blood-lords-bestiary/weeping-jack.json
+++ b/packs/blood-lords-bestiary/weeping-jack.json
@@ -878,12 +878,37 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<ul>\n<li><strong>Bat</strong> Jack changes into a @UUID[Compendium.pf2e.pathfinder-bestiary.Actor.Giant Bat]. He gains echolocation 40 feet, a land Speed of 20 feet and a fly Speed of 30 feet, and a fangs Strike ([[/r 1d20+25]]{+25}, [[/r 1d20+20]]{+20}, [[/r 1d20+15]]{+15}) @Damage[(2d8+13)[piercing]]</li>\n</ul>\n<hr />\n<p>@Localize[PF2E.NPC.Abilities.Glossary.ChangeShape]</p>"
+                    "value": "<ul>\n<li><strong>Bat</strong> Jack changes into a @UUID[Compendium.pf2e.pathfinder-bestiary.Actor.Giant Bat]. He gains echolocation 40 feet, a land Speed of 20 feet and a fly Speed of 30 feet, and a fangs Strike +25 for 2d8+13 piercing</li>\n</ul>\n<hr />\n<p>@Localize[PF2E.NPC.Abilities.Glossary.ChangeShape]</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "domain": "all",
+                        "key": "RollOption",
+                        "option": "change-shape",
+                        "toggleable": true
+                    },
+                    {
+                        "attackModifier": 25,
+                        "damage": {
+                            "base": {
+                                "damageType": "piercing",
+                                "dice": 2,
+                                "die": "d8",
+                                "modifier": 13
+                            }
+                        },
+                        "key": "Strike",
+                        "label": "PF2E.BattleForm.Attack.Fangs",
+                        "predicate": [
+                            "change-shape"
+                        ],
+                        "slug": "fangs",
+                        "traits": []
+                    }
+                ],
                 "slug": "vampire-true-change-shape",
                 "source": {
                     "value": "Pathfinder Bestiary"

--- a/packs/pathfinder-bestiary-3/pukwudgie.json
+++ b/packs/pathfinder-bestiary-3/pukwudgie.json
@@ -1024,12 +1024,54 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The pukwudgie takes on the physical form of a @UUID[Compendium.pf2e.pathfinder-bestiary-3.Actor.Giant Porcupine]. Their size changes to Medium, they lose their weapon Strikes, and they gain a quill Strike ([[/r 1d20+18 #Quill]]{+18}/[[/r 1d20+13 #Quill]]{+13}/[[/r 1d20+8 #Quill]]{+8} for @Damage[(2d8+6)[piercing]] damage plus @Damage[1d8[persistent,poison]]).</p>\n<hr />\n<p>@Localize[PF2E.NPC.Abilities.Glossary.ChangeShape]</p>"
+                    "value": "<p>The pukwudgie takes on the physical form of a @UUID[Compendium.pf2e.pathfinder-bestiary-3.Actor.Giant Porcupine]. Their size changes to Medium, they lose their weapon Strikes, and they gain a quill Strike (+18 for 2d8+6 piercing plus 1d8 persistent poison).</p>\n<hr />\n<p>@Localize[PF2E.NPC.Abilities.Glossary.ChangeShape]</p>"
                 },
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "domain": "all",
+                        "key": "RollOption",
+                        "option": "change-shape",
+                        "toggleable": true
+                    },
+                    {
+                        "key": "CreatureSize",
+                        "predicate": [
+                            "change-shape"
+                        ],
+                        "value": "medium"
+                    },
+                    {
+                        "attackModifier": 18,
+                        "damage": {
+                            "base": {
+                                "damageType": "piercing",
+                                "dice": 2,
+                                "die": "d8",
+                                "modifier": 6
+                            }
+                        },
+                        "key": "Strike",
+                        "label": "PF2E.BattleForm.Attack.Quill",
+                        "predicate": [
+                            "change-shape"
+                        ],
+                        "replaceAll": true,
+                        "slug": "quill",
+                        "traits": []
+                    },
+                    {
+                        "category": "persistent",
+                        "damageType": "poison",
+                        "diceNumber": 1,
+                        "dieSize": "d8",
+                        "key": "DamageDice",
+                        "label": "PF2E.BattleForm.Attack.Quill",
+                        "selector": "{item|id}-damage"
+                    }
+                ],
                 "slug": "change-shape",
                 "source": {
                     "value": "Pathfinder Bestiary"

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -120,6 +120,7 @@
                 "PiercingHymn": "Piercing Hymn",
                 "Pincer": "Pincer",
                 "Pseudopod": "Pseudopod",
+                "Quill": "Quill",
                 "Rock": "Rock",
                 "Spikes": "Spikes",
                 "Spine": "Spine",


### PR DESCRIPTION
Wasn't sure if I should add CreatureSize to Harmony In Agony and Weeping Jack's Shape Change REs. Giant Bats are large, but it's not explicitly called out in their stat blocks.

The rules for Shape Change say: "... might potentially change its senses or size. Any changes are listed in its stat block."