### PR TITLE
Add removeAfterRoll to Aid effect

### DIFF
--- a/packs/other-effects/effect-aid.json
+++ b/packs/other-effects/effect-aid.json
@@ -50,6 +50,7 @@
             },
             {
                 "key": "FlatModifier",
+                "removeAfterRoll": true,
                 "selector": "all",
                 "type": "circumstance",
                 "value": "{item|flags.pf2e.rulesSelections.aidBonus}"


### PR DESCRIPTION
Since Aid is a reaction triggered for a single, specific roll, I figure it makes sense for it to be removed after the roll.