### PR TITLE
Fix inline roll for Brutal Bully and Overpowering Charge and emit note on critical success

### DIFF
--- a/packs/feats/brutal-bully.json
+++ b/packs/feats/brutal-bully.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>You push your foes around and leave bruises. While raging, when you successfully Disarm, Grapple, Shove, or Trip a foe, you deal that foe [[/r @actor.abilties.str.mod[bludgeoning]]]{bludgeoning damage} equal to your Strength modifier; add this to the damage from a critical success to Trip.</p>"
+            "value": "<p>You push your foes around and leave bruises. While raging, when you successfully Disarm, Grapple, Shove, or Trip a foe, you deal that foe @Damage[@actor.abilities.str.mod[bludgeoning]]{bludgeoning} damage equal to your Strength modifier; add this to the damage from a critical success to Trip.</p>"
         },
         "level": {
             "value": 6
@@ -32,6 +32,7 @@
             {
                 "key": "Note",
                 "outcome": [
+                    "criticalSuccess",
                     "success"
                 ],
                 "predicate": [
@@ -40,8 +41,8 @@
                         "or": [
                             "action:disarm",
                             "action:grapple",
-                            "action:trip",
-                            "action:shove"
+                            "action:shove",
+                            "action:trip"
                         ]
                     }
                 ],

--- a/packs/feats/overpowering-charge.json
+++ b/packs/feats/overpowering-charge.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>You trample foes as you charge past. When you use Barreling Charge and successfully move through a creature's space, that creature takes @Damage[@actor.abilties.str.mod[bludgeoning]]{bludgeoning} damage equal to your Strength modifier. On a critical success, the creature takes double damage and is @UUID[Compendium.pf2e.conditionitems.Item.Off-Guard] until the end of your next turn.</p>"
+            "value": "<p>You trample foes as you charge past. When you use Barreling Charge and successfully move through a creature's space, that creature takes @Damage[@actor.abilities.str.mod[bludgeoning]]{bludgeoning} damage equal to your Strength modifier. On a critical success, the creature takes double damage and is @UUID[Compendium.pf2e.conditionitems.Item.Off-Guard] until the end of your next turn.</p>"
         },
         "level": {
             "value": 10


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/11982