### PR TITLE
Add two missing abilities to Siabrae NPC

### DIFF
--- a/packs/book-of-the-dead-bestiary/siabrae.json
+++ b/packs/book-of-the-dead-bestiary/siabrae.json
@@ -200,7 +200,8 @@
                 },
                 "tradition": {
                     "value": "primal"
-                }
+                },
+                "traits": {}
             },
             "type": "spellcastingEntry"
         },
@@ -306,7 +307,8 @@
                 },
                 "tradition": {
                     "value": "primal"
-                }
+                },
+                "traits": {}
             },
             "type": "spellcastingEntry"
         },
@@ -2792,6 +2794,55 @@
             "type": "action"
         },
         {
+            "_id": "3QJY9QrJIcqYhDrN",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-family-ability-glossary.Item.Es8g7kZrLAuNdiD1"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Miasma",
+            "sort": 3800000,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "defensive",
+                "description": {
+                    "value": "<p>20 foot, @Check[type:fortitude|dc:37]{DC equal to the siabrae's spell DC - 4}.</p>\n<hr />\n<p>A creature that enters the aura or begins its turn there becomes @UUID[Compendium.pf2e.conditionitems.Item.Sickened]{Sickened 2} on a failure (or sickened 4 on a critical failure). An animal, fey, or plant that rolls a failure gets a critical failure instead. Regardless of the result of the saving throw, the creature is temporarily immune to the siabrae's miasma for 1 minute.</p>"
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Book of the Dead"
+                },
+                "rules": [
+                    {
+                        "key": "Aura",
+                        "radius": 20,
+                        "slug": "miasma",
+                        "traits": [
+                            "disease",
+                            "primal"
+                        ]
+                    }
+                ],
+                "slug": "siabrae-miasma",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "aura",
+                        "disease",
+                        "primal"
+                    ]
+                }
+            },
+            "type": "action"
+        },
+        {
             "_id": "SQt7rET9Z2MgoK8E",
             "flags": {
                 "core": {
@@ -2800,7 +2851,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Rejuvenation",
-            "sort": 3800000,
+            "sort": 3900000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -2838,7 +2889,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Void Healing",
-            "sort": 3900000,
+            "sort": 4000000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -2880,7 +2931,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Blight Mastery",
-            "sort": 4000000,
+            "sort": 4100000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -2907,10 +2958,45 @@
             "type": "action"
         },
         {
+            "_id": "aU4ED1uwXIfy7MTJ",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.bestiary-family-ability-glossary.Item.DIYZNvVP28U2UnDb"
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Earth Glide",
+            "sort": 4200000,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "offensive",
+                "description": {
+                    "value": "<p>The siabrae can @UUID[Compendium.pf2e.actionspf2e.Item.Burrow] through any earthen matter, including rock. When it does so, the siabrae moves at its full burrow Speed, leaving no tunnels or signs of its passing.</p>"
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Book of the Dead"
+                },
+                "rules": [],
+                "slug": "siabrae-earth-glide",
+                "traits": {
+                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "action"
+        },
+        {
             "_id": "xrhhvmqzd4qp9cx9",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Steady Spellcasting",
-            "sort": 4100000,
+            "sort": 4300000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -2945,7 +3031,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Stony Shards",
-            "sort": 4200000,
+            "sort": 4400000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -2980,7 +3066,7 @@
             "_id": "dho4oism23fp8j92",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Acrobatics",
-            "sort": 4300000,
+            "sort": 4500000,
             "system": {
                 "description": {
                     "value": ""
@@ -2997,7 +3083,8 @@
                     "title": ""
                 },
                 "rules": [],
-                "slug": null
+                "slug": null,
+                "traits": {}
             },
             "type": "lore"
         },
@@ -3005,7 +3092,7 @@
             "_id": "d0835iflv3tq14nn",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Athletics",
-            "sort": 4400000,
+            "sort": 4600000,
             "system": {
                 "description": {
                     "value": ""
@@ -3022,7 +3109,8 @@
                     "title": ""
                 },
                 "rules": [],
-                "slug": null
+                "slug": null,
+                "traits": {}
             },
             "type": "lore"
         },
@@ -3030,7 +3118,7 @@
             "_id": "p7zj3s9j0fb3cnls",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Crafting",
-            "sort": 4500000,
+            "sort": 4700000,
             "system": {
                 "description": {
                     "value": ""
@@ -3047,7 +3135,8 @@
                     "title": ""
                 },
                 "rules": [],
-                "slug": null
+                "slug": null,
+                "traits": {}
             },
             "type": "lore"
         },
@@ -3055,7 +3144,7 @@
             "_id": "eo7zu1ch6cj02saa",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Intimidation",
-            "sort": 4600000,
+            "sort": 4800000,
             "system": {
                 "description": {
                     "value": ""
@@ -3072,7 +3161,8 @@
                     "title": ""
                 },
                 "rules": [],
-                "slug": null
+                "slug": null,
+                "traits": {}
             },
             "type": "lore"
         },
@@ -3080,7 +3170,7 @@
             "_id": "z2p98nsvu4y5xtn9",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Nature",
-            "sort": 4700000,
+            "sort": 4900000,
             "system": {
                 "description": {
                     "value": ""
@@ -3097,7 +3187,8 @@
                     "title": ""
                 },
                 "rules": [],
-                "slug": null
+                "slug": null,
+                "traits": {}
             },
             "type": "lore"
         },
@@ -3105,7 +3196,7 @@
             "_id": "1xyp2mlawbwibmxo",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Religion",
-            "sort": 4800000,
+            "sort": 5000000,
             "system": {
                 "description": {
                     "value": ""
@@ -3122,7 +3213,8 @@
                     "title": ""
                 },
                 "rules": [],
-                "slug": null
+                "slug": null,
+                "traits": {}
             },
             "type": "lore"
         },
@@ -3130,7 +3222,7 @@
             "_id": "adkqone5xnj7qgmo",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Stealth",
-            "sort": 4900000,
+            "sort": 5100000,
             "system": {
                 "description": {
                     "value": ""
@@ -3147,7 +3239,8 @@
                     "title": ""
                 },
                 "rules": [],
-                "slug": null
+                "slug": null,
+                "traits": {}
             },
             "type": "lore"
         },
@@ -3155,7 +3248,7 @@
             "_id": "nrqrmsmlyedp5zq5",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Survival",
-            "sort": 5000000,
+            "sort": 5200000,
             "system": {
                 "description": {
                     "value": ""
@@ -3172,7 +3265,8 @@
                     "title": ""
                 },
                 "rules": [],
-                "slug": null
+                "slug": null,
+                "traits": {}
             },
             "type": "lore"
         }


### PR DESCRIPTION
Closes #12543

Confirmed Earth Glide and Miasma were missing from the abilities block per the Book of the Dead. Also provided the correct DC for Miasma.