### PR TITLE
Remove spell components from actor sheets

### DIFF
--- a/src/module/actor/creature/spell-preparation-sheet.ts
+++ b/src/module/actor/creature/spell-preparation-sheet.ts
@@ -36,7 +36,7 @@ class SpellPreparationSheet<TActor extends CreaturePF2e> extends ActorSheet<TAct
             classes: ["default", "sheet", "spellcasting-entry", "preparation"],
             width: 480,
             height: 600,
-            template: "systems/pf2e/templates/actors/spellcasting-prep-sheet.hbs",
+            template: "systems/pf2e/templates/actors/spell-preparation-sheet.hbs",
             scrollY: [".sheet-content"],
             filters: [{ inputSelector: "input[type=search]", contentSelector: "ol.directory-list" }],
             sheetConfig: false,

--- a/src/scripts/register-templates.ts
+++ b/src/scripts/register-templates.ts
@@ -50,11 +50,11 @@ export function registerTemplates(): void {
         "systems/pf2e/templates/actors/partials/inventory.hbs",
         "systems/pf2e/templates/actors/partials/item-line.hbs",
         "systems/pf2e/templates/actors/partials/modifiers-tooltip.hbs",
+        "systems/pf2e/templates/actors/partials/spell-collection.hbs",
         "systems/pf2e/templates/actors/partials/toggles.hbs",
         "systems/pf2e/templates/actors/partials/total-bulk.hbs",
         "systems/pf2e/templates/actors/crafting-entry-alchemical.hbs",
         "systems/pf2e/templates/actors/crafting-entry-list.hbs",
-        "systems/pf2e/templates/actors/spell-collection.hbs",
         "systems/pf2e/templates/actors/character/partials/proficiencylevels-dropdown.hbs",
 
         // SVG icons

--- a/src/styles/actor/_spell-collection.scss
+++ b/src/styles/actor/_spell-collection.scss
@@ -12,13 +12,9 @@ ol.spell-list {
         align-items: center;
         background: none;
         cursor: default;
-        display: grid;
-        grid:
-            "name range components cast-spell controls" auto
-            "content content content content content" auto
-            / 9fr 4fr 4fr 2fr 2.5fr;
-        justify-content: center;
-        padding: 0 0.3em 1px 0.35em;
+        display: flex;
+        flex-wrap: wrap;
+        padding: 0 0.35em;
 
         &[data-expended-state="true"] {
             h4 {
@@ -26,7 +22,7 @@ ol.spell-list {
                 text-decoration: line-through;
             }
 
-            .cast-spell {
+            .cast-spell button {
                 background: var(--color-disabled);
                 box-shadow: inset 0 0 0 1px rgba(white, 0.5);
                 cursor: not-allowed;
@@ -46,7 +42,6 @@ ol.spell-list {
         }
 
         &.spell-level-header {
-            @include p-reset;
             background: rgba($sub-color, 0.25);
             border: 1px solid var(--color-border-light-2);
             border-radius: 2px;
@@ -54,7 +49,6 @@ ol.spell-list {
             font: 500 var(--font-size-12) var(--sans-serif);
             letter-spacing: 0.25px;
             line-height: 1;
-            padding: 0 0.5em;
             text-transform: uppercase;
 
             h3 {
@@ -67,14 +61,11 @@ ol.spell-list {
             .item-name {
                 line-height: 1;
                 gap: 0.25em;
+                padding-left: 0.2em;
                 h3 {
                     @include p-reset;
                     font-weight: 700;
                 }
-            }
-
-            .item-controls {
-                grid-column: span 2;
             }
         }
 
@@ -118,10 +109,13 @@ ol.spell-list {
         .item-name {
             align-items: center;
             display: flex;
+            flex: 1;
             flex-wrap: nowrap;
-            justify-content: start;
-            justify-self: start;
             min-height: 1.75rem;
+
+            &.empty {
+                pointer-events: none;
+            }
 
             h3 {
                 white-space: nowrap;
@@ -176,64 +170,47 @@ ol.spell-list {
                 margin-left: 4px;
                 font-size: small;
             }
-
-            &.empty {
-                grid-column: 1 / span 4;
-            }
         }
 
         .spell-range {
-            grid-area: range;
+            flex: 0 0 6rem;
             padding-left: 0.2em;
         }
 
-        .spell-components {
-            grid-area: components;
-            justify-self: right;
-            padding: 0 0.5em;
+        .cast-spell {
+            flex: 0 0 3.5rem;
+            display: flex;
+            justify-content: center;
 
-            .tag {
-                font: var(--font-size-12) var(--sans-serif-condensed);
+            button {
+                align-items: center;
+                background: var(--secondary);
+                border-radius: 2px;
+                border: black;
+                box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.5);
+                color: var(--text-light);
+                cursor: pointer;
+                font: 700 0.55rem var(--sans-serif);
+                letter-spacing: 0.25px;
+                max-width: fit-content;
+                padding: 0.5em 1em;
+                text-transform: uppercase;
             }
         }
 
-        .spell-cast {
-            grid-area: cast-spell;
-            display: flex;
-            justify-content: center;
-        }
-
         .item-controls {
-            grid-area: controls;
+            flex: 0 0 3.25rem;
             display: flex;
-            justify-self: end;
+            justify-content: end;
             padding-right: 0.25em;
         }
 
-        button.cast-spell {
-            align-items: center;
-            background: var(--secondary);
-            border-radius: 2px;
-            border: black;
-            box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.5);
-            color: var(--text-light);
-            cursor: pointer;
-            display: flex;
-            font: 700 0.55rem var(--sans-serif);
-            justify-self: center;
-            letter-spacing: 0.25px;
-            max-width: fit-content;
-            padding: 0.5em 1em;
-            text-transform: uppercase;
-        }
-
         .item-summary {
-            grid-area: content;
-            width: 100%;
-            padding: 8px;
+            background-color: var(--bg);
             border-bottom: 1px solid var(--sub);
             border-top: 1px solid lighten($sub-color, 30);
-            background-color: var(--bg);
+            flex: 100%;
+            padding: 8px;
         }
     }
 
@@ -264,13 +241,6 @@ ol.spell-list {
         text-align: center;
         background: var(--secondary);
         position: relative;
-    }
-
-    .spell {
-        .item-name {
-            // Fill grid area for easier drag drop
-            width: 100%;
-        }
     }
 
     input.toggle-signature-spell[type="checkbox"] {

--- a/static/templates/actors/character/tabs/spellcasting.hbs
+++ b/static/templates/actors/character/tabs/spellcasting.hbs
@@ -76,7 +76,7 @@
                     </div>
                 {{/unless}}
                 {{#if entry.hasCollection}}
-                    {{> "systems/pf2e/templates/actors/spell-collection.hbs" entry=entry}}
+                    {{> "systems/pf2e/templates/actors/partials/spell-collection.hbs" entry=entry}}
                 {{/if}}
             </li>
         {{/each}}

--- a/static/templates/actors/npc/tabs/spells.hbs
+++ b/static/templates/actors/npc/tabs/spells.hbs
@@ -64,7 +64,7 @@
                 </div>
                 {{#if entry.hasCollection}}
                     <div class="body">
-                        {{> "systems/pf2e/templates/actors/spell-collection.hbs" entry=entry}}
+                        {{> "systems/pf2e/templates/actors/partials/spell-collection.hbs" entry=entry}}
                     </div>
                 {{/if}}
             </li>

--- a/static/templates/actors/partials/spell-collection.hbs
+++ b/static/templates/actors/partials/spell-collection.hbs
@@ -4,7 +4,7 @@
         {{#each entry.levels as |section|}}
             {{#if (or (gt section.active.length 0) entry.showSlotlessLevels)}}
                 <li class="spell-level-header spellbook-header item" data-item-id="{{entry.id}}" data-item-type="spellLevel" data-level="{{section.level}}">
-                    <div class="item-name flexrow">
+                    <div class="item-name">
                         <h3>{{localize section.label}}</h3>
 
                         {{#if (and section.isCantrip (not section.uses))}}
@@ -46,14 +46,16 @@
                             {{localize "PF2E.SpellRangeLabel"}}
                         {{/if}}
                     </div>
-                    <div class="spell-components">{{localize "PF2E.SpellComponentsLabel"}}</div>
 
-                    {{#if (and (not entry.isPrepared) @root.options.editable)}}
+                    <div class="cast-spell"></div>
+                    {{#if @root.options.editable}}
                         <div class="item-controls">
-                            <a class="item-control spell-create" title="{{localize "PF2E.CreateSpellTitle"}}" data-type="spell"
-                                data-level="{{section.level}}" data-location="{{entry.id}}"><i class="fas fa-fw fa-plus"></i></a>
-                            <a class="item-control spell-browse" title="{{localize "PF2E.OpenSpellBrowserTitle"}}" data-type="spell"
-                                data-level="{{section.level}}" data-location="{{entry.id}}"><i class="fas fa-fw fa-search"></i></a>
+                            {{#unless entry.isPrepared}}
+                                <a class="item-control spell-create" title="{{localize "PF2E.CreateSpellTitle"}}" data-type="spell"
+                                    data-level="{{section.level}}" data-location="{{entry.id}}"><i class="fas fa-fw fa-plus"></i></a>
+                                <a class="item-control spell-browse" title="{{localize "PF2E.OpenSpellBrowserTitle"}}" data-type="spell"
+                                    data-level="{{section.level}}" data-location="{{entry.id}}"><i class="fas fa-fw fa-search"></i></a>
+                            {{/unless}}
                         </div>
                     {{/if}}
                 </li>
@@ -102,43 +104,28 @@
                                 {{/if}}
                             </div>
 
-                            <div class="spell-components tags">
-                                {{#if spell.system.components.focus}}
-                                    <span class="tag tag_transparent">{{localize "PF2E.SpellComponentShortF"}}</span>
-                                {{/if}}
-                                {{#if spell.system.components.material}}
-                                    <span class="tag tag_transparent">{{localize "PF2E.SpellComponentShortM"}}</span>
-                                {{/if}}
-                                {{#if spell.system.components.somatic}}
-                                    <span class="tag tag_transparent">{{localize "PF2E.SpellComponentShortS"}}</span>
-                                {{/if}}
-                                {{#if spell.system.components.verbal}}
-                                    <span class="tag tag_transparent">{{localize "PF2E.SpellComponentShortV"}}</span>
-                                {{/if}}
-                            </div>
-
                             {{#if @root.options.editable}}
-                                <button type="button" class="cast-spell" data-action="cast-spell">{{localize "PF2E.CastLabel"}}</button>
-                                {{#unless (and entry.isFlexible (not section.isCantrip))}}
-                                    <div class="item-controls">
-                                        {{#if entry.isPrepared}}
-                                            {{#unless section.isCantrip}}
-                                                <a class="item-control item-toggle-prepare" title="{{#if expended}}{{localize "PF2E.RestoreSpellTitle"}}{{else}}{{localize "PF2E.ExpendSpellTitle"}}{{/if}}"><i class="fas fa-fw fa-{{#if expended}}plus{{else}}minus{{/if}}-square"></i></a>
-                                            {{/unless}}
-                                            <a class="item-control item-unprepare" title="{{localize "PF2E.UnprepareItemTitle"}}"><i class="fas fa-fw fa-trash"></i></a>
-                                        {{else}}
-                                            {{#if (and entry.isSpontaneous (not section.isCantrip))}}
-                                                <a class="item-control toggle-signature-spell" title="{{localize "PF2E.ToggleSignatureSpellTitle"}}">
-                                                    {{#if signature}}<i class="fas fa-fw fa-star"></i>{{else}}<i class="far fa-fw fa-star"></i>{{/if}}
-                                                </a>
-                                            {{/if}}
-                                            {{#unless virtual}}
-                                                <a class="item-control item-edit" title="{{localize "PF2E.EditItemTitle"}}"><i class="fas fa-fw fa-edit"></i></a>
-                                                <a class="item-control item-delete" title="{{localize "PF2E.DeleteItemTitle"}}"><i class="fas fa-fw fa-trash"></i></a>
-                                            {{/unless}}
+                                <div class="cast-spell">
+                                    <button type="button" data-action="cast-spell">{{localize "PF2E.CastLabel"}}</button>
+                                </div>
+                                <div class="item-controls">
+                                    {{#if entry.isPrepared}}
+                                        {{#unless section.isCantrip}}
+                                            <a class="item-control item-toggle-prepare" title="{{#if expended}}{{localize "PF2E.RestoreSpellTitle"}}{{else}}{{localize "PF2E.ExpendSpellTitle"}}{{/if}}"><i class="fas fa-fw fa-{{#if expended}}plus{{else}}minus{{/if}}-square"></i></a>
+                                        {{/unless}}
+                                        <a class="item-control item-unprepare" title="{{localize "PF2E.UnprepareItemTitle"}}"><i class="fas fa-fw fa-trash"></i></a>
+                                    {{else}}
+                                        {{#if (and entry.isSpontaneous (not section.isCantrip))}}
+                                            <a class="item-control toggle-signature-spell" title="{{localize "PF2E.ToggleSignatureSpellTitle"}}">
+                                                {{#if signature}}<i class="fas fa-fw fa-star"></i>{{else}}<i class="far fa-fw fa-star"></i>{{/if}}
+                                            </a>
                                         {{/if}}
-                                    </div>
-                                {{/unless}}
+                                        {{#unless virtual}}
+                                            <a class="item-control item-edit" title="{{localize "PF2E.EditItemTitle"}}"><i class="fas fa-fw fa-edit"></i></a>
+                                            <a class="item-control item-delete" title="{{localize "PF2E.DeleteItemTitle"}}"><i class="fas fa-fw fa-trash"></i></a>
+                                        {{/unless}}
+                                    {{/if}}
+                                </div>
                             {{/if}}
                         </li>
                     {{else}}

--- a/static/templates/actors/spell-preparation-sheet.hbs
+++ b/static/templates/actors/spell-preparation-sheet.hbs
@@ -58,7 +58,6 @@
                         </div>
 
                         <div class="spell-range">{{localize "PF2E.SpellRangeLabel"}}</div>
-                        <div class="spell-components">{{localize "PF2E.SpellComponentsLabel"}}</div>
                         {{#if @root.options.editable}}
                             <div class="item-controls">
                                 <a
@@ -92,23 +91,9 @@
 
                             <div class="spell-range">{{spell.system.range.value}}</div>
 
-                            <div class="spell-components tags">
-                                {{#if spell.system.components.focus}}
-                                    <span class="tag tag_transparent">{{localize "PF2E.SpellComponentShortF"}}</span>
-                                {{/if}}
-                                {{#if spell.system.components.material}}
-                                    <span class="tag tag_transparent">{{localize "PF2E.SpellComponentShortM"}}</span>
-                                {{/if}}
-                                {{#if spell.system.components.somatic}}
-                                    <span class="tag tag_transparent">{{localize "PF2E.SpellComponentShortS"}}</span>
-                                {{/if}}
-                                {{#if spell.system.components.verbal}}
-                                    <span class="tag tag_transparent">{{localize "PF2E.SpellComponentShortV"}}</span>
-                                {{/if}}
-                            </div>
                             {{#unless spell.isCantrip}}
                                 {{#if @root.entry.isFlexible}}
-                                    <div class="spell-cast">
+                                    <div class="cast-spell">
                                         <input
                                             type="checkbox"
                                             data-action="toggle-flexible-collection"


### PR DESCRIPTION
Also addressed a minor issue involving resize behavior and extra whitespace in the spell preparation sheet caused by the lack of a casting button.

![image](https://github.com/foundryvtt/pf2e/assets/1286721/e90d86f3-f775-4bad-bd19-68aca0528b9d)
