### PR TITLE
Fix label path for Fury Cocktail

### DIFF
--- a/packs/equipment-effects/effect-fury-cocktail-greater.json
+++ b/packs/equipment-effects/effect-fury-cocktail-greater.json
@@ -29,27 +29,27 @@
             {
                 "choices": [
                     {
-                        "label": "PF2E.Equipment.FuryCocktail.AnimalisticLabel",
+                        "label": "PF2E.SpecificRule.Equipment.FuryCocktail.AnimalisticLabel",
                         "value": "animalistic"
                     },
                     {
-                        "label": "PF2E.Equipment.FuryCocktail.DoubleLabel",
+                        "label": "PF2E.SpecificRule.Equipment.FuryCocktail.DoubleLabel",
                         "value": "double"
                     },
                     {
-                        "label": "PF2E.Equipment.FuryCocktail.MournfulLabel",
+                        "label": "PF2E.SpecificRule.Equipment.FuryCocktail.MournfulLabel",
                         "value": "mournful"
                     },
                     {
-                        "label": "PF2E.Equipment.FuryCocktail.SkepticalLabel",
+                        "label": "PF2E.SpecificRule.Equipment.FuryCocktail.SkepticalLabel",
                         "value": "skeptical"
                     },
                     {
-                        "label": "PF2E.Equipment.FuryCocktail.TitanicLabel",
+                        "label": "PF2E.SpecificRule.Equipment.FuryCocktail.TitanicLabel",
                         "value": "titanic"
                     },
                     {
-                        "label": "PF2E.Equipment.FuryCocktail.WyrmhideLabel",
+                        "label": "PF2E.SpecificRule.Equipment.FuryCocktail.WyrmhideLabel",
                         "value": "wyrmhide"
                     }
                 ],

--- a/packs/equipment-effects/effect-fury-cocktail-lesser.json
+++ b/packs/equipment-effects/effect-fury-cocktail-lesser.json
@@ -24,27 +24,27 @@
             {
                 "choices": [
                     {
-                        "label": "PF2E.Equipment.FuryCocktail.AnimalisticLabel",
+                        "label": "PF2E.SpecificRule.Equipment.FuryCocktail.AnimalisticLabel",
                         "value": "animalistic"
                     },
                     {
-                        "label": "PF2E.Equipment.FuryCocktail.DoubleLabel",
+                        "label": "PF2E.SpecificRule.Equipment.FuryCocktail.DoubleLabel",
                         "value": "double"
                     },
                     {
-                        "label": "PF2E.Equipment.FuryCocktail.MournfulLabel",
+                        "label": "PF2E.SpecificRule.Equipment.FuryCocktail.MournfulLabel",
                         "value": "mournful"
                     },
                     {
-                        "label": "PF2E.Equipment.FuryCocktail.SkepticalLabel",
+                        "label": "PF2E.SpecificRule.Equipment.FuryCocktail.SkepticalLabel",
                         "value": "skeptical"
                     },
                     {
-                        "label": "PF2E.Equipment.FuryCocktail.TitanicLabel",
+                        "label": "PF2E.SpecificRule.Equipment.FuryCocktail.TitanicLabel",
                         "value": "titanic"
                     },
                     {
-                        "label": "PF2E.Equipment.FuryCocktail.WyrmhideLabel",
+                        "label": "PF2E.SpecificRule.Equipment.FuryCocktail.WyrmhideLabel",
                         "value": "wyrmhide"
                     }
                 ],

--- a/packs/equipment-effects/effect-fury-cocktail-moderate.json
+++ b/packs/equipment-effects/effect-fury-cocktail-moderate.json
@@ -29,27 +29,27 @@
             {
                 "choices": [
                     {
-                        "label": "PF2E.Equipment.FuryCocktail.AnimalisticLabel",
+                        "label": "PF2E.SpecificRule.Equipment.FuryCocktail.AnimalisticLabel",
                         "value": "animalistic"
                     },
                     {
-                        "label": "PF2E.Equipment.FuryCocktail.DoubleLabel",
+                        "label": "PF2E.SpecificRule.Equipment.FuryCocktail.DoubleLabel",
                         "value": "double"
                     },
                     {
-                        "label": "PF2E.Equipment.FuryCocktail.MournfulLabel",
+                        "label": "PF2E.SpecificRule.Equipment.FuryCocktail.MournfulLabel",
                         "value": "mournful"
                     },
                     {
-                        "label": "PF2E.Equipment.FuryCocktail.SkepticalLabel",
+                        "label": "PF2E.SpecificRule.Equipment.FuryCocktail.SkepticalLabel",
                         "value": "skeptical"
                     },
                     {
-                        "label": "PF2E.Equipment.FuryCocktail.TitanicLabel",
+                        "label": "PF2E.SpecificRule.Equipment.FuryCocktail.TitanicLabel",
                         "value": "titanic"
                     },
                     {
-                        "label": "PF2E.Equipment.FuryCocktail.WyrmhideLabel",
+                        "label": "PF2E.SpecificRule.Equipment.FuryCocktail.WyrmhideLabel",
                         "value": "wyrmhide"
                     }
                 ],


### PR DESCRIPTION
Noticed in production - missed a level in the localization.