### PR TITLE
Add effect for Vitrifying Blast

### DIFF
--- a/packs/spell-effects/spell-effect-vitrifying-blast.json
+++ b/packs/spell-effects/spell-effect-vitrifying-blast.json
@@ -1,0 +1,50 @@
+{
+    "_id": "UFfItbPq9cVq3LNa",
+    "img": "icons/magic/water/projectiles-ice-faceted-shard-salvo-gray.webp",
+    "name": "Spell Effect: Vitrifying Blast",
+    "system": {
+        "badge": {
+            "max": 3,
+            "type": "counter",
+            "value": 1
+        },
+        "description": {
+            "value": "<p>Granted by <em>@UUID[Compendium.pf2e.spells-srd.Item.Vitrifying Blast]</em></p>\n<p>The target gains weakness to sonic and bludgeoning damage.</p>"
+        },
+        "duration": {
+            "expiry": null,
+            "sustained": false,
+            "unit": "unlimited",
+            "value": -1
+        },
+        "level": {
+            "value": 6
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": true,
+            "title": "Pathfinder Rage of Elements"
+        },
+        "rules": [
+            {
+                "key": "Weakness",
+                "type": [
+                    "bludgeoning",
+                    "sonic"
+                ],
+                "value": "@item.system.badge.value*3"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/spells/vitrifying-blast.json
+++ b/packs/spells/vitrifying-blast.json
@@ -1,6 +1,6 @@
 {
     "_id": "g2V4ID0pl1ZGAxZj",
-    "img": "systems/pf2e/icons/default-icons/spell.svg",
+    "img": "icons/magic/water/projectiles-ice-faceted-shard-salvo-gray.webp",
     "name": "Vitrifying Blast",
     "system": {
         "area": {
@@ -31,7 +31,7 @@
             }
         },
         "description": {
-            "value": "<p>You launch a cone of glass shards, which embed in creatures to turn them partially to glass. The shards deal @Damage[8d6[piercing]] damage to creatures in the area, based on each creature's saving throw.</p>\n<hr />\n<p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target takes half damage and gains weakness 3 to sonic and bludgeoning damage for 1 round.</p>\n<p><strong>Failure</strong> The target takes full damage, is @UUID[Compendium.pf2e.conditionitems.Item.Slowed]{Slowed 1}, and gains weakness to sonic and bludgeoning damage. The weakness is equal to 3 × the slowed value it has from this spell. The target must attempt a Fortitude save at the end of each of its turns; this ongoing save has the incapacitation trait. On a failed save, the creature's slowed value increases by 1 (or by 2 on a critical failure), to a maximum of @UUID[Compendium.pf2e.conditionitems.Item.Slowed]{Slowed 3}. A successful save reduces the creature's slowed value by 1 (or by 2 on a critical success). If the creature ends its turn with a slowed value of 0, the effect ends.</p>\n<p>Critical Failure As failure, but the target is initially @UUID[Compendium.pf2e.conditionitems.Item.Slowed]{Slowed 2}.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by [[/r 1d6]].</p>"
+            "value": "<p>You launch a cone of glass shards, which embed in creatures to turn them partially to glass. The shards deal 8d6 piercing damage to creatures in the area, based on each creature's saving throw.</p>\n<hr />\n<p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target takes half damage and gains weakness 3 to sonic and bludgeoning damage for 1 round.</p>\n<p><strong>Failure</strong> The target takes full damage, is @UUID[Compendium.pf2e.conditionitems.Item.Slowed]{Slowed 1}, and gains weakness to sonic and bludgeoning damage. The weakness is equal to 3 × the slowed value it has from this spell. The target must attempt a Fortitude save at the end of each of its turns; this ongoing save has the incapacitation trait. On a failed save, the creature's slowed value increases by 1 (or by 2 on a critical failure), to a maximum of @UUID[Compendium.pf2e.conditionitems.Item.Slowed]{Slowed 3}. A successful save reduces the creature's slowed value by 1 (or by 2 on a critical success). If the creature ends its turn with a slowed value of 0, the effect ends.</p>\n<p><strong>Critical Failure</strong> As failure, but the target is initially @UUID[Compendium.pf2e.conditionitems.Item.Slowed]{Slowed 2}.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 1d6.</p>"
         },
         "duration": {
             "value": "varies"


### PR DESCRIPTION
Only handle the weakness, as I don't believe you can update the slowed badge value based on the granter's badge value.
Also, this is useful for the successful save as it doesn't grant slowed.