### PR TITLE
Adjust migration 828 to skip "hb_" traits

### DIFF
--- a/src/module/migration/migrations/828-prune-invalid-traits.ts
+++ b/src/module/migration/migrations/828-prune-invalid-traits.ts
@@ -46,7 +46,8 @@ export class Migration828PruneInvalidTraits extends MigrationBase {
 
     override async updateItem(source: ItemSourcePF2e): Promise<void> {
         const traits: { value?: string[] } | undefined = source.system.traits;
-        if (!traits?.value) return;
+        if (!traits?.value || !Array.isArray(traits.value)) return;
+        traits.value = traits.value.filter((t) => typeof t === "string");
 
         switch (source.type) {
             case "action": {
@@ -58,16 +59,18 @@ export class Migration828PruneInvalidTraits extends MigrationBase {
                             .replace(/^(interact|manipulation)$/i, "manipulate")
                             .replace(/^vocal$/, "verbal"),
                     )
-                    .filter((t): t is ActionTrait => t in actionTraits);
+                    .filter((t): t is ActionTrait => t.startsWith("hb_") || t in actionTraits);
                 return;
             }
             case "affliction":
             case "effect": {
-                traits.value = traits.value.filter((t) => t in actionTraits || t in spellTraits);
+                traits.value = traits.value.filter((t) => t.startsWith("hb_") || t in actionTraits || t in spellTraits);
                 return;
             }
             case "ancestry": {
-                traits.value = traits.value.filter((t) => t in creatureTraits || ["animal"].includes(t));
+                traits.value = traits.value.filter(
+                    (t) => t.startsWith("hb_") || t in creatureTraits || ["animal"].includes(t),
+                );
                 return;
             }
             case "armor": {
@@ -79,38 +82,38 @@ export class Migration828PruneInvalidTraits extends MigrationBase {
                               ? t.replace(/^integrated$/, "integrated-1d6-s-versatile-p")
                               : t,
                     )
-                    .filter((t): t is ArmorTrait => t in armorTraits);
+                    .filter((t): t is ArmorTrait => t.startsWith("hb_") || t in armorTraits);
                 return;
             }
             case "backpack":
             case "equipment": {
-                traits.value = traits.value.filter((t) => t in equipmentTraits);
+                traits.value = traits.value.filter((t) => t.startsWith("hb_") || t in equipmentTraits);
                 return;
             }
             case "consumable": {
-                traits.value = traits.value.filter((t) => t in consumableTraits);
+                traits.value = traits.value.filter((t) => t.startsWith("hb_") || t in consumableTraits);
                 return;
             }
             case "class": {
-                traits.value = traits.value.filter((t) => t in classTraits);
+                traits.value = traits.value.filter((t) => t.startsWith("hb_") || t in classTraits);
                 return;
             }
             case "feat": {
-                traits.value = traits.value.filter((t) => t in featTraits);
+                traits.value = traits.value.filter((t) => t.startsWith("hb_") || t in featTraits);
                 return;
             }
             case "melee": {
-                traits.value = traits.value.filter((t) => t in npcAttackTraits);
+                traits.value = traits.value.filter((t) => t.startsWith("hb_") || t in npcAttackTraits);
                 return;
             }
             case "spell": {
                 traits.value = traits.value
                     .map((t) => t.replace(/^audible$/, "auditory"))
-                    .filter((t): t is SpellTrait => t in spellTraits);
+                    .filter((t): t is SpellTrait => t.startsWith("hb_") || t in spellTraits);
                 return;
             }
             case "weapon": {
-                traits.value = traits.value.filter((t) => t in weaponTraits);
+                traits.value = traits.value.filter((t) => t.startsWith("hb_") || t in weaponTraits);
                 return;
             }
         }


### PR DESCRIPTION
Now that module-provided homebrew traits are stored without the "hb_" prefix, migration 828 suddenly considers them invalid and prunes them. This would only affect modules with compendium content that hasn't been migrated since then.