### PR TITLE
Draft: Convert embeddd items to references in `extractPack` if possible. Restore full items on world import

### DIFF
--- a/build/extract-packs.ts
+++ b/build/extract-packs.ts
@@ -17,6 +17,11 @@ const args = argv
                 type: "boolean",
                 default: false,
             })
+            .option("convertReferences", {
+                describe: "Converts items to references if possible.",
+                type: "boolean",
+                default: false,
+            })
             .option("logWarnings", {
                 describe: "Turns on logging out warnings about extracted data.",
                 type: "boolean",

--- a/build/lib/compendium-pack.ts
+++ b/build/lib/compendium-pack.ts
@@ -34,7 +34,8 @@ function isItemSource(docSource: PackEntry): docSource is ItemSourcePF2e {
         "type" in docSource &&
         isObject(docSource.system) &&
         !("text" in docSource) && // JournalEntryPage
-        !isActorSource(docSource)
+        !isActorSource(docSource) &&
+        !isItemReference(docSource)
     );
 }
 

--- a/build/lib/helpers.ts
+++ b/build/lib/helpers.ts
@@ -20,4 +20,25 @@ const getFilesRecursively = (directory: string, filePaths: string[] = []): strin
     return filePaths;
 };
 
-export { getFilesRecursively, PackError };
+const deepClone = <T>(original: T): T => {
+    // Simple types
+    if (typeof original !== "object" || original === null) return original;
+
+    // Arrays
+    if (Array.isArray(original)) return original.map(deepClone) as unknown as T;
+
+    // Dates
+    if (original instanceof Date) return new Date(original) as T & Date;
+
+    // Unsupported advanced objects
+    if ("constructor" in original && (original as { constructor?: unknown })["constructor"] !== Object) return original;
+
+    // Other objects
+    const clone: Record<string, unknown> = {};
+    for (const k of Object.keys(original)) {
+        clone[k] = deepClone((original as Record<string, unknown>)[k]);
+    }
+    return clone as T;
+};
+
+export { deepClone, getFilesRecursively, PackError };

--- a/build/lib/item-references.ts
+++ b/build/lib/item-references.ts
@@ -1,0 +1,203 @@
+import fs from "fs";
+import path from "path";
+import * as R from "remeda";
+import systemJSON from "../../static/system.json" assert { type: "json" };
+import type { ActorSourcePF2e } from "@actor/data/index.ts";
+import { isPhysicalData, type ItemSourcePF2e, type PhysicalItemSource } from "@item/data/index.ts";
+import type { ItemReferenceSource, PhyiscalItemReferenceSource, SpellReferenceSource } from "@item/data/base.ts";
+import type { SpellSource } from "@item/spell/data.ts";
+import { sluggify } from "@util";
+import { deepClone } from "./helpers.ts";
+import { CompendiumPack } from "./compendium-pack.ts";
+import { PackEntry } from "./types.ts";
+
+class ItemReferences {
+    #metadata: CompendiumMetadata[];
+    #idNameMap: Map<string, Map<string, string>>;
+    /** Only exists while extracting */
+    #convertUUIDs?: ItemReferencesOptions["convertUUIDs"];
+
+    static #itemCache = new Map<string, ItemSourcePF2e>();
+
+    constructor({ idNameMap, convertUUIDs }: ItemReferencesOptions) {
+        this.#metadata = systemJSON.packs as unknown as CompendiumMetadata[];
+        this.#idNameMap = idNameMap;
+        this.#convertUUIDs = convertUUIDs;
+    }
+
+    /** Replaces actor items with item references if possible */
+    toReferences(items: ItemSourcePF2e[]): ItemSourcePF2e[] {
+        for (let i = 0; i < items.length; i++) {
+            const source = deepClone(items[i]);
+            switch (source.type) {
+                case "armor":
+                case "backpack":
+                case "book":
+                case "consumable":
+                case "equipment":
+                case "treasure":
+                case "weapon": {
+                    const reference = this.#convertPhysicalItem(source);
+                    if (reference) {
+                        (items as (ItemSourcePF2e | ItemReferenceSource)[])[i] = reference;
+                    }
+                    break;
+                }
+                case "spell": {
+                    const reference = this.#convertSpell(source);
+                    if (reference) {
+                        (items as (ItemSourcePF2e | ItemReferenceSource)[])[i] = reference;
+                    }
+                    break;
+                }
+            }
+        }
+        return items;
+    }
+
+    /** Move reference data to an actor flag during build to get it past DataModel validation */
+    moveToFlag(actorSource: ActorSourcePF2e, reference: ItemReferenceSource): void {
+        reference.flags = { pf2e: { fromReference: true } };
+        reference.sourceId = CompendiumPack.convertUUID(reference.sourceId, { to: "id", map: this.#idNameMap });
+
+        if (!actorSource.flags) {
+            actorSource.flags = { pf2e: { itemReferences: [reference] } };
+        } else if (!actorSource.flags.pf2e) {
+            actorSource.flags.pf2e = { itemReferences: [reference] };
+        } else if (!actorSource.flags.pf2e.itemReferences) {
+            actorSource.flags.pf2e.itemReferences = [reference];
+        } else {
+            actorSource.flags.pf2e.itemReferences.push(reference);
+        }
+    }
+
+    #convertPhysicalItem(source: PhysicalItemSource): PhyiscalItemReferenceSource | null {
+        const sourceId = this.#convertIdToName(source.flags?.core?.sourceId);
+        if (sourceId && this.#canConvert(source, sourceId)) {
+            const reference: PhyiscalItemReferenceSource = {
+                _id: source._id,
+                sort: source.sort,
+                sourceId,
+                system: {
+                    equipped: source.system.equipped,
+                    quantity: source.system.quantity,
+                    usage: source.system.usage,
+                },
+                type: source.type,
+            };
+            if (source.system.containerId) {
+                reference.system.containerId = source.system.containerId;
+            }
+            return reference;
+        }
+        return null;
+    }
+
+    #convertSpell(source: SpellSource): SpellReferenceSource | null {
+        const sourceId = this.#convertIdToName(source.flags?.core?.sourceId);
+        if (sourceId && this.#canConvert(source, sourceId)) {
+            return {
+                _id: source._id,
+                sort: source.sort,
+                sourceId,
+                system: {
+                    location: source.system.location,
+                },
+                type: "spell",
+            };
+        }
+        return null;
+    }
+
+    /** Determine wether an item source an its pack source are similar enough to create a reference */
+    #canConvert(originalSource: ItemSourcePF2e, packSourceId: ItemUUID): boolean {
+        const packSource = this.#getPackSource(packSourceId);
+        if (!packSource) return false;
+        const cloned = deepClone(originalSource);
+        // Delete slug here to avoid warnings from convertUUIDs
+        if (cloned.system.slug) {
+            delete (cloned.system as { slug: unknown }).slug;
+        }
+        const { pack } = this.#parseUUID(cloned.flags?.core?.sourceId);
+        const cleanedSource = this.#convertUUIDs?.(cloned, pack) as ItemSourcePF2e;
+        if (!cleanedSource) return false;
+
+        // Prepare general values
+        packSource._id = cleanedSource._id;
+        packSource.img = cleanedSource.img;
+
+        // Physical item values
+        if (isPhysicalData(cleanedSource) && isPhysicalData(packSource)) {
+            this.#equalizePhysicalItems(cleanedSource, packSource);
+        }
+
+        // Spell values
+        if (cleanedSource.type === "spell" && packSource.type === "spell") {
+            if (!cleanedSource.system.overlays) {
+                delete packSource.system.overlays;
+            }
+        }
+
+        return R.equals(cleanedSource, packSource);
+    }
+
+    #equalizePhysicalItems(source: PhysicalItemSource, packSource: PhysicalItemSource): void {
+        // Base values
+        packSource.system.containerId = source.system.containerId;
+        packSource.system.quantity = source.system.quantity;
+        packSource.system.usage = source.system.usage;
+
+        if (source.type === "weapon" && packSource.type === "weapon") {
+            const { system } = source;
+            // Can be an empty string or null
+            if (!system.strikingRune.value) {
+                packSource.system.strikingRune = system.strikingRune;
+            }
+            // Can be an empty string or null
+            if (!system.potencyRune.value) {
+                packSource.system.potencyRune = system.potencyRune;
+            }
+            // Can be an empty string or null
+            for (const index of ["1", "2", "3", "4"] as const) {
+                const propertyRune = system[`propertyRune${index}`];
+                if (!propertyRune.value) {
+                    packSource.system[`propertyRune${index}`] = propertyRune;
+                }
+            }
+        }
+    }
+
+    #getPackSource(sourceId: ItemUUID): ItemSourcePF2e | null {
+        if (!sourceId) return null;
+
+        if (ItemReferences.#itemCache.has(sourceId)) {
+            return deepClone(ItemReferences.#itemCache.get(sourceId)!);
+        }
+        const parsed = this.#parseUUID(sourceId);
+        const metadata = this.#metadata.find((p) => p.name === parsed.pack);
+        if (!metadata) return null;
+        const itemPath = path.resolve(metadata.path, sluggify(parsed.item).concat(".json"));
+        if (!fs.existsSync(itemPath)) return null;
+
+        const packSource = JSON.parse(fs.readFileSync(itemPath, { encoding: "utf-8" }));
+        ItemReferences.#itemCache.set(sourceId, packSource);
+        return deepClone(packSource);
+    }
+
+    #convertIdToName(uuid?: ItemUUID): ItemUUID | null {
+        if (!uuid?.startsWith("Compendium.")) return null;
+        return CompendiumPack.convertUUID(uuid, { to: "name", map: this.#idNameMap });
+    }
+
+    #parseUUID(uuid?: ItemUUID): { pack: string; item: string } {
+        const parts = uuid?.split(".") ?? [];
+        return { pack: parts.at(2) ?? "", item: parts.at(4) ?? "" };
+    }
+}
+
+interface ItemReferencesOptions {
+    idNameMap: Map<string, Map<string, string>>;
+    convertUUIDs?: (docSource: PackEntry, packName: string) => PackEntry;
+}
+
+export { ItemReferences };

--- a/build/run-migration.ts
+++ b/build/run-migration.ts
@@ -5,7 +5,7 @@ import fs from "fs-extra";
 import { JSDOM } from "jsdom";
 import path from "path";
 import { populateFoundryUtilFunctions } from "../tests/fixtures/foundryshim.ts";
-import { getFilesRecursively } from "./lib/helpers.ts";
+import { deepClone, getFilesRecursively } from "./lib/helpers.ts";
 
 import { MigrationBase } from "@module/migration/base.ts";
 import { MigrationRunnerBase } from "@module/migration/runner/base.ts";
@@ -54,26 +54,7 @@ const migrations: MigrationBase[] = [
     new Migration874MoveStaminaStuff(),
 ];
 
-global.deepClone = <T>(original: T): T => {
-    // Simple types
-    if (typeof original !== "object" || original === null) return original;
-
-    // Arrays
-    if (Array.isArray(original)) return original.map(deepClone) as unknown as T;
-
-    // Dates
-    if (original instanceof Date) return new Date(original) as T & Date;
-
-    // Unsupported advanced objects
-    if ("constructor" in original && (original as { constructor?: unknown })["constructor"] !== Object) return original;
-
-    // Other objects
-    const clone: Record<string, unknown> = {};
-    for (const k of Object.keys(original)) {
-        clone[k] = deepClone((original as Record<string, unknown>)[k]);
-    }
-    return clone as T;
-};
+global.deepClone = deepClone;
 
 global.randomID = function randomID(length = 16): string {
     const rnd = () => Math.random().toString(36).substring(2);

--- a/packs/troubles-in-otari-bestiary/morgrym-leadbuster.json
+++ b/packs/troubles-in-otari-bestiary/morgrym-leadbuster.json
@@ -254,116 +254,14 @@
         },
         {
             "_id": "oNWam7Aw7UjbskXG",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.Item.f8hRqLJaxBVhF1u0"
-                }
-            },
-            "img": "icons/skills/melee/spear-tips-double-purple.webp",
-            "name": "Acid Arrow",
             "sort": 300000,
+            "sourceId": "Compendium.pf2e.spells-srd.Item.Acid Arrow",
             "system": {
-                "ability": {
-                    "value": ""
-                },
-                "area": null,
-                "category": {
-                    "value": "spell"
-                },
-                "components": {
-                    "somatic": true,
-                    "verbal": true
-                },
-                "cost": {
-                    "value": ""
-                },
-                "damage": {
-                    "value": {
-                        "0": {
-                            "applyMod": false,
-                            "type": {
-                                "categories": [],
-                                "subtype": "",
-                                "value": "acid"
-                            },
-                            "value": "3d8"
-                        }
-                    }
-                },
-                "description": {
-                    "value": "<p>You conjure an arrow of acid that keeps corroding the target after it hits. Make a spell attack against the target. On a hit, you deal 3d8 acid damage plus [[/r floor(@item.level/2)d6[persistent,acid]]] damage. On a critical hit, double the initial damage, but not the persistent damage.</p>\n<hr />\n<p><strong>Heightened (+2)</strong> The initial damage increases by 2d8, and the persistent acid damage increases by 1d6.</p>"
-                },
-                "duration": {
-                    "value": ""
-                },
-                "hasCounteractCheck": {
-                    "value": false
-                },
-                "heightening": {
-                    "damage": {
-                        "0": "2d8"
-                    },
-                    "interval": 2,
-                    "type": "interval"
-                },
                 "level": {
                     "value": 2
                 },
                 "location": {
                     "value": "OOCu4hNQg4NvyXLU"
-                },
-                "materials": {
-                    "value": ""
-                },
-                "prepared": {
-                    "value": ""
-                },
-                "primarycheck": {
-                    "value": ""
-                },
-                "range": {
-                    "value": "120 feet"
-                },
-                "rules": [],
-                "save": {
-                    "basic": "",
-                    "value": ""
-                },
-                "secondarycasters": {
-                    "value": ""
-                },
-                "secondarycheck": {
-                    "value": ""
-                },
-                "slug": "acid-arrow",
-                "source": {
-                    "value": "Pathfinder Core Rulebook"
-                },
-                "spellType": {
-                    "value": "attack"
-                },
-                "sustained": {
-                    "value": false
-                },
-                "target": {
-                    "value": "1 creature"
-                },
-                "time": {
-                    "value": "2"
-                },
-                "traditions": {
-                    "value": [
-                        "arcane",
-                        "primal"
-                    ]
-                },
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "acid",
-                        "attack",
-                        "evocation"
-                    ]
                 }
             },
             "type": "spell"
@@ -472,342 +370,42 @@
         },
         {
             "_id": "TLWlBerjUtbtCHzr",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.Item.Fr58LDSrbndgld9n"
-                }
-            },
-            "img": "icons/magic/defensive/shield-barrier-deflect-teal.webp",
-            "name": "Resist Energy",
             "sort": 500000,
+            "sourceId": "Compendium.pf2e.spells-srd.Item.Resist Energy",
             "system": {
-                "ability": {
-                    "value": ""
-                },
-                "area": null,
-                "category": {
-                    "value": "spell"
-                },
-                "components": {
-                    "somatic": true,
-                    "verbal": true
-                },
-                "cost": {
-                    "value": ""
-                },
-                "damage": {
-                    "value": {}
-                },
-                "description": {
-                    "value": "<p>A shield of elemental energy protects a creature against one type of energy damage. Choose acid, cold, electricity, fire, or sonic damage. The target and its gear gain resistance 5 against the damage type you chose.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Resist Energy]</p>\n<hr />\n<p><strong>Heightened (4th)</strong> The resistance increases to 10, and you can target up to two creatures.</p>\n<p><strong>Heightened (7th)</strong> The resistance increases to 15, and you can target up to five creatures.</p>"
-                },
-                "duration": {
-                    "value": "10 minutes"
-                },
-                "hasCounteractCheck": {
-                    "value": false
-                },
-                "heightening": {
-                    "levels": {
-                        "4": {
-                            "target": {
-                                "value": "2 creatures"
-                            }
-                        },
-                        "7": {
-                            "target": {
-                                "value": "5 creatures"
-                            }
-                        }
-                    },
-                    "type": "fixed"
-                },
                 "level": {
                     "value": 2
                 },
                 "location": {
                     "value": "OOCu4hNQg4NvyXLU"
-                },
-                "materials": {
-                    "value": ""
-                },
-                "prepared": {
-                    "value": ""
-                },
-                "primarycheck": {
-                    "value": ""
-                },
-                "range": {
-                    "value": "touch"
-                },
-                "rules": [],
-                "save": {
-                    "basic": "",
-                    "value": ""
-                },
-                "secondarycasters": {
-                    "value": ""
-                },
-                "secondarycheck": {
-                    "value": ""
-                },
-                "slug": "resist-energy",
-                "source": {
-                    "value": "Pathfinder Core Rulebook"
-                },
-                "spellType": {
-                    "value": "utility"
-                },
-                "sustained": {
-                    "value": false
-                },
-                "target": {
-                    "value": "1 creature"
-                },
-                "time": {
-                    "value": "2"
-                },
-                "traditions": {
-                    "value": [
-                        "arcane",
-                        "divine",
-                        "occult",
-                        "primal"
-                    ]
-                },
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "abjuration"
-                    ]
                 }
             },
             "type": "spell"
         },
         {
             "_id": "P2eKpIYTpVqeAKfp",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.Item.aIHY2DArKFweIrpf"
-                }
-            },
-            "img": "systems/pf2e/icons/spells/command.webp",
-            "name": "Command",
             "sort": 600000,
+            "sourceId": "Compendium.pf2e.spells-srd.Item.Command",
             "system": {
-                "ability": {
-                    "value": ""
-                },
-                "area": null,
-                "category": {
-                    "value": "spell"
-                },
-                "components": {
-                    "somatic": true,
-                    "verbal": true
-                },
-                "cost": {
-                    "value": ""
-                },
-                "damage": {
-                    "value": {}
-                },
-                "description": {
-                    "value": "<p>You shout a command that's hard to ignore. You can command the target to approach you, run away (as if it had the @UUID[Compendium.pf2e.conditionitems.Item.Fleeing] condition), release what it's holding, drop @UUID[Compendium.pf2e.conditionitems.Item.Prone], or stand in place. It can't Delay or take any reactions until it has obeyed your command. The effects depend on the target's Will save.</p>\n<hr /><strong>Success</strong> The creature is unaffected.\n<p><strong>Failure</strong> For the first action on its next turn, the creature must use a single action to do as you command.</p>\n<p><strong>Critical Failure</strong> The target must use all its actions on its next turn to obey your command.</p>\n<hr /><strong>Heightened (5th)</strong> You can target up to 10 creatures."
-                },
-                "duration": {
-                    "value": "until the end of the target's next turn"
-                },
-                "hasCounteractCheck": {
-                    "value": false
-                },
-                "heightening": {
-                    "levels": {
-                        "5": {
-                            "target": {
-                                "value": "10 creatures"
-                            }
-                        }
-                    },
-                    "type": "fixed"
-                },
                 "level": {
                     "value": 1
                 },
                 "location": {
                     "value": "OOCu4hNQg4NvyXLU"
-                },
-                "materials": {
-                    "value": ""
-                },
-                "prepared": {
-                    "value": ""
-                },
-                "primarycheck": {
-                    "value": ""
-                },
-                "range": {
-                    "value": "30 feet"
-                },
-                "rules": [],
-                "save": {
-                    "basic": "",
-                    "value": "will"
-                },
-                "secondarycasters": {
-                    "value": ""
-                },
-                "secondarycheck": {
-                    "value": ""
-                },
-                "slug": "command",
-                "source": {
-                    "value": "Pathfinder Core Rulebook"
-                },
-                "spellType": {
-                    "value": "save"
-                },
-                "sustained": {
-                    "value": false
-                },
-                "target": {
-                    "value": "1 creature"
-                },
-                "time": {
-                    "value": "2"
-                },
-                "traditions": {
-                    "value": [
-                        "arcane",
-                        "divine",
-                        "occult"
-                    ]
-                },
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "auditory",
-                        "linguistic",
-                        "mental",
-                        "enchantment"
-                    ]
                 }
             },
             "type": "spell"
         },
         {
             "_id": "5dRHW6KPiYke6J31",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.Item.4gBIw4IDrSfFHik4"
-                }
-            },
-            "img": "systems/pf2e/icons/spells/daze.webp",
-            "name": "Daze",
             "sort": 700000,
+            "sourceId": "Compendium.pf2e.spells-srd.Item.Daze",
             "system": {
-                "ability": {
-                    "value": ""
-                },
-                "area": null,
-                "category": {
-                    "value": "spell"
-                },
-                "components": {
-                    "somatic": true,
-                    "verbal": true
-                },
-                "cost": {
-                    "value": ""
-                },
-                "damage": {
-                    "value": {
-                        "0": {
-                            "applyMod": true,
-                            "type": {
-                                "categories": [],
-                                "value": "mental"
-                            },
-                            "value": "0"
-                        }
-                    }
-                },
-                "description": {
-                    "value": "<p>You cloud the target's mind and daze it with a mental jolt. The jolt deals mental damage equal to your spellcasting ability modifier; the target must attempt a basic Will save. If the target critically fails the save, it is also @UUID[Compendium.pf2e.conditionitems.Item.Stunned]{Stunned 1}.</p>\n<hr />\n<p><strong>Heightened (+2)</strong> The damage increases by 1d6.</p>"
-                },
-                "duration": {
-                    "value": "1 round"
-                },
-                "hasCounteractCheck": {
-                    "value": false
-                },
-                "heightening": {
-                    "damage": {
-                        "0": "1d6"
-                    },
-                    "interval": 2,
-                    "type": "interval"
-                },
                 "level": {
                     "value": 1
                 },
                 "location": {
                     "value": "OOCu4hNQg4NvyXLU"
-                },
-                "materials": {
-                    "value": ""
-                },
-                "prepared": {
-                    "value": ""
-                },
-                "primarycheck": {
-                    "value": ""
-                },
-                "range": {
-                    "value": "60 feet"
-                },
-                "rules": [],
-                "save": {
-                    "basic": "basic",
-                    "value": "will"
-                },
-                "secondarycasters": {
-                    "value": ""
-                },
-                "secondarycheck": {
-                    "value": ""
-                },
-                "slug": "daze",
-                "source": {
-                    "value": "Pathfinder Core Rulebook"
-                },
-                "spellType": {
-                    "value": "save"
-                },
-                "sustained": {
-                    "value": false
-                },
-                "target": {
-                    "value": "1 creature"
-                },
-                "time": {
-                    "value": "2"
-                },
-                "traditions": {
-                    "value": [
-                        "arcane",
-                        "divine",
-                        "occult"
-                    ]
-                },
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "cantrip",
-                        "mental",
-                        "nonlethal",
-                        "enchantment"
-                    ]
                 }
             },
             "type": "spell"
@@ -919,327 +517,42 @@
         },
         {
             "_id": "rfaUjMXBlYA3f1bD",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.Item.4koZzrnMXhhosn0D"
-                }
-            },
-            "img": "systems/pf2e/icons/spells/fear.webp",
-            "name": "Fear",
             "sort": 900000,
+            "sourceId": "Compendium.pf2e.spells-srd.Item.Fear",
             "system": {
-                "ability": {
-                    "value": ""
-                },
-                "area": null,
-                "category": {
-                    "value": "spell"
-                },
-                "components": {
-                    "somatic": true,
-                    "verbal": true
-                },
-                "cost": {
-                    "value": ""
-                },
-                "damage": {
-                    "value": {}
-                },
-                "description": {
-                    "value": "<p>You plant fear in the target; it must attempt a Will save.</p>\n<hr />\n<p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target is @UUID[Compendium.pf2e.conditionitems.Item.Frightened]{Frightened 1}.</p>\n<p><strong>Failure</strong> The target is @UUID[Compendium.pf2e.conditionitems.Item.Frightened]{Frightened 2}.</p>\n<p><strong>Critical Failure</strong> The target is @UUID[Compendium.pf2e.conditionitems.Item.Frightened]{Frightened 3} and @UUID[Compendium.pf2e.conditionitems.Item.Fleeing] for 1 round.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You can target up to five creatures.</p>"
-                },
-                "duration": {
-                    "value": "varies"
-                },
-                "hasCounteractCheck": {
-                    "value": false
-                },
-                "heightening": {
-                    "levels": {
-                        "3": {
-                            "target": {
-                                "value": "5 creatures"
-                            }
-                        }
-                    },
-                    "type": "fixed"
-                },
                 "level": {
                     "value": 1
                 },
                 "location": {
                     "value": "zhR9Ys8AyYNjAz29"
-                },
-                "materials": {
-                    "value": ""
-                },
-                "prepared": {
-                    "value": ""
-                },
-                "primarycheck": {
-                    "value": ""
-                },
-                "range": {
-                    "value": "30 feet"
-                },
-                "rules": [],
-                "save": {
-                    "basic": "",
-                    "value": "will"
-                },
-                "secondarycasters": {
-                    "value": ""
-                },
-                "secondarycheck": {
-                    "value": ""
-                },
-                "slug": "fear",
-                "source": {
-                    "value": "Pathfinder Core Rulebook"
-                },
-                "spellType": {
-                    "value": "save"
-                },
-                "sustained": {
-                    "value": false
-                },
-                "target": {
-                    "value": "1 creature"
-                },
-                "time": {
-                    "value": "2"
-                },
-                "traditions": {
-                    "value": [
-                        "arcane",
-                        "divine",
-                        "occult",
-                        "primal"
-                    ]
-                },
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "emotion",
-                        "fear",
-                        "mental",
-                        "enchantment"
-                    ]
                 }
             },
             "type": "spell"
         },
         {
             "_id": "5IhT0N12gNd3ojxs",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.Item.atlgGNI1E1Ox3O3a"
-                }
-            },
-            "img": "systems/pf2e/icons/spells/ghost-sound.webp",
-            "name": "Ghost Sound",
             "sort": 1000000,
+            "sourceId": "Compendium.pf2e.spells-srd.Item.Ghost Sound",
             "system": {
-                "ability": {
-                    "value": ""
-                },
-                "area": null,
-                "category": {
-                    "value": "spell"
-                },
-                "components": {
-                    "somatic": true,
-                    "verbal": true
-                },
-                "cost": {
-                    "value": ""
-                },
-                "damage": {
-                    "value": {}
-                },
-                "description": {
-                    "value": "<p>You create an auditory illusion of simple sounds that has a maximum volume equal to four normal humans shouting. The sounds emanate from a square you designate within range. You can't create intelligible words or other intricate sounds (such as music).</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> The range increases to 60 feet.</p>\n<p><strong>Heightened (5th)</strong> The range increases to 120 feet.</p>"
-                },
-                "duration": {
-                    "value": "sustained"
-                },
-                "hasCounteractCheck": {
-                    "value": false
-                },
-                "heightening": {
-                    "levels": {
-                        "3": {
-                            "range": {
-                                "value": "60 feet"
-                            }
-                        },
-                        "5": {
-                            "range": {
-                                "value": "120 feet"
-                            }
-                        }
-                    },
-                    "type": "fixed"
-                },
                 "level": {
                     "value": 1
                 },
                 "location": {
                     "value": "OOCu4hNQg4NvyXLU"
-                },
-                "materials": {
-                    "value": ""
-                },
-                "prepared": {
-                    "value": ""
-                },
-                "primarycheck": {
-                    "value": ""
-                },
-                "range": {
-                    "value": "30 feet"
-                },
-                "rules": [],
-                "save": {
-                    "basic": "",
-                    "value": ""
-                },
-                "secondarycasters": {
-                    "value": ""
-                },
-                "secondarycheck": {
-                    "value": ""
-                },
-                "slug": "ghost-sound",
-                "source": {
-                    "value": "Pathfinder Core Rulebook"
-                },
-                "spellType": {
-                    "value": "utility"
-                },
-                "sustained": {
-                    "value": false
-                },
-                "target": {
-                    "value": ""
-                },
-                "time": {
-                    "value": "2"
-                },
-                "traditions": {
-                    "value": [
-                        "arcane",
-                        "occult"
-                    ]
-                },
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "auditory",
-                        "cantrip",
-                        "illusion"
-                    ]
                 }
             },
             "type": "spell"
         },
         {
             "_id": "2rOQ7HjEutsKVPmn",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.Item.g8QqHpv2CWDwmIm1"
-                }
-            },
-            "img": "systems/pf2e/icons/spells/gust-of-wind.webp",
-            "name": "Gust of Wind",
             "sort": 1100000,
+            "sourceId": "Compendium.pf2e.spells-srd.Item.Gust of Wind",
             "system": {
-                "ability": {
-                    "value": ""
-                },
-                "area": {
-                    "type": "line",
-                    "value": 60
-                },
-                "category": {
-                    "value": "spell"
-                },
-                "components": {
-                    "somatic": true,
-                    "verbal": true
-                },
-                "cost": {
-                    "value": ""
-                },
-                "damage": {
-                    "value": {}
-                },
-                "description": {
-                    "value": "<p>A violent wind issues forth from your palm, blowing from the point where you are when you cast the spell to the line's opposite end. The wind extinguishes small non-magical fires, disperses fog and mist, blows objects of light Bulk or less around, and pushes larger objects. Large or smaller creatures in the area must attempt a Fortitude save. Large or smaller creatures that later move into the gust must attempt the save on entering.</p>\n<hr />\n<p><strong>Critical Success</strong> The creature is unaffected.</p>\n<p><strong>Success</strong> The creature can't move against the wind.</p>\n<p><strong>Failure</strong> The creature is knocked @UUID[Compendium.pf2e.conditionitems.Item.Prone]. If it was flying, it suffers the effects of critical failure instead.</p>\n<p><strong>Critical Failure</strong> The creature is pushed 30 feet in the wind's direction, knocked Prone, and takes 2d6 bludgeoning damage.</p>"
-                },
-                "duration": {
-                    "value": "until the start of your next turn"
-                },
-                "hasCounteractCheck": {
-                    "value": false
-                },
                 "level": {
                     "value": 1
                 },
                 "location": {
                     "value": "OOCu4hNQg4NvyXLU"
-                },
-                "materials": {
-                    "value": ""
-                },
-                "prepared": {
-                    "value": ""
-                },
-                "primarycheck": {
-                    "value": ""
-                },
-                "range": {
-                    "value": ""
-                },
-                "rules": [],
-                "save": {
-                    "basic": "",
-                    "value": "fortitude"
-                },
-                "secondarycasters": {
-                    "value": ""
-                },
-                "secondarycheck": {
-                    "value": ""
-                },
-                "slug": "gust-of-wind",
-                "source": {
-                    "value": "Pathfinder Core Rulebook"
-                },
-                "spellType": {
-                    "value": "save"
-                },
-                "sustained": {
-                    "value": false
-                },
-                "target": {
-                    "value": ""
-                },
-                "time": {
-                    "value": "2"
-                },
-                "traditions": {
-                    "value": [
-                        "arcane",
-                        "primal"
-                    ]
-                },
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "air",
-                        "evocation"
-                    ]
                 }
             },
             "type": "spell"
@@ -1470,228 +783,28 @@
         },
         {
             "_id": "rlqs0WH4XFzsUkU4",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.Item.vLzFcIaSXs7YTIqJ"
-                }
-            },
-            "img": "systems/pf2e/icons/spells/message.webp",
-            "name": "Message",
             "sort": 1400000,
+            "sourceId": "Compendium.pf2e.spells-srd.Item.Message",
             "system": {
-                "ability": {
-                    "value": ""
-                },
-                "area": null,
-                "category": {
-                    "value": "spell"
-                },
-                "components": {
-                    "verbal": true
-                },
-                "cost": {
-                    "value": ""
-                },
-                "damage": {
-                    "value": {}
-                },
-                "description": {
-                    "value": "<p>You mouth words quietly, but instead of coming out of your mouth, they're transferred directly to the ears of the target. While others can't hear your words any better than if you normally mouthed them, the target can hear your words as if they were standing next to you.</p>\n<p>The target can give a brief response as a reaction, or as a free action on their next turn if they wish, but they must be able to see you and be within range to do so. If they respond, their response is delivered directly to your ear, just like the original message.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> The spell's range increases to 500 feet.</p>"
-                },
-                "duration": {
-                    "value": "see below"
-                },
-                "hasCounteractCheck": {
-                    "value": false
-                },
-                "heightening": {
-                    "levels": {
-                        "3": {
-                            "range": {
-                                "value": "500 feet"
-                            }
-                        }
-                    },
-                    "type": "fixed"
-                },
                 "level": {
                     "value": 1
                 },
                 "location": {
                     "value": "OOCu4hNQg4NvyXLU"
-                },
-                "materials": {
-                    "value": ""
-                },
-                "prepared": {
-                    "value": ""
-                },
-                "primarycheck": {
-                    "value": ""
-                },
-                "range": {
-                    "value": "120 feet"
-                },
-                "rules": [],
-                "save": {
-                    "basic": "",
-                    "value": ""
-                },
-                "secondarycasters": {
-                    "value": ""
-                },
-                "secondarycheck": {
-                    "value": ""
-                },
-                "slug": "message",
-                "source": {
-                    "value": "Pathfinder Core Rulebook"
-                },
-                "spellType": {
-                    "value": "utility"
-                },
-                "sustained": {
-                    "value": false
-                },
-                "target": {
-                    "value": "1 creature"
-                },
-                "time": {
-                    "value": "1"
-                },
-                "traditions": {
-                    "value": [
-                        "arcane",
-                        "divine",
-                        "occult"
-                    ]
-                },
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "auditory",
-                        "cantrip",
-                        "linguistic",
-                        "mental",
-                        "illusion"
-                    ]
                 }
             },
             "type": "spell"
         },
         {
             "_id": "pUmcxyyawXK5m6OE",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.Item.gYjPm7YwGtEa1oxh"
-                }
-            },
-            "img": "icons/magic/movement/trail-streak-impact-blue.webp",
-            "name": "Ray of Frost",
             "sort": 1500000,
+            "sourceId": "Compendium.pf2e.spells-srd.Item.Ray of Frost",
             "system": {
-                "ability": {
-                    "value": ""
-                },
-                "area": null,
-                "category": {
-                    "value": "spell"
-                },
-                "components": {
-                    "somatic": true,
-                    "verbal": true
-                },
-                "cost": {
-                    "value": ""
-                },
-                "damage": {
-                    "value": {
-                        "0": {
-                            "applyMod": true,
-                            "type": {
-                                "categories": [],
-                                "value": "cold"
-                            },
-                            "value": "1d4"
-                        }
-                    }
-                },
-                "description": {
-                    "value": "<p>You blast an icy ray. Make a spell attack roll. The ray deals cold damage equal to 1d4 + your spellcasting ability modifier.</p>\n<hr />\n<p><strong>Critical Success</strong> The target takes double damage and takes a -10-foot status penalty to its Speeds for 1 round.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Ray of Frost]</p>\n<p><strong>Success</strong> The target takes normal damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 1d4.</p>"
-                },
-                "duration": {
-                    "value": ""
-                },
-                "hasCounteractCheck": {
-                    "value": false
-                },
-                "heightening": {
-                    "damage": {
-                        "0": "1d4"
-                    },
-                    "interval": 1,
-                    "type": "interval"
-                },
                 "level": {
                     "value": 1
                 },
                 "location": {
                     "value": "OOCu4hNQg4NvyXLU"
-                },
-                "materials": {
-                    "value": ""
-                },
-                "prepared": {
-                    "value": ""
-                },
-                "primarycheck": {
-                    "value": ""
-                },
-                "range": {
-                    "value": "120 feet"
-                },
-                "rules": [],
-                "save": {
-                    "basic": "",
-                    "value": ""
-                },
-                "secondarycasters": {
-                    "value": ""
-                },
-                "secondarycheck": {
-                    "value": ""
-                },
-                "slug": "ray-of-frost",
-                "source": {
-                    "value": "Pathfinder Core Rulebook"
-                },
-                "spellType": {
-                    "value": "attack"
-                },
-                "sustained": {
-                    "value": false
-                },
-                "target": {
-                    "value": "1 creature"
-                },
-                "time": {
-                    "value": "2"
-                },
-                "traditions": {
-                    "custom": "",
-                    "value": [
-                        "arcane",
-                        "primal"
-                    ]
-                },
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "attack",
-                        "cold",
-                        "cantrip",
-                        "evocation"
-                    ]
                 }
             },
             "type": "spell"
@@ -1797,103 +910,17 @@
         },
         {
             "_id": "E9IuWpulcCWHu1c5",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.equipment-srd.Item.FVjTuBCIefAgloUU"
-                }
-            },
-            "img": "icons/weapons/staves/staff-simple.webp",
-            "name": "Staff",
             "sort": 1700000,
+            "sourceId": "Compendium.pf2e.equipment-srd.Item.Staff",
             "system": {
-                "baseItem": "staff",
-                "bonus": {
-                    "value": 0
-                },
-                "bonusDamage": {
-                    "value": 0
-                },
-                "category": "simple",
-                "containerId": null,
-                "damage": {
-                    "damageType": "bludgeoning",
-                    "dice": 1,
-                    "die": "d4"
-                },
-                "description": {
-                    "value": "<p>This long piece of wood can aid in walking and deliver a mighty blow.</p>"
-                },
                 "equipped": {
                     "carryType": "worn",
                     "handsHeld": 0,
                     "invested": null
                 },
-                "equippedBulk": {
-                    "value": ""
-                },
-                "group": "club",
-                "hardness": 0,
-                "hp": {
-                    "max": 0,
-                    "value": 0
-                },
-                "level": {
-                    "value": 0
-                },
-                "material": {
-                    "grade": null,
-                    "type": null
-                },
-                "negateBulk": {
-                    "value": "0"
-                },
-                "potencyRune": {
-                    "value": null
-                },
-                "price": {
-                    "value": {}
-                },
-                "propertyRune1": {
-                    "value": ""
-                },
-                "propertyRune2": {
-                    "value": ""
-                },
-                "propertyRune3": {
-                    "value": ""
-                },
-                "propertyRune4": {
-                    "value": ""
-                },
                 "quantity": 1,
-                "range": null,
-                "reload": {
-                    "value": ""
-                },
-                "rules": [],
-                "size": "med",
-                "slug": "staff",
-                "source": {
-                    "value": "Pathfinder Core Rulebook"
-                },
-                "splashDamage": {
-                    "value": 0
-                },
-                "stackGroup": null,
-                "strikingRune": {
-                    "value": ""
-                },
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "two-hand-d8"
-                    ]
-                },
                 "usage": {
                     "value": "held-in-one-hand"
-                },
-                "weight": {
-                    "value": "1"
                 }
             },
             "type": "weapon"
@@ -1965,64 +992,16 @@
         },
         {
             "_id": "gTjE5Ad9b6jVEcWf",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.equipment-srd.Item.VHxXMvBeBTq2FSdf"
-                }
-            },
-            "img": "icons/containers/bags/pack-engraved-leather-blue.webp",
-            "name": "Material Component Pouch",
             "sort": 1900000,
+            "sourceId": "Compendium.pf2e.equipment-srd.Item.Material Component Pouch",
             "system": {
-                "baseItem": null,
-                "containerId": null,
-                "description": {
-                    "value": "<p>This pouch contains material components for those spells that require them. Though the components are used up over time, you can refill spent components during your daily preparations.</p>"
-                },
                 "equipped": {
                     "carryType": "worn",
                     "invested": null
                 },
-                "equippedBulk": {
-                    "value": ""
-                },
-                "hardness": 0,
-                "hp": {
-                    "max": 0,
-                    "value": 0
-                },
-                "level": {
-                    "value": 0
-                },
-                "material": {
-                    "grade": null,
-                    "type": null
-                },
-                "negateBulk": {
-                    "value": ""
-                },
-                "price": {
-                    "value": {
-                        "sp": 5
-                    }
-                },
                 "quantity": 1,
-                "rules": [],
-                "size": "med",
-                "slug": "material-component-pouch",
-                "source": {
-                    "value": "Pathfinder Core Rulebook"
-                },
-                "stackGroup": null,
-                "traits": {
-                    "rarity": "common",
-                    "value": []
-                },
                 "usage": {
                     "value": "held-in-one-hand"
-                },
-                "weight": {
-                    "value": "L"
                 }
             },
             "type": "equipment"

--- a/src/module/actor/data/base.ts
+++ b/src/module/actor/data/base.ts
@@ -14,6 +14,7 @@ import type { DamageRoll } from "@system/damage/roll.ts";
 import { StatisticTraceData } from "@system/statistic/data.ts";
 import { ActorType } from "./index.ts";
 import type { Immunity, ImmunitySource, Resistance, ResistanceSource, Weakness, WeaknessSource } from "./iwr.ts";
+import { ItemReferenceSource } from "@item/data/base.ts";
 
 /** Base interface for all actor data */
 interface BaseActorSourcePF2e<TType extends ActorType, TSystemSource extends ActorSystemSource = ActorSystemSource>
@@ -27,6 +28,7 @@ interface ActorFlagsPF2e extends foundry.documents.ActorFlags {
         rollOptions: RollOptionFlags;
         /** IDs of granted items that are tracked */
         trackedItems: Record<string, string>;
+        itemReferences?: ItemReferenceSource[];
         [key: string]: unknown;
     };
 }

--- a/src/module/item/data/base.ts
+++ b/src/module/item/data/base.ts
@@ -127,6 +127,7 @@ interface ItemReferenceBaseSource {
 
 interface SpellReferenceSource extends ItemReferenceBaseSource {
     system?: {
+        level: SpellSystemSource["level"];
         location: SpellSystemSource["location"];
     };
     type: "spell";

--- a/src/module/item/data/base.ts
+++ b/src/module/item/data/base.ts
@@ -2,7 +2,9 @@ import { CreatureTrait } from "@actor/creature/types.ts";
 import { ActionTrait } from "@item/ability/types.ts";
 import { KingmakerTrait } from "@item/campaign-feature/types.ts";
 import { NPCAttackTrait } from "@item/melee/data.ts";
-import { PhysicalItemTrait } from "@item/physical/data.ts";
+import type { PhysicalItemTrait, PhysicalSystemSource } from "@item/physical/data.ts";
+import type { PhysicalItemType } from "@item/physical/types.ts";
+import type { SpellSystemSource } from "@item/spell/data.ts";
 import { MigrationRecord, OneToThree, Rarity } from "@module/data.ts";
 import { RuleElementSource } from "@module/rules/index.ts";
 import { ItemType } from "./index.ts";
@@ -48,6 +50,7 @@ interface ItemFlagsPF2e extends foundry.documents.ItemFlags {
         rulesSelections: Record<string, string | number | object | null>;
         itemGrants: Record<string, ItemGrantData>;
         grantedBy: ItemGrantData | null;
+        fromReference?: boolean;
         [key: string]: unknown;
     };
 }
@@ -57,6 +60,7 @@ interface ItemSourceFlagsPF2e extends DeepPartial<foundry.documents.ItemFlags> {
         rulesSelections?: Record<string, string | number | object>;
         itemGrants?: Record<string, ItemGrantSource>;
         grantedBy?: ItemGrantSource | null;
+        fromReference?: boolean;
         [key: string]: unknown;
     };
 }
@@ -109,6 +113,37 @@ interface Frequency extends FrequencySource {
     value: number;
 }
 
+interface ItemReferenceBaseSource {
+    _id: string;
+    flags?: {
+        pf2e: {
+            fromReference: boolean;
+        };
+    };
+    sort: number;
+    sourceId: ItemUUID;
+    type: string;
+}
+
+interface SpellReferenceSource extends ItemReferenceBaseSource {
+    system?: {
+        location: SpellSystemSource["location"];
+    };
+    type: "spell";
+}
+
+interface PhyiscalItemReferenceSource extends ItemReferenceBaseSource {
+    system: {
+        containerId?: PhysicalSystemSource["containerId"];
+        equipped: PhysicalSystemSource["equipped"];
+        quantity: PhysicalSystemSource["quantity"];
+        usage: PhysicalSystemSource["usage"];
+    };
+    type: PhysicalItemType;
+}
+
+type ItemReferenceSource = SpellReferenceSource | PhyiscalItemReferenceSource;
+
 export type {
     ActionCost,
     ActionType,
@@ -120,11 +155,14 @@ export type {
     ItemGrantData,
     ItemGrantDeleteAction,
     ItemGrantSource,
+    ItemReferenceSource,
     ItemSystemData,
     ItemSystemSource,
     ItemTrait,
     ItemTraits,
     ItemTraitsNoRarity,
     OtherTagsOnly,
+    PhyiscalItemReferenceSource,
     RarityTraitAndOtherTags,
+    SpellReferenceSource,
 };

--- a/src/module/item/data/helpers.ts
+++ b/src/module/item/data/helpers.ts
@@ -1,6 +1,6 @@
 import { PHYSICAL_ITEM_TYPES } from "@item/physical/values.ts";
 import { isObject, setHasElement } from "@util/misc.ts";
-import { ItemSystemData } from "./base.ts";
+import { ItemReferenceSource, ItemSystemData } from "./base.ts";
 import { ItemSourcePF2e, MagicItemSource, PhysicalItemSource } from "./index.ts";
 
 function isItemSystemData(data: unknown): data is ItemSystemData {
@@ -39,4 +39,8 @@ function isInventoryItem(type: string): boolean {
     return false;
 }
 
-export { hasInvestedProperty, isInventoryItem, isItemSystemData, isPhysicalData };
+function isItemReference(source: unknown): source is ItemReferenceSource {
+    return isObject(source) && "sourceId" in source;
+}
+
+export { hasInvestedProperty, isInventoryItem, isItemReference, isItemSystemData, isPhysicalData };

--- a/src/module/item/data/helpers.ts
+++ b/src/module/item/data/helpers.ts
@@ -1,5 +1,5 @@
 import { PHYSICAL_ITEM_TYPES } from "@item/physical/values.ts";
-import { isObject, setHasElement } from "@util/misc.ts";
+import { isObject, setHasElement } from "src/util/misc.ts";
 import { ItemReferenceSource, ItemSystemData } from "./base.ts";
 import { ItemSourcePF2e, MagicItemSource, PhysicalItemSource } from "./index.ts";
 

--- a/src/module/migration/base.ts
+++ b/src/module/migration/base.ts
@@ -1,5 +1,6 @@
 import { ActorPF2e } from "@actor";
 import { ActorSourcePF2e } from "@actor/data/index.ts";
+import { ItemReferenceSource } from "@item/data/base.ts";
 import { ItemSourcePF2e } from "@item/data/index.ts";
 import { ScenePF2e } from "@scene/index.ts";
 
@@ -51,6 +52,21 @@ interface MigrationBase {
      * @param actorSource If the item is part of an actor, this is set to the actor. For instance
      */
     updateItem?(source: ItemSourcePF2e, actorSource?: ActorSourcePF2e): Promise<void>;
+
+    /**
+     * Update the item reference to the latest schema version, handling changes that must happen before any other
+     * migration in a given list. Only available during compendium JSON migrations.
+     * @param source Item reference to update. This should be an `ItemReferenceSource` from the previous version
+     * @param actorSource If the item is part of an actor, this is set to the actor source
+     */
+    preUpdateItemReference?(source: ItemReferenceSource, actorSource?: ActorSourcePF2e): Promise<void>;
+
+    /**
+     * Update the item reference to the latest schema version. Only available during compendium JSON migrations.
+     * @param source Item reference to update. This should be an `ItemReferenceSource` from the previous version.
+     * @param actorSource If the item is part of an actor, this is set to the actor. For instance
+     */
+    updateItemReference?(source: ItemReferenceSource, actorSource?: ActorSourcePF2e): Promise<void>;
 
     /**
      * Update the macro to the latest schema version.

--- a/src/module/migration/runner/base.ts
+++ b/src/module/migration/runner/base.ts
@@ -68,12 +68,12 @@ export class MigrationRunnerBase {
         for (const migration of migrations) {
             for (const currentItem of currentActor.items) {
                 if (isCompendiumSource && isItemReference(currentItem)) {
-                    // TODO: Support migration of item references
-                    continue;
-                }
-                await migration.preUpdateItem?.(currentItem, currentActor);
-                if (currentItem.type === "consumable" && currentItem.system.spell) {
-                    await migration.preUpdateItem?.(currentItem.system.spell, currentActor);
+                    await migration.preUpdateItemReference?.(currentItem, currentActor);
+                } else {
+                    await migration.preUpdateItem?.(currentItem, currentActor);
+                    if (currentItem.type === "consumable" && currentItem.system.spell) {
+                        await migration.preUpdateItem?.(currentItem.system.spell, currentActor);
+                    }
                 }
             }
         }
@@ -83,13 +83,13 @@ export class MigrationRunnerBase {
 
             for (const currentItem of currentActor.items) {
                 if (isCompendiumSource && isItemReference(currentItem)) {
-                    // TODO: Support migration of item references
-                    continue;
-                }
-                await migration.updateItem?.(currentItem, currentActor);
-                // Handle embedded spells
-                if (currentItem.type === "consumable" && currentItem.system.spell) {
-                    await migration.updateItem?.(currentItem.system.spell, currentActor);
+                    await migration.updateItemReference?.(currentItem, currentActor);
+                } else {
+                    await migration.updateItem?.(currentItem, currentActor);
+                    // Handle embedded spells
+                    if (currentItem.type === "consumable" && currentItem.system.spell) {
+                        await migration.updateItem?.(currentItem.system.spell, currentActor);
+                    }
                 }
             }
         }

--- a/src/module/system/client-backend.ts
+++ b/src/module/system/client-backend.ts
@@ -1,7 +1,12 @@
 import { ActorPF2e } from "@actor";
+import type { ActorSourcePF2e } from "@actor/data/index.ts";
 import { ItemPF2e } from "@item";
+import type { ItemReferenceSource } from "@item/data/base.ts";
+import { ItemSourcePF2e } from "@item/data/index.ts";
 import { MigrationList, MigrationRunner } from "@module/migration/index.ts";
 import { UserPF2e } from "@module/user/document.ts";
+import { UUIDUtils } from "@util/uuid.ts";
+
 import * as R from "remeda";
 
 class ClientDatabaseBackendPF2e extends ClientDatabaseBackend {
@@ -11,7 +16,7 @@ class ClientDatabaseBackendPF2e extends ClientDatabaseBackend {
         user: UserPF2e
     ): Promise<(DeepPartial<ClientDocument["_source"]> & CompendiumIndexData)[] | foundry.abstract.Document[]> {
         const type = documentClass.documentName;
-        if (!["Actor", "Item"].includes(type) || context.pack?.startsWith("pf2e.") || context.options?.index) {
+        if (!["Actor", "Item"].includes(type) || context.options?.index) {
             return super._getDocuments(documentClass, context, user);
         }
 
@@ -22,19 +27,49 @@ class ClientDatabaseBackendPF2e extends ClientDatabaseBackend {
         // Create Document objects
         return Promise.all(
             response.result.map(async (data) => {
+                // System sources can contain item references
+                if (context.pack?.startsWith("pf2e.") && R.isObject<ActorSourcePF2e>(data) && "items" in data) {
+                    const references = data.flags.pf2e?.itemReferences;
+                    if (references?.length) {
+                        data.items = await this.#itemsfromReferences(data.items, references);
+                        delete data.flags.pf2e?.itemReferences;
+                    }
+                    return documentClass.fromSource(data, { pack: context.pack }) as ActorPF2e | ItemPF2e;
+                }
+
                 const document = documentClass.fromSource(data, { pack: context.pack }) as ActorPF2e | ItemPF2e;
-                const migrations = MigrationList.constructFromVersion(document.schemaVersion);
-                if (migrations.length > 0) {
-                    try {
-                        await MigrationRunner.ensureSchemaVersion(document, migrations);
-                    } catch (error) {
-                        if (error instanceof Error) console.error(error.message);
+                // Run migrations on documents from non-system sources
+                if (!context.pack?.startsWith("pf2e.")) {
+                    const migrations = MigrationList.constructFromVersion(document.schemaVersion);
+                    if (migrations.length > 0) {
+                        try {
+                            await MigrationRunner.ensureSchemaVersion(document, migrations);
+                        } catch (error) {
+                            if (error instanceof Error) console.error(error.message);
+                        }
                     }
                 }
 
                 return document;
             })
         );
+    }
+
+    /** Restore item references to full items */
+    async #itemsfromReferences(items: ItemSourcePF2e[], references: ItemReferenceSource[]): Promise<ItemSourcePF2e[]> {
+        const packSources = (await UUIDUtils.fromUUIDs(references.map((r) => r.sourceId))).map((i) =>
+            i.toObject()
+        ) as ItemSourcePF2e[];
+
+        const merged = packSources.flatMap((source) => {
+            const reference = references.find((r) => r.sourceId === source.flags.core?.sourceId);
+            if (!reference) return [];
+            delete (reference as { sourceId: unknown }).sourceId;
+            return mergeObject(source, reference);
+        });
+        console.log(`PF2e System | Resolved ${merged.length} item ${merged.length === 1 ? "reference" : "references"}`);
+
+        return [...items, ...merged].sort((a, b) => a.sort - b.sort);
     }
 }
 


### PR DESCRIPTION
Supported item types that have a `sourceId` flag are compared to their source item. If the data is similar enough the item is replaced with item reference data.
References are resolved in `ClientDatabaseBackend#_getDocuments` prior to creating the actor.
Currently supports spells and physical items.

```ts
interface SpellReferenceSource extends ItemReferenceBaseSource {
    system?: {
        level: SpellSystemSource["level"];
        location: SpellSystemSource["location"];
    };
    type: "spell";
}

interface PhyiscalItemReferenceSource extends ItemReferenceBaseSource {
    system: {
        containerId?: PhysicalSystemSource["containerId"];
        equipped: PhysicalSystemSource["equipped"];
        quantity: PhysicalSystemSource["quantity"];
        usage: PhysicalSystemSource["usage"];
    };
    type: PhysicalItemType;
}
```


ToDo:
- Determine which `system` values are absolutely necessary per item type. This might be easier once we have full `DataModel` support.
- Thoroughly check all physical item type references for differences in required data.
- Try to unify migrations of `ItemSource` and `ItemReferenceSource`.