### PR TITLE
Fix primal bandersnatch damage types and strike ability

### DIFF
--- a/packs/kingmaker-bestiary/primal-bandersnatch.json
+++ b/packs/kingmaker-bestiary/primal-bandersnatch.json
@@ -112,7 +112,7 @@
                 "damageRolls": {
                     "PG5YnSEe59Gob0Rg": {
                         "damage": "4d4+18",
-                        "damageType": "spirit"
+                        "damageType": "piercing"
                     }
                 },
                 "description": {
@@ -149,7 +149,10 @@
                     "value": ""
                 },
                 "attackEffects": {
-                    "value": []
+                    "custom": "",
+                    "value": [
+                        "pain"
+                    ]
                 },
                 "bonus": {
                     "value": 33
@@ -157,7 +160,7 @@
                 "damageRolls": {
                     "Iojo7x3z1RrZWsEW": {
                         "damage": "4d4+18",
-                        "damageType": "spirit"
+                        "damageType": "piercing"
                     }
                 },
                 "description": {
@@ -662,7 +665,8 @@
                     "title": ""
                 },
                 "rules": [],
-                "slug": null
+                "slug": null,
+                "traits": {}
             },
             "type": "lore"
         },
@@ -687,7 +691,8 @@
                     "title": ""
                 },
                 "rules": [],
-                "slug": null
+                "slug": null,
+                "traits": {}
             },
             "type": "lore"
         },
@@ -712,7 +717,8 @@
                     "title": ""
                 },
                 "rules": [],
-                "slug": null
+                "slug": null,
+                "traits": {}
             },
             "type": "lore"
         },
@@ -737,7 +743,8 @@
                     "title": ""
                 },
                 "rules": [],
-                "slug": null
+                "slug": null,
+                "traits": {}
             },
             "type": "lore"
         },
@@ -762,7 +769,8 @@
                     "title": ""
                 },
                 "rules": [],
-                "slug": null
+                "slug": null,
+                "traits": {}
             },
             "type": "lore"
         }
@@ -825,6 +833,7 @@
             },
             "weaknesses": [
                 {
+                    "exceptions": [],
                     "type": "cold-iron",
                     "value": 15
                 }


### PR DESCRIPTION
closes #12406

The Quill strike was also missing the Pain monster ability per the statblock in Kingmaker