### PR TITLE
Use pack query for armor innovation's initial modification choice set

### DIFF
--- a/packs/classfeatures/armor-innovation.json
+++ b/packs/classfeatures/armor-innovation.json
@@ -64,43 +64,30 @@
             },
             {
                 "adjustName": false,
-                "allowedDrops": {
-                    "label": "PF2E.SpecificRule.Inventor.Modification.Initial.AllowedDrops",
-                    "predicate": [
+                "choices": {
+                    "filter": [
                         "item:level:1",
                         "item:type:feature",
-                        "item:trait:inventor"
+                        "item:trait:inventor",
+                        "item:tag:armor-innovation-modification",
+                        {
+                            "or": [
+                                "armor-innovation:power-suit",
+                                {
+                                    "not": "item:tag:power-suit-modification"
+                                }
+                            ]
+                        },
+                        {
+                            "or": [
+                                "armor-innovation:subterfuge-suit",
+                                {
+                                    "not": "item:tag:subterfuge-suit-modification"
+                                }
+                            ]
+                        }
                     ]
                 },
-                "choices": [
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Harmonic Oscillator"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Metallic Reactance"
-                    },
-                    {
-                        "predicate": [
-                            "armor-innovation:power-suit"
-                        ],
-                        "value": "Compendium.pf2e.classfeatures.Item.Muscular Exoskeleton"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Otherworldly Protection"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Phlogistonic Regulator"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Speed Boosters"
-                    },
-                    {
-                        "predicate": [
-                            "armor-innovation:subterfuge-suit"
-                        ],
-                        "value": "Compendium.pf2e.classfeatures.Item.Subtle Dampeners"
-                    }
-                ],
                 "flag": "initialModification",
                 "key": "ChoiceSet",
                 "predicate": [

--- a/packs/classfeatures/harmonic-oscillator.json
+++ b/packs/classfeatures/harmonic-oscillator.json
@@ -53,6 +53,9 @@
             "value": "Pathfinder Guns & Gears"
         },
         "traits": {
+            "otherTags": [
+                "armor-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/metallic-reactance.json
+++ b/packs/classfeatures/metallic-reactance.json
@@ -53,6 +53,9 @@
             "value": "Pathfinder Guns & Gears"
         },
         "traits": {
+            "otherTags": [
+                "armor-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/muscular-exoskeleton.json
+++ b/packs/classfeatures/muscular-exoskeleton.json
@@ -57,6 +57,10 @@
             "value": "Pathfinder Guns & Gears"
         },
         "traits": {
+            "otherTags": [
+                "armor-innovation-modification",
+                "power-suit-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/otherworldly-protection.json
+++ b/packs/classfeatures/otherworldly-protection.json
@@ -81,6 +81,9 @@
             "value": "Pathfinder Guns & Gears"
         },
         "traits": {
+            "otherTags": [
+                "armor-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/phlogistonic-regulator.json
+++ b/packs/classfeatures/phlogistonic-regulator.json
@@ -53,6 +53,9 @@
             "value": "Pathfinder Guns & Gears"
         },
         "traits": {
+            "otherTags": [
+                "armor-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/speed-boosters.json
+++ b/packs/classfeatures/speed-boosters.json
@@ -50,6 +50,9 @@
             "value": "Pathfinder Guns & Gears"
         },
         "traits": {
+            "otherTags": [
+                "armor-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/subtle-dampeners.json
+++ b/packs/classfeatures/subtle-dampeners.json
@@ -57,6 +57,10 @@
             "value": "Pathfinder Guns & Gears"
         },
         "traits": {
+            "otherTags": [
+                "armor-innovation-modification",
+                "subterfuge-suit-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/src/module/item/feat/document.ts
+++ b/src/module/item/feat/document.ts
@@ -100,7 +100,7 @@ class FeatPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
             this.system.onlyLevel1 = true;
         }
 
-        // `Infinity` stored as `null` in JSON, so change back
+        // `Infinity` is stored as `null` in JSON, so change back
         this.system.maxTakable ??= Infinity;
 
         // Feats takable only at level 1 can never be taken multiple times


### PR DESCRIPTION
Initial weapon modifications have very individual requirements for each, making this approach a little less viable.