### PR TITLE
Add remaster changes to high jump action macro

### DIFF
--- a/src/module/system/action-macros/athletics/high-jump.ts
+++ b/src/module/system/action-macros/athletics/high-jump.ts
@@ -12,7 +12,7 @@ export function highJump(options: SkillActionOptions): void {
         traits: ["move"],
         event: options.event,
         callback: options.callback,
-        difficultyClass: options.difficultyClass,
+        difficultyClass: options.difficultyClass ?? { value: 30 },
         extraNotes: (selector: string) => [
             ActionMacroHelpers.note(selector, "PF2E.Actions.HighJump", "criticalSuccess"),
             ActionMacroHelpers.note(selector, "PF2E.Actions.HighJump", "success"),

--- a/static/lang/action-en.json
+++ b/static/lang/action-en.json
@@ -323,10 +323,10 @@
             },
             "HighJump": {
                 "Notes": {
-                    "criticalFailure": "<strong>Critical Failure</strong> You don't @UUID[Compendium.pf2e.actionspf2e.Item.d5I6018Mci2SWokk]{Leap} at all, and instead you fall @UUID[Compendium.pf2e.conditionitems.Item.j91X7x0XSomq8d60]{Prone} in your space.",
-                    "criticalSuccess": "<strong>Critical Success</strong> Increase the maximum vertical distance to 8 feet, or increase the maximum vertical distance to 5 feet and maximum horizontal distance to 10 feet.",
+                    "criticalFailure": "<strong>Critical Failure</strong> You fall @UUID[Compendium.pf2e.conditionitems.Item.j91X7x0XSomq8d60]{Prone} in your space.",
+                    "criticalSuccess": "<strong>Critical Success</strong> You @UUID[Compendium.pf2e.actionspf2e.Item.d5I6018Mci2SWokk]{Leap} up to 8 feet vertically and 10 feet horizontally.",
                     "failure": "<strong>Failure</strong> You @UUID[Compendium.pf2e.actionspf2e.Item.d5I6018Mci2SWokk]{Leap} normally.",
-                    "success": "<strong>Success</strong> Increase the maximum vertical distance to 5 feet."
+                    "success": "<strong>Success</strong> You @UUID[Compendium.pf2e.actionspf2e.Item.d5I6018Mci2SWokk]{Leap} up to 5 feet vertically and 5 feet horizontally."
                 },
                 "Title": "High Jump"
             },


### PR DESCRIPTION
Update the outcome text to reflect the text in Player Core, and assign the default difficulty class for the action macro when no other DC is provided.