### PR TITLE
Mark some unarmed attacks as "grasping appendages"

### DIFF
--- a/src/module/item/weapon/data.ts
+++ b/src/module/item/weapon/data.ts
@@ -136,6 +136,9 @@ interface WeaponSystemSource extends Investable<PhysicalSystemSource> {
 
     material: WeaponMaterialData;
 
+    /** Whether this is an unarmed attack that is a grasping appendage: requires a free hand for use */
+    graspingAppendage?: boolean;
+
     // Refers to custom damage, *not* property runes
     property1: {
         value: string;
@@ -169,6 +172,7 @@ interface WeaponSystemData
     };
     runes: WeaponRuneData;
     usage: WeaponUsageDetails;
+    graspingAppendage: boolean;
     meleeUsage?: Required<ComboWeaponMeleeUsage>;
 }
 

--- a/src/module/item/weapon/document.ts
+++ b/src/module/item/weapon/document.ts
@@ -286,6 +286,12 @@ class WeaponPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
         systemData.propertyRune2.value ||= null;
         systemData.propertyRune3.value ||= null;
         systemData.propertyRune4.value ||= null;
+        systemData.graspingAppendage = ["fist", "claw"].includes(this.baseType ?? "")
+            ? true
+            : this.category === "unarmed"
+            ? !!systemData.graspingAppendage
+            : false;
+
         if (!setHasElement(ATTRIBUTE_ABBREVIATIONS, systemData.attribute)) {
             systemData.attribute = null;
         }

--- a/src/module/rules/rule-element/strike.ts
+++ b/src/module/rules/rule-element/strike.ts
@@ -13,7 +13,6 @@ import {
     WeaponTrait,
 } from "@item/weapon/types.ts";
 import { DamageDieSize, DamageType } from "@system/damage/index.ts";
-import { PredicatePF2e } from "@system/predication.ts";
 import { objectHasKey, sluggify } from "@util";
 import type {
     ArrayField,
@@ -194,7 +193,6 @@ class StrikeRuleElement extends RuleElementPF2e<StrikeSchema> {
             this.fist = true;
             this.replaceAll = false;
             this.replaceBasicUnarmed = false;
-            this.predicate = new PredicatePF2e([...(this._source.predicate ?? []), { gt: ["hands-free", 0] }]);
         } else {
             super._initialize(options);
         }


### PR DESCRIPTION
This also removes the hands-free predicate from Strike REs using the "fist" shorthand. Will follow up with a UI update that is wise to it.