### PR TITLE
Update Lamashtu for Remaster

### DIFF
--- a/packs/deities/lamashtu.json
+++ b/packs/deities/lamashtu.json
@@ -9,7 +9,7 @@
         ],
         "category": "deity",
         "description": {
-            "value": "<p>Lamashtu, the Mother of Monsters, revels in corruption of the pure. The physical changes and nightmares left by her interventions are treated as gifts by her followers and unwelcome terrors by the outside world. There are some that find respite or even a family among Lamashtu's followers due to the faith's greater acceptance of differences.</p>\n<p><strong>Edicts</strong> bring power to outcasts and the downtrodden, indoctrinate others in Lamashtu’s teachings, make the beautiful monstrous, reveal the corruption and flaws in all things</p>\n<p><strong>Anathema</strong> attempt to change that which makes you different, provide succor to Lamashtu's enemies</p>\n<p><strong>Areas of Concern</strong> aberrance, monsters, and nightmares</p>"
+            "value": "<p>Lamashtu, the Mother of Monsters, revels in corruption of the pure. The physical changes and nightmares left by her interventions are treated as gifts by her followers and unwelcome terrors by the outside world. There are some that find respite or even a family among Lamashtu's followers due to the faith's greater acceptance of differences.</p>\n<p><strong>Edicts</strong> bring power to outcasts and the downtrodden, indoctrinate others in Lamashtu's teachings, make the beautiful monstrous, reveal the corruption and flaws in all things</p>\n<p><strong>Anathema</strong> attempt to change that which makes you different, provide succor to Lamashtu's enemies</p>\n<p><strong>Areas of Concern</strong> aberrance, monsters, and nightmares</p>"
         },
         "domains": {
             "alternate": [

--- a/packs/deities/lamashtu.json
+++ b/packs/deities/lamashtu.json
@@ -9,7 +9,7 @@
         ],
         "category": "deity",
         "description": {
-            "value": "<p>Lamashtu, the Mother of Monsters, revels in corruption of the pure. The physical changes and nightmares left by her interventions are treated as gifts by her followers and unwelcome terrors by the outside world. There are some that find respite or even a family among Lamashtu's followers due to the faith's greater acceptance of differences.</p>\n<p><strong>Edicts</strong> bring power to outcasts and the downtrodden, indoctrinate children in Lamashtu's teachings, make the beautiful monstrous, reveal the corruption and flaws in all things</p>\n<p><strong>Anathema</strong> attempt to treat a mental illness or deformity, provide succor to Lamashtu's enemies</p>\n<p><strong>Areas of Concern</strong> aberrance, monsters, and nightmares</p>"
+            "value": "<p>Lamashtu, the Mother of Monsters, revels in corruption of the pure. The physical changes and nightmares left by her interventions are treated as gifts by her followers and unwelcome terrors by the outside world. There are some that find respite or even a family among Lamashtu's followers due to the faith's greater acceptance of differences.</p>\n<p><strong>Edicts</strong> bring power to outcasts and the downtrodden, indoctrinate others in Lamashtu’s teachings, make the beautiful monstrous, reveal the corruption and flaws in all things</p>\n<p><strong>Anathema</strong> attempt to change that which makes you different, provide succor to Lamashtu's enemies</p>\n<p><strong>Areas of Concern</strong> aberrance, monsters, and nightmares</p>"
         },
         "domains": {
             "alternate": [
@@ -40,7 +40,7 @@
         },
         "skill": "sur",
         "spells": {
-            "1": "Compendium.pf2e.spells-srd.Item.EE7Q5BHIrfWNCPtT",
+            "1": "Compendium.pf2e.spells-srd.Item.DYdvMZ8G2LiSLVWw",
             "2": "Compendium.pf2e.spells-srd.Item.wp09USMB3GIW1qbp",
             "4": "Compendium.pf2e.spells-srd.Item.Uqj344bezBq3ESdq"
         },


### PR DESCRIPTION
Corrects Lamashtu’s Level 1 Cleric Spell to Spider Sting, and updates her Anathema and Edicts according to changes made in PC1.

Closes [#11516](https://github.com/foundryvtt/pf2e/issues/11516).