### PR TITLE
Cleanup custom damage versatile traits (and restrict deletion to damage types only)

### DIFF
--- a/types/foundry/common/primitives/set.d.ts
+++ b/types/foundry/common/primitives/set.d.ts
@@ -82,8 +82,8 @@ declare interface Set<T> {
      * the index of iteration, and the set being filtered.
      * @returns {Set}  A new Set containing only elements which satisfy the test criterion.
      */
-    filter<U extends T = T>(test: (value: T) => value is U): U[];
-    filter(test: (value: T) => boolean): T[];
+    filter<U extends T = T>(test: (value: T) => value is U): Set<U>;
+    filter(test: (value: T) => boolean): Set<T>;
 
     /**
      * Find the first element in this set which satisfies a certain test criterion.


### PR DESCRIPTION
Technically a bugfix, though the bug has already been fixed. This is mostly future proofing to avoid the bug resurfacing again at a later date.