### PR TITLE
Use magnifying glass icon consistently

### DIFF
--- a/static/templates/actors/character/tabs/general.hbs
+++ b/static/templates/actors/character/tabs/general.hbs
@@ -178,7 +178,7 @@
             {{#if item}}
                 <span class="detail-item-control" data-item-id="{{item.id}}"><i class="fa-solid fa-fw fa-ellipsis-v"></i></span>
             {{else}}
-                <a class="open-compendium" data-compendium={{compendium}}><i class="fa-solid fa-fw fa-plus-circle"></i></a>
+                <a class="open-compendium" data-compendium={{compendium}}><i class="fa-solid fa-fw fa-search"></i></a>
             {{/if}}
         {{/if}}
     </h3>


### PR DESCRIPTION
nearly the easiest pull request of your life. This changes the icon from a plus to a magnifying glass, which is consistent with behavior throughout the rest of the character sheet