### PR TITLE
Replace edicts/anathema with autogrowing text

### DIFF
--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -489,6 +489,20 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
 
         this.#activateNavListeners(html);
 
+        // Handlers for content editable text inputs
+        for (const input of htmlQueryAll(html, "div[contenteditable][data-property]")) {
+            if (!this.options.editable) {
+                input.contentEditable = "false";
+                continue;
+            }
+
+            const propertyPath = input.dataset.property ?? "";
+            input.addEventListener("blur", () => {
+                const newValue = input.innerText;
+                this.actor.update({ [propertyPath]: newValue });
+            });
+        }
+
         // Toggle the availability of the roll-initiative link
         this.toggleInitiativeLink();
 

--- a/src/scripts/handlebars.ts
+++ b/src/scripts/handlebars.ts
@@ -19,6 +19,11 @@ export function registerHandlebarsHelpers(): void {
         return args.slice(0, -1).some((a) => !!a);
     });
 
+    /** Used for content editables. Keeps the text as plain text but enables newlines */
+    Handlebars.registerHelper("breakLines", (value: string): string => {
+        return Handlebars.Utils.escapeExpression(value).replaceAll("\n", "<br/>");
+    });
+
     Handlebars.registerHelper("disabled", (condition: unknown): string => {
         return condition ? "disabled" : "";
     });

--- a/src/styles/actor/character/_biography.scss
+++ b/src/styles/actor/character/_biography.scss
@@ -11,10 +11,25 @@
     }
 
     section {
+        div[contenteditable] {
+            line-height: 1.5em;
+            padding: calc((var(--form-field-height) - 1.5em) / 2) 3px;
+            width: calc(100% - 6px);
+        }
+
         &.editable {
             .editor-content,
             input {
                 background: rgba(0, 0, 0, 5%);
+            }
+
+            div[contenteditable] {
+                border: none;
+                background: rgba(0, 0, 0, 5%);
+
+                &:focus {
+                    outline: none;
+                }
             }
 
             .editor-content {
@@ -58,6 +73,12 @@
                     width: 100%;
                 }
             }
+
+            .edicts,
+            .anathema,
+            .catchphrases {
+                flex-basis: 100%;
+            }
         }
 
         &.campaign {
@@ -95,33 +116,6 @@
         }
 
         .bio {
-            h3 {
-                @include p-reset;
-                background-color: rgba($text-dark-color, 0.1);
-                border: none;
-                color: var(--text-dark);
-                font: 700 var(--font-size-14) var(--body-serif);
-                grid-area: mod;
-                height: 26px;
-                padding: 8px 4px 6px;
-                width: calc(100% - 6px);
-
-                i {
-                    position: relative;
-                    right: -2px;
-                    top: -2px;
-                    float: right;
-                }
-
-                span.value {
-                    display: inline-block;
-                    max-width: 87%;
-                    overflow: hidden;
-                    text-overflow: ellipsis;
-                    white-space: nowrap;
-                }
-            }
-
             h4.details-label {
                 margin-bottom: 0;
                 width: 100%;

--- a/static/templates/actors/character/tabs/biography.hbs
+++ b/static/templates/actors/character/tabs/biography.hbs
@@ -73,15 +73,11 @@
             </div>
             <div class="bio edicts">
                 <label class="details-label" for="{{document.uuid}}-edicts">{{localize "PF2E.BiographyEdicts"}}</label>
-                <span>
-                    <input type="text" id="{{document.uuid}}-edicts" name="system.details.biography.edicts" value="{{biography.edicts}}" />
-                </span>
+                <div role="textarea" id="{{document.uuid}}-edicts" data-property="system.details.biography.edicts" contenteditable>{{{breakLines biography.edicts}}}</div>
             </div>
             <div class="bio anathema">
                 <label class="details-label" for="{{document.uuid}}-anathema">{{localize "PF2E.BiographyAnathema"}}</label>
-                <span>
-                    <input type="text" id="{{document.uuid}}-anathema" name="system.details.biography.anathema" value="{{biography.anathema}}" />
-                </span>
+                <div role="textarea" id="{{document.uuid}}-anathema" data-property="system.details.biography.anathema" contenteditable>{{{breakLines biography.anathema}}}</div>
             </div>
             <div class="bio likes">
                 <label class="details-label" for="{{document.uuid}}-likes">{{localize "PF2E.BiographyLikes"}}</label>


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/12122

Also fixed a bug with h3's in rich text bio's having weird styling, but I think the journal styling differing from the result is problematic. It might be worth gutting all of the biography-content styling, but I'd rather not touch that right now.

![image](https://github.com/foundryvtt/pf2e/assets/1286721/d6a7603f-cd87-4f00-a34b-e745b143b6d6)

![image](https://github.com/foundryvtt/pf2e/assets/1286721/b29be21b-f458-4331-9fc2-5ea4d30f0311)

