### PR TITLE
Add unified effect for Sweet Dream and update

### DIFF
--- a/packs/spell-effects/spell-effect-sweet-dream.json
+++ b/packs/spell-effects/spell-effect-sweet-dream.json
@@ -1,0 +1,85 @@
+{
+    "_id": "yEQXaB7XyaROVqyb",
+    "img": "systems/pf2e/icons/spells/sweet-dream.webp",
+    "name": "Spell Effect: Sweet Dream",
+    "system": {
+        "description": {
+            "value": "<p>Granted by <em>@UUID[Compendium.pf2e.spells-srd.Item.Sweet Dream]</em></p>\n<ul>\n<li><strong>Dream of Insight</strong> status bonus to Intelligence-based skill checks</li>\n<li><strong>Dream of Glamor</strong> status bonus to Charisma-based skill checks</li>\n<li><strong>Dream of Voyaging</strong> +5-foot status bonus to Speed</li>\n</ul>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "hours",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "rules": [
+            {
+                "choices": [
+                    {
+                        "label": "PF2E.SpecificRule.SpellEffectSweetDream.Insight",
+                        "value": "insight"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.SpellEffectSweetDream.Glamor",
+                        "value": "glamor"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.SpellEffectSweetDream.Voyaging",
+                        "value": "voyaging"
+                    }
+                ],
+                "flag": "sweetDream",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.SpellEffectSweetDream.Prompt",
+                "rollOption": "sweet-dream"
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "sweet-dream:insight"
+                ],
+                "selector": "int-based",
+                "type": "status",
+                "value": "ternary(gte(@item.level,7),3,ternary(gte(@item.level,4),2,1))"
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "sweet-dream:glamor"
+                ],
+                "selector": "cha-based",
+                "type": "status",
+                "value": "ternary(gte(@item.level,7),3,ternary(gte(@item.level,4),2,1))"
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "sweet-dream:voyaging"
+                ],
+                "selector": "land-speed",
+                "type": "status",
+                "value": 5
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "rarity": "common",
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/spells/sweet-dream.json
+++ b/packs/spells/sweet-dream.json
@@ -11,11 +11,11 @@
         "damage": {},
         "defense": null,
         "description": {
-            "value": "<p>With your soothing words, you lull the target into an enchanting dream. When you Cast the Spell, the target falls @UUID[Compendium.pf2e.conditionitems.Item.Unconscious] if it wasn't already. While Unconscious, it experiences a dream of your choice, though lucidly enough it can wake when it pleases.If it wakes up before 1 minute of sleep has passed, the spell ends.</p>\n<ul>\n<li><strong>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Sweet Dream (Insight)]{Dream of Insight}</strong> +1 status bonus to Intelligence-based skill checks</li>\n<li><strong>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Sweet Dream (Glamour)]{Dream of Glamour}</strong> +1 status bonus to Charisma-based skill checks</li>\n<li><strong>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Sweet Dream (Voyaging)]{Dream of Voyaging}</strong> +5-foot status bonus to Speed</li>\n</ul>\n<p>If you Cast this Spell again, any previous <em>sweet dream</em> you cast ends.</p>\n<hr />\n<p><strong>Heightened (4th)</strong> The bonus for a dream of insight or glamor is +2.</p>\n<p><strong>Heightened (7th)</strong> The bonus for a dream of insight or glamor is +3.</p>"
+            "value": "<p>With your soothing words, you lull the target into an enchanting dream. When you Cast the Spell, the target falls @UUID[Compendium.pf2e.conditionitems.Item.Unconscious] if it wasn't already. While unconscious, it experiences a dream of your choice, though lucidly enough it can wake when it pleases. If it wakes up before 1 minute of sleep has passed, the spell ends.</p>\n<ul>\n<li><strong>Dream of Insight</strong> +1 status bonus to Intelligence-based skill checks</li>\n<li><strong>Dream of Glamor</strong> +1 status bonus to Charisma-based skill checks</li>\n<li><strong>Dream of Voyaging</strong> +5-foot status bonus to Speed</li>\n</ul>\n<p>If you Cast this Spell again, any previous <em>sweet dream</em> you cast ends.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Sweet Dream]</p>\n<hr />\n<p><strong>Heightened (4th)</strong> The bonus for a dream of insight or glamor is +2.</p>\n<p><strong>Heightened (7th)</strong> The bonus for a dream of insight or glamor is +3.</p>"
         },
         "duration": {
             "sustained": false,
-            "value": "10 minutes"
+            "value": "1 hour"
         },
         "level": {
             "value": 1
@@ -34,7 +34,7 @@
             "value": "1 willing creature"
         },
         "time": {
-            "value": "3"
+            "value": "2"
         },
         "traits": {
             "rarity": "uncommon",

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2750,6 +2750,12 @@
             "SpellEffectProtection": {
                 "Prompt": "Choose which alignment trait you are protecting against."
             },
+            "SpellEffectSweetDream": {
+                "Glamor": "Dream of Glamor",
+                "Insight": "Dream of Insight",
+                "Prompt": "Select a dream.",
+                "Voyaging": "Dream of Voyaging"
+            },
             "SpellEffectThermalRemedy": {
                 "BonusVsDisease": "Bonus vs. Disease",
                 "FireResistance": "Fire Resistance",


### PR DESCRIPTION
If accepted, "Spell Effect: Sweet Dream (Glamour)", "Spell Effect: Sweet Dream (Insight)", "Spell Effect: Sweet Dream (Voyaging)" can be added to the migrate/delete list