### PR TITLE
Change Runic Mindsmith feats to the remaster runes

### DIFF
--- a/packs/feats/advanced-runic-mind-smithing.json
+++ b/packs/feats/advanced-runic-mind-smithing.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>Your mind can hold onto more complicated patterns than ever before. You can etch the greater forms of any runes on the list from the Runic Mind Smithing feat and add them to the list of options you can choose during your daily preparations, as well as the <em>anarchic</em>, <em>axiomatic</em>, <em>holy</em>, or <em>unholy</em> runes.</p>\n<p>In addition, once per day, you can spend 10 minutes of uninterrupted focus to swap your daily prepared rune from Runic Mind Smithing to another rune from the same list. Once this swap is made, that second rune remains on the weapon until your next daily preparations.</p>"
+            "value": "<p>Your mind can hold onto more complicated patterns than ever before. You can etch the greater forms of any runes on the list from the Runic Mind Smithing feat and add them to the list of options you can choose during your daily preparations, as well as the <em>holy</em> or <em>unholy</em> runes.</p>\n<p>In addition, once per day, you can spend 10 minutes of uninterrupted focus to swap your daily prepared rune from Runic Mind Smithing to another rune from the same list. Once this swap is made, that second rune remains on the weapon until your next daily preparations.</p>"
         },
         "level": {
             "value": 16

--- a/packs/feats/runic-mind-smithing.json
+++ b/packs/feats/runic-mind-smithing.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>You focus your mind on thoughtforms of fundamental magical forces, shaping them into a property rune that you mentally etch onto your mind weapon. During your daily preparations, choose one rune from the following list of weapon property runes: <em>corrosive</em>, <em>disrupting</em>, <em>flaming</em>, <em>frost</em>, <em>shock</em>, and <em>thundering</em>. You enhance your weapon with the chosen rune until your next daily preparations. This rune counts toward your maximum limit of runes as normal.</p>"
+            "value": "<p>You focus your mind on thoughtforms of fundamental magical forces, shaping them into a property rune that you mentally etch onto your mind weapon. During your daily preparations, choose one rune from the following list of weapon property runes: <em>corrosive</em>, <em>vitalizing</em>, <em>flaming</em>, <em>frost</em>, <em>shock</em>, and <em>thundering</em>. You enhance your weapon with the chosen rune until your next daily preparations. This rune counts toward your maximum limit of runes as normal.</p>"
         },
         "level": {
             "value": 10


### PR DESCRIPTION
Removes the axiomatic and anarchic runes from Advanced feat and changes disrupting to vitalizing in the base feat.