### PR TITLE
Add Effect for Ocean's Balm

### DIFF
--- a/packs/feat-effects/effect-oceans-balm.json
+++ b/packs/feat-effects/effect-oceans-balm.json
@@ -1,0 +1,42 @@
+{
+    "_id": "uG1EljvrnC9HGwUh",
+    "img": "systems/pf2e/icons/spells/elemental-form-water.webp",
+    "name": "Effect: Ocean's Balm",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Ocean's Balm]</p>\n<p>Implemented effects:</p>\n<ul>\n<li>Leveled Fire Resistance</li>\n</ul>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "minutes",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": true,
+            "title": "Pathfinder Rage of Elements"
+        },
+        "rules": [
+            {
+                "key": "Resistance",
+                "type": "fire",
+                "value": "floor((max(1,@item.origin.level)-1)/2)+2"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feat-effects/effect-oceans-balm.json
+++ b/packs/feat-effects/effect-oceans-balm.json
@@ -4,7 +4,7 @@
     "name": "Effect: Ocean's Balm",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Ocean's Balm]</p>\n<p>Implemented effects:</p>\n<ul>\n<li>Leveled Fire Resistance</li>\n</ul>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Ocean's Balm]</p>\n<p>You gain fire resistance.</p>"
         },
         "duration": {
             "expiry": "turn-start",

--- a/packs/feats/oceans-balm.json
+++ b/packs/feats/oceans-balm.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>A blessing of the living sea salves wounds and douses flames. Touch a willing living creature. It regains 1d8 HP and gains resistance 2 to fire for 1 minute. If it has persistent fire damage, it can attempt a flat check to remove it with especially appropriate help. The target is temporarily immune to healing from Ocean's Balm for 10 minutes.</p>\n<hr />\n<p><strong>Level (+2)</strong> The healing increases by 1d8, and the resistance increases by 1.</p>\n<p>[[/r (floor((max(1,@actor.level)-1)/2)+1)d8[healing]]]{Leveled HP}</p>"
+            "value": "<p>A blessing of the living sea salves wounds and douses flames. Touch a willing living creature. It regains 1d8 HP and gains resistance 2 to fire for 1 minute. If it has persistent fire damage, it can attempt a flat check to remove it with especially appropriate help. The target is temporarily immune to healing from Ocean's Balm for 10 minutes.</p>\n<hr />\n<p><strong>Level (+2)</strong> The healing increases by 1d8, and the resistance increases by 1.</p>\n<p>[[/r (floor((max(1,@actor.level)-1)/2)+1)d8[healing]]]{Leveled HP}</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Ocean's Balm]</p>"
         },
         "level": {
             "value": 1


### PR DESCRIPTION
Adds an effect for Ocean's Balm. 

The healing is still from the feat, but the effect allows the correct fire resistance value and duration to be tracked. 

This does not track the timed healing immunity.