### PR TITLE
Add remaster changes to climb action macro

### DIFF
--- a/src/module/system/action-macros/athletics/climb.ts
+++ b/src/module/system/action-macros/athletics/climb.ts
@@ -1,25 +1,45 @@
 import { ActionMacroHelpers, SkillActionOptions } from "../index.ts";
+import { SingleCheckAction } from "@actor/actions/index.ts";
 
-export function climb(options: SkillActionOptions): void {
+const PREFIX = "PF2E.Actions.Climb";
+
+function climb(options: SkillActionOptions): void {
     const slug = options?.skill ?? "athletics";
     const rollOptions = ["action:climb"];
     const modifiers = options?.modifiers;
     ActionMacroHelpers.simpleRollActionCheck({
         actors: options.actors,
         actionGlyph: options.glyph ?? "A",
-        title: "PF2E.Actions.Climb.Title",
+        title: `${PREFIX}.Title`,
         checkContext: (opts) => ActionMacroHelpers.defaultCheckContext(opts, { modifiers, rollOptions, slug }),
         traits: ["move"],
         event: options.event,
         callback: options.callback,
         difficultyClass: options.difficultyClass,
         extraNotes: (selector: string) => [
-            ActionMacroHelpers.note(selector, "PF2E.Actions.Climb", "criticalSuccess"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.Climb", "success"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.Climb", "criticalFailure"),
+            ActionMacroHelpers.note(selector, PREFIX, "criticalSuccess"),
+            ActionMacroHelpers.note(selector, PREFIX, "success"),
+            ActionMacroHelpers.note(selector, PREFIX, "criticalFailure"),
         ],
     }).catch((error: Error) => {
         ui.notifications.error(error.message);
         throw error;
     });
 }
+
+const action = new SingleCheckAction({
+    cost: 1,
+    description: `${PREFIX}.Description`,
+    name: `${PREFIX}.Title`,
+    notes: [
+        { outcome: ["criticalSuccess"], text: `${PREFIX}.Notes.criticalSuccess` },
+        { outcome: ["success"], text: `${PREFIX}.Notes.success` },
+        { outcome: ["criticalFailure"], text: `${PREFIX}.Notes.criticalFailure` },
+    ],
+    rollOptions: ["action:climb"],
+    slug: "climb",
+    statistic: "athletics",
+    traits: ["move"],
+});
+
+export { climb as legacy, action };

--- a/src/module/system/action-macros/index.ts
+++ b/src/module/system/action-macros/index.ts
@@ -3,7 +3,7 @@ import * as maneuverInFlight from "./acrobatics/maneuver-in-flight.ts";
 import * as squeeze from "./acrobatics/squeeze.ts";
 import * as tumbleThrough from "./acrobatics/tumble-through.ts";
 import { arcaneSlam } from "./ancestry/automaton/arcane-slam.ts";
-import { climb } from "./athletics/climb.ts";
+import * as climb from "./athletics/climb.ts";
 import { disarm } from "./athletics/disarm.ts";
 import * as forceOpen from "./athletics/force-open.ts";
 import { grapple } from "./athletics/grapple.ts";
@@ -87,7 +87,7 @@ export const ActionMacros = {
     tumbleThrough: tumbleThrough.legacy,
 
     // Athletics
-    climb,
+    climb: climb.legacy,
     disarm,
     forceOpen: forceOpen.legacy,
     grapple,
@@ -154,6 +154,7 @@ export const SystemActions: Action[] = [
     aid,
     avoidNotice.action,
     balance.action,
+    climb.action,
     coerce.action,
     commandAnAnimal.action,
     concealAnObject.action,

--- a/static/lang/action-en.json
+++ b/static/lang/action-en.json
@@ -104,10 +104,11 @@
                 "Title": "Burrow"
             },
             "Climb": {
+                "Description": "<p><strong>Requirements</strong> You have two hands free.</p><hr><p>You attempt an Athletics check to move a maximum distance of 5 feet up, down, or across an incline. You're @UUID[Compendium.pf2e.conditionitems.Item.AJh5ex99aV6VTggg]{off-guard} while climbing unless you have a climb Speed. The GM determines the DC based on the nature of the incline and environmental circumstances; you might get an automatic critical success on an incline that's trivial to climb. If your land Speed is 40 feet or higher, increase the maximum distance by 5 feet for every 20 feet of Speed above 20 feet.</p><p><strong>Critical Success</strong> You move along the incline, increasing the maximum distance by 5 feet.<br><strong>Success</strong> You move along the incline.<br><strong>Critical Failure</strong> You fall. If you began the climb on stable ground, you fall and land @UUID[Compendium.pf2e.conditionitems.Item.j91X7x0XSomq8d60]{prone}.</p><section class=\"sample-tasks\"><h2>Sample Climb Tasks</h2><p><strong>Untrained</strong> ladder, steep slope, low-branched tree</p><p><strong>Trained</strong> rigging, rope, typical tree</p><p><strong>Expert</strong> wall with small handholds and footholds</p><p><strong>Master</strong> ceiling with handholds and footholds, rock wall</p><p><strong>Legendary</strong> smooth surface</p></section>",
                 "Notes": {
-                    "criticalFailure": "<strong>Critical Failure</strong> You fall. If you began the climb on stable ground, you fall and land @UUID[Compendium.pf2e.conditionitems.Item.j91X7x0XSomq8d60]{Prone}.",
-                    "criticalSuccess": "<strong>Critical Success</strong> You move up, across, or safely down the incline for 5 feet plus 5 feet per 20 feet of your land Speed (a total of 10 feet for most PCs).",
-                    "success": "<strong>Success</strong> You move up, across, or safely down the incline for 5 feet per 20 feet of your land Speed (a total of 5 feet for most PCs, minimum 5 feet if your Speed is below 20 feet)."
+                    "criticalFailure": "<strong>Critical Failure</strong> You fall. If you began the climb on stable ground, you fall and land @UUID[Compendium.pf2e.conditionitems.Item.j91X7x0XSomq8d60]{prone}.",
+                    "criticalSuccess": "<strong>Critical Success</strong> You move along the incline, increasing the maximum distance by 5 feet.",
+                    "success": "<strong>Success</strong> You move along the incline."
                 },
                 "Title": "Climb"
             },


### PR DESCRIPTION
Update the outcome text to reflect the text in Player Core. Also convert it to an action object and add the remaster description.