### PR TITLE
Add remaster changes to force open action macro

### DIFF
--- a/src/module/system/action-macros/athletics/force-open.ts
+++ b/src/module/system/action-macros/athletics/force-open.ts
@@ -1,13 +1,16 @@
 import { ActionMacroHelpers, SkillActionOptions } from "../index.ts";
+import { SingleCheckAction } from "@actor/actions/index.js";
 
-export function forceOpen(options: SkillActionOptions): void {
+const PREFIX = "PF2E.Actions.ForceOpen";
+
+function forceOpen(options: SkillActionOptions): void {
     const slug = options?.skill ?? "athletics";
     const rollOptions = ["action:force-open"];
     const modifiers = options?.modifiers;
     ActionMacroHelpers.simpleRollActionCheck({
         actors: options.actors,
         actionGlyph: options.glyph ?? "A",
-        title: "PF2E.Actions.ForceOpen.Title",
+        title: `${PREFIX}.Title`,
         checkContext: (opts) => ActionMacroHelpers.defaultCheckContext(opts, { modifiers, rollOptions, slug }),
         traits: ["attack"],
         event: options.event,
@@ -23,3 +26,20 @@ export function forceOpen(options: SkillActionOptions): void {
         throw error;
     });
 }
+
+const action = new SingleCheckAction({
+    cost: 1,
+    description: `${PREFIX}.Description`,
+    name: `${PREFIX}.Title`,
+    notes: [
+        { outcome: ["criticalSuccess"], text: `${PREFIX}.Notes.criticalSuccess` },
+        { outcome: ["success"], text: `${PREFIX}.Notes.success` },
+        { outcome: ["criticalFailure"], text: `${PREFIX}.Notes.criticalFailure` },
+    ],
+    rollOptions: ["action:force-open"],
+    slug: "force-open",
+    statistic: "athletics",
+    traits: ["attack"],
+});
+
+export { forceOpen as legacy, action };

--- a/src/module/system/action-macros/index.ts
+++ b/src/module/system/action-macros/index.ts
@@ -5,7 +5,7 @@ import * as tumbleThrough from "./acrobatics/tumble-through.ts";
 import { arcaneSlam } from "./ancestry/automaton/arcane-slam.ts";
 import { climb } from "./athletics/climb.ts";
 import { disarm } from "./athletics/disarm.ts";
-import { forceOpen } from "./athletics/force-open.ts";
+import * as forceOpen from "./athletics/force-open.ts";
 import { grapple } from "./athletics/grapple.ts";
 import { highJump } from "./athletics/high-jump.ts";
 import { longJump } from "./athletics/long-jump.ts";
@@ -89,7 +89,7 @@ export const ActionMacros = {
     // Athletics
     climb,
     disarm,
-    forceOpen,
+    forceOpen: forceOpen.legacy,
     grapple,
     highJump,
     longJump,
@@ -165,6 +165,7 @@ export const SystemActions: Action[] = [
     disableDevice.action,
     dropProne,
     escape.action,
+    forceOpen.action,
     hide.action,
     interact,
     leap,

--- a/static/lang/action-en.json
+++ b/static/lang/action-en.json
@@ -335,11 +335,12 @@
                 "Title": "Fly"
             },
             "ForceOpen": {
+                "Description": "<p>Using your body, a lever, or some other tool, you attempt to forcefully open a door, window, container or heavy gate. With a high enough result, you can even smash through walls. Without a crowbar, prying something open takes a -2 item penalty to the Athletics check to Force Open.</p><p><strong>Critical Success</strong> You open the door, window, container, or gate and can avoid damaging it in the process.<br><strong>Success</strong> You break the door, window, container, or gate open, and it gains the @UUID[Compendium.pf2e.conditionitems.Item.6dNUvdb1dhToNDj3]{broken} condition. If it's especially sturdy, the GM might have it take damage but not be broken.<br><strong>Critical Failure</strong> Your attempt jams the door, window, container, or gate shut, imposing a –2 circumstance penalty on future attempts to Force it Open.</p><section class=\"sample-tasks\"><h2>Sample Force Open Tasks</h2><p><strong>Untrained</strong> fabric, flimsy glass</p><p><strong>Trained</strong> ice, sturdy glass</p><p><strong>Expert</strong> flimsy wooden door, wooden portcullis</p><p><strong>Master</strong> sturdy wooden door, iron portcullis, metal bar</p><p><strong>Legendary</strong> stone or iron door</p></section>",
                 "NoCrowbarPenalty": "No Crowbar",
                 "Notes": {
                     "criticalFailure": "<strong>Critical Failure</strong> Your attempt jams the door, window, container, or gate shut, imposing a -2 circumstance penalty on future attempts to Force it Open.",
                     "criticalSuccess": "<strong>Critical Success</strong> You open the door, window, container, or gate and can avoid damaging it in the process.",
-                    "success": "<strong>Success</strong> You break the door, window, container, or gate open, and the door, window, container, or gate gains the @UUID[Compendium.pf2e.conditionitems.Item.6dNUvdb1dhToNDj3]{Broken} condition. If it's especially sturdy, the GM might have it take damage but not be broken."
+                    "success": "<strong>Success</strong> You break the door, window, container, or gate open, and it gains the @UUID[Compendium.pf2e.conditionitems.Item.6dNUvdb1dhToNDj3]{broken} condition. If it's especially sturdy, the GM might have it take damage but not be broken."
                 },
                 "Title": "Force Open"
             },


### PR DESCRIPTION
Update the outcome text to reflect the text in Player Core. Also convert it to an action object and add the remaster description.