### PR TITLE
Include `target` as resolvable in strike, spell, and blast damage rolls

### DIFF
--- a/src/module/actor/character/elemental-blast.ts
+++ b/src/module/actor/character/elemental-blast.ts
@@ -405,7 +405,7 @@ class ElementalBlast {
             }),
             dice: extractDamageDice(this.actor.synthetics.damageDice, domains, {
                 test: context.options,
-                resolvables: { blast: item },
+                resolvables: { blast: item, target: context.target?.actor ?? null },
             }),
             test: context.options,
         });

--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -340,7 +340,10 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
                         })
                 );
 
-            const extractOptions = { resolvables: { spell: this }, test: options };
+            const extractOptions = {
+                resolvables: { spell: this, target: damageOptions.target ?? null },
+                test: options,
+            };
             const extracted = processDamageCategoryStacking(base, {
                 modifiers: [attributeModifiers, extractModifiers(actor.synthetics, domains, extractOptions)].flat(),
                 dice: extractDamageDice(actor.synthetics.damageDice, domains, extractOptions),

--- a/src/module/system/damage/weapon.ts
+++ b/src/module/system/damage/weapon.ts
@@ -440,7 +440,11 @@ class WeaponDamagePF2e {
 
         // Synthetics
 
-        const extractOptions = { test: options, resolvables: { weapon }, injectables: { weapon } };
+        const extractOptions = {
+            test: options,
+            resolvables: { weapon, target: context.target?.actor ?? null },
+            injectables: { weapon },
+        };
         const extracted = processDamageCategoryStacking(base, {
             modifiers: [modifiers, extractModifiers(actor.synthetics, domains, extractOptions)].flat(),
             dice: extractDamageDice(actor.synthetics.damageDice, domains, extractOptions),


### PR DESCRIPTION
Including in attack rolls will require a little more work.