### PR TITLE
Fix Multishot Stance's prerequisite feat

### DIFF
--- a/packs/feats/multishot-stance.json
+++ b/packs/feats/multishot-stance.json
@@ -19,7 +19,7 @@
         "prerequisites": {
             "value": [
                 {
-                    "value": "Triple Shot"
+                    "value": "Double Shot"
                 }
             ]
         },


### PR DESCRIPTION
Multishot Stance's prerequisite changed from Triple Shot to Double Shot in Player Core 1.