### PR TITLE
Automatically italicize spell content links

### DIFF
--- a/src/styles/_globals.scss
+++ b/src/styles/_globals.scss
@@ -133,6 +133,11 @@ a.foundry-href {
 
 a.content-link {
     line-height: 1.6em;
+
+    // Automatically italicize spell content links
+    &:has(i.fa-sparkles) {
+        font-style: italic;
+    }
 }
 
 #tooltip a.content-link {


### PR DESCRIPTION
Look, ma, no \<em\>!
![image](https://github.com/foundryvtt/pf2e/assets/106829671/d4ab34f0-dd64-4288-923d-a6753b6bb617)

![image](https://github.com/foundryvtt/pf2e/assets/106829671/f57cb7f4-997b-4eb0-8afe-b57cc32a4871)
