### PR TITLE
Fix NPC damage formula creation when precision/splash occurs first

### DIFF
--- a/src/module/item/melee/document.ts
+++ b/src/module/item/melee/document.ts
@@ -74,7 +74,8 @@ class MeleePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
 
     /** The first of this attack's damage instances */
     get baseDamage(): ConvertedNPCDamage {
-        const instance = Object.values(this.system.damageRolls).shift();
+        const partials = Object.values(this.system.damageRolls);
+        const instance = partials.find((p) => !p.category) ?? partials.at(0);
         if (!instance) {
             return {
                 dice: 0,

--- a/src/module/system/damage/weapon.ts
+++ b/src/module/system/damage/weapon.ts
@@ -36,7 +36,10 @@ class WeaponDamagePF2e {
         actionTraits = [],
         context,
     }: NPCStrikeCalculateParams): Promise<WeaponDamageTemplate | null> {
-        const secondaryInstances = Object.values(attack.system.damageRolls).slice(1).map(this.npcDamageToWeaponDamage);
+        const { baseDamage } = attack;
+        const secondaryInstances = Object.values(attack.system.damageRolls)
+            .map(this.npcDamageToWeaponDamage)
+            .filter((d) => !R.equals(d, baseDamage));
 
         // Collect damage dice and modifiers from secondary damage instances
         const damageDice: DamageDicePF2e[] = [];


### PR DESCRIPTION
Closes #10932