### PR TITLE
Fix recently adjusted container bulk localisation strings

### DIFF
--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1702,8 +1702,10 @@
                 }
             },
             "Container": {
-                "Capacity": "Bulk Capacity",
-                "Ignored": "Bulk Ignored",
+                "Bulk": {
+                    "Capacity": "Bulk Capacity",
+                    "Ignored": "Bulk Ignored"
+                },
                 "Plural": "Containers",
                 "Stowing": "Is Stowing Container?"
             },


### PR DESCRIPTION
This was just a minor error that was missed during the item bulk refactor: the modified localisation strings don't have the nested `Bulk` level.