### PR TITLE
Fix land speed of Tiger Form effect

### DIFF
--- a/packs/campaign-effects/effect-tiger-form.json
+++ b/packs/campaign-effects/effect-tiger-form.json
@@ -41,7 +41,7 @@
                         }
                     },
                     "speeds": {
-                        "land": 40
+                        "land": 30
                     },
                     "strikes": {
                         "claw": {


### PR DESCRIPTION
The land speed of the Tiger Form effect (from Fists of the Ruby Phoenix) was set to 40 feet, probably a copy-paste error from the Boar Form effect from the same module. It should actually be 30 feet according to the module (both the initial printing and the hardcover compilation).