### PR TITLE
Add effect for Heart of the Kaiju

### DIFF
--- a/packs/feat-effects/effect-kaiju-form.json
+++ b/packs/feat-effects/effect-kaiju-form.json
@@ -1,0 +1,99 @@
+{
+    "_id": "bzpW0owbAV3UX7UA",
+    "img": "icons/creatures/magical/humanoid-silhouette-green.webp",
+    "name": "Effect: Kaiju Form",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Heart of the Kaiju]</p>\n<p>You take on a kaiju form. The battle form is Gargantuan size with the following specific abilities.</p>\n<p><strong>Kaiju</strong> Speed 40 feet; physical resistance 5;</p>\n<p><strong>Melee</strong> <span class=\"action-glyph\">1</span> jaws (reach 20 feet), <strong>Damage</strong> 3d12+20 piercing;</p>\n<p><strong>Melee</strong> <span class=\"action-glyph\">1</span> claws (agile, reach 20 feet), <strong>Damage</strong> 3d8+20 slashing;</p>\n<p><strong>Breath Weapon</strong> <span class=\"action-glyph\">2</span> (evocation, primal) Each creature in a 60-foot cone takes 15d6 damage (of your chosen damage type), with a basic Reflex save against your spell DC. Once activated, your breath weapon can't be used again for 1d4 rounds.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "minutes",
+            "value": 1
+        },
+        "level": {
+            "value": 20
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder #168: King of the Mountain"
+        },
+        "rules": [
+            {
+                "key": "BattleForm",
+                "overrides": {
+                    "armorClass": {
+                        "modifier": "22 + @actor.level"
+                    },
+                    "resistances": [
+                        {
+                            "type": "physical",
+                            "value": 5
+                        }
+                    ],
+                    "senses": {
+                        "darkvision": {}
+                    },
+                    "size": "gargantuan",
+                    "skills": {
+                        "ath": {
+                            "modifier": 33
+                        }
+                    },
+                    "speeds": {
+                        "land": 40
+                    },
+                    "strikes": {
+                        "claw": {
+                            "ability": "str",
+                            "baseType": "claw",
+                            "category": "unarmed",
+                            "damage": {
+                                "damageType": "slashing",
+                                "dice": 3,
+                                "die": "d8",
+                                "modifier": 20
+                            },
+                            "modifier": 31,
+                            "traits": [
+                                "agile",
+                                "reach-20",
+                                "unarmed"
+                            ]
+                        },
+                        "jaws": {
+                            "ability": "str",
+                            "category": "unarmed",
+                            "damage": {
+                                "damageType": "piercing",
+                                "dice": 3,
+                                "die": "d12",
+                                "modifier": 20
+                            },
+                            "modifier": 31,
+                            "traits": [
+                                "reach-20",
+                                "unarmed"
+                            ]
+                        }
+                    },
+                    "tempHP": 25
+                }
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "rarity": "common",
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feats/heart-of-the-kaiju.json
+++ b/packs/feats/heart-of-the-kaiju.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>Witnessing the might of the kaiju King Mogaru, Alru, and Toraloa up close awoke a new ferocity within you. When you transform using @UUID[Compendium.pf2e.feats-srd.Item.Monstrosity Shape], you can take on a kaiju form. When you take this feat, choose acid, cold, electricity, fire, or sonic damage; this is the damage your breath weapon deals. You can't change this later. The battle form is Gargantuan size with the following specific abilities; the damage values already include the extra die from being a 9th-level spell.</p>\n<p><strong>Kaiju</strong> Speed 40 feet; physical resistance 5;</p>\n<p><strong>Melee</strong> <span class=\"action-glyph\">1</span> jaws (reach 20 feet), <strong>Damage</strong> @Damage[(3d12+20)[piercing]] damage;</p>\n<p><strong>Melee</strong> <span class=\"action-glyph\">1</span> claws (agile, reach 20 feet), <strong>Damage</strong> @Damage[(3d8+20)[slashing]] damage</p>\n<p><strong>Breath Weapon</strong> <span class=\"action-glyph\">2</span> (evocation, primal) Each creature in a @Template[type:cone|distance:60] takes [[/r {15d6}]]{15d6 damage} (of your chosen damage type), with a basic @Check[type:reflex|dc:resolve(@actor.attributes.spellDC.value)|basic:true] save against your spell DC. Once activated, your breath weapon can't be used again for [[/r 1d4 #Recharge Breath Weapon]]{1d4 rounds}.</p>"
+            "value": "<p>Witnessing the might of the kaiju King Mogaru, Alru, and Toraloa up close awoke a new ferocity within you. When you transform using @UUID[Compendium.pf2e.feats-srd.Item.Monstrosity Shape], you can take on a kaiju form. When you take this feat, choose acid, cold, electricity, fire, or sonic damage; this is the damage your breath weapon deals. You can't change this later. The battle form is Gargantuan size with the following specific abilities; the damage values already include the extra die from being a 9th-level spell.</p>\n<p><strong>Kaiju</strong> Speed 40 feet; physical resistance 5;</p>\n<p><strong>Melee</strong> <span class=\"action-glyph\">1</span> jaws (reach 20 feet), <strong>Damage</strong> 3d12+20 piercing;</p>\n<p><strong>Melee</strong> <span class=\"action-glyph\">1</span> claws (agile, reach 20 feet), <strong>Damage</strong> 3d8+20 slashing;</p>\n<p><strong>Breath Weapon</strong> <span class=\"action-glyph\">2</span> (evocation, primal) Each creature in a @Template[type:cone|distance:60] takes @Damage[15d6[@item.flags.pf2e.rulesSelections.damageType]] damage (of your chosen damage type), with a basic @Check[type:reflex|dc:resolve(@actor.attributes.spellDC.value)|basic:true] save against your spell DC. Once activated, your breath weapon can't be used again for [[/r 1d4 #Recharge Breath Weapon]]{1d4 rounds}.</p>"
         },
         "level": {
             "value": 20
@@ -28,7 +28,43 @@
             "remaster": false,
             "title": "Pathfinder #168: King of the Mountain"
         },
-        "rules": [],
+        "rules": [
+            {
+                "choices": [
+                    {
+                        "label": "PF2E.TraitAcid",
+                        "value": "acid"
+                    },
+                    {
+                        "label": "PF2E.TraitCold",
+                        "value": "cold"
+                    },
+                    {
+                        "label": "PF2E.TraitElectricity",
+                        "value": "electricity"
+                    },
+                    {
+                        "label": "PF2E.TraitFire",
+                        "value": "fire"
+                    },
+                    {
+                        "label": "PF2E.TraitSonic",
+                        "value": "sonic"
+                    }
+                ],
+                "flag": "damageType",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.EnergyType"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.wildShapeForms",
+                "value": {
+                    "value": "Compendium.pf2e.feat-effects.Item.Effect: Kaiju Form"
+                }
+            }
+        ],
         "traits": {
             "rarity": "uncommon",
             "value": [

--- a/packs/feats/heart-of-the-kaiju.json
+++ b/packs/feats/heart-of-the-kaiju.json
@@ -61,7 +61,7 @@
                 "mode": "add",
                 "path": "flags.pf2e.wildShapeForms",
                 "value": {
-                    "value": "Compendium.pf2e.feat-effects.Item.Effect: Kaiju Form"
+                    "value": "Compendium.pf2e.spell-effects.Item.Spell Effect: Monstrosity Form (Kaiju)"
                 }
             }
         ],

--- a/packs/spell-effects/spell-effect-monstrosity-form-kaiju.json
+++ b/packs/spell-effects/spell-effect-monstrosity-form-kaiju.json
@@ -1,7 +1,7 @@
 {
     "_id": "bzpW0owbAV3UX7UA",
-    "img": "icons/creatures/magical/humanoid-silhouette-green.webp",
-    "name": "Effect: Kaiju Form",
+    "img": "systems/pf2e/icons/spells/monstrosity-form.webp",
+    "name": "Spell Effect: Monstrosity Form (Kaiju)",
     "system": {
         "description": {
             "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Heart of the Kaiju]</p>\n<p>You take on a kaiju form. The battle form is Gargantuan size with the following specific abilities.</p>\n<p><strong>Kaiju</strong> Speed 40 feet; physical resistance 5;</p>\n<p><strong>Melee</strong> <span class=\"action-glyph\">1</span> jaws (reach 20 feet), <strong>Damage</strong> 3d12+20 piercing;</p>\n<p><strong>Melee</strong> <span class=\"action-glyph\">1</span> claws (agile, reach 20 feet), <strong>Damage</strong> 3d8+20 slashing;</p>\n<p><strong>Breath Weapon</strong> <span class=\"action-glyph\">2</span> (evocation, primal) Each creature in a 60-foot cone takes 15d6 damage (of your chosen damage type), with a basic Reflex save against your spell DC. Once activated, your breath weapon can't be used again for 1d4 rounds.</p>"


### PR DESCRIPTION
Wasn't sure if it should be a feat effect or a spell effect since access is granted by a feat, but the effect is applied via the Untamed Form spell.
~~Ultimately went with feat effect, since it's the primary source.~~
Now a spell effect to group with the other Monstrosity Forms.

Closes https://github.com/foundryvtt/pf2e/issues/11904