### PR TITLE
Add Fly Speed to Constant Levitation Feat

### DIFF
--- a/packs/feats/constant-levitation.json
+++ b/packs/feats/constant-levitation.json
@@ -26,6 +26,11 @@
         },
         "rules": [
             {
+                "key": "BaseSpeed",
+                "selector": "fly",
+                "value": "max(20,@actor.attributes.speed.total)"
+            },
+            {
                 "key": "FlatModifier",
                 "predicate": [
                     "self:effect:unleash-psyche"


### PR DESCRIPTION
IDK what the thoughts of the team are on this one. Feat gives you the benefits of a constant Fly spell
![image](https://github.com/foundryvtt/pf2e/assets/13396742/ad93f051-2316-44a6-af3b-05039643d8e7)
