### PR TITLE
Allow setting the ability of a flatmodifer to a resolvable

### DIFF
--- a/src/module/rules/rule-element/flat-modifier.ts
+++ b/src/module/rules/rule-element/flat-modifier.ts
@@ -196,7 +196,7 @@ type FlatModifierSchema = RuleElementSchema & {
     /** The modifier (or bonus/penalty) type */
     type: StringField<ModifierType, ModifierType, true, false, true>;
     /** If this is an ability modifier, the ability score it modifies */
-    ability: StringField<AttributeString, AttributeString, false, false, false>;
+    ability: StringField<string, string, false, false, false>;
     /** Hide this modifier from breakdown tooltips if it is disabled */
     min: NumberField<number, number, false, false, false>;
     max: NumberField<number, number, false, false, false>;

--- a/src/module/rules/rule-element/flat-modifier.ts
+++ b/src/module/rules/rule-element/flat-modifier.ts
@@ -20,6 +20,8 @@ class FlatModifierRuleElement extends RuleElementPF2e<FlatModifierSchema> {
             this.fromEquipment = false;
         }
 
+        this.ability = this.resolveInjectedProperties(this.ability);
+
         if (this.type === "ability") {
             if (this.ability) {
                 this.slug = this.ability;
@@ -67,7 +69,7 @@ class FlatModifierRuleElement extends RuleElementPF2e<FlatModifierSchema> {
                 choices: Array.from(MODIFIER_TYPES),
                 initial: "untyped",
             }),
-            ability: new fields.StringField({ required: false, choices: CONFIG.PF2E.abilities, initial: undefined }),
+            ability: new fields.StringField({ required: false, initial: undefined }),
             min: new fields.NumberField({ required: false, nullable: false, initial: undefined }),
             max: new fields.NumberField({ required: false, nullable: false, initial: undefined }),
             force: new fields.BooleanField(),


### PR DESCRIPTION
eg `{actor|class.system.keyAbility.selected}`. Don't know what to do about the form input for that field being only a select, and I don't know where/how best to add back in the checking that its a valid ability string.