### PR TITLE
Update Light spell effect description

### DIFF
--- a/packs/spell-effects/spell-effect-light.json
+++ b/packs/spell-effects/spell-effect-light.json
@@ -4,7 +4,7 @@
     "name": "Spell Effect: Light",
     "system": {
         "description": {
-            "value": "<p>Granted by <em>@UUID[Compendium.pf2e.spells-srd.Item.Light]</em></p>\n<hr />\n<p>The object glows, casting bright light in a 20-foot radius (and dim light for the next 20 feet) like a torch. If you cast this spell again on a second object, the light spell on the first object ends.</p>\n<hr />\n<p><strong>Heightened (4th)</strong> The object sheds bright light in a 60-foot radius (and dim light for the next 60 feet).</p>"
+            "value": "<p>Granted by <em>@UUID[Compendium.pf2e.spells-srd.Item.Light]</em></p>\n<hr />\n<p>The target casts bright light in a 20-foot radius (and dim light for the next 20 feet) like a torch.</p>\n<hr />\n<p><strong>Heightened (4th)</strong> The target sheds bright light in a 60-foot radius (and dim light for the next 60 feet).</p>"
         },
         "duration": {
             "expiry": "turn-start",


### PR DESCRIPTION
Closes #10495

We don't need extraneous text in the description that isn't part of the automation and not helpful to users, so it's been cut down to just what the effect actually does.