### PR TITLE
Change grikkitog resistance from "all 10" to "physical 10"

### DIFF
--- a/packs/pathfinder-bestiary/grikkitog.json
+++ b/packs/pathfinder-bestiary/grikkitog.json
@@ -433,7 +433,7 @@
                     "exceptions": [
                         "adamantine"
                     ],
-                    "type": "all-damage",
+                    "type": "physical",
                     "value": 10
                 }
             ],


### PR DESCRIPTION
The book ([as seen on AoN](https://2e.aonprd.com/Monsters.aspx?ID=249)) just says the resistance is "10 (except adamantine)", this is an editing mistake.  The data entry team decided that this means "all 10" in the past, but I believe it's much more likely to be "physical 10".

That is because every other monster with resistance that is pierced by adamantine always has it be a physical resistance.  See filter:  https://2e.aonprd.com/Search.aspx?q=type%3Acreature%20%22except%20adamantine%22%20-clockwork