### PR TITLE
fix: Fixed Draconic and Wyrmblessed Dragon Options syncing with other Draconic Options

### DIFF
--- a/packs/classfeatures/bloodline-draconic.json
+++ b/packs/classfeatures/bloodline-draconic.json
@@ -323,6 +323,11 @@
                     "damageType": "{item|flags.pf2e.rulesSelections.dragon.damageType}",
                     "slug": "{item|flags.pf2e.rulesSelections.dragon.slug}"
                 }
+            },
+            {
+                "key": "RollOption",
+                "domain": "all",
+                "option": "feature:bloodline:draconic:{item|flags.pf2e.rulesSelections.dragon.slug}"
             }
         ],
         "traits": {

--- a/packs/classfeatures/bloodline-wyrmblessed.json
+++ b/packs/classfeatures/bloodline-wyrmblessed.json
@@ -323,6 +323,11 @@
                     "damageType": "{item|flags.pf2e.rulesSelections.dragon.damageType}",
                     "slug": "{item|flags.pf2e.rulesSelections.dragon.slug}"
                 }
+            },
+            {
+                "key": "RollOption",
+                "domain": "all",
+                "option": "feature:bloodline:wyrmblessed:{item|flags.pf2e.rulesSelections.dragon.slug}"
             }
         ],
         "traits": {


### PR DESCRIPTION
This fixes an issue we learned with Draconic Bloodlines.
Before this change, if you were a draconic or wyrmblessed sorcerer, your dragon choices did not properly carry over in other places that mattered, such as the Dragon Disciple Dedication