### PR TITLE
Add support for property-rune strike adjustments on melee items

### DIFF
--- a/src/module/item/melee/data.ts
+++ b/src/module/item/melee/data.ts
@@ -6,6 +6,7 @@ import {
     ItemTraitsNoRarity,
 } from "@item/base/data/system.ts";
 import { WeaponMaterialData } from "@item/weapon/data.ts";
+import { WeaponPropertyRuneType } from "@item/weapon/types.ts";
 import { DamageType } from "@system/damage/types.ts";
 
 type MeleeSource = BaseItemSourcePF2e<"melee", MeleeSystemSource> & {
@@ -38,6 +39,7 @@ interface MeleeSystemSource extends ItemSystemSource {
 
 interface MeleeSystemData extends MeleeSystemSource, Omit<ItemSystemData, "level" | "traits"> {
     material: WeaponMaterialData;
+    runes: { property: WeaponPropertyRuneType[] };
 }
 
 interface NPCAttackDamageSource {

--- a/src/module/item/melee/document.ts
+++ b/src/module/item/melee/document.ts
@@ -7,7 +7,8 @@ import type { ChatMessagePF2e } from "@module/chat-message/document.ts";
 import { simplifyFormula } from "@scripts/dice.ts";
 import { DamageCategorization } from "@system/damage/helpers.ts";
 import { ConvertedNPCDamage, WeaponDamagePF2e } from "@system/damage/weapon.ts";
-import { tupleHasValue } from "@util";
+import { sluggify, tupleHasValue } from "@util";
+import * as R from "remeda";
 import { MeleeFlags, MeleeSource, MeleeSystemData, NPCAttackTrait } from "./data.ts";
 
 class MeleePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends ItemPF2e<TParent> {
@@ -126,6 +127,9 @@ class MeleePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
         // Set precious material (currently unused)
         this.system.material = { type: null, grade: null };
 
+        // Set empty property runes array for use by rule elements
+        this.system.runes = { property: [] };
+
         for (const attackDamage of Object.values(this.system.damageRolls)) {
             attackDamage.category ||= null;
             if (attackDamage.damageType === "bleed") {
@@ -175,6 +179,7 @@ class MeleePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
         const { damageType } = this.baseDamage;
         const damageCategory = DamageCategorization.fromDamageType(damageType);
         const rangeIncrement = this.range?.increment;
+        const propertyRunes = R.mapToObj(this.system.runes.property, (p) => [`rune:property:${sluggify(p)}`, true]);
 
         const otherOptions = Object.entries({
             equipped: true,
@@ -187,6 +192,7 @@ class MeleePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
             [`range-increment:${rangeIncrement}`]: !!rangeIncrement,
             [`damage:type:${damageType}`]: true,
             [`damage:category:${damageCategory}`]: !!damageCategory,
+            ...propertyRunes,
         })
             .filter(([, isTrue]) => isTrue)
             .map(([key]) => `${prefix}:${key}`);

--- a/src/module/item/weapon/document.ts
+++ b/src/module/item/weapon/document.ts
@@ -210,9 +210,7 @@ class WeaponPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
             return baseTypes.reduce((types, t) => ({ ...types, [`base:${t}`]: true }), {} as Record<string, boolean>);
         })();
         const { persistent } = this.system.damage;
-        const propertyRunes = this.system.runes.property
-            .map((p) => `rune:property:${sluggify(p)}`)
-            .reduce((statements, s) => ({ ...statements, [s]: true }), {} as Record<string, boolean>);
+        const propertyRunes = R.mapToObj(this.system.runes.property, (p) => [`rune:property:${sluggify(p)}`, true]);
 
         // Ammunition
         const ammunitionRollOptions = ((ammunition: ConsumablePF2e | WeaponPF2e | null) => {

--- a/src/module/rules/rule-element/adjust-strike.ts
+++ b/src/module/rules/rule-element/adjust-strike.ts
@@ -189,8 +189,6 @@ class AdjustStrikeRuleElement extends RuleElementPF2e<AdjustStrikeSchema> {
                 case "property-runes":
                     return {
                         adjustWeapon: (weapon: WeaponPF2e | MeleePF2e): void => {
-                            if (weapon.isOfType("melee")) return; // Currently not supported
-
                             if (!["add", "subtract", "remove"].includes(this.mode)) {
                                 return this.failValidation(
                                     'A strike adjustment of weapon property runes must be used with the "add", "subtract", or "remove" mode.',

--- a/src/module/system/damage/weapon.ts
+++ b/src/module/system/damage/weapon.ts
@@ -302,7 +302,7 @@ class WeaponDamagePF2e {
         damageDice.push(...critSpecEffect.filter((e): e is DamageDicePF2e => e instanceof DamageDicePF2e));
 
         // Property Runes
-        const propertyRunes = weapon.isOfType("weapon") ? weapon.system.runes.property : [];
+        const propertyRunes = weapon.system.runes.property;
         damageDice.push(...getPropertyRuneDice(propertyRunes, options));
         const propertyRuneAdjustments = getPropertyRuneModifierAdjustments(propertyRunes);
         const ignoredResistances = propertyRunes.flatMap(


### PR DESCRIPTION
Closes #7496

Warning to data contributors: this will actually add damage if the property rune provides it, so such runes generally aren't appropriate for NPCs.