### PR TITLE
Fix spell counteraction property reference in template file

### DIFF
--- a/src/module/migration/migrations/882-spell-data-reorganization.ts
+++ b/src/module/migration/migrations/882-spell-data-reorganization.ts
@@ -137,7 +137,7 @@ export class Migration882SpellDataReorganization extends MigrationBase {
         }
         if ("sustained" in system) system["-=sustained"] = null;
 
-        // Shorten `hasCounteractCheck.value` to `counteracts`
+        // Shorten `hasCounteractCheck.value` to `counteraction`
         if (isObject(system.hasCounteractCheck)) {
             system.counteraction = !!system.hasCounteractCheck.value;
         } else if (topLevel) {

--- a/static/templates/chat/spell-card.hbs
+++ b/static/templates/chat/spell-card.hbs
@@ -36,7 +36,7 @@
                     {{{data.save.label}}}
                 </button>
             {{/if}}
-            {{#if (or data.check data.hasDamage data.hasCounteractCheck.value data.area.type)}}
+            {{#if (or data.check data.hasDamage data.counteraction data.area.type)}}
                 <section class="owner-buttons">
                     {{#if data.check}}
                         <div class="spell-attack-buttons">
@@ -50,7 +50,7 @@
                             <button type="button" data-action="spell-damage" data-visibility="owner">{{localize data.damageLabel}}</button>
                         </div>
                     {{/if}}
-                    {{#if data.hasCounteractCheck.value}}
+                    {{#if data.counteraction}}
                         <div class="spell-button">
                             <button type="button" data-action="spell-counteract" data-visibility="owner">{{localize "PF2E.Item.Spell.Counteract.Label"}}</button>
                         </div>


### PR DESCRIPTION
the recent migration (12 days ago) did not migrate the code itself to use the new name