### PR TITLE
Add very rudimentary action browser application

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -10,6 +10,7 @@ import type { ItemPF2e, PhysicalItemPF2e } from "@item";
 import type { ConditionSource } from "@item/condition/data.ts";
 import type { CoinsPF2e } from "@item/physical/helpers.ts";
 import type { ActiveEffectPF2e } from "@module/active-effect.ts";
+import type { ActionBrowser } from "@module/apps/action-browser/app.ts";
 import type {
     CompendiumBrowser,
     CompendiumBrowserSettings,
@@ -85,6 +86,7 @@ interface GamePF2e
         UserPF2e
     > {
     pf2e: {
+        actionBrowser: ActionBrowser;
         actions: Record<string, Function> & Collection<Action>;
         compendiumBrowser: CompendiumBrowser;
         licenseViewer: LicenseViewer;

--- a/src/module/actor/actions/single-check.ts
+++ b/src/module/actor/actions/single-check.ts
@@ -109,7 +109,7 @@ class SingleCheckActionVariant extends BaseActionVariant {
 
     preview(options: Partial<ActionVariantCheckPreviewOptions> = {}): ActionCheckPreview[] {
         const slugs = this.#statistic || this.#action.statistic;
-        const candidates = Array.isArray(slugs) ? slugs : [slugs];
+        const candidates = [slugs].flat().filter((slug) => !!slug?.trim());
 
         // TODO: append relevant statistic replacements from the actor
 

--- a/src/module/apps/action-browser/app.ts
+++ b/src/module/apps/action-browser/app.ts
@@ -1,0 +1,198 @@
+import type { ActorPF2e } from "@actor";
+import {
+    Action,
+    ActionSection,
+    ActionVariant,
+    SingleCheckAction,
+    SingleCheckActionVariant,
+} from "@actor/actions/index.ts";
+import type { TokenPF2e } from "@module/canvas/index.ts";
+import { htmlClosest, htmlQuery } from "@util";
+import { getSelectedActors } from "@util/token-actor-utils.ts";
+
+interface ActionBrowserData {
+    actions: Record<ActionSection | "favorites" | "other", ActionListItem[]>;
+    actor?: ActorPF2e;
+    disabled: boolean;
+}
+
+class ActionVariantListItem {
+    readonly checks;
+    readonly #variant;
+
+    constructor(variant: ActionVariant, actor?: ActorPF2e) {
+        this.checks = variant instanceof SingleCheckActionVariant ? variant.preview({ actor }) : undefined;
+        this.#variant = variant;
+    }
+
+    get cost(): ActionVariant["cost"] {
+        return this.#variant.cost;
+    }
+
+    get name(): ActionVariant["name"] {
+        return this.#variant.name;
+    }
+
+    get slug(): ActionVariant["slug"] {
+        return this.#variant.slug;
+    }
+
+    get traits(): ActionVariant["traits"] {
+        return this.#variant.traits;
+    }
+}
+
+class ActionListItem {
+    readonly #action;
+    readonly checks;
+    readonly variants;
+
+    constructor(action: Action, actor?: ActorPF2e) {
+        this.#action = action;
+        if (action.variants.size === 0) {
+            this.checks = action instanceof SingleCheckAction ? action.preview({ actor }) : undefined;
+        }
+        const variants: [string, ActionVariantListItem][] = action.variants.contents
+            .map((variant) => new ActionVariantListItem(variant, actor))
+            .map((variant) => [variant.slug, variant]);
+        this.variants = new Collection<ActionVariantListItem>(variants);
+    }
+
+    get cost(): Action["cost"] {
+        return this.#action.cost;
+    }
+
+    get img(): Action["img"] {
+        return this.#action.img;
+    }
+
+    get name(): Action["name"] {
+        return this.#action.name;
+    }
+
+    get section(): Action["section"] {
+        return this.#action.section;
+    }
+
+    get slug(): Action["slug"] {
+        return this.#action.slug;
+    }
+
+    get traits(): Action["traits"] {
+        return this.#action.traits;
+    }
+}
+
+export class ActionBrowser extends Application {
+    readonly #controlTokenHandler: HookCallback<unknown[]>;
+
+    constructor(options?: Partial<ApplicationOptions>) {
+        super(options);
+        this.#controlTokenHandler = this.onControlToken.bind(this) as HookCallback<unknown[]>;
+    }
+
+    static override get defaultOptions(): ApplicationOptions {
+        return fu.mergeObject(super.defaultOptions, {
+            id: "action-browser",
+            height: 550,
+            width: 700,
+            resizable: true,
+            tabs: [{ navSelector: ".tabs", contentSelector: ".content", initial: "favorites" }],
+            template: "systems/pf2e/templates/action-browser/action-browser.hbs",
+            title: "PF2E.ActionBrowser.Title",
+        });
+    }
+
+    override get title(): string {
+        const actors = getSelectedActors({ assignedFallback: true });
+        const actor = actors.length === 1 ? actors[0] : undefined;
+        return actor ? `${super.title} (${actor.name})` : super.title;
+    }
+
+    override getData(_options?: ApplicationOptions): ActionBrowserData | Promise<ActionBrowserData> {
+        const actors = getSelectedActors({ assignedFallback: true });
+        const actor = actors.length === 1 ? actors[0] : undefined;
+        const actions: ActionBrowserData["actions"] = {
+            favorites: [],
+            basic: [],
+            ["specialty-basic"]: [],
+            skill: [],
+            other: [],
+        };
+        [...game.pf2e.actions.values()]
+            .map((action) => new ActionListItem(action, actor))
+            .forEach((action) => {
+                actions[action.section ?? "other"].push(action);
+            });
+        return {
+            actions,
+            actor,
+            disabled: actors.length === 0,
+        };
+    }
+
+    override activateListeners($html: JQuery): void {
+        super.activateListeners($html);
+        const html = $html[0];
+
+        // Action usage
+        htmlQuery(html, ".content")?.addEventListener("click", (event) => {
+            const enabled = getSelectedActors({ assignedFallback: true }).length > 0;
+            const action = htmlClosest(event.target, "[data-action-slug]")?.dataset.actionSlug;
+            if (action) {
+                const handler = htmlClosest(event.target, "[data-action-handler]")?.dataset.actionHandler;
+                if (handler === "use" && enabled) {
+                    const multipleAttackPenalty = htmlClosest(event.target, "[data-action-map]")?.dataset.actionMap;
+                    const statistic = htmlClosest(event.target, "[data-action-statistic]")?.dataset.actionStatistic;
+                    const variant = htmlClosest(event.target, "[data-action-variant-slug]")?.dataset.actionVariantSlug;
+                    game.pf2e.actions
+                        .get(action ?? "")
+                        ?.use({
+                            event,
+                            multipleAttackPenalty: multipleAttackPenalty ? Number(multipleAttackPenalty) : undefined,
+                            statistic,
+                            variant,
+                        })
+                        .catch((reason: Error | string) => {
+                            if (reason) {
+                                ui.notifications.warn(reason.toString());
+                            }
+                        });
+                } else if (handler === "chat") {
+                    game.pf2e.actions.get(action ?? "")?.toMessage();
+                } else {
+                    // show in details panel
+                }
+            }
+        });
+    }
+
+    override render(force?: boolean, options?: RenderOptions): this {
+        if (force && !this.rendered) {
+            Hooks.on("controlToken", this.#controlTokenHandler);
+            getSelectedActors({ assignedFallback: true }).forEach((actor) => (actor.apps[this.appId] = this));
+        }
+        return super.render(force, options);
+    }
+
+    override close(options?: { force?: boolean }): Promise<void> {
+        Hooks.off("controlToken", this.#controlTokenHandler);
+        getSelectedActors({ assignedFallback: true }).forEach((actor) => delete actor.apps[this.appId]);
+        return super.close(options);
+    }
+
+    // debounced render method to prevent double-rendering in case of rapidly fired control token events, like when
+    // tabbing through tokens on the canvas
+    private refresh = fu.debounce(this.render, 100);
+
+    private onControlToken(token: TokenPF2e, control: boolean) {
+        if (token.actor) {
+            if (control) {
+                token.actor.apps[this.appId] = this;
+            } else if (token.actor) {
+                delete token.actor.apps[this.appId];
+            }
+        }
+        this.refresh(false);
+    }
+}

--- a/src/module/apps/action-browser/index.ts
+++ b/src/module/apps/action-browser/index.ts
@@ -1,0 +1,1 @@
+export { ActionBrowser } from "./app.ts";

--- a/src/scripts/hooks/get-scene-control-buttons.ts
+++ b/src/scripts/hooks/get-scene-control-buttons.ts
@@ -4,8 +4,27 @@ import { SceneDarknessAdjuster } from "@module/apps/scene-darkness-adjuster.ts";
 export const GetSceneControlButtons = {
     listen: (): void => {
         Hooks.on("getSceneControlButtons", (controls) => {
-            // World Clock
             const tokenTools = controls.find((c) => c.name === "token")?.tools;
+
+            if (BUILD_MODE === "development") {
+                // Action Browser
+                tokenTools?.push({
+                    name: "actionbrowser",
+                    title: "CONTROLS.ActionBrowser",
+                    icon: "action-browser",
+                    button: true,
+                    visible: true,
+                    onClick: () => {
+                        if (game.pf2e.actionBrowser.rendered) {
+                            game.pf2e.actionBrowser.close({ force: true });
+                        } else {
+                            game.pf2e.actionBrowser.render(true);
+                        }
+                    },
+                });
+            }
+
+            // World Clock
             tokenTools?.push({
                 name: "worldclock",
                 title: "CONTROLS.WorldClock",

--- a/src/scripts/register-templates.ts
+++ b/src/scripts/register-templates.ts
@@ -132,6 +132,10 @@ export function registerTemplates(): void {
         "systems/pf2e/templates/actors/vehicle/tabs/description.hbs",
         "systems/pf2e/templates/actors/vehicle/tabs/effects.hbs",
 
+        // Action Browser Partials
+        "systems/pf2e/templates/action-browser/action-buttons.hbs",
+        "systems/pf2e/templates/action-browser/action-list.hbs",
+
         // Compendium Browser Partials
         "systems/pf2e/templates/compendium-browser/settings/settings.hbs",
         "systems/pf2e/templates/compendium-browser/settings/pack-settings.hbs",

--- a/src/scripts/set-game-pf2e.ts
+++ b/src/scripts/set-game-pf2e.ts
@@ -37,6 +37,7 @@ import { ModuleArt } from "@system/module-art.ts";
 import { Predicate } from "@system/predication.ts";
 import { TextEditorPF2e } from "@system/text-editor.ts";
 import { sluggify } from "@util";
+import { ActionBrowser } from "@module/apps/action-browser/app.ts";
 
 /** Expose public game.pf2e interface */
 export const SetGamePF2e = {
@@ -158,6 +159,9 @@ export const SetGamePF2e = {
     onSetup: (): void => {},
 
     onReady: (): void => {
+        if (BUILD_MODE === "development") {
+            game.pf2e.actionBrowser = new ActionBrowser();
+        }
         game.pf2e.compendiumBrowser = new CompendiumBrowser();
         game.pf2e.worldClock = new WorldClock();
     },

--- a/src/styles/system/_action-browser.scss
+++ b/src/styles/system/_action-browser.scss
@@ -1,0 +1,129 @@
+.control-tool {
+    .action-browser:before {
+        content: "A";
+        font-family: "Pathfinder2eActions";
+        font-style: normal;
+    }
+}
+
+@mixin button-group {
+    font-size: var(--font-size-14);
+    margin-bottom: 0;
+    padding: 2px 0;
+
+    display: flex;
+    justify-content: right;
+    flex-wrap: wrap;
+    gap: 3px;
+
+    &.multiple-attack-penalty {
+        display: grid;
+        grid-template-columns: repeat(3, min-content);
+    }
+
+    button {
+        border: none;
+        flex: 0;
+        gap: 2px;
+        height: 1.25rem;
+        line-height: unset;
+        margin: 0;
+        padding: 0 0.5em;
+        white-space: nowrap;
+        display: flex;
+        column-gap: 3px;
+        justify-content: space-between;
+
+        &:disabled {
+            opacity: 0.7;
+        }
+
+        &:not(:disabled):hover {
+            box-shadow: none;
+            text-shadow: 0 0 2px var(--text-light);
+        }
+    }
+}
+
+.action-browser {
+    @import "../packs/nav";
+
+    .action-list {
+        margin-top: 5px;
+
+        .action-list-item:not(:first-child) {
+            border-top: 1px solid rgba(120, 100, 82, 0.3);
+        }
+
+        .action-list-item {
+            padding-top: 3px;
+            padding-bottom: 3px;
+
+            &:nth-child(odd) {
+                background-color: rgba(120, 100, 82, 0.1);
+            }
+            .action {
+                --action-icon-size: 32px;
+
+                display: flex;
+                column-gap: 5px;
+                align-items: start;
+                padding: 0 4px 0 4px;
+
+                .action-icon {
+                    flex: 0 0 var(--action-icon-size);
+                    height: var(--action-icon-size);
+
+                    img {
+                        height: var(--action-icon-size);
+                        width: var(--action-icon-size);
+                    }
+                }
+
+                .action-summary {
+                    flex: 1 1 max-content;
+                    min-height: var(--action-icon-size);
+                    display: flex;
+                    flex-direction: column;
+                    justify-content: center;
+
+                    .action-heading {
+                        font-weight: bold;
+                    }
+                }
+
+                .action-buttons {
+                    flex: 1 1 max-content;
+                    display: flex;
+                    align-items: center;
+                    justify-content: right;
+                    min-height: var(--action-icon-size);
+
+                    .button-group {
+                        @include button-group;
+                    }
+                }
+            }
+
+            .action-variants {
+                display: flex;
+                flex-direction: column;
+                margin: -2px 0 0 17px;
+                border-left: 3px dotted #786452;
+                padding: 0 0 3px 14px;
+
+                .action-variant {
+                    display: flex;
+                    column-gap: 5px;
+                    justify-content: space-between;
+                    align-items: center;
+                    padding: 4px 4px 0 7px;
+
+                    .button-group {
+                        @include button-group;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/styles/system/_index.scss
+++ b/src/styles/system/_index.scss
@@ -1,2 +1,2 @@
-@import "actions", "choice-set-prompt", "compendium-migration-status", "effects-panel", "journal", "migration-summary",
-    "upw-viewer", "world-clock";
+@import "action-browser", "actions", "choice-set-prompt", "compendium-migration-status", "effects-panel", "journal",
+    "migration-summary", "upw-viewer", "world-clock";

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -24,6 +24,7 @@
         "MigrationStatus": "Migration Status"
     },
     "CONTROLS": {
+        "ActionBrowser": "Action Browser",
         "AdjustSceneDarkness": "Adjust Scene Darkness",
         "EffectPanel": "Effects Panel",
         "WorldClock": "World Clock"
@@ -100,6 +101,31 @@
         },
         "ActionActionTypeLabel": "Action Type",
         "ActionActionsLabel": "Actions",
+        "ActionBrowser": {
+            "Buttons": {
+                "Use": {
+                    "Label": "Use"
+                }
+            },
+            "Tabs": {
+                "Basic": {
+                    "Title": "Basic"
+                },
+                "Favorites": {
+                    "Title": "Favorites"
+                },
+                "Other": {
+                    "Title": "Other"
+                },
+                "Skill": {
+                    "Title": "Skill"
+                },
+                "SpecialtyBasic": {
+                    "Title": "Specialty Basic"
+                }
+            },
+            "Title": "Action Browser"
+        },
         "ActionBrowserSearchHint": "You can search for name or custom attributes. Possible searchable attributes are:<br> source, spellType, level, materials, target, range, time, duration, damage, damageType, save, concentration, ritual, ability and classes. <br>Example: 'fire, damage:d6' to show all spells that have fire in their name and a d6 in the damage",
         "ActionDeathNoteLabel": "Death Note",
         "ActionNumber1": "One",

--- a/static/templates/action-browser/action-browser.hbs
+++ b/static/templates/action-browser/action-browser.hbs
@@ -1,0 +1,29 @@
+<div class="action-browser">
+    <nav class="tabs" data-group="primary-tabs">
+        <!--
+        <a class="item" data-tab="favorites" data-group="primary-tabs">{{localize "PF2E.ActionBrowser.Tabs.Favorites.Title"}}</a>
+        -->
+        <a class="item" data-tab="basic" data-group="primary-tabs">{{localize "PF2E.ActionBrowser.Tabs.Basic.Title"}}</a>
+        <a class="item" data-tab="specialty-basic" data-group="primary-tabs">{{localize "PF2E.ActionBrowser.Tabs.SpecialtyBasic.Title"}}</a>
+        <a class="item" data-tab="skill" data-group="primary-tabs">{{localize "PF2E.ActionBrowser.Tabs.Skill.Title"}}</a>
+        <a class="item" data-tab="other" data-group="primary-tabs">{{localize "PF2E.ActionBrowser.Tabs.Other.Title"}}</a>
+    </nav>
+
+    <section class="content">
+        <div class="tab" data-tab="favorites" data-group="primary-tabs">
+            {{> systems/pf2e/templates/action-browser/action-list.hbs actions=actions.favorites actor=actor disabled=disabled}}
+        </div>
+        <div class="tab" data-tab="basic" data-group="primary-tabs">
+            {{> systems/pf2e/templates/action-browser/action-list.hbs actions=actions.basic actor=actor disabled=disabled}}
+        </div>
+        <div class="tab" data-tab="specialty-basic" data-group="primary-tabs">
+            {{> systems/pf2e/templates/action-browser/action-list.hbs actions=actions.specialty-basic actor=actor disabled=disabled}}
+        </div>
+        <div class="tab" data-tab="skill" data-group="primary-tabs">
+            {{> systems/pf2e/templates/action-browser/action-list.hbs actions=actions.skill actor=actor disabled=disabled}}
+        </div>
+        <div class="tab" data-tab="other" data-group="primary-tabs">
+            {{> systems/pf2e/templates/action-browser/action-list.hbs actions=actions.other actor=actor disabled=disabled}}
+        </div>
+    </section>
+</div>

--- a/static/templates/action-browser/action-buttons.hbs
+++ b/static/templates/action-browser/action-buttons.hbs
@@ -1,0 +1,18 @@
+{{#if action.checks.length}}
+    {{#each action.checks as |check|}}
+        <button type="button" class="tag tag_secondary" {{disabled @root.disabled}} data-action-handler="use" data-action-statistic="{{check.slug}}">
+            {{localize check.label}}
+            {{#if check.modifier includeZero=true}}
+                {{numberFormat check.modifier decimals=0 sign=true}}
+            {{/if}}
+        </button>
+        {{#if (includes ../action.traits "attack")}}
+            <button type="button" class="tag tag_secondary" {{disabled @root.disabled}} data-action-handler="use" data-action-statistic="{{check.slug}}" data-action-map="1">{{localize "PF2E.MAPAbbreviationLabel" penalty=-5}}</button>
+            <button type="button" class="tag tag_secondary" {{disabled @root.disabled}} data-action-handler="use" data-action-statistic="{{check.slug}}" data-action-map="2">{{localize "PF2E.MAPAbbreviationLabel" penalty=-10}}</button>
+        {{/if}}
+    {{/each}}
+{{else}}
+    <button type="button" class="tag tag_secondary" {{disabled @root.disabled}} data-action-handler="use">
+        {{localize "PF2E.ActionBrowser.Buttons.Use.Label"}}
+    </button>
+{{/if}}

--- a/static/templates/action-browser/action-list.hbs
+++ b/static/templates/action-browser/action-list.hbs
@@ -1,0 +1,55 @@
+<div class="action-list">
+    {{#each actions as |action|}}
+        <div class="action-list-item" data-action-slug="{{ action.slug }}">
+            <div class="action">
+                <div class="action-icon" data-action-handler="chat">
+                    <img src="{{coalesce action.img 'systems/pf2e/icons/features/classes/choice-feature.webp'}}" alt="{{localize action.name}}">
+                </div>
+                <div class="action-summary">
+                    <div class="action-heading">
+                        {{localize action.name}}
+                        {{#if (eq action.variants.size 0)}}
+                            {{{actionGlyph action.cost}}}
+                        {{/if}}
+                    </div>
+                    <div class="tags">
+                        {{#if (eq action.variants.size 0)}}
+                            {{#each action.traits as |trait|}}
+                                <span class="tag">{{ trait }}</span>
+                            {{/each}}
+                        {{/if}}
+                    </div>
+                </div>
+                <div class="action-buttons">
+                    <div class="button-group tags{{#if (includes action.traits "attack")}} multiple-attack-penalty{{/if}}">
+                        {{#if (eq action.variants.size 0)}}
+                            {{> systems/pf2e/templates/action-browser/action-buttons.hbs action=action actor=@root.actor disabled=@root.disabled}}
+                        {{/if}}
+                    </div>
+                </div>
+            </div>
+            {{#if action.variants.size}}
+                <div class="action-variants">
+                    {{#each action.variants as |variant|}}
+                        <div data-action-variant-slug="{{variant.slug}}" class="action-variant">
+                            <div>
+                                <span>
+                                    {{localize (coalesce variant.name action.name)}}
+                                    {{{actionGlyph variant.cost}}}
+                                </span>
+                                <div class="tags">
+                                    {{#each variant.traits as |trait|}}
+                                        <span class="tag">{{ trait }}</span>
+                                    {{/each}}
+                                </div>
+                            </div>
+                            <div class="button-group tags{{#if (includes variant.traits "attack")}} multiple-attack-penalty{{/if}}">
+                                {{> systems/pf2e/templates/action-browser/action-buttons.hbs action=variant actor=@root.actor disabled=@root.disabled}}
+                            </div>
+                        </div>
+                    {{/each}}
+                </div>
+            {{/if}}
+        </div>
+    {{/each}}
+</div>


### PR DESCRIPTION
Add an application that lists actions sourced from the built-in system actions. The actions are split into tabs based on a section field in the action data, defaulting to the "other" tab. The built-in list of actions can potentially be expanded by modules.

Disable the use and check buttons in case no actor is controlled by, or assigned to, the user. In case of only a single controlled or assigned actor, show the relevant modifier on any check buttons.

Also add a control tool for opening the action browser (only in development mode for now).

_Without_ a token selected or default actor:
<img width="704" alt="image" src="https://github.com/foundryvtt/pf2e/assets/6374503/43731ea1-9cf0-435e-84e7-e7487ca01c8d">

_With_ a token selected:
<img width="705" alt="image" src="https://github.com/foundryvtt/pf2e/assets/6374503/b3e9e23e-1228-433f-b9a8-31c2211649c8">

~~Depends on https://github.com/foundryvtt/pf2e/pull/12682~~
