### PR TITLE
Add categories to spell tab storeFields so search works with category filter

### DIFF
--- a/src/module/apps/compendium-browser/tabs/spell.ts
+++ b/src/module/apps/compendium-browser/tabs/spell.ts
@@ -12,7 +12,19 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
 
     /* MiniSearch */
     override searchFields = ["name"];
-    override storeFields = ["type", "name", "img", "uuid", "rank", "time", "traditions", "traits", "rarity", "source"];
+    override storeFields = [
+        "type",
+        "name",
+        "img",
+        "uuid",
+        "rank",
+        "time",
+        "traditions",
+        "traits",
+        "categories",
+        "rarity",
+        "source",
+    ];
 
     constructor(browser: CompendiumBrowser) {
         super(browser);


### PR DESCRIPTION
Without this when searching while you have 1 or more categories selected categories would be undefined, causing an exception to be raised.