### PR TITLE
Fix regression in ancestry flaws tooltip

### DIFF
--- a/src/module/actor/character/attribute-builder.ts
+++ b/src/module/actor/character/attribute-builder.ts
@@ -160,6 +160,7 @@ class AttributeBuilder extends Application {
             buttons,
             remaining,
             labels: this.#getBoostFlawLabels(ancestry.system.boosts),
+            flawLabels: this.#getBoostFlawLabels(ancestry.system.flaws),
             alternate: !!ancestry.system.alternateAncestryBoosts,
         };
 
@@ -564,6 +565,7 @@ interface BoostFlawRow {
 interface AncestryBoosts extends BoostFlawRow {
     alternate: boolean;
     labels: string[];
+    flawLabels: string[];
 }
 
 interface VoluntaryFlaws extends BoostFlawRow {


### PR DESCRIPTION
![ancestry-flaw1](https://github.com/foundryvtt/pf2e/assets/4469633/9e6f5d63-1d20-40f6-869e-e5d593c40959) -> ![ancestry-flaw2](https://github.com/foundryvtt/pf2e/assets/4469633/8819bb5c-e7f2-4389-826b-10b9b8993995)

Lines were deleted in an old refactor.