### PR TITLE
Move AE-like/roll-option processing during item pre-creation to own method

### DIFF
--- a/src/module/actor/conditions.ts
+++ b/src/module/actor/conditions.ts
@@ -20,6 +20,10 @@ class ActorConditions<TActor extends ActorPF2e> {
         return this.#idMap.filter((c) => !c.inMemoryOnly);
     }
 
+    get contents(): ConditionPF2e<TActor>[] {
+        return this.#idMap.contents;
+    }
+
     /** Convenience getters for active badged conditions, especially for use by @actor resolvables in rule elements */
     get clumsy(): ConditionPF2e<TActor> | null {
         return this.bySlug("clumsy", { active: true }).shift() ?? null;

--- a/src/module/item/base/document.ts
+++ b/src/module/item/base/document.ts
@@ -560,7 +560,13 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
             const rules = item.prepareRuleElements({ suppressWarnings: true });
             for (const rule of rules) {
                 const ruleSource = itemSource.system.rules[rules.indexOf(rule)] as RuleElementSource;
-                await rule.preCreate?.({ itemSource, ruleSource, pendingItems: outputSources, context });
+                await rule.preCreate?.({
+                    itemSource,
+                    ruleSource,
+                    pendingItems: outputSources,
+                    tempItems: items,
+                    context,
+                });
             }
         }
 
@@ -804,7 +810,7 @@ interface ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends 
     onPrepareSynthetics?(this: ItemPF2e<ActorPF2e>): void;
 
     /** Returns items that should also be added when this item is created */
-    createGrantedItems(options?: object): Promise<ItemPF2e[]>;
+    createGrantedItems?(options?: object): Promise<ItemPF2e[]>;
 
     /** Returns items that should also be deleted should this item be deleted */
     getLinkedItems?(): ItemPF2e<ActorPF2e>[];

--- a/src/module/rules/rule-element/ae-like.ts
+++ b/src/module/rules/rule-element/ae-like.ts
@@ -90,27 +90,32 @@ class AELikeRuleElement<TSchema extends AELikeSchema> extends RuleElementPF2e<TS
         );
     }
 
+    /** Process this rule element during item pre-creation to inform subsequent choice sets. */
+    override async preCreate(): Promise<void> {
+        if (this.phase === "applyAEs") this.#applyAELike();
+    }
+
     /** Apply the modifications immediately after proper ActiveEffects are applied */
     override onApplyActiveEffects(): void {
-        if (this.phase === "applyAEs") this.applyAELike();
+        if (this.phase === "applyAEs") this.#applyAELike();
     }
 
     /** Apply the modifications near the beginning of the actor's derived-data preparation */
     override beforePrepareData(): void {
-        if (this.phase === "beforeDerived") this.applyAELike();
+        if (this.phase === "beforeDerived") this.#applyAELike();
     }
 
     /** Apply the modifications at the conclusion of the actor's derived-data preparation */
     override afterPrepareData(): void {
-        if (this.phase === "afterDerived") this.applyAELike();
+        if (this.phase === "afterDerived") this.#applyAELike();
     }
 
     /** Apply the modifications prior to a Check (roll) */
     override beforeRoll(_domains: string[], rollOptions: Set<string>): void {
-        if (this.phase === "beforeRoll") this.applyAELike(rollOptions);
+        if (this.phase === "beforeRoll") this.#applyAELike(rollOptions);
     }
 
-    protected applyAELike(rollOptions?: Set<string>): void {
+    #applyAELike(rollOptions?: Set<string>): void {
         if (this.ignored) return;
         // Convert long-form skill slugs in paths to short forms
         const path = this.#rewriteSkillLongFormPath(this.resolveInjectedProperties(this.path));

--- a/src/module/rules/rule-element/base.ts
+++ b/src/module/rules/rule-element/base.ts
@@ -463,7 +463,9 @@ namespace RuleElementPF2e {
         /** The source of the rule in `itemSource`'s `system.rules` array */
         ruleSource: T;
         /** All items pending creation in a `ItemPF2e.createDocuments` call */
-        pendingItems: PreCreate<ItemSourcePF2e>[];
+        pendingItems: ItemSourcePF2e[];
+        /** Items temporarily constructed from pending item source */
+        tempItems: ItemPF2e<ActorPF2e>[];
         /** The context object from the `ItemPF2e.createDocuments` call */
         context: DocumentModificationContext<ActorPF2e | null>;
         /** Whether this preCreate run is from a pre-update reevaluation */

--- a/src/module/rules/rule-element/roll-option.ts
+++ b/src/module/rules/rule-element/roll-option.ts
@@ -136,6 +136,11 @@ class RollOptionRuleElement extends RuleElementPF2e<RollOptionSchema> {
         }
     }
 
+    /** Process this rule element during item pre-creation to inform subsequent choice sets. */
+    override async preCreate(): Promise<void> {
+        if (this.phase === "applyAEs") this.#setRollOption();
+    }
+
     override onApplyActiveEffects(): void {
         if (this.phase === "applyAEs") this.#setRollOption();
     }


### PR DESCRIPTION
This will have the effect of them waiting to run until after choice sets are resolved.