### PR TITLE
Include damage dice overrides and criticals in dialog

### DIFF
--- a/src/module/actor/character/elemental-blast.ts
+++ b/src/module/actor/character/elemental-blast.ts
@@ -17,7 +17,6 @@ import { CheckRoll } from "@system/check/index.ts";
 import { DamagePF2e } from "@system/damage/damage.ts";
 import { DamageModifierDialog } from "@system/damage/dialog.ts";
 import { createDamageFormula } from "@system/damage/formula.ts";
-import { applyDamageDiceOverrides } from "@system/damage/helpers.ts";
 import { DamageRoll } from "@system/damage/roll.ts";
 import {
     BaseDamageData,
@@ -411,8 +410,6 @@ class ElementalBlast {
         });
         const extraModifiers = R.compact([...damageSynthetics.modifiers, this.#strengthModToDamage(item, domains)]);
         const modifiers = new StatisticModifier("", extraModifiers).modifiers;
-        applyDamageDiceOverrides([baseDamage], damageSynthetics.dice);
-
         const formulaData: DamageFormulaData = {
             dice: damageSynthetics.dice,
             modifiers,

--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -24,7 +24,7 @@ import { CheckRoll } from "@system/check/index.ts";
 import { DamagePF2e } from "@system/damage/damage.ts";
 import { DamageModifierDialog } from "@system/damage/dialog.ts";
 import { combinePartialTerms, createDamageFormula, parseTermsFromSimpleFormula } from "@system/damage/formula.ts";
-import { DamageCategorization, applyDamageDiceOverrides } from "@system/damage/helpers.ts";
+import { DamageCategorization } from "@system/damage/helpers.ts";
 import { DamageRoll } from "@system/damage/roll.ts";
 import { BaseDamageData, DamageFormulaData, DamageRollContext, SpellDamageTemplate } from "@system/damage/types.ts";
 import { DEGREE_OF_SUCCESS_STRINGS } from "@system/degree-of-success.ts";
@@ -365,10 +365,6 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
             const rolled = await new DamageModifierDialog({ formulaData, context }).resolve();
             if (!rolled) return null;
         }
-
-        // Apply any damage dice upgrades (such as harmful font)
-        // This is similar to weapon's finalizeDamage(), and both will need to be centralized
-        applyDamageDiceOverrides(base, damageDice);
 
         const { formula, breakdown } = createDamageFormula(formulaData);
         const roll = new DamageRoll(formula);

--- a/src/module/system/damage/formula.ts
+++ b/src/module/system/damage/formula.ts
@@ -11,6 +11,7 @@ import {
     MaterialDamageEffect,
 } from "./types.ts";
 import { CRITICAL_INCLUSION } from "./values.ts";
+import { applyDamageDiceOverrides } from "./helpers.ts";
 
 /** A compiled formula with its associated breakdown */
 interface AssembledFormula {
@@ -45,6 +46,9 @@ function createDamageFormula(
     if (!damage.base.length) {
         return null;
     }
+
+    // Apply damage dice increases and overrides first. These affect base damage, so must be done before
+    applyDamageDiceOverrides(damage.base, damage.dice, { critical, maxIncreases: damage.maxIncreases });
 
     // Group dice by damage type
     const typeMap: DamageTypeMap = new Map();

--- a/src/module/system/damage/helpers.ts
+++ b/src/module/system/damage/helpers.ts
@@ -47,7 +47,14 @@ const DamageCategorization = {
 const FACES = [4, 6, 8, 10, 12];
 
 /** Apply damage dice overrides and upgrades to a non-weapon's damage formula */
-function applyDamageDiceOverrides(base: BaseDamageData[], dice: DamageDicePF2e[]): void {
+function applyDamageDiceOverrides(
+    baseEntries: BaseDamageData[],
+    dice: DamageDicePF2e[],
+    options: { critical?: boolean; maxIncreases?: number } = {},
+): void {
+    const critical = options.critical ?? false;
+    const maxIncreases = options.maxIncreases ?? Infinity;
+
     type RequiredNonNullable<T, K extends keyof T> = T & { [P in K]-?: NonNullable<T[P]> };
     const overrideDice = dice.filter(
         (d): d is RequiredNonNullable<DamageDicePF2e, "override"> => !d.ignored && !!d.override,
@@ -55,25 +62,50 @@ function applyDamageDiceOverrides(base: BaseDamageData[], dice: DamageDicePF2e[]
 
     if (!overrideDice.length) return;
 
-    for (const data of base) {
-        for (const adjustment of overrideDice) {
-            const die = data.terms?.find((t): t is RequiredNonNullable<DamagePartialTerm, "dice"> => !!t.dice);
-            if (!die || (adjustment.damageType && adjustment.damageType !== data.damageType)) {
-                continue;
-            }
+    for (const base of baseEntries) {
+        const die = base.terms?.find((t): t is RequiredNonNullable<DamagePartialTerm, "dice"> => !!t.dice);
+        if (base.terms && !die) continue;
 
-            die.dice.number = adjustment.override.diceNumber ?? die.dice.number;
-            if (adjustment.override.dieSize) {
-                const faces = Number(/\d{1,2}/.exec(adjustment.override.dieSize)?.shift());
-                if (Number.isInteger(faces)) die.dice.faces = faces;
-            } else if (adjustment.override.upgrade || adjustment.override.downgrade) {
-                // die size increases are once-only for weapons, but has no such limit for non-weapons
-                const direction = adjustment.override.upgrade ? 1 : -1;
+        // filter adjustments that can apply here
+        const adjustments = overrideDice.filter((m) => {
+            const outcomeMatches = m.critical === null || (critical && m.critical) || (!critical && !m.critical);
+            return outcomeMatches && (!m.damageType || m.damageType === base.damageType);
+        });
+
+        // First, increase or decrease the damage die. This has to occur before overrides (ex: fatal powerful fist)
+        // die size increases are once-only for weapons, but has no such limit elsewhere
+        const numUpgrades = Math.min(maxIncreases, adjustments.filter((d) => d.override?.upgrade).length);
+        const numDowngrades = Math.min(maxIncreases, adjustments.filter((d) => d.override?.downgrade).length);
+        const delta = numUpgrades - numDowngrades;
+        for (let i = 0; i < Math.abs(delta); i++) {
+            if (die) {
+                const direction = delta > 0 ? 1 : -1;
                 die.dice.faces = FACES[FACES.indexOf(die.dice.faces) + direction] ?? die.dice.faces;
+            } else if (base.dieSize) {
+                base.dieSize =
+                    delta > 0
+                        ? nextDamageDieSize({ upgrade: base.dieSize })
+                        : nextDamageDieSize({ downgrade: base.dieSize });
             }
+        }
 
-            if (adjustment.override.damageType) {
-                data.damageType = adjustment.override.damageType;
+        // Perform overrides, and handle fatal/deadly
+        for (const adjustment of adjustments) {
+            if (die) {
+                if (adjustment.override.dieSize) {
+                    const faces = Number(/\d{1,2}/.exec(adjustment.override.dieSize)?.shift());
+                    if (Number.isInteger(faces)) die.dice.faces = faces;
+                }
+                if (adjustment.override.damageType) {
+                    base.damageType = adjustment.override.damageType;
+                }
+            } else if (adjustment.override) {
+                base.dieSize = adjustment.override.dieSize ?? base.dieSize;
+                base.damageType = adjustment.override.damageType ?? base.damageType;
+                base.diceNumber = adjustment.override.diceNumber ?? base.diceNumber;
+                for (const die of dice.filter((d) => /^(?:deadly|fatal)-/.test(d.slug))) {
+                    die.damageType = adjustment.override.damageType ?? die.damageType;
+                }
             }
         }
     }

--- a/src/module/system/damage/types.ts
+++ b/src/module/system/damage/types.ts
@@ -57,6 +57,8 @@ interface DamageFormulaData {
     base: BaseDamageData[];
     dice: DamageDicePF2e[];
     modifiers: ModifierPF2e[];
+    /** Maximum number of die increases. Weapons should be set to 1 */
+    maxIncreases?: number;
     ignoredResistances: { type: ResistanceType; max: number | null }[];
 }
 

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -29,7 +29,7 @@ import * as R from "remeda";
 import { DamagePF2e } from "./damage/damage.ts";
 import { DamageModifierDialog } from "./damage/dialog.ts";
 import { createDamageFormula } from "./damage/formula.ts";
-import { applyDamageDiceOverrides, damageDiceIcon, extractBaseDamage, looksLikeDamageRoll } from "./damage/helpers.ts";
+import { damageDiceIcon, extractBaseDamage, looksLikeDamageRoll } from "./damage/helpers.ts";
 import { DamageRoll } from "./damage/roll.ts";
 import { DamageFormulaData, DamageRollContext, SimpleDamageTemplate } from "./damage/types.ts";
 import { Statistic } from "./statistic/index.ts";
@@ -802,7 +802,6 @@ async function augmentInlineDamageRoll(
             if (!rolled) return null;
         }
 
-        applyDamageDiceOverrides(base, dice);
         const { formula, breakdown } = createDamageFormula(formulaData);
 
         const roll = new DamageRoll(formula);


### PR DESCRIPTION
There's still a few weapon vs not-weapon seams, but at least they're all in one place now for the clobbering later.