### PR TITLE
Fix NPC shield labels

### DIFF
--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -210,18 +210,6 @@
                 },
                 "Rest": {
                     "Label": "Rest for the Night"
-                },
-                "Shield": {
-                    "ACBonus": "Shield AC Bonus (When Raised)",
-                    "BrokenThreshold": "Shield Broken Threshold",
-                    "Hardness": {
-                        "Hint": "Shield Hardness",
-                        "Label": "H"
-                    },
-                    "HitPoints": {
-                        "Value": "Shield HP",
-                        "Max": "Shield Max HP"
-                    }
                 }
             },
             "Creature": {
@@ -267,6 +255,18 @@
                     },
                     "WithAcuity": "{sense} ({acuity})",
                     "WithAcuityAndRange": "{sense} ({acuity} {range} Ft)"
+                },
+                "Shield": {
+                    "ACBonus": "Shield AC Bonus (When Raised)",
+                    "BrokenThreshold": "Shield Broken Threshold",
+                    "Hardness": {
+                        "Hint": "Shield Hardness",
+                        "Label": "H"
+                    },
+                    "HitPoints": {
+                        "Value": "Shield HP",
+                        "Max": "Shield Max HP"
+                    }
                 },
                 "SpellPreparation": {
                     "Hint": "To prepare a spell, drag one from this list to a slot on the actor sheet.",

--- a/static/templates/actors/character/partials/sidebar.hbs
+++ b/static/templates/actors/character/partials/sidebar.hbs
@@ -118,11 +118,11 @@
         <div class="data-value">
             <input id="{{@root.options.id}}-shield-hp" type="number" placeholder="0" name="system.attributes.shield.hp.value" value="{{data.attributes.shield.hp.value}}" />
         </div>
-        <label for="{{@root.options.id}}-shield-hp" class="sidebar_label">{{localize "PF2E.Actor.Character.Shield.HitPoints.Value"}}</label>
+        <label for="{{@root.options.id}}-shield-hp" class="sidebar_label">{{localize "PF2E.Actor.Creature.Shield.HitPoints.Value"}}</label>
     </div>
     <div class="shield-stats">
         <ol>
-            <li data-tooltip="PF2E.Actor.Character.Shield.ACBonus">
+            <li data-tooltip="PF2E.Actor.Creature.Shield.ACBonus">
                 <div class="shield-label">
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11.9 14">
                         <path
@@ -136,21 +136,21 @@
                     <input type="number" placeholder="0" value="{{data.attributes.shield.ac}}" readonly="readonly" />
                 </span>
             </li>
-            <li data-tooltip="PF2E.Actor.Character.Shield.Hardness.Hint">
+            <li data-tooltip="PF2E.Actor.Creature.Shield.Hardness.Hint">
                 <div class="shield-label">
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11.9 14">
                         <path
                             d="M5.9 13.5c-.9-.4-1.9-1-2.7-1.6-.7-.5-1.3-1.1-1.9-1.7C.8 9.6.5 8.9.5 8.1v-6L6 .5l5.4 1.6v6c0 .7-.3 1.5-.8 2.1-.6.7-1.2 1.3-1.9 1.7-.9.6-1.8 1.2-2.8 1.6z"
                             fill="#fff"
                         />
-                        <text x="6" y="8.5" font-family="Verdana" text-anchor="middle" font-size="5" fill="black">{{localize "PF2E.Actor.Character.Shield.Hardness.Label"}}</text>
+                        <text x="6" y="8.5" font-family="Verdana" text-anchor="middle" font-size="5" fill="black">{{localize "PF2E.Actor.Creature.Shield.Hardness.Label"}}</text>
                     </svg>
                 </div>
                 <span class="data-value">
                     <input type="number" placeholder="0" value="{{data.attributes.shield.hardness}}" readonly="readonly" />
                 </span>
             </li>
-            <li data-tooltip="PF2E.Actor.Character.Shield.BrokenThreshold">
+            <li data-tooltip="PF2E.Actor.Creature.Shield.BrokenThreshold">
                 <div class="shield-label">
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11.9 14">
                         <path
@@ -169,7 +169,7 @@
     <div class="armor_footer">
         <div class="shield-max">
             <label for="{{@root.options.id}}-shield-max" class="sidebar_label">
-                {{localize "PF2E.Actor.Character.Shield.HitPoints.Max"}}
+                {{localize "PF2E.Actor.Creature.Shield.HitPoints.Max"}}
             </label>
             <span class="data-value">
                 <input id="{{@root.options.id}}-shield-max" type="number" placeholder="0" value="{{data.attributes.shield.hp.max}}" readonly="readonly" />

--- a/static/templates/actors/npc/partials/sidebar.hbs
+++ b/static/templates/actors/npc/partials/sidebar.hbs
@@ -51,11 +51,11 @@
         </div>
         <div class="side-bar-section-content">
             <div class="shield-details">
-                <label class="label" title="{{localize "PF2E.ShieldACBonusTitle"}}">{{localize "PF2E.ArmorClassShortLabel"}}</label>
+                <label class="label" title="{{localize "PF2E.Actor.Character.Shield.ACBonus"}}">{{localize "PF2E.ArmorClassShortLabel"}}</label>
                 <label class="value">{{data.attributes.shield.ac}}</label>
-                <label class="label" title="{{localize "PF2E.ShieldHardnessTitle"}}">{{localize "PF2E.ShieldHardnessShortLabel"}}</label>
+                <label class="label" title="{{localize "PF2E.Actor.Character.Shield.Hardness.Hint"}}">{{localize "PF2E.Actor.Character.Shield.Hardness.Label"}}</label>
                 <label class="value">{{data.attributes.shield.hardness}}</label>
-                <label class="label" title="{{localize "PF2E.ShieldBTTitle"}}">{{localize "PF2E.ShieldBTShortLabel"}}</label>
+                <label class="label" title="{{localize "PF2E.Actor.Character.Shield.BrokenThreshold"}}">{{localize "PF2E.Item.Physical.BrokenThreshold.ShortLabel"}}</label>
                 <label class="value">{{data.attributes.shield.brokenThreshold}}</label>
             </div>
         </div>

--- a/static/templates/actors/npc/partials/sidebar.hbs
+++ b/static/templates/actors/npc/partials/sidebar.hbs
@@ -51,11 +51,11 @@
         </div>
         <div class="side-bar-section-content">
             <div class="shield-details">
-                <label class="label" title="{{localize "PF2E.Actor.Character.Shield.ACBonus"}}">{{localize "PF2E.ArmorClassShortLabel"}}</label>
+                <label class="label" title="{{localize "PF2E.Actor.Creature.Shield.ACBonus"}}">{{localize "PF2E.ArmorClassShortLabel"}}</label>
                 <label class="value">{{data.attributes.shield.ac}}</label>
-                <label class="label" title="{{localize "PF2E.Actor.Character.Shield.Hardness.Hint"}}">{{localize "PF2E.Actor.Character.Shield.Hardness.Label"}}</label>
+                <label class="label" title="{{localize "PF2E.Actor.Creature.Shield.Hardness.Hint"}}">{{localize "PF2E.Actor.Creature.Shield.Hardness.Label"}}</label>
                 <label class="value">{{data.attributes.shield.hardness}}</label>
-                <label class="label" title="{{localize "PF2E.Actor.Character.Shield.BrokenThreshold"}}">{{localize "PF2E.Item.Physical.BrokenThreshold.ShortLabel"}}</label>
+                <label class="label" title="{{localize "PF2E.Actor.Creature.Shield.BrokenThreshold"}}">{{localize "PF2E.Item.Physical.BrokenThreshold.ShortLabel"}}</label>
                 <label class="value">{{data.attributes.shield.brokenThreshold}}</label>
             </div>
         </div>


### PR DESCRIPTION
This fixes NPC shield stat labels, which broke sometime between 5.7.4 and 5.8.0 when the old localized text was removed.

For the moment I've pointed the text to the newer `PF2E.Actor.Character.Shield` and `PF2E.Item.Physical` strings since they're already there rather than adding `Shield` to `PF2E.Actor.NPC` and having duplicates there. I suspect it's best to have one place outside of Character and NPC for these shield specific strings but wasn't quite sure where, so let me know what/where is preferred.

Before: 
<img width="169" alt="Screenshot 2023-11-05 at 8 18 58 PM" src="https://github.com/foundryvtt/pf2e/assets/43155846/3fedf42d-a88c-4826-84dc-8e43de2cd6ea">
<img width="559" alt="Screenshot 2023-11-05 at 8 23 14 PM" src="https://github.com/foundryvtt/pf2e/assets/43155846/b044e595-0ada-47f5-8417-d702f168c385">
After:
<img width="468" alt="Screenshot 2023-11-05 at 8 22 58 PM" src="https://github.com/foundryvtt/pf2e/assets/43155846/5ccc7966-6a06-4976-8475-e788175bd329">