### PR TITLE
Filter out inactive homebrew/legacy traits from certain item types

### DIFF
--- a/src/module/item/ability/document.ts
+++ b/src/module/item/ability/document.ts
@@ -41,6 +41,8 @@ class AbilityItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> exten
         if (this.system.actionType.value === "passive") {
             this.system.selfEffect = null;
         }
+
+        this.system.traits.value = this.system.traits.value.filter((t) => t in CONFIG.PF2E.actionTraits);
     }
 
     override onPrepareSynthetics(this: AbilityItemPF2e<ActorPF2e>): void {

--- a/src/module/item/melee/document.ts
+++ b/src/module/item/melee/document.ts
@@ -125,6 +125,8 @@ class MeleePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
     override prepareBaseData(): void {
         super.prepareBaseData();
 
+        this.system.traits.value = this.system.traits.value.filter((t) => t in CONFIG.PF2E.npcAttackTraits);
+
         // Set precious material (currently unused)
         this.system.material = { type: null, grade: null, effects: [] };
 

--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -560,6 +560,7 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
             this.system.location.value = "rituals";
         }
 
+        this.system.traits.value = this.system.traits.value.filter((t) => t in CONFIG.PF2E.spellTraits);
         if (this.system.traits.value.includes("attack")) {
             this.system.defense = mergeObject(this.system.defense ?? {}, {
                 passive: { statistic: "ac" as const },

--- a/src/module/item/weapon/document.ts
+++ b/src/module/item/weapon/document.ts
@@ -312,6 +312,7 @@ class WeaponPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
         if (this.system.category === "unarmed" && !this.system.traits.value.includes("unarmed")) {
             this.system.traits.value.push("unarmed");
         }
+        this.system.traits.value = this.system.traits.value.filter((t) => t in CONFIG.PF2E.npcAttackTraits);
 
         // Force a weapon to be ranged if it is among a set of certain groups or has a thrown trait
         const traitSet = this.traits;


### PR DESCRIPTION
(during data preparation, not from compendium data)