### PR TITLE
Highlight adjusted @Damage and show base value in a tooltip

### DIFF
--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -596,13 +596,27 @@ class TextEditorPF2e extends TextEditor {
             extraRollOptions,
         });
 
+        // Determine base formula (pre-heighten) that we may show on mouse-over
+        const baseFormula = (() => {
+            const baseRollData = {
+                ...(item?.getRollData() ?? {}),
+                actor: { level: (item && "level" in item ? item.level : null) ?? 1 },
+            };
+            return new DamageRoll(params.formula, baseRollData).formula;
+        })();
+
         const roll = result?.template.damage.roll ?? new DamageRoll(params.formula, args.rollData);
+        const formula = roll.formula;
         const element = createHTMLElement("a", {
-            classes: ["inline-roll", "roll"],
-            children: [damageDiceIcon(roll), args.inlineLabel ?? roll.formula],
+            classes: R.compact(["inline-roll", "roll", baseFormula !== formula ? "altered" : null]),
+            children: [damageDiceIcon(roll), args.inlineLabel ?? formula],
             dataset: {
                 formula: roll._formula,
-                tooltip: roll.formula,
+                tooltip: args.inlineLabel
+                    ? formula
+                    : baseFormula !== formula
+                    ? game.i18n.format("PF2E.InlineDamage.Base", { formula: baseFormula })
+                    : null,
                 damageRoll: params.formula,
                 pf2Domains: domains?.join(",") || null,
                 pf2BaseFormula: result ? params.formula : null,

--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -83,6 +83,7 @@ $adjusted-lower: #cc3311 !default;
     --text-dark: var(--color-text-dark-primary);
     --text-light: #f5efe0;
     --color-text-dark-input: #333;
+    --color-text-dark-improved: #006644;
 
     /* Borders */
     --color-border-divider: #baa991;

--- a/src/styles/_globals.scss
+++ b/src/styles/_globals.scss
@@ -139,6 +139,10 @@ a.content-link {
     color: var(--color-text-dark-primary);
 }
 
+.inline-roll.altered {
+    color: var(--color-text-dark-improved);
+}
+
 /* ----------------------------------------- */
 /* PF2E Action Custom Element                */
 /* ----------------------------------------- */

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1454,6 +1454,9 @@
                 "InvalidDomains": "{type} domains must be sluggified and end with -damage"
             }
         },
+        "InlineDamage": {
+            "Base": "Base: {formula}"
+        },
         "InlineTemplateErrors": {
             "DistanceMissing": "Error in @Template: distance parameter is mandatory",
             "DistanceNoNumber": "Error in @Template: dimension {distance} is not a number",


### PR DESCRIPTION
If we are about to release, its ok to delay since I suspect there will be scenarios where this might be wrong. This presumes it's always adjusted higher, I'd like to see a scenario where it can actually be adjusted lower before accounting for that.

![image](https://github.com/foundryvtt/pf2e/assets/1286721/611eb0cc-025f-44b3-91d2-9bf9c978cd1d)

![image](https://github.com/foundryvtt/pf2e/assets/1286721/fc7a9130-a3c0-4a3a-a999-4d0f3cb114ab)
