### PR TITLE
Fix compendium browser publication source loading

### DIFF
--- a/src/module/apps/compendium-browser/loader.ts
+++ b/src/module/apps/compendium-browser/loader.ts
@@ -133,7 +133,7 @@ class PackLoader {
         const progress = new Progress({ max: packs.length });
 
         const loadedSources = new Set<string>();
-        const indexFields = ["system.details.source.value", "system.source.value"];
+        const indexFields = ["system.publication.title", "system.source.value"];
         const knownDocumentTypes = ["Actor", "Item"];
 
         for (const packId of packs) {
@@ -160,8 +160,8 @@ class PackLoader {
 
     #getSourceFromDocument(document: CompendiumIndexData): string {
         // There are two possible fields where the source can be, check them in order
-        if (document.system?.details?.source?.value) {
-            return document.system.details.source.value;
+        if (document.system?.publication?.title) {
+            return document.system.publication.title;
         }
 
         if (document.system?.source?.value) {

--- a/src/module/apps/compendium-browser/tabs/bestiary.ts
+++ b/src/module/apps/compendium-browser/tabs/bestiary.ts
@@ -30,7 +30,7 @@ export class CompendiumBrowserBestiaryTab extends CompendiumBrowserTab {
         "actorSize",
         "traits",
         "rarity",
-        "publication",
+        "source",
     ];
 
     constructor(browser: CompendiumBrowser) {

--- a/src/module/apps/compendium-browser/tabs/equipment.ts
+++ b/src/module/apps/compendium-browser/tabs/equipment.ts
@@ -24,7 +24,7 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
         "priceInCopper",
         "traits",
         "rarity",
-        "publication",
+        "source",
     ];
 
     #localizeCoins = localizer("PF2E.CurrencyAbbreviations");


### PR DESCRIPTION
I'm not sure if `"system.source.value"` is needed anymore so I left it in.

Closes #10750 