### PR TITLE
Fix action cost of Vengeful Spirit Deck and autolevel damage links

### DIFF
--- a/packs/feats/vengeful-spirit-deck.json
+++ b/packs/feats/vengeful-spirit-deck.json
@@ -4,14 +4,14 @@
     "name": "Vengeful Spirit Deck",
     "system": {
         "actionType": {
-            "value": "passive"
+            "value": "action"
         },
         "actions": {
-            "value": null
+            "value": 2
         },
         "category": "class",
         "description": {
-            "value": "<p><strong>Requirements</strong> You have an active harrow omen.</p>\n<hr />\n<p>You manifest a ghostly deck of harrow cards. Draw a card from a harrow deck, then select a target within 60 feet. The card flies through the air to strike at that target, inflicting 4d6 damage, with a @Check[type:reflex|dc:resolve(@actor.attributes.classOrSpellDC.value)|basic:true] saving throw against your class DC or spell DC. The type of damage inflicted is determined by your active harrow omen; if the card drawn is in the same suit as your active harrow omen, the target takes a –2 status penalty to its saving throw. The damage increases to 6d6 if you're 10th level and 8d6 if you're 15th level. You can continue to throw cards at targets on your turn as long as you Sustain the Vengeful Spirit Deck—throwing a card takes two actions. This effect lasts as long as you Sustain it, up to 1 minute, or until you no longer have an active harrow omen. Once the effect ends, you lose your active harrow omen.</p>\n<p><strong>Hammers:</strong> @Damage[4d6[cold]] damage, @Damage[6d6[cold]], @Damage[8d6[cold]]</p>\n<p><strong>Keys:</strong> @Damage[4d6[fire]] damage, @Damage[6d6[fire]], @Damage[8d6[fire]]</p>\n<p><strong>Shields:</strong> @Damage[4d6[poison]] damage, @Damage[6d6[poison]], @Damage[8d6[poison]]</p>\n<p><strong>Books:</strong> @Damage[4d6[electricity]] damage, @Damage[6d6[electricity]], @Damage[8d6[electricity]]</p>\n<p><strong>Stars:</strong> @Damage[4d6[mental]] damage, @Damage[6d6[mental]], @Damage[8d6[mental]]</p>\n<p><strong>Crowns:</strong> @Damage[4d6[acid]] damage, @Damage[6d6[acid]], @Damage[8d6[acid]]</p>"
+            "value": "<p><strong>Requirements</strong> You have an active harrow omen.</p>\n<hr />\n<p>You manifest a ghostly deck of harrow cards. Draw a card from a harrow deck, then select a target within 60 feet. The card flies through the air to strike at that target, inflicting 4d6 damage, with a @Check[type:reflex|dc:resolve(@actor.attributes.classOrSpellDC.value)|basic:true] saving throw against your class DC or spell DC. The type of damage inflicted is determined by your active harrow omen; if the card drawn is in the same suit as your active harrow omen, the target takes a –2 status penalty to its saving throw. The damage increases to 6d6 if you're 10th level and 8d6 if you're 15th level. You can continue to throw cards at targets on your turn as long as you Sustain the Vengeful Spirit Deck—throwing a card takes two actions. This effect lasts as long as you Sustain it, up to 1 minute, or until you no longer have an active harrow omen. Once the effect ends, you lose your active harrow omen.</p>\n<p><strong>Hammers:</strong> @Damage[(ternary(gte(@actor.level,15),8,ternary(gte(@actor.level,10),6,4)))d6[cold]]</p>\n<p><strong>Keys:</strong> @Damage[(ternary(gte(@actor.level,15),8,ternary(gte(@actor.level,10),6,4)))d6[fire]]</p>\n<p><strong>Shields:</strong> @Damage[(ternary(gte(@actor.level,15),8,ternary(gte(@actor.level,10),6,4)))d6[poison]]</p>\n<p><strong>Books:</strong> @Damage[(ternary(gte(@actor.level,15),8,ternary(gte(@actor.level,10),6,4)))d6[electricity]]</p>\n<p><strong>Stars:</strong> @Damage[(ternary(gte(@actor.level,15),8,ternary(gte(@actor.level,10),6,4)))d6[mental]]</p>\n<p><strong>Crowns:</strong> @Damage[(ternary(gte(@actor.level,15),8,ternary(gte(@actor.level,10),6,4)))d6[acid]]</p>"
         },
         "level": {
             "value": 6
@@ -28,7 +28,8 @@
         "traits": {
             "rarity": "uncommon",
             "value": [
-                "archetype"
+                "archetype",
+                "spellshape"
             ]
         }
     },


### PR DESCRIPTION
Also added spellshape trait since source lists it as metamagic

Closes https://github.com/foundryvtt/pf2e/issues/12283