### PR TITLE
Fix consumable summary use localization regression, and only show button if there's no formula

### DIFF
--- a/src/module/item/consumable/data.ts
+++ b/src/module/item/consumable/data.ts
@@ -26,7 +26,7 @@ interface ConsumableSystemSource extends PhysicalSystemSource {
         max: number;
     };
     consume: {
-        value: string;
+        value: string | null;
     };
     autoDestroy: {
         value: boolean;

--- a/src/module/item/consumable/document.ts
+++ b/src/module/item/consumable/document.ts
@@ -46,7 +46,7 @@ class ConsumablePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extend
     }
 
     get formula(): string | null {
-        return this.system.consume.value.trim() || null;
+        return this.system.consume.value?.trim() || null;
     }
 
     override prepareBaseData(): void {

--- a/static/templates/actors/partials/item-summary.hbs
+++ b/static/templates/actors/partials/item-summary.hbs
@@ -46,8 +46,8 @@
             {{/if}}
         {{/unless}}
 
-        {{#if (and (eq item.type "consumable") item.uses.max)}}
-            <span><button type="button" class="consume" data-action="consume">{{localize "PF2E.ConsumableUseLabel"}} {{item.name}}</button></span>
+        {{#if (and (eq item.type "consumable") item.uses.max item.formula)}}
+            <button type="button" class="consume" data-action="consume">{{localize "PF2E.Item.Consumable.Uses.Use"}}</button>
         {{/if}}
     </div>
 {{/if}}


### PR DESCRIPTION
The button in item summary only shows "Use" now, which is consistent with using consumables via chat.

The template's default formula value is "" but some entries in our database have a formula of null. Given all of this is going to need tweaking anyways (and I don't see what coerces "" to null), I widened the type to handle the possible error from clicking use on items such as Cold Iron Blanch.

I'm tempted on removing the use button from item summaries outright though, but I guess they can be useful for like healing potions...