### PR TITLE
Import item-type-specific scss files after main item-sheet styling

### DIFF
--- a/src/styles/_globals.scss
+++ b/src/styles/_globals.scss
@@ -19,21 +19,6 @@ hr.vr {
     margin: 1px 2px;
 }
 
-/* ----------------------------------------- */
-/* Typography                                */
-/* ----------------------------------------- */
-
-.pf2e,
-.app.sheet.actor {
-    font-family: var(--sans-serif);
-    h1,
-    h2,
-    h3,
-    h4 {
-        font-weight: 600;
-    }
-}
-
 // ensure higher specificity than the sheet styles
 .pf2e.sheet form span.pf2-icon,
 .pf2e.sheet form span[data-pf2-action],

--- a/src/styles/actor/_index.scss
+++ b/src/styles/actor/_index.scss
@@ -8,7 +8,29 @@ $header-height: 89px; /* Adjust height of the header */
 @import "character/attribute-builder";
 @import "iwr-editor";
 
-.actor.sheet {
+.actor.sheet form {
+    @import "../reset";
+    font-family: var(--sans-serif);
+
+    h1,
+    h2,
+    h3,
+    h4 {
+        font-weight: 600;
+    }
+
+    a.disabled {
+        cursor: default;
+
+        &:hover {
+            text-shadow: none;
+        }
+    }
+
+    i.fa-info-circle {
+        cursor: help;
+    }
+
     .image-container {
         position: relative;
 
@@ -28,21 +50,8 @@ $header-height: 89px; /* Adjust height of the header */
         }
     }
 
-    @import "../reset";
     @import "item-summary";
     @import "inventory";
-
-    a.disabled {
-        cursor: default;
-
-        &:hover {
-            text-shadow: none;
-        }
-    }
-
-    i.fa-info-circle {
-        cursor: help;
-    }
 
     .item-image {
         cursor: pointer;
@@ -115,7 +124,9 @@ $header-height: 89px; /* Adjust height of the header */
             background-color: var(--color-rarity-unique);
         }
     }
+}
 
+.actor.sheet {
     &.character {
         @import "character/attack-popout";
     }

--- a/src/styles/item/_header.scss
+++ b/src/styles/item/_header.scss
@@ -1,18 +1,14 @@
-form > header {
-    display: flex;
-    padding-bottom: 0.5em;
-    border-bottom: 1px solid var(--secondary-background);
-
+> header {
     img {
         border: none;
         object-fit: contain;
     }
 
     .details {
+        align-items: baseline;
+        column-gap: 0.33rem;
         display: flex;
         flex-wrap: wrap;
-        column-gap: 0.33rem;
-        align-items: baseline;
 
         input,
         .level {

--- a/src/styles/item/_index.scss
+++ b/src/styles/item/_index.scss
@@ -1,79 +1,16 @@
 .pf2e.item.sheet {
     @import "../reset";
-    @import "header";
-
-    a.disabled {
-        cursor: default;
-
-        &:hover {
-            text-shadow: none;
-        }
-
-        &.header-button {
-            color: var(--color-text-light-5);
-        }
-    }
-
-    .sheet-body {
-        height: calc(100% - 2.25rem);
-        overflow: hidden;
-        display: flex;
-        flex-direction: column;
-        flex-wrap: nowrap;
-    }
-
-    &.action form {
-        @import "ability-sheet";
-    }
-
-    &.affliction form {
-        @import "affliction-sheet";
-    }
-
-    &.deity form {
-        @import "deity-sheet";
-    }
-
-    &.effect form {
-        @import "effect-sheet";
-    }
-
-    &.feat form {
-        @import "feat-sheet";
-    }
-
-    &.heritage form {
-        @import "heritage-sheet";
-    }
-
-    &.kit form {
-        @import "kit-sheet";
-    }
-
-    &.melee form {
-        @import "melee-sheet";
-    }
-
-    &.spell form {
-        @import "spell-sheet";
-    }
-
-    &.weapon form {
-        @import "weapon-sheet";
-    }
 
     form {
         display: flex;
-        flex-direction: column;
-        flex-wrap: nowrap;
-        width: 100%;
+        flex-flow: column nowrap;
+        font-family: var(--sans-serif);
         height: 100%;
         overflow: hidden;
+        width: 100%;
 
-        @import "abc-sheet";
-        @import "activations";
-        @import "mystification";
-        @import "rules";
+        @import "header";
+        @import "nav";
 
         .mce-panel span {
             display: inherit;
@@ -127,49 +64,6 @@
             cursor: help;
         }
 
-        > nav {
-            display: flex;
-            align-items: baseline;
-            border-bottom: 1px solid var(--secondary-background);
-            flex: 0 0 30px;
-            line-height: 30px;
-            margin-bottom: 0.5rem;
-
-            a {
-                flex: 1 1 auto;
-            }
-
-            a.active {
-                text-decoration: underline;
-            }
-
-            .sidebar-summary {
-                flex: 0 0 220px;
-                margin: 0;
-                text-align: center;
-            }
-
-            .sheet-tabs {
-                font-weight: 500;
-                margin: 0;
-                flex: 1;
-                align-items: baseline;
-
-                > .list-row {
-                    font-size: var(--font-size-12);
-                    text-align: center;
-
-                    &:last-of-type {
-                        padding-right: 4px;
-                    }
-
-                    &.active {
-                        font-weight: 600;
-                    }
-                }
-            }
-        }
-
         .sheet-content {
             width: 100%;
             display: flex;
@@ -187,18 +81,26 @@
                 display: block;
             }
 
+            input {
+                color: var(--color-text-dark-input);
+            }
+
+            input[type="checkbox"] {
+                margin: 0.25em 0.5em;
+            }
+
+            input[type="number"],
+            input[type="text"] {
+                margin: 1px 0;
+                width: calc(100% - 2px);
+            }
+
             input[type="checkbox"],
             input[type="number"],
             input[type="text"],
             select {
                 background: rgba(255, 255, 255, 0.5);
                 border: 1px solid var(--color-border-light-2);
-            }
-
-            input {
-                color: var(--color-text-dark-input);
-                margin: 1px 0;
-                width: calc(100% - 2px);
             }
 
             select {
@@ -232,6 +134,12 @@
         }
 
         .sheet-body {
+            height: calc(100% - 2.25rem);
+            overflow: hidden;
+            display: flex;
+            flex-direction: column;
+            flex-wrap: nowrap;
+
             .tab.active {
                 overflow: hidden scroll;
                 padding-left: 0.5rem;
@@ -589,6 +497,63 @@
                 align-self: center;
             }
         }
+
+        @import "abc-sheet";
+        @import "activations";
+        @import "mystification";
+        @import "rules";
+    }
+
+    a.disabled {
+        cursor: default;
+
+        &:hover {
+            text-shadow: none;
+        }
+
+        &.header-button {
+            color: var(--color-text-light-5);
+        }
+    }
+
+    &.action form {
+        @import "ability-sheet";
+    }
+
+    &.affliction form {
+        @import "affliction-sheet";
+    }
+
+    &.deity form {
+        @import "deity-sheet";
+    }
+
+    &.effect form {
+        @import "effect-sheet";
+    }
+
+    &.feat form {
+        @import "feat-sheet";
+    }
+
+    &.heritage form {
+        @import "heritage-sheet";
+    }
+
+    &.kit form {
+        @import "kit-sheet";
+    }
+
+    &.melee form {
+        @import "melee-sheet";
+    }
+
+    &.spell form {
+        @import "spell-sheet";
+    }
+
+    &.weapon form {
+        @import "weapon-sheet";
     }
 }
 

--- a/src/styles/item/_nav.scss
+++ b/src/styles/item/_nav.scss
@@ -1,0 +1,42 @@
+> nav {
+    align-items: baseline;
+    border-bottom: 1px solid var(--secondary-background);
+    border-top: 1px solid var(--secondary-background);
+    display: flex;
+    flex: 0 0 1.75rem;
+    line-height: 1.75rem;
+
+    a {
+        flex: 1 1 auto;
+    }
+
+    a.active {
+        text-decoration: underline;
+    }
+
+    .sidebar-summary {
+        flex: 0 0 220px;
+        margin: 0;
+        text-align: center;
+    }
+
+    > .tabs {
+        font-weight: 500;
+        margin: 0;
+        flex: 1;
+        align-items: baseline;
+
+        > a {
+            font-size: var(--font-size-12);
+            text-align: center;
+
+            &:last-of-type {
+                padding-right: 0.25rem;
+            }
+
+            &.active {
+                font-weight: 600;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is to make it easier for them to override general styling

Also:
- Move item-sheet nav styling to own file
- Move global font-family and h1-h6 overrides to individual sheets