### PR TITLE
Correct Channeling Block level and Mark Others as Remastered

### DIFF
--- a/packs/feats/channeling-block.json
+++ b/packs/feats/channeling-block.json
@@ -14,7 +14,7 @@
             "value": "<p>You pour divine energy into a desperate block. When you Shield Block, you can expend a harm or heal spell. Roll 1d8 for each rank of the spell, and increase the shield's Hardness by the total for this block.</p>"
         },
         "level": {
-            "value": 12
+            "value": 14
         },
         "prerequisites": {
             "value": [

--- a/packs/feats/channeling-block.json
+++ b/packs/feats/channeling-block.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>You pour divine energy into a desperate block. When you Shield Block, you can expend a harm or heal spell. Roll 1d8 for each rank of the spell, and increase the shield's Hardness by the total for this block.</p>"
+            "value": "<p>You pour divine energy into a desperate block. When you Shield Block, you can expend a @UUID[Compendium.pf2e.spells-srd.Item.Harm] or @UUID[Compendium.pf2e.spells-srd.Item.Heal] spell. Roll 1d8 for each rank of the spell, and increase the shield's Hardness by the total for this block.</p>"
         },
         "level": {
             "value": 14

--- a/packs/feats/lasting-armament.json
+++ b/packs/feats/lasting-armament.json
@@ -24,9 +24,9 @@
             ]
         },
         "publication": {
-            "license": "OGL",
-            "remaster": false,
-            "title": "Pathfinder Core Rulebook"
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
         },
         "rules": [],
         "traits": {

--- a/packs/feats/restorative-channel.json
+++ b/packs/feats/restorative-channel.json
@@ -24,9 +24,9 @@
             ]
         },
         "publication": {
-            "license": "OGL",
-            "remaster": false,
-            "title": "Pathfinder Core Rulebook"
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
         },
         "rules": [],
         "traits": {

--- a/packs/feats/spellshape-channel.json
+++ b/packs/feats/spellshape-channel.json
@@ -20,9 +20,9 @@
             "value": []
         },
         "publication": {
-            "license": "OGL",
-            "remaster": false,
-            "title": "Pathfinder Core Rulebook"
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
         },
         "rules": [],
         "traits": {


### PR DESCRIPTION
Fixes https://github.com/foundryvtt/pf2e/issues/11530
Updates Lasting Armament, Restorative Channel, and Spellshape Channel to Remaster.