### PR TITLE
Use a V5 UUID hash digest of Foundry UUIDs for roll options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "foundry-pf2e",
-    "version": "5.7.4",
+    "version": "5.8.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "foundry-pf2e",
-            "version": "5.7.4",
+            "version": "5.8.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@codemirror/autocomplete": "^6.10.2",
@@ -17,7 +17,8 @@
                 "minisearch": "^6.2.0",
                 "nouislider": "^15.7.1",
                 "remeda": "^1.28.0",
-                "sortablejs": "^1.15.0"
+                "sortablejs": "^1.15.0",
+                "uuid": "^9.0.1"
             },
             "devDependencies": {
                 "@pixi/graphics-smooth": "^1.1.0",
@@ -58,7 +59,7 @@
                 "sass": "^1.69.5",
                 "socket.io": "4.6.2",
                 "socket.io-client": "4.6.2",
-                "tinymce": "6.4.2",
+                "tinymce": "6.7.2",
                 "tsconfig-paths": "^4.2.0",
                 "typescript": "^5.2.2",
                 "vite": "^4.5.0",
@@ -7924,9 +7925,9 @@
             "dev": true
         },
         "node_modules/tinymce": {
-            "version": "6.4.2",
-            "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.4.2.tgz",
-            "integrity": "sha512-te+4c8PoAwTKPMBQtMQehnSZlOO9Ay5tDgaRFJKBehYb6SlX2PYZ0v3oe/cmiv5EfqdwZLkEMXk2MNOeApZZLg==",
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.7.2.tgz",
+            "integrity": "sha512-6h/02jHmXyghekFzmzccZxUUEFtlPEKHxOd+gd49bjno3ybavZInPIaDd/pp2GeEwsFm20oGgJCL7UiebXm9dw==",
             "dev": true
         },
         "node_modules/titleize": {
@@ -8238,6 +8239,18 @@
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
             "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
             "dev": true
+        },
+        "node_modules/uuid": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
         },
         "node_modules/v8-to-istanbul": {
             "version": "9.1.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "sass": "^1.69.5",
         "socket.io": "4.6.2",
         "socket.io-client": "4.6.2",
-        "tinymce": "6.4.2",
+        "tinymce": "6.7.2",
         "tsconfig-paths": "^4.2.0",
         "typescript": "^5.2.2",
         "vite": "^4.5.0",
@@ -82,6 +82,7 @@
         "minisearch": "^6.2.0",
         "nouislider": "^15.7.1",
         "remeda": "^1.28.0",
-        "sortablejs": "^1.15.0"
+        "sortablejs": "^1.15.0",
+        "uuid": "^9.0.1"
     }
 }

--- a/packs/feat-effects/effect-aura-junction-fire.json
+++ b/packs/feat-effects/effect-aura-junction-fire.json
@@ -25,7 +25,7 @@
                 "definition": [
                     "damage:type:fire",
                     "item:trait:impulse",
-                    "origin:uuid:{item|system.context.origin.actor}"
+                    "origin:signature:{item|origin.signature}"
                 ],
                 "key": "Weakness",
                 "label": "PF2E.IWR.Custom.ImpulseFireFrom",

--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -78,6 +78,7 @@ import { ActorSheetPF2e } from "./sheet/base.ts";
 import { ActorSpellcasting } from "./spellcasting.ts";
 import { TokenEffect } from "./token-effect.ts";
 import { CREATURE_ACTOR_TYPES, SAVE_TYPES, SIZE_LINKABLE_ACTOR_TYPES, UNAFFECTED_TYPES } from "./values.ts";
+import { v5 as UUIDv5 } from "uuid";
 
 /**
  * Extend the base Actor class to implement additional logic specialized for PF2e.
@@ -86,6 +87,9 @@ import { CREATURE_ACTOR_TYPES, SAVE_TYPES, SIZE_LINKABLE_ACTOR_TYPES, UNAFFECTED
 class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | null> extends Actor<TParent> {
     /** Has this actor completed construction? */
     constructed = true;
+
+    /** A UUIDv5 hash digest of the foundry UUID */
+    declare signature: string;
 
     /** Handles rolling initiative for the current actor */
     declare initiative: ActorInitiative | null;
@@ -605,6 +609,7 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
 
     protected override _initialize(options?: Record<string, unknown>): void {
         this.constructed ??= false;
+        this.signature ??= UUIDv5(this.uuid, "e9fa1461-0edc-4791-826e-08633f1c6ef7"); // magic number as namespace
         this._itemTypes = null;
         this.rules = [];
         this.initiative = null;
@@ -733,7 +738,7 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
             rollOptions: {
                 all: {
                     [`self:type:${this.type}`]: true,
-                    [`self:uuid:${this.uuid}`]: true,
+                    [`self:signature:${this.signature}`]: true,
                     ...createEncounterRollOptions(this),
                 },
             },


### PR DESCRIPTION
This replaces "actor:uuid:*" with "actor:signature:*"