### PR TITLE
Rename Hearing to Echolocation in Batsbreath Cane Effect

### DIFF
--- a/packs/equipment-effects/effect-batsbreath-cane.json
+++ b/packs/equipment-effects/effect-batsbreath-cane.json
@@ -25,7 +25,7 @@
                 "acuity": "precise",
                 "key": "Sense",
                 "range": 60,
-                "selector": "hearing"
+                "selector": "echolocation"
             }
         ],
         "start": {


### PR DESCRIPTION
It did not work properly when applied before this fix.