### PR TITLE
Set Weapon Surge effect duration to 1 round

### DIFF
--- a/packs/spell-effects/spell-effect-weapon-surge-major-striking.json
+++ b/packs/spell-effects/spell-effect-weapon-surge-major-striking.json
@@ -9,8 +9,8 @@
         "duration": {
             "expiry": "turn-start",
             "sustained": false,
-            "unit": "unlimited",
-            "value": -1
+            "unit": "rounds",
+            "value": 1
         },
         "level": {
             "value": 1

--- a/packs/spell-effects/spell-effect-weapon-surge.json
+++ b/packs/spell-effects/spell-effect-weapon-surge.json
@@ -9,8 +9,8 @@
         "duration": {
             "expiry": "turn-start",
             "sustained": false,
-            "unit": "unlimited",
-            "value": -1
+            "unit": "rounds",
+            "value": 1
         },
         "level": {
             "value": 1


### PR DESCRIPTION
Can't make it expire on use since the basic one also adds damage.

Closes https://github.com/foundryvtt/pf2e/issues/11036