### PR TITLE
Fix Llorona's Wail to use @Template

### DIFF
--- a/packs/book-of-the-dead-bestiary/llorona.json
+++ b/packs/book-of-the-dead-bestiary/llorona.json
@@ -270,7 +270,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The llorona unleashes a somber wail. Each living creature within @Check[type:emanation|distance:120]{120 feet} must attempt a @Check[type:will|dc:31] save. Regardless of its result, the creature is then temporarily immune for 24 hours.</p>\n<hr />\n<p><strong>Critical Success</strong> The creature is unaffected.</p>\n<p><strong>Success</strong> The creature is @UUID[Compendium.pf2e.conditionitems.Item.Stunned]{Stunned 1}.</p>\n<p><strong>Failure</strong> The creature is @UUID[Compendium.pf2e.conditionitems.Item.Fascinated] with the nearest body of water and compelled to move toward the water and drown itself. If there's no nearby body of water, the creature instead remains still. The creature can attempt another @Check[type:will|dc:31] save at the end of each of its turns. On a success, the creature is no longer fascinated. Once the fascinated condition ends, the creature becomes stunned 1.</p>\n<p><strong>Critical Failure</strong> As failure, except the creature receives another Will save only at the end of a round in which it's submerged in water.</p>"
+                    "value": "<p>The llorona unleashes a somber wail. Each living creature within @Template[type:emanation|distance:120]{120 feet} must attempt a @Check[type:will|dc:31] save. Regardless of its result, the creature is then temporarily immune for 24 hours.</p>\n<hr />\n<p><strong>Critical Success</strong> The creature is unaffected.</p>\n<p><strong>Success</strong> The creature is @UUID[Compendium.pf2e.conditionitems.Item.Stunned]{Stunned 1}.</p>\n<p><strong>Failure</strong> The creature is @UUID[Compendium.pf2e.conditionitems.Item.Fascinated] with the nearest body of water and compelled to move toward the water and drown itself. If there's no nearby body of water, the creature instead remains still. The creature can attempt another @Check[type:will|dc:31] save at the end of each of its turns. On a success, the creature is no longer fascinated. Once the fascinated condition ends, the creature becomes stunned 1.</p>\n<p><strong>Critical Failure</strong> As failure, except the creature receives another Will save only at the end of a round in which it's submerged in water.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -348,7 +348,8 @@
                     "title": ""
                 },
                 "rules": [],
-                "slug": null
+                "slug": null,
+                "traits": {}
             },
             "type": "lore"
         },
@@ -373,7 +374,8 @@
                     "title": ""
                 },
                 "rules": [],
-                "slug": null
+                "slug": null,
+                "traits": {}
             },
             "type": "lore"
         },
@@ -398,7 +400,8 @@
                     "title": ""
                 },
                 "rules": [],
-                "slug": null
+                "slug": null,
+                "traits": {}
             },
             "type": "lore"
         },
@@ -423,7 +426,8 @@
                     "title": ""
                 },
                 "rules": [],
-                "slug": null
+                "slug": null,
+                "traits": {}
             },
             "type": "lore"
         }

--- a/packs/pfs-season-3-bestiary/wailing-ghost.json
+++ b/packs/pfs-season-3-bestiary/wailing-ghost.json
@@ -176,7 +176,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The wailing ghost shakes with a terrible sob, forcing each living creature within @Check[type:emanation|distance:15]{15 feet} to attempt a @Check[type:will|dc:18] save. On a failure, a creature becomes @UUID[Compendium.pf2e.conditionitems.Item.Frightened]{Frightened 1} (or @UUID[Compendium.pf2e.conditionitems.Item.Frightened]{Frightened 2} on a critical failure). On a success, a creature is temporarily immune to this ghost's Weeping Moan for 1 minute.</p>"
+                    "value": "<p>The wailing ghost shakes with a terrible sob, forcing each living creature within @Template[type:emanation|distance:15]{15 feet} to attempt a @Check[type:will|dc:18] save. On a failure, a creature becomes @UUID[Compendium.pf2e.conditionitems.Item.Frightened]{Frightened 1} (or @UUID[Compendium.pf2e.conditionitems.Item.Frightened]{Frightened 2} on a critical failure). On a success, a creature is temporarily immune to this ghost's Weeping Moan for 1 minute.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -219,7 +219,8 @@
                     "title": ""
                 },
                 "rules": [],
-                "slug": null
+                "slug": null,
+                "traits": {}
             },
             "type": "lore"
         },
@@ -244,7 +245,8 @@
                     "title": ""
                 },
                 "rules": [],
-                "slug": null
+                "slug": null,
+                "traits": {}
             },
             "type": "lore"
         },
@@ -269,7 +271,8 @@
                     "title": ""
                 },
                 "rules": [],
-                "slug": null
+                "slug": null,
+                "traits": {}
             },
             "type": "lore"
         }


### PR DESCRIPTION
Closes #12523

Scanned and found Wailing Ghost had the same issue, so fixed as well in this PR.