### PR TITLE
Add actors to the Kingmaker compendium to represent armies

### DIFF
--- a/packs/kingmaker-bestiary/_folders.json
+++ b/packs/kingmaker-bestiary/_folders.json
@@ -1,0 +1,12 @@
+[
+    {
+        "_id": "BRkIyvmgOgyA2kq7",
+        "color": "#640909",
+        "flags": {},
+        "folder": null,
+        "name": "Armies",
+        "sort": 0,
+        "sorting": "a",
+        "type": "Actor"
+    }
+]

--- a/packs/kingmaker-bestiary/armies/basic-cavalry.json
+++ b/packs/kingmaker-bestiary/armies/basic-cavalry.json
@@ -24,7 +24,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a Morale check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
+                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a @Check[type:morale|defense:morale|roller:self] check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -67,7 +67,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<p>Your army tries to escape from the battlefield.</p>\n<p>If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed].</p>\n<p>Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
+                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<hr />\n<p>Your army tries to escape from the battlefield. If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed]. Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -108,7 +108,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a Maneuver check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
+                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a @Check[type:maneuver|defense:maneuver|roller:self] check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -142,7 +142,6 @@
             "name": "Guard",
             "sort": 0,
             "system": {
-                "-=level": null,
                 "actionType": {
                     "value": "action"
                 },
@@ -152,7 +151,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a Maneuver check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
+                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a @Check[type:maneuver|defense:maneuver|roller:self] check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p>@UUID[Compendium.pf2e.kingmaker-features.Item.Effect: Guard (Critical Success)]</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p>@UUID[Compendium.pf2e.kingmaker-features.Item.Effect: Guard (Success)]</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -163,25 +162,7 @@
                     "remaster": false,
                     "title": "Pathfinder Kingmaker"
                 },
-                "rules": [
-                    {
-                        "key": "FlatModifier",
-                        "label": "Guarded",
-                        "predicate": [
-                            "guarded-critical"
-                        ],
-                        "selector": "ac",
-                        "type": "item",
-                        "value": 2
-                    },
-                    {
-                        "domain": "ac",
-                        "key": "RollOption",
-                        "label": "Guarded (Critical Success)",
-                        "option": "guarded-critical",
-                        "toggleable": true
-                    }
-                ],
+                "rules": [],
                 "slug": "guard",
                 "traits": {
                     "rarity": "common",
@@ -256,7 +237,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a Maneuver check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
+                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a @Check[type:maneuver|defense:maneuver|roller:self] check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
                 },
                 "location": null,
                 "prerequisites": {

--- a/packs/kingmaker-bestiary/armies/basic-cavalry.json
+++ b/packs/kingmaker-bestiary/armies/basic-cavalry.json
@@ -1,0 +1,421 @@
+{
+    "_id": "MN2Bw4uzDJxuIOWa",
+    "folder": "BRkIyvmgOgyA2kq7",
+    "img": "systems/pf2e/icons/default-icons/army.svg",
+    "items": [
+        {
+            "_id": "Jd1g3ovpiC39CYRk",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.8XXylMGJuqe1ozMk"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Rally",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a Morale check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "rally",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "morale"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "1egfYGFDnAX5opwc",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.IhjlbJinff1wUSjL"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/ThreeActions.webp",
+            "name": "Retreat",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 3
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<p>Your army tries to escape from the battlefield.</p>\n<p>If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed].</p>\n<p>Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "retreat",
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "A5deiJajssYXsGeB",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.Pu5bptxLrKFyEzFh"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Disengage",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a Maneuver check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "disengage",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "pF7BiYB0G1hNsXek",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.phtwOol1wETryF7b"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Guard",
+            "sort": 0,
+            "system": {
+                "-=level": null,
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a Maneuver check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "label": "Guarded",
+                        "predicate": [
+                            "guarded-critical"
+                        ],
+                        "selector": "ac",
+                        "type": "item",
+                        "value": 2
+                    },
+                    {
+                        "domain": "ac",
+                        "key": "RollOption",
+                        "label": "Guarded (Critical Success)",
+                        "option": "guarded-critical",
+                        "toggleable": true
+                    }
+                ],
+                "slug": "guard",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "AutD88eYafZX1wQW",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.qCxyuNhzaaYlYBum"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Battle",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attacks an enemy army with a Strike against the enemy army's AC. You can do so with a melee Strike only if you are @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with the target army. Otherwise, you must use a ranged Strike.</p>\n<p>An army can attempt a maximum of 5 ranged Strikes per war encounter (unless it has the @UUID[Compendium.pf2e.kingmaker-features.Item.Increased Ammunition] tactic). As with any attack, multiple Strikes in a single round suffer a multiple attack penalty.</p>\n<p>A siege engine can use the Battle action to attack and damage a fortification.</p>\n<p><strong>Critical Success</strong> You deal 2 points of damage to the army.</p>\n<p><strong>Success</strong> You deal 1 point of damage to the army.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "battle",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "attack"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "rGxlncNMXLVMXZ6s",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.wHoXoyci1lddRR2R"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Advance",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a Maneuver check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "advance",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "uNxToGmQN5AbL2Gl",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.ib8BcumGskNVJdZS"
+                }
+            },
+            "folder": "tavHHn3vqI7bCnl6",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Overrun",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p><em><strong>Note</strong>: Basic cavalry armies know Overrun automatically, and must 'spend' their first tactic on it.</em></p>\n<hr />\n<p>Cavalry armies gain a +1 status bonus on weapon attacks against infantry and skirmisher armies, but they suffer a –1 status penalty on Maneuver and Morale saves against area attacks and mental attacks.</p>"
+                },
+                "level": {
+                    "value": 3
+                },
+                "location": "0",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "label": "vs Infantry and Skirmisher",
+                        "predicate": [
+                            {
+                                "or": [
+                                    "target:trait:infantry",
+                                    "target:trait:skirmisher"
+                                ]
+                            }
+                        ],
+                        "selector": "attack-roll",
+                        "slug": "overrun-attacks",
+                        "type": "status",
+                        "value": 1
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "label": "vs Area or Mental attacks",
+                        "predicate": [
+                            {
+                                "or": [
+                                    "mental-attack",
+                                    "area-attack"
+                                ]
+                            }
+                        ],
+                        "selector": [
+                            "maneuver-check",
+                            "morale-check"
+                        ],
+                        "slug": "overrun-saves",
+                        "type": "status",
+                        "value": -1
+                    }
+                ],
+                "slug": "overrun",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "cavalry"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        }
+    ],
+    "name": "Basic Cavalry",
+    "prototypeToken": {
+        "name": "Cavalry"
+    },
+    "system": {
+        "ac": {
+            "potency": 0,
+            "value": 19
+        },
+        "attributes": {
+            "hp": {
+                "max": 4,
+                "routThreshold": 2,
+                "value": 4
+            }
+        },
+        "consumption": 2,
+        "details": {
+            "alignment": "N",
+            "blurb": "",
+            "description": "<p>Cavalry consists of armored soldiers armed with melee weapons and mounted on horses.</p>",
+            "level": {
+                "value": 3
+            }
+        },
+        "recruitmentDC": 18,
+        "resources": {
+            "ammunition": {
+                "max": 5,
+                "value": 5
+            },
+            "potions": {
+                "value": 0
+            }
+        },
+        "saves": {
+            "maneuver": 12,
+            "morale": 6
+        },
+        "scouting": 9,
+        "traits": {
+            "rarity": "common",
+            "size": {
+                "value": "med"
+            },
+            "type": "cavalry",
+            "value": []
+        },
+        "weapons": {
+            "melee": {
+                "name": "Weapons",
+                "potency": 0
+            },
+            "ranged": null
+        }
+    },
+    "type": "army"
+}

--- a/packs/kingmaker-bestiary/armies/basic-infantry.json
+++ b/packs/kingmaker-bestiary/armies/basic-infantry.json
@@ -24,7 +24,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a Morale check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
+                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a @Check[type:morale|defense:morale|roller:self] check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -67,7 +67,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<p>Your army tries to escape from the battlefield.</p>\n<p>If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed].</p>\n<p>Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
+                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<hr />\n<p>Your army tries to escape from the battlefield. If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed]. Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -108,7 +108,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a Maneuver check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
+                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a @Check[type:maneuver|defense:maneuver|roller:self] check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -142,7 +142,6 @@
             "name": "Guard",
             "sort": 0,
             "system": {
-                "-=level": null,
                 "actionType": {
                     "value": "action"
                 },
@@ -152,7 +151,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a Maneuver check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
+                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a @Check[type:maneuver|defense:maneuver|roller:self] check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p>@UUID[Compendium.pf2e.kingmaker-features.Item.Effect: Guard (Critical Success)]</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p>@UUID[Compendium.pf2e.kingmaker-features.Item.Effect: Guard (Success)]</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -163,25 +162,7 @@
                     "remaster": false,
                     "title": "Pathfinder Kingmaker"
                 },
-                "rules": [
-                    {
-                        "key": "FlatModifier",
-                        "label": "Guarded",
-                        "predicate": [
-                            "guarded-critical"
-                        ],
-                        "selector": "ac",
-                        "type": "item",
-                        "value": 2
-                    },
-                    {
-                        "domain": "ac",
-                        "key": "RollOption",
-                        "label": "Guarded (Critical Success)",
-                        "option": "guarded-critical",
-                        "toggleable": true
-                    }
-                ],
+                "rules": [],
                 "slug": "guard",
                 "traits": {
                     "rarity": "common",
@@ -256,7 +237,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a Maneuver check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
+                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a @Check[type:maneuver|defense:maneuver|roller:self] check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
                 },
                 "location": null,
                 "prerequisites": {

--- a/packs/kingmaker-bestiary/armies/basic-infantry.json
+++ b/packs/kingmaker-bestiary/armies/basic-infantry.json
@@ -1,0 +1,339 @@
+{
+    "_id": "FLmrdtZlP2LZTkyr",
+    "folder": "BRkIyvmgOgyA2kq7",
+    "img": "systems/pf2e/icons/default-icons/army.svg",
+    "items": [
+        {
+            "_id": "Jd1g3ovpiC39CYRk",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.8XXylMGJuqe1ozMk"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Rally",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a Morale check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "rally",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "morale"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "1egfYGFDnAX5opwc",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.IhjlbJinff1wUSjL"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/ThreeActions.webp",
+            "name": "Retreat",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 3
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<p>Your army tries to escape from the battlefield.</p>\n<p>If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed].</p>\n<p>Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "retreat",
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "A5deiJajssYXsGeB",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.Pu5bptxLrKFyEzFh"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Disengage",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a Maneuver check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "disengage",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "pF7BiYB0G1hNsXek",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.phtwOol1wETryF7b"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Guard",
+            "sort": 0,
+            "system": {
+                "-=level": null,
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a Maneuver check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "label": "Guarded",
+                        "predicate": [
+                            "guarded-critical"
+                        ],
+                        "selector": "ac",
+                        "type": "item",
+                        "value": 2
+                    },
+                    {
+                        "domain": "ac",
+                        "key": "RollOption",
+                        "label": "Guarded (Critical Success)",
+                        "option": "guarded-critical",
+                        "toggleable": true
+                    }
+                ],
+                "slug": "guard",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "AutD88eYafZX1wQW",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.qCxyuNhzaaYlYBum"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Battle",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attacks an enemy army with a Strike against the enemy army's AC. You can do so with a melee Strike only if you are @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with the target army. Otherwise, you must use a ranged Strike.</p>\n<p>An army can attempt a maximum of 5 ranged Strikes per war encounter (unless it has the @UUID[Compendium.pf2e.kingmaker-features.Item.Increased Ammunition] tactic). As with any attack, multiple Strikes in a single round suffer a multiple attack penalty.</p>\n<p>A siege engine can use the Battle action to attack and damage a fortification.</p>\n<p><strong>Critical Success</strong> You deal 2 points of damage to the army.</p>\n<p><strong>Success</strong> You deal 1 point of damage to the army.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "battle",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "attack"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "rGxlncNMXLVMXZ6s",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.wHoXoyci1lddRR2R"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Advance",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a Maneuver check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "advance",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        }
+    ],
+    "name": "Basic Infantry",
+    "prototypeToken": {
+        "name": "Infantry"
+    },
+    "system": {
+        "ac": {
+            "potency": 0,
+            "value": 16
+        },
+        "attributes": {
+            "hp": {
+                "max": 4,
+                "routThreshold": 2,
+                "value": 4
+            }
+        },
+        "consumption": 1,
+        "details": {
+            "alignment": "N",
+            "blurb": "",
+            "description": "<p>This is a platoon of armored soldiers armed with melee weapons.</p>",
+            "level": {
+                "value": 1
+            }
+        },
+        "recruitmentDC": 15,
+        "resources": {
+            "ammunition": {
+                "max": 5,
+                "value": 5
+            },
+            "potions": {
+                "value": 0
+            }
+        },
+        "saves": {
+            "maneuver": 4,
+            "morale": 10
+        },
+        "scouting": 7,
+        "traits": {
+            "rarity": "common",
+            "size": {
+                "value": "med"
+            },
+            "type": "infantry",
+            "value": []
+        },
+        "weapons": {
+            "melee": {
+                "name": "Weapons",
+                "potency": 0
+            },
+            "ranged": null
+        }
+    },
+    "type": "army"
+}

--- a/packs/kingmaker-bestiary/armies/basic-siege-engines.json
+++ b/packs/kingmaker-bestiary/armies/basic-siege-engines.json
@@ -24,7 +24,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a Morale check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
+                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a @Check[type:morale|defense:morale|roller:self] check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -67,7 +67,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<p>Your army tries to escape from the battlefield.</p>\n<p>If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed].</p>\n<p>Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
+                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<hr />\n<p>Your army tries to escape from the battlefield. If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed]. Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -108,7 +108,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a Maneuver check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
+                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a @Check[type:maneuver|defense:maneuver|roller:self] check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -142,7 +142,6 @@
             "name": "Guard",
             "sort": 0,
             "system": {
-                "-=level": null,
                 "actionType": {
                     "value": "action"
                 },
@@ -152,7 +151,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a Maneuver check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
+                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a @Check[type:maneuver|defense:maneuver|roller:self] check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p>@UUID[Compendium.pf2e.kingmaker-features.Item.Effect: Guard (Critical Success)]</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p>@UUID[Compendium.pf2e.kingmaker-features.Item.Effect: Guard (Success)]</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -163,25 +162,7 @@
                     "remaster": false,
                     "title": "Pathfinder Kingmaker"
                 },
-                "rules": [
-                    {
-                        "key": "FlatModifier",
-                        "label": "Guarded",
-                        "predicate": [
-                            "guarded-critical"
-                        ],
-                        "selector": "ac",
-                        "type": "item",
-                        "value": 2
-                    },
-                    {
-                        "domain": "ac",
-                        "key": "RollOption",
-                        "label": "Guarded (Critical Success)",
-                        "option": "guarded-critical",
-                        "toggleable": true
-                    }
-                ],
+                "rules": [],
                 "slug": "guard",
                 "traits": {
                     "rarity": "common",
@@ -256,7 +237,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a Maneuver check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
+                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a @Check[type:maneuver|defense:maneuver|roller:self] check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
                 },
                 "location": null,
                 "prerequisites": {

--- a/packs/kingmaker-bestiary/armies/basic-siege-engines.json
+++ b/packs/kingmaker-bestiary/armies/basic-siege-engines.json
@@ -1,0 +1,383 @@
+{
+    "_id": "rRFSwMaphI2v0CCZ",
+    "folder": "BRkIyvmgOgyA2kq7",
+    "img": "systems/pf2e/icons/default-icons/army.svg",
+    "items": [
+        {
+            "_id": "Jd1g3ovpiC39CYRk",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.8XXylMGJuqe1ozMk"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Rally",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a Morale check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "rally",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "morale"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "1egfYGFDnAX5opwc",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.IhjlbJinff1wUSjL"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/ThreeActions.webp",
+            "name": "Retreat",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 3
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<p>Your army tries to escape from the battlefield.</p>\n<p>If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed].</p>\n<p>Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "retreat",
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "A5deiJajssYXsGeB",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.Pu5bptxLrKFyEzFh"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Disengage",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a Maneuver check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "disengage",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "pF7BiYB0G1hNsXek",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.phtwOol1wETryF7b"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Guard",
+            "sort": 0,
+            "system": {
+                "-=level": null,
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a Maneuver check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "label": "Guarded",
+                        "predicate": [
+                            "guarded-critical"
+                        ],
+                        "selector": "ac",
+                        "type": "item",
+                        "value": 2
+                    },
+                    {
+                        "domain": "ac",
+                        "key": "RollOption",
+                        "label": "Guarded (Critical Success)",
+                        "option": "guarded-critical",
+                        "toggleable": true
+                    }
+                ],
+                "slug": "guard",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "AutD88eYafZX1wQW",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.qCxyuNhzaaYlYBum"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Battle",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attacks an enemy army with a Strike against the enemy army's AC. You can do so with a melee Strike only if you are @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with the target army. Otherwise, you must use a ranged Strike.</p>\n<p>An army can attempt a maximum of 5 ranged Strikes per war encounter (unless it has the @UUID[Compendium.pf2e.kingmaker-features.Item.Increased Ammunition] tactic). As with any attack, multiple Strikes in a single round suffer a multiple attack penalty.</p>\n<p>A siege engine can use the Battle action to attack and damage a fortification.</p>\n<p><strong>Critical Success</strong> You deal 2 points of damage to the army.</p>\n<p><strong>Success</strong> You deal 1 point of damage to the army.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "battle",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "attack"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "rGxlncNMXLVMXZ6s",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.wHoXoyci1lddRR2R"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Advance",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a Maneuver check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "advance",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "x3joyvDKdRuq7HCH",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.8bBRW8SxM5bgwjXJ"
+                }
+            },
+            "folder": "tavHHn3vqI7bCnl6",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Engines of War",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p><em><strong>Note</strong>: Basic siege armies know Engines of War automatically, and must 'spend' their first tactic on it.</em></p>\n<hr />\n<p>Siege engines cannot be outfitted with gear. They cannot attack @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] armies. They are more difficult to destroy due to their higher hit points than other basic armies. A siege engine can attack and damage fortifications with its ranged attacks as part of the @UUID[Compendium.pf2e.kingmaker-features.Item.Battle] or @UUID[Compendium.pf2e.kingmaker-features.Item.Overwhelming Bombardment] actions.</p>"
+                },
+                "level": {
+                    "value": 7
+                },
+                "location": "0",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [],
+                "slug": "engines-of-war",
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        }
+    ],
+    "name": "Basic Siege Engines",
+    "prototypeToken": {
+        "name": "Siege Engines"
+    },
+    "system": {
+        "ac": {
+            "potency": 0,
+            "value": 25
+        },
+        "attributes": {
+            "hp": {
+                "max": 6,
+                "routThreshold": 3,
+                "value": 6
+            }
+        },
+        "consumption": 1,
+        "details": {
+            "alignment": "N",
+            "blurb": "",
+            "description": "<p>A siege engine army consists of several catapults, ballistae, trebuchets, or other mechanized engines of war.</p>\n<p><em><strong>Note</strong>: In Pathfinder: Kingmaker, the attack bonus for the basic Siege Engine is +15. This has been assumed to be an error, and substituted with the default.</em></p>",
+            "level": {
+                "value": 7
+            }
+        },
+        "recruitmentDC": 23,
+        "resources": {
+            "ammunition": {
+                "max": 5,
+                "value": 5
+            },
+            "potions": {
+                "value": 0
+            }
+        },
+        "saves": {
+            "maneuver": 12,
+            "morale": 18
+        },
+        "scouting": 15,
+        "traits": {
+            "rarity": "common",
+            "size": {
+                "value": "med"
+            },
+            "type": "siege",
+            "value": []
+        },
+        "weapons": {
+            "melee": null,
+            "ranged": {
+                "name": "Siege engine",
+                "potency": 0
+            }
+        }
+    },
+    "type": "army"
+}

--- a/packs/kingmaker-bestiary/armies/basic-skirmishers.json
+++ b/packs/kingmaker-bestiary/armies/basic-skirmishers.json
@@ -1,0 +1,342 @@
+{
+    "_id": "WFKh1twN246LMp8Z",
+    "folder": "BRkIyvmgOgyA2kq7",
+    "img": "systems/pf2e/icons/default-icons/army.svg",
+    "items": [
+        {
+            "_id": "Jd1g3ovpiC39CYRk",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.8XXylMGJuqe1ozMk"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Rally",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a Morale check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "rally",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "morale"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "1egfYGFDnAX5opwc",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.IhjlbJinff1wUSjL"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/ThreeActions.webp",
+            "name": "Retreat",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 3
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<p>Your army tries to escape from the battlefield.</p>\n<p>If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed].</p>\n<p>Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "retreat",
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "A5deiJajssYXsGeB",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.Pu5bptxLrKFyEzFh"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Disengage",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a Maneuver check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "disengage",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "pF7BiYB0G1hNsXek",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.phtwOol1wETryF7b"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Guard",
+            "sort": 0,
+            "system": {
+                "-=level": null,
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a Maneuver check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "label": "Guarded",
+                        "predicate": [
+                            "guarded-critical"
+                        ],
+                        "selector": "ac",
+                        "type": "item",
+                        "value": 2
+                    },
+                    {
+                        "domain": "ac",
+                        "key": "RollOption",
+                        "label": "Guarded (Critical Success)",
+                        "option": "guarded-critical",
+                        "toggleable": true
+                    }
+                ],
+                "slug": "guard",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "AutD88eYafZX1wQW",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.qCxyuNhzaaYlYBum"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Battle",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attacks an enemy army with a Strike against the enemy army's AC. You can do so with a melee Strike only if you are @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with the target army. Otherwise, you must use a ranged Strike.</p>\n<p>An army can attempt a maximum of 5 ranged Strikes per war encounter (unless it has the @UUID[Compendium.pf2e.kingmaker-features.Item.Increased Ammunition] tactic). As with any attack, multiple Strikes in a single round suffer a multiple attack penalty.</p>\n<p>A siege engine can use the Battle action to attack and damage a fortification.</p>\n<p><strong>Critical Success</strong> You deal 2 points of damage to the army.</p>\n<p><strong>Success</strong> You deal 1 point of damage to the army.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "battle",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "attack"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "rGxlncNMXLVMXZ6s",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.wHoXoyci1lddRR2R"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Advance",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a Maneuver check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "advance",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        }
+    ],
+    "name": "Basic Skirmishers",
+    "prototypeToken": {
+        "name": "Skirmishers"
+    },
+    "system": {
+        "ac": {
+            "potency": 0,
+            "value": 35
+        },
+        "attributes": {
+            "hp": {
+                "max": 4,
+                "routThreshold": 2,
+                "value": 4
+            }
+        },
+        "consumption": 1,
+        "details": {
+            "alignment": "N",
+            "blurb": "",
+            "description": "<p>Skirmishers are lightly armored, but their ability to move quickly and to focus on individual tactics rather than working as a unit make them more resilient in other ways. A skirmisher army’s AC is two lower than normal for its level, but its Maneuver and Morale are two higher than normal for its level.</p>",
+            "level": {
+                "value": 15
+            }
+        },
+        "recruitmentDC": 20,
+        "resources": {
+            "ammunition": {
+                "max": 5,
+                "value": 4
+            },
+            "potions": {
+                "value": 0
+            }
+        },
+        "saves": {
+            "maneuver": 31,
+            "morale": 25
+        },
+        "scouting": 26,
+        "traits": {
+            "rarity": "common",
+            "size": {
+                "value": "med"
+            },
+            "type": "skirmisher",
+            "value": []
+        },
+        "weapons": {
+            "melee": {
+                "name": "Weapons",
+                "potency": 0
+            },
+            "ranged": {
+                "name": "",
+                "potency": 0
+            }
+        }
+    },
+    "type": "army"
+}

--- a/packs/kingmaker-bestiary/armies/basic-skirmishers.json
+++ b/packs/kingmaker-bestiary/armies/basic-skirmishers.json
@@ -24,7 +24,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a Morale check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
+                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a @Check[type:morale|defense:morale|roller:self] check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -67,7 +67,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<p>Your army tries to escape from the battlefield.</p>\n<p>If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed].</p>\n<p>Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
+                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<hr />\n<p>Your army tries to escape from the battlefield. If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed]. Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -108,7 +108,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a Maneuver check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
+                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a @Check[type:maneuver|defense:maneuver|roller:self] check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -142,7 +142,6 @@
             "name": "Guard",
             "sort": 0,
             "system": {
-                "-=level": null,
                 "actionType": {
                     "value": "action"
                 },
@@ -152,7 +151,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a Maneuver check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
+                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a @Check[type:maneuver|defense:maneuver|roller:self] check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p>@UUID[Compendium.pf2e.kingmaker-features.Item.Effect: Guard (Critical Success)]</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p>@UUID[Compendium.pf2e.kingmaker-features.Item.Effect: Guard (Success)]</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -163,25 +162,7 @@
                     "remaster": false,
                     "title": "Pathfinder Kingmaker"
                 },
-                "rules": [
-                    {
-                        "key": "FlatModifier",
-                        "label": "Guarded",
-                        "predicate": [
-                            "guarded-critical"
-                        ],
-                        "selector": "ac",
-                        "type": "item",
-                        "value": 2
-                    },
-                    {
-                        "domain": "ac",
-                        "key": "RollOption",
-                        "label": "Guarded (Critical Success)",
-                        "option": "guarded-critical",
-                        "toggleable": true
-                    }
-                ],
+                "rules": [],
                 "slug": "guard",
                 "traits": {
                     "rarity": "common",
@@ -256,7 +237,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a Maneuver check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
+                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a @Check[type:maneuver|defense:maneuver|roller:self] check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
                 },
                 "location": null,
                 "prerequisites": {

--- a/packs/kingmaker-bestiary/armies/catspaw-marauders.json
+++ b/packs/kingmaker-bestiary/armies/catspaw-marauders.json
@@ -24,7 +24,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a Morale check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
+                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a @Check[type:morale|defense:morale|roller:self] check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -67,7 +67,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<p>Your army tries to escape from the battlefield.</p>\n<p>If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed].</p>\n<p>Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
+                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<hr />\n<p>Your army tries to escape from the battlefield. If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed]. Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -108,7 +108,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a Maneuver check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
+                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a @Check[type:maneuver|defense:maneuver|roller:self] check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -142,7 +142,6 @@
             "name": "Guard",
             "sort": 0,
             "system": {
-                "-=level": null,
                 "actionType": {
                     "value": "action"
                 },
@@ -152,7 +151,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a Maneuver check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
+                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a @Check[type:maneuver|defense:maneuver|roller:self] check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p>@UUID[Compendium.pf2e.kingmaker-features.Item.Effect: Guard (Critical Success)]</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p>@UUID[Compendium.pf2e.kingmaker-features.Item.Effect: Guard (Success)]</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -163,25 +162,7 @@
                     "remaster": false,
                     "title": "Pathfinder Kingmaker"
                 },
-                "rules": [
-                    {
-                        "key": "FlatModifier",
-                        "label": "Guarded",
-                        "predicate": [
-                            "guarded-critical"
-                        ],
-                        "selector": "ac",
-                        "type": "item",
-                        "value": 2
-                    },
-                    {
-                        "domain": "ac",
-                        "key": "RollOption",
-                        "label": "Guarded (Critical Success)",
-                        "option": "guarded-critical",
-                        "toggleable": true
-                    }
-                ],
+                "rules": [],
                 "slug": "guard",
                 "traits": {
                     "rarity": "common",
@@ -256,7 +237,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a Maneuver check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
+                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a @Check[type:maneuver|defense:maneuver|roller:self] check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
                 },
                 "location": null,
                 "prerequisites": {

--- a/packs/kingmaker-bestiary/armies/catspaw-marauders.json
+++ b/packs/kingmaker-bestiary/armies/catspaw-marauders.json
@@ -1,0 +1,534 @@
+{
+    "_id": "NeOFdBMSjhuZKEwG",
+    "folder": "BRkIyvmgOgyA2kq7",
+    "img": "systems/pf2e/icons/default-icons/army.svg",
+    "items": [
+        {
+            "_id": "Jd1g3ovpiC39CYRk",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.8XXylMGJuqe1ozMk"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Rally",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a Morale check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "rally",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "morale"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "1egfYGFDnAX5opwc",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.IhjlbJinff1wUSjL"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/ThreeActions.webp",
+            "name": "Retreat",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 3
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<p>Your army tries to escape from the battlefield.</p>\n<p>If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed].</p>\n<p>Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "retreat",
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "A5deiJajssYXsGeB",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.Pu5bptxLrKFyEzFh"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Disengage",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a Maneuver check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "disengage",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "pF7BiYB0G1hNsXek",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.phtwOol1wETryF7b"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Guard",
+            "sort": 0,
+            "system": {
+                "-=level": null,
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a Maneuver check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "label": "Guarded",
+                        "predicate": [
+                            "guarded-critical"
+                        ],
+                        "selector": "ac",
+                        "type": "item",
+                        "value": 2
+                    },
+                    {
+                        "domain": "ac",
+                        "key": "RollOption",
+                        "label": "Guarded (Critical Success)",
+                        "option": "guarded-critical",
+                        "toggleable": true
+                    }
+                ],
+                "slug": "guard",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "AutD88eYafZX1wQW",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.qCxyuNhzaaYlYBum"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Battle",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attacks an enemy army with a Strike against the enemy army's AC. You can do so with a melee Strike only if you are @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with the target army. Otherwise, you must use a ranged Strike.</p>\n<p>An army can attempt a maximum of 5 ranged Strikes per war encounter (unless it has the @UUID[Compendium.pf2e.kingmaker-features.Item.Increased Ammunition] tactic). As with any attack, multiple Strikes in a single round suffer a multiple attack penalty.</p>\n<p>A siege engine can use the Battle action to attack and damage a fortification.</p>\n<p><strong>Critical Success</strong> You deal 2 points of damage to the army.</p>\n<p><strong>Success</strong> You deal 1 point of damage to the army.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "battle",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "attack"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "rGxlncNMXLVMXZ6s",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.wHoXoyci1lddRR2R"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Advance",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a Maneuver check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "advance",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "4jCRKsBUCHXnjB3y",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.o4LgcCVBBpf0wpfD"
+                }
+            },
+            "folder": "e185cDQaLjU3uZ62",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Low-Light Vision",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p>The army includes several spotters and scouts who have low-light vision, and the rest of the soldiers have been trained to follow their lead so that the army itself functions as if it had low-light vision.</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": "0",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "low-light-vision",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "cavalry",
+                        "infantry",
+                        "siege",
+                        "skirmisher"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "gz6czmyiSK98aBxc",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.4h7c6C5doDA5rxyO"
+                }
+            },
+            "folder": "e185cDQaLjU3uZ62",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Ambush",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p>Your skirmishers are experts at ambushing. On the first round of a war encounter, if your turn occurs before any enemy army turns, you can choose to start the encounter with your army already engaged with an enemy army whose initiative result is lower than yours. If you do so, your army gains a +2 status bonus on the first Attack war action they make against that army on the first round of the encounter.</p>"
+                },
+                "level": {
+                    "value": 8
+                },
+                "location": "2",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [
+                    {
+                        "domain": "attack-roll",
+                        "key": "RollOption",
+                        "label": "First Attack war action against ambushed opponent",
+                        "option": "ambushed",
+                        "toggleable": true
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "predicate": [
+                            "ambushed"
+                        ],
+                        "selector": "attack-roll",
+                        "type": "status",
+                        "value": 2
+                    }
+                ],
+                "slug": "ambush",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "skirmisher"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "v2dxVfLV0uTtLUEC",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.lcNZMlMNPUrnMgQ2"
+                }
+            },
+            "folder": "e185cDQaLjU3uZ62",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Sharpshooter",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p>The commander drills the army in precision ranged attacks. You gain a +1 status bonus on attacks with ranged Strikes, but suffer a –2 status bonus on attacks with melee Strikes. At 9th level, the penalty to melee Strikes is reduced to –1, and at 15th level the penalty to melee Strikes is removed.</p>\n<p>The army can use the @UUID[Compendium.pf2e.kingmaker-features.Item.Covering Fire] tactical war action.</p>"
+                },
+                "level": {
+                    "value": 5
+                },
+                "location": "1",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [
+                    {
+                        "key": "GrantItem",
+                        "uuid": "Compendium.pf2e.kingmaker-features.Item.Covering Fire"
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "selector": "ranged-attack-roll",
+                        "type": "status",
+                        "value": 1
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "selector": "melee-attack-roll",
+                        "type": "status",
+                        "value": {
+                            "brackets": [
+                                {
+                                    "end": 8,
+                                    "start": 1,
+                                    "value": -2
+                                },
+                                {
+                                    "end": 14,
+                                    "start": 9,
+                                    "value": -1
+                                },
+                                {
+                                    "start": 15,
+                                    "value": 0
+                                }
+                            ],
+                            "field": "actor|level"
+                        }
+                    }
+                ],
+                "slug": "sharpshooter",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "cavalry",
+                        "infantry",
+                        "skirmisher"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        }
+    ],
+    "name": "Catspaw Marauders",
+    "system": {
+        "ac": {
+            "potency": 0,
+            "value": 31
+        },
+        "attributes": {
+            "hp": {
+                "max": 4,
+                "routThreshold": 2,
+                "value": 4
+            }
+        },
+        "consumption": null,
+        "details": {
+            "alignment": "CN",
+            "blurb": "",
+            "description": "<p>The Catspaw Marauders consist mostly of humans and half-elves who fight with kukris and longbows.</p>",
+            "level": {
+                "value": 11
+            }
+        },
+        "recruitmentDC": null,
+        "resources": {
+            "ammunition": {
+                "max": 5,
+                "value": 5
+            },
+            "potions": {
+                "value": 0
+            }
+        },
+        "saves": {
+            "maneuver": 24,
+            "morale": 18
+        },
+        "scouting": 21,
+        "traits": {
+            "rarity": "common",
+            "size": {
+                "value": "med"
+            },
+            "type": "skirmisher",
+            "value": []
+        },
+        "weapons": {
+            "melee": {
+                "name": "Kukris",
+                "potency": 0
+            },
+            "ranged": {
+                "name": "Magic Longbows",
+                "potency": 1
+            }
+        }
+    },
+    "type": "army"
+}

--- a/packs/kingmaker-bestiary/armies/drelev-irregulars.json
+++ b/packs/kingmaker-bestiary/armies/drelev-irregulars.json
@@ -24,7 +24,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a Morale check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
+                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a @Check[type:morale|defense:morale|roller:self] check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -67,7 +67,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<p>Your army tries to escape from the battlefield.</p>\n<p>If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed].</p>\n<p>Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
+                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<hr />\n<p>Your army tries to escape from the battlefield. If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed]. Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -108,7 +108,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a Maneuver check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
+                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a @Check[type:maneuver|defense:maneuver|roller:self] check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -142,7 +142,6 @@
             "name": "Guard",
             "sort": 0,
             "system": {
-                "-=level": null,
                 "actionType": {
                     "value": "action"
                 },
@@ -152,7 +151,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a Maneuver check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
+                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a @Check[type:maneuver|defense:maneuver|roller:self] check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p>@UUID[Compendium.pf2e.kingmaker-features.Item.Effect: Guard (Critical Success)]</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p>@UUID[Compendium.pf2e.kingmaker-features.Item.Effect: Guard (Success)]</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -163,25 +162,7 @@
                     "remaster": false,
                     "title": "Pathfinder Kingmaker"
                 },
-                "rules": [
-                    {
-                        "key": "FlatModifier",
-                        "label": "Guarded",
-                        "predicate": [
-                            "guarded-critical"
-                        ],
-                        "selector": "ac",
-                        "type": "item",
-                        "value": 2
-                    },
-                    {
-                        "domain": "ac",
-                        "key": "RollOption",
-                        "label": "Guarded (Critical Success)",
-                        "option": "guarded-critical",
-                        "toggleable": true
-                    }
-                ],
+                "rules": [],
                 "slug": "guard",
                 "traits": {
                     "rarity": "common",
@@ -256,7 +237,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a Maneuver check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
+                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a @Check[type:maneuver|defense:maneuver|roller:self] check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -381,7 +362,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p><strong>Requirement</strong> @UUID[Compendium.pf2e.kingmaker-features.Item.Merciless]</p>\n<p>Your army attacks with frightening vigor. Attempt a melee Strike against an enemy army's AC. Critical Success Your army inflicts 3 points of damage to the target army. If your army's next war action this turn is an attack war action against a different target army, you gain a +1 circumstance bonus to the Strike as your fury continues to the new target. Success Your army deals 2 points of damage to the target army. Failure Your army falters, but still deals 1 point of damage to the target army. Critical Failure Your army deals no damage to the target army and becomes outflanked until the start of its next turn.</p>"
+                    "value": "<p><strong>Requirement</strong> @UUID[Compendium.pf2e.kingmaker-features.Item.Merciless]</p>\n<hr />\n<p>Your army attacks with frightening vigor. Attempt a melee Strike against an enemy army's AC.</p>\n<p><strong>Critical Success</strong> Your army inflicts @Damage[3|domains:melee-damage,strike-damage] points of damage to the target army. If your army's next war action this turn is an attack war action against a different target army, you gain a +1 circumstance bonus to the Strike as your fury continues to the new target.</p>\n<p><strong>Success</strong> Your army deals @Damage[2|domains:melee-damage,strike-damage] points of damage to the target army.</p>\n<p><strong>Failure</strong> Your army falters, but still deals @Damage[1|domains:melee-damage,strike-damage] point of damage to the target army.</p>\n<p><strong>Critical Failure</strong> Your army deals no damage to the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Outflanked] until the start of its next turn.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -392,7 +373,25 @@
                     "remaster": false,
                     "title": "Pathfinder Kingmaker"
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "domain": "attack-roll",
+                        "key": "RollOption",
+                        "label": "All-Out Assault Followup Attack (Crit Success)",
+                        "option": "all-out-assault-followup",
+                        "toggleable": true
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "label": "All-Out Assault Followup (Crit Success)",
+                        "predicate": [
+                            "all-out-assault-followup"
+                        ],
+                        "selector": "attack-roll",
+                        "type": "circumstance",
+                        "value": 1
+                    }
+                ],
                 "slug": "all-out-assault",
                 "traits": {
                     "rarity": "common",
@@ -432,7 +431,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Requirement Flexible Tactics Trigger An army you are engaged with attempts a maneuver war action. Your army lashes out at the foe as they attempt to perform a maneuver. Attempt a melee Strike against the triggering army's AC. Counterattack doesn't count toward your multiple attack penalty, and your multiple attack penalty doesn't apply to this Strike. Critical Success You inflict 1 point of damage on the army and increase its shaken condition value by 1. Success You inflict 1 point of damage on the army.</p>"
+                    "value": "<p><strong>Requirement</strong> @UUID[Compendium.pf2e.kingmaker-features.Item.Flexible Tactics]</p>\n<p><strong>Trigger</strong> An army you are engaged with attempts a maneuver war action.</p>\n<hr />\n<p>Your army lashes out at the foe as they attempt to perform a maneuver. Attempt a melee Strike against the triggering army's AC. Counterattack doesn't count toward your multiple attack penalty, and your multiple attack penalty doesn't apply to this Strike.</p>\n<p><strong>Critical Success</strong> You inflict 1 point of damage on the army and increase its @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition value by 1.</p>\n<p><strong>Success</strong> You inflict 1 point of damage on the army.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -482,7 +481,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Requirement Flexible Tactics Your army uses trickery, deception, and unfair tactics to attempt a devastating attack against an outflanked army. Attempt a melee Strike or a ranged Strike against the AC of a target outflanked army that is not distant. Critical Success The target army becomes weary 2 until the start of your next turn. Success The target army becomes weary 1 until the start of your next turn. Critical Failure Your attack deals no damage to the target army, which is emboldened by your failed attempt at dirty fighting. This reduces the target army's weary value by 1.</p>"
+                    "value": "<p><strong>Requirement</strong> @UUID[Compendium.pf2e.kingmaker-features.Item.Flexible Tactics]</p>\n<hr />\n<p>Your army uses trickery, deception, and unfair tactics to attempt a devastating attack against an outflanked army. Attempt a melee Strike or a ranged Strike against the AC of a target outflanked army that is not distant.</p>\n<p><strong>Critical Success</strong> The target army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Weary]{Weary 2} until the start of your next turn.</p>\n<p><strong>Success</strong> The target army becomes weary 1 until the start of your next turn.</p>\n<p><strong>Critical Failure</strong> Your attack deals no damage to the target army, which is emboldened by your failed attempt at dirty fighting. This reduces the target army's weary value by 1.</p>"
                 },
                 "location": null,
                 "prerequisites": {

--- a/packs/kingmaker-bestiary/armies/drelev-irregulars.json
+++ b/packs/kingmaker-bestiary/armies/drelev-irregulars.json
@@ -1,0 +1,607 @@
+{
+    "_id": "E5rhB1dzkBVnaEDX",
+    "folder": "BRkIyvmgOgyA2kq7",
+    "img": "systems/pf2e/icons/default-icons/army.svg",
+    "items": [
+        {
+            "_id": "DzE7Ak5Wa6ZNrS2U",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.8XXylMGJuqe1ozMk"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Rally",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a Morale check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "rally",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "morale"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "agTytKqXthSBLPyU",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.IhjlbJinff1wUSjL"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/ThreeActions.webp",
+            "name": "Retreat",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 3
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<p>Your army tries to escape from the battlefield.</p>\n<p>If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed].</p>\n<p>Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "retreat",
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "yzEpwKcdcuEjK3OT",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.Pu5bptxLrKFyEzFh"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Disengage",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a Maneuver check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "disengage",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "GJgxw57AoY9F4gz8",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.phtwOol1wETryF7b"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Guard",
+            "sort": 0,
+            "system": {
+                "-=level": null,
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a Maneuver check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "label": "Guarded",
+                        "predicate": [
+                            "guarded-critical"
+                        ],
+                        "selector": "ac",
+                        "type": "item",
+                        "value": 2
+                    },
+                    {
+                        "domain": "ac",
+                        "key": "RollOption",
+                        "label": "Guarded (Critical Success)",
+                        "option": "guarded-critical",
+                        "toggleable": true
+                    }
+                ],
+                "slug": "guard",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "cdUU5qBOCBri8NCy",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.qCxyuNhzaaYlYBum"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Battle",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attacks an enemy army with a Strike against the enemy army's AC. You can do so with a melee Strike only if you are @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with the target army. Otherwise, you must use a ranged Strike.</p>\n<p>An army can attempt a maximum of 5 ranged Strikes per war encounter (unless it has the @UUID[Compendium.pf2e.kingmaker-features.Item.Increased Ammunition] tactic). As with any attack, multiple Strikes in a single round suffer a multiple attack penalty.</p>\n<p>A siege engine can use the Battle action to attack and damage a fortification.</p>\n<p><strong>Critical Success</strong> You deal 2 points of damage to the army.</p>\n<p><strong>Success</strong> You deal 1 point of damage to the army.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "battle",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "attack"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "94bR9nxbJRpYhGiI",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.wHoXoyci1lddRR2R"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Advance",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a Maneuver check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "advance",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "5hijiZfVSnfNTlQ6",
+            "flags": {
+                "core": {
+                    "sourceId": "Item.h5GN6TwNPgBnppeZ"
+                },
+                "pf2e": {
+                    "itemGrants": {
+                        "allOutAssault": {
+                            "id": "v7wzHu1D3duO4IS2",
+                            "onDelete": "detach"
+                        },
+                        "counterattack": {
+                            "id": "4IBaD7FuRPjVjJkV",
+                            "onDelete": "detach"
+                        },
+                        "dirtyFighting": {
+                            "id": "5B01aXaes4bLX0P0",
+                            "onDelete": "detach"
+                        }
+                    }
+                }
+            },
+            "folder": "uzT6OylJkqdfcjJM",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Tactical Training",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p>The Drelev Irregulars can use the @UUID[Compendium.pf2e.kingmaker-features.Item.All-Out Assault], @UUID[Compendium.pf2e.kingmaker-features.Item.Counterattack], and @UUID[Compendium.pf2e.kingmaker-features.Item.Dirty Fighting] tactical actions.</p>"
+                },
+                "level": {
+                    "value": 7
+                },
+                "location": "0",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [
+                    {
+                        "flag": "allOutAssault",
+                        "key": "GrantItem",
+                        "uuid": "Compendium.pf2e.kingmaker-features.Item.All-Out Assault"
+                    },
+                    {
+                        "flag": "counterattack",
+                        "key": "GrantItem",
+                        "uuid": "Compendium.pf2e.kingmaker-features.Item.Counterattack"
+                    },
+                    {
+                        "flag": "dirtyFighting",
+                        "key": "GrantItem",
+                        "uuid": "Compendium.pf2e.kingmaker-features.Item.Dirty Fighting"
+                    }
+                ],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "v7wzHu1D3duO4IS2",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.Z6jMZgAxI1zRO7Sl"
+                },
+                "pf2e": {
+                    "grantedBy": {
+                        "id": "5hijiZfVSnfNTlQ6",
+                        "onDelete": "cascade"
+                    }
+                }
+            },
+            "folder": "i18YzT3zo3skuWng",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "All-Out Assault",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p><strong>Requirement</strong> @UUID[Compendium.pf2e.kingmaker-features.Item.Merciless]</p>\n<p>Your army attacks with frightening vigor. Attempt a melee Strike against an enemy army's AC. Critical Success Your army inflicts 3 points of damage to the target army. If your army's next war action this turn is an attack war action against a different target army, you gain a +1 circumstance bonus to the Strike as your fury continues to the new target. Success Your army deals 2 points of damage to the target army. Failure Your army falters, but still deals 1 point of damage to the target army. Critical Failure Your army deals no damage to the target army and becomes outflanked until the start of its next turn.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "all-out-assault",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "attack",
+                        "cavalry",
+                        "infantry"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "4IBaD7FuRPjVjJkV",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.8wjiF3ctXUjP9oyX"
+                },
+                "pf2e": {
+                    "grantedBy": {
+                        "id": "5hijiZfVSnfNTlQ6",
+                        "onDelete": "cascade"
+                    }
+                }
+            },
+            "folder": "i18YzT3zo3skuWng",
+            "img": "systems/pf2e/icons/actions/Reaction.webp",
+            "name": "Counterattack",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "reaction"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Requirement Flexible Tactics Trigger An army you are engaged with attempts a maneuver war action. Your army lashes out at the foe as they attempt to perform a maneuver. Attempt a melee Strike against the triggering army's AC. Counterattack doesn't count toward your multiple attack penalty, and your multiple attack penalty doesn't apply to this Strike. Critical Success You inflict 1 point of damage on the army and increase its shaken condition value by 1. Success You inflict 1 point of damage on the army.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "counterattack",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "infantry",
+                        "skirmisher"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "5B01aXaes4bLX0P0",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.G2eBcOnUHb3yT7JL"
+                },
+                "pf2e": {
+                    "grantedBy": {
+                        "id": "5hijiZfVSnfNTlQ6",
+                        "onDelete": "cascade"
+                    }
+                }
+            },
+            "folder": "i18YzT3zo3skuWng",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Dirty Fighting",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Requirement Flexible Tactics Your army uses trickery, deception, and unfair tactics to attempt a devastating attack against an outflanked army. Attempt a melee Strike or a ranged Strike against the AC of a target outflanked army that is not distant. Critical Success The target army becomes weary 2 until the start of your next turn. Success The target army becomes weary 1 until the start of your next turn. Critical Failure Your attack deals no damage to the target army, which is emboldened by your failed attempt at dirty fighting. This reduces the target army's weary value by 1.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "dirty-fighting",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "attack",
+                        "skirmisher"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "lCKz8286lk4mNMfK",
+            "flags": {
+                "core": {
+                    "sourceId": "Item.pIs4FsKSIWoBWgnd"
+                }
+            },
+            "folder": "uzT6OylJkqdfcjJM",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Unpredictable Movement",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p>It’s difficult to do significant damage to the Drelev Irregulars with ranged attacks, as the mob moves about in a haphazard manner. All ranged attacks against the Drelev Irregulars suffer a –2 circumstance penalty as a result.</p>"
+                },
+                "level": {
+                    "value": 7
+                },
+                "location": "1",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        }
+    ],
+    "name": "Drelev Irregulars",
+    "system": {
+        "ac": {
+            "potency": 0,
+            "value": 25
+        },
+        "attributes": {
+            "hp": {
+                "max": 4,
+                "routThreshold": 2,
+                "value": 4
+            }
+        },
+        "consumption": 1,
+        "details": {
+            "alignment": "NG",
+            "blurb": "",
+            "description": "<p>The Drelev Irregulars are composed of equal parts Tiger Lords and mercenaries who were once bandits. Their fighting style is more akin to a mob than a disciplined force; while this allows the irregulars an advantage in mobility, it decentralizes their command structure and lessens their morale.</p>",
+            "level": {
+                "value": 7
+            }
+        },
+        "recruitmentDC": null,
+        "resources": {
+            "ammunition": {
+                "max": 5,
+                "value": 5
+            },
+            "potions": {
+                "value": 0
+            }
+        },
+        "saves": {
+            "maneuver": 19,
+            "morale": 11
+        },
+        "scouting": 15,
+        "traits": {
+            "rarity": "common",
+            "size": {
+                "value": "med"
+            },
+            "type": "infantry",
+            "value": []
+        },
+        "weapons": {
+            "melee": {
+                "name": "Swords and Axes",
+                "potency": 0
+            },
+            "ranged": null
+        }
+    },
+    "type": "army"
+}

--- a/packs/kingmaker-bestiary/armies/first-world-army.json
+++ b/packs/kingmaker-bestiary/armies/first-world-army.json
@@ -1,0 +1,1036 @@
+{
+    "_id": "2nCGeGTO7HQjEETs",
+    "folder": "BRkIyvmgOgyA2kq7",
+    "img": "systems/pf2e/icons/default-icons/army.svg",
+    "items": [
+        {
+            "_id": "Jd1g3ovpiC39CYRk",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.8XXylMGJuqe1ozMk"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Rally",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a Morale check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "rally",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "morale"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "1egfYGFDnAX5opwc",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.IhjlbJinff1wUSjL"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/ThreeActions.webp",
+            "name": "Retreat",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 3
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<p>Your army tries to escape from the battlefield.</p>\n<p>If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed].</p>\n<p>Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "retreat",
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "A5deiJajssYXsGeB",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.Pu5bptxLrKFyEzFh"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Disengage",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a Maneuver check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "disengage",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "pF7BiYB0G1hNsXek",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.phtwOol1wETryF7b"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Guard",
+            "sort": 0,
+            "system": {
+                "-=level": null,
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a Maneuver check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "label": "Guarded",
+                        "predicate": [
+                            "guarded-critical"
+                        ],
+                        "selector": "ac",
+                        "type": "item",
+                        "value": 2
+                    },
+                    {
+                        "domain": "ac",
+                        "key": "RollOption",
+                        "label": "Guarded (Critical Success)",
+                        "option": "guarded-critical",
+                        "toggleable": true
+                    }
+                ],
+                "slug": "guard",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "AutD88eYafZX1wQW",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.qCxyuNhzaaYlYBum"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Battle",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attacks an enemy army with a Strike against the enemy army's AC. You can do so with a melee Strike only if you are @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with the target army. Otherwise, you must use a ranged Strike.</p>\n<p>An army can attempt a maximum of 5 ranged Strikes per war encounter (unless it has the @UUID[Compendium.pf2e.kingmaker-features.Item.Increased Ammunition] tactic). As with any attack, multiple Strikes in a single round suffer a multiple attack penalty.</p>\n<p>A siege engine can use the Battle action to attack and damage a fortification.</p>\n<p><strong>Critical Success</strong> You deal 2 points of damage to the army.</p>\n<p><strong>Success</strong> You deal 1 point of damage to the army.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "battle",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "attack"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "rGxlncNMXLVMXZ6s",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.wHoXoyci1lddRR2R"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Advance",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a Maneuver check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "advance",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "i1JPZN2W4H4q1lv3",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.y1JGtzGmMtVh5USK"
+                }
+            },
+            "folder": "e185cDQaLjU3uZ62",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Darkvision",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p>The army includes several spotters and scouts who have darkvision, and the rest of the soldiers have been trained to follow their lead so that the army itself functions as if it had darkvision.</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "darkvision",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "cavalry",
+                        "infantry",
+                        "siege",
+                        "skirmisher"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "AY2NO75pZICF0XpF",
+            "flags": {
+                "core": {
+                    "sourceId": "Item.YbYXwVTcKHmY0GEk"
+                }
+            },
+            "folder": "uLbGIZIMsFR1IrAN",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Battlefield Adaptability",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>The First World army has a wide range of creatures in its ranks, and it can shift its tactics to support those with different mobilities. It can take this action to achieve one of the following benefits: Ignore ground-based difficult terrain, reduce @UUID[Compendium.pf2e.kingmaker-features.Item.Mired] to 0, become @UUID[Compendium.pf2e.kingmaker-features.Item.Concealed], or gain a +2 circumstance bonus on Maneuver checks to Advance and to Disengage. The effect lasts until the start of the First World Army’s next turn.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "label": "Used Battlefield Adaptability",
+                        "predicate": [
+                            "battlefield-adaptability",
+                            "action:advance",
+                            "action:disengage"
+                        ],
+                        "selector": "maneuver-check",
+                        "type": "circumstance",
+                        "value": 2
+                    }
+                ],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "X0zUD7ZGrBohmkIo",
+            "flags": {
+                "core": {
+                    "sourceId": "Item.uX6NPOLF0v5Acz4V"
+                }
+            },
+            "folder": "uLbGIZIMsFR1IrAN",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Primal Magic",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p><strong>Requirement</strong> The First World army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged];</p>\n<hr />\n<p><strong>Effect</strong> The First World army uses its primal magic against another army on the battlefield and must attempt a Morale check against the target’s Morale DC. If they succeed, the First World army applies one of the following effects, determined randomly ([[/r 1d10]]), to the target army.</p>\n<p><strong>1–2 Entangling Vines</strong> Coils of whipping vines grow out of the ground to entangle the army. The army increases its @UUID[Compendium.pf2e.kingmaker-features.Item.Mired] condition by 1 (2 on a critical hit).</p>\n<p><strong>3–4 Horrific Visions</strong> The soldiers’ minds are assaulted with horrific illusions. The army increases its @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 1 (2 on a critical hit).</p>\n<p><strong>5–6 Primal Storm</strong> A churning storm cloud above the army strikes the soldiers dozens of times with bolts of lightning, inflicting 1 point of damage to the army (2 points of damage on a critical hit). Until the end of the targeted army’s next turn, it functions as if in high wind and rain (see Battlefield Terrain Features on page 578).</p>\n<p><strong>7–8 Sensory Assault</strong> The soldiers become overwhelmed with strange lights or tricked by illusions. Until the end of their next turn, the army takes a –2 circumstance penalty on all attacks and Maneuver checks.</p>\n<p><strong>9–10 Overwhelming Magic</strong> Roll twice and apply both results, but the First World army suffers a –4 circumstance penalty on its Morale check against the target army’s Morale DC.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "primal"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "Ki0hKh6wGZNOoUQ4",
+            "flags": {
+                "core": {
+                    "sourceId": "Item.h4NITFrc7jDJtt0v"
+                }
+            },
+            "folder": "uLbGIZIMsFR1IrAN",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Battlefield Adaptability",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "kingdom-activity",
+                "description": {
+                    "value": ""
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "4y82QTrhUtnUuOJ5",
+            "flags": {
+                "core": {
+                    "sourceId": "Item.h4NITFrc7jDJtt0v"
+                }
+            },
+            "folder": "uLbGIZIMsFR1IrAN",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Battlefield Adaptability",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p>The army gains the unique Battlefield Adaptability war action.</p>"
+                },
+                "level": {
+                    "value": 16
+                },
+                "location": "1",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "WkkGL2yvRPyYRUef",
+            "flags": {
+                "core": {
+                    "sourceId": "Item.h4NITFrc7jDJtt0v"
+                }
+            },
+            "folder": "uLbGIZIMsFR1IrAN",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Primal Magic",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p>The army gains the unique Primal Magic war action.</p>"
+                },
+                "level": {
+                    "value": 16
+                },
+                "location": "0",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "E8m5W5YjbYBLCmCr",
+            "flags": {
+                "core": {
+                    "sourceId": "Item.h4NITFrc7jDJtt0v"
+                }
+            },
+            "folder": "uLbGIZIMsFR1IrAN",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Swift Recovery",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p>The army gains the unique Swift Recovery war action.</p>"
+                },
+                "level": {
+                    "value": 16
+                },
+                "location": "3",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "6HoAqX3dVG5JpFr1",
+            "flags": {
+                "core": {
+                    "sourceId": "Item.Y7FEwot01pJaeO7p"
+                }
+            },
+            "folder": "uLbGIZIMsFR1IrAN",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Supernatural Attacks",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p>Whenever a First World army scores a critical hit on another army, it increases that army’s @UUID[Compendium.pf2e.kingmaker-features.Item.Weary] condition by 1 as their attacks cause some soldiers to become poisoned, fall asleep, shrink in size, or suffer other eerie side effects.</p>"
+                },
+                "level": {
+                    "value": 16
+                },
+                "location": "4",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "6mPy5lldAAxIx3uB",
+            "flags": {
+                "core": {
+                    "sourceId": "Item.4ggMoGJ7fZlGR7P7"
+                },
+                "pf2e": {
+                    "itemGrants": {
+                        "counterattack": {
+                            "id": "7gxdZ17ZVnIaeQJ0",
+                            "onDelete": "detach"
+                        },
+                        "dirtyFighting": {
+                            "id": "dA3qooHGMtiyMWlU",
+                            "onDelete": "detach"
+                        },
+                        "feint": {
+                            "id": "bywShUI7f26P8Tjb",
+                            "onDelete": "detach"
+                        },
+                        "taunt": {
+                            "id": "XN0yNEBpJrB6PWoD",
+                            "onDelete": "detach"
+                        }
+                    }
+                }
+            },
+            "folder": "uLbGIZIMsFR1IrAN",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Tactical Training",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p>The First World Army can use the following tactical actions: @UUID[Compendium.pf2e.kingmaker-features.Item.Counterattack], @UUID[Compendium.pf2e.kingmaker-features.Item.Dirty Fighting], @UUID[Compendium.pf2e.kingmaker-features.Item.Feint], and @UUID[Compendium.pf2e.kingmaker-features.Item.Taunt].</p>\n<hr />\n<p><em><strong>Note</strong>: This tactic also grants the army a +1 bonus to attacks in order to keep its attack bonus in line with the statistics given in the Kingmaker adventure.</em></p>"
+                },
+                "level": {
+                    "value": 16
+                },
+                "location": "2",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [
+                    {
+                        "flag": "counterattack",
+                        "key": "GrantItem",
+                        "uuid": "Compendium.pf2e.kingmaker-features.Item.Counterattack"
+                    },
+                    {
+                        "flag": "dirtyFighting",
+                        "key": "GrantItem",
+                        "uuid": "Compendium.pf2e.kingmaker-features.Item.Dirty Fighting"
+                    },
+                    {
+                        "flag": "feint",
+                        "key": "GrantItem",
+                        "uuid": "Compendium.pf2e.kingmaker-features.Item.Feint"
+                    },
+                    {
+                        "flag": "taunt",
+                        "key": "GrantItem",
+                        "uuid": "Compendium.pf2e.kingmaker-features.Item.Taunt"
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "selector": "attack-roll",
+                        "type": "untyped",
+                        "value": 1
+                    }
+                ],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "7gxdZ17ZVnIaeQJ0",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.8wjiF3ctXUjP9oyX"
+                },
+                "pf2e": {
+                    "grantedBy": {
+                        "id": "6mPy5lldAAxIx3uB",
+                        "onDelete": "cascade"
+                    }
+                }
+            },
+            "folder": "i18YzT3zo3skuWng",
+            "img": "systems/pf2e/icons/actions/Reaction.webp",
+            "name": "Counterattack",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "reaction"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p><strong>Requirement</strong> @UUID[Compendium.pf2e.kingmaker-features.Item.Flexible Tactics]</p>\n<p><strong>Trigger</strong> An army you are engaged with attempts a maneuver war action.</p>\n<hr />\n<p>Your army lashes out at the foe as they attempt to perform a maneuver. Attempt a melee Strike against the triggering army's AC. Counterattack doesn't count toward your multiple attack penalty, and your multiple attack penalty doesn't apply to this Strike.</p>\n<p><strong>Critical Success</strong> You inflict 1 point of damage on the army and increase its @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition value by 1.</p>\n<p><strong>Success</strong> You inflict 1 point of damage on the army.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "counterattack",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "infantry",
+                        "skirmisher"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "dA3qooHGMtiyMWlU",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.G2eBcOnUHb3yT7JL"
+                },
+                "pf2e": {
+                    "grantedBy": {
+                        "id": "6mPy5lldAAxIx3uB",
+                        "onDelete": "cascade"
+                    }
+                }
+            },
+            "folder": "i18YzT3zo3skuWng",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Dirty Fighting",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p><strong>Requirement</strong> @UUID[Compendium.pf2e.kingmaker-features.Item.Flexible Tactics]</p>\n<hr />\n<p>Your army uses trickery, deception, and unfair tactics to attempt a devastating attack against an outflanked army. Attempt a melee Strike or a ranged Strike against the AC of a target outflanked army that is not distant.</p>\n<p><strong>Critical Success</strong> The target army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Weary]{Weary 2} until the start of your next turn. </p>\n<p><strong>Success</strong> The target army becomes weary 1 until the start of your next turn.</p>\n<p><strong>Critical Failure</strong> Your attack deals no damage to the target army, which is emboldened by your failed attempt at dirty fighting. This reduces the target army's weary value by 1.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "dirty-fighting",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "attack",
+                        "skirmisher"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "bywShUI7f26P8Tjb",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.Hi4LKGOKe6yMDOH5"
+                },
+                "pf2e": {
+                    "grantedBy": {
+                        "id": "6mPy5lldAAxIx3uB",
+                        "onDelete": "cascade"
+                    }
+                }
+            },
+            "folder": "i18YzT3zo3skuWng",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Feint",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Requirement Flexible Tactics Your army launches a probing attack meant to trick the enemy into thinking you are attacking from one quarter while your real thrust comes elsewhere. Critical Success The target army's defenses are thrown off; it is outflanked until the end of your turn. Success The target army is fooled, but only momentarily. It is outflanked against the next melee Strike your army attempts against it before the end of your current turn. Critical Failure The enemy anticipates your feint and presses the advantage. You are outflanked by the target army until the end of your next turn.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "feint",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "attack",
+                        "infantry",
+                        "skirmisher"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "XN0yNEBpJrB6PWoD",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.ggVahjiAlVICpiPA"
+                },
+                "pf2e": {
+                    "grantedBy": {
+                        "id": "6mPy5lldAAxIx3uB",
+                        "onDelete": "cascade"
+                    }
+                }
+            },
+            "folder": "i18YzT3zo3skuWng",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Taunt",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p><strong>Requirement</strong>@UUID[Compendium.pf2e.kingmaker-features.Item.Focused Devotion]</p>\n<hr />\n<p>Your army attempts to frighten and cow an enemy army. Attempt a @Check[morale|defense:morale] check against the target army.</p>\n<p><strong>Critical Success</strong> The target army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken]{Shaken 2} until the start of your next turn.</p>\n<p><strong>Success</strong> The target army becomes shaken 1 until the start of your next turn.</p>\n<p><strong>Critical Failure</strong> Your failed attempt bolsters the enemy's spirits. This reduces the target army's shaken value by 1.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "taunt",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "morale"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "CN7EFuW1kD1V2Cj9",
+            "flags": {
+                "core": {
+                    "sourceId": "Item.uX6NPOLF0v5Acz4V"
+                }
+            },
+            "folder": "uLbGIZIMsFR1IrAN",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Swift Recovery",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p><strong>Frequency</strong> once per battle;</p>\n<p><strong>Effect</strong> The army calls upon its magical connection to the First World to recover. This either restores 2 hit points or reduces the army’s @UUID[Compendium.pf2e.kingmaker-features.Item.Weary] condition value by 2.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "primal"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        }
+    ],
+    "name": "First World Army",
+    "system": {
+        "ac": {
+            "potency": 0,
+            "value": 38
+        },
+        "attributes": {
+            "hp": {
+                "max": 6,
+                "routThreshold": 3,
+                "value": 6
+            }
+        },
+        "consumption": null,
+        "details": {
+            "alignment": "CE",
+            "blurb": "",
+            "description": "<p>This army is composed of an eclectic mix of fey, beasts, and plants—a supernatural mob of monsters with a wide range of options in battle.</p>",
+            "level": {
+                "value": 16
+            }
+        },
+        "recruitmentDC": null,
+        "resources": {
+            "ammunition": {
+                "max": 5,
+                "value": 5
+            },
+            "potions": {
+                "value": 0
+            }
+        },
+        "saves": {
+            "maneuver": 30,
+            "morale": 25
+        },
+        "scouting": 28,
+        "traits": {
+            "rarity": "rare",
+            "size": {
+                "value": "med"
+            },
+            "type": "skirmisher",
+            "value": []
+        },
+        "weapons": {
+            "melee": {
+                "name": "Weapons and claws",
+                "potency": 0
+            },
+            "ranged": {
+                "name": "Bows and hurled thorns",
+                "potency": 0
+            }
+        }
+    },
+    "type": "army"
+}

--- a/packs/kingmaker-bestiary/armies/first-world-army.json
+++ b/packs/kingmaker-bestiary/armies/first-world-army.json
@@ -24,7 +24,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a Morale check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
+                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a @Check[type:morale|defense:morale|roller:self] check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -67,7 +67,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<p>Your army tries to escape from the battlefield.</p>\n<p>If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed].</p>\n<p>Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
+                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<hr />\n<p>Your army tries to escape from the battlefield. If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed]. Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -108,7 +108,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a Maneuver check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
+                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a @Check[type:maneuver|defense:maneuver|roller:self] check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -142,7 +142,6 @@
             "name": "Guard",
             "sort": 0,
             "system": {
-                "-=level": null,
                 "actionType": {
                     "value": "action"
                 },
@@ -152,7 +151,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a Maneuver check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
+                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a @Check[type:maneuver|defense:maneuver|roller:self] check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p>@UUID[Compendium.pf2e.kingmaker-features.Item.Effect: Guard (Critical Success)]</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p>@UUID[Compendium.pf2e.kingmaker-features.Item.Effect: Guard (Success)]</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -163,25 +162,7 @@
                     "remaster": false,
                     "title": "Pathfinder Kingmaker"
                 },
-                "rules": [
-                    {
-                        "key": "FlatModifier",
-                        "label": "Guarded",
-                        "predicate": [
-                            "guarded-critical"
-                        ],
-                        "selector": "ac",
-                        "type": "item",
-                        "value": 2
-                    },
-                    {
-                        "domain": "ac",
-                        "key": "RollOption",
-                        "label": "Guarded (Critical Success)",
-                        "option": "guarded-critical",
-                        "toggleable": true
-                    }
-                ],
+                "rules": [],
                 "slug": "guard",
                 "traits": {
                     "rarity": "common",
@@ -256,7 +237,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a Maneuver check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
+                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a @Check[type:maneuver|defense:maneuver|roller:self] check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -809,7 +790,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p><strong>Requirement</strong> @UUID[Compendium.pf2e.kingmaker-features.Item.Flexible Tactics]</p>\n<hr />\n<p>Your army uses trickery, deception, and unfair tactics to attempt a devastating attack against an outflanked army. Attempt a melee Strike or a ranged Strike against the AC of a target outflanked army that is not distant.</p>\n<p><strong>Critical Success</strong> The target army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Weary]{Weary 2} until the start of your next turn. </p>\n<p><strong>Success</strong> The target army becomes weary 1 until the start of your next turn.</p>\n<p><strong>Critical Failure</strong> Your attack deals no damage to the target army, which is emboldened by your failed attempt at dirty fighting. This reduces the target army's weary value by 1.</p>"
+                    "value": "<p><strong>Requirement</strong> @UUID[Compendium.pf2e.kingmaker-features.Item.Flexible Tactics]</p>\n<hr />\n<p>Your army uses trickery, deception, and unfair tactics to attempt a devastating attack against an outflanked army. Attempt a melee Strike or a ranged Strike against the AC of a target outflanked army that is not distant.</p>\n<p><strong>Critical Success</strong> The target army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Weary]{Weary 2} until the start of your next turn.</p>\n<p><strong>Success</strong> The target army becomes weary 1 until the start of your next turn.</p>\n<p><strong>Critical Failure</strong> Your attack deals no damage to the target army, which is emboldened by your failed attempt at dirty fighting. This reduces the target army's weary value by 1.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -910,7 +891,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p><strong>Requirement</strong>@UUID[Compendium.pf2e.kingmaker-features.Item.Focused Devotion]</p>\n<hr />\n<p>Your army attempts to frighten and cow an enemy army. Attempt a @Check[morale|defense:morale] check against the target army.</p>\n<p><strong>Critical Success</strong> The target army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken]{Shaken 2} until the start of your next turn.</p>\n<p><strong>Success</strong> The target army becomes shaken 1 until the start of your next turn.</p>\n<p><strong>Critical Failure</strong> Your failed attempt bolsters the enemy's spirits. This reduces the target army's shaken value by 1.</p>"
+                    "value": "<p><strong>Requirement</strong>@UUID[Compendium.pf2e.kingmaker-features.Item.Focused Devotion]</p>\n<hr />\n<p>Your army attempts to frighten and cow an enemy army. Attempt a @Check[morale|defense:morale|roller:self] check against the target army.</p>\n<p><strong>Critical Success</strong> The target army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken]{Shaken 2} until the start of your next turn.</p>\n<p><strong>Success</strong> The target army becomes shaken 1 until the start of your next turn.</p>\n<p><strong>Critical Failure</strong> Your failed attempt bolsters the enemy's spirits. This reduces the target army's shaken value by 1.</p>"
                 },
                 "location": null,
                 "prerequisites": {

--- a/packs/kingmaker-bestiary/armies/narlmarch-hunters.json
+++ b/packs/kingmaker-bestiary/armies/narlmarch-hunters.json
@@ -24,7 +24,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a Morale check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
+                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a @Check[type:morale|defense:morale|roller:self] check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -67,7 +67,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<p>Your army tries to escape from the battlefield.</p>\n<p>If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed].</p>\n<p>Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
+                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<hr />\n<p>Your army tries to escape from the battlefield. If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed]. Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -108,7 +108,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a Maneuver check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
+                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a @Check[type:maneuver|defense:maneuver|roller:self] check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -142,7 +142,6 @@
             "name": "Guard",
             "sort": 0,
             "system": {
-                "-=level": null,
                 "actionType": {
                     "value": "action"
                 },
@@ -152,7 +151,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a Maneuver check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
+                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a @Check[type:maneuver|defense:maneuver|roller:self] check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p>@UUID[Compendium.pf2e.kingmaker-features.Item.Effect: Guard (Critical Success)]</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p>@UUID[Compendium.pf2e.kingmaker-features.Item.Effect: Guard (Success)]</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -163,25 +162,7 @@
                     "remaster": false,
                     "title": "Pathfinder Kingmaker"
                 },
-                "rules": [
-                    {
-                        "key": "FlatModifier",
-                        "label": "Guarded",
-                        "predicate": [
-                            "guarded-critical"
-                        ],
-                        "selector": "ac",
-                        "type": "item",
-                        "value": 2
-                    },
-                    {
-                        "domain": "ac",
-                        "key": "RollOption",
-                        "label": "Guarded (Critical Success)",
-                        "option": "guarded-critical",
-                        "toggleable": true
-                    }
-                ],
+                "rules": [],
                 "slug": "guard",
                 "traits": {
                     "rarity": "common",
@@ -256,7 +237,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a Maneuver check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
+                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a @Check[type:maneuver|defense:maneuver|roller:self] check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
                 },
                 "location": null,
                 "prerequisites": {

--- a/packs/kingmaker-bestiary/armies/narlmarch-hunters.json
+++ b/packs/kingmaker-bestiary/armies/narlmarch-hunters.json
@@ -1,0 +1,481 @@
+{
+    "_id": "EM8SeGIwho2W1EMX",
+    "folder": "BRkIyvmgOgyA2kq7",
+    "img": "systems/pf2e/icons/default-icons/army.svg",
+    "items": [
+        {
+            "_id": "DzE7Ak5Wa6ZNrS2U",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.8XXylMGJuqe1ozMk"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Rally",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a Morale check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "rally",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "morale"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "agTytKqXthSBLPyU",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.IhjlbJinff1wUSjL"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/ThreeActions.webp",
+            "name": "Retreat",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 3
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<p>Your army tries to escape from the battlefield.</p>\n<p>If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed].</p>\n<p>Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "retreat",
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "yzEpwKcdcuEjK3OT",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.Pu5bptxLrKFyEzFh"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Disengage",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a Maneuver check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "disengage",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "GJgxw57AoY9F4gz8",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.phtwOol1wETryF7b"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Guard",
+            "sort": 0,
+            "system": {
+                "-=level": null,
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a Maneuver check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "label": "Guarded",
+                        "predicate": [
+                            "guarded-critical"
+                        ],
+                        "selector": "ac",
+                        "type": "item",
+                        "value": 2
+                    },
+                    {
+                        "domain": "ac",
+                        "key": "RollOption",
+                        "label": "Guarded (Critical Success)",
+                        "option": "guarded-critical",
+                        "toggleable": true
+                    }
+                ],
+                "slug": "guard",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "cdUU5qBOCBri8NCy",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.qCxyuNhzaaYlYBum"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Battle",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attacks an enemy army with a Strike against the enemy army's AC. You can do so with a melee Strike only if you are @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with the target army. Otherwise, you must use a ranged Strike.</p>\n<p>An army can attempt a maximum of 5 ranged Strikes per war encounter (unless it has the @UUID[Compendium.pf2e.kingmaker-features.Item.Increased Ammunition] tactic). As with any attack, multiple Strikes in a single round suffer a multiple attack penalty.</p>\n<p>A siege engine can use the Battle action to attack and damage a fortification.</p>\n<p><strong>Critical Success</strong> You deal 2 points of damage to the army.</p>\n<p><strong>Success</strong> You deal 1 point of damage to the army.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "battle",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "attack"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "94bR9nxbJRpYhGiI",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.wHoXoyci1lddRR2R"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Advance",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a Maneuver check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "advance",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "uyQLjXUU5UdUafiQ",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.DrUT5sE0EuU5dtPa"
+                }
+            },
+            "folder": "e185cDQaLjU3uZ62",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Increased Ammunition",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p>You increase the number of times your army can use ranged Strikes in each war encounter by 2. This tactic can be taken multiple times; each time you do so, increase the army's maximum number of ranged Strikes by 2.</p>"
+                },
+                "level": {
+                    "value": 5
+                },
+                "location": "0",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "add",
+                        "path": "system.resources.ammunition.max",
+                        "value": 2
+                    }
+                ],
+                "slug": "increased-ammunition",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "cavalry",
+                        "infantry",
+                        "siege",
+                        "skirmisher"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "wqsQjbcWjRcqJ0jJ",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.lcNZMlMNPUrnMgQ2"
+                }
+            },
+            "folder": "e185cDQaLjU3uZ62",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Sharpshooter",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p>The commander drills the army in precision ranged attacks. You gain a +1 status bonus on attacks with ranged Strikes, but suffer a –2 status bonus on attacks with melee Strikes. At 9th level, the penalty to melee Strikes is reduced to –1, and at 15th level the penalty to melee Strikes is removed.</p>\n<p>The army can use the @UUID[Compendium.pf2e.kingmaker-features.Item.Covering Fire] tactical war action.</p>"
+                },
+                "level": {
+                    "value": 5
+                },
+                "location": "1",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [
+                    {
+                        "key": "GrantItem",
+                        "uuid": "Compendium.pf2e.kingmaker-features.Item.Covering Fire"
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "selector": "ranged-attack-roll",
+                        "type": "status",
+                        "value": 1
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "selector": "melee-attack-roll",
+                        "type": "status",
+                        "value": {
+                            "brackets": [
+                                {
+                                    "end": 8,
+                                    "start": 1,
+                                    "value": -2
+                                },
+                                {
+                                    "end": 14,
+                                    "start": 9,
+                                    "value": -1
+                                },
+                                {
+                                    "start": 15,
+                                    "value": 0
+                                }
+                            ],
+                            "field": "actor|level"
+                        }
+                    }
+                ],
+                "slug": "sharpshooter",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "cavalry",
+                        "infantry",
+                        "skirmisher"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        }
+    ],
+    "name": "Narlmarch Hunters",
+    "prototypeToken": {
+        "name": "Tatzlford Town Guard"
+    },
+    "system": {
+        "ac": {
+            "potency": 0,
+            "value": 24
+        },
+        "attributes": {
+            "hp": {
+                "max": 4,
+                "routThreshold": 2,
+                "value": 4
+            }
+        },
+        "consumption": 1,
+        "details": {
+            "alignment": "NG",
+            "blurb": "",
+            "description": "<p>This army is a band of hunters and trappers who have gathered into a ragtag group of archers led by Mayor Loy Rezbin.</p>",
+            "level": {
+                "value": 6
+            }
+        },
+        "recruitmentDC": null,
+        "resources": {
+            "ammunition": {
+                "max": 5,
+                "value": 7
+            },
+            "potions": {
+                "value": 0
+            }
+        },
+        "saves": {
+            "maneuver": 17,
+            "morale": 11
+        },
+        "scouting": 14,
+        "traits": {
+            "rarity": "common",
+            "size": {
+                "value": "med"
+            },
+            "type": "skirmisher",
+            "value": []
+        },
+        "weapons": {
+            "melee": {
+                "name": "Hatchets and shortswords",
+                "potency": 0
+            },
+            "ranged": {
+                "name": "Longbows",
+                "potency": 0
+            }
+        }
+    },
+    "type": "army"
+}

--- a/packs/kingmaker-bestiary/armies/pitax-horde.json
+++ b/packs/kingmaker-bestiary/armies/pitax-horde.json
@@ -1,0 +1,625 @@
+{
+    "_id": "EJ0a2F8Z01HfeFy9",
+    "folder": "BRkIyvmgOgyA2kq7",
+    "img": "systems/pf2e/icons/default-icons/army.svg",
+    "items": [
+        {
+            "_id": "Jd1g3ovpiC39CYRk",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.8XXylMGJuqe1ozMk"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Rally",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a Morale check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "rally",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "morale"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "1egfYGFDnAX5opwc",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.IhjlbJinff1wUSjL"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/ThreeActions.webp",
+            "name": "Retreat",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 3
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<p>Your army tries to escape from the battlefield.</p>\n<p>If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed].</p>\n<p>Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "retreat",
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "A5deiJajssYXsGeB",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.Pu5bptxLrKFyEzFh"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Disengage",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a Maneuver check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "disengage",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "pF7BiYB0G1hNsXek",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.phtwOol1wETryF7b"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Guard",
+            "sort": 0,
+            "system": {
+                "-=level": null,
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a Maneuver check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "label": "Guarded",
+                        "predicate": [
+                            "guarded-critical"
+                        ],
+                        "selector": "ac",
+                        "type": "item",
+                        "value": 2
+                    },
+                    {
+                        "domain": "ac",
+                        "key": "RollOption",
+                        "label": "Guarded (Critical Success)",
+                        "option": "guarded-critical",
+                        "toggleable": true
+                    }
+                ],
+                "slug": "guard",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "AutD88eYafZX1wQW",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.qCxyuNhzaaYlYBum"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Battle",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attacks an enemy army with a Strike against the enemy army's AC. You can do so with a melee Strike only if you are @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with the target army. Otherwise, you must use a ranged Strike.</p>\n<p>An army can attempt a maximum of 5 ranged Strikes per war encounter (unless it has the @UUID[Compendium.pf2e.kingmaker-features.Item.Increased Ammunition] tactic). As with any attack, multiple Strikes in a single round suffer a multiple attack penalty.</p>\n<p>A siege engine can use the Battle action to attack and damage a fortification.</p>\n<p><strong>Critical Success</strong> You deal 2 points of damage to the army.</p>\n<p><strong>Success</strong> You deal 1 point of damage to the army.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "battle",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "attack"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "rGxlncNMXLVMXZ6s",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.wHoXoyci1lddRR2R"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Advance",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a Maneuver check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "advance",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "OXLVr0p2vK6WnR8C",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.sdwSrVfu9yG1uwio"
+                }
+            },
+            "folder": "e185cDQaLjU3uZ62",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Live off the Land",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p>The army is trained to be self-sufficient and sustains itself via hunting and gathering when they're in the wild. If during a Kingdom turn's Upkeep phase this army is located in a hex that doesn't include a settlement, and if the army is not garrisoned, it reduces its Consumption by 1.</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": "0",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [
+                    {
+                        "key": "RollOption",
+                        "label": "PF2E.Kingmaker.Army.Toggles.LiveOffTheLand",
+                        "option": "live-off-the-land",
+                        "priority": 1,
+                        "toggleable": true,
+                        "value": true
+                    },
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "add",
+                        "path": "system.consumption",
+                        "predicate": [
+                            "live-off-the-land"
+                        ],
+                        "value": -1
+                    }
+                ],
+                "slug": "live-off-the-land",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "cavalry",
+                        "infantry",
+                        "skirmisher"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "loV9bkQRMcG5lT8f",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.IiD3kKszFfHZ9cZ1"
+                }
+            },
+            "folder": "e185cDQaLjU3uZ62",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Toughened Soldiers",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p>The army is particularly hardy. Increase its maximum Hit Points by 1. You can take this tactic multiple times; each time you do, increase the army's maximum Hit Points by 1.</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": "1",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "add",
+                        "path": "system.attributes.hp.max",
+                        "value": 1
+                    }
+                ],
+                "slug": "toughened-soldiers",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "cavalry",
+                        "infantry",
+                        "siege",
+                        "skirmisher"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "RIn3bxyfP41ZVDI7",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.QRwIcmCEHpDQm9DO"
+                },
+                "pf2e": {
+                    "itemGrants": {
+                        "allOutAssault": {
+                            "id": "OrIi052QUBcxEZcU",
+                            "onDelete": "detach"
+                        }
+                    }
+                }
+            },
+            "folder": "e185cDQaLjU3uZ62",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Merciless",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p>This army is difficult to escape from. The army's Mobility DC gains a +2 status bonus when other armies attempt Mobility checks against it while attempting to Disengage.</p>\n<p>This army can use the @UUID[Compendium.pf2e.kingmaker-features.Item.All-Out Assault] tactical war action.</p>"
+                },
+                "level": {
+                    "value": 5
+                },
+                "location": "2",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [
+                    {
+                        "flag": "allOutAssault",
+                        "key": "GrantItem",
+                        "uuid": "Compendium.pf2e.kingmaker-features.Item.All-Out Assault"
+                    }
+                ],
+                "slug": "merciless",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "cavalry",
+                        "infantry"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "OrIi052QUBcxEZcU",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.Z6jMZgAxI1zRO7Sl"
+                },
+                "pf2e": {
+                    "grantedBy": {
+                        "id": "RIn3bxyfP41ZVDI7",
+                        "onDelete": "cascade"
+                    }
+                }
+            },
+            "folder": "i18YzT3zo3skuWng",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "All-Out Assault",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p><strong>Requirement</strong> @UUID[Compendium.pf2e.kingmaker-features.Item.Merciless]</p>\n<p>Your army attacks with frightening vigor. Attempt a melee Strike against an enemy army's AC. Critical Success Your army inflicts 3 points of damage to the target army. If your army's next war action this turn is an attack war action against a different target army, you gain a +1 circumstance bonus to the Strike as your fury continues to the new target. Success Your army deals 2 points of damage to the target army. Failure Your army falters, but still deals 1 point of damage to the target army. Critical Failure Your army deals no damage to the target army and becomes outflanked until the start of its next turn.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "all-out-assault",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "attack",
+                        "cavalry",
+                        "infantry"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "tQazZSr74WnjIerz",
+            "flags": {
+                "core": {
+                    "sourceId": "Item.XRvL4gA2lCMx4Bqf"
+                }
+            },
+            "folder": "pnkpw6p0Fx3fHK0x",
+            "img": "icons/skills/movement/arrow-upward-white.webp",
+            "name": "Home Advantage (Area GL2)",
+            "sort": 0,
+            "system": {
+                "description": {
+                    "value": "<p>The Pitax Horde knows the open plains and rolling dells of of this area well, and can use the terrain to their advantage if they are attacked here. They <span style=\"font-family:var(--font-primary);font-size:var(--font-size-14)\">gain a +2 bonus to Maneuver and +3 bonus to Scouting while in area GL2. </span></p>\n<hr />\n<p><em><span style=\"font-family:var(--font-primary);font-size:var(--font-size-14)\"><strong>Note</strong>: This effect automates the above bonuses. Remove it if the Pitax Horde are found elsewhere.</span></em></p>"
+                },
+                "duration": {
+                    "expiry": null,
+                    "sustained": false,
+                    "unit": "unlimited",
+                    "value": -1
+                },
+                "level": {
+                    "value": 10
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "selector": "scouting-check",
+                        "value": 3
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "selector": "maneuver-check",
+                        "value": 2
+                    }
+                ],
+                "slug": null,
+                "start": {
+                    "initiative": null,
+                    "value": 0
+                },
+                "tokenIcon": {
+                    "show": false
+                },
+                "traits": {
+                    "value": []
+                }
+            },
+            "type": "effect"
+        }
+    ],
+    "name": "Pitax Horde",
+    "system": {
+        "ac": {
+            "potency": 0,
+            "value": 30
+        },
+        "attributes": {
+            "hp": {
+                "max": 4,
+                "routThreshold": 2,
+                "value": 5
+            }
+        },
+        "consumption": null,
+        "details": {
+            "alignment": "CN",
+            "blurb": "",
+            "description": "<p>The Pitax Horde consists of human warriors from seven different minor clans in Glenebon.</p>",
+            "level": {
+                "value": 10
+            }
+        },
+        "recruitmentDC": null,
+        "resources": {
+            "ammunition": {
+                "max": 5,
+                "value": 5
+            },
+            "potions": {
+                "value": 0
+            }
+        },
+        "saves": {
+            "maneuver": 22,
+            "morale": 16
+        },
+        "scouting": 19,
+        "traits": {
+            "rarity": "common",
+            "size": {
+                "value": "med"
+            },
+            "type": "infantry",
+            "value": []
+        },
+        "weapons": {
+            "melee": {
+                "name": "Greater magic axes",
+                "potency": 2
+            },
+            "ranged": null
+        }
+    },
+    "type": "army"
+}

--- a/packs/kingmaker-bestiary/armies/pitax-horde.json
+++ b/packs/kingmaker-bestiary/armies/pitax-horde.json
@@ -24,7 +24,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a Morale check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
+                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a @Check[type:morale|defense:morale|roller:self] check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -67,7 +67,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<p>Your army tries to escape from the battlefield.</p>\n<p>If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed].</p>\n<p>Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
+                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<hr />\n<p>Your army tries to escape from the battlefield. If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed]. Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -108,7 +108,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a Maneuver check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
+                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a @Check[type:maneuver|defense:maneuver|roller:self] check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -142,7 +142,6 @@
             "name": "Guard",
             "sort": 0,
             "system": {
-                "-=level": null,
                 "actionType": {
                     "value": "action"
                 },
@@ -152,7 +151,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a Maneuver check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
+                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a @Check[type:maneuver|defense:maneuver|roller:self] check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p>@UUID[Compendium.pf2e.kingmaker-features.Item.Effect: Guard (Critical Success)]</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p>@UUID[Compendium.pf2e.kingmaker-features.Item.Effect: Guard (Success)]</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -163,25 +162,7 @@
                     "remaster": false,
                     "title": "Pathfinder Kingmaker"
                 },
-                "rules": [
-                    {
-                        "key": "FlatModifier",
-                        "label": "Guarded",
-                        "predicate": [
-                            "guarded-critical"
-                        ],
-                        "selector": "ac",
-                        "type": "item",
-                        "value": 2
-                    },
-                    {
-                        "domain": "ac",
-                        "key": "RollOption",
-                        "label": "Guarded (Critical Success)",
-                        "option": "guarded-critical",
-                        "toggleable": true
-                    }
-                ],
+                "rules": [],
                 "slug": "guard",
                 "traits": {
                     "rarity": "common",
@@ -256,7 +237,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a Maneuver check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
+                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a @Check[type:maneuver|defense:maneuver|roller:self] check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -488,7 +469,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p><strong>Requirement</strong> @UUID[Compendium.pf2e.kingmaker-features.Item.Merciless]</p>\n<p>Your army attacks with frightening vigor. Attempt a melee Strike against an enemy army's AC. Critical Success Your army inflicts 3 points of damage to the target army. If your army's next war action this turn is an attack war action against a different target army, you gain a +1 circumstance bonus to the Strike as your fury continues to the new target. Success Your army deals 2 points of damage to the target army. Failure Your army falters, but still deals 1 point of damage to the target army. Critical Failure Your army deals no damage to the target army and becomes outflanked until the start of its next turn.</p>"
+                    "value": "<p><strong>Requirement</strong> @UUID[Compendium.pf2e.kingmaker-features.Item.Merciless]</p>\n<hr />\n<p>Your army attacks with frightening vigor. Attempt a melee Strike against an enemy army's AC.</p>\n<p><strong>Critical Success</strong> Your army inflicts @Damage[3|domains:melee-damage,strike-damage] points of damage to the target army. If your army's next war action this turn is an attack war action against a different target army, you gain a +1 circumstance bonus to the Strike as your fury continues to the new target.</p>\n<p><strong>Success</strong> Your army deals @Damage[2|domains:melee-damage,strike-damage] points of damage to the target army.</p>\n<p><strong>Failure</strong> Your army falters, but still deals @Damage[1|domains:melee-damage,strike-damage] point of damage to the target army.</p>\n<p><strong>Critical Failure</strong> Your army deals no damage to the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Outflanked] until the start of its next turn.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -499,7 +480,25 @@
                     "remaster": false,
                     "title": "Pathfinder Kingmaker"
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "domain": "attack-roll",
+                        "key": "RollOption",
+                        "label": "All-Out Assault Followup Attack (Crit Success)",
+                        "option": "all-out-assault-followup",
+                        "toggleable": true
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "label": "All-Out Assault Followup (Crit Success)",
+                        "predicate": [
+                            "all-out-assault-followup"
+                        ],
+                        "selector": "attack-roll",
+                        "type": "circumstance",
+                        "value": 1
+                    }
+                ],
                 "slug": "all-out-assault",
                 "traits": {
                     "rarity": "common",

--- a/packs/kingmaker-bestiary/armies/pitax-war-machines.json
+++ b/packs/kingmaker-bestiary/armies/pitax-war-machines.json
@@ -1,0 +1,614 @@
+{
+    "_id": "mCUB9NQUkbEayP7d",
+    "folder": "BRkIyvmgOgyA2kq7",
+    "img": "systems/pf2e/icons/default-icons/army.svg",
+    "items": [
+        {
+            "_id": "Jd1g3ovpiC39CYRk",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.8XXylMGJuqe1ozMk"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Rally",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a Morale check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "rally",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "morale"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "1egfYGFDnAX5opwc",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.IhjlbJinff1wUSjL"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/ThreeActions.webp",
+            "name": "Retreat",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 3
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<p>Your army tries to escape from the battlefield.</p>\n<p>If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed].</p>\n<p>Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "retreat",
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "A5deiJajssYXsGeB",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.Pu5bptxLrKFyEzFh"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Disengage",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a Maneuver check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "disengage",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "pF7BiYB0G1hNsXek",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.phtwOol1wETryF7b"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Guard",
+            "sort": 0,
+            "system": {
+                "-=level": null,
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a Maneuver check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "label": "Guarded",
+                        "predicate": [
+                            "guarded-critical"
+                        ],
+                        "selector": "ac",
+                        "type": "item",
+                        "value": 2
+                    },
+                    {
+                        "domain": "ac",
+                        "key": "RollOption",
+                        "label": "Guarded (Critical Success)",
+                        "option": "guarded-critical",
+                        "toggleable": true
+                    }
+                ],
+                "slug": "guard",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "AutD88eYafZX1wQW",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.qCxyuNhzaaYlYBum"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Battle",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attacks an enemy army with a Strike against the enemy army's AC. You can do so with a melee Strike only if you are @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with the target army. Otherwise, you must use a ranged Strike.</p>\n<p>An army can attempt a maximum of 5 ranged Strikes per war encounter (unless it has the @UUID[Compendium.pf2e.kingmaker-features.Item.Increased Ammunition] tactic). As with any attack, multiple Strikes in a single round suffer a multiple attack penalty.</p>\n<p>A siege engine can use the Battle action to attack and damage a fortification.</p>\n<p><strong>Critical Success</strong> You deal 2 points of damage to the army.</p>\n<p><strong>Success</strong> You deal 1 point of damage to the army.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "battle",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "attack"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "rGxlncNMXLVMXZ6s",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.wHoXoyci1lddRR2R"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Advance",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a Maneuver check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "advance",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "3b2RJnJKoGKlvWfq",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.DrUT5sE0EuU5dtPa"
+                }
+            },
+            "folder": "e185cDQaLjU3uZ62",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Increased Ammunition",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p>You increase the number of times your army can use ranged Strikes in each war encounter by 2. This tactic can be taken multiple times; each time you do so, increase the army's maximum number of ranged Strikes by 2.</p>"
+                },
+                "level": {
+                    "value": 5
+                },
+                "location": "0",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "add",
+                        "path": "system.resources.ammunition.max",
+                        "value": 2
+                    }
+                ],
+                "slug": "increased-ammunition",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "cavalry",
+                        "infantry",
+                        "siege",
+                        "skirmisher"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "d5x6WrErWAOeUlLO",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.ZSUPsqeMBDTaX2H4"
+                },
+                "pf2e": {
+                    "itemGrants": {
+                        "overwhelmingBombardment": {
+                            "id": "4VhEvG7Plwz0Wszk",
+                            "onDelete": "detach"
+                        }
+                    }
+                }
+            },
+            "folder": "e185cDQaLjU3uZ62",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Explosive Shot",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p>The army's ranged attacks explode and spray fire, shrapnel, or other damaging material in every direction. Whenever the army critically hits a non-distant army with a ranged Strike, inflict 1 point of additional damage to another non-distant enemy army of your choice. You can use the @UUID[Compendium.pf2e.kingmaker-features.Item.Overwhelming Bombardment] tactical war action with the army.</p>"
+                },
+                "level": {
+                    "value": 11
+                },
+                "location": "1",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [
+                    {
+                        "flag": "overwhelmingBombardment",
+                        "key": "GrantItem",
+                        "uuid": "Compendium.pf2e.kingmaker-features.Item.Overwhelming Bombardment"
+                    }
+                ],
+                "slug": "explosive-shot",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "siege"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "4VhEvG7Plwz0Wszk",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.HLu1o1RzCZxWjOJJ"
+                },
+                "pf2e": {
+                    "grantedBy": {
+                        "id": "d5x6WrErWAOeUlLO",
+                        "onDelete": "cascade"
+                    }
+                }
+            },
+            "folder": "i18YzT3zo3skuWng",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Overwhelming Bombardment",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p><strong>Requirement</strong>@UUID[Compendium.pf2e.kingmaker-features.Item.Explosive Shot]</p>\n<hr />\n<p>Your siege engines focus all their fire on a fortification. This war action counts as using two ranged Strikes for the purposes of depleting an army's shots. Attempt a ranged Strike against the target fortification's AC.</p>\n<p><strong>Critical Success</strong> You deal 2 points of damage to the fortification. You also deal 1 point of damage to up to two armies of your choice that are within the fortification.</p>\n<p><strong>Success</strong> You deal 1 point of damage to the fortification, and an additional 1 point of damage either to the fortification or to an army within the fortification (your choice of which).</p>\n<p><strong>Failure</strong> You deal 1 damage to the fortification.</p>\n<p><strong>Critical Failure</strong> You deal no damage, and your army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Outflanked] until the start of its next turn.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "overwhelming-bombardment",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "attack",
+                        "siege"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "8MX7QPWvOAspWNmN",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.IiD3kKszFfHZ9cZ1"
+                }
+            },
+            "folder": "e185cDQaLjU3uZ62",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Toughened Soldiers",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p>The army is particularly hardy. Increase its maximum Hit Points by 1. You can take this tactic multiple times; each time you do, increase the army's maximum Hit Points by 1.</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": "2",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "add",
+                        "path": "system.attributes.hp.max",
+                        "value": 1
+                    }
+                ],
+                "slug": "toughened-soldiers",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "cavalry",
+                        "infantry",
+                        "siege",
+                        "skirmisher"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "WzQrGDUWVBV0XU2r",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.IiD3kKszFfHZ9cZ1"
+                }
+            },
+            "folder": "e185cDQaLjU3uZ62",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Toughened Soldiers",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p>The army is particularly hardy. Increase its maximum Hit Points by 1. You can take this tactic multiple times; each time you do, increase the army's maximum Hit Points by 1.</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": "3",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "add",
+                        "path": "system.attributes.hp.max",
+                        "value": 1
+                    }
+                ],
+                "slug": "toughened-soldiers",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "cavalry",
+                        "infantry",
+                        "siege",
+                        "skirmisher"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        }
+    ],
+    "name": "Pitax War Machines",
+    "system": {
+        "ac": {
+            "potency": 0,
+            "value": 36
+        },
+        "attributes": {
+            "hp": {
+                "max": 6,
+                "routThreshold": 4,
+                "value": 8
+            }
+        },
+        "consumption": null,
+        "details": {
+            "alignment": "CN",
+            "blurb": "",
+            "description": "<p>These siege weapons are positioned atop all of the city’s watchtowers and afford a controlling view of all approaches.</p>",
+            "level": {
+                "value": 14
+            }
+        },
+        "recruitmentDC": null,
+        "resources": {
+            "ammunition": {
+                "max": 5,
+                "value": 7
+            },
+            "potions": {
+                "value": 0
+            }
+        },
+        "saves": {
+            "maneuver": 22,
+            "morale": 28
+        },
+        "scouting": 25,
+        "traits": {
+            "rarity": "common",
+            "size": {
+                "value": "med"
+            },
+            "type": "siege",
+            "value": []
+        },
+        "weapons": {
+            "melee": null,
+            "ranged": {
+                "name": "Siege Engine",
+                "potency": 0
+            }
+        }
+    },
+    "type": "army"
+}

--- a/packs/kingmaker-bestiary/armies/pitax-war-machines.json
+++ b/packs/kingmaker-bestiary/armies/pitax-war-machines.json
@@ -24,7 +24,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a Morale check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
+                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a @Check[type:morale|defense:morale|roller:self] check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -67,7 +67,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<p>Your army tries to escape from the battlefield.</p>\n<p>If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed].</p>\n<p>Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
+                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<hr />\n<p>Your army tries to escape from the battlefield. If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed]. Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -108,7 +108,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a Maneuver check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
+                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a @Check[type:maneuver|defense:maneuver|roller:self] check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -142,7 +142,6 @@
             "name": "Guard",
             "sort": 0,
             "system": {
-                "-=level": null,
                 "actionType": {
                     "value": "action"
                 },
@@ -152,7 +151,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a Maneuver check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
+                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a @Check[type:maneuver|defense:maneuver|roller:self] check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p>@UUID[Compendium.pf2e.kingmaker-features.Item.Effect: Guard (Critical Success)]</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p>@UUID[Compendium.pf2e.kingmaker-features.Item.Effect: Guard (Success)]</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -163,25 +162,7 @@
                     "remaster": false,
                     "title": "Pathfinder Kingmaker"
                 },
-                "rules": [
-                    {
-                        "key": "FlatModifier",
-                        "label": "Guarded",
-                        "predicate": [
-                            "guarded-critical"
-                        ],
-                        "selector": "ac",
-                        "type": "item",
-                        "value": 2
-                    },
-                    {
-                        "domain": "ac",
-                        "key": "RollOption",
-                        "label": "Guarded (Critical Success)",
-                        "option": "guarded-critical",
-                        "toggleable": true
-                    }
-                ],
+                "rules": [],
                 "slug": "guard",
                 "traits": {
                     "rarity": "common",
@@ -256,7 +237,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a Maneuver check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
+                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a @Check[type:maneuver|defense:maneuver|roller:self] check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
                 },
                 "location": null,
                 "prerequisites": {

--- a/packs/kingmaker-bestiary/armies/pitaxian-raiders.json
+++ b/packs/kingmaker-bestiary/armies/pitaxian-raiders.json
@@ -1,0 +1,624 @@
+{
+    "_id": "pz4U2u7oUA76JlJm",
+    "folder": "BRkIyvmgOgyA2kq7",
+    "img": "systems/pf2e/icons/default-icons/army.svg",
+    "items": [
+        {
+            "_id": "AFiSCPFFjsYxIH3m",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.8XXylMGJuqe1ozMk"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Rally",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a Morale check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "rally",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "morale"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "bNkyOTbuKDkP6wgW",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.IhjlbJinff1wUSjL"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/ThreeActions.webp",
+            "name": "Retreat",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 3
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<p>Your army tries to escape from the battlefield.</p>\n<p>If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed].</p>\n<p>Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "retreat",
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "0jmdIWvjcmNB6B01",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.Pu5bptxLrKFyEzFh"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Disengage",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a Maneuver check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "disengage",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "UjWbWvBMtBetoh1e",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.phtwOol1wETryF7b"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Guard",
+            "sort": 0,
+            "system": {
+                "-=level": null,
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a Maneuver check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "label": "Guarded",
+                        "predicate": [
+                            "guarded-critical"
+                        ],
+                        "selector": "ac",
+                        "type": "item",
+                        "value": 2
+                    },
+                    {
+                        "domain": "ac",
+                        "key": "RollOption",
+                        "label": "Guarded (Critical Success)",
+                        "option": "guarded-critical",
+                        "toggleable": true
+                    }
+                ],
+                "slug": "guard",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "l6RL5yMj08ePlOnM",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.qCxyuNhzaaYlYBum"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Battle",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attacks an enemy army with a Strike against the enemy army's AC. You can do so with a melee Strike only if you are @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with the target army. Otherwise, you must use a ranged Strike.</p>\n<p>An army can attempt a maximum of 5 ranged Strikes per war encounter (unless it has the @UUID[Compendium.pf2e.kingmaker-features.Item.Increased Ammunition] tactic). As with any attack, multiple Strikes in a single round suffer a multiple attack penalty.</p>\n<p>A siege engine can use the Battle action to attack and damage a fortification.</p>\n<p><strong>Critical Success</strong> You deal 2 points of damage to the army.</p>\n<p><strong>Success</strong> You deal 1 point of damage to the army.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "battle",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "attack"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "5dkDomPSXIRjbLwc",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.wHoXoyci1lddRR2R"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Advance",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a Maneuver check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "advance",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "SfS5ne2W6a9yHBl4",
+            "flags": {
+                "core": {
+                    "sourceId": "Item.FG2BifRmaZ54fxhS"
+                },
+                "pf2e": {
+                    "itemGrants": {
+                        "counterattack": {
+                            "id": "yDbd3BCYbZULuTwC",
+                            "onDelete": "detach"
+                        },
+                        "dirtyFighting": {
+                            "id": "N2toa3SxsMdrC0ni",
+                            "onDelete": "detach"
+                        },
+                        "feint": {
+                            "id": "ZdBXSPvHn6OklfJm",
+                            "onDelete": "detach"
+                        }
+                    }
+                }
+            },
+            "folder": "r0oRLqAxCBP3VxTz",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Pitaxian Training",
+            "sort": 100000,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p>The Pitaxian Raiders can use the @UUID[Compendium.pf2e.kingmaker-features.Item.Counterattack], @UUID[Compendium.pf2e.kingmaker-features.Item.Dirty Fighting], and @UUID[Compendium.pf2e.kingmaker-features.Item.Feint] tactical actions.</p>"
+                },
+                "level": {
+                    "value": 12
+                },
+                "location": "0",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [
+                    {
+                        "flag": "counterattack",
+                        "key": "GrantItem",
+                        "uuid": "Compendium.pf2e.kingmaker-features.Item.Counterattack"
+                    },
+                    {
+                        "flag": "dirtyFighting",
+                        "key": "GrantItem",
+                        "uuid": "Compendium.pf2e.kingmaker-features.Item.Dirty Fighting"
+                    },
+                    {
+                        "flag": "feint",
+                        "key": "GrantItem",
+                        "uuid": "Compendium.pf2e.kingmaker-features.Item.Feint"
+                    }
+                ],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "yDbd3BCYbZULuTwC",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.8wjiF3ctXUjP9oyX"
+                },
+                "pf2e": {
+                    "grantedBy": {
+                        "id": "SfS5ne2W6a9yHBl4",
+                        "onDelete": "cascade"
+                    }
+                }
+            },
+            "folder": "i18YzT3zo3skuWng",
+            "img": "systems/pf2e/icons/actions/Reaction.webp",
+            "name": "Counterattack",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "reaction"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Requirement Flexible Tactics Trigger An army you are engaged with attempts a maneuver war action. Your army lashes out at the foe as they attempt to perform a maneuver. Attempt a melee Strike against the triggering army's AC. Counterattack doesn't count toward your multiple attack penalty, and your multiple attack penalty doesn't apply to this Strike. Critical Success You inflict 1 point of damage on the army and increase its shaken condition value by 1. Success You inflict 1 point of damage on the army.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "counterattack",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "infantry",
+                        "skirmisher"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "N2toa3SxsMdrC0ni",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.G2eBcOnUHb3yT7JL"
+                },
+                "pf2e": {
+                    "grantedBy": {
+                        "id": "SfS5ne2W6a9yHBl4",
+                        "onDelete": "cascade"
+                    }
+                }
+            },
+            "folder": "i18YzT3zo3skuWng",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Dirty Fighting",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Requirement Flexible Tactics Your army uses trickery, deception, and unfair tactics to attempt a devastating attack against an outflanked army. Attempt a melee Strike or a ranged Strike against the AC of a target outflanked army that is not distant. Critical Success The target army becomes weary 2 until the start of your next turn. Success The target army becomes weary 1 until the start of your next turn. Critical Failure Your attack deals no damage to the target army, which is emboldened by your failed attempt at dirty fighting. This reduces the target army's weary value by 1.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "dirty-fighting",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "attack",
+                        "skirmisher"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "ZdBXSPvHn6OklfJm",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.Hi4LKGOKe6yMDOH5"
+                },
+                "pf2e": {
+                    "grantedBy": {
+                        "id": "SfS5ne2W6a9yHBl4",
+                        "onDelete": "cascade"
+                    }
+                }
+            },
+            "folder": "i18YzT3zo3skuWng",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Feint",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Requirement Flexible Tactics Your army launches a probing attack meant to trick the enemy into thinking you are attacking from one quarter while your real thrust comes elsewhere. Critical Success The target army's defenses are thrown off; it is outflanked until the end of your turn. Success The target army is fooled, but only momentarily. It is outflanked against the next melee Strike your army attempts against it before the end of your current turn. Critical Failure The enemy anticipates your feint and presses the advantage. You are outflanked by the target army until the end of your next turn.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "feint",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "attack",
+                        "infantry",
+                        "skirmisher"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "ESlSLDiToG3liLeC",
+            "flags": {
+                "core": {
+                    "sourceId": "Item.mHWGxMPebgifsdny"
+                }
+            },
+            "folder": "r0oRLqAxCBP3VxTz",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Plentiful Ammunition",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p><em><strong>Note</strong>: This tactic does not appear in the original text of Pathfinder: Kingmaker. It was created to serve as an explanation and source for some of the Pitaxian Raiders' unique modifiers which previously did not have a listed source, allowing the statistics you see here to match those used in the adventure.</em></p>\n<hr />\n<p>The well-supplied Pitaxian forces are not concerned with making every shot count. They have a -2 penalty to ranged strikes, but can carry additional ammunition, increasing the number of times they can use ranged Strikes in each war encounter by 2. This tactic does not count against the maximum number of tactics the Pitaxian Raiders can possess.</p>"
+                },
+                "level": {
+                    "value": 12
+                },
+                "location": "1",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "add",
+                        "path": "system.resources.ammunition.max",
+                        "value": 2
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "selector": [
+                            "ranged-attack-roll"
+                        ],
+                        "value": -2
+                    }
+                ],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        }
+    ],
+    "name": "Pitaxian Raiders",
+    "system": {
+        "ac": {
+            "potency": 0,
+            "value": 33
+        },
+        "attributes": {
+            "hp": {
+                "max": 4,
+                "routThreshold": 2,
+                "value": 4
+            }
+        },
+        "consumption": null,
+        "details": {
+            "alignment": "CN",
+            "blurb": "",
+            "description": "<p>The Pitaxian Raiders consist of a mix of Pitax city guards and mercenaries eager for battle.</p>",
+            "level": {
+                "value": 12
+            }
+        },
+        "recruitmentDC": null,
+        "resources": {
+            "ammunition": {
+                "max": 5,
+                "value": 7
+            },
+            "potions": {
+                "value": 0
+            }
+        },
+        "saves": {
+            "maneuver": 25,
+            "morale": 19
+        },
+        "scouting": 22,
+        "traits": {
+            "rarity": "common",
+            "size": {
+                "value": "med"
+            },
+            "type": "skirmisher",
+            "value": []
+        },
+        "weapons": {
+            "melee": {
+                "name": "Swords",
+                "potency": 0
+            },
+            "ranged": {
+                "name": "Longbows",
+                "potency": 0
+            }
+        }
+    },
+    "type": "army"
+}

--- a/packs/kingmaker-bestiary/armies/pitaxian-raiders.json
+++ b/packs/kingmaker-bestiary/armies/pitaxian-raiders.json
@@ -24,7 +24,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a Morale check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
+                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a @Check[type:morale|defense:morale|roller:self] check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -67,7 +67,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<p>Your army tries to escape from the battlefield.</p>\n<p>If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed].</p>\n<p>Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
+                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<hr />\n<p>Your army tries to escape from the battlefield. If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed]. Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -108,7 +108,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a Maneuver check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
+                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a @Check[type:maneuver|defense:maneuver|roller:self] check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -142,7 +142,6 @@
             "name": "Guard",
             "sort": 0,
             "system": {
-                "-=level": null,
                 "actionType": {
                     "value": "action"
                 },
@@ -152,7 +151,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a Maneuver check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
+                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a @Check[type:maneuver|defense:maneuver|roller:self] check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p>@UUID[Compendium.pf2e.kingmaker-features.Item.Effect: Guard (Critical Success)]</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p>@UUID[Compendium.pf2e.kingmaker-features.Item.Effect: Guard (Success)]</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -163,25 +162,7 @@
                     "remaster": false,
                     "title": "Pathfinder Kingmaker"
                 },
-                "rules": [
-                    {
-                        "key": "FlatModifier",
-                        "label": "Guarded",
-                        "predicate": [
-                            "guarded-critical"
-                        ],
-                        "selector": "ac",
-                        "type": "item",
-                        "value": 2
-                    },
-                    {
-                        "domain": "ac",
-                        "key": "RollOption",
-                        "label": "Guarded (Critical Success)",
-                        "option": "guarded-critical",
-                        "toggleable": true
-                    }
-                ],
+                "rules": [],
                 "slug": "guard",
                 "traits": {
                     "rarity": "common",
@@ -256,7 +237,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a Maneuver check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
+                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a @Check[type:maneuver|defense:maneuver|roller:self] check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -381,7 +362,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Requirement Flexible Tactics Trigger An army you are engaged with attempts a maneuver war action. Your army lashes out at the foe as they attempt to perform a maneuver. Attempt a melee Strike against the triggering army's AC. Counterattack doesn't count toward your multiple attack penalty, and your multiple attack penalty doesn't apply to this Strike. Critical Success You inflict 1 point of damage on the army and increase its shaken condition value by 1. Success You inflict 1 point of damage on the army.</p>"
+                    "value": "<p><strong>Requirement</strong> @UUID[Compendium.pf2e.kingmaker-features.Item.Flexible Tactics]</p>\n<p><strong>Trigger</strong> An army you are engaged with attempts a maneuver war action.</p>\n<hr />\n<p>Your army lashes out at the foe as they attempt to perform a maneuver. Attempt a melee Strike against the triggering army's AC. Counterattack doesn't count toward your multiple attack penalty, and your multiple attack penalty doesn't apply to this Strike.</p>\n<p><strong>Critical Success</strong> You inflict 1 point of damage on the army and increase its @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition value by 1.</p>\n<p><strong>Success</strong> You inflict 1 point of damage on the army.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -431,7 +412,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Requirement Flexible Tactics Your army uses trickery, deception, and unfair tactics to attempt a devastating attack against an outflanked army. Attempt a melee Strike or a ranged Strike against the AC of a target outflanked army that is not distant. Critical Success The target army becomes weary 2 until the start of your next turn. Success The target army becomes weary 1 until the start of your next turn. Critical Failure Your attack deals no damage to the target army, which is emboldened by your failed attempt at dirty fighting. This reduces the target army's weary value by 1.</p>"
+                    "value": "<p><strong>Requirement</strong> @UUID[Compendium.pf2e.kingmaker-features.Item.Flexible Tactics]</p>\n<hr />\n<p>Your army uses trickery, deception, and unfair tactics to attempt a devastating attack against an outflanked army. Attempt a melee Strike or a ranged Strike against the AC of a target outflanked army that is not distant.</p>\n<p><strong>Critical Success</strong> The target army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Weary]{Weary 2} until the start of your next turn.</p>\n<p><strong>Success</strong> The target army becomes weary 1 until the start of your next turn.</p>\n<p><strong>Critical Failure</strong> Your attack deals no damage to the target army, which is emboldened by your failed attempt at dirty fighting. This reduces the target army's weary value by 1.</p>"
                 },
                 "location": null,
                 "prerequisites": {

--- a/packs/kingmaker-bestiary/armies/tatzlford-town-guard.json
+++ b/packs/kingmaker-bestiary/armies/tatzlford-town-guard.json
@@ -24,7 +24,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a Morale check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
+                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a @Check[type:morale|defense:morale|roller:self] check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -67,7 +67,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<p>Your army tries to escape from the battlefield.</p>\n<p>If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed].</p>\n<p>Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
+                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<hr />\n<p>Your army tries to escape from the battlefield. If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed]. Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -108,7 +108,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a Maneuver check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
+                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a @Check[type:maneuver|defense:maneuver|roller:self] check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -142,7 +142,6 @@
             "name": "Guard",
             "sort": 0,
             "system": {
-                "-=level": null,
                 "actionType": {
                     "value": "action"
                 },
@@ -152,7 +151,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a Maneuver check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
+                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a @Check[type:maneuver|defense:maneuver|roller:self] check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p>@UUID[Compendium.pf2e.kingmaker-features.Item.Effect: Guard (Critical Success)]</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p>@UUID[Compendium.pf2e.kingmaker-features.Item.Effect: Guard (Success)]</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -163,25 +162,7 @@
                     "remaster": false,
                     "title": "Pathfinder Kingmaker"
                 },
-                "rules": [
-                    {
-                        "key": "FlatModifier",
-                        "label": "Guarded",
-                        "predicate": [
-                            "guarded-critical"
-                        ],
-                        "selector": "ac",
-                        "type": "item",
-                        "value": 2
-                    },
-                    {
-                        "domain": "ac",
-                        "key": "RollOption",
-                        "label": "Guarded (Critical Success)",
-                        "option": "guarded-critical",
-                        "toggleable": true
-                    }
-                ],
+                "rules": [],
                 "slug": "guard",
                 "traits": {
                     "rarity": "common",
@@ -256,7 +237,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a Maneuver check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
+                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a @Check[type:maneuver|defense:maneuver|roller:self] check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
                 },
                 "location": null,
                 "prerequisites": {

--- a/packs/kingmaker-bestiary/armies/tatzlford-town-guard.json
+++ b/packs/kingmaker-bestiary/armies/tatzlford-town-guard.json
@@ -1,0 +1,458 @@
+{
+    "_id": "CfSo8UrTJic4zroJ",
+    "folder": "BRkIyvmgOgyA2kq7",
+    "img": "systems/pf2e/icons/default-icons/army.svg",
+    "items": [
+        {
+            "_id": "DzE7Ak5Wa6ZNrS2U",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.8XXylMGJuqe1ozMk"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Rally",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a Morale check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "rally",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "morale"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "agTytKqXthSBLPyU",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.IhjlbJinff1wUSjL"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/ThreeActions.webp",
+            "name": "Retreat",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 3
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<p>Your army tries to escape from the battlefield.</p>\n<p>If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed].</p>\n<p>Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "retreat",
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "yzEpwKcdcuEjK3OT",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.Pu5bptxLrKFyEzFh"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Disengage",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a Maneuver check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "disengage",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "GJgxw57AoY9F4gz8",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.phtwOol1wETryF7b"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Guard",
+            "sort": 0,
+            "system": {
+                "-=level": null,
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a Maneuver check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "label": "Guarded",
+                        "predicate": [
+                            "guarded-critical"
+                        ],
+                        "selector": "ac",
+                        "type": "item",
+                        "value": 2
+                    },
+                    {
+                        "domain": "ac",
+                        "key": "RollOption",
+                        "label": "Guarded (Critical Success)",
+                        "option": "guarded-critical",
+                        "toggleable": true
+                    }
+                ],
+                "slug": "guard",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "cdUU5qBOCBri8NCy",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.qCxyuNhzaaYlYBum"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Battle",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attacks an enemy army with a Strike against the enemy army's AC. You can do so with a melee Strike only if you are @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with the target army. Otherwise, you must use a ranged Strike.</p>\n<p>An army can attempt a maximum of 5 ranged Strikes per war encounter (unless it has the @UUID[Compendium.pf2e.kingmaker-features.Item.Increased Ammunition] tactic). As with any attack, multiple Strikes in a single round suffer a multiple attack penalty.</p>\n<p>A siege engine can use the Battle action to attack and damage a fortification.</p>\n<p><strong>Critical Success</strong> You deal 2 points of damage to the army.</p>\n<p><strong>Success</strong> You deal 1 point of damage to the army.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "battle",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "attack"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "94bR9nxbJRpYhGiI",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.wHoXoyci1lddRR2R"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Advance",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a Maneuver check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "advance",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "MWtnzzojapVTZHGd",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.899sW8mbJSn16zga"
+                }
+            },
+            "folder": "e185cDQaLjU3uZ62",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Hold the Line",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p>The army has trained to maintain position even in the face of overwhelming opponents. The army gains a +1 status bonus on Morale checks made to resist rout, and its Rout Threshold is equal to 1/4 it's total Hit Points (rounded up).</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": "0",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "downgrade",
+                        "path": "system.attributes.hp.routThreshold",
+                        "value": "ceil(@actor.hitPoints.max / 4)"
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "label": "Morale checks made to resist Rout",
+                        "predicate": [
+                            "vs-rout"
+                        ],
+                        "selector": "morale-check",
+                        "type": "status",
+                        "value": 1
+                    }
+                ],
+                "slug": "hold-the-line",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "cavalry",
+                        "infantry",
+                        "siege",
+                        "skirmisher"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "RSTa5PC03EfvKjNr",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.IiD3kKszFfHZ9cZ1"
+                }
+            },
+            "folder": "e185cDQaLjU3uZ62",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Toughened Soldiers",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p>The army is particularly hardy. Increase its maximum Hit Points by 1. You can take this tactic multiple times; each time you do, increase the army's maximum Hit Points by 1.</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": "1",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "add",
+                        "path": "system.attributes.hp.max",
+                        "value": 1
+                    }
+                ],
+                "slug": "toughened-soldiers",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "cavalry",
+                        "infantry",
+                        "siege",
+                        "skirmisher"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        }
+    ],
+    "name": "Tatzlford Town Guard",
+    "system": {
+        "ac": {
+            "potency": 0,
+            "value": 25
+        },
+        "attributes": {
+            "hp": {
+                "max": 4,
+                "routThreshold": 2,
+                "value": 5
+            }
+        },
+        "consumption": 1,
+        "details": {
+            "alignment": "NG",
+            "blurb": "",
+            "description": "<p>Tatzlford’s town guards have been organized into an impromptu army, armed with longswords and led by Captain Coren Lawry.</p>",
+            "level": {
+                "value": 7
+            }
+        },
+        "recruitmentDC": null,
+        "resources": {
+            "ammunition": {
+                "max": 5,
+                "value": 5
+            },
+            "potions": {
+                "value": 0
+            }
+        },
+        "saves": {
+            "maneuver": 12,
+            "morale": 18
+        },
+        "scouting": 15,
+        "traits": {
+            "rarity": "common",
+            "size": {
+                "value": "med"
+            },
+            "type": "infantry",
+            "value": []
+        },
+        "weapons": {
+            "melee": {
+                "name": "Longwords",
+                "potency": 0
+            },
+            "ranged": null
+        }
+    },
+    "type": "army"
+}

--- a/packs/kingmaker-bestiary/armies/troll-marauders.json
+++ b/packs/kingmaker-bestiary/armies/troll-marauders.json
@@ -1,0 +1,650 @@
+{
+    "_id": "JMFfbmnOG75RuuXv",
+    "folder": "BRkIyvmgOgyA2kq7",
+    "img": "systems/pf2e/icons/default-icons/army.svg",
+    "items": [
+        {
+            "_id": "j2gip7Rq7DqlgBYI",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.8XXylMGJuqe1ozMk"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Rally",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a Morale check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "rally",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "morale"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "UUJ5abRNUDkfTI2e",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.IhjlbJinff1wUSjL"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/ThreeActions.webp",
+            "name": "Retreat",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 3
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<p>Your army tries to escape from the battlefield.</p>\n<p>If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed].</p>\n<p>Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "retreat",
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "G94cQIiALaWBjyk7",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.Pu5bptxLrKFyEzFh"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Disengage",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a Maneuver check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "disengage",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "iIl3JWBP4nIgBg11",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.phtwOol1wETryF7b"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Guard",
+            "sort": 0,
+            "system": {
+                "-=level": null,
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a Maneuver check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "label": "Guarded",
+                        "predicate": [
+                            "guarded-critical"
+                        ],
+                        "selector": "ac",
+                        "type": "item",
+                        "value": 2
+                    },
+                    {
+                        "domain": "ac",
+                        "key": "RollOption",
+                        "label": "Guarded (Critical Success)",
+                        "option": "guarded-critical",
+                        "toggleable": true
+                    }
+                ],
+                "slug": "guard",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "LT0wCvTBYJPO8YaH",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.qCxyuNhzaaYlYBum"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Battle",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attacks an enemy army with a Strike against the enemy army's AC. You can do so with a melee Strike only if you are @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with the target army. Otherwise, you must use a ranged Strike.</p>\n<p>An army can attempt a maximum of 5 ranged Strikes per war encounter (unless it has the @UUID[Compendium.pf2e.kingmaker-features.Item.Increased Ammunition] tactic). As with any attack, multiple Strikes in a single round suffer a multiple attack penalty.</p>\n<p>A siege engine can use the Battle action to attack and damage a fortification.</p>\n<p><strong>Critical Success</strong> You deal 2 points of damage to the army.</p>\n<p><strong>Success</strong> You deal 1 point of damage to the army.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "battle",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "attack"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "RG5xHYQaAlrVzBL4",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.wHoXoyci1lddRR2R"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Advance",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a Maneuver check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "advance",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "19k1Hz7RxuXoLfGr",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.y1JGtzGmMtVh5USK"
+                }
+            },
+            "folder": "e185cDQaLjU3uZ62",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Darkvision",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p>The army includes several spotters and scouts who have darkvision, and the rest of the soldiers have been trained to follow their lead so that the army itself functions as if it had darkvision.</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "darkvision",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "cavalry",
+                        "infantry",
+                        "siege",
+                        "skirmisher"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "a6FAJSwLzdqWyr1E",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.y1JGtzGmMtVh5USK"
+                },
+                "pf2e": {
+                    "itemGrants": {
+                        "allOutAssault": {
+                            "id": "dfkhWGWMHIa1bk83",
+                            "onDelete": "detach"
+                        }
+                    }
+                }
+            },
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Brutal Assault",
+            "sort": 100000,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p>The Troll Marauders can use the All-Out-Assault action. When they do, an army damaged by the assault must succeed at a DC24 Morale check to avoid becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken]{shaken 1} (or @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken]{shaken 2} on a critical failure) as a result of the brutality of this attack.</p>"
+                },
+                "level": {
+                    "value": 8
+                },
+                "location": "0",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [
+                    {
+                        "flag": "allOutAssault",
+                        "key": "GrantItem",
+                        "uuid": "Compendium.pf2e.kingmaker-features.Item.All-Out Assault"
+                    }
+                ],
+                "slug": "darkvision",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "cavalry",
+                        "infantry",
+                        "siege",
+                        "skirmisher"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "dfkhWGWMHIa1bk83",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.Z6jMZgAxI1zRO7Sl"
+                },
+                "pf2e": {
+                    "grantedBy": {
+                        "id": "a6FAJSwLzdqWyr1E",
+                        "onDelete": "cascade"
+                    }
+                }
+            },
+            "folder": "i18YzT3zo3skuWng",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "All-Out Assault",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p><strong>Requirement</strong> @UUID[Compendium.pf2e.kingmaker-features.Item.Merciless]</p>\n<p>Your army attacks with frightening vigor. Attempt a melee Strike against an enemy army's AC. Critical Success Your army inflicts 3 points of damage to the target army. If your army's next war action this turn is an attack war action against a different target army, you gain a +1 circumstance bonus to the Strike as your fury continues to the new target. Success Your army deals 2 points of damage to the target army. Failure Your army falters, but still deals 1 point of damage to the target army. Critical Failure Your army deals no damage to the target army and becomes outflanked until the start of its next turn.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "all-out-assault",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "attack",
+                        "cavalry",
+                        "infantry"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "jn0QB3sq8yQTujyd",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.y1JGtzGmMtVh5USK"
+                },
+                "pf2e": {
+                    "itemGrants": {
+                        "taunt": {
+                            "id": "zxEuPlI4wj8gArdg",
+                            "onDelete": "detach"
+                        }
+                    }
+                }
+            },
+            "folder": "DHXjHHXYj6zl4W6F",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Frightening Foe",
+            "sort": 200000,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p>The Troll Marauders can use the @UUID[Compendium.pf2e.kingmaker-features.Item.Taunt] tactical action. When they do, they gain a +2 status bonus on their Morale check if they used the Regeneration tactic this turn.</p>"
+                },
+                "level": {
+                    "value": 8
+                },
+                "location": "1",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [
+                    {
+                        "flag": "taunt",
+                        "key": "GrantItem",
+                        "uuid": "Compendium.pf2e.kingmaker-features.Item.Taunt"
+                    }
+                ],
+                "slug": "darkvision",
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "zxEuPlI4wj8gArdg",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.ggVahjiAlVICpiPA"
+                },
+                "pf2e": {
+                    "grantedBy": {
+                        "id": "jn0QB3sq8yQTujyd",
+                        "onDelete": "cascade"
+                    }
+                }
+            },
+            "folder": "i18YzT3zo3skuWng",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Taunt",
+            "sort": 0,
+            "system": {
+                "-=level": null,
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p><strong>Requirement</strong>@UUID[Compendium.pf2e.kingmaker-features.Item.Focused Devotion]</p>\n<hr />\n<p>Your army attempts to frighten and cow an enemy army. Attempt a @Check[morale|defense:morale] check against the target army.</p>\n<p><strong>Critical Success</strong> The target army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken]{Shaken 2} until the start of your next turn.</p>\n<p><strong>Success</strong> The target army becomes shaken 1 until the start of your next turn.</p>\n<p><strong>Critical Failure</strong> Your failed attempt bolsters the enemy's spirits. This reduces the target army's shaken value by 1.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "taunt",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "morale"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "nRUQZPAnP2YUPGdC",
+            "flags": {
+                "core": {
+                    "sourceId": "Item.w95Ah3tIP3fqZGmv"
+                }
+            },
+            "folder": "Orkajqnbw5JiOwtt",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Regeneration",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p>At the beginning of its turn, the Troll Marauders regain 1 Hit Point. The Troll Marauders cannot be destroyed as usual unless they lose this tactic. The PCs can cause the trolls to lose the Regeneration tactic via prepared firepots (see Kingmaker page 296); while the trolls’ Regeneration tactic is lost, their RT increases to 3.</p>\n<p>Otherwise, an army that engages the Troll Marauders while they are defeated can take a three-round action to burn the trolls and destroy their army.</p>"
+                },
+                "level": {
+                    "value": 8
+                },
+                "location": "2",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        }
+    ],
+    "name": "Troll Marauders",
+    "system": {
+        "ac": {
+            "potency": 0,
+            "value": 28
+        },
+        "attributes": {
+            "hp": {
+                "max": 5,
+                "routThreshold": 1,
+                "value": 5
+            }
+        },
+        "consumption": null,
+        "details": {
+            "alignment": "NE",
+            "blurb": "",
+            "description": "<p>There are only a few dozen trolls in this army, but their ferocity and regenerative capability make them a dangerous force nonetheless.</p>",
+            "level": {
+                "value": 8
+            }
+        },
+        "recruitmentDC": null,
+        "resources": {
+            "ammunition": {
+                "max": 5,
+                "value": 5
+            },
+            "potions": {
+                "value": 0
+            }
+        },
+        "saves": {
+            "maneuver": 13,
+            "morale": 19
+        },
+        "scouting": 16,
+        "traits": {
+            "rarity": "common",
+            "size": {
+                "value": "med"
+            },
+            "type": "infantry",
+            "value": []
+        },
+        "weapons": {
+            "melee": {
+                "name": "Claws and fangs",
+                "potency": 0
+            },
+            "ranged": null
+        }
+    },
+    "type": "army"
+}

--- a/packs/kingmaker-bestiary/armies/troll-marauders.json
+++ b/packs/kingmaker-bestiary/armies/troll-marauders.json
@@ -24,7 +24,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a Morale check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
+                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a @Check[type:morale|defense:morale|roller:self] check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -67,7 +67,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<p>Your army tries to escape from the battlefield.</p>\n<p>If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed].</p>\n<p>Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
+                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<hr />\n<p>Your army tries to escape from the battlefield. If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed]. Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -108,7 +108,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a Maneuver check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
+                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a @Check[type:maneuver|defense:maneuver|roller:self] check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -142,7 +142,6 @@
             "name": "Guard",
             "sort": 0,
             "system": {
-                "-=level": null,
                 "actionType": {
                     "value": "action"
                 },
@@ -152,7 +151,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a Maneuver check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
+                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a @Check[type:maneuver|defense:maneuver|roller:self] check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p>@UUID[Compendium.pf2e.kingmaker-features.Item.Effect: Guard (Critical Success)]</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p>@UUID[Compendium.pf2e.kingmaker-features.Item.Effect: Guard (Success)]</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -163,25 +162,7 @@
                     "remaster": false,
                     "title": "Pathfinder Kingmaker"
                 },
-                "rules": [
-                    {
-                        "key": "FlatModifier",
-                        "label": "Guarded",
-                        "predicate": [
-                            "guarded-critical"
-                        ],
-                        "selector": "ac",
-                        "type": "item",
-                        "value": 2
-                    },
-                    {
-                        "domain": "ac",
-                        "key": "RollOption",
-                        "label": "Guarded (Critical Success)",
-                        "option": "guarded-critical",
-                        "toggleable": true
-                    }
-                ],
+                "rules": [],
                 "slug": "guard",
                 "traits": {
                     "rarity": "common",
@@ -256,7 +237,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a Maneuver check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
+                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a @Check[type:maneuver|defense:maneuver|roller:self] check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -416,7 +397,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p><strong>Requirement</strong> @UUID[Compendium.pf2e.kingmaker-features.Item.Merciless]</p>\n<p>Your army attacks with frightening vigor. Attempt a melee Strike against an enemy army's AC. Critical Success Your army inflicts 3 points of damage to the target army. If your army's next war action this turn is an attack war action against a different target army, you gain a +1 circumstance bonus to the Strike as your fury continues to the new target. Success Your army deals 2 points of damage to the target army. Failure Your army falters, but still deals 1 point of damage to the target army. Critical Failure Your army deals no damage to the target army and becomes outflanked until the start of its next turn.</p>"
+                    "value": "<p><strong>Requirement</strong> @UUID[Compendium.pf2e.kingmaker-features.Item.Merciless]</p>\n<hr />\n<p>Your army attacks with frightening vigor. Attempt a melee Strike against an enemy army's AC.</p>\n<p><strong>Critical Success</strong> Your army inflicts @Damage[3|domains:melee-damage,strike-damage] points of damage to the target army. If your army's next war action this turn is an attack war action against a different target army, you gain a +1 circumstance bonus to the Strike as your fury continues to the new target.</p>\n<p><strong>Success</strong> Your army deals @Damage[2|domains:melee-damage,strike-damage] points of damage to the target army.</p>\n<p><strong>Failure</strong> Your army falters, but still deals @Damage[1|domains:melee-damage,strike-damage] point of damage to the target army.</p>\n<p><strong>Critical Failure</strong> Your army deals no damage to the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Outflanked] until the start of its next turn.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -427,7 +408,25 @@
                     "remaster": false,
                     "title": "Pathfinder Kingmaker"
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "domain": "attack-roll",
+                        "key": "RollOption",
+                        "label": "All-Out Assault Followup Attack (Crit Success)",
+                        "option": "all-out-assault-followup",
+                        "toggleable": true
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "label": "All-Out Assault Followup (Crit Success)",
+                        "predicate": [
+                            "all-out-assault-followup"
+                        ],
+                        "selector": "attack-roll",
+                        "type": "circumstance",
+                        "value": 1
+                    }
+                ],
                 "slug": "all-out-assault",
                 "traits": {
                     "rarity": "common",
@@ -516,7 +515,6 @@
             "name": "Taunt",
             "sort": 0,
             "system": {
-                "-=level": null,
                 "actionType": {
                     "value": "action"
                 },
@@ -526,7 +524,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p><strong>Requirement</strong>@UUID[Compendium.pf2e.kingmaker-features.Item.Focused Devotion]</p>\n<hr />\n<p>Your army attempts to frighten and cow an enemy army. Attempt a @Check[morale|defense:morale] check against the target army.</p>\n<p><strong>Critical Success</strong> The target army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken]{Shaken 2} until the start of your next turn.</p>\n<p><strong>Success</strong> The target army becomes shaken 1 until the start of your next turn.</p>\n<p><strong>Critical Failure</strong> Your failed attempt bolsters the enemy's spirits. This reduces the target army's shaken value by 1.</p>"
+                    "value": "<p><strong>Requirement</strong>@UUID[Compendium.pf2e.kingmaker-features.Item.Focused Devotion]</p>\n<hr />\n<p>Your army attempts to frighten and cow an enemy army. Attempt a @Check[morale|defense:morale|roller:self] check against the target army.</p>\n<p><strong>Critical Success</strong> The target army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken]{Shaken 2} until the start of your next turn.</p>\n<p><strong>Success</strong> The target army becomes shaken 1 until the start of your next turn.</p>\n<p><strong>Critical Failure</strong> Your failed attempt bolsters the enemy's spirits. This reduces the target army's shaken value by 1.</p>"
                 },
                 "location": null,
                 "prerequisites": {

--- a/packs/kingmaker-bestiary/armies/tusker-riders.json
+++ b/packs/kingmaker-bestiary/armies/tusker-riders.json
@@ -24,7 +24,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a Morale check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
+                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a @Check[type:morale|defense:morale|roller:self] check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -67,7 +67,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<p>Your army tries to escape from the battlefield.</p>\n<p>If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed].</p>\n<p>Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
+                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<hr />\n<p>Your army tries to escape from the battlefield. If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed]. Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -108,7 +108,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a Maneuver check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
+                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a @Check[type:maneuver|defense:maneuver|roller:self] check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -142,7 +142,6 @@
             "name": "Guard",
             "sort": 0,
             "system": {
-                "-=level": null,
                 "actionType": {
                     "value": "action"
                 },
@@ -152,7 +151,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a Maneuver check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
+                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a @Check[type:maneuver|defense:maneuver|roller:self] check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p>@UUID[Compendium.pf2e.kingmaker-features.Item.Effect: Guard (Critical Success)]</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p>@UUID[Compendium.pf2e.kingmaker-features.Item.Effect: Guard (Success)]</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -163,25 +162,7 @@
                     "remaster": false,
                     "title": "Pathfinder Kingmaker"
                 },
-                "rules": [
-                    {
-                        "key": "FlatModifier",
-                        "label": "Guarded",
-                        "predicate": [
-                            "guarded-critical"
-                        ],
-                        "selector": "ac",
-                        "type": "item",
-                        "value": 2
-                    },
-                    {
-                        "domain": "ac",
-                        "key": "RollOption",
-                        "label": "Guarded (Critical Success)",
-                        "option": "guarded-critical",
-                        "toggleable": true
-                    }
-                ],
+                "rules": [],
                 "slug": "guard",
                 "traits": {
                     "rarity": "common",
@@ -256,7 +237,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a Maneuver check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
+                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a @Check[type:maneuver|defense:maneuver|roller:self] check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -381,7 +362,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p><strong>Requirement</strong> @UUID[Compendium.pf2e.kingmaker-features.Item.Merciless]</p>\n<hr />\n<p>Your army attacks with frightening vigor. Attempt a melee Strike against an enemy army's AC.</p>\n<p><strong>Critical Success</strong> Your army inflicts 3 points of damage to the target army. If your army's next war action this turn is an attack war action against a different target army, you gain a +1 circumstance bonus to the Strike as your fury continues to the new target.</p>\n<p><strong>Success</strong> Your army deals 2 points of damage to the target army.</p>\n<p><strong>Failure</strong> Your army falters, but still deals 1 point of damage to the target army.</p>\n<p><strong>Critical Failure</strong> Your army deals no damage to the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Outflanked] until the start of its next turn.</p>"
+                    "value": "<p><strong>Requirement</strong> @UUID[Compendium.pf2e.kingmaker-features.Item.Merciless]</p>\n<hr />\n<p>Your army attacks with frightening vigor. Attempt a melee Strike against an enemy army's AC.</p>\n<p><strong>Critical Success</strong> Your army inflicts @Damage[3|domains:melee-damage,strike-damage] points of damage to the target army. If your army's next war action this turn is an attack war action against a different target army, you gain a +1 circumstance bonus to the Strike as your fury continues to the new target.</p>\n<p><strong>Success</strong> Your army deals @Damage[2|domains:melee-damage,strike-damage] points of damage to the target army.</p>\n<p><strong>Failure</strong> Your army falters, but still deals @Damage[1|domains:melee-damage,strike-damage] point of damage to the target army.</p>\n<p><strong>Critical Failure</strong> Your army deals no damage to the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Outflanked] until the start of its next turn.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -394,6 +375,13 @@
                 },
                 "rules": [
                     {
+                        "domain": "attack-roll",
+                        "key": "RollOption",
+                        "label": "All-Out Assault Followup Attack (Crit Success)",
+                        "option": "all-out-assault-followup",
+                        "toggleable": true
+                    },
+                    {
                         "key": "FlatModifier",
                         "label": "All-Out Assault Followup (Crit Success)",
                         "predicate": [
@@ -402,20 +390,6 @@
                         "selector": "attack-roll",
                         "type": "circumstance",
                         "value": 1
-                    },
-                    {
-                        "domain": "damage",
-                        "key": "RollOption",
-                        "label": "All-Out Assault",
-                        "option": "all-out-assault",
-                        "toggleable": true
-                    },
-                    {
-                        "domain": "attack-roll",
-                        "key": "RollOption",
-                        "label": "All-Out Assault Followup Attack (Crit Success)",
-                        "option": "all-out-assault-followup",
-                        "toggleable": true
                     }
                 ],
                 "slug": "all-out-assault",
@@ -509,7 +483,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p><strong>Requirement</strong>@UUID[Compendium.pf2e.kingmaker-features.Item.Focused Devotion]</p>\n<hr />\n<p>Your army attempts to frighten and cow an enemy army. Attempt a @Check[morale|defense:morale] check against the target army.</p>\n<p><strong>Critical Success</strong> The target army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken]{Shaken 2} until the start of your next turn.</p>\n<p><strong>Success</strong> The target army becomes shaken 1 until the start of your next turn.</p>\n<p><strong>Critical Failure</strong> Your failed attempt bolsters the enemy's spirits. This reduces the target army's shaken value by 1.</p>"
+                    "value": "<p><strong>Requirement</strong>@UUID[Compendium.pf2e.kingmaker-features.Item.Focused Devotion]</p>\n<hr />\n<p>Your army attempts to frighten and cow an enemy army. Attempt a @Check[morale|defense:morale|roller:self] check against the target army.</p>\n<p><strong>Critical Success</strong> The target army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken]{Shaken 2} until the start of your next turn.</p>\n<p><strong>Success</strong> The target army becomes shaken 1 until the start of your next turn.</p>\n<p><strong>Critical Failure</strong> Your failed attempt bolsters the enemy's spirits. This reduces the target army's shaken value by 1.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -552,7 +526,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>The Riders trample an enemy army. They attempt a Maneuver check against a target non-engaged army’s Maneuver DC. Trampling Charge does not trigger @UUID[Compendium.pf2e.kingmaker-features.Item.Counterattack] reactions.</p>\n<p><strong>Critical Success</strong> The target army takes 2 points of damage and increases their @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] value by 1.</p>\n<p><strong>Success</strong> The target army takes 1 point of damage.</p>\n<p><strong>Failure</strong> The target army takes 1 point of damage. The Tusker Riders are now @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with the target army. </p>\n<p><strong>Critical Failure</strong> The Tusker Riders are now @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with the target army and are flat-footed until the start of their next turn.</p>"
+                    "value": "<p>The Riders trample an enemy army. They attempt a Maneuver check against a target non-engaged army’s Maneuver DC. Trampling Charge does not trigger @UUID[Compendium.pf2e.kingmaker-features.Item.Counterattack] reactions.</p>\n<p><strong>Critical Success</strong> The target army takes 2 points of damage and increases their @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] value by 1.</p>\n<p><strong>Success</strong> The target army takes 1 point of damage.</p>\n<p><strong>Failure</strong> The target army takes 1 point of damage. The Tusker Riders are now @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with the target army.</p>\n<p><strong>Critical Failure</strong> The Tusker Riders are now @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with the target army and are flat-footed until the start of their next turn.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -625,7 +599,7 @@
             },
             "folder": "ACotoADnRFIDqvPc",
             "img": "icons/sundries/books/book-red-exclamation.webp",
-            "name": "Close Combat Specialists",
+            "name": "Increased Ammunition",
             "sort": 200000,
             "system": {
                 "actionType": {
@@ -637,10 +611,10 @@
                 "campaign": "kingmaker",
                 "category": "army-tactic",
                 "description": {
-                    "value": "<p><em><strong>Note</strong>: This tactic does not appear in the original text of Pathfinder: Kingmaker. It was created to serve as an explanation and source for some of the Tusker Riders' unique modifiers which previously did not have a listed source, allowing the statistics you see here to match those used in the adventure.</em></p>\n<hr />\n<p>The Tusker Riders specialise in closing the distance and defeating their foes with overwhelming force. They gain a +1 bonus to melee strikes and a -1 penalty to ranged strikes. This tactic does not count against the maximum number of tactics the Tusker Riders can possess.</p>"
+                    "value": "<p>You increase the number of times your army can use ranged Strikes in each war encounter by 2. This tactic can be taken multiple times; each time you do so, increase the army's maximum number of ranged Strikes by 2.</p>"
                 },
                 "level": {
-                    "value": 14
+                    "value": 5
                 },
                 "location": "2",
                 "prerequisites": {
@@ -653,24 +627,21 @@
                 },
                 "rules": [
                     {
-                        "key": "FlatModifier",
-                        "selector": [
-                            "ranged-attack-roll"
-                        ],
-                        "value": -1
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "selector": [
-                            "melee-attack-roll"
-                        ],
-                        "value": 1
+                        "key": "ActiveEffectLike",
+                        "mode": "add",
+                        "path": "system.resources.ammunition.max",
+                        "value": 2
                     }
                 ],
                 "slug": "increased-ammunition",
                 "traits": {
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "cavalry",
+                        "infantry",
+                        "siege",
+                        "skirmisher"
+                    ]
                 }
             },
             "type": "campaignFeature"

--- a/packs/kingmaker-bestiary/armies/tusker-riders.json
+++ b/packs/kingmaker-bestiary/armies/tusker-riders.json
@@ -1,0 +1,785 @@
+{
+    "_id": "s8Ol97yji6CbWt1l",
+    "folder": "BRkIyvmgOgyA2kq7",
+    "img": "systems/pf2e/icons/default-icons/army.svg",
+    "items": [
+        {
+            "_id": "Jd1g3ovpiC39CYRk",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.8XXylMGJuqe1ozMk"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Rally",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a Morale check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "rally",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "morale"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "1egfYGFDnAX5opwc",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.IhjlbJinff1wUSjL"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/ThreeActions.webp",
+            "name": "Retreat",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 3
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<p>Your army tries to escape from the battlefield.</p>\n<p>If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed].</p>\n<p>Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "retreat",
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "A5deiJajssYXsGeB",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.Pu5bptxLrKFyEzFh"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Disengage",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a Maneuver check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "disengage",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "pF7BiYB0G1hNsXek",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.phtwOol1wETryF7b"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Guard",
+            "sort": 0,
+            "system": {
+                "-=level": null,
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a Maneuver check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "label": "Guarded",
+                        "predicate": [
+                            "guarded-critical"
+                        ],
+                        "selector": "ac",
+                        "type": "item",
+                        "value": 2
+                    },
+                    {
+                        "domain": "ac",
+                        "key": "RollOption",
+                        "label": "Guarded (Critical Success)",
+                        "option": "guarded-critical",
+                        "toggleable": true
+                    }
+                ],
+                "slug": "guard",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "AutD88eYafZX1wQW",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.qCxyuNhzaaYlYBum"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Battle",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attacks an enemy army with a Strike against the enemy army's AC. You can do so with a melee Strike only if you are @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with the target army. Otherwise, you must use a ranged Strike.</p>\n<p>An army can attempt a maximum of 5 ranged Strikes per war encounter (unless it has the @UUID[Compendium.pf2e.kingmaker-features.Item.Increased Ammunition] tactic). As with any attack, multiple Strikes in a single round suffer a multiple attack penalty.</p>\n<p>A siege engine can use the Battle action to attack and damage a fortification.</p>\n<p><strong>Critical Success</strong> You deal 2 points of damage to the army.</p>\n<p><strong>Success</strong> You deal 1 point of damage to the army.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "battle",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "attack"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "rGxlncNMXLVMXZ6s",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.wHoXoyci1lddRR2R"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Advance",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a Maneuver check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "advance",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "UO4ZrO70143knKB5",
+            "flags": {
+                "core": {
+                    "sourceId": "Item.FG2BifRmaZ54fxhS"
+                },
+                "pf2e": {
+                    "itemGrants": {
+                        "allOutAssault": {
+                            "id": "Q0BxNJvtO2wNU03I",
+                            "onDelete": "detach"
+                        },
+                        "coveringFire": {
+                            "id": "x1no5xGe948GsvRT",
+                            "onDelete": "detach"
+                        },
+                        "taunt": {
+                            "id": "ikuuCz9uU4Ubkp1A",
+                            "onDelete": "detach"
+                        }
+                    }
+                }
+            },
+            "folder": "ACotoADnRFIDqvPc",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Tusker Training",
+            "sort": 100000,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p>The Tusker Riders can use the @UUID[Compendium.pf2e.kingmaker-features.Item.All-Out Assault], @UUID[Compendium.pf2e.kingmaker-features.Item.Covering Fire], and @UUID[Compendium.pf2e.kingmaker-features.Item.Taunt] tactical actions.</p>"
+                },
+                "level": {
+                    "value": 14
+                },
+                "location": "0",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [
+                    {
+                        "flag": "allOutAssault",
+                        "key": "GrantItem",
+                        "uuid": "Compendium.pf2e.kingmaker-features.Item.All-Out Assault"
+                    },
+                    {
+                        "flag": "coveringFire",
+                        "key": "GrantItem",
+                        "uuid": "Compendium.pf2e.kingmaker-features.Item.Covering Fire"
+                    },
+                    {
+                        "flag": "taunt",
+                        "key": "GrantItem",
+                        "uuid": "Compendium.pf2e.kingmaker-features.Item.Taunt"
+                    }
+                ],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "Q0BxNJvtO2wNU03I",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.Z6jMZgAxI1zRO7Sl"
+                },
+                "pf2e": {
+                    "grantedBy": {
+                        "id": "UO4ZrO70143knKB5",
+                        "onDelete": "cascade"
+                    }
+                }
+            },
+            "folder": "i18YzT3zo3skuWng",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "All-Out Assault",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p><strong>Requirement</strong> @UUID[Compendium.pf2e.kingmaker-features.Item.Merciless]</p>\n<hr />\n<p>Your army attacks with frightening vigor. Attempt a melee Strike against an enemy army's AC.</p>\n<p><strong>Critical Success</strong> Your army inflicts 3 points of damage to the target army. If your army's next war action this turn is an attack war action against a different target army, you gain a +1 circumstance bonus to the Strike as your fury continues to the new target.</p>\n<p><strong>Success</strong> Your army deals 2 points of damage to the target army.</p>\n<p><strong>Failure</strong> Your army falters, but still deals 1 point of damage to the target army.</p>\n<p><strong>Critical Failure</strong> Your army deals no damage to the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Outflanked] until the start of its next turn.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "label": "All-Out Assault Followup (Crit Success)",
+                        "predicate": [
+                            "all-out-assault-followup"
+                        ],
+                        "selector": "attack-roll",
+                        "type": "circumstance",
+                        "value": 1
+                    },
+                    {
+                        "domain": "damage",
+                        "key": "RollOption",
+                        "label": "All-Out Assault",
+                        "option": "all-out-assault",
+                        "toggleable": true
+                    },
+                    {
+                        "domain": "attack-roll",
+                        "key": "RollOption",
+                        "label": "All-Out Assault Followup Attack (Crit Success)",
+                        "option": "all-out-assault-followup",
+                        "toggleable": true
+                    }
+                ],
+                "slug": "all-out-assault",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "attack",
+                        "cavalry",
+                        "infantry"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "x1no5xGe948GsvRT",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.GIbm9qo8VuFgPywJ"
+                },
+                "pf2e": {
+                    "grantedBy": {
+                        "id": "UO4ZrO70143knKB5",
+                        "onDelete": "cascade"
+                    }
+                }
+            },
+            "folder": "i18YzT3zo3skuWng",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Covering Fire",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p><strong>Requirement</strong> @UUID[Compendium.pf2e.kingmaker-features.Item.Sharpshooter]</p>\n<hr />\n<p>Your army's ranged fire provides cover and protection for an allied army to maneuver. Attempt a ranged Strike against a target army's AC.</p>\n<p><strong>Critical Success</strong> You inflict 2 points of damage to the target army, and it cannot take reactions triggered by maneuver war actions from any army until the start of your next turn.</p>\n<p><strong>Success</strong> You inflict 1 point of damage to the target army, and it can't take reactions triggered by maneuver war actions from any army until the start of your next turn.</p>\n<p><strong>Failure</strong> Your attack fails to provide covering fire, but you inflict 1 point of damage to the target army.</p>\n<p><strong>Critical Failure</strong> Your attempt fails.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "covering-fire",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "attack",
+                        "cavalry",
+                        "infantry",
+                        "skirmisher"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "ikuuCz9uU4Ubkp1A",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.ggVahjiAlVICpiPA"
+                },
+                "pf2e": {
+                    "grantedBy": {
+                        "id": "UO4ZrO70143knKB5",
+                        "onDelete": "cascade"
+                    }
+                }
+            },
+            "folder": "i18YzT3zo3skuWng",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Taunt",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p><strong>Requirement</strong>@UUID[Compendium.pf2e.kingmaker-features.Item.Focused Devotion]</p>\n<hr />\n<p>Your army attempts to frighten and cow an enemy army. Attempt a @Check[morale|defense:morale] check against the target army.</p>\n<p><strong>Critical Success</strong> The target army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken]{Shaken 2} until the start of your next turn.</p>\n<p><strong>Success</strong> The target army becomes shaken 1 until the start of your next turn.</p>\n<p><strong>Critical Failure</strong> Your failed attempt bolsters the enemy's spirits. This reduces the target army's shaken value by 1.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "taunt",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "morale"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "DMfCBeXGOxuaHuPv",
+            "flags": {
+                "core": {
+                    "sourceId": "Item.FG2BifRmaZ54fxhS"
+                }
+            },
+            "folder": "ACotoADnRFIDqvPc",
+            "img": "systems/pf2e/icons/actions/ThreeActions.webp",
+            "name": "Trampling Charge",
+            "sort": 400000,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 3
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>The Riders trample an enemy army. They attempt a Maneuver check against a target non-engaged army’s Maneuver DC. Trampling Charge does not trigger @UUID[Compendium.pf2e.kingmaker-features.Item.Counterattack] reactions.</p>\n<p><strong>Critical Success</strong> The target army takes 2 points of damage and increases their @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] value by 1.</p>\n<p><strong>Success</strong> The target army takes 1 point of damage.</p>\n<p><strong>Failure</strong> The target army takes 1 point of damage. The Tusker Riders are now @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with the target army. </p>\n<p><strong>Critical Failure</strong> The Tusker Riders are now @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with the target army and are flat-footed until the start of their next turn.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "LzMw2GEXvqzP9w8a",
+            "flags": {
+                "core": {
+                    "sourceId": "Item.FG2BifRmaZ54fxhS"
+                }
+            },
+            "folder": "ACotoADnRFIDqvPc",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Trampling Charge",
+            "sort": 300000,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": ""
+                },
+                "level": {
+                    "value": 14
+                },
+                "location": "1",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "iVb6NJ7ZSqdxPh2x",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.DrUT5sE0EuU5dtPa"
+                }
+            },
+            "folder": "ACotoADnRFIDqvPc",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Close Combat Specialists",
+            "sort": 200000,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p><em><strong>Note</strong>: This tactic does not appear in the original text of Pathfinder: Kingmaker. It was created to serve as an explanation and source for some of the Tusker Riders' unique modifiers which previously did not have a listed source, allowing the statistics you see here to match those used in the adventure.</em></p>\n<hr />\n<p>The Tusker Riders specialise in closing the distance and defeating their foes with overwhelming force. They gain a +1 bonus to melee strikes and a -1 penalty to ranged strikes. This tactic does not count against the maximum number of tactics the Tusker Riders can possess.</p>"
+                },
+                "level": {
+                    "value": 14
+                },
+                "location": "2",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "selector": [
+                            "ranged-attack-roll"
+                        ],
+                        "value": -1
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "selector": [
+                            "melee-attack-roll"
+                        ],
+                        "value": 1
+                    }
+                ],
+                "slug": "increased-ammunition",
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "kkymoTq5exKsAKF0",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.y1JGtzGmMtVh5USK"
+                }
+            },
+            "folder": "e185cDQaLjU3uZ62",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Darkvision",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p>The army includes several spotters and scouts who have darkvision, and the rest of the soldiers have been trained to follow their lead so that the army itself functions as if it had darkvision.</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "darkvision",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "cavalry",
+                        "infantry",
+                        "siege",
+                        "skirmisher"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        }
+    ],
+    "name": "Tusker Riders",
+    "system": {
+        "ac": {
+            "potency": 0,
+            "value": 35
+        },
+        "attributes": {
+            "hp": {
+                "max": 8,
+                "routThreshold": 4,
+                "value": 8
+            }
+        },
+        "consumption": null,
+        "details": {
+            "alignment": "CE",
+            "blurb": "",
+            "description": "<p>The hill giant warlord Kob Moleg sent these mammoth-mounted hill giants to King Irovetti as a gift.</p>",
+            "level": {
+                "value": 14
+            }
+        },
+        "recruitmentDC": null,
+        "resources": {
+            "ammunition": {
+                "max": 5,
+                "value": 5
+            },
+            "potions": {
+                "value": 0
+            }
+        },
+        "saves": {
+            "maneuver": 22,
+            "morale": 28
+        },
+        "scouting": 24,
+        "traits": {
+            "rarity": "common",
+            "size": {
+                "value": "med"
+            },
+            "type": "infantry",
+            "value": []
+        },
+        "weapons": {
+            "melee": {
+                "name": "Morningstars and tusks",
+                "potency": 0
+            },
+            "ranged": {
+                "name": "Thrown rock",
+                "potency": 0
+            }
+        }
+    },
+    "type": "army"
+}

--- a/packs/kingmaker-bestiary/armies/wyvern-flight.json
+++ b/packs/kingmaker-bestiary/armies/wyvern-flight.json
@@ -1,0 +1,668 @@
+{
+    "_id": "B9FuY1XYxU5SOcuI",
+    "folder": "BRkIyvmgOgyA2kq7",
+    "img": "systems/pf2e/icons/default-icons/army.svg",
+    "items": [
+        {
+            "_id": "Jd1g3ovpiC39CYRk",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.8XXylMGJuqe1ozMk"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Rally",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a Morale check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "rally",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "morale"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "1egfYGFDnAX5opwc",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.IhjlbJinff1wUSjL"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/ThreeActions.webp",
+            "name": "Retreat",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 3
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<p>Your army tries to escape from the battlefield.</p>\n<p>If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed].</p>\n<p>Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "retreat",
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "A5deiJajssYXsGeB",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.Pu5bptxLrKFyEzFh"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "Disengage",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a Maneuver check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "disengage",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "pF7BiYB0G1hNsXek",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.phtwOol1wETryF7b"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Guard",
+            "sort": 0,
+            "system": {
+                "-=level": null,
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a Maneuver check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "label": "Guarded",
+                        "predicate": [
+                            "guarded-critical"
+                        ],
+                        "selector": "ac",
+                        "type": "item",
+                        "value": 2
+                    },
+                    {
+                        "domain": "ac",
+                        "key": "RollOption",
+                        "label": "Guarded (Critical Success)",
+                        "option": "guarded-critical",
+                        "toggleable": true
+                    }
+                ],
+                "slug": "guard",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "AutD88eYafZX1wQW",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.qCxyuNhzaaYlYBum"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Battle",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attacks an enemy army with a Strike against the enemy army's AC. You can do so with a melee Strike only if you are @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with the target army. Otherwise, you must use a ranged Strike.</p>\n<p>An army can attempt a maximum of 5 ranged Strikes per war encounter (unless it has the @UUID[Compendium.pf2e.kingmaker-features.Item.Increased Ammunition] tactic). As with any attack, multiple Strikes in a single round suffer a multiple attack penalty.</p>\n<p>A siege engine can use the Battle action to attack and damage a fortification.</p>\n<p><strong>Critical Success</strong> You deal 2 points of damage to the army.</p>\n<p><strong>Success</strong> You deal 1 point of damage to the army.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "battle",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "attack"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "rGxlncNMXLVMXZ6s",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.wHoXoyci1lddRR2R"
+                }
+            },
+            "folder": "Vqp8b64uH35zkncy",
+            "img": "systems/pf2e/icons/actions/OneAction.webp",
+            "name": "Advance",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a Maneuver check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "advance",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "maneuver"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "rTgVHaEGaXgWZGA9",
+            "flags": {
+                "core": {
+                    "sourceId": "Item.FG2BifRmaZ54fxhS"
+                }
+            },
+            "folder": "jZWW6y5VjVRbbU7t",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Flight",
+            "sort": 100000,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p>The Wyvern Flight ignores all ground- based difficult terrain and cannot become mired by effects that can be escaped by flight. When they use the @UUID[Compendium.pf2e.kingmaker-features.Item.Disengage] action against armies that can’t fly, their check result is improved one degree. Armies that lack the ability to fly suffer a –2 circumstance penalty on Advance actions against a Wyvern Flight.</p>"
+                },
+                "level": {
+                    "value": 12
+                },
+                "location": "0",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "NIOdavTEHCo3wpRC",
+            "flags": {
+                "core": {
+                    "sourceId": "Item.FG2BifRmaZ54fxhS"
+                }
+            },
+            "folder": "jZWW6y5VjVRbbU7t",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Wyvern Venom",
+            "sort": 200000,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p>An army that takes damage from a Wyvern Flight’s melee strike increases its @UUID[Compendium.pf2e.kingmaker-features.Item.Weary] condition value by 1. If this would cause an army to increase its weary condition above 4, it instead takes 1 point of damage.</p>\n<p>Each time an army regains Hit Points during a battle, it can attempt a @Check[type:flat|DC:11]{DC 11 Flat Check}; on a success, it no longer suffers the ongoing effects of Wyvern Venom (but can still be affected by it later from a future attack, and does not reset its weary condition). The effects of Wyvern Venom also end as soon as an army escapes the battlefield or once the battle ends.</p>"
+                },
+                "level": {
+                    "value": 12
+                },
+                "location": "1",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "0WhMYXnSoIuLZPsd",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.y1JGtzGmMtVh5USK"
+                },
+                "pf2e": {
+                    "itemGrants": {
+                        "allOutAssault": {
+                            "id": "j6MA4necWTNznnJ6",
+                            "onDelete": "detach"
+                        },
+                        "counterattack": {
+                            "id": "F9OTvJKp0WMVee5M",
+                            "onDelete": "detach"
+                        }
+                    }
+                }
+            },
+            "folder": "jZWW6y5VjVRbbU7t",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Wyvern Tactics",
+            "sort": 300000,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p>The Wyvern Flight can use the @UUID[Compendium.pf2e.kingmaker-features.Item.All-Out Assault] and @UUID[Compendium.pf2e.kingmaker-features.Item.Counterattack] tactical actions.</p>"
+                },
+                "level": {
+                    "value": 12
+                },
+                "location": "2",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [
+                    {
+                        "flag": "allOutAssault",
+                        "key": "GrantItem",
+                        "uuid": "Compendium.pf2e.kingmaker-features.Item.All-Out Assault"
+                    },
+                    {
+                        "flag": "counterattack",
+                        "key": "GrantItem",
+                        "uuid": "Compendium.pf2e.kingmaker-features.Item.Counterattack"
+                    }
+                ],
+                "slug": "darkvision",
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "j6MA4necWTNznnJ6",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.Z6jMZgAxI1zRO7Sl"
+                },
+                "pf2e": {
+                    "grantedBy": {
+                        "id": "0WhMYXnSoIuLZPsd",
+                        "onDelete": "cascade"
+                    }
+                }
+            },
+            "folder": "i18YzT3zo3skuWng",
+            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "name": "All-Out Assault",
+            "sort": 0,
+            "system": {
+                "-=level": null,
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 2
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p><strong>Requirement</strong> @UUID[Compendium.pf2e.kingmaker-features.Item.Merciless]</p>\n<hr />\n<p>Your army attacks with frightening vigor. Attempt a melee Strike against an enemy army's AC.</p>\n<p><strong>Critical Success</strong> Your army inflicts 3 points of damage to the target army. If your army's next war action this turn is an attack war action against a different target army, you gain a +1 circumstance bonus to the Strike as your fury continues to the new target.</p>\n<p><strong>Success</strong> Your army deals 2 points of damage to the target army.</p>\n<p><strong>Failure</strong> Your army falters, but still deals 1 point of damage to the target army.</p>\n<p><strong>Critical Failure</strong> Your army deals no damage to the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Outflanked] until the start of its next turn.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "label": "All-Out Assault Followup (Crit Success)",
+                        "predicate": [
+                            "all-out-assault-followup"
+                        ],
+                        "selector": "attack-roll",
+                        "type": "circumstance",
+                        "value": 1
+                    },
+                    {
+                        "domain": "damage",
+                        "key": "RollOption",
+                        "label": "All-Out Assault",
+                        "option": "all-out-assault",
+                        "toggleable": true
+                    },
+                    {
+                        "domain": "attack-roll",
+                        "key": "RollOption",
+                        "label": "All-Out Assault Followup Attack (Crit Success)",
+                        "option": "all-out-assault-followup",
+                        "toggleable": true
+                    }
+                ],
+                "slug": "all-out-assault",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "attack",
+                        "cavalry",
+                        "infantry"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "F9OTvJKp0WMVee5M",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.8wjiF3ctXUjP9oyX"
+                },
+                "pf2e": {
+                    "grantedBy": {
+                        "id": "0WhMYXnSoIuLZPsd",
+                        "onDelete": "cascade"
+                    }
+                }
+            },
+            "folder": "i18YzT3zo3skuWng",
+            "img": "systems/pf2e/icons/actions/Reaction.webp",
+            "name": "Counterattack",
+            "sort": 0,
+            "system": {
+                "-=level": null,
+                "actionType": {
+                    "value": "reaction"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-war-action",
+                "description": {
+                    "value": "<p><strong>Requirement</strong> @UUID[Compendium.pf2e.kingmaker-features.Item.Flexible Tactics]</p>\n<p><strong>Trigger</strong> An army you are engaged with attempts a maneuver war action.</p>\n<hr />\n<p>Your army lashes out at the foe as they attempt to perform a maneuver. Attempt a melee Strike against the triggering army's AC. Counterattack doesn't count toward your multiple attack penalty, and your multiple attack penalty doesn't apply to this Strike.</p>\n<p><strong>Critical Success</strong> You inflict 1 point of damage on the army and increase its @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition value by 1.</p>\n<p><strong>Success</strong> You inflict 1 point of damage on the army.</p>"
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "counterattack",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "infantry",
+                        "skirmisher"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        },
+        {
+            "_id": "FuKuiqxcwZyfmotw",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.kingmaker-features.Item.y1JGtzGmMtVh5USK"
+                }
+            },
+            "folder": "e185cDQaLjU3uZ62",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Darkvision",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "campaign": "kingmaker",
+                "category": "army-tactic",
+                "description": {
+                    "value": "<p>The army includes several spotters and scouts who have darkvision, and the rest of the soldiers have been trained to follow their lead so that the army itself functions as if it had darkvision.</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Kingmaker"
+                },
+                "rules": [],
+                "slug": "darkvision",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "cavalry",
+                        "infantry",
+                        "siege",
+                        "skirmisher"
+                    ]
+                }
+            },
+            "type": "campaignFeature"
+        }
+    ],
+    "name": "Wyvern Flight",
+    "system": {
+        "ac": {
+            "potency": 0,
+            "value": 33
+        },
+        "attributes": {
+            "hp": {
+                "max": 4,
+                "routThreshold": 3,
+                "value": 4
+            }
+        },
+        "consumption": null,
+        "details": {
+            "alignment": "CE",
+            "blurb": "",
+            "description": "<p>This flight of wyverns has been trained to obey orders in battle.</p>\n<p><em><strong>Note</strong>: In Pathfinder: Kingmaker, the Wyvern Flight has a melee strike bonus of +18. This has been assumed to be an error, and substituted with +26, the default value for a level 12 army.</em></p>",
+            "level": {
+                "value": 12
+            }
+        },
+        "recruitmentDC": null,
+        "resources": {
+            "ammunition": {
+                "max": 5,
+                "value": 5
+            },
+            "potions": {
+                "value": 0
+            }
+        },
+        "saves": {
+            "maneuver": 25,
+            "morale": 17
+        },
+        "scouting": 23,
+        "traits": {
+            "rarity": "common",
+            "size": {
+                "value": "med"
+            },
+            "type": "cavalry",
+            "value": []
+        },
+        "weapons": {
+            "melee": {
+                "name": "Fangs, claws, and stingers",
+                "potency": 0
+            },
+            "ranged": null
+        }
+    },
+    "type": "army"
+}

--- a/packs/kingmaker-bestiary/armies/wyvern-flight.json
+++ b/packs/kingmaker-bestiary/armies/wyvern-flight.json
@@ -24,7 +24,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a Morale check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
+                    "value": "<p>Your army's leaders attempt to bolster the soldiers' morale and fight back the effects of fear and panic. Attempt a @Check[type:morale|defense:morale|roller:self] check against a target enemy army of your choice.</p>\n<p><strong>Critical Success</strong> If your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Routed], it loses the routed condition. Reduce your army's @UUID[Compendium.pf2e.kingmaker-features.Item.Shaken] condition by 2.</p>\n<p><strong>Success</strong> Reduce your army's shaken condition by 1.</p>\n<p><strong>Critical Failure</strong> Your attempt to rally backfires—increase your army's shaken condition by 1.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -67,7 +67,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<p>Your army tries to escape from the battlefield.</p>\n<p>If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed].</p>\n<p>Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
+                    "value": "<p><strong>Prerequisite</strong> Your army is not @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged].</p>\n<hr />\n<p>Your army tries to escape from the battlefield. If your army is already @UUID[Compendium.pf2e.kingmaker-features.Item.Distant], it flees the battlefield, is no longer part of the war encounter, and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Routed]. Otherwise, your army gains the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -108,7 +108,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a Maneuver check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
+                    "value": "<p>Your army attempts to disengage from enemy armies to put some distance between itself and the enemy.</p>\n<p>Attempt a @Check[type:maneuver|defense:maneuver|roller:self] check against each army your army is @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with.</p>\n<p><strong>Critical Success</strong> Your army is no longer engaged with the target army. In addition, your army is automatically no longer engaged with any armies you haven't yet rolled a Maneuver check against during this war action.</p>\n<p><strong>Success</strong> Your army breaks free and is no longer engaged with the target army.</p>\n<p><strong>Failure</strong> Your army remains engaged with the target army.</p>\n<p><strong>Critical Failure</strong> Your army remains engaged with the target army and, for the remainder of this turn, your army cannot attempt to disengage from any army with which it is still engaged.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -142,7 +142,6 @@
             "name": "Guard",
             "sort": 0,
             "system": {
-                "-=level": null,
                 "actionType": {
                     "value": "action"
                 },
@@ -152,7 +151,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a Maneuver check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
+                    "value": "<p>Your army spends a war action to adopt a defensive pose—raising shields, focusing on parrying attacks, or seeking cover. Attempt a @Check[type:maneuver|defense:maneuver|roller:self] check against a target army.</p>\n<p><strong>Critical Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn; this bonus applies to all attacks against this army, not just from the targeted army.</p>\n<p>@UUID[Compendium.pf2e.kingmaker-features.Item.Effect: Guard (Critical Success)]</p>\n<p><strong>Success</strong> Your army gains a +2 item bonus to its AC until the start of your next turn against attacks from the target army.</p>\n<p>@UUID[Compendium.pf2e.kingmaker-features.Item.Effect: Guard (Success)]</p>\n<p><strong>Failure</strong> Your army fails to guard against the target army.</p>\n<p><strong>Critical Failure</strong> Your army fails spectacularly to guard against the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1}.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -163,25 +162,7 @@
                     "remaster": false,
                     "title": "Pathfinder Kingmaker"
                 },
-                "rules": [
-                    {
-                        "key": "FlatModifier",
-                        "label": "Guarded",
-                        "predicate": [
-                            "guarded-critical"
-                        ],
-                        "selector": "ac",
-                        "type": "item",
-                        "value": 2
-                    },
-                    {
-                        "domain": "ac",
-                        "key": "RollOption",
-                        "label": "Guarded (Critical Success)",
-                        "option": "guarded-critical",
-                        "toggleable": true
-                    }
-                ],
+                "rules": [],
                 "slug": "guard",
                 "traits": {
                     "rarity": "common",
@@ -256,7 +237,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a Maneuver check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
+                    "value": "<p>Your army attempts to close the distance with a target enemy army it is not engaged with by attempting a @Check[type:maneuver|defense:maneuver|roller:self] check.</p>\n<p><strong>Critical Success</strong> The enemy army becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Engaged] with your army, even if it previously had the @UUID[Compendium.pf2e.kingmaker-features.Item.Distant] condition (in which case it loses that condition and becomes engaged).</p>\n<p><strong>Success</strong> If the target army is distant, it loses that condition; otherwise, it becomes engaged.</p>\n<p><strong>Failure</strong> Your army's attempt to advance fails.</p>\n<p><strong>Critical Failure</strong> Your army's attempt to advance fails, and it becomes disorganized, becoming @UUID[Compendium.pf2e.kingmaker-features.Item.Mired]{Mired 1} until the start of its next turn.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -451,7 +432,6 @@
             "name": "All-Out Assault",
             "sort": 0,
             "system": {
-                "-=level": null,
                 "actionType": {
                     "value": "action"
                 },
@@ -461,7 +441,7 @@
                 "campaign": "kingmaker",
                 "category": "army-war-action",
                 "description": {
-                    "value": "<p><strong>Requirement</strong> @UUID[Compendium.pf2e.kingmaker-features.Item.Merciless]</p>\n<hr />\n<p>Your army attacks with frightening vigor. Attempt a melee Strike against an enemy army's AC.</p>\n<p><strong>Critical Success</strong> Your army inflicts 3 points of damage to the target army. If your army's next war action this turn is an attack war action against a different target army, you gain a +1 circumstance bonus to the Strike as your fury continues to the new target.</p>\n<p><strong>Success</strong> Your army deals 2 points of damage to the target army.</p>\n<p><strong>Failure</strong> Your army falters, but still deals 1 point of damage to the target army.</p>\n<p><strong>Critical Failure</strong> Your army deals no damage to the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Outflanked] until the start of its next turn.</p>"
+                    "value": "<p><strong>Requirement</strong> @UUID[Compendium.pf2e.kingmaker-features.Item.Merciless]</p>\n<hr />\n<p>Your army attacks with frightening vigor. Attempt a melee Strike against an enemy army's AC.</p>\n<p><strong>Critical Success</strong> Your army inflicts @Damage[3|domains:melee-damage,strike-damage] points of damage to the target army. If your army's next war action this turn is an attack war action against a different target army, you gain a +1 circumstance bonus to the Strike as your fury continues to the new target.</p>\n<p><strong>Success</strong> Your army deals @Damage[2|domains:melee-damage,strike-damage] points of damage to the target army.</p>\n<p><strong>Failure</strong> Your army falters, but still deals @Damage[1|domains:melee-damage,strike-damage] point of damage to the target army.</p>\n<p><strong>Critical Failure</strong> Your army deals no damage to the target army and becomes @UUID[Compendium.pf2e.kingmaker-features.Item.Outflanked] until the start of its next turn.</p>"
                 },
                 "location": null,
                 "prerequisites": {
@@ -474,6 +454,13 @@
                 },
                 "rules": [
                     {
+                        "domain": "attack-roll",
+                        "key": "RollOption",
+                        "label": "All-Out Assault Followup Attack (Crit Success)",
+                        "option": "all-out-assault-followup",
+                        "toggleable": true
+                    },
+                    {
                         "key": "FlatModifier",
                         "label": "All-Out Assault Followup (Crit Success)",
                         "predicate": [
@@ -482,20 +469,6 @@
                         "selector": "attack-roll",
                         "type": "circumstance",
                         "value": 1
-                    },
-                    {
-                        "domain": "damage",
-                        "key": "RollOption",
-                        "label": "All-Out Assault",
-                        "option": "all-out-assault",
-                        "toggleable": true
-                    },
-                    {
-                        "domain": "attack-roll",
-                        "key": "RollOption",
-                        "label": "All-Out Assault Followup Attack (Crit Success)",
-                        "option": "all-out-assault-followup",
-                        "toggleable": true
                     }
                 ],
                 "slug": "all-out-assault",
@@ -528,7 +501,6 @@
             "name": "Counterattack",
             "sort": 0,
             "system": {
-                "-=level": null,
                 "actionType": {
                     "value": "reaction"
                 },

--- a/src/module/item/base/document.ts
+++ b/src/module/item/base/document.ts
@@ -367,7 +367,7 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
                     return;
                 }
             }
-        } else if (itemIsOfType(currentSource, "feat", "spell")) {
+        } else if (itemIsOfType(currentSource, "campaignFeature", "feat", "spell")) {
             // Preserve feat and spellcasting entry location
             mergeObject(updates, expandObject({ "system.location": currentSource.system.location }));
         }

--- a/src/module/item/campaign-feature/document.ts
+++ b/src/module/item/campaign-feature/document.ts
@@ -149,7 +149,7 @@ class CampaignFeaturePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> e
                 : KINGMAKER_CATEGORY_TYPES[0];
             const behavior = KINGDOM_CATEGORY_DATA[category].behavior;
             if (behavior === "activity") {
-                system["-=level"] = null;
+                if ("level" in this.system) system["-=level"] = null;
             } else {
                 const level = system.level?.value ?? this.system.level?.value ?? 0;
                 system.level = { value: level };


### PR DESCRIPTION
Some limitations are discussed here:

https://github.com/foundryvtt/pf2e/issues/12161

Most notably this does not include the appendix actors yet, only the ones that are used in the adventure itself