### PR TITLE
Allow Thaumaturge Implements to accept homebrew

### DIFF
--- a/packs/classfeatures/amulet.json
+++ b/packs/classfeatures/amulet.json
@@ -29,6 +29,9 @@
             "value": "Pathfinder Dark Archive"
         },
         "traits": {
+            "otherTags": [
+                "thaumaturge-implement"
+            ],
             "rarity": "common",
             "value": [
                 "thaumaturge"

--- a/packs/classfeatures/bell.json
+++ b/packs/classfeatures/bell.json
@@ -29,6 +29,9 @@
             "value": "Pathfinder Dark Archive"
         },
         "traits": {
+            "otherTags": [
+                "thaumaturge-implement"
+            ],
             "rarity": "common",
             "value": [
                 "thaumaturge"

--- a/packs/classfeatures/chalice.json
+++ b/packs/classfeatures/chalice.json
@@ -29,6 +29,9 @@
             "value": "Pathfinder Dark Archive"
         },
         "traits": {
+            "otherTags": [
+                "thaumaturge-implement"
+            ],
             "rarity": "common",
             "value": [
                 "thaumaturge"

--- a/packs/classfeatures/first-implement-and-esoterica.json
+++ b/packs/classfeatures/first-implement-and-esoterica.json
@@ -22,35 +22,11 @@
         "rules": [
             {
                 "adjustName": false,
-                "choices": [
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Amulet"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Bell"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Chalice"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Lantern"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Mirror"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Regalia"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Tome"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Wand"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Weapon"
-                    }
-                ],
+                "choices": {
+                    "filter": [
+                        "item:tag:thaumaturge-implement"
+                    ]
+                },
                 "flag": "implement",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.FirstImplement"

--- a/packs/classfeatures/implement-adept.json
+++ b/packs/classfeatures/implement-adept.json
@@ -21,7 +21,6 @@
         },
         "rules": [
             {
-                "adjustName": false,
                 "choices": {
                   "ownedItems": true,
                   "types": [

--- a/packs/classfeatures/implement-adept.json
+++ b/packs/classfeatures/implement-adept.json
@@ -22,76 +22,28 @@
         "rules": [
             {
                 "adjustName": false,
-                "choices": [
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.Amulet",
-                        "predicate": [
-                            "feature:amulet"
-                        ],
-                        "value": "amulet"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.Bell",
-                        "predicate": [
-                            "feature:bell"
-                        ],
-                        "value": "bell"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.Chalice",
-                        "predicate": [
-                            "feature:chalice"
-                        ],
-                        "value": "chalice"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.Lantern",
-                        "predicate": [
-                            "feature:lantern"
-                        ],
-                        "value": "lantern"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.Mirror",
-                        "predicate": [
-                            "feature:mirror"
-                        ],
-                        "value": "mirror"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.Regalia",
-                        "predicate": [
-                            "feature:regalia"
-                        ],
-                        "value": "regalia"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.Tome",
-                        "predicate": [
-                            "feature:tome"
-                        ],
-                        "value": "tome"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.Wand",
-                        "predicate": [
-                            "feature:wand"
-                        ],
-                        "value": "wand"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.Weapon",
-                        "predicate": [
-                            "feature:weapon"
-                        ],
-                        "value": "weapon"
-                    }
-                ],
+                "choices": {
+                  "ownedItems": true,
+                  "types": [
+                    "feat"
+                  ],
+                  "predicate": [
+                    "item:tag:thaumaturge-implement"
+                  ]
+                },
                 "flag": "implementAdept",
-                "key": "ChoiceSet",
-                "prompt": "PF2E.UI.RuleElements.ChoiceSet.Prompt",
-                "rollOption": "adept"
-            }
+                "key": "ChoiceSet"
+              },
+              {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                  "item:id:{item|flags.pf2e.rulesSelections.implementAdept}"
+                ],
+                "property": "other-tags",
+                "value": "thaumaturge-implement-adept"
+              }
         ],
         "source": {
             "value": "Pathfinder Dark Archive"

--- a/packs/classfeatures/implement-paragon.json
+++ b/packs/classfeatures/implement-paragon.json
@@ -21,7 +21,6 @@
         },
         "rules": [
             {
-                "adjustName": false,
                 "choices": {
                   "ownedItems": true,
                   "types": [

--- a/packs/classfeatures/implement-paragon.json
+++ b/packs/classfeatures/implement-paragon.json
@@ -22,85 +22,30 @@
         "rules": [
             {
                 "adjustName": false,
-                "choices": [
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.Amulet",
-                        "predicate": [
-                            "feature:amulet",
-                            "adept:amulet"
-                        ],
-                        "value": "amulet"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.Bell",
-                        "predicate": [
-                            "feature:bell",
-                            "adept:bell"
-                        ],
-                        "value": "bell"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.Chalice",
-                        "predicate": [
-                            "feature:chalice",
-                            "adept:chalice"
-                        ],
-                        "value": "chalice"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.Lantern",
-                        "predicate": [
-                            "feature:lantern",
-                            "adept:lantern"
-                        ],
-                        "value": "lantern"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.Mirror",
-                        "predicate": [
-                            "feature:mirror",
-                            "adept:mirror"
-                        ],
-                        "value": "mirror"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.Regalia",
-                        "predicate": [
-                            "feature:regalia",
-                            "adept:regalia"
-                        ],
-                        "value": "regalia"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.Tome",
-                        "predicate": [
-                            "feature:tome",
-                            "adept:tome"
-                        ],
-                        "value": "tome"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.Wand",
-                        "predicate": [
-                            "feature:wand",
-                            "adept:wand"
-                        ],
-                        "value": "wand"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.Weapon",
-                        "predicate": [
-                            "feature:weapon",
-                            "adept:weapon"
-                        ],
-                        "value": "weapon"
-                    }
-                ],
+                "choices": {
+                  "ownedItems": true,
+                  "types": [
+                    "feat"
+                  ],
+                  "predicate": [
+                    "item:tag:thaumaturge-implement",
+                    "item:tag:thaumaturge-implement-adept"
+                  ]
+                },
                 "flag": "implementParagon",
                 "key": "ChoiceSet",
-                "prompt": "PF2E.UI.RuleElements.ChoiceSet.Prompt",
-                "rollOption": "paragon"
-            }
+                "prompt": "PF2E.UI.RuleElements.ChoiceSet.Prompt"
+              },
+              {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                  "item:id:{item|flags.pf2e.rulesSelections.implementParagon}"
+                ],
+                "property": "other-tags",
+                "value": "thaumaturge-implement-paragon"
+              }
         ],
         "source": {
             "value": "Pathfinder Dark Archive"

--- a/packs/classfeatures/lantern.json
+++ b/packs/classfeatures/lantern.json
@@ -24,6 +24,9 @@
             "value": "Pathfinder Dark Archive"
         },
         "traits": {
+            "otherTags": [
+                "thaumaturge-implement"
+            ],
             "rarity": "common",
             "value": [
                 "thaumaturge"

--- a/packs/classfeatures/mirror.json
+++ b/packs/classfeatures/mirror.json
@@ -29,6 +29,9 @@
             "value": "Pathfinder Dark Archive"
         },
         "traits": {
+            "otherTags": [
+                "thaumaturge-implement"
+            ],
             "rarity": "common",
             "value": [
                 "thaumaturge"

--- a/packs/classfeatures/regalia.json
+++ b/packs/classfeatures/regalia.json
@@ -24,6 +24,9 @@
             "value": "Pathfinder Dark Archive"
         },
         "traits": {
+            "otherTags": [
+                "thaumaturge-implement"
+            ],
             "rarity": "common",
             "value": [
                 "thaumaturge"

--- a/packs/classfeatures/second-adept.json
+++ b/packs/classfeatures/second-adept.json
@@ -21,7 +21,6 @@
         },
         "rules": [
             {
-                "adjustName": false,
                 "choices": {
                   "ownedItems": true,
                   "types": [

--- a/packs/classfeatures/second-adept.json
+++ b/packs/classfeatures/second-adept.json
@@ -22,103 +22,33 @@
         "rules": [
             {
                 "adjustName": false,
-                "choices": [
+                "choices": {
+                  "ownedItems": true,
+                  "types": [
+                    "feat"
+                  ],
+                  "predicate": [
+                    "item:tag:thaumaturge-implement",
                     {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.Amulet",
-                        "predicate": [
-                            "feature:amulet",
-                            {
-                                "not": "adept:amulet"
-                            }
-                        ],
-                        "value": "amulet"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.Bell",
-                        "predicate": [
-                            "feature:bell",
-                            {
-                                "not": "adept:bell"
-                            }
-                        ],
-                        "value": "bell"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.Chalice",
-                        "predicate": [
-                            "feature:chalice",
-                            {
-                                "not": "adept:chalice"
-                            }
-                        ],
-                        "value": "chalice"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.Lantern",
-                        "predicate": [
-                            "feature:lantern",
-                            {
-                                "not": "adept:lantern"
-                            }
-                        ],
-                        "value": "lantern"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.Mirror",
-                        "predicate": [
-                            "feature:mirror",
-                            {
-                                "not": "adept:mirror"
-                            }
-                        ],
-                        "value": "mirror"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.Regalia",
-                        "predicate": [
-                            "feature:regalia",
-                            {
-                                "not": "adept:regalia"
-                            }
-                        ],
-                        "value": "regalia"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.Tome",
-                        "predicate": [
-                            "feature:tome",
-                            {
-                                "not": "adept:tome"
-                            }
-                        ],
-                        "value": "tome"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.Wand",
-                        "predicate": [
-                            "feature:wand",
-                            {
-                                "not": "adept:wand"
-                            }
-                        ],
-                        "value": "wand"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.Weapon",
-                        "predicate": [
-                            "feature:weapon",
-                            {
-                                "not": "adept:weapon"
-                            }
-                        ],
-                        "value": "weapon"
+                      "not": "item:tag:thaumaturge-implement-adept"
                     }
-                ],
+                  ]
+                },
                 "flag": "secondAdept",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.UI.RuleElements.ChoiceSet.Prompt",
                 "rollOption": "adept"
-            }
+              },
+              {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                  "item:id:{item|flags.pf2e.rulesSelections.secondAdept}"
+                ],
+                "property": "other-tags",
+                "value": "thaumaturge-implement-adept"
+              }
         ],
         "source": {
             "value": "Pathfinder Dark Archive"

--- a/packs/classfeatures/second-implement.json
+++ b/packs/classfeatures/second-implement.json
@@ -22,80 +22,11 @@
         "rules": [
             {
                 "adjustName": false,
-                "choices": [
-                    {
-                        "predicate": [
-                            {
-                                "not": "feature:amulet"
-                            }
-                        ],
-                        "value": "Compendium.pf2e.classfeatures.Item.Amulet"
-                    },
-                    {
-                        "predicate": [
-                            {
-                                "not": "feature:bell"
-                            }
-                        ],
-                        "value": "Compendium.pf2e.classfeatures.Item.Bell"
-                    },
-                    {
-                        "predicate": [
-                            {
-                                "not": "feature:chalice"
-                            }
-                        ],
-                        "value": "Compendium.pf2e.classfeatures.Item.Chalice"
-                    },
-                    {
-                        "predicate": [
-                            {
-                                "not": "feature:lantern"
-                            }
-                        ],
-                        "value": "Compendium.pf2e.classfeatures.Item.Lantern"
-                    },
-                    {
-                        "predicate": [
-                            {
-                                "not": "feature:mirror"
-                            }
-                        ],
-                        "value": "Compendium.pf2e.classfeatures.Item.Mirror"
-                    },
-                    {
-                        "predicate": [
-                            {
-                                "not": "feature:regalia"
-                            }
-                        ],
-                        "value": "Compendium.pf2e.classfeatures.Item.Regalia"
-                    },
-                    {
-                        "predicate": [
-                            {
-                                "not": "feature:tome"
-                            }
-                        ],
-                        "value": "Compendium.pf2e.classfeatures.Item.Tome"
-                    },
-                    {
-                        "predicate": [
-                            {
-                                "not": "feature:wand"
-                            }
-                        ],
-                        "value": "Compendium.pf2e.classfeatures.Item.Wand"
-                    },
-                    {
-                        "predicate": [
-                            {
-                                "not": "feature:weapon"
-                            }
-                        ],
-                        "value": "Compendium.pf2e.classfeatures.Item.Weapon"
-                    }
-                ],
+                "choices": {
+                  "filter": [
+                    "item:tag:thaumaturge-implement"
+                  ]
+                },
                 "flag": "implement",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.SecondImplement"

--- a/packs/classfeatures/third-implement.json
+++ b/packs/classfeatures/third-implement.json
@@ -22,80 +22,11 @@
         "rules": [
             {
                 "adjustName": false,
-                "choices": [
-                    {
-                        "predicate": [
-                            {
-                                "not": "feature:amulet"
-                            }
-                        ],
-                        "value": "Compendium.pf2e.classfeatures.Item.Amulet"
-                    },
-                    {
-                        "predicate": [
-                            {
-                                "not": "feature:bell"
-                            }
-                        ],
-                        "value": "Compendium.pf2e.classfeatures.Item.Bell"
-                    },
-                    {
-                        "predicate": [
-                            {
-                                "not": "feature:chalice"
-                            }
-                        ],
-                        "value": "Compendium.pf2e.classfeatures.Item.Chalice"
-                    },
-                    {
-                        "predicate": [
-                            {
-                                "not": "feature:lantern"
-                            }
-                        ],
-                        "value": "Compendium.pf2e.classfeatures.Item.Lantern"
-                    },
-                    {
-                        "predicate": [
-                            {
-                                "not": "feature:mirror"
-                            }
-                        ],
-                        "value": "Compendium.pf2e.classfeatures.Item.Mirror"
-                    },
-                    {
-                        "predicate": [
-                            {
-                                "not": "feature:regalia"
-                            }
-                        ],
-                        "value": "Compendium.pf2e.classfeatures.Item.Regalia"
-                    },
-                    {
-                        "predicate": [
-                            {
-                                "not": "feature:tome"
-                            }
-                        ],
-                        "value": "Compendium.pf2e.classfeatures.Item.Tome"
-                    },
-                    {
-                        "predicate": [
-                            {
-                                "not": "feature:wand"
-                            }
-                        ],
-                        "value": "Compendium.pf2e.classfeatures.Item.Wand"
-                    },
-                    {
-                        "predicate": [
-                            {
-                                "not": "feature:weapon"
-                            }
-                        ],
-                        "value": "Compendium.pf2e.classfeatures.Item.Weapon"
-                    }
-                ],
+                "choices": {
+                  "filter": [
+                    "item:tag:thaumaturge-implement"
+                  ]
+                },
                 "flag": "implement",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.ThirdImplement"

--- a/packs/classfeatures/tome.json
+++ b/packs/classfeatures/tome.json
@@ -24,6 +24,9 @@
             "value": "Pathfinder Dark Archive"
         },
         "traits": {
+            "otherTags": [
+                "thaumaturge-implement"
+            ],
             "rarity": "common",
             "value": [
                 "thaumaturge"

--- a/packs/classfeatures/wand.json
+++ b/packs/classfeatures/wand.json
@@ -29,6 +29,9 @@
             "value": "Pathfinder Dark Archive"
         },
         "traits": {
+            "otherTags": [
+                "thaumaturge-implement"
+            ],
             "rarity": "common",
             "value": [
                 "thaumaturge"

--- a/packs/classfeatures/weapon.json
+++ b/packs/classfeatures/weapon.json
@@ -29,6 +29,9 @@
             "value": "Pathfinder Dark Archive"
         },
         "traits": {
+            "otherTags": [
+                "thaumaturge-implement"
+            ],
             "rarity": "common",
             "value": [
                 "thaumaturge"

--- a/src/module/rules/rule-element/choice-set/rule-element.ts
+++ b/src/module/rules/rule-element/choice-set/rule-element.ts
@@ -221,7 +221,7 @@ class ChoiceSetRuleElement extends RuleElementPF2e<ChoiceSetSchema> {
      * If an array was passed, localize & sort the labels and return. If a string, look it up in CONFIG.PF2E and
      * create an array of choices.
      * @param rollOptions  A set of actor roll options to for use in predicate testing
-     * @param pendingItems Items passed to #queryCompendium for checking max takability of feats
+     * @param pendingItems Items passed to #queryCompendium for checking max takability of feats and for #choicesFromOwnedItems to refer to already selected items that are yet to be created
      * @returns The array of choices to present to the user
      */
     async inflateChoices(
@@ -232,7 +232,7 @@ class ChoiceSetRuleElement extends RuleElementPF2e<ChoiceSetSchema> {
             ? this.#choicesFromArray(this.choices, rollOptions) // Static choices from RE constructor data
             : isObject(this.choices) // ChoiceSetAttackQuery or ChoiceSetItemQuery
             ? this.choices.ownedItems
-                ? this.#choicesFromOwnedItems(this.choices, rollOptions)
+                ? this.#choicesFromOwnedItems(this.choices, rollOptions, pendingItems)
                 : this.choices.attacks || this.choices.unarmedAttacks
                 ? this.#choicesFromAttacks(
                       new PredicatePF2e(this.resolveInjectedProperties(this.choices.predicate)),
@@ -306,7 +306,11 @@ class ChoiceSetRuleElement extends RuleElementPF2e<ChoiceSetSchema> {
         return [];
     }
 
-    #choicesFromOwnedItems(options: ChoiceSetOwnedItems, actorRollOptions: Set<string>): PickableThing<string>[] {
+    #choicesFromOwnedItems(
+        options: ChoiceSetOwnedItems,
+        actorRollOptions: Set<string>,
+        pendingItems: PreCreate<ItemSourcePF2e>[]
+    ): PickableThing<string>[] {
         const { includeHandwraps, types } = options;
         const predicate = new PredicatePF2e(this.resolveInjectedProperties(options.predicate));
 
@@ -332,6 +336,24 @@ class ChoiceSetRuleElement extends RuleElementPF2e<ChoiceSetSchema> {
                     .map((h) => ({ img: h.img, label: h.name, value: "unarmed" }))
             );
         }
+
+        choices.push(
+            ...pendingItems
+                .map((source) => {
+                    return new ItemProxyPF2e(deepClone(source));
+                })
+                .filter(
+                    (i) => i.isOfType(...types) && predicate.test([...actorRollOptions, ...i.getRollOptions("item")])
+                )
+                .filter((i) => !i.isOfType("weapon") || i.category !== "unarmed")
+                .map(
+                    (i): PickableThing<string> => ({
+                        img: i.img,
+                        label: i.name,
+                        value: i.id,
+                    })
+                )
+        );
 
         return choices;
     }


### PR DESCRIPTION
As the title says.
Replaces the hardcoded ChoiceSet lists in every implement-related class feature with `other-tags` based ChoiceSet filters and ItemAlterations.

All implements now have the `thaumaturge-implement` other tag. Second and Third Implement by default will not pick the already picked implements because class features by default get a `maxTakeable` of 1. 

Adept implements get the `thaumaturge-implement-adept` other tag, and Second Adept checks for its (non-)presence.

Paragon implements get the `thaumaturge-implement-paragon` other tag.

`adept:XYZ` and `paragon:XYZ` rollOptions are thrown out as literally nothing checks for them (but could _theoretically_ be readded if I add a `RollOption` RE to every implement that forces it to add the relevant rollOption when it has the `thaumaturge-implement-adept` or `thaumaturge-implement-paragon` other tag).

**There is currently a bug that I'm unsure how to solve** where because ChoiceSets are ran first, if you set your level to a high enough point where you jump over multiple such ChoiceSets, you might have erroneous options -- for example, from level 0 to level 7, where you can correctly pick your two implements, but Implement Adept will be unable to detect them.