### PR TITLE
Include damage type and category in "damage-received" roll options

### DIFF
--- a/packs/bestiary-family-ability-glossary/skeleton-bone-powder.json
+++ b/packs/bestiary-family-ability-glossary/skeleton-bone-powder.json
@@ -27,6 +27,9 @@
                 "outcome": [
                     "criticalSuccess"
                 ],
+                "predicate": [
+                    "damage:category:physical"
+                ],
                 "selector": "damage-received",
                 "text": "{item|system.description.value}",
                 "title": "{item|name}",

--- a/packs/gatewalkers-bestiary/demontangle.json
+++ b/packs/gatewalkers-bestiary/demontangle.json
@@ -279,7 +279,18 @@
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "key": "Note",
+                        "predicate": [
+                            "damage:type:slashing"
+                        ],
+                        "selector": "damage-received",
+                        "text": "{item|system.description.value}",
+                        "title": "{item|name}",
+                        "visibility": "owner"
+                    }
+                ],
                 "slug": "reactive-gnaw",
                 "traits": {
                     "rarity": "common",

--- a/packs/pathfinder-bestiary/gibbering-mouther.json
+++ b/packs/pathfinder-bestiary/gibbering-mouther.json
@@ -279,7 +279,18 @@
                 "requirements": {
                     "value": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "key": "Note",
+                        "predicate": [
+                            "damage:type:slashing"
+                        ],
+                        "selector": "damage-received",
+                        "text": "{item|system.description.value}",
+                        "title": "{item|name}",
+                        "visibility": "owner"
+                    }
+                ],
                 "slug": "reactive-gnaw",
                 "traits": {
                     "rarity": "common",

--- a/src/module/chat-message/helpers.ts
+++ b/src/module/chat-message/helpers.ts
@@ -179,11 +179,15 @@ async function applyDamageFromMessage({
         const hasDamage = typeof damage === "number" ? damage !== 0 : damage.total !== 0;
         const notes = (() => {
             if (!hasDamage) return [];
+
+            const damageRollOptions = roll.instances.flatMap((i) => Array.from(i.formalDescription));
+            const notesRollOptions = new Set([...applicationRollOptions, ...damageRollOptions]);
+
             return extractNotes(contextClone.synthetics.rollNotes, [domain])
                 .filter(
                     (n) =>
                         (!outcome || n.outcome.length === 0 || n.outcome.includes(outcome)) &&
-                        n.predicate.test(applicationRollOptions),
+                        n.predicate.test(notesRollOptions),
                 )
                 .map((note) => note.text);
         })();


### PR DESCRIPTION
Includes updates to "(Skeleton) Bone Powder" and Gibbering Mouther "Reactive Gnaw" to demonstrate utility.