### PR TITLE
Fix Witches Armaments not adding the selected strike to character sheet

### DIFF
--- a/packs/feats/witchs-armaments.json
+++ b/packs/feats/witchs-armaments.json
@@ -57,7 +57,7 @@
                 "key": "Strike",
                 "label": "Eldritch Nails",
                 "predicate": [
-                    "witchs-armament:nails"
+                    "witchs-armaments:nails"
                 ],
                 "range": null,
                 "traits": [
@@ -78,7 +78,7 @@
                 "key": "Strike",
                 "label": "Iron Teeth",
                 "predicate": [
-                    "witchs-armament:teeth"
+                    "witchs-armaments:teeth"
                 ],
                 "range": null,
                 "traits": [
@@ -98,7 +98,7 @@
                 "key": "Strike",
                 "label": "Living Hair",
                 "predicate": [
-                    "witchs-armament:hair"
+                    "witchs-armaments:hair"
                 ],
                 "range": null,
                 "traits": [


### PR DESCRIPTION
Witches Armaments was not adding the selected strike to the players character sheets because the predicate specified "witchs-armament" instead of "witchs-armaments"