### PR TITLE
Fix Deadly Hair Feat to apply to Living Hair

### DIFF
--- a/packs/feats/syu-tak-nwas-deadly-hair.json
+++ b/packs/feats/syu-tak-nwas-deadly-hair.json
@@ -35,7 +35,7 @@
                 "override": {
                     "dieSize": "d6"
                 },
-                "selector": "hair-damage"
+                "selector": "living-hair-damage"
             }
         ],
         "traits": {

--- a/packs/feats/syu-tak-nwas-deadly-hair.json
+++ b/packs/feats/syu-tak-nwas-deadly-hair.json
@@ -36,6 +36,15 @@
                     "dieSize": "d6"
                 },
                 "selector": "living-hair-damage"
+            },
+            {
+                "definition": [
+                    "item:slug:living-hair"
+                ],
+                "key": "AdjustStrike",
+                "mode": "add",
+                "property": "weapon-traits",
+                "value": "grapple"
             }
         ],
         "traits": {


### PR DESCRIPTION
Reported on discord.

Also adds the missing Grapple trait the feat provides.