### PR TITLE
Update damage links in Shed Spirit and Stitching Strike to autolevel

### DIFF
--- a/packs/actions/shed-spirit.json
+++ b/packs/actions/shed-spirit.json
@@ -11,7 +11,7 @@
         },
         "category": "offensive",
         "description": {
-            "value": "<p><strong>Frequency</strong> once per 10 minutes</p>\n<hr />\n<p><strong>Effect</strong> Your familiar's spirit exits its body, leaving its empty shell behind, before flying at an enemy within 20 feet and dealing @Damage[6d6[spirit]] damage, with a basic Will save against your spell DC. If the familiar dealt damage, it then flies to an ally within 30 feet of the enemy, restoring Hit Points equal to half the damage dealt. Your familiar then re-forms in its original square. At 9th level, and every 2 levels thereafter, the attack deals an additional 2d6 damage.</p>"
+            "value": "<p><strong>Frequency</strong> once per 10 minutes</p>\n<hr />\n<p><strong>Effect</strong> Your familiar's spirit exits its body, leaving its empty shell behind, before flying at an enemy within 20 feet and dealing @Damage[(6+max(0,(ceil((@actor.level -8)/2)*2)))d6[spirit]] damage, with a @Check[type:will|basic:true] save against your spell DC. If the familiar dealt damage, it then flies to an ally within 30 feet of the enemy, restoring Hit Points equal to half the damage dealt. Your familiar then re-forms in its original square. At 9th level, and every 2 levels thereafter, the attack deals an additional 2d6 damage.</p>"
         },
         "frequency": {
             "max": 1,

--- a/packs/actions/stitching-strike.json
+++ b/packs/actions/stitching-strike.json
@@ -11,7 +11,7 @@
         },
         "category": "offensive",
         "description": {
-            "value": "<p><strong>Frequency</strong> once per 10 minutes</p>\n<hr />\n<p><strong>Effect</strong> Your familiar unravels into magical fibers that encompass an enemy within 30 feet and deal @Damage[6d6[slashing]] damage, with a basic Reflex save against your spell DC. On a failure, the target is also @UUID[Compendium.pf2e.conditionitems.Item.Immobilized] for 1 round or until it Escapes against your spell DC. Your familiar then re-forms in its original square. At 9th level, and every 2 levels thereafter, the attack deals an additional 2d6 damage.</p>"
+            "value": "<p><strong>Frequency</strong> once per 10 minutes</p>\n<hr />\n<p><strong>Effect</strong> Your familiar unravels into magical fibers that encompass an enemy within 30 feet and deal @Damage[(6+max(0,(ceil((@actor.level -8)/2)*2)))d6[slashing]] damage, with a @Check[type:reflex|basic:true] save against your spell DC. On a failure, the target is also @UUID[Compendium.pf2e.conditionitems.Item.Immobilized] for 1 round or until it @UUID[Compendium.pf2e.actionspf2e.Item.Escape]{Escapes} against your spell DC. Your familiar then re-forms in its original square. At 9th level, and every 2 levels thereafter, the attack deals an additional 2d6 damage.</p>"
         },
         "frequency": {
             "max": 1,


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/11451

Using max() so that the base damage hover text works as expected.
<img width="177" alt="Screen Shot 2023-11-16 at 5 38 06 PM" src="https://github.com/foundryvtt/pf2e/assets/1904698/db3d7cc2-321d-40a0-87bd-7be12fecf64f">
