### PR TITLE
Fix the Athletics modifier RE on Trip and Tangle

### DIFF
--- a/packs/outlaws-of-alkenstar-bestiary/trapjaw-tangle.json
+++ b/packs/outlaws-of-alkenstar-bestiary/trapjaw-tangle.json
@@ -215,7 +215,7 @@
                             "trip-tangle"
                         ],
                         "selector": "athletics",
-                        "value": 2
+                        "value": 4
                     }
                 ],
                 "slug": null,


### PR DESCRIPTION
got a report to the Outlaws of Alkenstar premium module, fixing it here

![image](https://github.com/foundryvtt/pf2e/assets/74384067/c3a0bbe8-f25c-4d19-8424-98add1ebebe9)
