### PR TITLE
Fix ancestry featgroup not being able to filter for homebrew ancestries

### DIFF
--- a/src/module/actor/character/feats.ts
+++ b/src/module/actor/character/feats.ts
@@ -32,11 +32,10 @@ class CharacterFeats<TActor extends CharacterPF2e> extends Collection<FeatGroup<
 
         // Find every ancestry and versatile heritage the actor counts as, then get all the traits that match them,
         // falling back to homebrew
-        const ancestryTraitsFilter = (
+        const ancestryTraitsFilter =
             actor.system.details.ancestry?.countsAs
                 .map((t) => getVanillaOrHomebrewTrait(t))
-                .filter((e): e is Exclude<typeof e, null> => e !== null) ?? []
-        ).map((x) => `traits-${x}`);
+                .flatMap((t) => (t ? `traits-${t}` : [])) ?? [];
 
         this.createGroup({
             id: "ancestry",

--- a/src/module/actor/character/feats.ts
+++ b/src/module/actor/character/feats.ts
@@ -30,22 +30,25 @@ class CharacterFeats<TActor extends CharacterPF2e> extends Collection<FeatGroup<
             supported: ["classfeature"],
         });
 
+        // Find every ancestry and versatile heritage the actor counts as, then get all the traits that match them,
+        // falling back to homebrew
+        const ancestryTraitsFilter = (
+            actor.system.details.ancestry?.countsAs
+                .map((t) => getVanillaOrHomebrewTrait(t))
+                .filter((e): e is Exclude<typeof e, null> => e !== null) ?? []
+        ).map((x) => `traits-${x}`);
+
         this.createGroup({
             id: "ancestry",
             label: "PF2E.FeatAncestryHeader",
-            featFilter: actor.system.details.ancestry?.countsAs.map((t) => `traits-${t}`) ?? [],
+            featFilter: ancestryTraitsFilter,
             supported: ["ancestry"],
             slots: classFeatSlots?.ancestry ?? [],
         });
 
         // Attempt to acquire the trait corresponding with actor's class, falling back to homebrew variations
         const classSlug = actor.class ? actor.class.slug ?? sluggify(actor.class.name) : null;
-        const classTrait =
-            (classSlug ?? "") in CONFIG.PF2E.featTraits
-                ? classSlug
-                : `hb_${classSlug}` in CONFIG.PF2E.featTraits
-                ? `hb_${classSlug}`
-                : null;
+        const classTrait = getVanillaOrHomebrewTrait(classSlug);
 
         const classFeatFilter = !classTrait
             ? // A class hasn't been selected: no useful pre-filtering available
@@ -394,6 +397,10 @@ class FeatGroup<TActor extends ActorPF2e = ActorPF2e, TItem extends FeatLike = F
 
         return changed;
     }
+}
+
+function getVanillaOrHomebrewTrait(slug: string | null) {
+    return (slug ?? "") in CONFIG.PF2E.featTraits ? slug : `hb_${slug}` in CONFIG.PF2E.featTraits ? `hb_${slug}` : null;
 }
 
 function isBoonOrCurse(feat: FeatPF2e) {


### PR DESCRIPTION
Simple enough: the ancestry featgroup didn't account for the `hb_` prepended string for homebrew ancestries (and heritages), so when you tried to filter for those using the magnifying glass icons next to the ancestry feat slots, you'd get shown all ancestries' feats. 
Used the same logic as the class featgroup uses, then lifted out the now-common logic.

An alternate option would have been to modify either the slug or the filling up of `sameAs`, but neither felt like safe options. 

The previous logic would have worked if the homebrew ancestry / versatile heritage slugs started with `hb_`, but this isn't communicated anywhere, and honestly should not be expected considering no other feat or feature would need it.
So I think this is the most reasonable approach to fixing the issue.