### PR TITLE
Allow frequency ItemAlterations (`max` and `per`) to alter items without a frequency

### DIFF
--- a/src/module/rules/rule-element/item-alteration/alteration.ts
+++ b/src/module/rules/rule-element/item-alteration/alteration.ts
@@ -264,7 +264,7 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
             case "frequency-max": {
                 const validator = ITEM_ALTERATION_VALIDATORS[this.property];
                 if (!validator.isValid(data)) return;
-                if (!data.item.system.frequency) data.item.system.frequency = { max: 1, per: "day" };
+                data.item.system.frequency ??= { max: 1, per: "day" };
                 const frequency = data.item.system.frequency;
                 const newValue = AELikeRuleElement.getNewValue(this.mode, frequency.max, data.alteration.value);
                 if (newValue instanceof DataModelValidationFailure) {
@@ -277,7 +277,7 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
             case "frequency-per": {
                 const validator = ITEM_ALTERATION_VALIDATORS[this.property];
                 if (!validator.isValid(data)) return;
-                if (!data.item.system.frequency) data.item.system.frequency = { max: 1, per: "day" };
+                data.item.system.frequency ??= { max: 1, per: "day" };
                 const newValue = this.#getNewInterval(this.mode, data.item.system.frequency.per, data.alteration.value);
                 if (newValue instanceof DataModelValidationFailure) {
                     throw newValue.asError();

--- a/src/module/rules/rule-element/item-alteration/alteration.ts
+++ b/src/module/rules/rule-element/item-alteration/alteration.ts
@@ -264,7 +264,7 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
             case "frequency-max": {
                 const validator = ITEM_ALTERATION_VALIDATORS[this.property];
                 if (!validator.isValid(data)) return;
-                if (!data.item.system.frequency) data.item.system.frequency = { value: 1, max: 1, per: "day" };
+                if (!data.item.system.frequency) data.item.system.frequency = { max: 1, per: "day" };
                 const frequency = data.item.system.frequency;
                 const newValue = AELikeRuleElement.getNewValue(this.mode, frequency.max, data.alteration.value);
                 if (newValue instanceof DataModelValidationFailure) {
@@ -277,7 +277,7 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
             case "frequency-per": {
                 const validator = ITEM_ALTERATION_VALIDATORS[this.property];
                 if (!validator.isValid(data)) return;
-                if (!data.item.system.frequency) data.item.system.frequency = { value: 1, max: 1, per: "day" };
+                if (!data.item.system.frequency) data.item.system.frequency = { max: 1, per: "day" };
                 const newValue = this.#getNewInterval(this.mode, data.item.system.frequency.per, data.alteration.value);
                 if (newValue instanceof DataModelValidationFailure) {
                     throw newValue.asError();

--- a/src/module/rules/rule-element/item-alteration/alteration.ts
+++ b/src/module/rules/rule-element/item-alteration/alteration.ts
@@ -263,7 +263,8 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
             }
             case "frequency-max": {
                 const validator = ITEM_ALTERATION_VALIDATORS[this.property];
-                if (!validator.isValid(data) || !data.item.system.frequency) return;
+                if (!validator.isValid(data)) return;
+                if (!data.item.system.frequency) data.item.system.frequency = { value: 1, max: 1, per: "day" };
                 const frequency = data.item.system.frequency;
                 const newValue = AELikeRuleElement.getNewValue(this.mode, frequency.max, data.alteration.value);
                 if (newValue instanceof DataModelValidationFailure) {
@@ -275,7 +276,8 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
             }
             case "frequency-per": {
                 const validator = ITEM_ALTERATION_VALIDATORS[this.property];
-                if (!validator.isValid(data) || !data.item.system.frequency) return;
+                if (!validator.isValid(data)) return;
+                if (!data.item.system.frequency) data.item.system.frequency = { value: 1, max: 1, per: "day" };
                 const newValue = this.#getNewInterval(this.mode, data.item.system.frequency.per, data.alteration.value);
                 if (newValue instanceof DataModelValidationFailure) {
                     throw newValue.asError();


### PR DESCRIPTION
If using either `frequency-max` or `frequency-per` in ItemAlteration (or GrantItem's `alterations`), it will set a default if the item has no frequency before doing the alteration.

The default is simply the, well, default from `activateActionSheetListeners`.
I found that that one also hard-coded `"day"` as the `per` value rather than referring to `CONFIG.PF2E.frequencies.day`. I tried doing it with the `CONFIG` frequency values, but then it'd complain about mismatched types, string vs `FrequencyInterval`, so I went with `"day"` since there was an example of it already in the code -- and it's exactly what I want to replicate anyways.

I don't think this has an in-system example, this is a purely self-serving PR.