### PR TITLE
Remove superfluous `PackLoader#loadedPacks` cache

### DIFF
--- a/src/module/apps/compendium-browser/loader.ts
+++ b/src/module/apps/compendium-browser/loader.ts
@@ -3,11 +3,6 @@ import { localizer, sluggify } from "@util";
 import { CompendiumBrowserSources } from "./index.ts";
 
 class PackLoader {
-    loadedPacks: {
-        Actor: Record<string, { pack: CompendiumCollection; index: CompendiumIndex } | undefined>;
-        Item: Record<string, { pack: CompendiumCollection; index: CompendiumIndex } | undefined>;
-    } = { Actor: {}, Item: {} };
-
     loadedSources: string[] = [];
     sourcesSettings: CompendiumBrowserSources;
 
@@ -20,44 +15,29 @@ class PackLoader {
         packs: string[],
         indexFields: string[]
     ): AsyncGenerator<{ pack: CompendiumCollection<CompendiumDocument>; index: CompendiumIndex }, void, unknown> {
-        this.loadedPacks[documentType] ??= {};
         const localize = localizer("PF2E.ProgressBar");
         const sources = this.#getSources();
 
         const progress = new Progress({ max: packs.length });
         for (const packId of packs) {
-            let data = this.loadedPacks[documentType][packId];
-            if (data) {
-                const { pack } = data;
-                progress.advance({ label: localize("LoadingPack", { pack: pack?.metadata.label ?? "" }) });
-            } else {
-                const pack = game.packs.get(packId);
-                if (!pack) {
-                    progress.advance();
-                    continue;
-                }
-                progress.advance({ label: localize("LoadingPack", { pack: pack.metadata.label }) });
-                if (pack.documentName === documentType) {
-                    const index = await pack.getIndex({ fields: indexFields });
-                    const firstResult: Partial<CompendiumIndexData> = index.contents.at(0) ?? {};
-                    // Every result should have the "system" property otherwise the indexFields were wrong for that pack
-                    if (firstResult.system) {
-                        const filteredIndex = this.#createFilteredIndex(index, sources);
-                        this.#setModuleArt(packId, filteredIndex);
-                        data = { pack, index: filteredIndex };
-                        this.loadedPacks[documentType][packId] = data;
-                    } else {
-                        ui.notifications.warn(
-                            game.i18n.format("PF2E.BrowserWarnPackNotLoaded", { pack: pack.collection })
-                        );
-                        continue;
-                    }
+            const pack = game.packs.get(packId);
+            if (!pack) {
+                progress.advance();
+                continue;
+            }
+            progress.advance({ label: localize("LoadingPack", { pack: pack.metadata.label }) });
+            if (pack.documentName === documentType) {
+                const index = await pack.getIndex({ fields: indexFields });
+                const firstResult: Partial<CompendiumIndexData> = index.contents.at(0) ?? {};
+                // Every result should have the "system" property otherwise the indexFields were wrong for that pack
+                if (firstResult.system) {
+                    const filteredIndex = this.#createFilteredIndex(index, sources);
+                    this.#setModuleArt(packId, filteredIndex);
+                    yield { pack, index: filteredIndex };
                 } else {
-                    continue;
+                    ui.notifications.warn(game.i18n.format("PF2E.BrowserWarnPackNotLoaded", { pack: pack.collection }));
                 }
             }
-
-            yield data;
         }
         progress.close({ label: localize("LoadingComplete") });
     }
@@ -172,7 +152,6 @@ class PackLoader {
     }
 
     reset(): void {
-        this.loadedPacks = { Actor: {}, Item: {} };
         this.loadedSources = [];
     }
 


### PR DESCRIPTION
~~This is more of a workaround than a fix. The problem is that hazards and npcs live in the same packs but need different index fields and indexing npcs with added hazard fields would brick the bestiary tab checks.~~

~~This change ensures that either the hazard or the bestiary tab can be openeded first and the other one will still get fresh index data.~~

Closes #10928 