### PR TITLE
Add homebrew IWR to Migration 881

### DIFF
--- a/src/module/migration/migrations/881-no-hb-prefix.ts
+++ b/src/module/migration/migrations/881-no-hb-prefix.ts
@@ -2,6 +2,7 @@ import { ActorSourcePF2e } from "@actor/data/index.ts";
 import { ItemSourcePF2e } from "@item/base/data/index.ts";
 import { recursiveReplaceString } from "@util";
 import { MigrationBase } from "../base.ts";
+import { IWRType } from "@actor/types.ts";
 
 /** Remove "hb_" prefixes from homebrew element slugs. */
 export class Migration881NoHBPrefix extends MigrationBase {
@@ -19,6 +20,16 @@ export class Migration881NoHBPrefix extends MigrationBase {
                 if (key.includes("hb_")) {
                     attacks[key.replace("hb_", "")] = value;
                     attacks[`-=${key}`] = null;
+                }
+            }
+        }
+
+        for (const type of ["immunities", "weaknesses", "resistances"] as const) {
+            const entries = source.system.attributes[type];
+            if (!Array.isArray(entries)) continue;
+            for (const entry of entries) {
+                if (entry.type.startsWith("hb_")) {
+                    entry.type = entry.type.replace("hb_", "") as IWRType;
                 }
             }
         }


### PR DESCRIPTION
Anyone with broken IWR homebrew types should run `game.pf2e.system.remigrate({ from: 0.881, to: 0.881 })`