### PR TITLE
Fix loss of flavor on numeric inline splash and precision

### DIFF
--- a/src/module/system/damage/helpers.ts
+++ b/src/module/system/damage/helpers.ts
@@ -204,12 +204,9 @@ function simplifyTerm<T extends RollTerm>(term: T): T | Die | NumericTerm {
     if (term instanceof IntermediateDie) {
         return term.die ?? term;
     }
-    if (!term.isDeterministic || term instanceof NumericTerm) {
-        return term;
-    }
 
-    // Skip a deterministic `ArithmeticExpression` if at least one operand has its own flavor
-    if (isFlavoredArithmetic(term) || (term instanceof Grouping && isFlavoredArithmetic(term.term))) {
+    const shouldPreserve = (t: RollTerm) => !t.isDeterministic || t instanceof NumericTerm || isFlavoredArithmetic(t);
+    if (shouldPreserve(term) || (term instanceof Grouping && shouldPreserve(term.term))) {
         return term;
     }
 


### PR DESCRIPTION
Without this fix inline number splash and precision lose their flavor. 
For example `@Damage[(1d4[splash])[fire]]` works fine.
However, `@Damage[(1[splash])[fire]]` does not.

This addresses the issue by also checking if Grouping.term is not isDeterministic or is NumericTerm.

Another test: `@Damage[1d4[acid],(1[splash])[fire],(1[precision])[poison]]`