### PR TITLE
Skip ignored attribute modifiers when extracting for strike damage rolls

### DIFF
--- a/src/module/actor/helpers.ts
+++ b/src/module/actor/helpers.ts
@@ -334,7 +334,7 @@ function getStrikeDamageDomains(
             ...extractModifiers(actor.synthetics, domains, {
                 resolvables: { weapon },
                 test: [...actor.getRollOptions(domains), ...weapon.getRollOptions("item")],
-            }).filter((m) => m.type === "ability"),
+            }).filter((m) => !m.ignored && m.type === "ability"),
         ].reduce((best, candidate) =>
             candidate && best ? (candidate.value > best.value ? candidate : best) : candidate ?? best
         );

--- a/src/module/actor/modifiers.ts
+++ b/src/module/actor/modifiers.ts
@@ -243,6 +243,7 @@ class ModifierPF2e implements RawModifier {
 
     /** Sets the ignored property after testing the predicate */
     test(options: string[] | Set<string>): void {
+        if (this.predicate.length === 0) return;
         const rollOptions = this.rule ? [...options, ...this.rule.item.getRollOptions("parent")] : options;
         this.ignored = !this.predicate.test(rollOptions);
     }


### PR DESCRIPTION
Closes #10822 