### PR TITLE
Improve automation for granting champion reactions

### DIFF
--- a/packs/classfeatures/antipaladin.json
+++ b/packs/classfeatures/antipaladin.json
@@ -26,10 +26,17 @@
         },
         "rules": [
             {
+                "allowDuplicate": false,
                 "key": "GrantItem",
                 "predicate": [
-                    "class:champion"
+                    {
+                        "or": [
+                            "class:champion",
+                            "feat:champions-reaction"
+                        ]
+                    }
                 ],
+                "reevaluateOnUpdate": true,
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Destructive Vengeance"
             }
         ],

--- a/packs/classfeatures/desecrator.json
+++ b/packs/classfeatures/desecrator.json
@@ -26,10 +26,17 @@
         },
         "rules": [
             {
+                "allowDuplicate": false,
                 "key": "GrantItem",
                 "predicate": [
-                    "class:champion"
+                    {
+                        "or": [
+                            "class:champion",
+                            "feat:champions-reaction"
+                        ]
+                    }
                 ],
+                "reevaluateOnUpdate": true,
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Selfish Shield"
             }
         ],

--- a/packs/classfeatures/liberator.json
+++ b/packs/classfeatures/liberator.json
@@ -26,10 +26,17 @@
         },
         "rules": [
             {
+                "allowDuplicate": false,
                 "key": "GrantItem",
                 "predicate": [
-                    "class:champion"
+                    {
+                        "or": [
+                            "class:champion",
+                            "feat:champions-reaction"
+                        ]
+                    }
                 ],
+                "reevaluateOnUpdate": true,
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Liberating Step"
             }
         ],

--- a/packs/classfeatures/paladin.json
+++ b/packs/classfeatures/paladin.json
@@ -26,19 +26,31 @@
         },
         "rules": [
             {
+                "allowDuplicate": false,
                 "key": "GrantItem",
                 "predicate": [
-                    "class:champion"
+                    {
+                        "or": [
+                            "class:champion",
+                            "feat:champions-reaction"
+                        ]
+                    }
                 ],
+                "reevaluateOnUpdate": true,
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Retributive Strike"
             },
             {
                 "domain": "all",
                 "key": "RollOption",
-                "label": "PF2E.SpecificRule.Champion.DivineSmite.Label",
-                "option": "divine-smite",
+                "label": "PF2E.SpecificRule.Champion.RetributiveStrike",
+                "option": "retributive-strike",
                 "predicate": [
-                    "feature:divine-smite"
+                    {
+                        "or": [
+                            "class:champion",
+                            "feat:champions-reaction"
+                        ]
+                    }
                 ],
                 "toggleable": true
             },
@@ -48,7 +60,8 @@
                 "key": "FlatModifier",
                 "label": "PF2E.SpecificRule.Champion.DivineSmite.Label",
                 "predicate": [
-                    "divine-smite"
+                    "feature:divine-smite",
+                    "retributive-strike"
                 ],
                 "selector": "strike-damage",
                 "value": "@actor.system.abilities.cha.mod"

--- a/packs/classfeatures/redeemer.json
+++ b/packs/classfeatures/redeemer.json
@@ -26,10 +26,17 @@
         },
         "rules": [
             {
+                "allowDuplicate": false,
                 "key": "GrantItem",
                 "predicate": [
-                    "class:champion"
+                    {
+                        "or": [
+                            "class:champion",
+                            "feat:champions-reaction"
+                        ]
+                    }
                 ],
+                "reevaluateOnUpdate": true,
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Glimpse of Redemption"
             }
         ],

--- a/packs/classfeatures/tyrant.json
+++ b/packs/classfeatures/tyrant.json
@@ -26,10 +26,17 @@
         },
         "rules": [
             {
+                "allowDuplicate": false,
                 "key": "GrantItem",
                 "predicate": [
-                    "class:champion"
+                    {
+                        "or": [
+                            "class:champion",
+                            "feat:champions-reaction"
+                        ]
+                    }
                 ],
+                "reevaluateOnUpdate": true,
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Iron Command"
             }
         ],

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -1645,6 +1645,7 @@
                 },
                 "EvilDamage": "Spirit Damage",
                 "NegativeDamage": "Void Damage",
+                "RetributiveStrike": "Retributive Strike",
                 "TargetReaction": "Target triggered your champion reaction"
             },
             "ChromaticArmor": {


### PR DESCRIPTION
Paladin needs the general toggle for retributive strike since some feats key off making one, it will just be inert until they get a feat like shining oath or the divine smite feature.