### PR TITLE
Add support for "fuzzy-matching" token marks

### DIFF
--- a/src/module/rules/rule-element/token-mark/rule-element.ts
+++ b/src/module/rules/rule-element/token-mark/rule-element.ts
@@ -1,19 +1,18 @@
 import { TokenDocumentPF2e } from "@scene/index.ts";
-import { SlugField } from "@system/schema-data-fields.ts";
+import { SlugField, StrictStringField } from "@system/schema-data-fields.ts";
 import { ErrorPF2e } from "@util";
 import { UUIDUtils } from "@util/uuid.ts";
-import type { StringField } from "types/foundry/common/data/fields.d.ts";
 import { RuleElementPF2e, RuleElementSchema, RuleElementSource } from "../index.ts";
 import { MarkTargetPrompt } from "./prompt.ts";
 
 /** Remember a token for later referencing */
 class TokenMarkRuleElement extends RuleElementPF2e<TokenMarkSchema> {
     static override defineSchema(): TokenMarkSchema {
-        const { fields } = foundry.data;
         return {
             ...super.defineSchema(),
             slug: new SlugField({ required: true, nullable: false, initial: undefined }),
-            uuid: new fields.StringField({ required: false, nullable: true, initial: null }),
+            uuid: new StrictStringField({ required: false, nullable: true, initial: null }),
+            fuzzyMatch: new StrictStringField({ required: false, nullable: true, initial: null }),
         };
     }
 
@@ -44,7 +43,12 @@ class TokenMarkRuleElement extends RuleElementPF2e<TokenMarkSchema> {
 
     override beforePrepareData(): void {
         if (UUIDUtils.isTokenUUID(this.uuid) && this.test()) {
-            this.actor.synthetics.tokenMarks.set(this.uuid, this.slug);
+            const fuzzyMatch = this.resolveInjectedProperties(this.fuzzyMatch) || null;
+            this.actor.synthetics.tokenMarks.push({
+                slug: this.slug,
+                uuid: this.uuid,
+                fuzzyMatch: fuzzyMatch === "base-actor" ? fuzzyMatch : null,
+            });
         }
     }
 
@@ -57,7 +61,10 @@ class TokenMarkRuleElement extends RuleElementPF2e<TokenMarkSchema> {
 
 type TokenMarkSchema = Omit<RuleElementSchema, "slug"> & {
     slug: SlugField<true, false, false>;
-    uuid: StringField<string, string, false, true, true>;
+    /** The UUID of the marked token */
+    uuid: StrictStringField<string, string, false, true, true>;
+    /** Extend the mark to any actor that shares an unlinked token's base actor */
+    fuzzyMatch: StrictStringField<string, string, false, true, true>;
 };
 
 interface TokenMarkRuleElement extends RuleElementPF2e<TokenMarkSchema>, ModelPropsFromSchema<TokenMarkSchema> {

--- a/src/module/rules/synthetics.ts
+++ b/src/module/rules/synthetics.ts
@@ -42,7 +42,7 @@ interface RuleElementSynthetics {
     striking: Record<string, StrikingSynthetic[]>;
     toggles: RollOptionToggle[];
     tokenEffectIcons: TokenEffect[];
-    tokenMarks: Map<TokenDocumentUUID, string>;
+    tokenMarks: TokenMark[];
     tokenOverrides: DeepPartial<Pick<foundry.documents.TokenSource, "light" | "name" | "alpha">> & {
         texture?:
             | { src: VideoFilePath; tint?: HexColorString }
@@ -129,6 +129,12 @@ interface StrikeAdjustment {
     adjustTraits?: (weapon: WeaponPF2e | MeleePF2e, traits: ActionTrait[]) => void;
 }
 
+interface TokenMark {
+    slug: string;
+    uuid: TokenDocumentUUID;
+    fuzzyMatch: "base-actor" | null;
+}
+
 interface StrikingSynthetic {
     label: string;
     bonus: number;
@@ -162,4 +168,5 @@ export type {
     SenseSynthetic,
     StrikeAdjustment,
     StrikingSynthetic,
+    TokenMark,
 };

--- a/types/foundry/client/data/documents/token-document.d.ts
+++ b/types/foundry/client/data/documents/token-document.d.ts
@@ -21,6 +21,9 @@ declare global {
          */
         get actor(): Actor<this | null> | null;
 
+        /** A reference to the base, World-level Actor this token represents. */
+        get baseActor(): Actor<null> | undefined;
+
         /** An indicator for whether or not the current User has full control over this Token document. */
         override get isOwner(): boolean;
 


### PR DESCRIPTION
Currently the only fuzzy-matching method is to match against any unlinked token with a shared base actor as the marked token