### PR TITLE
Not setting the turn value if an encounter hasn't started yet

### DIFF
--- a/src/module/encounter/document.ts
+++ b/src/module/encounter/document.ts
@@ -200,7 +200,7 @@ class EncounterPF2e extends Combat {
         );
         await this.updateEmbeddedDocuments("Combatant", updates);
         // Ensure the current turn is preserved
-        await this.update({ turn: this.turns.findIndex((c) => c.id === currentId) });
+        if (this.turn !== null) await this.update({ turn: this.turns.findIndex((c) => c.id === currentId) });
     }
 
     override async setInitiative(id: string, value: number): Promise<void> {


### PR DESCRIPTION
When an encounter hasn't started yet, rolling initiative causes the current turn to be set to that combatant. This will ensure that turn remains null when rolling initiative before combat starts.