### PR TITLE
Migrate Devise a Stratagem and related feats to use token mark

### DIFF
--- a/build/run-migration.ts
+++ b/build/run-migration.ts
@@ -10,7 +10,6 @@ import { getFilesRecursively } from "./lib/helpers.ts";
 import { MigrationBase } from "@module/migration/base.ts";
 import { MigrationRunnerBase } from "@module/migration/runner/base.ts";
 
-import { Migration859MaterialTypeGrade } from "@module/migration/migrations/859-material-type-grade.ts";
 import { Migration860RMGroup } from "@module/migration/migrations/860-rm-group.ts";
 import { Migration862SpecificMagicArmor } from "@module/migration/migrations/862-specific-magic-armor.ts";
 import { Migration863FixMisspelledOrganaizationsProperty } from "@module/migration/migrations/863-fix-misspelled-organaizations-property.ts";
@@ -26,7 +25,7 @@ import { Migration875SetInnovationIdEarly } from "@module/migration/migrations/8
 import { Migration876FeatLevelTaken } from "@module/migration/migrations/876-feat-level-taken.ts";
 import { Migration877PublicationData } from "@module/migration/migrations/877-publication-data.ts";
 import { Migration878TakeABreather } from "@module/migration/migrations/878-take-a-breather.ts";
-
+import { Migration879DeviseAStratagemAndFriends } from "@module/migration/migrations/879-devise-a-stratagem-and-friends.ts";
 // ^^^ don't let your IDE use the index in these imports. you need to specify the full path ^^^
 
 const { window } = new JSDOM();
@@ -36,7 +35,6 @@ globalThis.HTMLParagraphElement = window.HTMLParagraphElement;
 globalThis.Text = window.Text;
 
 const migrations: MigrationBase[] = [
-    new Migration859MaterialTypeGrade(),
     new Migration860RMGroup(),
     new Migration862SpecificMagicArmor(),
     new Migration863FixMisspelledOrganaizationsProperty(),
@@ -52,6 +50,7 @@ const migrations: MigrationBase[] = [
     new Migration876FeatLevelTaken(),
     new Migration877PublicationData(),
     new Migration878TakeABreather(),
+    new Migration879DeviseAStratagemAndFriends(),
 ];
 
 global.deepClone = <T>(original: T): T => {

--- a/packs/actions/devise-a-stratagem.json
+++ b/packs/actions/devise-a-stratagem.json
@@ -29,7 +29,7 @@
             {
                 "domain": "all",
                 "key": "RollOption",
-                "option": "devise-a-stratagem",
+                "option": "target:mark:devise-a-stratagem",
                 "toggleable": "totm"
             },
             {
@@ -37,12 +37,7 @@
                 "key": "FlatModifier",
                 "predicate": [
                     "class:investigator",
-                    {
-                        "or": [
-                            "devise-a-stratagem",
-                            "target:mark:devise-a-stratagem"
-                        ]
-                    },
+                    "target:mark:devise-a-stratagem",
                     {
                         "or": [
                             "item:trait:agile",

--- a/packs/feat-effects/effect-devise-a-stratagem.json
+++ b/packs/feat-effects/effect-devise-a-stratagem.json
@@ -34,12 +34,7 @@
             {
                 "key": "SubstituteRoll",
                 "predicate": [
-                    {
-                        "or": [
-                            "devise-a-stratagem",
-                            "target:mark:devise-a-stratagem"
-                        ]
-                    }
+                    "target:mark:devise-a-stratagem"
                 ],
                 "removeAfterRoll": "if-enabled",
                 "required": true,

--- a/packs/feats/athletic-strategist.json
+++ b/packs/feats/athletic-strategist.json
@@ -34,12 +34,7 @@
                 "key": "FlatModifier",
                 "predicate": [
                     "class:investigator",
-                    {
-                        "or": [
-                            "devise-a-stratagem",
-                            "target:mark:devise-a-stratagem"
-                        ]
-                    },
+                    "target:mark:devise-a-stratagem",
                     {
                         "or": [
                             "action:disarm",
@@ -60,7 +55,14 @@
                                     }
                                 ]
                             },
-                            "item:base:sap"
+                            "item:base:sap",
+                            {
+                                "and": [
+                                    "feat:takedown-expert",
+                                    "item:group:club",
+                                    "item:hands-held:1"
+                                ]
+                            }
                         ]
                     }
                 ],

--- a/packs/feats/shared-stratagem.json
+++ b/packs/feats/shared-stratagem.json
@@ -27,26 +27,15 @@
         "rules": [
             {
                 "key": "Note",
-                "predicate": [
-                    "devise-a-stratagem",
-                    {
-                        "or": [
-                            "item:trait:agile",
-                            "item:trait:finesse",
-                            {
-                                "and": [
-                                    "item:ranged",
-                                    {
-                                        "not": "item:thrown-melee"
-                                    }
-                                ]
-                            },
-                            "item:base:sap"
-                        ]
-                    }
+                "outcome": [
+                    "success",
+                    "criticalSuccess"
                 ],
-                "selector": "strike-damage",
-                "text": "The creature you hit is @UUID[Compendium.pf2e.conditionitems.Item.Off-Guard] to a designated ally on the next attack the ally makes against the creature before the start of your next turn.",
+                "predicate": [
+                    "target:mark:devise-a-stratagem"
+                ],
+                "selector": "strike-attack-roll",
+                "text": "PF2E.SpecificRule.Investigator.SharedStratagem.Note",
                 "title": "{item|name}"
             }
         ],

--- a/packs/feats/takedown-expert.json
+++ b/packs/feats/takedown-expert.json
@@ -29,7 +29,8 @@
                 "ability": "int",
                 "key": "FlatModifier",
                 "predicate": [
-                    "devise-a-stratagem",
+                    "class:investigator",
+                    "target:mark:devise-a-stratagem",
                     "item:hands-held:1"
                 ],
                 "selector": "club-group-attack-roll",

--- a/packs/iconics/quinn-level-1.json
+++ b/packs/iconics/quinn-level-1.json
@@ -2380,7 +2380,7 @@
                     {
                         "domain": "all",
                         "key": "RollOption",
-                        "option": "devise-a-stratagem",
+                        "option": "target:mark:devise-a-stratagem",
                         "toggleable": "totm"
                     },
                     {
@@ -2388,12 +2388,7 @@
                         "key": "FlatModifier",
                         "predicate": [
                             "class:investigator",
-                            {
-                                "or": [
-                                    "devise-a-stratagem",
-                                    "target:mark:devise-a-stratagem"
-                                ]
-                            },
+                            "target:mark:devise-a-stratagem",
                             {
                                 "or": [
                                     "item:trait:agile",

--- a/packs/iconics/quinn-level-5.json
+++ b/packs/iconics/quinn-level-5.json
@@ -1342,7 +1342,21 @@
                     "remaster": false,
                     "title": "Pathfinder Advanced Player's Guide"
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "key": "Note",
+                        "outcome": [
+                            "success",
+                            "criticalSuccess"
+                        ],
+                        "predicate": [
+                            "target:mark:devise-a-stratagem"
+                        ],
+                        "selector": "strike-attack-roll",
+                        "text": "PF2E.SpecificRule.Investigator.SharedStratagem.Note",
+                        "title": "{item|name}"
+                    }
+                ],
                 "slug": "shared-stratagem",
                 "traits": {
                     "rarity": "common",
@@ -3569,7 +3583,7 @@
                     {
                         "domain": "all",
                         "key": "RollOption",
-                        "option": "devise-a-stratagem",
+                        "option": "target:mark:devise-a-stratagem",
                         "toggleable": "totm"
                     },
                     {
@@ -3577,12 +3591,7 @@
                         "key": "FlatModifier",
                         "predicate": [
                             "class:investigator",
-                            {
-                                "or": [
-                                    "devise-a-stratagem",
-                                    "target:mark:devise-a-stratagem"
-                                ]
-                            },
+                            "target:mark:devise-a-stratagem",
                             {
                                 "or": [
                                     "item:trait:agile",

--- a/packs/paizo-pregens/oraka.json
+++ b/packs/paizo-pregens/oraka.json
@@ -420,7 +420,7 @@
                         "key": "FlatModifier",
                         "predicate": [
                             "class:investigator",
-                            "devise-a-stratagem",
+                            "target:mark:devise-a-stratagem",
                             {
                                 "or": [
                                     "action:disarm",
@@ -441,7 +441,14 @@
                                             }
                                         ]
                                     },
-                                    "item:base:sap"
+                                    "item:base:sap",
+                                    {
+                                        "and": [
+                                            "feat:takedown-expert",
+                                            "item:group:club",
+                                            "item:hands-held:1"
+                                        ]
+                                    }
                                 ]
                             }
                         ],
@@ -3628,7 +3635,7 @@
                     {
                         "domain": "all",
                         "key": "RollOption",
-                        "option": "devise-a-stratagem",
+                        "option": "target:mark:devise-a-stratagem",
                         "toggleable": "totm"
                     },
                     {
@@ -3636,12 +3643,7 @@
                         "key": "FlatModifier",
                         "predicate": [
                             "class:investigator",
-                            {
-                                "or": [
-                                    "devise-a-stratagem",
-                                    "target:mark:devise-a-stratagem"
-                                ]
-                            },
+                            "target:mark:devise-a-stratagem",
                             {
                                 "or": [
                                     "item:trait:agile",

--- a/src/module/migration/migrations/879-devise-a-stratagem-and-friends.ts
+++ b/src/module/migration/migrations/879-devise-a-stratagem-and-friends.ts
@@ -1,0 +1,80 @@
+import { ItemSourcePF2e } from "@item/base/data/index.ts";
+import { MigrationBase } from "../base.js";
+
+/** Update rule element on Devise a Stratagem action and related feats. */
+export class Migration879DeviseAStratagemAndFriends extends MigrationBase {
+    static override version = 0.879;
+
+    override async updateItem(source: ItemSourcePF2e): Promise<void> {
+        if (source.type === "action" && source.system.slug === "devise-a-stratagem") {
+            const rules = [
+                {
+                    domain: "all",
+                    key: "RollOption",
+                    option: "target:mark:devise-a-stratagem",
+                    toggleable: "totm",
+                },
+                {
+                    ability: "int",
+                    key: "FlatModifier",
+                    predicate: [
+                        "class:investigator",
+                        "target:mark:devise-a-stratagem",
+                        {
+                            or: [
+                                "item:trait:agile",
+                                "item:trait:finesse",
+                                { and: ["item:ranged", { not: "item:thrown-melee" }] },
+                                "item:base:sap",
+                            ],
+                        },
+                    ],
+                    selector: "strike-attack-roll",
+                    type: "ability",
+                },
+            ];
+            source.system.rules = rules;
+        } else if (source.type === "feat" && source.system.slug === "athletic-strategist") {
+            const rule = {
+                ability: "int",
+                key: "FlatModifier",
+                predicate: [
+                    "class:investigator",
+                    "target:mark:devise-a-stratagem",
+                    { or: ["action:disarm", "action:grapple", "action:shove", "action:trip"] },
+                    {
+                        or: [
+                            "item:trait:agile",
+                            "item:trait:finesse",
+                            { and: ["item:ranged", { not: "item:thrown-melee" }] },
+                            "item:base:sap",
+                            { and: ["feat:takedown-expert", "item:group:club", "item:hands-held:1"] },
+                        ],
+                    },
+                ],
+                selector: "athletics",
+                type: "ability",
+            };
+            source.system.rules = [rule];
+        } else if (source.type === "feat" && source.system.slug === "shared-stratagem") {
+            const rule = {
+                key: "Note",
+                predicate: ["target:mark:devise-a-stratagem"],
+                selector: "strike-attack-roll",
+                text: "PF2E.SpecificRule.Investigator.SharedStratagem.Note",
+                title: "{item|name}",
+                outcome: ["success", "criticalSuccess"],
+            };
+            source.system.rules = [rule];
+        } else if (source.type === "feat" && source.system.slug === "takedown-expert") {
+            const rule = {
+                ability: "int",
+                key: "FlatModifier",
+                predicate: ["class:investigator", "target:mark:devise-a-stratagem", "item:hands-held:1"],
+                selector: "club-group-attack-roll",
+                type: "ability",
+            };
+            source.system.rules = [rule];
+        }
+    }
+}

--- a/src/module/migration/migrations/index.ts
+++ b/src/module/migration/migrations/index.ts
@@ -276,3 +276,4 @@ export { Migration875SetInnovationIdEarly } from "./875-set-innovation-id-early.
 export { Migration876FeatLevelTaken } from "./876-feat-level-taken.ts";
 export { Migration877PublicationData } from "./877-publication-data.ts";
 export { Migration878TakeABreather } from "./878-take-a-breather.ts";
+export { Migration879DeviseAStratagemAndFriends } from "./879-devise-a-stratagem-and-friends.ts";

--- a/src/module/migration/runner/base.ts
+++ b/src/module/migration/runner/base.ts
@@ -13,7 +13,7 @@ interface CollectionDiff<T extends foundry.documents.ActiveEffectSource | ItemSo
 export class MigrationRunnerBase {
     migrations: MigrationBase[];
 
-    static LATEST_SCHEMA_VERSION = 0.878;
+    static LATEST_SCHEMA_VERSION = 0.879;
 
     static MINIMUM_SAFE_VERSION = 0.618;
 

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2218,6 +2218,9 @@
                 },
                 "PursueALead": {
                     "Label": "Investigating a designated subject with Pursue a Lead"
+                },
+                "SharedStratagem": {
+                    "Note": "The creature you hit is @UUID[Compendium.pf2e.conditionitems.Item.AJh5ex99aV6VTggg]{Off-Guard} to a designated ally on the next attack the ally makes against the creature before the start of your next turn."
                 }
             },
             "Kineticist": {


### PR DESCRIPTION
This also removes the totm toggle, which doesn't really work alongside a token mark