### PR TITLE
Add remaster changes to disarm action macro

### DIFF
--- a/packs/equipment-effects/effect-disarm-success.json
+++ b/packs/equipment-effects/effect-disarm-success.json
@@ -4,36 +4,50 @@
     "name": "Effect: Disarm (Success)",
     "system": {
         "description": {
-            "value": "<p>The target takes a -2 circumstance penalty to attacks with the item or other checks requiring a firm grasp on the item.</p>"
+            "value": "<p>Granted by a successful @UUID[Compendium.pf2e.actionspf2e.Item.Disarm]</p>\n<hr />\n<p>You have a weakened grasp on an item. Further attempts to Disarm the item gain a +2 circumstance bonus, and you take a –2 circumstance penalty to attacks with the item or other checks requiring a firm grasp on the item. You can end the effect by Interacting to change your grip on the item; otherwise, it lasts as long as you hold the item.</p>"
         },
         "duration": {
-            "expiry": "turn-start",
+            "expiry": null,
             "sustained": false,
-            "unit": "rounds",
-            "value": 1
+            "unit": "unlimited",
+            "value": -1
         },
         "level": {
             "value": 1
         },
         "publication": {
-            "license": "OGL",
-            "remaster": false,
-            "title": "Pathfinder Core Rulebook"
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
         },
         "rules": [
             {
-                "domain": "attack-roll",
-                "key": "RollOption",
-                "label": "PF2E.Actions.Disarm.EffectLabel",
-                "option": "partially-disarmed",
-                "toggleable": true
+                "choices": {
+                    "ownedItems": true,
+                    "predicate": [
+                        "item:equipped"
+                    ],
+                    "types": [
+                        "melee",
+                        "weapon"
+                    ]
+                },
+                "flag": "disarmWeakenedGrasp",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.Weapon"
+            },
+            {
+                "key": "FlatModifier",
+                "selector": "{item|flags.pf2e.rulesSelections.disarmWeakenedGrasp}-attack",
+                "type": "circumstance",
+                "value": -2
             },
             {
                 "key": "FlatModifier",
                 "predicate": [
-                    "partially-disarmed"
+                    "action:disarm"
                 ],
-                "selector": "attack",
+                "selector": "reflex-dc",
                 "type": "circumstance",
                 "value": -2
             }

--- a/static/lang/action-en.json
+++ b/static/lang/action-en.json
@@ -241,11 +241,10 @@
                 "Title": "Disable Device"
             },
             "Disarm": {
-                "EffectLabel": "Using weapon with loose grip",
                 "Notes": {
                     "criticalFailure": "<strong>Critical Failure</strong> You lose your balance and become @UUID[Compendium.pf2e.conditionitems.Item.AJh5ex99aV6VTggg]{Off-Guard} until the start of your next turn.",
                     "criticalSuccess": "<strong>Critical Success</strong> You knock the item out of the opponent's grasp. It falls to the ground in the opponent's space.",
-                    "success": "<strong>Success</strong> You weaken your opponent's grasp on the item. Until the start of that creature's turn, attempts to Disarm the opponent of that item gain a +2 circumstance bonus, and the target takes a -2 circumstance penalty to attacks with the item or other checks requiring a firm grasp on the item. @UUID[Compendium.pf2e.equipment-effects.Item.z3ATL8DcRVrT0Uzt]{Effect: Disarm (Success)}"
+                    "success": "<strong>Success</strong> You weaken your target's grasp on the item. Further attempts to Disarm the target of that item gain a +2 circumstance bonus, and the target takes a –2 circumstance penalty to attacks with the item or other checks requiring a firm grasp on the item. The creature can end the effect by Interacting to change its grip on the item; otherwise, it lasts as long as the creature holds the item.<br>@UUID[Compendium.pf2e.equipment-effects.Item.z3ATL8DcRVrT0Uzt]{Effect: Disarm (Success)}"
                 },
                 "Title": "Disarm"
             },


### PR DESCRIPTION
Update the text for the success outcome to reflect the text in Player Core, and slightly refined the rule elements on the effect for the success outcome.

<img width="293" alt="Disarm action macro success" src="https://github.com/foundryvtt/pf2e/assets/6374503/c02e4406-694d-4416-9cb4-fde2aeeeeb2c">
