### PR TITLE
Don't create non-effect macros from compendium item hotbar drops

### DIFF
--- a/src/module/apps/hotbar.ts
+++ b/src/module/apps/hotbar.ts
@@ -2,12 +2,12 @@ import { SKILL_ABBREVIATIONS } from "@actor/values.ts";
 import { ItemPF2e } from "@item";
 import { MacroPF2e } from "@module/macro.ts";
 import { createActionMacro, createSkillMacro, createToggleEffectMacro } from "@scripts/macros/hotbar.ts";
-import { ErrorPF2e, isObject, setHasElement } from "@util";
+import { ErrorPF2e, htmlClosest, isObject, setHasElement } from "@util";
 
 class HotbarPF2e extends Hotbar<MacroPF2e> {
     /** Handle macro creation from non-macros */
     override async _onDrop(event: ElementDragEvent): Promise<void> {
-        const li = event.target.closest<HTMLElement>(".macro");
+        const li = htmlClosest(event.target, ".macro");
         const slot = Number(li?.dataset.slot) || null;
         if (!slot) return;
 
@@ -38,8 +38,12 @@ class HotbarPF2e extends Hotbar<MacroPF2e> {
 
                 if (item.isOfType("condition", "effect")) {
                     return createToggleEffectMacro(item, slot);
+                } else if (uuid?.startsWith("Compendium.")) {
+                    ui.notifications.error("PF2E.Macro.NoCompendiumItem", { localize: true });
+                    return;
+                } else {
+                    return HotbarPF2e.#createItemMacro(item, slot);
                 }
-                return HotbarPF2e.#createItemMacro(item, slot);
             }
             case "RollOption": {
                 const item = fromUuidSync(data.uuid ?? "");

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2440,7 +2440,8 @@
                 "Off": "OFF",
                 "On": "ON"
             },
-            "Plural": "Macros"
+            "Plural": "Macros",
+            "NoCompendiumItem": "A macro cannot be created from a compendium item that isn't an effect or condition."
         },
         "MacroActionNoActionError": "This action no longer exists!",
         "MacroActionNoActorError": "This actor no longer exists!",


### PR DESCRIPTION
![image](https://github.com/foundryvtt/pf2e/assets/106829671/ea6bdcc0-457e-4c55-9653-ee9282605b0c)
