### PR TITLE
Condense effects for Corrosive Body and Fiery Body

### DIFF
--- a/packs/spell-effects/spell-effect-corrosive-body.json
+++ b/packs/spell-effects/spell-effect-corrosive-body.json
@@ -4,7 +4,7 @@
     "name": "Spell Effect: Corrosive Body",
     "system": {
         "description": {
-            "value": "<p>Granted by <em>@UUID[Compendium.pf2e.spells-srd.Item.Corrosive Body]</em></p>\n<p>You exhale corrosive gas, and acidic secretions coat your skin as you transform into a being of living acid. You gain acid immunity. Any creature that touches you or damages you with an unarmed melee attack or non-reach melee weapon takes @Damage[3d6[acid]] damage, and your unarmed attacks deal 1d4 additional acid damage. The first time each round that you deal acid damage to a creature in this way, you gain [[/r 3d6 #Temporary Hit Points]]{3d6 temporary Hit Points} as your body digests the eroded material and transforms it into a protective acid. When the spell ends, any remaining temporary HP expires as well. Your acid spells deal one additional die of acid damage (of the same damage die the spell uses). You can cast acid splash as an innate spell; the splash damage affects all creatures within 15 feet instead of the normal 5 feet.</p>"
+            "value": "<p>Granted by <em>@UUID[Compendium.pf2e.spells-srd.Item.Corrosive Body]</em></p>\n<p>You exhale corrosive gas, and acidic secretions coat your skin as you transform into a being of living acid. You gain acid immunity. Any creature that touches you or damages you with an unarmed melee attack or non-reach melee weapon takes @Damage[3d6[acid]] damage, and your unarmed attacks deal 1d4 additional acid damage. The first time each round that you deal acid damage to a creature in this way, you gain [[/r 3d6 #Temporary Hit Points]]{3d6 temporary Hit Points} as your body digests the eroded material and transforms it into a protective acid. When the spell ends, any remaining temporary HP expires as well. Your acid spells deal one additional die of acid damage (of the same damage die the spell uses). You can cast <em>@UUID[Compendium.pf2e.spells-srd.Item.Acid Splash]</em> as an innate spell; the splash damage affects all creatures within 15 feet instead of the normal 5 feet.</p>\n<hr />\n<p><strong>Heightened (9th)</strong> Creatures touching you take @Damage[4d6[acid]] damage instead of 3d6, your unarmed attacks deal 2d4 additional acid damage, and you gain [[/r 5d6 #Temporary Hit Points]]{5d6 temporary Hit Points}.</p>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -18,7 +18,7 @@
         "rules": [
             {
                 "damageType": "acid",
-                "diceNumber": 1,
+                "diceNumber": "{item|flags.pf2e.rulesSelections.corrosiveBody.unarmedDice}",
                 "dieSize": "d4",
                 "key": "DamageDice",
                 "predicate": [
@@ -44,9 +44,42 @@
                 "diceNumber": 1,
                 "key": "DamageDice",
                 "predicate": [
-                    "acid"
+                    "acid",
+                    {
+                        "not": "item:corrosive-body"
+                    }
                 ],
                 "selector": "spell-damage"
+            },
+            {
+                "adjustName": true,
+                "choices": [
+                    {
+                        "label": "PF2E.SpellLevel7",
+                        "predicate": [
+                            {
+                                "lte": [
+                                    "parent:level",
+                                    8
+                                ]
+                            }
+                        ],
+                        "value": {
+                            "unarmedDice": 1
+                        }
+                    },
+                    {
+                        "label": "PF2E.SpellLevel9",
+                        "predicate": [
+                            "parent:level:9"
+                        ],
+                        "value": {
+                            "unarmedDice": 2
+                        }
+                    }
+                ],
+                "flag": "corrosiveBody",
+                "key": "ChoiceSet"
             }
         ],
         "source": {

--- a/packs/spell-effects/spell-effect-corrosive-body.json
+++ b/packs/spell-effects/spell-effect-corrosive-body.json
@@ -4,7 +4,7 @@
     "name": "Spell Effect: Corrosive Body",
     "system": {
         "description": {
-            "value": "<p>Granted by <em>@UUID[Compendium.pf2e.spells-srd.Item.Corrosive Body]</em></p>\n<p>You exhale corrosive gas, and acidic secretions coat your skin as you transform into a being of living acid. You gain acid immunity. Any creature that touches you or damages you with an unarmed melee attack or non-reach melee weapon takes @Damage[3d6[acid]] damage, and your unarmed attacks deal 1d4 additional acid damage. The first time each round that you deal acid damage to a creature in this way, you gain [[/r 3d6 #Temporary Hit Points]]{3d6 temporary Hit Points} as your body digests the eroded material and transforms it into a protective acid. When the spell ends, any remaining temporary HP expires as well. Your acid spells deal one additional die of acid damage (of the same damage die the spell uses). You can cast <em>@UUID[Compendium.pf2e.spells-srd.Item.Acid Splash]</em> as an innate spell; the splash damage affects all creatures within 15 feet instead of the normal 5 feet.</p>\n<hr />\n<p><strong>Heightened (9th)</strong> Creatures touching you take @Damage[4d6[acid]] damage instead of 3d6, your unarmed attacks deal 2d4 additional acid damage, and you gain [[/r 5d6 #Temporary Hit Points]]{5d6 temporary Hit Points}.</p>"
+            "value": "<p>Granted by <em>@UUID[Compendium.pf2e.spells-srd.Item.Corrosive Body]</em></p>\n<p>You exhale corrosive gas, and acidic secretions coat your skin as you transform into a being of living acid. You gain acid immunity. Any creature that touches you or damages you with an unarmed melee attack or non-reach melee weapon takes @Damage[3d6[acid]] damage, and your unarmed attacks deal 1d4 additional acid damage. The first time each round that you deal acid damage to a creature in this way, you gain [[/r 3d6 #Temporary Hit Points]] temporary Hit Points as your body digests the eroded material and transforms it into a protective acid. When the spell ends, any remaining temporary HP expires as well. Your acid spells deal one additional die of acid damage (of the same damage die the spell uses). You can cast <em>@UUID[Compendium.pf2e.spells-srd.Item.Acid Splash]</em> as an innate spell; the splash damage affects all creatures within 15 feet instead of the normal 5 feet.</p>\n<hr />\n<p><strong>Heightened (9th)</strong> Creatures touching you take @Damage[4d6[acid]] damage instead of 3d6, your unarmed attacks deal 2d4 additional acid damage, and you gain [[/r 5d6 #Temporary Hit Points]] temporary Hit Points.</p>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -18,7 +18,7 @@
         "rules": [
             {
                 "damageType": "acid",
-                "diceNumber": "{item|flags.pf2e.rulesSelections.corrosiveBody.unarmedDice}",
+                "diceNumber": "ternary(gte(@item.level,9),2,1)",
                 "dieSize": "d4",
                 "key": "DamageDice",
                 "predicate": [
@@ -44,42 +44,9 @@
                 "diceNumber": 1,
                 "key": "DamageDice",
                 "predicate": [
-                    "acid",
-                    {
-                        "not": "item:corrosive-body"
-                    }
+                    "acid"
                 ],
                 "selector": "spell-damage"
-            },
-            {
-                "adjustName": true,
-                "choices": [
-                    {
-                        "label": "PF2E.SpellLevel7",
-                        "predicate": [
-                            {
-                                "lte": [
-                                    "parent:level",
-                                    8
-                                ]
-                            }
-                        ],
-                        "value": {
-                            "unarmedDice": 1
-                        }
-                    },
-                    {
-                        "label": "PF2E.SpellLevel9",
-                        "predicate": [
-                            "parent:level:9"
-                        ],
-                        "value": {
-                            "unarmedDice": 2
-                        }
-                    }
-                ],
-                "flag": "corrosiveBody",
-                "key": "ChoiceSet"
             }
         ],
         "source": {

--- a/packs/spell-effects/spell-effect-fiery-body.json
+++ b/packs/spell-effects/spell-effect-fiery-body.json
@@ -35,7 +35,7 @@
             },
             {
                 "damageType": "fire",
-                "diceNumber": "{item|flags.pf2e.rulesSelections.fieryBody.unarmedDice}",
+                "diceNumber": "ternary(gte(@item.level, 9),2,1)",
                 "dieSize": "d4",
                 "key": "DamageDice",
                 "label": "Fiery Body",
@@ -55,42 +55,9 @@
                 "key": "DamageDice",
                 "label": "Fiery Body",
                 "predicate": [
-                    "fire",
-                    {
-                        "not": "item:fiery-body"
-                    }
+                    "fire"
                 ],
                 "selector": "spell-damage"
-            },
-            {
-                "adjustName": true,
-                "choices": [
-                    {
-                        "label": "PF2E.SpellLevel7",
-                        "predicate": [
-                            {
-                                "lte": [
-                                    "parent:level",
-                                    8
-                                ]
-                            }
-                        ],
-                        "value": {
-                            "unarmedDice": 1
-                        }
-                    },
-                    {
-                        "label": "PF2E.SpellLevel9",
-                        "predicate": [
-                            "parent:level:9"
-                        ],
-                        "value": {
-                            "unarmedDice": 2
-                        }
-                    }
-                ],
-                "flag": "fieryBody",
-                "key": "ChoiceSet"
             }
         ],
         "source": {

--- a/packs/spell-effects/spell-effect-fiery-body.json
+++ b/packs/spell-effects/spell-effect-fiery-body.json
@@ -4,7 +4,7 @@
     "name": "Spell Effect: Fiery Body",
     "system": {
         "description": {
-            "value": "<p>Granted by <em>@UUID[Compendium.pf2e.spells-srd.Item.Fiery Body]</em></p>\n<p>You become living flame, giving you fire immunity, resistance 10 to precision damage, and weakness 5 to cold and to water. Any creature that touches you or damages you with an unarmed attack or non-reach melee weapon takes @Damage[3d6[fire]] damage. Your unarmed attacks deal 1d4 additional fire damage, and your fire spells deal one additional die of fire damage (of the same damage die the spell uses). You can cast <em>@UUID[Compendium.pf2e.spells-srd.Item.Produce Flame]</em> as an innate spell; the casting is reduced from 2 actions to 1. In fire form, you have a fly Speed of 40 feet and don't need to breathe.</p>"
+            "value": "<p>Granted by <em>@UUID[Compendium.pf2e.spells-srd.Item.Fiery Body]</em></p>\n<p>You become living flame, giving you fire immunity, resistance 10 to precision damage, and weakness 5 to cold and to water. Any creature that touches you or damages you with an unarmed attack or non-reach melee weapon takes @Damage[3d6[fire]] damage. Your unarmed attacks deal 1d4 additional fire damage, and your fire spells deal one additional die of fire damage (of the same damage die the spell uses). You can cast <em>@UUID[Compendium.pf2e.spells-srd.Item.Produce Flame]</em> as an innate spell; the casting is reduced from 2 actions to 1. In fire form, you have a fly Speed of 40 feet and don't need to breathe.</p>\n<hr />\n<p><strong>Heightened (9th)</strong> Creatures touching you take @Damage[4d6[fire]] damage instead of 3d6, your unarmed attacks deal 2d4 additional fire damage, and you have a fly Speed of 60 feet.</p>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -35,7 +35,7 @@
             },
             {
                 "damageType": "fire",
-                "diceNumber": 1,
+                "diceNumber": "{item|flags.pf2e.rulesSelections.fieryBody.unarmedDice}",
                 "dieSize": "d4",
                 "key": "DamageDice",
                 "label": "Fiery Body",
@@ -55,9 +55,42 @@
                 "key": "DamageDice",
                 "label": "Fiery Body",
                 "predicate": [
-                    "fire"
+                    "fire",
+                    {
+                        "not": "item:fiery-body"
+                    }
                 ],
                 "selector": "spell-damage"
+            },
+            {
+                "adjustName": true,
+                "choices": [
+                    {
+                        "label": "PF2E.SpellLevel7",
+                        "predicate": [
+                            {
+                                "lte": [
+                                    "parent:level",
+                                    8
+                                ]
+                            }
+                        ],
+                        "value": {
+                            "unarmedDice": 1
+                        }
+                    },
+                    {
+                        "label": "PF2E.SpellLevel9",
+                        "predicate": [
+                            "parent:level:9"
+                        ],
+                        "value": {
+                            "unarmedDice": 2
+                        }
+                    }
+                ],
+                "flag": "fieryBody",
+                "key": "ChoiceSet"
             }
         ],
         "source": {

--- a/packs/spells/corrosive-body.json
+++ b/packs/spells/corrosive-body.json
@@ -18,46 +18,16 @@
             "value": ""
         },
         "damage": {
-            "value": {
-                "Pb1eT1upkmw6q6JG": {
-                    "applyMod": false,
-                    "type": {
-                        "categories": [],
-                        "subtype": "",
-                        "value": "acid"
-                    },
-                    "value": "3d6"
-                }
-            }
+            "value": {}
         },
         "description": {
-            "value": "<p>You exhale corrosive gas, and acidic secretions coat your skin as you transform into a being of living acid. You gain acid immunity. Any creature that touches you or damages you with an unarmed melee attack or non-reach melee weapon takes @Damage[3d6[acid]] damage, and your unarmed attacks deal 1d4 additional acid damage. The first time each round that you deal acid damage to a creature in this way, you gain [[/r 3d6 #Temporary Hit Points]]{3d6 temporary Hit Points} as your body digests the eroded material and transforms it into a protective acid. When the spell ends, any remaining temporary HP expires as well. Your acid spells deal one additional die of acid damage (of the same damage die the spell uses). You can cast acid splash as an innate spell; the splash damage affects all creatures within 15 feet instead of the normal 5 feet.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Corrosive Body]</p>\n<hr />\n<p><strong>Heightened (9th)</strong> Creatures touching you take @Damage[4d6[acid]] damage instead of 3d6, your unarmed attacks deal 2d4 additional acid damage, and you gain [[/r 5d6 #Temporary Hit Points]]{5d6 temporary Hit Points}.</p>"
+            "value": "<p>You exhale corrosive gas, and acidic secretions coat your skin as you transform into a being of living acid. You gain acid immunity. Any creature that touches you or damages you with an unarmed melee attack or non-reach melee weapon takes @Damage[3d6[acid]] damage, and your unarmed attacks deal 1d4 additional acid damage. The first time each round that you deal acid damage to a creature in this way, you gain [[/r 3d6 #Temporary Hit Points]] temporary Hit Points as your body digests the eroded material and transforms it into a protective acid. When the spell ends, any remaining temporary HP expires as well. Your acid spells deal one additional die of acid damage (of the same damage die the spell uses). You can cast <em>@UUID[Compendium.pf2e.spells-srd.Item.Acid Splash]</em> as an innate spell; the splash damage affects all creatures within 15 feet instead of the normal 5 feet.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Corrosive Body]</p>\n<hr />\n<p><strong>Heightened (9th)</strong> Creatures touching you take @Damage[4d6[acid]] damage instead of 3d6, your unarmed attacks deal 2d4 additional acid damage, and you gain [[/r 5d6 #Temporary Hit Points]] temporary Hit Points.</p>"
         },
         "duration": {
             "value": "1 minute"
         },
         "hasCounteractCheck": {
             "value": false
-        },
-        "heightening": {
-            "levels": {
-                "9": {
-                    "damage": {
-                        "value": {
-                            "Pb1eT1upkmw6q6JG": {
-                                "applyMod": false,
-                                "type": {
-                                    "categories": [],
-                                    "subtype": "",
-                                    "value": "acid"
-                                },
-                                "value": "4d6"
-                            }
-                        }
-                    }
-                }
-            },
-            "type": "fixed"
         },
         "level": {
             "value": 7

--- a/packs/spells/corrosive-body.json
+++ b/packs/spells/corrosive-body.json
@@ -18,16 +18,46 @@
             "value": ""
         },
         "damage": {
-            "value": {}
+            "value": {
+                "Pb1eT1upkmw6q6JG": {
+                    "applyMod": false,
+                    "type": {
+                        "categories": [],
+                        "subtype": "",
+                        "value": "acid"
+                    },
+                    "value": "3d6"
+                }
+            }
         },
         "description": {
-            "value": "<p>You exhale corrosive gas, and acidic secretions coat your skin as you transform into a being of living acid. You gain acid immunity. Any creature that touches you or damages you with an unarmed melee attack or non-reach melee weapon takes @Damage[3d6[acid]] damage, and your unarmed attacks deal 1d4 additional acid damage. The first time each round that you deal acid damage to a creature in this way, you gain [[/r 3d6 #Temporary Hit Points]]{3d6 temporary Hit Points} as your body digests the eroded material and transforms it into a protective acid. When the spell ends, any remaining temporary HP expires as well. Your acid spells deal one additional die of acid damage (of the same damage die the spell uses). You can cast acid splash as an innate spell; the splash damage affects all creatures within 15 feet instead of the normal 5 feet.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Corrosive Body]</p>\n<hr />\n<p><strong>Heightened (9th)</strong> Creatures touching you take @Damage[4d6[acid]] damage instead of 3d6, your unarmed attacks deal 2d4 additional acid damage, and you gain [[/r 5d6 #Temporary Hit Points]]{5d6 temporary Hit Points}. @UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Corrosive Body (Heightened 9th)]</p>"
+            "value": "<p>You exhale corrosive gas, and acidic secretions coat your skin as you transform into a being of living acid. You gain acid immunity. Any creature that touches you or damages you with an unarmed melee attack or non-reach melee weapon takes @Damage[3d6[acid]] damage, and your unarmed attacks deal 1d4 additional acid damage. The first time each round that you deal acid damage to a creature in this way, you gain [[/r 3d6 #Temporary Hit Points]]{3d6 temporary Hit Points} as your body digests the eroded material and transforms it into a protective acid. When the spell ends, any remaining temporary HP expires as well. Your acid spells deal one additional die of acid damage (of the same damage die the spell uses). You can cast acid splash as an innate spell; the splash damage affects all creatures within 15 feet instead of the normal 5 feet.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Corrosive Body]</p>\n<hr />\n<p><strong>Heightened (9th)</strong> Creatures touching you take @Damage[4d6[acid]] damage instead of 3d6, your unarmed attacks deal 2d4 additional acid damage, and you gain [[/r 5d6 #Temporary Hit Points]]{5d6 temporary Hit Points}.</p>"
         },
         "duration": {
             "value": "1 minute"
         },
         "hasCounteractCheck": {
             "value": false
+        },
+        "heightening": {
+            "levels": {
+                "9": {
+                    "damage": {
+                        "value": {
+                            "Pb1eT1upkmw6q6JG": {
+                                "applyMod": false,
+                                "type": {
+                                    "categories": [],
+                                    "subtype": "",
+                                    "value": "acid"
+                                },
+                                "value": "4d6"
+                            }
+                        }
+                    }
+                }
+            },
+            "type": "fixed"
         },
         "level": {
             "value": 7

--- a/packs/spells/fiery-body.json
+++ b/packs/spells/fiery-body.json
@@ -31,13 +31,33 @@
             }
         },
         "description": {
-            "value": "<p>You become living flame, giving you fire immunity, resistance 10 to precision damage, and weakness 5 to cold and to water. Any creature that touches you or damages you with an unarmed attack or non-reach melee weapon takes @Damage[3d6[fire]] damage. Your unarmed attacks deal 1d4 additional fire damage, and your fire spells deal one additional die of fire damage (of the same damage die the spell uses). You can cast <em>@UUID[Compendium.pf2e.spells-srd.Item.Produce Flame]</em> as an innate spell; the casting is reduced from 2 actions to 1. In fire form, you have a fly Speed of 40 feet and don't need to breathe.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Fiery Body]</p>\n<hr />\n<p><strong>Heightened (9th)</strong> Creatures touching you take @Damage[4d6[fire]] damage instead of 3d6, your unarmed attacks deal 2d4 additional fire damage, and you have a fly Speed of 60 feet.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Fiery Body (9th Level)]</p>"
+            "value": "<p>You become living flame, giving you fire immunity, resistance 10 to precision damage, and weakness 5 to cold and to water. Any creature that touches you or damages you with an unarmed attack or non-reach melee weapon takes @Damage[3d6[fire]] damage. Your unarmed attacks deal 1d4 additional fire damage, and your fire spells deal one additional die of fire damage (of the same damage die the spell uses). You can cast <em>@UUID[Compendium.pf2e.spells-srd.Item.Produce Flame]</em> as an innate spell; the casting is reduced from 2 actions to 1. In fire form, you have a fly Speed of 40 feet and don't need to breathe.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Fiery Body]</p>\n<hr />\n<p><strong>Heightened (9th)</strong> Creatures touching you take @Damage[4d6[fire]] damage instead of 3d6, your unarmed attacks deal 2d4 additional fire damage, and you have a fly Speed of 60 feet.</p>"
         },
         "duration": {
             "value": "1 minute"
         },
         "hasCounteractCheck": {
             "value": false
+        },
+        "heightening": {
+            "levels": {
+                "9": {
+                    "damage": {
+                        "value": {
+                            "0": {
+                                "applyMod": false,
+                                "type": {
+                                    "categories": [],
+                                    "subtype": "",
+                                    "value": "fire"
+                                },
+                                "value": "4d6"
+                            }
+                        }
+                    }
+                }
+            },
+            "type": "fixed"
         },
         "level": {
             "value": 7

--- a/packs/spells/fiery-body.json
+++ b/packs/spells/fiery-body.json
@@ -18,17 +18,7 @@
             "value": ""
         },
         "damage": {
-            "value": {
-                "0": {
-                    "applyMod": false,
-                    "type": {
-                        "categories": [],
-                        "subtype": "",
-                        "value": "fire"
-                    },
-                    "value": "3d6"
-                }
-            }
+            "value": {}
         },
         "description": {
             "value": "<p>You become living flame, giving you fire immunity, resistance 10 to precision damage, and weakness 5 to cold and to water. Any creature that touches you or damages you with an unarmed attack or non-reach melee weapon takes @Damage[3d6[fire]] damage. Your unarmed attacks deal 1d4 additional fire damage, and your fire spells deal one additional die of fire damage (of the same damage die the spell uses). You can cast <em>@UUID[Compendium.pf2e.spells-srd.Item.Produce Flame]</em> as an innate spell; the casting is reduced from 2 actions to 1. In fire form, you have a fly Speed of 40 feet and don't need to breathe.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Fiery Body]</p>\n<hr />\n<p><strong>Heightened (9th)</strong> Creatures touching you take @Damage[4d6[fire]] damage instead of 3d6, your unarmed attacks deal 2d4 additional fire damage, and you have a fly Speed of 60 feet.</p>"
@@ -38,26 +28,6 @@
         },
         "hasCounteractCheck": {
             "value": false
-        },
-        "heightening": {
-            "levels": {
-                "9": {
-                    "damage": {
-                        "value": {
-                            "0": {
-                                "applyMod": false,
-                                "type": {
-                                    "categories": [],
-                                    "subtype": "",
-                                    "value": "fire"
-                                },
-                                "value": "4d6"
-                            }
-                        }
-                    }
-                }
-            },
-            "type": "fixed"
         },
         "level": {
             "value": 7


### PR DESCRIPTION
- Condenses spell effects for Corrosive Body and Fiery Body with a ChoiceSet predicated on parent level.
- Adds description of 9th level heightened effects to both spell effects' descriptions, and links to Acid Splash in Corrosive Body's description.
- Adds damage entry for Corrosive Body and adds heightened damage for Fiery Body.
- Adds predicates preventing both spells from buffing their own damage.