### PR TITLE
Allow for user defined cone angles in HTML inline templates

### DIFF
--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -271,7 +271,7 @@ export const InlineRollLinks = {
                             CONFIG.MeasuredTemplate.defaults.width * (canvas.dimensions?.distance ?? 1);
                         break;
                     case "cone":
-                        templateData.angle = CONFIG.MeasuredTemplate.defaults.angle;
+                        templateData.angle ||= CONFIG.MeasuredTemplate.defaults.angle;
                         break;
                     case "rect": {
                         const distance = templateData.distance ?? 0;


### PR DESCRIPTION
This is a very rarely used feature so I'm fine not including an angle property in `@Template` and telling people to use the older HTML style.