### PR TITLE
Fix bonus feats not appearing on the character sheet

### DIFF
--- a/src/module/actor/character/feats.ts
+++ b/src/module/actor/character/feats.ts
@@ -317,7 +317,7 @@ class FeatGroup<TActor extends ActorPF2e = ActorPF2e, TItem extends FeatLike = F
         const slot: FeatSlot<TItem> | undefined = this.slots[slotId];
         if (!slot && this.slotted) return false;
 
-        if (setHasElement(FEAT_CATEGORIES, this.id) && feat.category !== this.id) {
+        if (setHasElement(FEAT_CATEGORIES, this.id) && this.id !== "bonus" && feat.category !== this.id) {
             // If this feat group has an ID of a feat category, only allow feats of that category
             return false;
         }


### PR DESCRIPTION
Because [the bonus feat group now uses `assignFeat` instead of `feat.push`](https://github.com/foundryvtt/pf2e/pull/10677#discussion_r1357635350), the bonus feat group now goes through a bunch of checks it previously didn't when getting a new feat assigned to it -- one of which is the check to only allow feats whose category is the same as the current group's ID.

This causes the bonus feat group to reject any feat whose category is not bonus feat.

Since custom groups don't (read: shouldn't) have IDs that match the existing categories, and since `assignFeat` is probably the more "proper" way to add feats, I decided to just hardcode one specific exception to the bonus feat group.