### PR TITLE
Add "weapons" type to IWR calculations

### DIFF
--- a/src/module/actor/data/iwr.ts
+++ b/src/module/actor/data/iwr.ts
@@ -134,6 +134,8 @@ abstract class IWR<TType extends IWRType> {
             }
             case "unarmed-attacks":
                 return ["item:category:unarmed"];
+            case "weapons":
+                return ["item:type:weapon"];
             default: {
                 if (iwrType in CONFIG.PF2E.damageTypes) {
                     return [`damage:type:${iwrType}`];


### PR DESCRIPTION
Adds the "weapons" type to IWR calculations. The type already exists but wasn't implemented.