### PR TITLE
Add melee/ranged and damage type to elemental blast roll options

### DIFF
--- a/src/module/actor/character/elemental-blast.ts
+++ b/src/module/actor/character/elemental-blast.ts
@@ -347,7 +347,12 @@ class ElementalBlast {
             melee,
             damaging: true,
             dc: { slug: "ac" },
-            extraRollOptions: [`action:${actionSlug}`, `action:cost:${actionCost}`],
+            extraRollOptions: [
+                `action:${actionSlug}`,
+                `action:cost:${actionCost}`,
+                meleeOrRanged,
+                `item:${meleeOrRanged}`,
+            ],
             ...eventToRollParams(params.event, { type: "check" }),
         });
     }
@@ -384,7 +389,14 @@ class ElementalBlast {
             outcome,
             melee,
             checkContext: params.checkContext,
-            options: new Set([`action:${actionSlug}`, `action:cost:${actionCost}`, meleeOrRanged, ...item.traits]),
+            options: new Set([
+                `action:${actionSlug}`,
+                `action:cost:${actionCost}`,
+                meleeOrRanged,
+                `item:${meleeOrRanged}`,
+                `item:damage:type:${params.damageType}`,
+                ...item.traits,
+            ]),
         });
 
         const baseDamage: BaseDamageData = {


### PR DESCRIPTION
Added the melee-attack-roll and ranged-attack-roll domains will require a migration, so roll option only for now.

Closes https://github.com/foundryvtt/pf2e/issues/10722