### PR TITLE
Ensure action icon grid column not grow larger than needed

### DIFF
--- a/src/styles/actor/tabs/_actions.scss
+++ b/src/styles/actor/tabs/_actions.scss
@@ -251,7 +251,7 @@ ol.actions-list {
                 "icon    name    tracking controls" 1fr
                 "icon    buttons tracking controls" auto
                 "summary summary summary   summary" auto
-                / min-content auto 20% 10%;
+                / min-content 1fr 20% 10%;
 
             > .icon {
                 grid-area: icon;


### PR DESCRIPTION
Expanded actions with short names relative to the longest non breaking text in their description (usually content-links, which have `white-space: nowrap` applied) would see their first grid column grow larger as the character sheet was made narrower. This could be seen with Bon Mot at the default character sheet size, for example.

`1fr` is greedier than `auto` when allocating remaining space and prevents this behavior.

Before:
<img width="530" alt="Screenshot 2023-10-19 at 10 02 20 PM" src="https://github.com/foundryvtt/pf2e/assets/43155846/9398f17e-7966-40d6-ba56-126b042c0bc7">

After:
<img width="533" alt="Screenshot 2023-10-19 at 10 03 12 PM" src="https://github.com/foundryvtt/pf2e/assets/43155846/ca627f41-ff83-4dbf-865c-97ac7e9aab73">
