### PR TITLE
Data updates for Vegetable Lamb and Falling Stars

### DIFF
--- a/packs/rage-of-elements-bestiary/vegetable-lamb.json
+++ b/packs/rage-of-elements-bestiary/vegetable-lamb.json
@@ -5,7 +5,7 @@
         {
             "_id": "8yXRzLvC6wlIOXL3",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "New Attack",
+            "name": "Headbutt",
             "sort": 100000,
             "system": {
                 "attack": {
@@ -15,9 +15,14 @@
                     "value": []
                 },
                 "bonus": {
-                    "value": 0
+                    "value": 8
                 },
-                "damageRolls": {},
+                "damageRolls": {
+                    "n6UrJ81FWW7QfWCW": {
+                        "damage": "1d6+2",
+                        "damageType": "bludgeoning"
+                    }
+                },
                 "description": {
                     "value": ""
                 },
@@ -40,7 +45,7 @@
         {
             "_id": "EI7wF763adZJK468",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "New Attack",
+            "name": "Hoof",
             "sort": 200000,
             "system": {
                 "attack": {
@@ -50,9 +55,14 @@
                     "value": []
                 },
                 "bonus": {
-                    "value": 0
+                    "value": 6
                 },
-                "damageRolls": {},
+                "damageRolls": {
+                    "SkEVjGun2EQ3ZE8z": {
+                        "damage": "1d6",
+                        "damageType": "bludgeoning"
+                    }
+                },
                 "description": {
                     "value": ""
                 },

--- a/packs/spells/falling-stars.json
+++ b/packs/spells/falling-stars.json
@@ -71,11 +71,24 @@
                 "system": {
                     "damage": {
                         "value": {
-                            "i7p7fmqd0A8a64Oz": {
+                            "5hgRJg7CfV9pZSUa": {
                                 "type": {
                                     "value": "electricity"
                                 }
+                            },
+                            "i7p7fmqd0A8a64Oz": {
+                                "applyMod": false,
+                                "type": {
+                                    "subtype": "",
+                                    "value": "electricity"
+                                },
+                                "value": "0"
                             }
+                        }
+                    },
+                    "heightening": {
+                        "damage": {
+                            "i7p7fmqd0A8a64Oz": "0"
                         }
                     }
                 }
@@ -118,13 +131,20 @@
                 "system": {
                     "damage": {
                         "value": {
-                            "i7p7fmqd0A8a64Oz": {
-                                "applyMod": false,
-                                "type": {
-                                    "subtype": "",
-                                    "value": "cold"
+                            "value": {
+                                "5hgRJg7CfV9pZSUa": {
+                                    "type": {
+                                        "value": "cold"
+                                    }
                                 },
-                                "value": "0"
+                                "i7p7fmqd0A8a64Oz": {
+                                    "applyMod": false,
+                                    "type": {
+                                        "subtype": "",
+                                        "value": "cold"
+                                    },
+                                    "value": "0"
+                                }
                             }
                         }
                     },

--- a/packs/spells/falling-stars.json
+++ b/packs/spells/falling-stars.json
@@ -131,20 +131,18 @@
                 "system": {
                     "damage": {
                         "value": {
-                            "value": {
-                                "5hgRJg7CfV9pZSUa": {
-                                    "type": {
-                                        "value": "cold"
-                                    }
-                                },
-                                "i7p7fmqd0A8a64Oz": {
-                                    "applyMod": false,
-                                    "type": {
-                                        "subtype": "",
-                                        "value": "cold"
-                                    },
-                                    "value": "0"
+                            "5hgRJg7CfV9pZSUa": {
+                                "type": {
+                                    "value": "cold"
                                 }
+                            },
+                            "i7p7fmqd0A8a64Oz": {
+                                "applyMod": false,
+                                "type": {
+                                    "subtype": "",
+                                    "value": "cold"
+                                },
+                                "value": "0"
                             }
                         }
                     },


### PR DESCRIPTION
In my recent games I noticed that two items had data issues.

Vegetable Lamb now has correct Strikes.
Falling Stars variants now should work correctly for all variants, not just Airburst.