### PR TITLE
Add workaround for `Babele` extending `ClientDatabaseBackend#_getDocuments` instead of `CONFIG.DatabaseBackend`

### DIFF
--- a/types/foundry/common/abstract/document.d.ts
+++ b/types/foundry/common/abstract/document.d.ts
@@ -26,7 +26,7 @@ export default abstract class Document<
      */
     static fromSource<T extends Document>(
         this: AbstractConstructorOf<T>,
-        source: Record<string, unknown>,
+        source: Document["_source"] | Record<string, unknown>,
         context?: DataModelConstructionOptions<null>
     ): T;
 


### PR DESCRIPTION
I've confirmed that this is an issue that prevents translation of documents from non-system packs.