### PR TITLE
Reduce duplicate fields in DamageTemplate

### DIFF
--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -1639,7 +1639,6 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
                     weapon: context.self.item,
                     actor: context.self.actor,
                     actionTraits: context.traits,
-                    domains,
                     weaponPotency,
                     context: damageContext,
                 });

--- a/src/module/actor/character/elemental-blast.ts
+++ b/src/module/actor/character/elemental-blast.ts
@@ -400,7 +400,6 @@ class ElementalBlast {
 
         const damageTemplate: SimpleDamageTemplate = {
             name: `${game.i18n.localize("PF2E.DamageRoll")}: ${item.name}`,
-            notes: [],
             traits: item.system.traits.value,
             materials: [],
             modifiers,

--- a/src/module/actor/helpers.ts
+++ b/src/module/actor/helpers.ts
@@ -572,7 +572,6 @@ function strikeFromMeleeItem(item: MeleePF2e<ActorPF2e>): NPCStrike {
             const damage = await WeaponDamagePF2e.fromNPCAttack({
                 attack: context.self.item,
                 actor: context.self.actor,
-                domains,
                 actionTraits: [attackTrait],
                 context: damageContext,
             });

--- a/src/module/item/affliction/document.ts
+++ b/src/module/item/affliction/document.ts
@@ -111,7 +111,6 @@ class AfflictionPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extend
             const template: AfflictionDamageTemplate = {
                 name: `${this.name} - ${stageLabel}`,
                 damage: { roll, breakdown },
-                notes: [],
                 materials: [],
                 traits: this.system.traits.value,
                 modifiers: [],

--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -367,7 +367,6 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
         const template: SpellDamageTemplate = {
             name: this.name,
             damage: { roll, breakdown },
-            notes: [],
             materials: roll.materials,
             traits: this.castingTraits,
             modifiers,

--- a/src/module/system/damage/damage.ts
+++ b/src/module/system/damage/damage.ts
@@ -157,7 +157,8 @@ export class DamagePF2e {
         const syntheticNotes = context.self?.actor
             ? extractNotes(context.self?.actor.synthetics.rollNotes, context.domains ?? [])
             : [];
-        const notes = [...syntheticNotes, ...data.notes].filter(
+        const contextNotes = context.notes?.map((n) => (n instanceof RollNotePF2e ? n : new RollNotePF2e(n))) ?? [];
+        const notes = [...syntheticNotes, ...contextNotes].filter(
             (n) =>
                 (n.outcome.length === 0 || (outcome && n.outcome.includes(outcome))) &&
                 n.predicate.test(context.options)

--- a/src/module/system/damage/types.ts
+++ b/src/module/system/damage/types.ts
@@ -1,7 +1,6 @@
 import { DamageDicePF2e, ModifierPF2e } from "@actor/modifiers.ts";
 import { ResistanceType, RollTarget, StrikeSelf } from "@actor/types.ts";
 import { ZeroToTwo } from "@module/data.ts";
-import { RollNotePF2e } from "@module/notes.ts";
 import { DegreeOfSuccessString } from "@system/degree-of-success.ts";
 import { BaseRollContext } from "@system/rolls.ts";
 import { DamageRoll } from "./roll.ts";
@@ -89,7 +88,6 @@ interface WeaponBaseDamageData extends BaseDamageData {
 
 interface BaseDamageTemplate {
     name: string;
-    notes: RollNotePF2e[];
     traits: string[];
     materials: MaterialDamageEffect[];
     modifiers?: (ModifierPF2e | DamageDicePF2e)[];
@@ -97,7 +95,6 @@ interface BaseDamageTemplate {
 
 interface WeaponDamageTemplate extends BaseDamageTemplate {
     damage: ResolvedDamageFormulaData;
-    domains: string[];
 }
 
 interface SpellDamageTemplate extends BaseDamageTemplate {

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -785,7 +785,6 @@ async function augmentInlineDamageRoll(
             damage: { roll, breakdown },
             modifiers: [...modifiers, ...dice],
             traits: traits?.filter((t) => t in CONFIG.PF2E.actionTraits) ?? [],
-            notes: [],
             materials: [],
         };
 

--- a/static/templates/chat/damage/damage-modifier-dialog.hbs
+++ b/static/templates/chat/damage/damage-modifier-dialog.hbs
@@ -135,7 +135,6 @@
 
 {{#*inline "dice-row"}}
     <div class="dialog-row{{#unless dice.enabled}} disabled{{/unless}}">
-        {{log dice}}
         <span class="mod">{{dice.label}}</span>
         <div class="value" title="{{dice.typeLabel}}">
             <div class="dice-type damage color{{#if dice.damageType}} {{dice.damageType}}{{/if}}">


### PR DESCRIPTION
The DamageContext already contains domains and notes, and the code was sometimes inconsistent about which it used. The CheckRollContext and DamageRollContextFlag also has those fields, so we prioritize them for damage as well.

The context.notes sideeffect in the weapon damage calculate rubs me the wrong way, however that function already does a lot of roll option side-effects to the context, so it'll need a deeper refactor to remove that from there.