### PR TITLE
Change Arcane trait given from Stance: Arcane Cascade to be a weapon trait

### DIFF
--- a/packs/feat-effects/stance-arcane-cascade.json
+++ b/packs/feat-effects/stance-arcane-cascade.json
@@ -107,7 +107,7 @@
                 ],
                 "key": "AdjustStrike",
                 "mode": "add",
-                "property": "traits",
+                "property": "weapon-traits",
                 "value": "arcane"
             },
             {


### PR DESCRIPTION
Fixes an issue with damage resistances when interacting with Arcane Cascade.

Before change:

![image](https://github.com/foundryvtt/pf2e/assets/59530629/2e2441e4-0cf8-42aa-a0ae-670d4a7c9732)

After change: 

![image](https://github.com/foundryvtt/pf2e/assets/59530629/f0415a15-2978-4c06-8ac7-6ec3c8d78977)

This change is consistent with packs/feats/arcane-fists.json but it may not be best practice, given that arcane (alongside magical, the general trait) is not considered a weapon trait in [PF2E terminology](https://2e.aonprd.com/Traits.aspx). A future solution could be to change the _Immunities, Weaknesses & Resistances_ implementation to consider general traits when calculating damage for weapons. 