### PR TITLE
Add `none` group to rollOptions for weapons and armour without groups

### DIFF
--- a/src/module/item/armor/document.ts
+++ b/src/module/item/armor/document.ts
@@ -100,11 +100,13 @@ class ArmorPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Phy
 
     /** Generate a list of strings for use in predication */
     override getRollOptions(prefix = "armor"): string[] {
+        const group = this.group || "null";
+
         return [
             super.getRollOptions(prefix),
             Object.entries({
                 [`category:${this.category}`]: true,
-                [`group:${this.group}`]: !!this.group,
+                [`group:${group}`]: true,
                 [`base:${this.baseType}`]: !!this.baseType,
                 [`rune:potency`]: this.system.runes.potency > 0,
                 [`rune:resilient`]: this.system.runes.resilient > 0,

--- a/src/module/item/armor/document.ts
+++ b/src/module/item/armor/document.ts
@@ -100,13 +100,11 @@ class ArmorPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Phy
 
     /** Generate a list of strings for use in predication */
     override getRollOptions(prefix = "armor"): string[] {
-        const group = this.group || "null";
-
         return [
             super.getRollOptions(prefix),
             Object.entries({
                 [`category:${this.category}`]: true,
-                [`group:${group}`]: true,
+                [`group:${this.group ?? "none"}`]: true,
                 [`base:${this.baseType}`]: !!this.baseType,
                 [`rune:potency`]: this.system.runes.potency > 0,
                 [`rune:resilient`]: this.system.runes.resilient > 0,

--- a/src/module/item/weapon/document.ts
+++ b/src/module/item/weapon/document.ts
@@ -234,13 +234,12 @@ class WeaponPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
             return unitBulk.isNegligible ? "negligible" : unitBulk.isLight ? "light" : unitBulk.toString();
         })();
         const rangeIncrement = this.range?.increment;
-        const group = this.group || "null";
 
         return [
             super.getRollOptions(prefix),
             Object.entries({
                 [`category:${this.category}`]: true,
-                [`group:${group}`]: true,
+                [`group:${this.group ?? "none"}`]: true,
                 ...baseTypeRollOptions,
                 [`base:${this.baseType}`]: !!this.baseType,
                 [`bulk:${bulk}`]: true,

--- a/src/module/item/weapon/document.ts
+++ b/src/module/item/weapon/document.ts
@@ -234,12 +234,13 @@ class WeaponPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
             return unitBulk.isNegligible ? "negligible" : unitBulk.isLight ? "light" : unitBulk.toString();
         })();
         const rangeIncrement = this.range?.increment;
+        const group = this.group || "null";
 
         return [
             super.getRollOptions(prefix),
             Object.entries({
                 [`category:${this.category}`]: true,
-                [`group:${this.group}`]: !!this.group,
+                [`group:${group}`]: true,
                 ...baseTypeRollOptions,
                 [`base:${this.baseType}`]: !!this.baseType,
                 [`bulk:${bulk}`]: true,


### PR DESCRIPTION
As the title says.

Decided to *only* modify the rollOptions and not the logic before it so anything that depended on an actual `null` value in-code or in modules need not change.
This rollOption change is just an additional value that didn't exist before, and `group:null` should be "unnatural" enough to not fuck anything over for modules and the like.