### PR TITLE
Add REs for Doubling Rings

### DIFF
--- a/packs/equipment/doubling-rings-greater.json
+++ b/packs/equipment/doubling-rings-greater.json
@@ -34,7 +34,87 @@
             "title": "Pathfinder GM Core"
         },
         "quantity": 1,
-        "rules": [],
+        "rules": [
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Equipment.DoublingRings.GreaterPotencyToggleLabel",
+                "option": "doubling-rings-greater-potency",
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.BonusLabel.PlusOne",
+                        "value": "1"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.BonusLabel.PlusTwo",
+                        "value": "2"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.BonusLabel.PlusThree",
+                        "value": "3"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Equipment.DoublingRings.GreaterStrikingToggleLabel",
+                "option": "doubling-rings-greater-striking",
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Equipment.DoublingRings.StrikingLabel",
+                        "value": "1"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Equipment.DoublingRings.StrikingGreaterLabel",
+                        "value": "2"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Equipment.DoublingRings.StrikingMajorLabel",
+                        "value": "3"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "item:melee",
+                    "item:hands-held:1",
+                    "item:usage:hands:1",
+                    "doubling-rings-greater-potency"
+                ],
+                "selector": "attack",
+                "type": "item",
+                "value": "{item|flags.pf2e.rulesSelections.doublingRingsGreaterPotency}"
+            },
+            {
+                "definition": [
+                    "item:melee",
+                    "item:hands-held:1",
+                    "item:usage:hands:1"
+                ],
+                "key": "AdjustStrike",
+                "mode": "add",
+                "predicate": [
+                    "doubling-rings-greater-potency"
+                ],
+                "property": "weapon-traits",
+                "value": "magical"
+            },
+            {
+                "key": "Striking",
+                "predicate": [
+                    "item:melee",
+                    "item:hands-held:1",
+                    "item:usage:hands:1",
+                    "doubling-rings-greater-striking"
+                ],
+                "selector": "melee-strike-damage",
+                "value": "{item|flags.pf2e.rulesSelections.doublingRingsGreaterStriking}"
+            }
+        ],
         "size": "med",
         "traits": {
             "rarity": "common",

--- a/packs/equipment/doubling-rings.json
+++ b/packs/equipment/doubling-rings.json
@@ -34,7 +34,87 @@
             "title": "Pathfinder GM Core"
         },
         "quantity": 1,
-        "rules": [],
+        "rules": [
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Equipment.DoublingRings.PotencyToggleLabel",
+                "option": "doubling-rings-potency",
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.BonusLabel.PlusOne",
+                        "value": "1"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.BonusLabel.PlusTwo",
+                        "value": "2"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.BonusLabel.PlusThree",
+                        "value": "3"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Equipment.DoublingRings.StrikingToggleLabel",
+                "option": "doubling-rings-striking",
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Equipment.DoublingRings.StrikingLabel",
+                        "value": "1"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Equipment.DoublingRings.StrikingGreaterLabel",
+                        "value": "2"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Equipment.DoublingRings.StrikingMajorLabel",
+                        "value": "3"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "key": "Striking",
+                "predicate": [
+                    "item:melee",
+                    "item:hands-held:1",
+                    "item:usage:hands:1",
+                    "doubling-rings-striking"
+                ],
+                "selector": "melee-strike-damage",
+                "value": "{item|flags.pf2e.rulesSelections.doublingRingsStriking}"
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "item:melee",
+                    "item:hands-held:1",
+                    "item:usage:hands:1",
+                    "doubling-rings-potency"
+                ],
+                "selector": "attack",
+                "type": "item",
+                "value": "{item|flags.pf2e.rulesSelections.doublingRingsPotency}"
+            },
+            {
+                "definition": [
+                    "item:melee",
+                    "item:hands-held:1",
+                    "item:usage:hands:1"
+                ],
+                "key": "AdjustStrike",
+                "mode": "add",
+                "predicate": [
+                    "doubling-rings-potency"
+                ],
+                "property": "weapon-traits",
+                "value": "magical"
+            }
+        ],
         "size": "med",
         "traits": {
             "rarity": "common",

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -1972,6 +1972,15 @@
                     "MatchingSuitPrompt": "Is the drawn card's suit related the check?",
                     "WealOrWoePrompt": "Select Weal or Woe."
                 },
+                "DoublingRings":{
+                    "PotencyToggleLabel": "Doubling Rings Potency",
+                    "StrikingToggleLabel": "Doubling Rings Striking",
+                    "GreaterPotencyToggleLabel": "Doubling Rings (Greater) Potency",
+                    "GreaterStrikingToggleLabel": "Doubling Rings (Greater) Striking",
+                    "StrikingLabel": "Striking",
+                    "StrikingGreaterLabel":"Striking (Greater)",
+                    "StrikingMajorLabel":"Striking (Major)"
+                },
                 "EagleEyeElixir": {
                     "Greater": {
                         "SecretLabel": "Greater Eagle Eye Elixir (To Find Secret Doors or Traps)"


### PR DESCRIPTION
This adds REs to the Doubling Rings, both versions, using toggleable roll options.

The only thing not supported is the Greater version's transfer of Property runes, although that may be doable in the future when the rune system gets reworked.
