### PR TITLE
Add support for affliction duration and stage duration

### DIFF
--- a/src/module/apps/effects-panel.ts
+++ b/src/module/apps/effects-panel.ts
@@ -1,10 +1,10 @@
-import { AbstractEffectPF2e, AfflictionPF2e, ConditionPF2e, EffectPF2e } from "@item";
-import { EffectExpiryType } from "@item/effect/data.ts";
 import { ActorPF2e } from "@actor";
+import { AbstractEffectPF2e, AfflictionPF2e, ConditionPF2e, EffectPF2e } from "@item";
+import type { EffectExpiryType } from "@item/abstract-effect/index.ts";
+import { PersistentDialog } from "@item/condition/persistent-damage-dialog.ts";
+import type { TokenDocumentPF2e } from "@scene/token-document/document.ts";
 import { InlineRollLinks } from "@scripts/ui/inline-roll-links.ts";
 import { htmlQuery, htmlQueryAll } from "@util";
-import type { TokenDocumentPF2e } from "@scene/token-document/document.ts";
-import { PersistentDialog } from "@item/condition/persistent-damage-dialog.ts";
 
 export class EffectsPanel extends Application {
     private get token(): TokenDocumentPF2e | null {

--- a/src/module/item/abstract-effect/data.ts
+++ b/src/module/item/abstract-effect/data.ts
@@ -7,6 +7,7 @@ import type { CheckRoll } from "@system/check/index.ts";
 interface AbstractEffectSystemSource extends ItemSystemSource {
     /** Whether this effect originated from a spell */
     fromSpell?: boolean;
+    expired?: boolean;
 }
 
 interface AbstractEffectSystemData extends ItemSystemData {
@@ -86,16 +87,25 @@ type EffectBadgeSource = EffectBadgeCounterSource | EffectBadgeValueSource | Eff
 type EffectBadge = EffectBadgeCounter | EffectBadgeValue | EffectBadgeFormula;
 
 type TimeUnit = "rounds" | "minutes" | "hours" | "days";
+type EffectExpiryType = "turn-start" | "turn-end";
+
+interface DurationData {
+    value: number;
+    unit: TimeUnit | "unlimited" | "encounter";
+    expiry: EffectExpiryType | null;
+}
 
 export type {
     AbstractEffectSystemData,
     AbstractEffectSystemSource,
+    DurationData,
     EffectAuraData,
     EffectBadge,
     EffectBadgeFormulaSource,
     EffectBadgeSource,
     EffectBadgeValueSource,
     EffectContextData,
+    EffectExpiryType,
     EffectTrait,
     EffectTraits,
     TimeUnit,

--- a/src/module/item/abstract-effect/document.ts
+++ b/src/module/item/abstract-effect/document.ts
@@ -8,6 +8,8 @@ import { TokenDocumentPF2e } from "@scene/index.ts";
 import { ErrorPF2e, sluggify } from "@util";
 import { EffectBadge } from "./data.ts";
 import type { UserPF2e } from "@module/user/document.ts";
+import { DURATION_UNITS } from "./values.ts";
+import { calculateRemainingDuration } from "./helpers.ts";
 
 /** Base effect type for all PF2e effects including conditions and afflictions */
 abstract class AbstractEffectPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends ItemPF2e<TParent> {
@@ -50,6 +52,19 @@ abstract class AbstractEffectPF2e<TParent extends ActorPF2e | null = ActorPF2e |
     /** Whether this effect originated from a spell */
     get fromSpell(): boolean {
         return this.system.fromSpell;
+    }
+
+    get totalDuration(): number {
+        const { duration } = this.system;
+        if (["unlimited", "encounter"].includes(duration.unit)) {
+            return Infinity;
+        } else {
+            return duration.value * (DURATION_UNITS[duration.unit] ?? 0);
+        }
+    }
+
+    get remainingDuration(): { expired: boolean; remaining: number } {
+        return calculateRemainingDuration(this, this.system.duration);
     }
 
     override getRollOptions(prefix = this.type): string[] {

--- a/src/module/item/abstract-effect/helpers.ts
+++ b/src/module/item/abstract-effect/helpers.ts
@@ -1,0 +1,40 @@
+import { DurationData } from "./data.ts";
+import type { AbstractEffectPF2e } from "./document.ts";
+import { DURATION_UNITS } from "./values.ts";
+
+export function calculateRemainingDuration(
+    effect: AbstractEffectPF2e,
+    durationData: DurationData | { unit: "unlimited" }
+): { expired: boolean; remaining: number } {
+    if (durationData.unit === "encounter") {
+        const isExpired = effect.system.expired;
+        return { expired: !!isExpired, remaining: isExpired ? 0 : Infinity };
+    } else if (durationData.unit === "unlimited" || !("start" in effect.system)) {
+        return { expired: false, remaining: Infinity };
+    }
+
+    const start = effect.system.start.value;
+    const { combatant } = game.combat ?? {};
+    const { unit, expiry } = durationData;
+
+    const duration = durationData.value * (DURATION_UNITS[durationData.unit] ?? 0);
+
+    // Prevent effects that expire at end of current turn from expiring immediately outside of encounters
+    const addend = !combatant && duration === 0 && unit === "rounds" && expiry === "turn-end" ? 1 : 0;
+    const remaining = start + duration + addend - game.time.worldTime;
+    const result = { remaining, expired: remaining <= 0 };
+
+    if (remaining === 0 && combatant?.actor) {
+        const startInitiative = effect.system.start.initiative ?? 0;
+        const currentInitiative = combatant.initiative ?? 0;
+
+        // A familiar won't be represented in the encounter tracker: use the master in its place
+        const fightyActor = effect.actor?.isOfType("familiar") ? effect.actor.master ?? effect.actor : effect.actor;
+        const isEffectTurnStart =
+            startInitiative === currentInitiative && combatant.actor === (effect.origin ?? fightyActor);
+
+        result.expired = isEffectTurnStart ? expiry === "turn-start" : currentInitiative < startInitiative;
+    }
+
+    return result;
+}

--- a/src/module/item/affliction/data.ts
+++ b/src/module/item/affliction/data.ts
@@ -2,6 +2,7 @@ import { SaveType } from "@actor/types.ts";
 import {
     AbstractEffectSystemData,
     AbstractEffectSystemSource,
+    DurationData,
     EffectAuraData,
     EffectContextData,
     EffectTraits,
@@ -31,7 +32,7 @@ interface AfflictionSystemSource extends AbstractEffectSystemSource {
     stage: number;
     stages: Record<string, AfflictionStageData>;
     onset?: AfflictionOnset;
-    duration: AfflictionDuration;
+    duration: DurationData;
     start: {
         value: number;
         initiative: number | null;
@@ -59,12 +60,7 @@ interface AfflictionStageData {
     damage: Record<string, AfflictionDamage>;
     conditions: Record<string, AfflictionConditionData>;
     effects: AfflictionEffectData[];
-}
-
-interface AfflictionDuration {
-    value: number;
-    unit: TimeUnit | "unlimited";
-    expiry: AfflictionExpiryType | null;
+    duration: Omit<DurationData, "expiry">;
 }
 
 interface AfflictionConditionData {
@@ -82,7 +78,6 @@ type AfflictionExpiryType = "turn-end";
 
 export type {
     AfflictionExpiryType,
-    AfflictionDuration,
     AfflictionConditionData,
     AfflictionDamage,
     AfflictionFlags,

--- a/src/module/item/affliction/document.ts
+++ b/src/module/item/affliction/document.ts
@@ -11,7 +11,8 @@ import { DamageRoll } from "@system/damage/roll.ts";
 import { DegreeOfSuccess } from "@system/degree-of-success.ts";
 import { ErrorPF2e } from "@util";
 import * as R from "remeda";
-import { AfflictionFlags, AfflictionSource, AfflictionSystemData } from "./data.ts";
+import { AfflictionFlags, AfflictionSource, AfflictionStageData, AfflictionSystemData } from "./data.ts";
+import { calculateRemainingDuration } from "@item/abstract-effect/helpers.ts";
 
 /** Condition types that don't need a duration to eventually disappear. These remain even when the affliction ends */
 const EXPIRING_CONDITIONS: Set<ConditionSlug> = new Set([
@@ -45,6 +46,10 @@ class AfflictionPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extend
         return this.system.stage;
     }
 
+    get stageData(): AfflictionStageData | null {
+        return Object.values(this.system.stages).at(this.stage - 1) ?? null;
+    }
+
     get maxStage(): number {
         return Object.keys(this.system.stages).length || 1;
     }
@@ -71,6 +76,11 @@ class AfflictionPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extend
             return 0;
         }
         return this.system.onset.value * (DURATION_UNITS[this.system.onset.unit] ?? 0);
+    }
+
+    get remainingStageDuration(): { expired: boolean; remaining: number } {
+        const stageDuration = this.stageData?.duration ?? { unit: "unlimited" };
+        return calculateRemainingDuration(this, { ...stageDuration, expiry: "turn-end" });
     }
 
     override prepareBaseData(): void {
@@ -143,7 +153,7 @@ class AfflictionPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extend
         const itemsToDelete = this.getLinkedItems().map((i) => i.id);
         await actor.deleteEmbeddedDocuments("Item", itemsToDelete);
 
-        const currentStage = Object.values(this.system.stages).at(this.stage - 1);
+        const currentStage = this.stageData;
         if (!currentStage) return;
 
         // Get all conditions we need to add or update
@@ -223,9 +233,6 @@ class AfflictionPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extend
     async createStageMessage(): Promise<void> {
         const actor = this.actor;
         if (!actor) return;
-
-        const currentStage = Object.values(this.system.stages).at(this.stage - 1);
-        if (!currentStage) return;
 
         const damage = this.getStageDamage(this.stage);
         if (damage) {

--- a/src/module/item/affliction/sheet.ts
+++ b/src/module/item/affliction/sheet.ts
@@ -83,6 +83,10 @@ class AfflictionSheetPF2e extends ItemSheetPF2e<AfflictionPF2e> {
                 damage: {},
                 conditions: {},
                 effects: [],
+                duration: {
+                    value: -1,
+                    unit: "unlimited",
+                },
             };
 
             const id = randomID();

--- a/src/module/item/condition/data.ts
+++ b/src/module/item/condition/data.ts
@@ -1,4 +1,4 @@
-import { AbstractEffectSystemData, AbstractEffectSystemSource } from "@item/abstract-effect/data.ts";
+import { AbstractEffectSystemData, AbstractEffectSystemSource, DurationData } from "@item/abstract-effect/data.ts";
 import { BaseItemSourcePF2e, OtherTagsOnly } from "@item/data/base.ts";
 import { DamageType } from "@system/damage/index.ts";
 import type { DamageRoll } from "@system/damage/roll.ts";
@@ -37,6 +37,7 @@ interface ConditionSystemData
     extends Omit<ConditionSystemSource, "fromSpell">,
         Omit<AbstractEffectSystemData, "level" | "slug" | "traits"> {
     persistent?: PersistentDamageData;
+    duration: DurationData;
 }
 
 interface PersistentDamageData extends PersistentSourceData {

--- a/src/module/item/condition/document.ts
+++ b/src/module/item/condition/document.ts
@@ -168,6 +168,11 @@ class ConditionPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends
 
         const systemData = this.system;
         systemData.value.value = systemData.value.isValued ? Number(systemData.value.value) || 1 : null;
+        systemData.duration = mergeObject(systemData.duration, {
+            value: -1,
+            unit: "unlimited",
+            expiry: null,
+        });
 
         // Append numeric badge value to condition name, set item image according to configured style
         if (typeof this.badge?.value === "number") {

--- a/src/module/item/effect/data.ts
+++ b/src/module/item/effect/data.ts
@@ -1,12 +1,12 @@
 import {
     AbstractEffectSystemData,
     AbstractEffectSystemSource,
+    DurationData,
     EffectAuraData,
     EffectBadge,
     EffectBadgeSource,
     EffectContextData,
     EffectTraits,
-    TimeUnit,
 } from "@item/abstract-effect/index.ts";
 import { BaseItemSourcePF2e, ItemFlagsPF2e } from "@item/data/base.ts";
 
@@ -27,17 +27,13 @@ interface EffectSystemSource extends AbstractEffectSystemSource {
         value: number;
         initiative: number | null;
     };
-    duration: {
-        value: number;
-        unit: TimeUnit | "unlimited" | "encounter";
+    duration: DurationData & {
         sustained: boolean;
-        expiry: EffectExpiryType | null;
     };
     tokenIcon: {
         show: boolean;
     };
     unidentified: boolean;
-    expired?: boolean;
     /** A numeric value or dice expression of some rules significance to the effect */
     badge: EffectBadgeSource | null;
     /** Origin, target, and roll context of the action that spawned this effect */
@@ -50,6 +46,4 @@ interface EffectSystemData extends Omit<EffectSystemSource, "fromSpell">, Omit<A
     remaining: string;
 }
 
-type EffectExpiryType = "turn-start" | "turn-end";
-
-export type { EffectExpiryType, EffectFlags, EffectSource, EffectSystemData };
+export type { EffectFlags, EffectSource, EffectSystemData };

--- a/static/template.json
+++ b/static/template.json
@@ -578,7 +578,8 @@
             ],
             "duration": {
                 "value": -1,
-                "unit": "unlimited"
+                "unit": "unlimited",
+                "expiry": null
             },
             "save": {
                 "type": "fortitude",
@@ -1185,7 +1186,9 @@
             ],
             "group": null,
             "duration": {
-                "value": 0
+                "value": -1,
+                "unit": "unlimited",
+                "expiry": null
             },
             "value": {
                 "isValued": false,
@@ -1209,8 +1212,8 @@
             "duration": {
                 "value": -1,
                 "unit": "unlimited",
-                "sustained": false,
-                "expiry": "turn-start"
+                "expiry": null,
+                "sustained": false
             },
             "start": {
                 "value": 0,

--- a/static/templates/items/affliction-details.hbs
+++ b/static/templates/items/affliction-details.hbs
@@ -106,6 +106,11 @@
                 </ul>
             {{/if}}
         </section>
+
+        <div class="form-group">
+            <h3>{{localize "PF2E.Time.Duration"}}</h3>
+            {{> systems/pf2e/templates/items/partials/duration.hbs base=(concat "system.stages." stageId ".duration") duration=stage.duration units=../durationUnits}}
+        </div>
     </ol>
 {{/each}}
 


### PR DESCRIPTION
This is similar to the inheritance parts of https://github.com/foundryvtt/pf2e/pull/9108 but since conditions also require durations in a later date (stunned for 1 round...) I put most of it in the base class.

This needs some UI in the effect panel, but testing in the console appears to function correctly.