### PR TITLE
Prevent attack item traits from appearing on saving throws

### DIFF
--- a/src/module/system/check/check.ts
+++ b/src/module/system/check/check.ts
@@ -305,16 +305,17 @@ class CheckPF2e {
                 .map((t) => toTagElement(t)) ?? [];
 
         const { item } = context;
-        const itemTraits = item?.isOfType("weapon", "melee")
-            ? Array.from(item.traits)
-                  .map((t): TraitViewData => {
-                      const obj = traitSlugToObject(t, CONFIG.PF2E.npcAttackTraits);
-                      obj.label = game.i18n.localize(obj.label);
-                      return obj;
-                  })
-                  .sort((a, b) => a.label.localeCompare(b.label, game.i18n.lang))
-                  .map((t): HTMLElement => toTagElement(t, "alt"))
-            : [];
+        const itemTraits =
+            item?.isOfType("weapon", "melee") && context.type !== "saving-throw"
+                ? Array.from(item.traits)
+                      .map((t): TraitViewData => {
+                          const obj = traitSlugToObject(t, CONFIG.PF2E.npcAttackTraits);
+                          obj.label = game.i18n.localize(obj.label);
+                          return obj;
+                      })
+                      .sort((a, b) => a.label.localeCompare(b.label, game.i18n.lang))
+                      .map((t): HTMLElement => toTagElement(t, "alt"))
+                : [];
 
         const properties = ((): HTMLElement[] => {
             const range = item?.isOfType("action", "weapon") ? item.range : null;
@@ -351,7 +352,11 @@ class CheckPF2e {
             children: [...modifiers, ...tagsFromOptions],
         });
 
-        return [traitsAndProperties, document.createElement("hr"), modifiersAndExtras];
+        return R.compact([
+            traitsAndProperties.childElementCount > 0 ? traitsAndProperties : null,
+            document.createElement("hr"),
+            modifiersAndExtras,
+        ]);
     }
 
     /** Reroll a rolled check given a chat message. */

--- a/src/module/system/statistic/statistic.ts
+++ b/src/module/system/statistic/statistic.ts
@@ -440,7 +440,7 @@ class StatisticCheck<TParent extends Statistic = Statistic> {
         }
 
         // Add any degree of success adjustments if rolling against a DC
-        const dosAdjustments = dc ? [extractDegreeOfSuccessAdjustments(actor.synthetics, domains)].flat() : [];
+        const dosAdjustments = dc ? extractDegreeOfSuccessAdjustments(actor.synthetics, domains) : [];
 
         // Handle special case of incapacitation trait
         if ((options.has("incapacitation") || options.has("item:trait:incapacitation")) && dc) {


### PR DESCRIPTION
Before & after:
![image](https://github.com/foundryvtt/pf2e/assets/106829671/2656320e-4b8e-481a-8038-b47c5753dacb)
