### PR TITLE
Add filter traits for runes to compendium browser equipment tab

### DIFF
--- a/src/module/apps/compendium-browser/index.ts
+++ b/src/module/apps/compendium-browser/index.ts
@@ -591,7 +591,7 @@ class CompendiumBrowser extends Application {
                         tagTextProp: "label",
                         dropdown: {
                             enabled: 0,
-                            fuzzySearch: false,
+                            fuzzySearch: true,
                             mapValueTo: "label",
                             maxItems: data.options.length,
                             searchKeys: ["label"],

--- a/src/module/apps/compendium-browser/tabs/data.ts
+++ b/src/module/apps/compendium-browser/tabs/data.ts
@@ -102,6 +102,14 @@ interface CampaignFeatureFilters extends BaseFilterData {
     };
 }
 
+type BrowserRuneTrait =
+    | "armor-potency-rune"
+    | "armor-property-rune"
+    | "resiliency-rune"
+    | "striking-rune"
+    | "weapon-potency-rune"
+    | "weapon-property-rune";
+
 interface EquipmentFilters extends BaseFilterData {
     checkboxes: {
         armorTypes: CheckboxData;
@@ -111,7 +119,7 @@ interface EquipmentFilters extends BaseFilterData {
         weaponTypes: CheckboxData;
     };
     multiselects: {
-        traits: MultiselectData<PhysicalItemTrait>;
+        traits: MultiselectData<PhysicalItemTrait | BrowserRuneTrait>;
     };
     ranges: {
         price: RangesInputData;
@@ -183,6 +191,7 @@ export type {
     BaseFilterData,
     BestiaryFilters,
     BrowserFilter,
+    BrowserRuneTrait,
     CampaignFeatureFilters,
     CheckboxData,
     CheckboxOptions,

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2221,6 +2221,12 @@
                     "Label": "Other Tags"
                 },
                 "PriceLabel": "Price: {price}",
+                "Runes": {
+                    "ArmorPotencyRuneLabel": "Armor Potency Rune",
+                    "ArmorPropertyRuneLabel": "Armor Property Rune",
+                    "WeaponPotencyRuneLabel": "Weapon Potency Rune",
+                    "WeaponPropertyRuneLabel": "Weapon Property Rune"
+                },
                 "Usage": {
                     "WornParenthetical": "Worn ({where})",
                     "WornSlot": {


### PR DESCRIPTION
Also enbales fuzzy search for the tagify traits dropdown.

Closes #6407 