### PR TITLE
Add configurable effect badge min/max, tweak flamewisp effect to use

### DIFF
--- a/packs/spell-effects/spell-effect-flame-wisp.json
+++ b/packs/spell-effects/spell-effect-flame-wisp.json
@@ -4,14 +4,10 @@
     "name": "Spell Effect: Flame Wisp",
     "system": {
         "badge": {
-            "labels": [
-                "0",
-                "1",
-                "2",
-                "3"
-            ],
+            "max": 3,
+            "min": 0,
             "type": "counter",
-            "value": 4
+            "value": 3
         },
         "description": {
             "value": "<p>Three faintly glowing wisps of fire float around your head. Each time you hit a creature with a Strike, one of the wisps goes hurtling towards that creature, dealing 1d4 fire damage. If you Cast a Spell with the fire trait while you have fewer than three wisps, a new wisp appears.</p>\n<hr />\n<p><strong>Heightened (+2)</strong> The damage increases by 1d4.</p>"

--- a/src/module/item/abstract-effect/data.ts
+++ b/src/module/item/abstract-effect/data.ts
@@ -26,11 +26,13 @@ interface EffectBadgeBase extends EffectBadgeBaseSource {
 
 interface EffectBadgeCounterSource extends EffectBadgeBaseSource {
     type: "counter";
+    min?: number;
     max?: number;
     value: number;
 }
 
 interface EffectBadgeCounter extends EffectBadgeCounterSource, EffectBadgeBase {
+    min: number;
     max: number;
 }
 
@@ -46,6 +48,7 @@ interface EffectBadgeValueSource extends EffectBadgeBaseSource {
 }
 
 interface EffectBadgeValue extends EffectBadgeValueSource, EffectBadgeBase {
+    min: number;
     max: number;
 }
 

--- a/src/module/item/affliction/document.ts
+++ b/src/module/item/affliction/document.ts
@@ -37,6 +37,7 @@ class AfflictionPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extend
         return {
             type: "counter",
             value: this.stage,
+            min: 1,
             max: this.maxStage,
             label,
         };

--- a/src/module/item/condition/document.ts
+++ b/src/module/item/condition/document.ts
@@ -27,6 +27,7 @@ class ConditionPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends
         return this.system.value.value
             ? {
                   type: "counter",
+                  min: 1,
                   max: Infinity,
                   label: null,
                   value: this.system.value.value,

--- a/src/styles/item/_effect-sheet.scss
+++ b/src/styles/item/_effect-sheet.scss
@@ -1,10 +1,60 @@
-.sheet-content .sidebar .inventory-details .form-group {
-    select {
-        max-width: fit-content;
+.sheet-content .sidebar {
+    .inventory-details .form-group {
+        select {
+            max-width: fit-content;
+        }
+
+        .form-group.duration label {
+            max-width: fit-content;
+            padding-right: 0.1em;
+        }
     }
 
-    .form-group.duration label {
-        max-width: fit-content;
-        padding-right: 0.1em;
+    .badge-label-row {
+        align-items: center;
+        display: flex;
+        gap: 4px;
+        width: 100%;
+        label {
+            cursor: pointer;
+            max-width: unset;
+        }
+
+        input[type="radio"] {
+            margin: 0;
+            top: 0;
+        }
+
+        .badge-value {
+            margin-right: 0.1rem;
+            width: 3ch;
+            font-weight: bold;
+            text-align: end;
+        }
+
+        input[type="text"] {
+            flex: 1;
+            text-align: end;
+        }
+    }
+
+    .badge-label-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin: 0.5em 0 0.25em 0;
+    }
+
+    .add-badge {
+        display: flex;
+        align-items: center;
+        select {
+            flex: 1;
+            max-width: unset;
+        }
+        button {
+            flex: 0;
+            line-height: 1.2em;
+        }
     }
 }

--- a/src/styles/item/_sidebar.scss
+++ b/src/styles/item/_sidebar.scss
@@ -97,42 +97,4 @@ section.sidebar {
         padding-bottom: 0;
         white-space: nowrap;
     }
-
-    .badge-label-row {
-        width: 100%;
-        label {
-            cursor: pointer;
-            max-width: unset;
-        }
-
-        input[type="radio"] {
-            margin: 0;
-            top: 0;
-        }
-
-        .badge-value {
-            margin-right: 0.1rem;
-            width: 3ch;
-            font-weight: bold;
-            text-align: end;
-        }
-
-        input[type="text"] {
-            flex: 1;
-            text-align: end;
-        }
-    }
-
-    .add-badge {
-        display: flex;
-        align-items: center;
-        select {
-            flex: 1;
-            max-width: unset;
-        }
-        button {
-            flex: 0;
-            line-height: 1.2em;
-        }
-    }
 }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1956,6 +1956,7 @@
                         "Hint": "The values of a badge can be given descriptive labels. They should be short enough to fit in the effects panel. Labels also serve as a natural maximum value for a badge.",
                         "Placeholder": "New Label"
                     },
+                    "Range": "Range",
                     "ReevaluateFormula": {
                         "Label": "Reevaluate?",
                         "Never": "Never",

--- a/static/templates/items/effect-sidebar.hbs
+++ b/static/templates/items/effect-sidebar.hbs
@@ -77,36 +77,46 @@
         {{/if}}
 
         {{#if data.badge.labels}}
-            <h4>{{localize "PF2E.Item.Effect.Badge.Labels.Label" type=badgeType}}</h4>
-        {{/if}}
-        {{#each data.badge.labels as |label idx|}}
-            <div class="badge-label-row form-fields">
-                {{#unless (eq @root.data.badge.type "formula")}}
-                    <label>
-                        <input
-                            type="radio"
-                            name="system.badge.value"
-                            value="{{add idx 1}}"
-                            data-dtype="Number"
-                            tabindex="-1"
-                            {{checked (eq @root.data.badge.value (add idx 1))}}
-                        />
-                        <span class="badge-value">{{add idx 1}}</span>
-                    </label>
-                {{/unless}}
-                <input type="text" name="system.badge.labels.{{idx}}" value="{{label}}" placeholder="{{localize "PF2E.Item.Effect.Badge.Labels.Placeholder"}}" />
-                {{#if @root.options.editable}}
-                    <div class="item-controls">
-                        <a data-action="badge-delete-label" data-idx="{{idx}}"><i class="fa-solid fa-fw fa-times"></i></a>
-                    </div>
-                {{/if}}
+            <h4 class="badge-label-header">
+                {{localize "PF2E.Item.Effect.Badge.Labels.Label" type=badgeType}}
+                <a class="add-badge" data-action="badge-add-label"><i class="fa-solid fa-fw fa-plus"></i></a>
+            </h4>
+            {{#each data.badge.labels as |label idx|}}
+                <div class="badge-label-row form-fields">
+                    {{#unless (eq @root.data.badge.type "formula")}}
+                        <label>
+                            <input
+                                type="radio"
+                                name="system.badge.value"
+                                value="{{add idx 1}}"
+                                data-dtype="Number"
+                                tabindex="-1"
+                                {{checked (eq @root.data.badge.value (add idx 1))}}
+                            />
+                            <span class="badge-value">{{add idx 1}}</span>
+                        </label>
+                    {{/unless}}
+                    <input type="text" name="system.badge.labels.{{idx}}" value="{{label}}" placeholder="{{localize "PF2E.Item.Effect.Badge.Labels.Placeholder"}}" />
+                    {{#if @root.options.editable}}
+                        <div class="item-controls">
+                            <a data-action="badge-delete-label" data-idx="{{idx}}"><i class="fa-solid fa-fw fa-times"></i></a>
+                        </div>
+                    {{/if}}
+                </div>
+            {{/each}}
+        {{else}}
+            <div class="form-group">
+                <label>{{localize "PF2E.Item.Effect.Badge.Range"}}</label>
+                <div class="form-fields">
+                    <input type="number" name="system.badge.min" value="{{document._source.system.badge.min}}" placeholder="1"/>
+                    -
+                    <input type="number" name="system.badge.max" value="{{document._source.system.badge.max}}" placeholder="Infinity"/>
+                </div>
             </div>
-        {{/each}}
-        <div class="form-fields">
             <button type="button" data-action="badge-add-label">
                 <i class="fa-solid fa-fw fa-plus"></i> {{localize "PF2E.Item.Effect.Badge.Labels.Add"}}
             </button>
-        </div>
+        {{/if}}
     {{else}}
         <div class="add-badge">
             <select class="badge-type">

--- a/static/templates/system/effects-panel.hbs
+++ b/static/templates/system/effects-panel.hbs
@@ -78,7 +78,6 @@
             <div class="value-wrapper">
                 <div class="value"><strong>{{coalesce effect.badge.label effect.badge.value}}</strong></div>
             </div>
-
         {{/if}}
     </div>
 </div>


### PR DESCRIPTION
Once this is in I'll push shattershields (once I find icons for it....)

![image](https://github.com/foundryvtt/pf2e/assets/1286721/adcf9239-bc21-477c-9fa4-423894fcb377)

Also tweaks adding new labels to be a button in the header, to make it easier to add them in mass
![image](https://github.com/foundryvtt/pf2e/assets/1286721/dead375e-967b-4a05-95ed-d6494e4bcc6d)

Is there an existing good way to localize "Infinity" given its a number in and of itself or do I add a localization entry for it?