### PR TITLE
Allow null categories in module custom damage

### DIFF
--- a/src/module/system/settings/homebrew/data.ts
+++ b/src/module/system/settings/homebrew/data.ts
@@ -38,7 +38,7 @@ type MainDamageCategories = "physical" | "energy";
 
 interface CustomDamageData {
     label: string;
-    category: MainDamageCategories | null;
+    category?: MainDamageCategories | null;
     icon: string | null;
 }
 

--- a/src/module/system/settings/homebrew/helpers.ts
+++ b/src/module/system/settings/homebrew/helpers.ts
@@ -23,7 +23,7 @@ function isHomebrewCustomDamage(value: object): value is Record<string, CustomDa
         (value) =>
             isObject<CustomDamageData>(value) &&
             typeof value.label === "string" &&
-            ["physical", "energy"].includes(value.category ?? ""),
+            (!value.category || ["physical", "energy"].includes(value.category)),
     );
 }
 

--- a/src/module/system/settings/homebrew/menu.ts
+++ b/src/module/system/settings/homebrew/menu.ts
@@ -393,7 +393,7 @@ class DamageTypeManager {
         if (tupleHasValue(["physical", "energy"], data.category)) {
             collections[data.category].push(slug);
         }
-        collections.BASE_DAMAGE_TYPES_TO_CATEGORIES[slug] = data.category;
+        collections.BASE_DAMAGE_TYPES_TO_CATEGORIES[slug] = data.category ?? null;
         collections.DAMAGE_TYPE_ICONS[slug] = data.icon?.substring(3) ?? null; // icons registered do not include the fa-
         collections.damageTypesLocalization[slug] = data.label;
 


### PR DESCRIPTION
It was previously allowed for world settings, this extends it to modules.