### PR TITLE
Enforce min stage for unowned afflictions and add onset stage

### DIFF
--- a/src/module/item/abstract-effect/data.ts
+++ b/src/module/item/abstract-effect/data.ts
@@ -104,6 +104,7 @@ export type {
     DurationData,
     EffectAuraData,
     EffectBadge,
+    EffectBadgeCounter,
     EffectBadgeFormulaSource,
     EffectBadgeSource,
     EffectBadgeValueSource,

--- a/src/module/item/affliction/data.ts
+++ b/src/module/item/affliction/data.ts
@@ -85,4 +85,5 @@ export type {
     AfflictionSource,
     AfflictionStageData,
     AfflictionSystemData,
+    AfflictionSystemSource,
 };

--- a/src/scripts/handlebars.ts
+++ b/src/scripts/handlebars.ts
@@ -69,7 +69,7 @@ export function registerHandlebarsHelpers(): void {
     });
 
     Handlebars.registerHelper("times", (count: unknown, options: Handlebars.HelperOptions): string =>
-        [...Array(Number(count)).keys()].map((i) => options.fn(i)).join("")
+        [...Array(Number(count)).keys()].map((i) => options.fn(i, { data: options.data, blockParams: [i] })).join("")
     );
 
     Handlebars.registerHelper("concat", (...params: unknown[]): string => {

--- a/src/styles/item/_affliction-sheet.scss
+++ b/src/styles/item/_affliction-sheet.scss
@@ -3,4 +3,10 @@
         opacity: 0.6;
         color: #a00;
     }
+
+    .formula-row {
+        align-items: center;
+        display: flex;
+        gap: 4px;
+    }
 }

--- a/static/templates/items/affliction-details.hbs
+++ b/static/templates/items/affliction-details.hbs
@@ -33,7 +33,7 @@
 
             {{#each stage.damage as |damage id|}}
                 <div class="formula-section">
-                    <div class="form-fields">
+                    <div class="formula-row">
                         <input type="text" name="system.stages.{{stageId}}.damage.{{id}}.formula" value="{{damage.formula}}" placeholder="{{localize "PF2E.FormulaPlaceholder"}}" />
                         <select name="system.stages.{{stageId}}.damage.{{id}}.category">
                             {{#select damage.category}}
@@ -108,7 +108,7 @@
         </section>
 
         <div class="form-group">
-            <h3>{{localize "PF2E.Time.Duration"}}</h3>
+            <label class="short">{{localize "PF2E.Time.Duration"}}</label>
             {{> systems/pf2e/templates/items/partials/duration.hbs base=(concat "system.stages." stageId ".duration") duration=stage.duration units=../durationUnits}}
         </div>
     </ol>

--- a/static/templates/items/affliction-sidebar.hbs
+++ b/static/templates/items/affliction-sidebar.hbs
@@ -30,9 +30,16 @@
 
     <div class="form-group">
         <label>{{localize "PF2E.Item.Affliction.StageLabel"}}</label>
-        <div class="form-fields">
-            <input type="number" name="system.stage" value="{{data.stage}}"/>
-        </div>
+        <select name="system.stage" data-dtype="Number" {{disabled (not item.actor)}}>
+            {{#select item.stage}}
+                {{#if item.onsetDuration}}
+                    <option value="0">{{localize "PF2E.Item.Affliction.OnsetLabel"}}</option>
+                {{/if}}
+                {{#times item.maxStage as |idx|}}
+                    <option value="{{add idx 1}}">{{localize "PF2E.Item.Affliction.Stage" stage=(add idx 1)}}</option>
+                {{/times}}
+            {{/select}}
+        </select>
     </div>
 
 </div>


### PR DESCRIPTION
I am very tempted on making initial stage always 0 and then clamping to 1 during data preparation if there's no onset, to save us the extra checks. Let me know if that sounds like a better idea than what I did.