### PR TITLE
Add missing links and traits to Death Gasp

### DIFF
--- a/packs/book-of-the-dead-bestiary/relictner-eroder.json
+++ b/packs/book-of-the-dead-bestiary/relictner-eroder.json
@@ -553,7 +553,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The relictner draws in a deep breath and holds it, temporarily suspending their biological processes and becoming undead. The relictner gains the undead trait and becomes immune to bleed, death effects, disease, @UUID[Compendium.pf2e.conditionitems.Item.Paralyzed], poison, and sleep. Any such effects the relictner is currently inflicted with are suspended but take effect again once they take a breath.</p>\n<p>Death Gasp lasts as long as the relictner holds their breath (up to 12 rounds).</p>"
+                    "value": "<p>The relictner draws in a deep breath and holds it, temporarily suspending their biological processes and becoming undead. The relictner gains the undead trait and becomes immune to bleed, death effects, disease, @UUID[Compendium.pf2e.conditionitems.Item.Paralyzed], poison, and sleep. Any such effects the relictner is currently inflicted with are suspended but take effect again once they take a breath.</p>\n<p>Death Gasp lasts as long as the relictner holds their breath (up to 12 rounds).</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Item.Effect: Death Gasp]</p>"
                 },
                 "requirements": {
                     "value": ""

--- a/packs/book-of-the-dead-bestiary/shadern-immolator.json
+++ b/packs/book-of-the-dead-bestiary/shadern-immolator.json
@@ -225,7 +225,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The shadern draws in a deep breath and holds it, temporarily suspending their biological processes and becoming undead. The shadern gains the undead trait and becomes immune to bleed, death effects, disease, @UUID[Compendium.pf2e.conditionitems.Item.Paralyzed], poison, and sleep. Any such effects the shadern is currently inflicted with are suspended but take effect again once they take a breath.</p>\n<p>Death Gasp lasts as long as the shadern holds their breath (up to 8 rounds).</p>"
+                    "value": "<p>The shadern draws in a deep breath and holds it, temporarily suspending their biological processes and becoming undead. The shadern gains the undead trait and becomes immune to bleed, death effects, disease, @UUID[Compendium.pf2e.conditionitems.Item.Paralyzed], poison, and sleep. Any such effects the shadern is currently inflicted with are suspended but take effect again once they take a breath.</p>\n<p>Death Gasp lasts as long as the shadern holds their breath (up to 8 rounds).</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Item.Effect: Death Gasp]</p>"
                 },
                 "requirements": {
                     "value": ""

--- a/packs/night-of-the-gray-death-bestiary/gray-gardener-enforcer.json
+++ b/packs/night-of-the-gray-death-bestiary/gray-gardener-enforcer.json
@@ -682,7 +682,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The Gray Gardener enforcer draws in a deep breath and holds it, temporarily suspending their biological processes and becoming undead. The Gray Gardener enforcer gains the undead trait and becomes immune to bleed, death effects, disease, @UUID[Compendium.pf2e.conditionitems.Item.Paralyzed], poison, and sleep. Any such effects the Gray Gardener is currently suffering from are suspended but take effect again once they take a breath. Death Gasp lasts as long as the Gray Gardener enforcer holds their breath.</p>"
+                    "value": "<p>The Gray Gardener enforcer draws in a deep breath and holds it, temporarily suspending their biological processes and becoming undead. The Gray Gardener enforcer gains the undead trait and becomes immune to bleed, death effects, disease, @UUID[Compendium.pf2e.conditionitems.Item.Paralyzed], poison, and sleep. Any such effects the Gray Gardener is currently suffering from are suspended but take effect again once they take a breath. Death Gasp lasts as long as the Gray Gardener enforcer holds their breath.</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Item.Effect: Death Gasp]</p>"
                 },
                 "requirements": {
                     "value": ""

--- a/packs/pathfinder-bestiary-3/angheuvore-flesh-gnawer.json
+++ b/packs/pathfinder-bestiary-3/angheuvore-flesh-gnawer.json
@@ -613,7 +613,7 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p>The angheuvore draws in a deep breath and holds it, temporarily suspending their biological processes and becoming undead.</p>\n<p>The angheuvore gains the undead trait and becomes immune to bleed, death effects, disease, paralyzed, poison, and sleep. Any such effects the angheuvore is currently suffering from are suspended, but take effect again once they take a breath.</p>\n<p>Death Gasp lasts as long as the angheuvore holds their breath (up to 8 rounds).</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Item.Effect: Death Gasp]</p>"
+                    "value": "<p>The angheuvore draws in a deep breath and holds it, temporarily suspending their biological processes and becoming undead.</p>\n<p>The angheuvore gains the undead trait and becomes immune to bleed, death effects, disease, @UUID[Compendium.pf2e.conditionitems.Item.Paralyzed], poison, and sleep. Any such effects the angheuvore is currently suffering from are suspended, but take effect again once they take a breath.</p>\n<p>Death Gasp lasts as long as the angheuvore holds their breath (up to 8 rounds).</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Item.Effect: Death Gasp]</p>"
                 },
                 "requirements": {
                     "value": ""

--- a/packs/pathfinder-bestiary-3/etioling-blightmage.json
+++ b/packs/pathfinder-bestiary-3/etioling-blightmage.json
@@ -3199,19 +3199,19 @@
         },
         {
             "_id": "NWXRpTU3jhjVFz93",
-            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
             "name": "Death Gasp",
             "sort": 3400000,
             "system": {
                 "actionType": {
-                    "value": "passive"
+                    "value": "action"
                 },
                 "actions": {
-                    "value": null
+                    "value": 1
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The etioling draws in a deep breath and holds it, temporarily suspending their biological processes and becoming undead.</p>\n<p>The etioling gains the undead and incorporeal traits and becomes immune to bleed, death effects, disease, paralyzed, poison, and sleep. Any such effects the etioling is currently suffering from are suspended, but take effect again once they take a breath. They gain a fly Speed of 25 feet, resistance 10 to all damage (except force, ghost touch, or positive; double this resistance vs. non-magical) while they hold their breath.They can't cast spells during this time.</p>\n<p>Death Gasp lasts as long as the etioling blightmage holds their breath (up to 8 rounds).</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Item.Effect: Death Gasp (Etioling)]</p>"
+                    "value": "<p>The etioling draws in a deep breath and holds it, temporarily suspending their biological processes and becoming undead.</p>\n<p>The etioling gains the undead and incorporeal traits and becomes immune to bleed, death effects, disease, @UUID[Compendium.pf2e.conditionitems.Item.Paralyzed], poison, and sleep. Any such effects the etioling is currently suffering from are suspended, but take effect again once they take a breath. They gain a fly Speed of 25 feet, resistance 10 to all damage (except force, ghost touch, or positive; double this resistance vs. non-magical) while they hold their breath.They can't cast spells during this time.</p>\n<p>Death Gasp lasts as long as the etioling blightmage holds their breath (up to 8 rounds).</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Item.Effect: Death Gasp (Etioling)]</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -3223,7 +3223,10 @@
                 },
                 "traits": {
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "divine",
+                        "necromancy"
+                    ]
                 },
                 "trigger": {
                     "value": ""

--- a/packs/pathfinder-bestiary-3/gurgist-mauler.json
+++ b/packs/pathfinder-bestiary-3/gurgist-mauler.json
@@ -810,7 +810,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The gurgist draws in a deep breath and holds it, temporarily suspending their biological processes and becoming undead.</p>\n<p>The gurgist gains the undead trait and becomes immune to bleed, death effects, disease, paralyzed, poison, and sleep. Any such effects the gurgist is currently suffering from are suspended, but take effect again once they take a breath.</p>\n<p>Death Gasp lasts as long as the gurgist holds their breath (up to 9 rounds).</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Item.Effect: Death Gasp]</p>"
+                    "value": "<p>The gurgist draws in a deep breath and holds it, temporarily suspending their biological processes and becoming undead.</p>\n<p>The gurgist gains the undead trait and becomes immune to bleed, death effects, disease, @UUID[Compendium.pf2e.conditionitems.Item.Paralyzed], poison, and sleep. Any such effects the gurgist is currently suffering from are suspended, but take effect again once they take a breath.</p>\n<p>Death Gasp lasts as long as the gurgist holds their breath (up to 9 rounds).</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Item.Effect: Death Gasp]</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -822,7 +822,10 @@
                 },
                 "traits": {
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "divine",
+                        "necromancy"
+                    ]
                 },
                 "trigger": {
                     "value": ""

--- a/packs/pathfinder-bestiary-3/lifeleecher-brawler.json
+++ b/packs/pathfinder-bestiary-3/lifeleecher-brawler.json
@@ -644,7 +644,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The lifeleecher draws in a deep breath and holds it, temporarily suspending their biological processes and becoming undead.</p>\n<p>The lifeleecher gains the undead trait and becomes immune to bleed, death effects, disease, paralyzed, poison, and sleep. Any such effects the angheuvore is currently suffering from are suspended, but take effect again once they take a breath.</p>\n<p>Death Gasp lasts as long as the lifeleecher holds their breath (up to 11 rounds).</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Item.Effect: Death Gasp]</p>"
+                    "value": "<p>The lifeleecher draws in a deep breath and holds it, temporarily suspending their biological processes and becoming undead.</p>\n<p>The lifeleecher gains the undead trait and becomes immune to bleed, death effects, disease, @UUID[Compendium.pf2e.conditionitems.Item.Paralyzed], poison, and sleep. Any such effects the angheuvore is currently suffering from are suspended, but take effect again once they take a breath.</p>\n<p>Death Gasp lasts as long as the lifeleecher holds their breath (up to 11 rounds).</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Item.Effect: Death Gasp]</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -656,7 +656,10 @@
                 },
                 "traits": {
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "divine",
+                        "necromancy"
+                    ]
                 },
                 "trigger": {
                     "value": ""

--- a/packs/pfs-season-1-bestiary/iloise-5-6.json
+++ b/packs/pfs-season-1-bestiary/iloise-5-6.json
@@ -776,7 +776,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>Iloise draws in a deep breath and holds it, temporarily suspending her biological processes and becoming undead. She gains the undead trait and becomes immune to bleed, death effects, disease, paralyzed, and poison. Any such effects she is currently suffering from are suspended. Death Gasp lasts as long as she holds her breath.</p>"
+                    "value": "<p>Iloise draws in a deep breath and holds it, temporarily suspending her biological processes and becoming undead. She gains the undead trait and becomes immune to bleed, death effects, disease, @UUID[Compendium.pf2e.conditionitems.Item.Paralyzed], and poison. Any such effects she is currently suffering from are suspended. Death Gasp lasts as long as she holds her breath.</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Item.Effect: Death Gasp]</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -789,7 +789,10 @@
                 "traits": {
                     "rarity": "common",
                     "selected": {},
-                    "value": []
+                    "value": [
+                        "divine",
+                        "necromancy"
+                    ]
                 },
                 "trigger": {
                     "value": ""

--- a/packs/pfs-season-1-bestiary/iloise-5-6.json
+++ b/packs/pfs-season-1-bestiary/iloise-5-6.json
@@ -789,10 +789,7 @@
                 "traits": {
                     "rarity": "common",
                     "selected": {},
-                    "value": [
-                        "divine",
-                        "necromancy"
-                    ]
+                    "value": []
                 },
                 "trigger": {
                     "value": ""

--- a/packs/pfs-season-1-bestiary/iloise-7-8.json
+++ b/packs/pfs-season-1-bestiary/iloise-7-8.json
@@ -776,7 +776,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>Iloise draws in a deep breath and holds it, temporarily suspending her biological processes and becoming undead. She gains the undead trait and becomes immune to bleed, death effects, disease, paralyzed, and poison. Any such effects she is currently suffering from are suspended. Death Gasp lasts as long as she holds her breath.</p>"
+                    "value": "<p>Iloise draws in a deep breath and holds it, temporarily suspending her biological processes and becoming undead. She gains the undead trait and becomes immune to bleed, death effects, disease, @UUID[Compendium.pf2e.conditionitems.Item.Paralyzed], and poison. Any such effects she is currently suffering from are suspended. Death Gasp lasts as long as she holds her breath.</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Item.Effect: Death Gasp]</p>"
                 },
                 "requirements": {
                     "value": ""
@@ -789,7 +789,10 @@
                 "traits": {
                     "rarity": "common",
                     "selected": {},
-                    "value": []
+                    "value": [
+                        "divine",
+                        "necromancy"
+                    ]
                 },
                 "trigger": {
                     "value": ""

--- a/packs/pfs-season-1-bestiary/iloise-7-8.json
+++ b/packs/pfs-season-1-bestiary/iloise-7-8.json
@@ -789,10 +789,7 @@
                 "traits": {
                     "rarity": "common",
                     "selected": {},
-                    "value": [
-                        "divine",
-                        "necromancy"
-                    ]
+                    "value": []
                 },
                 "trigger": {
                     "value": ""


### PR DESCRIPTION
Also fix Etioling Blightmage's action type and count.

~~**Note:** I don't have "Pathfinder Society Scenario #1-25: Grim Symphony" to check that Iloise's ability should have the traits "divine" and "necromancy". I'm assuming it's the same as the others.~~
Iloise's ability does not have these traits.