### PR TITLE
Add remaster changes to create a diversion action macro

### DIFF
--- a/src/module/system/action-macros/deception/create-a-diversion.ts
+++ b/src/module/system/action-macros/deception/create-a-diversion.ts
@@ -1,27 +1,29 @@
 import { ActionMacroHelpers, SkillActionOptions } from "../index.ts";
+import { SingleCheckAction } from "@actor/actions/index.ts";
 
 const PREFIX = "PF2E.Actions.CreateADiversion";
 const CREATE_A_DIVERSION_VARIANTS = ["distracting-words", "gesture", "trick"] as const;
 type CreateADiversionVariant = (typeof CREATE_A_DIVERSION_VARIANTS)[number];
 
-export function createADiversion(options: { variant: CreateADiversionVariant } & SkillActionOptions): void {
+function createADiversion(options: { variant: CreateADiversionVariant } & SkillActionOptions): void {
     const { title, traits, variant } = (() => {
+        const mainTitle = game.i18n.localize(`${PREFIX}.Title`);
         switch (options?.variant) {
             case "distracting-words":
                 return {
-                    title: `${PREFIX}.DistractingWords.Title`,
+                    title: mainTitle + " - " + game.i18n.localize(`${PREFIX}.DistractingWords.Title`),
                     traits: ["auditory", "linguistic", "mental"],
                     variant: options.variant,
                 };
             case "gesture":
                 return {
-                    title: `${PREFIX}.Gesture.Title`,
+                    title: mainTitle + " - " + game.i18n.localize(`${PREFIX}.Gesture.Title`),
                     traits: ["manipulate", "mental"],
                     variant: options.variant,
                 };
             case "trick":
                 return {
-                    title: `${PREFIX}.Trick.Title`,
+                    title: mainTitle + " - " + game.i18n.localize(`${PREFIX}.Trick.Title`),
                     traits: ["manipulate", "mental"],
                     variant: options.variant,
                 };
@@ -54,3 +56,39 @@ export function createADiversion(options: { variant: CreateADiversionVariant } &
         throw error;
     });
 }
+
+const action = new SingleCheckAction({
+    cost: 1,
+    description: `${PREFIX}.Description`,
+    difficultyClass: "perception",
+    name: `${PREFIX}.Title`,
+    notes: [
+        { outcome: ["criticalSuccess", "success"], text: `${PREFIX}.Notes.success` },
+        { outcome: ["criticalFailure", "failure"], text: `${PREFIX}.Notes.failure` },
+    ],
+    slug: "create-a-diversion",
+    statistic: "deception",
+    traits: ["mental"],
+    variants: [
+        {
+            name: `${PREFIX}.DistractingWords.Title`,
+            rollOptions: ["action:create-a-diversion", "action:create-a-diversion:distracting-words"],
+            slug: "distracting-words",
+            traits: ["auditory", "linguistic", "mental"],
+        },
+        {
+            name: `${PREFIX}.Gesture.Title`,
+            rollOptions: ["action:create-a-diversion", "action:create-a-diversion:gesture"],
+            slug: "gesture",
+            traits: ["manipulate", "mental"],
+        },
+        {
+            name: `${PREFIX}.Trick.Title`,
+            rollOptions: ["action:create-a-diversion", "action:create-a-diversion:trick"],
+            slug: "trick",
+            traits: ["manipulate", "mental"],
+        },
+    ],
+});
+
+export { createADiversion as legacy, action };

--- a/src/module/system/action-macros/index.ts
+++ b/src/module/system/action-macros/index.ts
@@ -31,7 +31,7 @@ import { stride } from "./basic/stride.ts";
 import { takeCover } from "./basic/take-cover.ts";
 import { tamper } from "./class/inventor/tamper.ts";
 import { craft, repair } from "./crafting/index.ts";
-import { createADiversion } from "./deception/create-a-diversion.ts";
+import * as createADiversion from "./deception/create-a-diversion.ts";
 import * as feint from "./deception/feint.ts";
 import * as impersonate from "./deception/impersonate.ts";
 import * as lie from "./deception/lie.ts";
@@ -104,7 +104,7 @@ export const ActionMacros = {
     repair,
 
     // Deception
-    createADiversion,
+    createADiversion: createADiversion.legacy,
     feint: feint.legacy,
     impersonate: impersonate.legacy,
     lie: lie.legacy,
@@ -159,6 +159,7 @@ export const SystemActions: Action[] = [
     commandAnAnimal.action,
     concealAnObject.action,
     crawl,
+    createADiversion.action,
     createForgery.action,
     decipherWriting.action,
     delay,

--- a/static/lang/action-en.json
+++ b/static/lang/action-en.json
@@ -189,19 +189,20 @@
                 "Title": "Crawl"
             },
             "CreateADiversion": {
+                "Description": "<p>With a gesture, a trick, or some distracting words, you can create a diversion that draws creatures' attention elsewhere. If you use a gesture or trick, this action gains the manipulate trait. If you use distracting words, it gains the auditory and linguistic traits.</p><p>Attempt a single Deception check and compare it to the Perception DCs of the creatures whose attention you're trying to divert. Whether or not you succeed, creatures you attempt to divert gain a +4 circumstance bonus to their Perception DCs against your attempts to Create a Diversion for 1 minute.</p><p><strong>Success</strong> You become @UUID[Compendium.pf2e.conditionitems.Item.iU0fEDdBp3rXpTMC]{hidden} to each creature whose Perception DC is less than or equal to your result. (The hidden condition allows you to @UUID[Compendium.pf2e.actionspf2e.Item.VMozDqMMuK5kpoX4]{Sneak} away.) This lasts until the end of your turn or until you do anything except @UUID[Compendium.pf2e.actionspf2e.Item.UHpkTuCtyaPqiCAB]{Step} or use the Stealth skill to @UUID[Compendium.pf2e.actionspf2e.Item.XMcnh4cSI32tljXa]{Hide} or Sneak. If you @UUID[Compendium.pf2e.actionspf2e.Item.VjxZFuUXrCU94MWR]{Strike} a creature, the creature remains @UUID[Compendium.pf2e.conditionitems.Item.AJh5ex99aV6VTggg]{off-guard} against that attack, and you then become @UUID[Compendium.pf2e.conditionitems.Item.1wQY3JYyhMYeeV2G]{observed}. If you do anything else, you become observed just before you act unless the GM determines otherwise.<br><strong>Failure</strong> You don't divert the attention of any creatures whose Perception DC exceeds your result, and those creatures are aware you were trying to trick them.</p>",
                 "DistractingWords": {
-                    "Title": "Create a Diversion - Distracting Words"
+                    "Title": "Distracting Words"
                 },
                 "Gesture": {
-                    "Title": "Create a Diversion - Gesture"
+                    "Title": "Gesture"
                 },
                 "Notes": {
                     "failure": "<strong>Failure</strong> You don't divert the attention of any creatures whose Perception DC exceeds your result, and those creatures are aware you were trying to trick them.",
-                    "success": "<strong>Success</strong> You become @UUID[Compendium.pf2e.conditionitems.Item.iU0fEDdBp3rXpTMC]{Hidden} to each creature whose Perception DC is less than or equal to your result. (The hidden condition allows you to @UUID[Compendium.pf2e.actionspf2e.Item.VMozDqMMuK5kpoX4]{Sneak} away.) This lasts until the end of your turn or until you do anything except Step or use the @UUID[Compendium.pf2e.actionspf2e.Item.XMcnh4cSI32tljXa]{Hide} or the @UUID[Compendium.pf2e.actionspf2e.Item.VMozDqMMuK5kpoX4]{Sneak} action of the Stealth skill. If you Strike a creature, the creature remains @UUID[Compendium.pf2e.conditionitems.Item.AJh5ex99aV6VTggg]{Off-Guard} against that attack, and you then become @UUID[Compendium.pf2e.conditionitems.Item.1wQY3JYyhMYeeV2G]{Observed}. If you do anything else, you become @UUID[Compendium.pf2e.conditionitems.Item.1wQY3JYyhMYeeV2G]{Observed} just before you act unless the GM determines otherwise."
+                    "success": "<strong>Success</strong> You become @UUID[Compendium.pf2e.conditionitems.Item.iU0fEDdBp3rXpTMC]{hidden} to each creature whose Perception DC is less than or equal to your result. (The hidden condition allows you to @UUID[Compendium.pf2e.actionspf2e.Item.VMozDqMMuK5kpoX4]{Sneak} away.) This lasts until the end of your turn or until you do anything except @UUID[Compendium.pf2e.actionspf2e.Item.UHpkTuCtyaPqiCAB]{Step} or use the Stealth skill to @UUID[Compendium.pf2e.actionspf2e.Item.XMcnh4cSI32tljXa]{Hide} or Sneak. If you @UUID[Compendium.pf2e.actionspf2e.Item.VjxZFuUXrCU94MWR]{Strike} a creature, the creature remains @UUID[Compendium.pf2e.conditionitems.Item.AJh5ex99aV6VTggg]{off-guard} against that attack, and you then become @UUID[Compendium.pf2e.conditionitems.Item.1wQY3JYyhMYeeV2G]{observed}. If you do anything else, you become observed just before you act unless the GM determines otherwise."
                 },
                 "Title": "Create a Diversion",
                 "Trick": {
-                    "Title": "Create a Diversion - Trick"
+                    "Title": "Trick"
                 },
                 "Warning": {
                     "UnknownVariant": "Unknown variant {variant} used for Create a Diversion, use one of {variants}."


### PR DESCRIPTION
Convert it to an action object and add the remaster description.