### PR TITLE
Improve damage/healing adjustment dialog

### DIFF
--- a/src/module/chat-message/helpers.ts
+++ b/src/module/chat-message/helpers.ts
@@ -215,8 +215,9 @@ async function shiftAdjustDamage(message: ChatMessagePF2e, multiplier: number, r
             $html[0].querySelector("input")?.focus();
         }
     };
+    const isHealing = multiplier < 0;
     new AdjustmentDialog({
-        title: game.i18n.localize("PF2E.UI.shiftModifyDamageTitle"),
+        title: game.i18n.localize(isHealing ? "PF2E.UI.shiftModifyHealingTitle" : "PF2E.UI.shiftModifyDamageTitle"),
         content,
         buttons: {
             ok: {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -4661,7 +4661,8 @@
             },
             "noDamageInfoForOutcome": "No damage information for outcome {outcome}.",
             "shiftModifyDamageLabel": "Amount",
-            "shiftModifyDamageTitle": "Adjust Damage/Healing"
+            "shiftModifyDamageTitle": "Adjust Damage",
+            "shiftModifyHealingTitle": "Adjust Healing"
         },
         "UUID": {
             "Label": "UUID",

--- a/static/templates/chat/damage/adjustment-dialog.hbs
+++ b/static/templates/chat/damage/adjustment-dialog.hbs
@@ -1,6 +1,6 @@
 <form>
     <div class="form-group">
         <label for="adjustment-quantity">{{localize "PF2E.UI.shiftModifyDamageLabel"}}</label>
-        <input type="number" id="adjustment-quantity" value="0" placeholder="0" />
+        <input type="number" id="adjustment-quantity" placeholder="0" />
     </div>
 </form>


### PR DESCRIPTION
1. Remove initial value from damage/healing adjustment dialog (leaving placeholder)

2. Alter title of damage/healing adjustment dialog depending on damage vs healing

The first change is needed because otherwise a user that immediately starts typing after the dialog opens up will get an extra 0 appended to the end - meaning they'll deal 10 times as much extra damage (or healing).

Before:

![image](https://github.com/foundryvtt/pf2e/assets/6516621/74f3b559-19db-41fe-ad18-a7cbbf47de8d)

After:

![image](https://github.com/foundryvtt/pf2e/assets/6516621/0b2bc570-d722-4266-8f9f-c8800d453c03)
