### PR TITLE
Fix regression restoring scroll positions after re-render

### DIFF
--- a/src/module/actor/sheet/item-summary-renderer.ts
+++ b/src/module/actor/sheet/item-summary-renderer.ts
@@ -155,9 +155,10 @@ export class ItemSummaryRenderer<TActor extends ActorPF2e> {
         // Re-open hidden item summaries
         if (elements.length > 0) {
             const selector = elements.map((s) => htmlSelectorFor(s)).join(",");
-            for (const container of htmlQueryAll(result, selector)) {
-                this.toggleSummary(container, { instant: true, visible: true });
-            }
+            const promises = htmlQueryAll(result, selector).map((container) =>
+                this.toggleSummary(container, { instant: true, visible: true }),
+            );
+            await Promise.all(promises);
         }
 
         return $result;


### PR DESCRIPTION
The await is necessary so foundry's built in "restore scroll y" feature runs after the item summaries are opened.