### PR TITLE
Fix Powerful Fist damage die increase in edge cases

### DIFF
--- a/packs/classfeatures/powerful-fist.json
+++ b/packs/classfeatures/powerful-fist.json
@@ -35,8 +35,11 @@
                 "override": {
                     "upgrade": true
                 },
+                "predicate": [
+                    "item:slug:fist"
+                ],
                 "selector": [
-                    "{item|id}-damage"
+                    "strike-damage"
                 ]
             }
         ],


### PR DESCRIPTION
If you have a fist strike from elsewhere (like a dual class cleric / monk worshipping Irori) the upgrade wasn't firing off.