### PR TITLE
Allow check DCs to resolve for an item with no actor

### DIFF
--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -678,7 +678,7 @@ function getCheckDC({
             const value = resolve && resolve?.length > 0 ? resolve[1] : "";
             const saferEval = (resolveString: string): number => {
                 try {
-                    const rollData = item?.getRollData() ?? actor!.getRollData();
+                    const rollData = item?.getRollData() ?? actor?.getRollData() ?? {};
                     return Roll.safeEval(Roll.replaceFormulaData(resolveString, rollData));
                 } catch {
                     return 0;

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -672,13 +672,13 @@ function getCheckDC({
     const { type } = params;
     const dc = params.dc;
     const base = (() => {
-        if (dc?.startsWith("resolve") && actor) {
+        if (dc?.startsWith("resolve") && (item || actor)) {
             params.immutable ||= "true";
             const resolve = dc.match(/resolve\((.+?)\)$/);
             const value = resolve && resolve?.length > 0 ? resolve[1] : "";
             const saferEval = (resolveString: string): number => {
                 try {
-                    const rollData = item?.getRollData() ?? actor?.getRollData();
+                    const rollData = item?.getRollData() ?? actor!.getRollData();
                     return Roll.safeEval(Roll.replaceFormulaData(resolveString, rollData));
                 } catch {
                     return 0;


### PR DESCRIPTION
Using updated Stupefied, and opened from the Compendium.

Before:
<img width="195" alt="Screen Shot 2023-12-13 at 4 35 09 PM" src="https://github.com/foundryvtt/pf2e/assets/1904698/e6a78dac-e4c2-49e1-a554-71553e95eda6">

After:
<img width="197" alt="Screen Shot 2023-12-13 at 4 31 31 PM" src="https://github.com/foundryvtt/pf2e/assets/1904698/54ea85c0-da9e-43bc-9aad-9ed5eab8a4d3">