### PR TITLE
Force emanation template creation at token center

### DIFF
--- a/src/module/canvas/layer/template.ts
+++ b/src/module/canvas/layer/template.ts
@@ -133,7 +133,17 @@ export class TemplateLayerPF2e<
                 preview.snapForShape();
                 const { document, position } = preview;
                 this.#deactivatePreviewListeners(initialLayer, event);
-                document.updateSource(canvas.grid.getSnappedPosition(position.x, position.y, this.gridPrecision));
+                const { x, y } = (() => {
+                    if (preview.areaType === "emanation" && !preview.document.flags.pf2e.unconstrained) {
+                        // Place emanations at token center unless the emanation is unconstrained
+                        const { token } = preview;
+                        if (token) {
+                            return { x: token.center.x, y: token.center.y };
+                        }
+                    }
+                    return { x: position.x, y: position.y };
+                })();
+                document.updateSource(canvas.grid.getSnappedPosition(x, y, this.gridPrecision));
                 canvas.scene?.createEmbeddedDocuments("MeasuredTemplate", [document.toObject()]);
             },
             rightdown: (event: PIXI.FederatedPointerEvent): void => {

--- a/src/module/canvas/measured-template.ts
+++ b/src/module/canvas/measured-template.ts
@@ -4,7 +4,7 @@ import type { EffectAreaType } from "@item/spell/types.ts";
 import type { ChatMessagePF2e } from "@module/chat-message/document.ts";
 import type { MeasuredTemplateDocumentPF2e, ScenePF2e } from "@scene";
 import { highlightGrid } from "./helpers.ts";
-import type { TemplateLayerPF2e } from "./index.ts";
+import type { TemplateLayerPF2e, TokenPF2e } from "./index.ts";
 
 class MeasuredTemplatePF2e<
     TDocument extends MeasuredTemplateDocumentPF2e<ScenePF2e | null> = MeasuredTemplateDocumentPF2e<ScenePF2e | null>,
@@ -23,6 +23,10 @@ class MeasuredTemplatePF2e<
 
     get areaType(): EffectAreaType | null {
         return this.document.areaType;
+    }
+
+    get token(): TokenPF2e | null {
+        return this.document.token?.object ?? null;
     }
 
     /** Set the template layer's grid precision appropriately for this measured template's shape. */

--- a/src/module/item/spell/data.ts
+++ b/src/module/item/spell/data.ts
@@ -50,7 +50,7 @@ interface SpellTraits extends ItemTraits<SpellTrait> {
     traditions: MagicTradition[];
 }
 
-interface SpellArea {
+interface SpellAreaBase {
     value: EffectAreaSize;
     type: EffectAreaType;
     /**
@@ -59,6 +59,18 @@ interface SpellArea {
      */
     details?: string;
 }
+
+interface SpellAreaEmanation extends SpellAreaBase {
+    type: "emanation";
+    /* Allow free placement of the emanation? */
+    unconstrained?: boolean;
+}
+
+interface SpellAreaOther extends SpellAreaBase {
+    type: "burst" | "cone" | "cube" | "line" | "square";
+}
+
+type SpellArea = SpellAreaEmanation | SpellAreaOther;
 
 interface SpellDamageSource {
     formula: string;

--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -512,6 +512,8 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
                         ...this.getOriginData(),
                     },
                     areaType: this.system.area?.type ?? null,
+                    unconstrained:
+                        this.system.area?.type === "emanation" ? this.system.area.unconstrained ?? null : null,
                 },
             },
         };

--- a/src/module/scene/measured-template-document.ts
+++ b/src/module/scene/measured-template-document.ts
@@ -6,6 +6,7 @@ import { ItemOriginFlag } from "@module/chat-message/data.ts";
 import type { ChatMessagePF2e } from "@module/chat-message/document.ts";
 import { toggleClearTemplatesButton } from "@module/chat-message/helpers.ts";
 import type { ScenePF2e } from "./document.ts";
+import { TokenDocumentPF2e } from "./token-document/document.ts";
 
 class MeasuredTemplateDocumentPF2e<
     TParent extends ScenePF2e | null = ScenePF2e | null,
@@ -54,6 +55,14 @@ class MeasuredTemplateDocumentPF2e<
         return initialized;
     }
 
+    get token(): TokenDocumentPF2e | null {
+        return this.message?.token
+            ? this.message.token
+            : this.actor
+              ? this.actor.getActiveTokens().at(0)?.document ?? null
+              : null;
+    }
+
     /** If present, show the clear-template button on the message from which this template was spawned */
     protected override _onCreate(
         data: this["_source"],
@@ -80,6 +89,7 @@ interface MeasuredTemplateDocumentPF2e<TParent extends ScenePF2e | null = SceneP
             messageId?: string;
             origin?: ItemOriginFlag;
             areaType: EffectAreaType | null;
+            unconstrained: boolean | null;
         };
     };
 }

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -315,6 +315,8 @@ class TextEditorPF2e extends TextEditor {
             html.setAttribute("data-pf2-distance", params.distance);
             if (params.traits !== "") html.setAttribute("data-pf2-traits", params.traits);
             if (params.type === "line") html.setAttribute("data-pf2-width", params.width ?? "5");
+            if (params.type === "emanation" && params.unconstrained === "true")
+                html.setAttribute("data-pf2-unconstrained", "true");
             return html;
         }
         return null;

--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -248,7 +248,7 @@ export const InlineRollLinks = {
         } as const;
 
         for (const link of links.filter((l) => l.hasAttribute("data-pf2-effect-area"))) {
-            const { pf2EffectArea, pf2Distance, pf2TemplateData, pf2Traits, pf2Width } = link.dataset;
+            const { pf2EffectArea, pf2Distance, pf2TemplateData, pf2Traits, pf2Width, pf2Unconstrained } = link.dataset;
             link.addEventListener("click", () => {
                 if (!canvas.ready) return;
 
@@ -291,6 +291,9 @@ export const InlineRollLinks = {
                     objectHasKey(CONFIG.PF2E.areaSizes, templateData.distance)
                 ) {
                     flags.pf2e.areaType = pf2EffectArea;
+                    if (pf2EffectArea === "emanation" && pf2Unconstrained === "true") {
+                        flags.pf2e.unconstrained = true;
+                    }
                 }
 
                 const messageId =

--- a/src/styles/item/_spell-sheet.scss
+++ b/src/styles/item/_spell-sheet.scss
@@ -57,6 +57,12 @@ fieldset.heightening {
     }
 }
 
+.area-emanation {
+    display: flex;
+    justify-content: flex-end;
+    margin-left: 2px;
+}
+
 .overlay {
     .traits {
         align-items: center;

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2319,6 +2319,13 @@
             "SidebarSummary": "{type} Summary",
             "Spell": {
                 "Area": "{size}-{unit} {shape}",
+                "AreaDetails": {
+                    "Emanation": {
+                        "PlacedAtToken": "Emanations are centered on the caster unless stated otherwise",
+                        "Unconstrained": "Unconstrained",
+                        "UnconstrainedDetails": "Allow free placement of the emanation?"
+                    }
+                },
                 "Cast": "Cast",
                 "Cost": "Cost",
                 "Counteract": {

--- a/static/templates/items/spell-details.hbs
+++ b/static/templates/items/spell-details.hbs
@@ -45,7 +45,7 @@
 
     <div class="form-group">
         <label>{{localize "PF2E.AreaLabel"}}</label>
-        <div class="details-container-two-columns">
+        <div class="details-container-{{#if (eq data.area.type "emanation")}}three{{else}}two{{/if}}-columns">
             <select name="system.area.value" data-dtype="Number">
                 <option value="0"></option>
                 {{#select data.area.value}}
@@ -62,6 +62,20 @@
                     {{/each}}
                 {{/select}}
             </select>
+            {{#if (eq data.area.type "emanation")}}
+                <div class="area-emanation">
+                    <label
+                        for="{{fieldIdPrefix}}area-unconstrained"
+                        data-tooltip="PF2E.Item.Spell.AreaDetails.Emanation.UnconstrainedDetails"
+                    >{{localize "PF2E.Item.Spell.AreaDetails.Emanation.Unconstrained"}}</label>
+                    <input
+                        type="checkbox"
+                        name="system.area.unconstrained"
+                        id="{{fieldIdPrefix}}area-unconstrained"
+                        {{checked data.area.unconstrained}}
+                    />
+                </div>
+            {{/if}}
         </div>
     </div>
 


### PR DESCRIPTION
Depends on #11759 

Movement can be enabled by a new emanation area property:

![image](https://github.com/foundryvtt/pf2e/assets/41452412/0c3f04ae-515f-4288-b92b-956381671e8e)


