### PR TITLE
Add metal and wood domains

### DIFF
--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1772,6 +1772,10 @@
                         "Description": "You perform the unexpected and inexplicable.",
                         "Label": "Magic"
                     },
+                    "Metal": {
+                        "Description": "You manipulate flexible, mutable metal.",
+                        "Label": "Metal"
+                    },
                     "Might": {
                         "Description": "Your physical power is bolstered by divine strength.",
                         "Label": "Might"
@@ -1899,6 +1903,10 @@
                     "Wealth": {
                         "Description": "You hold power over wealth, trade, and treasure.",
                         "Label": "Wealth"
+                    },
+                    "Wood": {
+                        "Description": "You command the indomitable power of wood.",
+                        "Label": "Wood"
                     },
                     "Wyrmkin": {
                         "Description": "You draw on the power of dragons, linnorms, and other powerful reptilian creatures.",


### PR DESCRIPTION
The deities already had these, so they clearly got dropped in the shuffle of getting RoE out.