### PR TITLE
Remove usage of `form-group-stacked` and `details-container-flex-row`

### DIFF
--- a/src/styles/item/_index.scss
+++ b/src/styles/item/_index.scss
@@ -481,9 +481,7 @@
             grid-template-columns: 1fr 1fr 1fr;
         }
 
-        .details-container-flex-row {
-            align-items: center;
-            display: flex;
+        .form-fields {
             justify-content: space-between;
 
             & > label {

--- a/src/styles/item/_spell-sheet.scss
+++ b/src/styles/item/_spell-sheet.scss
@@ -1,7 +1,7 @@
 .damage-formulas {
     margin-top: 8px;
 
-    .details-container-flex-row {
+    .form-fields {
         gap: 2px;
         margin-top: 4px;
     }

--- a/static/templates/items/activation-panel.hbs
+++ b/static/templates/items/activation-panel.hbs
@@ -14,7 +14,7 @@
                 </div>
             </header>
 
-            <div class="details-container-flex-row spell-components">
+            <div class="form-fields spell-components">
                 <label>
                     <input type="checkbox" name="{{base}}.components.command" {{checked action.components.command}} data-dtype="Boolean"/>
                     <span>{{localize "PF2E.Item.Activation.CommandSheetLabel"}}</span>
@@ -33,8 +33,8 @@
                 </label>
             </div>
 
-            <div class="details-container-flex-row">
-                <div class="details-container-flex-row activation-time">
+            <div class="form-fields">
+                <div class="form-fields activation-time">
                     <select name="{{base}}.actionCost.type" data-dtype="String">
                         {{#select action.actionCost.type}}
                             {{#each @root.actionTypes as |name type|}}
@@ -54,7 +54,7 @@
                 </div>
 
                 {{#if action.frequency}}
-                    <div class="details-container-flex-row frequency">
+                    <div class="form-fields frequency">
                         <input type="number" name="{{base}}.frequency.max" value="{{action.frequency.max}}" data-dtype="Number"/>
                         <span>{{localize "PF2E.Frequency.per"}}</span>
                         <select name="{{base}}.frequency.per" data-dtype="String">

--- a/static/templates/items/affliction-details.hbs
+++ b/static/templates/items/affliction-details.hbs
@@ -1,7 +1,7 @@
 <ol class="form-list">
     <div class="form-group">
         <label>{{localize "PF2E.Item.Affliction.SaveLabel"}}</label>
-        <div class="details-container-flex-row">
+        <div class="form-fields">
             <input type="number" name="system.save.value" value="{{data.save.value}}">
             <select name="system.save.type">
                 {{#select data.save.type}}
@@ -33,7 +33,7 @@
 
             {{#each stage.damage as |damage id|}}
                 <div class="formula-section">
-                    <div class="details-container-flex-row">
+                    <div class="form-fields">
                         <input type="text" name="system.stages.{{stageId}}.damage.{{id}}.formula" value="{{damage.formula}}" placeholder="{{localize "PF2E.FormulaPlaceholder"}}" />
                         <select name="system.stages.{{stageId}}.damage.{{id}}.category">
                             {{#select damage.category}}

--- a/static/templates/items/ancestry-details.hbs
+++ b/static/templates/items/ancestry-details.hbs
@@ -85,7 +85,7 @@
 </ul>
 {{~/inline~}}
 
-<div class="form-group-stacked item-ref-group" data-valid-drops="ancestryfeature">
+<div class="form-group stacked item-ref-group" data-valid-drops="ancestryfeature">
     <label for="data.traits">
         {{localize "PF2E.AncestryFeatures"}}
     </label>

--- a/static/templates/items/armor-details.hbs
+++ b/static/templates/items/armor-details.hbs
@@ -198,7 +198,7 @@
     <input type="number"{{#if (gt item.hardness item._source.system.hardness)}} class="adjusted-higher"{{else if (lt item.hardness item._source.system.hardness)}} class="adjusted-lower"{{/if}} data-property="system.hardness" data-value-base="{{item._source.system.hardness}}" value="{{item.hardness}}" />
 </div>
 
-<div class="form-group-stacked">
+<div class="form-group stacked">
     <label>
         {{localize "PF2E.Item.Physical.OtherTags.Label"}}
         <i class="fa-solid fa-info-circle" data-action="hint-tooltip" title="PF2E.Item.Physical.OtherTags.Hint"></i>

--- a/static/templates/items/background-details.hbs
+++ b/static/templates/items/background-details.hbs
@@ -50,7 +50,7 @@
     </ul>
 {{~/inline~}}
 
-<div class="form-group-stacked item-ref-group" data-valid-drops="skill">
+<div class="form-group stacked item-ref-group" data-valid-drops="skill">
     <label for="data.traits">
         {{localize "PF2E.BackgroundSkillFeats"}}
     </label>

--- a/static/templates/items/campaign-feature-details.hbs
+++ b/static/templates/items/campaign-feature-details.hbs
@@ -1,6 +1,6 @@
 {{> "systems/pf2e/templates/items/partials/ability-activation.hbs"}}
 
-<div class="form-group-stacked tags">
+<div class="form-group stacked">
     <label>{{localize "PF2E.FeatPrereqLabel"}}</label>
     <input class="pf2e-tagify" type="text" name="system.prerequisites.value" value="{{prerequisites}}" data-dtype="JSON" />
 </div>

--- a/static/templates/items/class-details.hbs
+++ b/static/templates/items/class-details.hbs
@@ -261,7 +261,7 @@
     </ul>
 </div>
 
-<div class="form-group-stacked item-ref-group" data-valid-drops="classfeature">
+<div class="form-group stacked item-ref-group" data-valid-drops="classfeature">
     <label for="data.traits">{{localize "PF2E.ClassFeatures"}}</label>
     {{#> abcItems}}{{/abcItems}}
     {{#unless data.items}}{{localize PF2E.DragDropFeats}}{{/unless}}

--- a/static/templates/items/consumable-details.hbs
+++ b/static/templates/items/consumable-details.hbs
@@ -19,7 +19,7 @@
     <input type="checkbox" name="system.autoDestroy.value" {{checked data.autoDestroy.value}} />
 </div>
 
-<div class="form-group-stacked">
+<div class="form-group stacked">
     <label>
         {{localize "PF2E.Item.Physical.OtherTags.Label"}}
         <i class="fa-solid fa-info-circle" data-action="hint-tooltip" title="PF2E.Item.Physical.OtherTags.Hint"></i>

--- a/static/templates/items/effect-sidebar.hbs
+++ b/static/templates/items/effect-sidebar.hbs
@@ -80,7 +80,7 @@
             <h4>{{localize "PF2E.Item.Effect.Badge.Labels.Label" type=badgeType}}</h4>
         {{/if}}
         {{#each data.badge.labels as |label idx|}}
-            <div class="badge-label-row details-container-flex-row">
+            <div class="badge-label-row form-fields">
                 {{#unless (eq @root.data.badge.type "formula")}}
                     <label>
                         <input

--- a/static/templates/items/equipment-details.hbs
+++ b/static/templates/items/equipment-details.hbs
@@ -1,7 +1,7 @@
 {{#if isApex}}
     <div class="form-group">
         <label>{{localize "PF2E.Actor.Character.Attribute.Apex"}}</label>
-        <div class="details-container-flex-row">
+        <div class="form-fields">
             <select name="system.apex.attribute">
                 {{#select item.system.apex.attribute}}
                     {{#each attributes as |label slug|}}

--- a/static/templates/items/kit-details.hbs
+++ b/static/templates/items/kit-details.hbs
@@ -1,4 +1,4 @@
-<div class="form-group-stacked kit-list">
+<div class="form-group stacked kit-list">
     <label for="system.traits">{{localize "PF2E.KitItems"}}</label>
     {{#> kitItems @root}}system.{{/kitItems}}
 </div>

--- a/static/templates/items/melee-details.hbs
+++ b/static/templates/items/melee-details.hbs
@@ -43,7 +43,7 @@
     </li>
 </ol>
 
-<div class="form-group-stacked">
+<div class="form-group stacked">
     <label>
         {{localize "PF2E.NPCWeaponAttackEffect"}}
         <a class="tag-selector" data-tag-selector="basic" data-title="PF2E.NPCWeaponAttackEffect" data-config-types="attackEffects" data-property="system.attackEffects"><i class="fas fa-edit"></i></a>

--- a/static/templates/items/partials/ability-activation.hbs
+++ b/static/templates/items/partials/ability-activation.hbs
@@ -1,6 +1,6 @@
 <div class="form-group">
     <label>{{localize "PF2E.ActionActionsLabel"}}</label>
-    <div class="details-container-flex-row">
+    <div class="form-fields">
         <select name="system.actionType.value" data-dtype="String">
             {{#select data.actionType.value}}
                 {{#each actionTypes as |name type|}}

--- a/static/templates/items/rules/grant-item.hbs
+++ b/static/templates/items/rules/grant-item.hbs
@@ -1,4 +1,4 @@
-<div class="details-container-flex-row">
+<div class="form-fields">
     <label>
         {{localize "PF2E.RuleEditor.GrantItem.AllowDuplicate"}}
         <input type="checkbox" name="system.rules.{{index}}.allowDuplicate" {{checked rule.allowDuplicate}}>

--- a/static/templates/items/spell-details.hbs
+++ b/static/templates/items/spell-details.hbs
@@ -33,7 +33,7 @@
 
     <div class="form-group">
         <label class="short">{{localize "PF2E.SpellComponentsLabel"}}</label>
-        <div class="details-container-flex-row spell-components">
+        <div class="form-fields spell-components">
             <label>
                 <input type="checkbox" name="system.components.focus" {{checked data.components.focus}} />
                 <span>{{localize "PF2E.SpellComponentShortF"}}</span>
@@ -170,7 +170,7 @@
 
         {{#each data.damage.value as |damage id|}}
             <div class="formula-section">
-                <div class="details-container-flex-row">
+                <div class="form-fields">
                     <input type="text" name="system.damage.value.{{id}}.value" value="{{damage.value}}" placeholder="{{localize "PF2E.FormulaPlaceholder"}}" />
                     <label>
                         <span>&nbsp;{{localize "PF2E.SpellAbilityModLabel"}}</span>

--- a/static/templates/items/spell-overlay.hbs
+++ b/static/templates/items/spell-overlay.hbs
@@ -2,7 +2,7 @@
     {{#if (eq type "heighten")}}
         <h3 class="form-group">
             <label>{{localize "PF2E.SpellScalingOverlay.Label"}}</label>
-            <div class="details-container-flex-row">
+            <div class="form-fields">
                 <select data-action="change-level">
                     {{#select level}}
                         {{#each heightenLevels as |key|}}
@@ -18,7 +18,7 @@
     {{else}}
         <div class="form-group">
             <label>{{localize "PF2E.Item.NameLabel"}}</label>
-            <div class="details-container-flex-row">
+            <div class="form-fields">
                 <input type="text" name="{{base}}.name" value="{{overlay.name}}" />
                 <div class="item-controls">
                     <a data-action="overlay-delete" title="{{localize "PF2E.DeleteItemTitle"}}"><i class="fas fa-trash"></i></a>
@@ -54,7 +54,7 @@
                 <a data-action="overlay-remove-property" data-property="components"><i class="fa fa-times" ></i></a>
                 {{localize "PF2E.SpellComponentsLabel"}}
             </label>
-            <div class="details-container-flex-row spell-components">
+            <div class="form-fields spell-components">
                 <label>
                     <input type="checkbox" name="{{dataPath}}.components.focus" {{checked system.components.focus}} />
                     <span>{{localize "PF2E.SpellComponentShortF"}}</span>
@@ -138,7 +138,7 @@
 
             {{#each system.damage.value as |damage id|}}
                 <div class="formula-section">
-                    <div class="details-container-flex-row">
+                    <div class="form-fields">
                         <input type="text" name="{{../dataPath}}.damage.value.{{id}}.value" value="{{damage.value}}" placeholder="{{localize "PF2E.FormulaPlaceholder"}}" />
                         <label>
                             <span>&nbsp;{{localize "PF2E.SpellAbilityModLabel"}}</span>

--- a/static/templates/items/weapon-details.hbs
+++ b/static/templates/items/weapon-details.hbs
@@ -364,7 +364,7 @@
                 </select>
             </div>
         </div>
-        <div class="form-group-stacked">
+        <div class="form-group">
             <label>
                 {{localize "PF2E.TraitsLabel"}}
                 <a class="tag-selector" data-tag-selector="basic" data-config-types="weaponTraits" data-property="system.meleeUsage.traits" data-no-custom="true" data-flat="true">
@@ -380,7 +380,7 @@
     </ol>
 {{/if}}
 
-<div class="form-group-stacked">
+<div class="form-group stacked">
     <label>
         {{localize "PF2E.Item.Physical.OtherTags.Label"}}
         <i class="fa-solid fa-info-circle" data-action="hint-tooltip" title="PF2E.Item.Physical.OtherTags.Hint"></i>

--- a/static/templates/system/tag-selector/basic.hbs
+++ b/static/templates/system/tag-selector/basic.hbs
@@ -16,7 +16,7 @@
         {{/each}}
     </ol>
     {{#if allowCustom}}
-    <div class="form-group-stacked trait-footer">
+    <div class="form-group stacked trait-footer">
         <label>{{localize "PF2E.SpecialLabel"}}:</label>
         <input type="text" name="custom" value="{{custom}}" />
     </div>


### PR DESCRIPTION
- `.form-group-stacked` CSS selector is moving to `.form-group.stacked` in core
- `details-container-flex-row` is most equivalent to core (and semantic) CSS class, `form-fields`: system overrides are preserved