### PR TITLE
Reduce vertical separation in item sheets with action glyph

### DIFF
--- a/src/styles/item/_header.scss
+++ b/src/styles/item/_header.scss
@@ -49,15 +49,13 @@
     }
 
     .action-glyph {
-        font-size: 2.25rem;
+        font-size: 2.125rem;
     }
 
     .paizo-style {
-        flex-basis: 100%;
-        width: 0;
         border: none;
-        margin-top: 2px;
-        padding-left: 0;
-        padding-right: 0;
+        flex-basis: 100%;
+        margin-top: 0.125rem;
+        padding: 0;
     }
 }


### PR DESCRIPTION
before (hide armor shown for comparison)
![image](https://github.com/foundryvtt/pf2e/assets/1286721/7eb6dd8d-a3ce-4497-a0a5-f59d67b7a1b6)

after (hide armor shown for comparison)
![image](https://github.com/foundryvtt/pf2e/assets/1286721/7de1f5e1-9aae-4392-8c8f-13d6f4f79206)
