### PR TITLE
Allow order explorer to grant order feat automatically for dedication

### DIFF
--- a/packs/classfeatures/animal-order.json
+++ b/packs/classfeatures/animal-order.json
@@ -39,7 +39,12 @@
             {
                 "key": "GrantItem",
                 "predicate": [
-                    "class:druid"
+                    {
+                        "or": [
+                            "class:druid",
+                            "feat:order-explorer:animal-order"
+                        ]
+                    }
                 ],
                 "uuid": "Compendium.pf2e.feats-srd.Item.Animal Companion"
             }

--- a/packs/classfeatures/flame-order.json
+++ b/packs/classfeatures/flame-order.json
@@ -39,7 +39,12 @@
             {
                 "key": "GrantItem",
                 "predicate": [
-                    "class:druid"
+                    {
+                        "or": [
+                            "class:druid",
+                            "feat:order-explorer:flame-order"
+                        ]
+                    }
                 ],
                 "uuid": "Compendium.pf2e.feats-srd.Item.Fire Lung"
             }

--- a/packs/classfeatures/leaf-order.json
+++ b/packs/classfeatures/leaf-order.json
@@ -39,7 +39,12 @@
             {
                 "key": "GrantItem",
                 "predicate": [
-                    "class:druid"
+                    {
+                        "or": [
+                            "class:druid",
+                            "feat:order-explorer:leaf-order"
+                        ]
+                    }
                 ],
                 "uuid": "Compendium.pf2e.feats-srd.Item.Leshy Familiar"
             }

--- a/packs/classfeatures/stone-order.json
+++ b/packs/classfeatures/stone-order.json
@@ -39,7 +39,12 @@
             {
                 "key": "GrantItem",
                 "predicate": [
-                    "class:druid"
+                    {
+                        "or": [
+                            "class:druid",
+                            "feat:order-explorer:stone-order"
+                        ]
+                    }
                 ],
                 "uuid": "Compendium.pf2e.feats-srd.Item.Steadying Stone"
             }

--- a/packs/classfeatures/storm-order.json
+++ b/packs/classfeatures/storm-order.json
@@ -40,7 +40,12 @@
                 "allowDuplicate": false,
                 "key": "GrantItem",
                 "predicate": [
-                    "class:druid"
+                    {
+                        "or": [
+                            "class:druid",
+                            "feat:order-explorer:storm-order"
+                        ]
+                    }
                 ],
                 "uuid": "Compendium.pf2e.feats-srd.Item.Storm Born"
             }

--- a/packs/classfeatures/untamed-order.json
+++ b/packs/classfeatures/untamed-order.json
@@ -39,7 +39,12 @@
             {
                 "key": "GrantItem",
                 "predicate": [
-                    "class:druid"
+                    {
+                        "or": [
+                            "class:druid",
+                            "feat:order-explorer:untamed-order"
+                        ]
+                    }
                 ],
                 "uuid": "Compendium.pf2e.feats-srd.Item.Untamed Form"
             }

--- a/packs/classfeatures/wave-order.json
+++ b/packs/classfeatures/wave-order.json
@@ -39,7 +39,12 @@
             {
                 "key": "GrantItem",
                 "predicate": [
-                    "class:druid"
+                    {
+                        "or": [
+                            "class:druid",
+                            "feat:order-explorer:wave-order"
+                        ]
+                    }
                 ],
                 "uuid": "Compendium.pf2e.feats-srd.Item.Shore Step"
             }


### PR DESCRIPTION
There is no grant on the order for dedication taken as part of the druid dedication, but order explorer allows *only* the feat and no other items from the dedication. This fixes the rule elements for each order to allow order explorer to grant the feat even if only a druid dedication is present.

Closes #9825.