### PR TITLE
Update Puff of Poison with Remaster errata

### DIFF
--- a/packs/spells/puff-of-poison.json
+++ b/packs/spells/puff-of-poison.json
@@ -10,9 +10,9 @@
         "counteraction": false,
         "damage": {
             "0": {
-                "applyMod": true,
+                "applyMod": false,
                 "category": null,
-                "formula": "",
+                "formula": "1d8",
                 "kinds": [
                     "damage"
                 ],
@@ -37,7 +37,7 @@
             }
         },
         "description": {
-            "value": "<p>You exhale a shimmering cloud of toxic breath at an enemy's face. The target takes poison damage equal to your spellcasting modifier and 2 persistent poison damage, depending on its Fortitude save.</p>\n<hr />\n<p><strong>Critical Success</strong> The creature is unaffected.</p>\n<p><strong>Success</strong> The target takes half initial and persistent damage.</p>\n<p><strong>Failure</strong> The target takes full initial and persistent damage.</p>\n<p><strong>Critical Failure</strong> The target takes double initial and persistent damage.</p>\n<hr />\n<p><strong>Heightened (+2)</strong> The initial poison damage increases by 1d8 and the persistent poison damage increases by 1.</p>"
+            "value": "<p>You exhale a shimmering cloud of toxic breath at an enemy's face. The target takes 1d8 poison damage and 2 persistent poison damage, depending on its Fortitude save.</p>\n<hr />\n<p><strong>Critical Success</strong> The creature is unaffected.</p>\n<p><strong>Success</strong> The target takes half initial and persistent damage.</p>\n<p><strong>Failure</strong> The target takes full initial and persistent damage.</p>\n<p><strong>Critical Failure</strong> The target takes double initial and persistent damage.</p>\n<hr />\n<p><strong>Heightened (+2)</strong> The initial poison damage increases by 1d8 and the persistent poison damage increases by 1.</p>"
         },
         "duration": {
             "sustained": false,


### PR DESCRIPTION
Per the official Secrets of Magic [errata](https://paizo.com/pathfinder/remaster/faq)

> Page 124: In the puff of poison spell, replace "poison damage equal to your spellcasting modifier and 2 persistent poison damage" with "1d8 poison damage and 2 persistent poison damage".