### PR TITLE
Avoid Whitespace wrap in tags

### DIFF
--- a/src/styles/_tags.scss
+++ b/src/styles/_tags.scss
@@ -7,6 +7,7 @@
     list-style-type: none;
     margin-bottom: 2px;
     padding-left: 0;
+    white-space: nowrap;
 
     .tag,
     .tag option {


### PR DESCRIPTION
Small CSS touch to avoid undesred CSS wrapping of tags in case of whitespaces. In the french translation, this happens:
![image](https://github.com/foundryvtt/pf2e/assets/63196064/dc28a287-6a6b-44a0-bef2-2239e0d183b0)

With the proposed change:
![image](https://github.com/foundryvtt/pf2e/assets/63196064/4ac65725-6570-471c-9cd3-85b8ca1baa1b)
