### PR TITLE
Add automation for Aurumvorax's Tenacious Stance

### DIFF
--- a/packs/pathfinder-bestiary-2/aurumvorax.json
+++ b/packs/pathfinder-bestiary-2/aurumvorax.json
@@ -232,7 +232,25 @@
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "predicate": [
+                            {
+                                "or": [
+                                    "action:shove",
+                                    "action:trip"
+                                ]
+                            }
+                        ],
+                        "selector": [
+                            "fortitude-dc",
+                            "reflex-dc"
+                        ],
+                        "type": "circumstance",
+                        "value": 4
+                    }
+                ],
                 "slug": null,
                 "source": {
                     "value": ""


### PR DESCRIPTION
I don't believe it's currently possible to automate the bonus to Athletics DC against attempts to escape its grab.
Tried:
```
{
	"key": "FlatModifier",
	"predicate": [
		"action:escape"
	],
	"selector": "athletics-dc",
	"type": "circumstance",
	"value": 4
}
```
but it didn't appear to function.