### PR TITLE
Add remaster changes to swim action macro

### DIFF
--- a/src/module/system/action-macros/athletics/swim.ts
+++ b/src/module/system/action-macros/athletics/swim.ts
@@ -1,25 +1,45 @@
 import { ActionMacroHelpers, SkillActionOptions } from "../index.ts";
+import { SingleCheckAction } from "@actor/actions/index.ts";
 
-export function swim(options: SkillActionOptions): void {
+const PREFIX = "PF2E.Actions.Swim";
+
+function swim(options: SkillActionOptions): void {
     const slug = options?.skill ?? "athletics";
     const rollOptions = ["action:swim"];
     const modifiers = options?.modifiers;
     ActionMacroHelpers.simpleRollActionCheck({
         actors: options.actors,
         actionGlyph: options.glyph ?? "A",
-        title: "PF2E.Actions.Swim.Title",
+        title: `${PREFIX}.Title`,
         checkContext: (opts) => ActionMacroHelpers.defaultCheckContext(opts, { modifiers, rollOptions, slug }),
         traits: ["move"],
         event: options.event,
         callback: options.callback,
         difficultyClass: options.difficultyClass,
         extraNotes: (selector: string) => [
-            ActionMacroHelpers.note(selector, "PF2E.Actions.Swim", "criticalSuccess"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.Swim", "success"),
-            ActionMacroHelpers.note(selector, "PF2E.Actions.Swim", "criticalFailure"),
+            ActionMacroHelpers.note(selector, PREFIX, "criticalSuccess"),
+            ActionMacroHelpers.note(selector, PREFIX, "success"),
+            ActionMacroHelpers.note(selector, PREFIX, "criticalFailure"),
         ],
     }).catch((error: Error) => {
         ui.notifications.error(error.message);
         throw error;
     });
 }
+
+const action = new SingleCheckAction({
+    cost: 1,
+    description: `${PREFIX}.Description`,
+    name: `${PREFIX}.Title`,
+    notes: [
+        { outcome: ["criticalSuccess"], text: `${PREFIX}.Notes.criticalSuccess` },
+        { outcome: ["success"], text: `${PREFIX}.Notes.success` },
+        { outcome: ["criticalFailure"], text: `${PREFIX}.Notes.criticalFailure` },
+    ],
+    rollOptions: ["action:swim"],
+    slug: "swim",
+    statistic: "athletics",
+    traits: ["move"],
+});
+
+export { swim as legacy, action };

--- a/src/module/system/action-macros/index.ts
+++ b/src/module/system/action-macros/index.ts
@@ -11,7 +11,7 @@ import { highJump } from "./athletics/high-jump.ts";
 import * as longJump from "./athletics/long-jump.ts";
 import * as reposition from "./athletics/reposition.ts";
 import { shove } from "./athletics/shove.ts";
-import { swim } from "./athletics/swim.ts";
+import * as swim from "./athletics/swim.ts";
 import * as trip from "./athletics/trip.ts";
 import { whirlingThrow } from "./athletics/whirling-throw.ts";
 import { aid } from "./basic/aid.ts";
@@ -95,7 +95,7 @@ export const ActionMacros = {
     longJump: longJump.legacy,
     reposition: reposition.legacy,
     shove,
-    swim,
+    swim: swim.legacy,
     trip: trip.legacy,
     whirlingThrow,
 
@@ -187,6 +187,7 @@ export const SystemActions: Action[] = [
     step,
     stride,
     subsist.action,
+    swim.action,
     takeCover,
     track.action,
     treatDisease.action,

--- a/static/lang/action-en.json
+++ b/static/lang/action-en.json
@@ -753,10 +753,11 @@
                 "Title": "Sustain"
             },
             "Swim": {
+                "Description": "<p>You attempt an Athletics check to move a maximum distance of 10 feet through water. The GM determines the DC based on the turbulence or danger of the water; in most instances of calm water, you get an automatic critical success. If your land Speed is 40 feet or higher, increase the maximum possible distance by 5 feet for every 20 feet of Speed above 20 feet.</p><p>If you end your turn in water and haven't succeeded at a Swim action that turn, you sink 10 feet or get moved by the current, as determined by the GM. This doesn't apply if your last action on your turn was to enter the water.</p><p><strong>Critical Success</strong> You move through the water, increasing the maximum distance by 5 feet.<br><strong>Success</strong> You move through the water.<br><strong>Critical Failure</strong> You make no progress. If you're holding your breath, you lose 1 round of air.</p><section class=\"sample-tasks\"><h2>Sample Swim Tasks</h2><p><strong>Untrained</strong> lake or other still water</p><p><strong>Trained</strong> flowing water, like a river</p><p><strong>Expert</strong> swiftly flowing river</p><p><strong>Master</strong> stormy sea</p><p><strong>Legendary</strong> maelstrom, waterfall</p></section>",
                 "Notes": {
-                    "criticalFailure": "<strong>Critical Failure</strong> You make no progress, and if you're holding your breath, you lose 1 round of air.",
-                    "criticalSuccess": "<strong>Critical Success</strong> You move through the water 10 feet, plus 5 feet per 20 feet of your land Speed (a total of 15 feet for most PCs).",
-                    "success": "<strong>Success</strong> You move through the water 5 feet, plus 5 feet per 20 feet of your land Speed (a total of 10 feet for most PCs)."
+                    "criticalFailure": "<strong>Critical Failure</strong> You make no progress. If you're holding your breath, you lose 1 round of air.",
+                    "criticalSuccess": "<strong>Critical Success</strong> You move through the water, increasing the maximum distance by 5 feet.",
+                    "success": "<strong>Success</strong> You move through the water."
                 },
                 "Title": "Swim"
             },


### PR DESCRIPTION
Update the outcome text to reflect the text in Player Core. Also convert it to an action object and add the remaster description.