### PR TITLE
Change `CharacterPF2e#abilities` to `null` when using boosts

### DIFF
--- a/src/module/actor/character/attribute-builder.ts
+++ b/src/module/actor/character/attribute-builder.ts
@@ -499,9 +499,28 @@ class AttributeBuilder extends Application {
         }
 
         htmlQuery(html, "input[name=toggle-manual-mode]")?.addEventListener("click", () => {
-            actor.toggleAttributeManagement();
+            this.#toggleAttributeManagement();
         });
         htmlQuery(html, "button[data-action=close]")?.addEventListener("click", () => this.close());
+    }
+
+    /** Toggle between boost-driven and manual management of attributes */
+    async #toggleAttributeManagement(): Promise<void> {
+        const { actor } = this;
+        if (Object.keys(actor._source.system.abilities ?? {}).length === 0) {
+            // Add stored attribute modifiers for manual management
+            const baseAbilities = Array.from(ATTRIBUTE_ABBREVIATIONS).reduce(
+                (accumulated: Record<string, { value: 10 }>, abbrev) => ({
+                    ...accumulated,
+                    [abbrev]: { value: 10 as const },
+                }),
+                {},
+            );
+            await actor.update({ "system.abilities": baseAbilities });
+        } else {
+            // Delete stored attribute modifiers for boost-driven management
+            await actor.update({ "system.abilities": null });
+        }
     }
 }
 

--- a/src/module/actor/character/data.ts
+++ b/src/module/actor/character/data.ts
@@ -66,7 +66,7 @@ type CharacterFlags = ActorFlagsPF2e & {
 };
 
 interface CharacterSystemSource extends CreatureSystemSource {
-    abilities?: Record<AttributeString, { mod: number }>;
+    abilities: Record<AttributeString, { mod: number }> | null;
     attributes: CharacterAttributesSource;
     details: CharacterDetailsSource;
     traits: CharacterTraitsSource;

--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -1896,24 +1896,6 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
 
         return super._preUpdate(changed, options, user);
     }
-
-    /** Toggle between boost-driven and manual management of ability scores */
-    async toggleAttributeManagement(): Promise<void> {
-        if (Object.keys(this._source.system.abilities ?? {}).length === 0) {
-            // Add stored ability scores for manual management
-            const baseAbilities = Array.from(ATTRIBUTE_ABBREVIATIONS).reduce(
-                (accumulated: Record<string, { value: 10 }>, abbrev) => ({
-                    ...accumulated,
-                    [abbrev]: { value: 10 as const },
-                }),
-                {},
-            );
-            await this.update({ "system.abilities": baseAbilities });
-        } else {
-            // Delete stored ability scores for boost-driven management
-            await this.update({ "system.-=abilities": null });
-        }
-    }
 }
 
 interface CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | null>

--- a/static/template.json
+++ b/static/template.json
@@ -59,7 +59,7 @@
             "templates": [
                 "common"
             ],
-            "exploration": [],
+            "abilities": null,
             "details": {
                 "biography": {
                     "appearance": "",
@@ -179,7 +179,8 @@
                     "RO": null,
                     "VW": null
                 }
-            }
+            },
+            "exploration": []
         },
         "npc": {
             "templates": [


### PR DESCRIPTION
This will fix the BB iconics in the premium module from ending up in manual mode.