### PR TITLE
Fix opening spellbook from focus and ritual entries

### DIFF
--- a/src/module/apps/compendium-browser/index.ts
+++ b/src/module/apps/compendium-browser/index.ts
@@ -243,13 +243,12 @@ class CompendiumBrowser extends Application {
         const filter = await spellTab.getFilterData();
         const { traditions } = filter.checkboxes;
 
-        // Focus spells are category "spell" but having both selected breaks the filter
-        if (category && filter.checkboxes.category.options[category] && !entry.isFocusPool) {
+        if (category && filter.checkboxes.category.options[category]) {
             filter.checkboxes.category.options[category].selected = true;
             filter.checkboxes.category.selected.push(category);
         }
 
-        if (entry.isFocusPool) {
+        if (entry.isRitual || entry.isFocusPool) {
             filter.checkboxes.category.options[entry.category].selected = true;
             filter.checkboxes.category.selected.push(entry.category);
         }

--- a/src/module/apps/compendium-browser/index.ts
+++ b/src/module/apps/compendium-browser/index.ts
@@ -243,12 +243,13 @@ class CompendiumBrowser extends Application {
         const filter = await spellTab.getFilterData();
         const { traditions } = filter.checkboxes;
 
-        if (category && filter.checkboxes.category.options[category]) {
+        // Focus spells are category "spell" but having both selected breaks the filter
+        if (category && filter.checkboxes.category.options[category] && !entry.isFocusPool) {
             filter.checkboxes.category.options[category].selected = true;
             filter.checkboxes.category.selected.push(category);
         }
 
-        if (entry.isRitual || entry.isFocusPool) {
+        if (entry.isFocusPool) {
             filter.checkboxes.category.options[entry.category].selected = true;
             filter.checkboxes.category.selected.push(entry.category);
         }

--- a/static/templates/actors/character/tabs/spellcasting.hbs
+++ b/static/templates/actors/character/tabs/spellcasting.hbs
@@ -14,7 +14,6 @@
                         <div class="item-controls">
                             {{#if entry.isFocusPool}}
                                 <a class="item-control spell-browse" data-tooltip="PF2E.OpenSpellBrowserTitle"
-                                    data-category="focus"
                                     data-location="{{entry.id}}"><i class="fa-solid fa-fw fa-search"></i></a>
                             {{/if}}
                             {{#if (or entry.isPrepared entry.isSpontaneous entry.isInnate)}}

--- a/static/templates/actors/partials/spell-collection.hbs
+++ b/static/templates/actors/partials/spell-collection.hbs
@@ -56,7 +56,7 @@
                                 <a
                                     class="item-control spell-browse"
                                     data-tooltip="{{localize "PF2E.OpenSpellBrowserTitle"}}"
-                                    data-category="{{#if (eq entry.category "ritual")}}ritual{{else if (eq section.level 0)}}cantrip{{else}}spell{{/if}}"
+                                    {{#if (eq section.level 0)}}data-category="cantrip"{{/if}}
                                     data-rank="{{#if (or (eq entry.category "ritual") (eq rank 0))}}10{{else}}{{rank}}{{/if}}"
                                     data-location="{{entry.id}}"
                                 ><i class="fa-solid fa-fw fa-search"></i></a>


### PR DESCRIPTION
Focus spells (non-cantrip) were adding both Spell and Focus category, which was causing issues. Similarly, Ritual was being added twice.

Not sure if this is the 100% best way to fix it but it works for me ™️ 