### PR TITLE
Localize damage label in item summary

### DIFF
--- a/static/templates/actors/partials/item-summary.hbs
+++ b/static/templates/actors/partials/item-summary.hbs
@@ -37,7 +37,7 @@
                 <span><button type="button" class="spell_attack" data-action="spellAttack">{{localize "PF2E.AttackLabel"}}</button></span>
             {{/if}}
             {{#if chatData.hasDamage}}
-                <span><button type="button" class="spell_damage" data-action="spellDamage">{{chatData.damageLabel}}: {{chatData.formula}}</button></span>
+                <span><button type="button" class="spell_damage" data-action="spellDamage">{{localize chatData.damageLabel}}: {{chatData.formula}}</button></span>
             {{/if}}
         {{/unless}}
 


### PR DESCRIPTION
#10994 changed the damageLabel property from a localised label to a localisation key. Now the partial localised it itself