### PR TITLE
Update REs on Champion's Code to not Add both Holy and Unholy when selecting a Deity that adds both

### DIFF
--- a/packs/classfeatures/antipaladin.json
+++ b/packs/classfeatures/antipaladin.json
@@ -31,6 +31,11 @@
                     "class:champion"
                 ],
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Destructive Vengeance"
+            },
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "option": "sanctification:unholy"
             }
         ],
         "traits": {

--- a/packs/classfeatures/champions-code.json
+++ b/packs/classfeatures/champions-code.json
@@ -28,38 +28,14 @@
             {
                 "key": "GrantItem",
                 "predicate": [
-                    {
-                        "or": [
-                            "deity:primary:sanctification:can:holy",
-                            "deity:primary:sanctification:must:holy"
-                        ]
-                    },
-                    {
-                        "or": [
-                            "feature:liberator",
-                            "feature:paladin",
-                            "feature:redeemer"
-                        ]
-                    }
+                    "sanctification:holy"
                 ],
                 "uuid": "Compendium.pf2e.classfeatures.Item.The Tenets of Good"
             },
             {
                 "key": "GrantItem",
                 "predicate": [
-                    {
-                        "or": [
-                            "deity:primary:sanctification:can:unholy",
-                            "deity:primary:sanctification:must:unholy"
-                        ]
-                    },
-                    {
-                        "or": [
-                            "feature:tyrant",
-                            "feature:antipaladin",
-                            "feature:desecrator"
-                        ]
-                    }
+                    "sanctification:unholy"
                 ],
                 "uuid": "Compendium.pf2e.classfeatures.Item.The Tenets of Evil"
             }

--- a/packs/classfeatures/champions-code.json
+++ b/packs/classfeatures/champions-code.json
@@ -33,6 +33,13 @@
                             "deity:primary:sanctification:can:holy",
                             "deity:primary:sanctification:must:holy"
                         ]
+                    },
+                    {
+                        "or": [
+                            "feature:liberator",
+                            "feature:paladin",
+                            "feature:redeemer"
+                        ]
                     }
                 ],
                 "uuid": "Compendium.pf2e.classfeatures.Item.The Tenets of Good"
@@ -44,6 +51,13 @@
                         "or": [
                             "deity:primary:sanctification:can:unholy",
                             "deity:primary:sanctification:must:unholy"
+                        ]
+                    },
+                    {
+                        "or": [
+                            "feature:tyrant",
+                            "feature:antipaladin",
+                            "feature:desecrator"
                         ]
                     }
                 ],

--- a/packs/classfeatures/desecrator.json
+++ b/packs/classfeatures/desecrator.json
@@ -31,6 +31,11 @@
                     "class:champion"
                 ],
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Selfish Shield"
+            },
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "option": "sanctification:unholy"
             }
         ],
         "traits": {

--- a/packs/classfeatures/liberator.json
+++ b/packs/classfeatures/liberator.json
@@ -31,6 +31,11 @@
                     "class:champion"
                 ],
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Liberating Step"
+            },
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "option": "sanctification:holy"
             }
         ],
         "traits": {

--- a/packs/classfeatures/paladin.json
+++ b/packs/classfeatures/paladin.json
@@ -52,6 +52,11 @@
                 ],
                 "selector": "strike-damage",
                 "value": "@actor.system.abilities.cha.mod"
+            },
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "option": "sanctification:holy"
             }
         ],
         "traits": {

--- a/packs/classfeatures/redeemer.json
+++ b/packs/classfeatures/redeemer.json
@@ -31,6 +31,11 @@
                     "class:champion"
                 ],
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Glimpse of Redemption"
+            },
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "option": "sanctification:holy"
             }
         ],
         "traits": {

--- a/packs/classfeatures/tyrant.json
+++ b/packs/classfeatures/tyrant.json
@@ -31,6 +31,11 @@
                     "class:champion"
                 ],
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Iron Command"
+            },
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "option": "sanctification:unholy"
             }
         ],
         "traits": {


### PR DESCRIPTION
Adds a predicate to check which variant of the Champion is selected and only add the Tenets of Evil or Tenets of Good based on that selection.