### PR TITLE
Fix maximum craftable item level for snarecrafter dedication

### DIFF
--- a/packs/feats/snarecrafter-dedication.json
+++ b/packs/feats/snarecrafter-dedication.json
@@ -40,6 +40,7 @@
                 "isPrepared": true,
                 "key": "CraftingEntry",
                 "label": "PF2E.SpecificRule.DedicationCraftingEntry.Snarecrafter",
+                "maxItemLevel": "@actor.level",
                 "selector": "snareCrafting"
             },
             {


### PR DESCRIPTION
Change the maximum craftable item level from the default to the actor level instead of using the default to 1 for the CraftingEntry rule element.