### PR TITLE
Implement spell references

### DIFF
--- a/build/lib/compendium-pack.ts
+++ b/build/lib/compendium-pack.ts
@@ -336,6 +336,10 @@ class CompendiumPack {
                     }
                 }
             }
+        } else if (itemIsOfType(source, "spellcastingEntry") && source.system.references) {
+            for (const reference of Object.values(source.system.references)) {
+                reference.sourceId = CompendiumPack.convertUUID(reference.sourceId, convertOptions);
+            }
         }
 
         source.system.rules = source.system.rules.map((r) =>

--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -431,6 +431,10 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
         );
     }
 
+    resetItemTypesCache(): void {
+        this._itemTypes = null;
+    }
+
     /** Apply effects from an aura: will later be expanded to handle effects from measured templates */
     async applyAreaEffects(aura: AuraData, origin: { actor: ActorPF2e; token: TokenDocumentPF2e }): Promise<void> {
         if (

--- a/src/module/item/spellcasting-entry/collection.ts
+++ b/src/module/item/spellcasting-entry/collection.ts
@@ -89,8 +89,8 @@ class SpellCollection<TActor extends ActorPF2e, TEntry extends BaseSpellcastingE
             );
         }
 
-        const isHeigthened = canHeighten && heightenedRank >= spell.baseRank;
-        const heightenedUpdate = isHeigthened ? { "system.location.heightenedLevel": heightenedRank } : {};
+        const isHeightened = canHeighten && heightenedRank >= spell.baseRank;
+        const heightenedUpdate = isHeightened ? { "system.location.heightenedLevel": heightenedRank } : {};
 
         if (spell.actor === actor) {
             // Reference
@@ -100,7 +100,7 @@ class SpellCollection<TActor extends ActorPF2e, TEntry extends BaseSpellcastingE
                     // Differnt entry
                     await spell.spellcasting?.references?.move(spell.id, this.id);
                     return (this.entry.references?.spellCache.get(spell.id) as SpellPF2e<TActor>) ?? null;
-                } else if (isHeigthened) {
+                } else if (isHeightened) {
                     // Same entry
                     return spell.update(heightenedUpdate) as Promise<SpellPF2e<TActor>>;
                 }
@@ -114,7 +114,7 @@ class SpellCollection<TActor extends ActorPF2e, TEntry extends BaseSpellcastingE
         } else {
             // Create reference if possible
             const result = await SpellReferences.fromSpell(spell, this.entry, {
-                heightenTo: isHeigthened ? heightenedRank : null,
+                heightenTo: isHeightened ? heightenedRank : null,
             });
             if (result) {
                 return result as SpellPF2e<TActor>;

--- a/src/module/item/spellcasting-entry/data.ts
+++ b/src/module/item/spellcasting-entry/data.ts
@@ -4,6 +4,7 @@ import { MagicTradition } from "@item/spell/types.ts";
 import { OneToTen, ZeroToEleven, ZeroToFour } from "@module/data.ts";
 import type { RollNotePF2e } from "@module/notes.ts";
 import { SpellcastingCategory } from "./types.ts";
+import { SpellReferenceSource } from "@item/spellcasting-entry/references.ts";
 
 // temporary type until the spellcasting entry is migrated to no longer use slotX keys
 type SlotKey = `slot${ZeroToEleven}`;
@@ -52,6 +53,7 @@ interface SpellcastingEntrySystemSource extends ItemSystemSource {
         slug: string;
         value: ZeroToFour;
     };
+    references: Record<string, SpellReferenceSource>;
     slots: Record<SlotKey, SpellSlotData>;
     autoHeightenLevel: {
         value: OneToTen | null;

--- a/src/module/item/spellcasting-entry/document.ts
+++ b/src/module/item/spellcasting-entry/document.ts
@@ -16,12 +16,15 @@ import {
     SpellcastingEntryPF2eCastOptions,
     SpellcastingSheetData,
 } from "./types.ts";
+import { SpellReferences } from "./references.ts";
 
 class SpellcastingEntryPF2e<TParent extends ActorPF2e | null = ActorPF2e | null>
     extends ItemPF2e<TParent>
     implements SpellcastingEntry<TParent>
 {
     declare spells: SpellCollection<NonNullable<TParent>, this> | null;
+
+    declare references: SpellReferences | null;
 
     /** Spellcasting attack and dc data created during actor preparation */
     declare statistic: Statistic;
@@ -108,6 +111,8 @@ class SpellcastingEntryPF2e<TParent extends ActorPF2e | null = ActorPF2e | null>
                 check: { type: "check" },
             });
         }
+
+        this.references = this.actor ? new SpellReferences(this as SpellcastingEntryPF2e<ActorPF2e>) : null;
     }
 
     override prepareSiblingData(this: SpellcastingEntryPF2e<ActorPF2e>): void {

--- a/src/module/item/spellcasting-entry/references.ts
+++ b/src/module/item/spellcasting-entry/references.ts
@@ -1,0 +1,293 @@
+import * as R from "remeda";
+import { ActorPF2e } from "@actor";
+import { CreatureSheetPF2e } from "@actor/creature/sheet.ts";
+import { ItemProxyPF2e, SpellPF2e, SpellcastingEntryPF2e } from "@item";
+import { SpellSystemSource } from "@item/spell/data.ts";
+import { UUIDUtils } from "@util/uuid.ts";
+import { SpellCollection } from "./collection.ts";
+import { ErrorPF2e } from "@util";
+import { BaseSpellcastingEntry } from "./index.ts";
+
+class SpellReferences extends Collection<SpellReferenceSource> {
+    actor: ActorPF2e;
+
+    constructor(public entry: SpellcastingEntryPF2e<ActorPF2e>) {
+        super(Object.entries(entry.system.references ?? {}));
+        this.actor = entry.actor;
+    }
+
+    get collection(): SpellCollection<ActorPF2e, SpellcastingEntryPF2e<ActorPF2e>> | null {
+        return this.entry.spells;
+    }
+
+    get spellCache(): Map<string, SpellPF2e<ActorPF2e>> {
+        if (!(this.actor.sheet instanceof CreatureSheetPF2e)) {
+            throw ErrorPF2e(`Invalid actor type "${this.actor.type}" for SpellReferences!`);
+        }
+        return this.actor.sheet.spellCache;
+    }
+
+    /** Cache all referenced spell documents in the compendium cache. This should run only once,
+     *  before individual references are resolved */
+    static async cacheAll<TActor extends ActorPF2e = ActorPF2e>(
+        collection: Collection<SpellCollection<TActor, BaseSpellcastingEntry<TActor>>>,
+    ): Promise<void> {
+        if (!collection) return;
+
+        const start = performance.now();
+        const sourceIds = R.compact(
+            collection.contents.flatMap((c) =>
+                Object.values(c.entry.system?.references ?? {}).flatMap((r) => r.sourceId),
+            ),
+        );
+        if (sourceIds.length === 0) return;
+
+        const result = await UUIDUtils.fromUUIDs(sourceIds);
+        const duration = performance.now() - start;
+        console.log(
+            `PF2e System | Retrieved ${result.length} Spell ${
+                result.length === 1 ? "reference" : "references"
+            } in ${duration}ms`,
+        );
+    }
+
+    /** Converts an existing spell reference to an embedded spell */
+    static async toItem(entry: Maybe<BaseSpellcastingEntry>, id: string): Promise<SpellPF2e | null> {
+        if (!entry?.references) return null;
+        if (!entry.references.has(id)) {
+            throw ErrorPF2e(`No Reference with id "${id}" in SpellcastinEntry with id "${entry.id}"`);
+        }
+        const spell = entry.references.spellCache.get(id);
+        if (!spell) return null;
+
+        const convert = await Dialog.confirm({
+            title: game.i18n.localize("PF2E.EditItemTitle"),
+            content: `<p>${game.i18n.localize("PF2E.Item.References.EditDialogText")}</p>`,
+            defaultYes: false,
+        });
+        if (convert) {
+            await entry.references.deleteReference(spell.id, { render: false });
+            const result = await spell.actor.createEmbeddedDocuments("Item", [spell.toObject()]);
+            return (result[0] as SpellPF2e) ?? null;
+        }
+        return null;
+    }
+
+    /** Converts a spell to a spell reference */
+    static async fromSpell<TActor extends ActorPF2e | null>(
+        spell: SpellPF2e,
+        entry: Maybe<BaseSpellcastingEntry>,
+        { heightenTo, skipDialog }: ToReferenceOptions = {},
+    ): Promise<SpellPF2e<TActor> | null> {
+        if (spell.isReference || !entry?.references) return null;
+
+        // Try to find a source UUID. World item references are not supported
+        const sourceId = spell.uuid.startsWith("Compendium.")
+            ? spell.uuid
+            : spell.uuid.startsWith("Item.")
+              ? null
+              : spell.flags.core?.sourceId;
+
+        // Ensure the UUID is not an embedded item inside of a compendium actor
+        if (!sourceId || !/^Compendium\..*?\..*?\.Item\..*$/.test(sourceId)) return null;
+
+        // Base reference data
+        const reference: SpellReferenceSource = {
+            sourceId,
+            sort: spell.sort,
+        };
+        // Set heightened if required
+        const heightenedRank = heightenTo ?? spell.system.location.heightenedLevel;
+        if (heightenedRank) {
+            reference.system = { location: { heightenedLevel: heightenedRank } };
+        }
+        // Set uses for innate spells
+        if (entry.isInnate) {
+            reference.system = mergeObject(
+                reference.system ?? {},
+                { location: { uses: { value: 1, max: 1 } } },
+                { overwrite: false },
+            );
+        }
+        // Handle embeddded spells
+        if (spell.actor) {
+            if (!skipDialog) {
+                const confirmed = await Dialog.confirm({
+                    title: game.i18n.localize("PF2E.Item.References.ToReferenceDialog.Title"),
+                    content: `<p>${game.i18n.localize("PF2E.Item.References.ToReferenceDialog.Text")}</p>`,
+                    defaultYes: false,
+                });
+                if (!confirmed) return null;
+            }
+            await spell.delete({ render: false });
+            return entry.references.create(reference, spell.id);
+        }
+        return entry.references.create(reference);
+    }
+
+    /** Resolve spell references and add spells to actor collections */
+    async resolve(): Promise<void> {
+        if (!this.actor || this.size === 0) return;
+
+        const cachedAndMisses = [...this.keys()].map((id) => this.spellCache.get(id) ?? id);
+        const cached = cachedAndMisses.filter((i): i is SpellPF2e<ActorPF2e> => typeof i !== "string");
+        if (cached.length === this.size) {
+            return this.#setCollections(cached);
+        }
+        const misses = cachedAndMisses.filter((i): i is string => typeof i === "string");
+        const uuids = R.compact(misses.map((id) => this.get(id)?.sourceId));
+
+        // Retrieve cache misses, merge with reference data and add to spell cache
+        const compendiumDocs = (await UUIDUtils.fromUUIDs(uuids)) as SpellPF2e<ActorPF2e>[];
+        const fromCompendium: SpellPF2e<ActorPF2e>[] = [];
+        for (const id of misses) {
+            const data = deepClone(this.get(id) ?? null);
+            const itemSource = compendiumDocs.find((i) => i.flags.core?.sourceId === data?.sourceId)?.toObject();
+            if (!data || !itemSource) continue;
+            delete (data as { sourceId: unknown }).sourceId;
+            itemSource._id = id;
+            itemSource.system.location.value = this.entry.id;
+            const newItem = new ItemProxyPF2e(mergeObject(itemSource, data), {
+                parent: this.actor,
+            }) as SpellPF2e<ActorPF2e>;
+            fromCompendium.push(newItem);
+            this.spellCache.set(id, newItem);
+        }
+        this.#setCollections([...cached, ...fromCompendium]);
+    }
+
+    #setCollections(spells: SpellPF2e<ActorPF2e>[]): void {
+        if (!this.actor || !this.collection) return;
+        for (const spell of spells) {
+            spell.isReference = true;
+            if (!this.collection.get(spell.id)) {
+                this.collection.set(spell.id, spell);
+            }
+            if (!this.actor.items.get(spell.id)) {
+                this.actor.items.set(spell.id, spell);
+            }
+        }
+        this.actor.resetItemTypesCache();
+    }
+
+    async create<TActor extends ActorPF2e | null>(
+        reference: SpellReferenceSource,
+        specificId?: string,
+    ): Promise<SpellPF2e<TActor> | null> {
+        const id = specificId ?? randomID();
+        await this.entry.update({ [`system.references.${id}`]: reference });
+        return (this.spellCache.get(id) as SpellPF2e<TActor>) ?? null;
+    }
+
+    async update(
+        id: string,
+        data: Record<string, unknown>,
+        context?: DocumentUpdateContext<ActorPF2e>,
+    ): Promise<SpellPF2e> {
+        if (!this.#isValidUpdateData(data)) {
+            throw ErrorPF2e(`Invalid spell reference update data: ${JSON.stringify(data)}`);
+        }
+        const spell = this.spellCache.get(id);
+        if (!spell) {
+            throw ErrorPF2e(`The Collection has no reference with id "${id}"!`);
+        }
+        // Update the cached spell
+        spell.updateSource(data);
+        // Update the reference data
+        await this.entry.update({ [`system.references.${id}`]: data }, context);
+        return spell;
+    }
+
+    override delete(id: string): boolean {
+        const deleted = !!(
+            super.delete(id) &&
+            this.spellCache.delete(id) &&
+            this.collection?.delete(id) &&
+            this.actor?.items.delete(id)
+        );
+        if (deleted) {
+            this.actor.resetItemTypesCache();
+        }
+        return deleted;
+    }
+
+    async deleteReference(id: string, context?: DocumentModificationContext<ActorPF2e>): Promise<void> {
+        if (this.delete(id)) {
+            await this.entry.update({ [`system.references.-=${id}`]: null }, context);
+        }
+    }
+
+    async move(spellId: string, newEntryId: string): Promise<void> {
+        const reference = this.get(spellId, { strict: true });
+        const newEntry = this.actor.items.get<SpellcastingEntryPF2e<ActorPF2e>>(newEntryId, { strict: true });
+        if (!this.delete(spellId)) {
+            return;
+        }
+
+        // Handle moving from/to innate entries
+        if (this.entry.isInnate && !newEntry.isInnate && reference.system?.location) {
+            delete reference.system.location.uses;
+            if (R.isEmpty(reference.system.location)) {
+                delete reference.system;
+            }
+        } else if (newEntry.isInnate) {
+            reference.system = mergeObject(
+                reference.system ?? {},
+                { location: { uses: { value: 1, max: 1 } } },
+                { overwrite: false },
+            );
+        }
+
+        const updates = [
+            {
+                _id: this.entry.id,
+                [`system.references.-=${spellId}`]: null,
+            },
+            {
+                _id: newEntry.id,
+                [`system.references.${spellId}`]: reference,
+            },
+        ];
+        await this.actor.updateEmbeddedDocuments("Item", updates);
+    }
+
+    #isValidUpdateData(data: Record<string, unknown>): boolean {
+        const topLevelKeys = ["sort", "system"];
+        const systemKeys = ["location"];
+        const locationKeys = ["autoHeightenLevel", "heightenedLevel", "signature", "uses"];
+        const expanded = expandObject(data);
+        for (const key of Object.keys(expanded)) {
+            if (!topLevelKeys.includes(key)) return false;
+        }
+        if (
+            "system" in expanded &&
+            R.isObject<{ system: { location?: Partial<SpellSystemSource["location"]> } }>(expanded)
+        ) {
+            for (const key of Object.keys(expanded.system)) {
+                if (!systemKeys.includes(key)) return false;
+            }
+            if (expanded.system.location) {
+                for (const key of Object.keys(expanded.system.location)) {
+                    if (!locationKeys.includes(key)) return false;
+                }
+            }
+        }
+        return true;
+    }
+}
+
+interface ToReferenceOptions {
+    heightenTo?: number | null;
+    skipDialog?: boolean;
+}
+
+interface SpellReferenceSource {
+    sourceId: ItemUUID;
+    sort: number;
+    system?: {
+        location: Partial<SpellSystemSource["location"]>;
+    };
+}
+
+export { SpellReferences };
+export type { SpellReferenceSource };

--- a/src/module/item/spellcasting-entry/types.ts
+++ b/src/module/item/spellcasting-entry/types.ts
@@ -7,6 +7,7 @@ import { ZeroToTen } from "@module/data.ts";
 import { Statistic, StatisticChatData } from "@system/statistic/index.ts";
 import { SpellCollection } from "./collection.ts";
 import { SpellcastingEntrySystemData } from "./data.ts";
+import { SpellReferences } from "./references.ts";
 
 interface BaseSpellcastingEntry<TActor extends ActorPF2e | null = ActorPF2e | null> {
     id: string;
@@ -24,6 +25,7 @@ interface BaseSpellcastingEntry<TActor extends ActorPF2e | null = ActorPF2e | nu
     statistic?: Statistic | null;
     tradition: MagicTradition | null;
     spells: SpellCollection<NonNullable<TActor>, this> | null;
+    references?: SpellReferences | null;
     system?: SpellcastingEntrySystemData;
 
     getSheetData(): Promise<SpellcastingSheetData>;

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2258,6 +2258,16 @@
                 }
             },
             "Plural": "Items",
+            "References": {
+                "CachingInfo": "Spell preparation is not finished yet. Please wait a moment.",
+                "EditDialogText": "Editing the item will prevent future data updates, except migrations, from being applied automatically. Are you sure you want to edit the item?",
+                "ToReferenceDialog": {
+                    "ButtonLabel": "To Reference",
+                    "Text": "Converting this spell to a reference will delete all local changes. Are you sure?",
+                    "Title": "Convert to Reference"
+                },
+                "ViewItemTitle": "View Item"
+            },
             "RefreshFromCompendium": {
                 "Label": "Refresh",
                 "SourceNotFound": "The compendium source for \"{item}\" (source ID: {sourceId}) was not found.",

--- a/static/templates/actors/partials/spell-collection.hbs
+++ b/static/templates/actors/partials/spell-collection.hbs
@@ -126,7 +126,11 @@
                                             </a>
                                         {{/if}}
                                         {{#unless virtual}}
-                                            <a class="item-control item-edit" title="{{localize "PF2E.EditItemTitle"}}"><i class="fa-solid fa-fw fa-edit"></i></a>
+                                            {{#if spell.isReference}}
+                                                <a class="item-control item-edit" title="{{localize "PF2E.Item.References.ViewItemTitle"}}"><i class="fa-solid fa-fw fa-eye"></i></a>
+                                            {{else}}
+                                                <a class="item-control item-edit" title="{{localize "PF2E.EditItemTitle"}}"><i class="fa-solid fa-fw fa-edit"></i></a>
+                                            {{/if}}
                                             <a class="item-control item-delete" title="{{localize "PF2E.DeleteItemTitle"}}"><i class="fa-solid fa-fw fa-trash"></i></a>
                                         {{/unless}}
                                     {{/if}}

--- a/static/templates/actors/spell-preparation-sheet.hbs
+++ b/static/templates/actors/spell-preparation-sheet.hbs
@@ -104,7 +104,11 @@
                             {{/unless}}
                             {{#if @root.editable}}
                                 <div class="item-controls">
-                                    <a class="control" data-action="edit-spell" data-tooltip="PF2E.EditItemTitle"><i class="fa-solid fa-edit fa-fw"></i></a>
+                                    {{#if spell.isReference}}
+                                        <a class="control" data-action="edit-spell" data-tooltip="PF2E.Item.References.ViewItemTitle"><i class="fa-solid fa-eye fa-fw"></i></a>
+                                    {{else}}
+                                        <a class="control" data-action="edit-spell" data-tooltip="PF2E.EditItemTitle"><i class="fa-solid fa-edit fa-fw"></i></a>
+                                    {{/if}}
                                     <a class="control" data-action="delete-spell" data-tooltip="PF2E.DeleteItemTitle"><i class="fa-solid fa-trash fa-fw"></i></a>
                                 </div>
                             {{/if}}

--- a/types/foundry/client/apps/app.d.ts
+++ b/types/foundry/client/apps/app.d.ts
@@ -347,7 +347,7 @@ declare global {
         label: string;
         class: string;
         icon: string;
-        onclick: ((event: Event) => void) | null;
+        onclick: ((event: MouseEvent) => void) | null;
     }
 
     interface RenderOptions extends Partial<ApplicationOptions> {


### PR DESCRIPTION
### General
All new embedded spells are created as spell references if they come from a compendium or if they have a valid `sourceId` flag.
References are resolved the first time a character or npc sheet is openend and a cache of resolved spells is kept indefinitely.
Loading the compendium spells works as efficient as possible but it can still take some time for slower connections.
The following is Chrome throttled to slow 3G:

![image](https://github.com/foundryvtt/pf2e/assets/41452412/45abc267-d14c-4e0f-90de-3d0f10a8d3ac)

References should be indistinguishable from normal embedded items in all workflows unless I've missed some edge cases.

The references store minimal data on their spellcasting entry:
```ts
interface SpellReferenceSource {
    sourceId: ItemUUID;
    sort: number;
    system?: {
        location: Partial<SpellSystemSource["location"]>;
    };
}
```

They are stored at `SpellcastingEntryPF2e#system.reference` as `Record<string, SpellReferenceSource>` where the key is the item id of the created reference.

### UI

Reference item sheets can be viewed but editing is diabled:
![image](https://github.com/foundryvtt/pf2e/assets/41452412/a8ad3b5e-98c6-45d5-96f7-baf200d9aefe)
![image](https://github.com/foundryvtt/pf2e/assets/41452412/bccc890c-7b24-4f21-ad4e-3ca51a08e6d5)

Pressing the `Edit Item` button will show a warning dialog and, if confirmed, convert the reference to a normal embedded item:
![image](https://github.com/foundryvtt/pf2e/assets/41452412/79c7497c-63cf-4827-b24c-5e41687c672e)

Embedded spells have a `To Reference` button that is currently only visible in development. Maybe useful for everyone?
![image](https://github.com/foundryvtt/pf2e/assets/41452412/53f217da-aa10-4d9f-b594-cde1123e606d)