### PR TITLE
Align header of action chat cards to consistently show action glyph in the same place

### DIFF
--- a/src/module/system/action-macros/helpers.ts
+++ b/src/module/system/action-macros/helpers.ts
@@ -168,7 +168,6 @@ export class ActionMacroHelpers {
                 );
                 const notes = options.extraNotes?.(statistic.slug) ?? [];
                 const label = (await options.content?.(header)) ?? header;
-                const title = `${game.i18n.localize(options.title)} - ${game.i18n.localize(subtitle)}`;
 
                 if (statistic instanceof Statistic) {
                     const dc = this.#resolveCheckDC({ unresolvedDC: options.difficultyClass });
@@ -176,7 +175,7 @@ export class ActionMacroHelpers {
                         ...eventToRollParams(options.event, { type: "check" }),
                         token: selfToken,
                         label,
-                        title,
+                        title: label,
                         dc,
                         extraRollNotes: notes,
                         extraRollOptions: combinedOptions,
@@ -240,7 +239,7 @@ export class ActionMacroHelpers {
                             dosAdjustments,
                             substitutions,
                             traits: actionTraits,
-                            title,
+                            title: label,
                         },
                         options.event,
                         (roll, outcome, message) => {

--- a/static/templates/actors/actions/base/chat-message-content.hbs
+++ b/static/templates/actors/actions/base/chat-message-content.hbs
@@ -1,8 +1,8 @@
 <h4 class="action">
+    <strong>{{localize name}}</strong>
     {{#if glyph}}
         <span class="pf2-icon larger">{{glyph}}</span>
     {{/if}}
-    <strong>{{localize name}}</strong>
 </h4>
 <div class="tags" data-tooltip-class="pf2e">
     {{#each traits as |trait|}}

--- a/static/templates/actors/actions/simple/chat-message-flavor.hbs
+++ b/static/templates/actors/actions/simple/chat-message-flavor.hbs
@@ -1,8 +1,8 @@
 <h4 class="action">
+    <strong>{{name}}</strong>
     {{#if glyph}}
         <span class="pf2-icon larger">{{glyph}}</span>
     {{/if}}
-    <strong>{{name}}</strong>
 </h4>
 <div class="tags" data-tooltip-class="pf2e">
     {{#each traits as |trait|}}


### PR DESCRIPTION
Before:
<img width="298" alt="Before" src="https://github.com/foundryvtt/pf2e/assets/6374503/6bc591d0-31ac-4163-b4c7-69dd5f10c7de">

After:
<img width="298" alt="After" src="https://github.com/foundryvtt/pf2e/assets/6374503/f25ceb8f-2fc4-42ae-bb90-e4c53ef5ab05">
