### PR TITLE
Conditionally roll vitality damage from property runes

### DIFF
--- a/src/module/item/physical/runes.ts
+++ b/src/module/item/physical/runes.ts
@@ -938,12 +938,13 @@ const WEAPON_PROPERTY_RUNES: { [T in WeaponPropertyRuneType]: WeaponPropertyRune
                     damageType: "good",
                     diceNumber: 1,
                     dieSize: "d4",
-                    predicate: [{ or: ["target:trait:fiend", { not: "target" }] }],
+                    predicate: ["target:trait:fiend"],
                 },
                 {
                     damageType: "vitality",
                     diceNumber: 1,
                     dieSize: "d4",
+                    predicate: ["target:mode:undead"],
                 },
             ],
             notes: [
@@ -1090,6 +1091,7 @@ const WEAPON_PROPERTY_RUNES: { [T in WeaponPropertyRuneType]: WeaponPropertyRune
                     damageType: "vitality",
                     diceNumber: 1,
                     dieSize: "d6",
+                    predicate: ["target:mode:undead"],
                 },
             ],
             notes: [
@@ -1097,6 +1099,7 @@ const WEAPON_PROPERTY_RUNES: { [T in WeaponPropertyRuneType]: WeaponPropertyRune
                     outcome: ["criticalSuccess"],
                     title: "PF2E.WeaponPropertyRune.disrupting.Name",
                     text: "PF2E.WeaponPropertyRune.disrupting.Note.criticalSuccess",
+                    predicate: ["target:mode:undead"],
                 },
             ],
         },
@@ -1203,15 +1206,6 @@ const WEAPON_PROPERTY_RUNES: { [T in WeaponPropertyRuneType]: WeaponPropertyRune
         traits: ["cold", "conjuration", "magical"],
     },
     ghostTouch: {
-        damage: {
-            notes: [
-                {
-                    predicate: [{ or: ["target:trait:incorporeal", { not: "target" }] }],
-                    title: "PF2E.WeaponPropertyRune.ghostTouch.Name",
-                    text: "PF2E.WeaponPropertyRune.ghostTouch.Note",
-                },
-            ],
-        },
         level: 4,
         name: "PF2E.WeaponPropertyRune.ghostTouch.Name",
         price: 75,
@@ -1309,12 +1303,13 @@ const WEAPON_PROPERTY_RUNES: { [T in WeaponPropertyRuneType]: WeaponPropertyRune
                     damageType: "good",
                     diceNumber: 1,
                     dieSize: "d4",
-                    predicate: [{ or: ["target:trait:fiend", { not: "target" }] }],
+                    predicate: ["target:trait:fiend"],
                 },
                 {
                     damageType: "vitality",
                     diceNumber: 1,
                     dieSize: "d4",
+                    predicate: ["target:mode:undead"],
                 },
             ],
             notes: [
@@ -1389,6 +1384,7 @@ const WEAPON_PROPERTY_RUNES: { [T in WeaponPropertyRuneType]: WeaponPropertyRune
                     damageType: "vitality",
                     diceNumber: 2,
                     dieSize: "d6",
+                    predicate: ["target:mode:undead"],
                 },
             ],
             notes: [
@@ -1396,6 +1392,7 @@ const WEAPON_PROPERTY_RUNES: { [T in WeaponPropertyRuneType]: WeaponPropertyRune
                     outcome: ["criticalSuccess"],
                     title: "PF2E.WeaponPropertyRune.greaterDisrupting.Name",
                     text: "PF2E.WeaponPropertyRune.greaterDisrupting.Note.criticalSuccess",
+                    predicate: ["target:mode:undead"],
                 },
             ],
         },

--- a/src/module/system/damage/damage.ts
+++ b/src/module/system/damage/damage.ts
@@ -87,6 +87,16 @@ export class DamagePF2e {
                   )
                 : "";
 
+            const runeTags =
+                context.options.has("item:rune:property:ghost-touch") && context.options.has("target:trait:incorporeal")
+                    ? toTags(["ghost-touch"], {
+                          labels: { "ghost-touch": "PF2E.WeaponPropertyRune.ghostTouch.Name" },
+                          descriptions: { "ghost-touch": "PF2E.WeaponPropertyRune.ghostTouch.Note" },
+                          cssClass: "ghost-touch",
+                          dataAttr: "slug",
+                      })
+                    : "";
+
             const properties = ((): string => {
                 const range = item?.isOfType("action", "melee", "weapon") ? item.range : null;
                 const label = createActionRangeLabel(range);
@@ -111,7 +121,7 @@ export class DamagePF2e {
                 dataAttr: "material",
             });
 
-            const otherTags = [itemTraits, properties, materialEffects].join("");
+            const otherTags = [itemTraits, properties, materialEffects, runeTags].join("");
 
             const tagsElem = createHTMLElement("div", { classes: ["tags"], dataset: { tooltipClass: "pf2e" } });
             tagsElem.innerHTML = otherTags.length > 0 ? `${traits}<hr class="vr" />${otherTags}` : traits;

--- a/src/styles/_tags.scss
+++ b/src/styles/_tags.scss
@@ -33,6 +33,10 @@
             background-color: var(--alt);
         }
 
+        &.ghost-touch {
+            background-color: #516178;
+        }
+
         &.tag_material {
             background-color: var(--alt-dark);
         }


### PR DESCRIPTION
This is to address the relatively common confusion over why vitality damage is being rolled against non-undead (or nothing).

Also move note that goes along with ghost touch rune to special tag:
![image](https://github.com/foundryvtt/pf2e/assets/106829671/519a4c0e-a5a6-4485-a05c-bb24102f563d)
