### PR TITLE
Skip clamping hit points when item alterations make updates

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -1976,7 +1976,7 @@ interface ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
     updateEmbeddedDocuments(
         embeddedName: "Item",
         updateData: EmbeddedDocumentUpdateData[],
-        options?: DocumentUpdateContext<this>,
+        options?: EmbeddedItemUpdateContext<this>,
     ): Promise<ItemPF2e<this>[]>;
     updateEmbeddedDocuments(
         embeddedName: "ActiveEffect" | "Item",
@@ -2000,6 +2000,10 @@ interface ActorUpdateContext<TParent extends TokenDocumentPF2e | null> extends D
     damageTaken?: number;
     finePowder?: boolean;
     damageUndo?: boolean;
+}
+
+interface EmbeddedItemUpdateContext<TParent extends ActorPF2e> extends DocumentUpdateContext<TParent> {
+    checkHP?: boolean;
 }
 
 /** A `Proxy` to to get Foundry to construct `ActorPF2e` subclasses */

--- a/src/module/item/physical/document.ts
+++ b/src/module/item/physical/document.ts
@@ -546,7 +546,7 @@ abstract class PhysicalItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | n
 
     protected override async _preUpdate(
         changed: DeepPartial<this["_source"]>,
-        options: DocumentUpdateContext<TParent>,
+        options: PhysicalItemUpdateContext<TParent>,
         user: UserPF2e,
     ): Promise<boolean | void> {
         if (!changed.system) return super._preUpdate(changed, options, user);
@@ -558,7 +558,7 @@ abstract class PhysicalItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | n
             }
         }
 
-        handleHPChange(this, changed);
+        if (options.checkHP ?? true) handleHPChange(this, changed);
 
         // Clear 0 price denominations and per fields with values 0 or 1
         if (isObject<Record<string, unknown>>(changed.system.price)) {
@@ -609,6 +609,10 @@ interface PhysicalItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> 
 interface PhysicalItemConstructionContext<TParent extends ActorPF2e | null>
     extends DocumentConstructionContext<TParent> {
     parentItem?: PhysicalItemPF2e<TParent>;
+}
+
+interface PhysicalItemUpdateContext<TParent extends ActorPF2e | null> extends DocumentUpdateContext<TParent> {
+    checkHP?: boolean;
 }
 
 export { PhysicalItemPF2e, type PhysicalItemConstructionContext };

--- a/src/module/rules/rule-element/item-alteration/rule-element.ts
+++ b/src/module/rules/rule-element/item-alteration/rule-element.ts
@@ -77,7 +77,9 @@ class ItemAlterationRuleElement extends RuleElementPF2e<ItemAlterationRuleSchema
             const newHPValue = Math.floor(oldHP.value * (newHP.max / oldHP.max));
             return newHPValue === oldHP.value ? [] : { _id: item.id, "system.hp.value": newHPValue };
         });
-        if (updates.length > 0) await this.actor.updateEmbeddedDocuments("Item", updates, { render: false });
+        if (updates.length > 0) {
+            await this.actor.updateEmbeddedDocuments("Item", updates, { render: false, checkHP: false });
+        }
     }
 
     #applyAlteration(additionalItems: ItemPF2e<ActorPF2e>[] = []): void {


### PR DESCRIPTION
This prevents issues from occuring where a physical item's `_preUpdate` method rejects an update to hit points after testing against a clone because the clone does not have the new item carrying HP-altering the rule element.