### PR TITLE
Add remaster changes to make an impression action macro

### DIFF
--- a/src/module/system/action-macros/diplomacy/make-an-impression.ts
+++ b/src/module/system/action-macros/diplomacy/make-an-impression.ts
@@ -1,6 +1,9 @@
 import { ActionMacroHelpers, SkillActionOptions } from "../index.ts";
+import { SingleCheckAction } from "@actor/actions/index.ts";
 
-export function makeAnImpression(options: SkillActionOptions): void {
+const PREFIX = "PF2E.Actions.MakeAnImpression";
+
+function makeAnImpression(options: SkillActionOptions): void {
     const slug = options?.skill ?? "diplomacy";
     const rollOptions = ["action:make-an-impression"];
     const modifiers = options?.modifiers;
@@ -23,3 +26,20 @@ export function makeAnImpression(options: SkillActionOptions): void {
         throw error;
     });
 }
+
+const action = new SingleCheckAction({
+    description: `${PREFIX}.Description`,
+    difficultyClass: "will",
+    name: `${PREFIX}.Title`,
+    notes: [
+        { outcome: ["criticalSuccess"], text: `${PREFIX}.Notes.criticalSuccess` },
+        { outcome: ["success"], text: `${PREFIX}.Notes.success` },
+        { outcome: ["criticalFailure"], text: `${PREFIX}.Notes.criticalFailure` },
+    ],
+    rollOptions: ["action:make-an-impression"],
+    slug: "make-an-impression",
+    statistic: "diplomacy",
+    traits: ["auditory", "concentrate", "exploration", "linguistic", "mental"],
+});
+
+export { makeAnImpression as legacy, action };

--- a/src/module/system/action-macros/index.ts
+++ b/src/module/system/action-macros/index.ts
@@ -37,7 +37,7 @@ import { impersonate } from "./deception/impersonate.ts";
 import * as lie from "./deception/lie.ts";
 import { bonMot } from "./diplomacy/bon-mot.ts";
 import { gatherInformation } from "./diplomacy/gather-information.ts";
-import { makeAnImpression } from "./diplomacy/make-an-impression.ts";
+import * as makeAnImpression from "./diplomacy/make-an-impression.ts";
 import * as request from "./diplomacy/request.ts";
 import * as avoidNotice from "./exploration/avoid-notice.ts";
 import * as senseDirection from "./exploration/sense-direction.ts";
@@ -112,7 +112,7 @@ export const ActionMacros = {
     // Diplomacy
     bonMot,
     gatherInformation,
-    makeAnImpression,
+    makeAnImpression: makeAnImpression.legacy,
     request: request.legacy,
 
     // General Skill Actions
@@ -173,6 +173,7 @@ export const SystemActions: Action[] = [
     leap,
     lie.action,
     longJump.action,
+    makeAnImpression.action,
     maneuverInFlight.action,
     palmAnObject.action,
     pickALock.action,

--- a/static/lang/action-en.json
+++ b/static/lang/action-en.json
@@ -483,6 +483,7 @@
                 "Title": "Lower Shield"
             },
             "MakeAnImpression": {
+                "Description": "<p>With at least 1 minute of conversation, during which you engage in charismatic overtures, flattery, and other acts of goodwill, you seek to make a good impression on someone to make them temporarily agreeable. At the end of the conversation, attempt a Diplomacy check against the Will DC of one target. You can instead choose up to five targets if you take a –2 penalty. The GM might add other bonuses or penalties based on the situation. Any impression you make lasts for only the current social interaction unless the GM decides otherwise.</p><strong>Critical Success</strong> The target's attitude toward you improves by two steps.<br><strong>Success</strong> The target's attitude toward you improves by one step.<br><p><strong>Critical Failure</strong> The target's attitude toward you decreases by one step.</p>",
                 "Notes": {
                     "criticalFailure": "<strong>Critical Failure</strong> The target's attitude toward you decreases by one step.",
                     "criticalSuccess": "<strong>Critical Success</strong> The target's attitude toward you improves by two steps.",


### PR DESCRIPTION
Convert it to an action object and add the remaster description.