### PR TITLE
Add effect for Stoke the Fervent

### DIFF
--- a/packs/bestiary-effects/effect-stoke-the-fervent.json
+++ b/packs/bestiary-effects/effect-stoke-the-fervent.json
@@ -1,10 +1,10 @@
 {
-    "_id": "J6EwMsXtXg30eaiB",
+    "_id": "eE3FEpjk2HdZDzSA",
     "img": "icons/skills/melee/hand-grip-hammer-spiked-blue.webp",
-    "name": "Effect: Stoke the Fervent (High Tormentor)",
+    "name": "Effect: Stoke the Fervent",
     "system": {
         "description": {
-            "value": "<p>Each ally that hears the call gains a +4 status bonus to attack rolls and damage rolls, a +2 status bonus to saving throws, and takes a -2 status penalty to AC. Affected allies must use at least one of their actions to Strike each round, if they are able (even if it means attacking an ally, object, or thin air).</p>\n<p><em>The effect duration has been set to the average duration of [[/br 2d4 #rounds]]{2d4 rounds}. Set the duration to the correct value when the effect is added.</em></p>"
+            "value": "<p>Each ally that hears the call gains a +1 status bonus to attack rolls, damage rolls, and saving throws, and takes a –1 status penalty to AC. Affected allies must use at least one of their actions to Strike each round, if they are able (even if it means attacking an ally, object, or thin air).</p>\n<p><em>The effect duration has been set to the average duration of [[/br 2d4 #rounds]]{2d4 rounds}. Set the duration to the correct value when the effect is added.</em></p>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -18,29 +18,24 @@
         "publication": {
             "license": "OGL",
             "remaster": false,
-            "title": "Pathfinder #155: Lord of the Black Sands"
+            "title": "Pathfinder Bestiary 2"
         },
         "rules": [
             {
                 "key": "FlatModifier",
                 "selector": [
                     "attack",
-                    "damage"
+                    "damage",
+                    "saving-throw"
                 ],
                 "type": "status",
-                "value": 4
-            },
-            {
-                "key": "FlatModifier",
-                "selector": "saving-throw",
-                "type": "status",
-                "value": 2
+                "value": 1
             },
             {
                 "key": "FlatModifier",
                 "selector": "ac",
                 "type": "status",
-                "value": -2
+                "value": -1
             }
         ],
         "start": {

--- a/packs/extinction-curse-bestiary/urdefhan-high-tormentor.json
+++ b/packs/extinction-curse-bestiary/urdefhan-high-tormentor.json
@@ -1655,7 +1655,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p><strong>Frequency</strong> once per day</p>\n<hr />\n<p><strong>Effect</strong> The urdefhan lets out a battle cry, sending itself and its allies into a fanatical frenzy. Each ally that hears the call gains a +4 status bonus to attack rolls and damage rolls, a +2 status bonus to saving throws, and takes a -2 status penalty to AC. Affected allies must use at least one of their actions to Strike each round, if they are able (even if it means attacking an ally, object, or thin air).</p>\n<p>This lasts for [[/br 2d4 #rounds]]{2d4 rounds}.</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Item.Effect: Stoke the Fervent - High Tormentor]{Effect: Stoke the Fervent}</p>"
+                    "value": "<p><strong>Frequency</strong> once per day</p>\n<hr />\n<p><strong>Effect</strong> The urdefhan lets out a battle cry, sending itself and its allies into a fanatical frenzy. Each ally that hears the call gains a +4 status bonus to attack rolls and damage rolls, a +2 status bonus to saving throws, and takes a -2 status penalty to AC. Affected allies must use at least one of their actions to Strike each round, if they are able (even if it means attacking an ally, object, or thin air).</p>\n<p>This lasts for [[/br 2d4 #rounds]]{2d4 rounds}.</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Item.Effect: Stoke the Fervent (High Tormentor)]</p>"
                 },
                 "frequency": {
                     "max": 1,

--- a/packs/pathfinder-bestiary-2/urdefhan-tormentor.json
+++ b/packs/pathfinder-bestiary-2/urdefhan-tormentor.json
@@ -1163,7 +1163,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p><strong>Frequency</strong> once per day</p>\n<hr />\n<p><strong>Effect</strong> The urdefhan lets out a battle cry, sending itself and its allies into a fanatical frenzy. Each ally that hears the call gains a +1 status bonus to attack rolls, damage rolls, and saving throws, and takes a -1 status penalty to AC. Affected allies must use at least one of their actions to Strike each round, if they are able (even if it means attacking an ally, object, or thin air).</p>\n<p>This lasts for [[/br 2d4 #rounds]]{2d4 rounds}.</p>"
+                    "value": "<p><strong>Frequency</strong> once per day</p>\n<hr />\n<p><strong>Effect</strong> The urdefhan lets out a battle cry, sending itself and its allies into a fanatical frenzy. Each ally that hears the call gains a +1 status bonus to attack rolls, damage rolls, and saving throws, and takes a -1 status penalty to AC. Affected allies must use at least one of their actions to Strike each round, if they are able (even if it means attacking an ally, object, or thin air).</p>\n<p>This lasts for [[/br 2d4 #rounds]]{2d4 rounds}.</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Item.Effect: Stoke the Fervent]</p>"
                 },
                 "frequency": {
                     "max": 1,

--- a/packs/pfs-season-4-bestiary/urdefhan-high-tormentor-pfs-4-11.json
+++ b/packs/pfs-season-4-bestiary/urdefhan-high-tormentor-pfs-4-11.json
@@ -1655,7 +1655,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p><strong>Frequency</strong> once per day</p>\n<hr />\n<p><strong>Effect</strong> The urdefhan lets out a battle cry, sending itself and its allies into a fanatical frenzy. Each ally that hears the call gains a +4 status bonus to attack rolls and damage rolls, a +2 status bonus to saving throws, and takes a -2 status penalty to AC. Affected allies must use at least one of their actions to Strike each round, if they are able (even if it means attacking an ally, object, or thin air).</p>\n<p>This lasts for [[/br 2d4 #rounds]]{2d4 rounds}.</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Item.Effect: Stoke the Fervent - High Tormentor]{Effect: Stoke the Fervent}</p>"
+                    "value": "<p><strong>Frequency</strong> once per day</p>\n<hr />\n<p><strong>Effect</strong> The urdefhan lets out a battle cry, sending itself and its allies into a fanatical frenzy. Each ally that hears the call gains a +4 status bonus to attack rolls and damage rolls, a +2 status bonus to saving throws, and takes a -2 status penalty to AC. Affected allies must use at least one of their actions to Strike each round, if they are able (even if it means attacking an ally, object, or thin air).</p>\n<p>This lasts for [[/br 2d4 #rounds]]{2d4 rounds}.</p>\n<p>@UUID[Compendium.pf2e.bestiary-effects.Item.Effect: Stoke the Fervent (High Tormentor)]</p>"
                 },
                 "frequency": {
                     "max": 1,


### PR DESCRIPTION
Renamed "Effect: Stoke the Fervent - High Tormentor" to "Effect: Stoke the Fervent (High Tormentor)" so that auto-labeling works without changing the slug.