### PR TITLE
Block invalid tactic types from armies

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -82,6 +82,7 @@ import { ActorSheetPF2e } from "./sheet/base.ts";
 import { ActorSpellcasting } from "./spellcasting.ts";
 import { TokenEffect } from "./token-effect.ts";
 import { CREATURE_ACTOR_TYPES, SAVE_TYPES, SIZE_LINKABLE_ACTOR_TYPES, UNAFFECTED_TYPES } from "./values.ts";
+import { itemIsOfType } from "@item/helpers.ts";
 
 /**
  * Extend the base Actor class to implement additional logic specialized for PF2e.
@@ -368,6 +369,21 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
         };
 
         return damageIsApplicable[damageType];
+    }
+
+    /** Checks if the item can be added to this actor by checking the valid item types. */
+    checkItemValidity(source: PreCreate<ItemSourcePF2e>): boolean {
+        if (!itemIsOfType(source, ...this.allowedItemTypes)) {
+            ui.notifications.error(
+                game.i18n.format("PF2E.Item.CannotAddType", {
+                    type: game.i18n.localize(CONFIG.Item.typeLabels[source.type] ?? source.type.titleCase()),
+                }),
+            );
+
+            return false;
+        }
+
+        return true;
     }
 
     /** Get (almost) any statistic by slug: handling expands in `ActorPF2e` subclasses */

--- a/src/module/item/helpers.ts
+++ b/src/module/item/helpers.ts
@@ -1,31 +1,31 @@
 import { ActorPF2e } from "@actor";
 import { setHasElement } from "@util";
-import { ItemType } from "./base/data/index.ts";
+import { ItemSourcePF2e, ItemType } from "./base/data/index.ts";
 import { PhysicalItemPF2e } from "./physical/document.ts";
 import { PHYSICAL_ITEM_TYPES } from "./physical/values.ts";
 import { ItemInstances } from "./types.ts";
+import { ItemPF2e } from "./base/document.ts";
+
+type ItemOrSource = PreCreate<ItemSourcePF2e> | ItemPF2e;
 
 /** Determine in a type-safe way whether an `ItemPF2e` or `ItemSourcePF2e` is among certain types */
 function itemIsOfType<TParent extends ActorPF2e | null, TType extends ItemType>(
-    item: { type: string; effects: Collection<object> | object[]; flags: DocumentFlags },
+    item: ItemOrSource,
     ...types: TType[]
 ): item is ItemInstances<TParent>[TType] | ItemInstances<TParent>[TType]["_source"];
 function itemIsOfType<TParent extends ActorPF2e | null>(
-    item: { type: string; effects: Collection<object> | object[]; flags: DocumentFlags },
+    item: ItemOrSource,
     type: "physical",
 ): item is PhysicalItemPF2e<TParent> | PhysicalItemPF2e["_source"];
 function itemIsOfType<TParent extends ActorPF2e | null, TType extends "physical" | ItemType>(
-    item: { type: string; effects: Collection<object> | object[]; flags: DocumentFlags },
+    item: ItemOrSource,
     ...types: TType[]
 ): item is TType extends "physical"
     ? PhysicalItemPF2e<TParent> | PhysicalItemPF2e<TParent>["_source"]
     : TType extends ItemType
       ? ItemInstances<TParent>[TType] | ItemInstances<TParent>[TType]["_source"]
       : never;
-function itemIsOfType(
-    item: { type: string; effects: Collection<object> | object[]; flags: DocumentFlags },
-    ...types: string[]
-): boolean {
+function itemIsOfType(item: ItemOrSource, ...types: string[]): boolean {
     return types.some((t) => (t === "physical" ? setHasElement(PHYSICAL_ITEM_TYPES, item.type) : item.type === t));
 }
 

--- a/static/lang/kingmaker-en.json
+++ b/static/lang/kingmaker-en.json
@@ -11,6 +11,9 @@
             "Adjustment": "Adjustment",
             "Base": "Base",
             "Description": "Description",
+            "Error": {
+                "InvalidTacticType": "The tactic {name} is not supported by {type} armies"
+            },
             "Gear": {
                 "Weapons": {
                     "name" : "Magic Weapons",


### PR DESCRIPTION
This has impact on the core embedded item creation workflow, so this will need eyes on it. Technically the item helpers type is incorrect, though it was never really correct.