### PR TITLE
Fix display of variant spell descriptions

### DIFF
--- a/static/templates/items/sheet.hbs
+++ b/static/templates/items/sheet.hbs
@@ -95,7 +95,9 @@
                     {{#if (not isVariant)}}
                         {{editor enrichedContent.description target="system.description.value" button=true owner=owner editable=editable}}
                     {{else}}
-                        {{{enrichedContent.description}}}
+                        <div class="editor">
+                            <div class="editor-content">{{{enrichedContent.description}}}</div>
+                        </div>
                     {{/if}}
                 </section>
             </section>


### PR DESCRIPTION
I could have tweaked a bunch of styles to no longer rely on editor/editor-content, but having variant description match the html of non-variants is probably better in the long run.