### PR TITLE
Revert "Fix fatal override when base damage type is overwritten"

### DIFF
--- a/src/module/system/damage/helpers.ts
+++ b/src/module/system/damage/helpers.ts
@@ -94,6 +94,9 @@ function applyDamageDiceOverrides(
             if (!adjustment.override) continue;
 
             base.damageType = adjustment.override.damageType ?? base.damageType;
+            for (const die of dice.filter((d) => /^(?:deadly|fatal)-/.test(d.slug))) {
+                die.damageType = adjustment.override.damageType ?? die.damageType;
+            }
 
             if (die) {
                 die.dice.number = adjustment.override.diceNumber ?? die.dice.number;

--- a/src/module/system/damage/weapon.ts
+++ b/src/module/system/damage/weapon.ts
@@ -356,8 +356,7 @@ class WeaponDamagePF2e {
             );
         }
 
-        // Fatal trait. Lack of a damage type assigns it to the first base instance
-        // If later we have assign a damage type to the additional damage, split override into a separate object
+        // Fatal trait
         for (const trait of weaponTraits.filter((t) => t.startsWith("fatal-d"))) {
             const dieSize = trait.substring(trait.indexOf("-") + 1) as DamageDieSize;
             damageDice.push(
@@ -365,6 +364,7 @@ class WeaponDamagePF2e {
                     selector: `${weapon.id}-damage`,
                     slug: trait,
                     label: traitLabels[trait],
+                    damageType: baseDamage.damageType,
                     diceNumber: 1,
                     dieSize,
                     critical: true,


### PR DESCRIPTION
Reverts foundryvtt/pf2e#11108. Superceded by https://github.com/foundryvtt/pf2e/pull/11118