### PR TITLE
Makes nonlethal attacks cause unconsciousness instead of death if dea…

### DIFF
--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -127,6 +127,7 @@
                     "FinePowder": "They are reduced to a fine powder; their gear remains.",
                     "MassiveDamage": "The massive damage immediately kills them."
                 },
+                "Nonlethal": "They become unconscious from the nonlethal attack.",
                 "ShieldAbsorbsAll": "<actor>{actor}</actor> is unscathed, their shield completely absorbing {absorbedDamage} damage.",
                 "ShieldDamagedForN": "Their shield is also damaged for {shieldDamage}.",
                 "ShieldDamagedForNBroken": "Their shield also takes {shieldDamage} damage, breaking it.",


### PR DESCRIPTION
…th at zero hp automation is enabled.

The implementation hinges on me being right that 'instant death' (whether by massive damage, death effects or being an npc undead with zero hp) takes precedence. E.g. if a level 20 fighter attacks a bunny with his (nonlethal) fists, the bunny will die due to massive damage.