### PR TITLE
Update effect for Weapon Surge

### DIFF
--- a/packs/spell-effects/spell-effect-weapon-surge.json
+++ b/packs/spell-effects/spell-effect-weapon-surge.json
@@ -4,7 +4,7 @@
     "name": "Spell Effect: Weapon Surge",
     "system": {
         "description": {
-            "value": "<p>Granted by <em>@UUID[Compendium.pf2e.spells-srd.Item.Weapon Surge]</em> when applied to a weapon without a major striking rune.</p>\n<p>On your next Strike with that weapon before the start of your next turn, you gain a +1 status bonus to the attack roll and the weapon deals an additional die of damage.</p>\n<p>If the weapon has a striking rune, this instead increases the number of dice from the striking rune by 1 (to a maximum of 3 extra weapon dice).</p>"
+            "value": "<p>Granted by <em>@UUID[Compendium.pf2e.spells-srd.Item.Weapon Surge]</em></p>\n<p>On your next Strike with the weapon before the start of your next turn, you gain a +1 status bonus to the attack roll, the weapon deals additional spirit damage, and the Strike gains the sanctified trait.</p>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -16,9 +16,9 @@
             "value": 1
         },
         "publication": {
-            "license": "OGL",
-            "remaster": false,
-            "title": "Pathfinder Core Rulebook"
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
         },
         "rules": [
             {
@@ -42,9 +42,20 @@
                 "value": 1
             },
             {
-                "diceNumber": 1,
+                "damageType": "spirit",
+                "diceNumber": "ternary(gte(@item.level,9),3,ternary(gte(@item.level,5),2,1))",
+                "dieSize": "d6",
                 "key": "DamageDice",
                 "selector": "{item|flags.pf2e.rulesSelections.spellEffectWeaponSurge}-damage"
+            },
+            {
+                "definition": [
+                    "item:id:{item|flags.pf2e.rulesSelections.spellEffectWeaponSurge}"
+                ],
+                "key": "AdjustStrike",
+                "mode": "add",
+                "property": "traits",
+                "value": "sanctified"
             }
         ],
         "start": {

--- a/packs/spells/weapon-surge.json
+++ b/packs/spells/weapon-surge.json
@@ -11,7 +11,7 @@
         "damage": {},
         "defense": null,
         "description": {
-            "value": "<p>Holding your weapon aloft, you fill it with divine energy. On your next Strike with that weapon before the start of your next turn, you gain a +1 status bonus to the attack roll and the weapon deals an additional 1d6 spirit damage, and the Strike gainst the sanctified trait.<em> Weapon</em> <em>surge</em> ends once you complete this Strike or the weapon leaves your possession.</p>\n<hr />\n<p><strong>Heightened (5th)</strong> The attack deals 2d6 additional spirit damage.</p>\n<p><strong>Heightened (9th)</strong> The attack deals 3d6 additional spirit damage</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Weapon Surge]</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Weapon Surge (Major Striking)]</p>"
+            "value": "<p>Holding your weapon aloft, you fill it with divine energy. On your next Strike with that weapon before the start of your next turn, you gain a +1 status bonus to the attack roll and the weapon deals an additional 1d6 spirit damage, and the Strike gainst the sanctified trait.<em> Weapon</em> <em>surge</em> ends once you complete this Strike or the weapon leaves your possession.</p>\n<hr />\n<p><strong>Heightened (5th)</strong> The attack deals 2d6 additional spirit damage.</p>\n<p><strong>Heightened (9th)</strong> The attack deals 3d6 additional spirit damage.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Weapon Surge]</p>"
         },
         "duration": {
             "sustained": false,
@@ -42,7 +42,8 @@
             "value": [
                 "cleric",
                 "focus",
-                "manipulate"
+                "manipulate",
+                "sanctified"
             ]
         }
     },


### PR DESCRIPTION
If accepted, the effect "Spell Effect: Weapon Surge (Major Striking)" can be added to the migrate/remove list.