### PR TITLE
Allow suppression of ui notifications in refreshFromCompendium

### DIFF
--- a/src/module/item/base/document.ts
+++ b/src/module/item/base/document.ts
@@ -374,7 +374,7 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
         }
 
         await this.update(updates, { diff: false, recursive: false });
-        if (notify) ui.notifications.info(`Item "${this.name}" has been refreshed.`);
+        if (options.notify) ui.notifications.info(`Item "${this.name}" has been refreshed.`);
     }
 
     getOriginData(): ItemOriginFlag {

--- a/src/module/item/base/document.ts
+++ b/src/module/item/base/document.ts
@@ -267,7 +267,9 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
     }
 
     /** Pull the latest system data from the source compendium and replace this item's with it */
-    async refreshFromCompendium(options: { name?: boolean, notify?: boolean } = { name: true, notify: true }): Promise<void> {
+    async refreshFromCompendium(
+        options: { name?: boolean; notify?: boolean } = { name: true, notify: true },
+    ): Promise<void> {
         if (!this.isOwned) {
             throw ErrorPF2e("This utility may only be used on owned items");
         }

--- a/src/module/item/base/document.ts
+++ b/src/module/item/base/document.ts
@@ -286,7 +286,8 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
                 (r) => typeof r.key === "string" && ["ChoiceSet", "GrantItem"].includes(r.key),
             )
         ) {
-            if (!options.silent) ui.notifications.warn("PF2E.Item.RefreshFromCompendium.Tooltip.Disabled", { localize: true });
+            if (!options.silent)
+                ui.notifications.warn("PF2E.Item.RefreshFromCompendium.Tooltip.Disabled", { localize: true });
             return;
         }
 
@@ -365,7 +366,7 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
                                 item: currentSource.system.spell.name,
                                 sourceId: spellSourceId,
                             }),
-                    );
+                        );
                     return;
                 }
             }

--- a/src/module/item/base/document.ts
+++ b/src/module/item/base/document.ts
@@ -267,9 +267,7 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
     }
 
     /** Pull the latest system data from the source compendium and replace this item's with it */
-    async refreshFromCompendium(
-        options: { name?: boolean; notify?: boolean } = { name: true, notify: true },
-    ): Promise<void> {
+    async refreshFromCompendium(options: { name?: boolean, notify?: boolean } = { name: true, notify: true }): Promise<void> {
         if (!this.isOwned) {
             throw ErrorPF2e("This utility may only be used on owned items");
         }
@@ -286,26 +284,23 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
                 (r) => typeof r.key === "string" && ["ChoiceSet", "GrantItem"].includes(r.key),
             )
         ) {
-            if (options.notify)
-                ui.notifications.warn("PF2E.Item.RefreshFromCompendium.Tooltip.Disabled", { localize: true });
+            ui.notifications.warn("PF2E.Item.RefreshFromCompendium.Tooltip.Disabled", { localize: true });
             return;
         }
 
         const latestSource = (await fromUuid<this>(this.sourceId))?.toObject();
         if (!latestSource) {
-            if (options.notify)
-                ui.notifications.warn(
-                    game.i18n.format("PF2E.Item.RefreshFromCompendium.SourceNotFound", {
-                        item: this.name,
-                        sourceId: this.sourceId,
-                    }),
-                );
+            ui.notifications.warn(
+                game.i18n.format("PF2E.Item.RefreshFromCompendium.SourceNotFound", {
+                    item: this.name,
+                    sourceId: this.sourceId,
+                }),
+            );
             return;
         } else if (latestSource.type !== this.type) {
-            if (options.notify)
-                ui.notifications.error(
-                    `The compendium source for "${this.name}" is of a different type than what is present on this actor.`,
-                );
+            ui.notifications.error(
+                `The compendium source for "${this.name}" is of a different type than what is present on this actor.`,
+            );
             return;
         }
 
@@ -360,13 +355,12 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
                         system: { spell: spellConsumableData.system.spell },
                     });
                 } else {
-                    if (options.notify)
-                        ui.notifications.warn(
-                            game.i18n.format("PF2E.Item.RefreshFromCompendium.SourceNotFound", {
-                                item: currentSource.system.spell.name,
-                                sourceId: spellSourceId,
-                            }),
-                        );
+                    ui.notifications.warn(
+                        game.i18n.format("PF2E.Item.RefreshFromCompendium.SourceNotFound", {
+                            item: currentSource.system.spell.name,
+                            sourceId: spellSourceId,
+                        }),
+                    );
                     return;
                 }
             }
@@ -380,7 +374,7 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
         }
 
         await this.update(updates, { diff: false, recursive: false });
-        if (options.notify) ui.notifications.info(`Item "${this.name}" has been refreshed.`);
+        if (notify) ui.notifications.info(`Item "${this.name}" has been refreshed.`);
     }
 
     getOriginData(): ItemOriginFlag {

--- a/src/module/item/base/document.ts
+++ b/src/module/item/base/document.ts
@@ -268,7 +268,7 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
 
     /** Pull the latest system data from the source compendium and replace this item's with it */
     async refreshFromCompendium(
-        options: { name?: boolean; silent?: boolean } = { name: true, silent: false },
+        options: { name?: boolean; notify?: boolean } = { name: true, notify: true },
     ): Promise<void> {
         if (!this.isOwned) {
             throw ErrorPF2e("This utility may only be used on owned items");
@@ -278,7 +278,7 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
         }
 
         options.name ??= true;
-        options.silent ??= false;
+        options.notify ??= true;
 
         const currentSource = this.toObject();
         if (
@@ -286,14 +286,14 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
                 (r) => typeof r.key === "string" && ["ChoiceSet", "GrantItem"].includes(r.key),
             )
         ) {
-            if (!options.silent)
+            if (options.notify)
                 ui.notifications.warn("PF2E.Item.RefreshFromCompendium.Tooltip.Disabled", { localize: true });
             return;
         }
 
         const latestSource = (await fromUuid<this>(this.sourceId))?.toObject();
         if (!latestSource) {
-            if (!options.silent)
+            if (options.notify)
                 ui.notifications.warn(
                     game.i18n.format("PF2E.Item.RefreshFromCompendium.SourceNotFound", {
                         item: this.name,
@@ -302,7 +302,7 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
                 );
             return;
         } else if (latestSource.type !== this.type) {
-            if (!options.silent)
+            if (options.notify)
                 ui.notifications.error(
                     `The compendium source for "${this.name}" is of a different type than what is present on this actor.`,
                 );
@@ -360,7 +360,7 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
                         system: { spell: spellConsumableData.system.spell },
                     });
                 } else {
-                    if (!options.silent)
+                    if (options.notify)
                         ui.notifications.warn(
                             game.i18n.format("PF2E.Item.RefreshFromCompendium.SourceNotFound", {
                                 item: currentSource.system.spell.name,
@@ -380,7 +380,7 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
         }
 
         await this.update(updates, { diff: false, recursive: false });
-        if (!options.silent) ui.notifications.info(`Item "${this.name}" has been refreshed.`);
+        if (options.notify) ui.notifications.info(`Item "${this.name}" has been refreshed.`);
     }
 
     getOriginData(): ItemOriginFlag {


### PR DESCRIPTION
For the use case of batch calling this method on many items, where a summary is being provided. not having several tens of notifications to click through is a better user experience.