### PR TITLE
Change combatant comparison to constructed object

### DIFF
--- a/src/module/actor/helpers.ts
+++ b/src/module/actor/helpers.ts
@@ -213,7 +213,7 @@ function createEncounterRollOptions(actor: ActorPF2e): Record<string, boolean> {
             [`encounter:threat:${threat}`, !!threat],
             [`encounter:round:${encounter.round}`, true],
             [`encounter:turn:${Number(encounter.turn) + 1}`, true],
-            ["self:participant:own-turn", encounter.combatant?.actor === actor],
+            ["self:participant:own-turn", encounter.combatant === actor.combatant],
             [`self:participant:initiative:roll:${initiativeRoll}`, true],
             [`self:participant:initiative:rank:${initiativeRank}`, true],
             [`self:participant:initiative:stat:${initiativeStatistic}`, !!initiativeStatistic],

--- a/src/module/actor/helpers.ts
+++ b/src/module/actor/helpers.ts
@@ -213,7 +213,7 @@ function createEncounterRollOptions(actor: ActorPF2e): Record<string, boolean> {
             [`encounter:threat:${threat}`, !!threat],
             [`encounter:round:${encounter.round}`, true],
             [`encounter:turn:${Number(encounter.turn) + 1}`, true],
-            ["self:participant:own-turn", encounter.combatant === actor.combatant],
+            ["self:participant:own-turn", encounter.combatant === participant],
             [`self:participant:initiative:roll:${initiativeRoll}`, true],
             [`self:participant:initiative:rank:${initiativeRank}`, true],
             [`self:participant:initiative:stat:${initiativeStatistic}`, !!initiativeStatistic],


### PR DESCRIPTION
If merged, resolves #10494

It looks like the `self:participant:own-turn` comparison in the entries array in `createEncounterRollOptions()` is comparing a constructed and not-yet-constructed actor when targeting. I quickly did a console log to see what was happening:
```js
    console.log(encounter.combatant?.actor === actor);
    console.log(encounter.combatant?.actor, actor);
```
and got
![image](https://github.com/foundryvtt/pf2e/assets/16602055/da44fe3f-c7fc-4d7d-b51d-544d9a911e2e)
The first pair (two combatants) of logs are when nothing is targeted, the second pair are when an enemy is targeted.