### PR TITLE
Add keybinding to focus compendium search bar

### DIFF
--- a/src/scripts/register-keybindings.ts
+++ b/src/scripts/register-keybindings.ts
@@ -1,4 +1,5 @@
 import type { PartyPF2e } from "@actor";
+import { CompendiumDirectoryPF2e } from "@module/apps/sidebar/compendium-directory.ts";
 
 export function registerKeybindings(): void {
     game.keybindings.register("pf2e", "cycle-token-stack", {
@@ -64,4 +65,33 @@ export function registerKeybindings(): void {
             },
         });
     }
+
+    game.keybindings.register("pf2e", "focus-compendium-search", {
+        name: "PF2E.Keybinding.FocusCompendiumSearch.Label",
+        hint: "PF2E.Keybinding.FocusCompendiumSearch.Hint",
+        // Defer to Quick Insert if enabled
+        editable: game.modules.get("quick-insert")?.active ? [] : [{ key: "Space", modifiers: ["Control"] }],
+        onDown: (context: KeyboardEventContext): boolean => {
+            context.event.preventDefault();
+            return true;
+        },
+        onUp: (): boolean => {
+            const focusSearchBox = (directoryHtml: HTMLElement) => {
+                const searchBox = directoryHtml.querySelector(".header-search input") as HTMLInputElement;
+                searchBox.focus();
+            };
+            const tabs = ui.sidebar.tabs as Tabs & { compendium: CompendiumDirectoryPF2e };
+            if (ui.sidebar._collapsed) {
+                const popout = tabs.compendium.createPopout();
+                Hooks.once("renderCompendiumDirectory", (compendiumDirectory) => {
+                    focusSearchBox(compendiumDirectory.element[0]);
+                });
+                popout.render(true);
+            } else {
+                ui.sidebar.activateTab("compendium");
+                focusSearchBox(tabs.compendium.element[0]);
+            }
+            return true;
+        },
+    });
 }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2407,6 +2407,10 @@
             "TogglePartySheet": {
                 "Hint": "Open or close the sheet of the active or (if a player) assigned party.",
                 "Label": "Toggle Party Sheet"
+            },
+            "FocusCompendiumSearch": {
+                "Hint": "Open the compendium sidebar and focus the search box.",
+                "Label": "Search Compendiums"
             }
         },
         "KitItems": "Items",

--- a/types/foundry/client/application/sidebar/sidebar-tab/base.d.ts
+++ b/types/foundry/client/application/sidebar/sidebar-tab/base.d.ts
@@ -31,6 +31,9 @@ declare global {
 
         override close(options?: { force?: boolean }): Promise<void>;
 
+        /** Create a second instance of this SidebarTab class which represents a singleton popped-out container */
+        createPopout(...args: unknown[]): typeof this;
+
         /** Render the SidebarTab as a pop-out container */
         renderPopout(...args: unknown[]): void;
     }


### PR DESCRIPTION
By default, Ctrl+Space is used as the keybinding, but only when Quick Insert isn't enabled due to the overlap in functionality and keybinding.