### PR TITLE
Update critical specialization of Lion's Fury and Veteran Reclaimer

### DIFF
--- a/packs/feats/lions-fury.json
+++ b/packs/feats/lions-fury.json
@@ -30,20 +30,15 @@
         },
         "rules": [
             {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "lion-scythe-damage",
-                "text": "PF2E.Item.Weapon.CriticalSpecialization.knife"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "sun-sling-damage",
-                "text": "PF2E.Item.Weapon.CriticalSpecialization.sling"
+                "key": "CriticalSpecialization",
+                "predicate": [
+                    {
+                        "or": [
+                            "item:base:lion-scythe",
+                            "item:base:sun-sling"
+                        ]
+                    }
+                ]
             }
         ],
         "traits": {

--- a/packs/npc-gallery/veteran-reclaimer.json
+++ b/packs/npc-gallery/veteran-reclaimer.json
@@ -1083,40 +1083,16 @@
                 },
                 "rules": [
                     {
-                        "key": "Note",
-                        "outcome": [
-                            "criticalSuccess"
-                        ],
-                        "selector": "composite-longbow-damage",
-                        "text": "PF2E.Item.Weapon.CriticalSpecialization.bow",
-                        "title": "PF2E.Actor.Creature.CriticalSpecialization"
+                        "domain": "all",
+                        "key": "RollOption",
+                        "option": "weapon-mastery",
+                        "toggleable": true
                     },
                     {
-                        "key": "Note",
-                        "outcome": [
-                            "criticalSuccess"
-                        ],
-                        "selector": "dagger-damage",
-                        "text": "PF2E.Item.Weapon.CriticalSpecialization.knife",
-                        "title": "PF2E.Actor.Creature.CriticalSpecialization"
-                    },
-                    {
-                        "key": "Note",
-                        "outcome": [
-                            "criticalSuccess"
-                        ],
-                        "selector": "bastard-sword-damage",
-                        "text": "PF2E.Item.Weapon.CriticalSpecialization.sword",
-                        "title": "PF2E.Actor.Creature.CriticalSpecialization"
-                    },
-                    {
-                        "key": "Note",
-                        "outcome": [
-                            "criticalSuccess"
-                        ],
-                        "selector": "bastard-sword-two-handed-damage",
-                        "text": "PF2E.Item.Weapon.CriticalSpecialization.sword",
-                        "title": "PF2E.Actor.Creature.CriticalSpecialization"
+                        "key": "CriticalSpecialization",
+                        "predicate": [
+                            "weapon-mastery"
+                        ]
                     }
                 ],
                 "slug": null,


### PR DESCRIPTION
Needed as "PF2E.Item.Weapon.CriticalSpecialization.knife" has been removed