### PR TITLE
Fix capitalization on Animal Instinct tongue image name

### DIFF
--- a/packs/classfeatures/animal-instinct.json
+++ b/packs/classfeatures/animal-instinct.json
@@ -357,7 +357,7 @@
                     }
                 },
                 "group": "brawling",
-                "img": "systems/pf2e/icons/unarmed-attacks/Tongue.webp",
+                "img": "systems/pf2e/icons/unarmed-attacks/tongue.webp",
                 "key": "Strike",
                 "label": "PF2E.BattleForm.Attack.Tongue",
                 "predicate": [


### PR DESCRIPTION
This affects case-sensitive file systems

Closes https://github.com/foundryvtt/pf2e/issues/11697