### PR TITLE
Change Basic Witchcraft to provide 3 familiar abilities per PC1

### DIFF
--- a/packs/feats/basic-witchcraft.json
+++ b/packs/feats/basic-witchcraft.json
@@ -34,7 +34,7 @@
                 "mode": "upgrade",
                 "path": "system.attributes.familiarAbilities.value",
                 "priority": 9,
-                "value": 2
+                "value": 3
             },
             {
                 "adjustName": false,


### PR DESCRIPTION
Closes #12539

I tested it and Witch Dedication appears to already provide a correct familiar ability count.