### PR TITLE
Fix Class image `title` attribute in Attribute Boosts dialog

### DIFF
--- a/static/templates/actors/character/attribute-builder.hbs
+++ b/static/templates/actors/character/attribute-builder.hbs
@@ -122,7 +122,7 @@
         <section class="row{{#if manual}} not-eligible{{/if}}">
             {{#if class}}
                 <div class="row-heading">
-                    <img class="" src="{{class.img}}" title="{{ancestry.name}}" width="32" height="32" loading="lazy" />
+                    <img class="" src="{{class.img}}" title="{{class.name}}" width="32" height="32" loading="lazy" />
                     <div>
                         <div class="title">{{localize "PF2E.Class"}}</div>
                         <div class="description">{{class.name}}</div>


### PR DESCRIPTION
Noticed while updating my character that the class icon title was displaying the Ancestry name instead of the Class name:

![image](https://github.com/foundryvtt/pf2e/assets/4469633/76d82cad-6b64-4df0-8c11-5ddf1a71b7c6)
