### PR TITLE
Add support for including material damage effects in consumable inline rolls

### DIFF
--- a/src/module/item/armor/data.ts
+++ b/src/module/item/armor/data.ts
@@ -29,7 +29,6 @@ interface ArmorSystemSource extends Investable<PhysicalSystemSource> {
     dexCap: number;
     checkPenalty: number | null;
     speedPenalty: number | null;
-    material: ItemMaterialData;
     /** Whether the armor is "specific magic armor" */
     specific?: SpecificArmorData;
 
@@ -62,12 +61,12 @@ type SpecificArmorData =
       }
     | {
           value: true;
-          material: ItemMaterialData;
+          material: Omit<ItemMaterialData, "effects">;
           runes: Pick<ArmorRuneData, "potency" | "resilient">;
       };
 
 interface ArmorSystemData
-    extends Omit<ArmorSystemSource, "hp" | "identification" | "price" | "temporary" | "usage">,
+    extends Omit<ArmorSystemSource, "hp" | "identification" | "material" | "price" | "temporary" | "usage">,
         Omit<Investable<PhysicalSystemData>, "traits"> {
     baseItem: BaseArmorType;
     runes: ArmorRuneData;

--- a/src/module/item/consumable/data.ts
+++ b/src/module/item/consumable/data.ts
@@ -35,7 +35,7 @@ interface ConsumableSystemSource extends PhysicalSystemSource {
 }
 
 interface ConsumableSystemData
-    extends Omit<ConsumableSystemSource, "hp" | "identification" | "price" | "temporary" | "usage">,
+    extends Omit<ConsumableSystemSource, "hp" | "identification" | "material" | "price" | "temporary" | "usage">,
         Omit<PhysicalSystemData, "traits"> {}
 
 export type { ConsumableCategory, ConsumableSource, ConsumableSystemData, ConsumableSystemSource, ConsumableTrait };

--- a/src/module/item/consumable/sheet.ts
+++ b/src/module/item/consumable/sheet.ts
@@ -9,6 +9,7 @@ export class ConsumableSheetPF2e extends PhysicalItemSheetPF2e<ConsumablePF2e> {
         return {
             ...sheetData,
             consumableTypes: CONFIG.PF2E.consumableTypes,
+            materialEffects: createSheetTags(CONFIG.PF2E.materialDamageEffects, item.system.material.effects),
             otherTags: createSheetTags(CONFIG.PF2E.otherConsumableTags, item.system.traits.otherTags),
         };
     }
@@ -16,5 +17,6 @@ export class ConsumableSheetPF2e extends PhysicalItemSheetPF2e<ConsumablePF2e> {
 
 interface ConsumableSheetData extends PhysicalItemSheetData<ConsumablePF2e> {
     consumableTypes: ConfigPF2e["PF2E"]["consumableTypes"];
+    materialEffects: SheetOptions;
     otherTags: SheetOptions;
 }

--- a/src/module/item/container/data.ts
+++ b/src/module/item/container/data.ts
@@ -21,7 +21,7 @@ interface ContainerSystemSource extends Investable<PhysicalSystemSource> {
 }
 
 interface ContainerSystemData
-    extends Omit<ContainerSystemSource, "hp" | "identification" | "price" | "temporary" | "usage">,
+    extends Omit<ContainerSystemSource, "hp" | "identification" | "material" | "price" | "temporary" | "usage">,
         Omit<Investable<PhysicalSystemData>, "traits"> {}
 
 export type { ContainerSource, ContainerSystemData };

--- a/src/module/item/equipment/data.ts
+++ b/src/module/item/equipment/data.ts
@@ -24,7 +24,7 @@ interface EquipmentSystemSource extends Investable<PhysicalSystemSource> {
 }
 
 interface EquipmentSystemData
-    extends Omit<EquipmentSystemSource, "hp" | "identification" | "price" | "temporary" | "usage">,
+    extends Omit<EquipmentSystemSource, "hp" | "identification" | "material" | "price" | "temporary" | "usage">,
         Omit<Investable<PhysicalSystemData>, "traits"> {
     apex?: {
         attribute: AttributeString;

--- a/src/module/item/melee/document.ts
+++ b/src/module/item/melee/document.ts
@@ -126,7 +126,7 @@ class MeleePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
         super.prepareBaseData();
 
         // Set precious material (currently unused)
-        this.system.material = { type: null, grade: null };
+        this.system.material = { type: null, grade: null, effects: [] };
 
         // Set empty property runes array for use by rule elements
         this.system.runes = { property: [] };

--- a/src/module/item/physical/data.ts
+++ b/src/module/item/physical/data.ts
@@ -4,6 +4,7 @@ import { ConsumableTrait } from "@item/consumable/data.ts";
 import { EquipmentTrait } from "@item/equipment/data.ts";
 import { WeaponTrait } from "@item/weapon/types.ts";
 import { Size, TraitsWithRarity, ValuesList } from "@module/data.ts";
+import { MaterialDamageEffect } from "@system/damage/types.ts";
 import { ActionCost, BaseItemSourcePF2e, Frequency, ItemSystemData, ItemSystemSource } from "../base/data/system.ts";
 import type { ITEM_CARRY_TYPES } from "../base/data/values.ts";
 import type { CoinsPF2e } from "./helpers.ts";
@@ -42,13 +43,25 @@ interface PhysicalSystemSource extends ItemSystemSource {
         value: string;
     };
     containerId: string | null;
-    material: ItemMaterialData;
+    material: ItemMaterialSource;
     size: Size;
     usage: {
         value: string;
     };
     activations?: Record<string, ItemActivation>;
     temporary?: boolean;
+}
+
+interface IdentificationSource {
+    status: IdentificationStatus;
+    unidentified: MystifiedData;
+    misidentified: object;
+}
+
+interface ItemMaterialSource {
+    grade: PreciousMaterialGrade | null;
+    type: PreciousMaterialType | null;
+    effects?: MaterialDamageEffect[];
 }
 
 interface PhysicalSystemData extends PhysicalSystemSource, Omit<ItemSystemData, "level"> {
@@ -92,13 +105,9 @@ interface MystifiedData {
     };
 }
 
-type IdentifiedData = DeepPartial<MystifiedData>;
+interface ItemMaterialData extends Required<ItemMaterialSource> {}
 
-interface IdentificationSource {
-    status: IdentificationStatus;
-    unidentified: MystifiedData;
-    misidentified: object;
-}
+type IdentifiedData = DeepPartial<MystifiedData>;
 
 interface IdentificationData extends IdentificationSource {
     identified: MystifiedData;
@@ -114,11 +123,6 @@ type EquippedData = {
 type PhysicalItemTrait = ArmorTrait | ConsumableTrait | EquipmentTrait | WeaponTrait;
 interface PhysicalItemTraits<T extends PhysicalItemTrait = PhysicalItemTrait> extends TraitsWithRarity<T> {
     otherTags: string[];
-}
-
-interface ItemMaterialData {
-    grade: PreciousMaterialGrade | null;
-    type: PreciousMaterialType | null;
 }
 
 interface ItemActivation {
@@ -175,6 +179,7 @@ export type {
     ItemActivation,
     ItemCarryType,
     ItemMaterialData,
+    ItemMaterialSource,
     MystifiedData,
     PartialPrice,
     PhysicalItemHPSource,

--- a/src/module/item/physical/document.ts
+++ b/src/module/item/physical/document.ts
@@ -198,6 +198,7 @@ abstract class PhysicalItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | n
         systemData.containerId ||= null;
         systemData.material.type ||= null;
         systemData.material.grade ||= null;
+        systemData.material.effects ??= [];
         systemData.stackGroup ||= null;
         systemData.equippedBulk.value ||= null;
         systemData.baseItem ??= sluggify(systemData.stackGroup ?? "") || null;

--- a/src/module/item/weapon/data.ts
+++ b/src/module/item/weapon/data.ts
@@ -4,6 +4,7 @@ import {
     BasePhysicalItemSource,
     Investable,
     ItemMaterialData,
+    ItemMaterialSource,
     PhysicalItemTraits,
     PhysicalSystemData,
     PhysicalSystemSource,
@@ -134,7 +135,7 @@ interface WeaponSystemSource extends Investable<PhysicalSystemSource> {
     propertyRune3: WeaponPropertyRuneSlot;
     propertyRune4: WeaponPropertyRuneSlot;
 
-    material: WeaponMaterialData;
+    material: WeaponMaterialSource;
 
     /** Whether this is an unarmed attack that is a grasping appendage, requiring a free hand for use */
     graspingAppendage?: boolean;
@@ -153,7 +154,7 @@ interface WeaponSystemSource extends Investable<PhysicalSystemSource> {
     selectedAmmoId: string | null;
 }
 
-interface WeaponMaterialData extends ItemMaterialData {
+interface WeaponMaterialSource extends ItemMaterialSource {
     type: WeaponMaterialType | null;
 }
 
@@ -162,6 +163,7 @@ interface WeaponSystemData
         Omit<Investable<PhysicalSystemData>, "material"> {
     traits: WeaponTraits;
     baseItem: BaseWeaponType | null;
+    material: WeaponMaterialData;
     maxRange: number | null;
     reload: {
         value: WeaponReloadTime | null;
@@ -181,6 +183,10 @@ type WeaponUsageDetails = UsageDetails & Required<WeaponSystemSource["usage"]>;
 interface WeaponTraits extends WeaponTraitsSource {
     otherTags: OtherWeaponTag[];
     toggles: WeaponTraitToggles;
+}
+
+interface WeaponMaterialData extends ItemMaterialData {
+    type: WeaponMaterialType | null;
 }
 
 interface WeaponRuneData {

--- a/src/module/system/damage/formula.ts
+++ b/src/module/system/damage/formula.ts
@@ -198,11 +198,7 @@ function instancesFromTypeMap(
         if (enclosed === "0" && persistent) return [];
 
         const flavor = ((): string => {
-            const kindFlavor = kinds.has("damage")
-                ? kinds.has("healing")
-                    ? ["damage", "healing"]
-                    : ["damage"]
-                : ["healing"];
+            const kindFlavor = kinds.has("damage") ? (kinds.has("healing") ? ["damage", "healing"] : []) : ["healing"];
             const typeFlavor = damageType === "untyped" && !persistent ? [] : [damageType];
             const persistentFlavor = persistent ? ["persistent"] : [];
             const materialFlavor = typePartials.flatMap((p) => p.materials ?? []);

--- a/src/styles/item/_index.scss
+++ b/src/styles/item/_index.scss
@@ -361,7 +361,8 @@
             }
         }
 
-        .form-list, fieldset {
+        .form-list,
+        fieldset {
             h3 {
                 font-weight: 600;
                 font-size: 1.05em;
@@ -416,21 +417,16 @@
         }
 
         .form-group {
-            &.scalable {
-                height: auto;
-                min-height: 1.5rem;
-
-                ul.traits-list {
-                    list-style-type: none;
-                }
-            }
-
             & > label:not(.large) {
                 max-width: 11em;
             }
 
             & > label.short {
                 max-width: 9em;
+            }
+
+            ul.tags {
+                margin: 0 0 0.5em;
             }
 
             .item-controls {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1499,13 +1499,6 @@
                 "InvalidDrop": "{badType} cannot be dropped here (must be {goodType})"
             },
             "Action": {
-                "SelfAppliedEffect": {
-                    "Applied": "{effect} was applied.",
-                    "Delete": "Delete Reference",
-                    "Drop": "Drop Effect",
-                    "Label": "Self-Applied Effect",
-                    "Hint": "A single effect item to be applied to the actor that uses this action"
-                },
                 "CategoryLabel": "Category",
                 "Category": {
                     "None": "None",
@@ -1513,6 +1506,13 @@
                     "Interaction": "Interaction",
                     "Offensive": "Offensive",
                     "Familiar": "Familiar Ability"
+                },
+                "SelfAppliedEffect": {
+                    "Applied": "{effect} was applied.",
+                    "Delete": "Delete Reference",
+                    "Drop": "Drop Effect",
+                    "Label": "Self-Applied Effect",
+                    "Hint": "A single effect item to be applied to the actor that uses this action"
                 },
                 "Type": {
                     "Activity": "Activity",
@@ -2037,6 +2037,10 @@
                 "RemoveAncestry": "Remove prerequisite ancestry"
             },
             "IconLabel": "Icon",
+            "MaterialEffects": {
+                "Hint": "Precious-material damage effects that can trigger or bypass some creatures' immunities, weaknesses, and resistances (applied to inline damage rolls)",
+                "Label": "Material Damage Effects"
+            },
             "NameLabel": "Name",
             "OtherTags": {
                 "Label": "Other Tags",
@@ -2101,7 +2105,7 @@
                     "Shoddy": "Shoddy"
                 },
                 "OtherTags": {
-                    "Hint": "These are tags indicating classifications in 2nd Edition rules that lack explicit status/definition but are still yet heavily relied upon. Some may be automatically added when other properties are present.",
+                    "Hint": "These are tags indicating classifications in Second Edition rules that lack explicit status/definition but are still yet heavily relied upon. Some may be automatically added when other properties are present.",
                     "Label": "Other Tags"
                 },
                 "PriceLabel": "Price: {price}",

--- a/static/templates/items/action-details.hbs
+++ b/static/templates/items/action-details.hbs
@@ -5,6 +5,6 @@
 {{/unless}}
 
 <div class="form-group">
-    <label for="{{item.uuid}}-death-note">{{localize "PF2E.ActionDeathNoteLabel"}}</label>
-    <input type="checkbox" name="system.deathNote" id="{{item.uuid}}-death-note" {{checked data.deathNote}} />
+    <label for="{{fieldIdPrefix}}death-note">{{localize "PF2E.ActionDeathNoteLabel"}}</label>
+    <input type="checkbox" name="system.deathNote" id="{{fieldIdPrefix}}death-note" {{checked data.deathNote}} />
 </div>

--- a/static/templates/items/consumable-details.hbs
+++ b/static/templates/items/consumable-details.hbs
@@ -9,19 +9,44 @@
     </select>
 </div>
 
-<div class="form-group">
-    <label>{{localize "PF2E.ConsumableConsumeLabel"}}</label>
-    <input type="text" name="system.consume.value" value="{{data.consume.value}}" placeholder="{{localize "PF2E.FormulaPlaceholder"}}" />
-</div>
+{{#unless item.isAmmunition}}
+    <div class="form-group">
+        <label>{{localize "PF2E.ConsumableConsumeLabel"}}</label>
+        <input type="text" name="system.consume.value" value="{{data.consume.value}}" placeholder="{{localize "PF2E.FormulaPlaceholder"}}" />
+    </div>
+{{/unless}}
 
 <div class="form-group">
     <label>{{localize "PF2E.ConsumableAutoDestroyLabel"}}</label>
     <input type="checkbox" name="system.autoDestroy.value" {{checked data.autoDestroy.value}} />
 </div>
 
+{{#unless item.isAmmunition}}
+    <div class="form-group stacked">
+        <label>
+            <span>{{localize "PF2E.Item.MaterialEffects.Label"}}</span>
+            <i class="fa-solid fa-info-circle" data-tooltip="PF2E.Item.MaterialEffects.Hint"></i>
+            {{#if editable}}
+                <a
+                    class="tag-selector"
+                    data-tag-selector="basic"
+                    data-title="PF2E.Item.Action.MaterialEffects.Label"
+                    data-config-types="materialDamageEffects"
+                    data-property="system.material.effects"
+                ><i class="fa-solid fa-fw fa-edit"></i></a>
+            {{/if}}
+        </label>
+        <ul class="traits-list tags">
+            {{#each materialEffects as |material|}}
+                <li class="tag tag_material" data-slug="{{material.value}}">{{material.label}}</li>
+            {{/each}}
+        </ul>
+    </div>
+{{/unless}}
+
 <div class="form-group stacked">
     <label>
-        {{localize "PF2E.Item.Physical.OtherTags.Label"}}
+        <span>{{localize "PF2E.Item.Physical.OtherTags.Label"}}</span>
         <i class="fa-solid fa-info-circle" data-tooltip="PF2E.Item.Physical.OtherTags.Hint"></i>
         {{#if editable}}
             <a


### PR DESCRIPTION
![image](https://github.com/foundryvtt/pf2e/assets/106829671/904f7ebe-4353-4a23-ae4b-67b62a548bb0)

![image](https://github.com/foundryvtt/pf2e/assets/106829671/2e0f9f17-f561-4eb9-a5be-43efb1d24ad3)