### PR TITLE
Fix invalid spacing in journals created with prosemirror

### DIFF
--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -54,10 +54,10 @@ class TextEditorPF2e extends TextEditor {
         options: EnrichmentOptionsPF2e = {},
     ): string | Promise<string> {
         options.secrets ??= game.user.isGM;
-        if (content?.startsWith("<p>@Localize")) {
-            // Remove tags
-            content = content.substring(3, content.length - 4);
-        }
+
+        // Remove tags from @Localize only enriches.
+        // Those often include HTML, including <p>, and <p> tags cannot be nested.
+        content = content?.replace(/^\s*<p>@Localize\[([\w.]+)\]<\/p>\s*$/, "@Localize[$1]") ?? null;
 
         const enriched = superEnrichHTML.apply(this, [content, options]);
         if (typeof enriched === "string" && (options.processVisibility ?? true)) {

--- a/src/styles/mixins/_typography.scss
+++ b/src/styles/mixins/_typography.scss
@@ -20,12 +20,6 @@
     --space-2xl: 2em;
     --radius: 3px;
 
-    // Override so that empty <p> (and <p>s with empty <span>) do not take space
-    // This comes up for @Localize
-    p {
-        min-height: unset;
-    }
-
     // Redeclared so that popout journals pages match embedded journal pages and item summaries
     :is(h1, h2, h3, h4, h5, h6):not(:first-child) {
         margin-top: 1em;


### PR DESCRIPTION
I would super appreciate some testing to make sure I didn't break any existing localizations, though roll notes and attack of opportunity seem to be working fine in this respect.