### PR TITLE
Restore converting selector to array for fresh flat modifier forms

### DIFF
--- a/src/module/rules/rule-element/flat-modifier.ts
+++ b/src/module/rules/rule-element/flat-modifier.ts
@@ -69,6 +69,7 @@ class FlatModifierRuleElement extends RuleElementPF2e<FlatModifierSchema> {
             ...super.defineSchema(),
             selector: new fields.ArrayField(
                 new fields.StringField({ required: true, blank: false, initial: undefined }),
+                { required: true, initial: undefined },
             ),
             type: new fields.StringField({
                 required: true,
@@ -195,7 +196,7 @@ interface FlatModifierRuleElement
 
 type FlatModifierSchema = RuleElementSchema & {
     /** All domains to add a modifier to */
-    selector: ArrayField<StringField<string, string, true, false, false>>;
+    selector: ArrayField<StringField<string, string, true, false, false>, string[], string[], true>;
     /** The modifier (or bonus/penalty) type */
     type: StringField<ModifierType, ModifierType, true, false, true>;
     /** If this is an ability modifier, the ability score it modifies */

--- a/src/module/rules/rule-element/flat-modifier.ts
+++ b/src/module/rules/rule-element/flat-modifier.ts
@@ -196,7 +196,7 @@ interface FlatModifierRuleElement
 
 type FlatModifierSchema = RuleElementSchema & {
     /** All domains to add a modifier to */
-    selector: ArrayField<StringField<string, string, true, false, false>, string[], string[], true>;
+    selector: ArrayField<StringField<string, string, true, false, false>, string[], string[], true, false, false>;
     /** The modifier (or bonus/penalty) type */
     type: StringField<ModifierType, ModifierType, true, false, true>;
     /** If this is an ability modifier, the ability score it modifies */


### PR DESCRIPTION
This prevents empty array from getting cleared out by the form's clearing behavior. FlatModifier's without a selector property now complain about selector cannot be undefined instead of "must have at least 1".