### PR TITLE
Add remaster changes to long jump action macro

### DIFF
--- a/src/module/system/action-macros/athletics/long-jump.ts
+++ b/src/module/system/action-macros/athletics/long-jump.ts
@@ -14,7 +14,7 @@ export function longJump(options: SkillActionOptions): void {
         traits: ["move"],
         event: options.event,
         callback: options.callback,
-        difficultyClass: options.difficultyClass,
+        difficultyClass: options.difficultyClass ?? { value: 15 },
         extraNotes: (selector: string) => [
             ActionMacroHelpers.outcomesNote(selector, `${PREFIX}.Notes.success`, ["success", "criticalSuccess"]),
             ActionMacroHelpers.note(selector, PREFIX, "failure"),

--- a/static/lang/action-en.json
+++ b/static/lang/action-en.json
@@ -392,9 +392,9 @@
             },
             "LongJump": {
                 "Notes": {
-                    "criticalFailure": "<strong>Critical Failure</strong> You @UUID[Compendium.pf2e.actionspf2e.Item.d5I6018Mci2SWokk]{Leap} normally, but then fall and land @UUID[Compendium.pf2e.conditionitems.Item.j91X7x0XSomq8d60]{Prone}.",
-                    "failure": "<strong>Failure</strong> You @UUID[Compendium.pf2e.actionspf2e.Item.d5I6018Mci2SWokk]{Leap} normally.",
-                    "success": "<strong>Success</strong> Increase the maximum horizontal distance you @UUID[Compendium.pf2e.actionspf2e.Item.d5I6018Mci2SWokk]{Leap} to the desired distance."
+                    "criticalFailure": "<strong>Critical Failure</strong> You make a normal horizontal @UUID[Compendium.pf2e.actionspf2e.Item.d5I6018Mci2SWokk]{Leap}, then fall and land @UUID[Compendium.pf2e.conditionitems.Item.j91X7x0XSomq8d60]{Prone}.",
+                    "failure": "<strong>Failure</strong> You make a normal horizontal @UUID[Compendium.pf2e.actionspf2e.Item.d5I6018Mci2SWokk]{Leap}.",
+                    "success": "<strong>Success</strong> You @UUID[Compendium.pf2e.actionspf2e.Item.d5I6018Mci2SWokk]{Leap} up to a distance equal to your check result rounded down to the nearest 5 feet. You can't jump farther than your land Speed."
                 },
                 "Title": "Long Jump"
             },


### PR DESCRIPTION
Update the text with the default difficulty class to reflect the text in Player Core, and assign the default difficulty class for the action macro when no other DC is provided.