### PR TITLE
Fix Spell Compendium action glyph sizing

### DIFF
--- a/src/styles/packs/_index.scss
+++ b/src/styles/packs/_index.scss
@@ -26,6 +26,10 @@
                     ul {
                         grid-column-start: 2;
                     }
+
+                    &.spell-browser > ul .action-glyph {
+                        font-size: 1.5em;
+                    }
                 }
             }
 


### PR DESCRIPTION
I noticed that the latest changes to spell list in the compendium made the glyphs a bit too small.

Not sure how specific we want the CSS styles so happy for feedback there.

Before vs After fix:
![pf2e-spell-compendium-action-glyph](https://github.com/foundryvtt/pf2e/assets/4469633/590a6a80-a07e-46df-a451-7808d348758e)
