### PR TITLE
Add REs to Golem Grafter Archetype feats

### DIFF
--- a/packs/feats/accursed-clay-fist.json
+++ b/packs/feats/accursed-clay-fist.json
@@ -43,7 +43,6 @@
                 },
                 "group": "brawling",
                 "key": "Strike",
-                "label": "Accursed Clay Fist",
                 "range": null,
                 "traits": [
                     "unarmed",

--- a/packs/feats/accursed-clay-fist.json
+++ b/packs/feats/accursed-clay-fist.json
@@ -43,12 +43,18 @@
                 },
                 "group": "brawling",
                 "key": "Strike",
-                "label": "Stone Fist",
+                "label": "Accursed Clay Fist",
                 "range": null,
                 "traits": [
                     "unarmed",
                     "nonlethal"
                 ]
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.golemGrafterDedicationCount",
+                "value": 1
             }
         ],
         "traits": {

--- a/packs/feats/accursed-clay-fist.json
+++ b/packs/feats/accursed-clay-fist.json
@@ -52,7 +52,7 @@
             {
                 "key": "ActiveEffectLike",
                 "mode": "add",
-                "path": "flags.pf2e.golemGrafterDedicationCount",
+                "path": "flags.pf2e.golemGrafter.featCount",
                 "value": 1
             }
         ],

--- a/packs/feats/golem-grafter-dedication.json
+++ b/packs/feats/golem-grafter-dedication.json
@@ -42,12 +42,7 @@
             },
             {
                 "exceptions": [
-                    {
-                        "definition": [
-                            "damage:material:adamantine"
-                        ],
-                        "label": "adamantine"
-                    }
+                    "adamantine"
                 ],
                 "key": "Resistance",
                 "type": "physical",

--- a/packs/feats/golem-grafter-dedication.json
+++ b/packs/feats/golem-grafter-dedication.json
@@ -37,7 +37,7 @@
             {
                 "key": "ActiveEffectLike",
                 "mode": "add",
-                "path": "flags.pf2e.golemGrafterDedicationCount",
+                "path": "flags.pf2e.golemGrafter.featCount",
                 "value": 1
             },
             {
@@ -46,7 +46,7 @@
                 ],
                 "key": "Resistance",
                 "type": "physical",
-                "value": "@actor.flags.pf2e.golemGrafterDedicationCount"
+                "value": "@actor.flags.pf2e.golemGrafter.featCount"
             }
         ],
         "traits": {

--- a/packs/feats/golem-grafter-dedication.json
+++ b/packs/feats/golem-grafter-dedication.json
@@ -33,6 +33,25 @@
                 "key": "FlatModifier",
                 "selector": "hp",
                 "value": "@actor.level"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.golemGrafterDedicationCount",
+                "value": 1
+            },
+            {
+                "exceptions": [
+                    {
+                        "definition": [
+                            "damage:material:adamantine"
+                        ],
+                        "label": "adamantine"
+                    }
+                ],
+                "key": "Resistance",
+                "type": "physical",
+                "value": "@actor.flags.pf2e.golemGrafterDedicationCount"
             }
         ],
         "traits": {

--- a/packs/feats/iron-lung.json
+++ b/packs/feats/iron-lung.json
@@ -28,7 +28,31 @@
             "remaster": false,
             "title": "Pathfinder #153: Life's Long Shadows"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.golemGrafterDedicationCount",
+                "value": 1
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.adventure-specific-actions.Item.Exhale Poison"
+            },
+            {
+                "adjustment": {
+                    "criticalFailure": "one-degree-better",
+                    "failure": "one-degree-better",
+                    "success": "one-degree-better"
+                },
+                "key": "AdjustDegreeOfSuccess",
+                "predicate": [
+                    "poison",
+                    "inhaled"
+                ],
+                "selector": "saving-throw"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/iron-lung.json
+++ b/packs/feats/iron-lung.json
@@ -32,7 +32,7 @@
             {
                 "key": "ActiveEffectLike",
                 "mode": "add",
-                "path": "flags.pf2e.golemGrafterDedicationCount",
+                "path": "flags.pf2e.golemGrafter.featCount",
                 "value": 1
             },
             {
@@ -41,9 +41,7 @@
             },
             {
                 "adjustment": {
-                    "criticalFailure": "one-degree-better",
-                    "failure": "one-degree-better",
-                    "success": "one-degree-better"
+                    "all": "one-degree-better"
                 },
                 "key": "AdjustDegreeOfSuccess",
                 "predicate": [

--- a/packs/feats/legs-of-stone.json
+++ b/packs/feats/legs-of-stone.json
@@ -52,7 +52,7 @@
             {
                 "key": "ActiveEffectLike",
                 "mode": "add",
-                "path": "flags.pf2e.golemGrafterDedicationCount",
+                "path": "flags.pf2e.golemGrafter.featCount",
                 "value": 1
             }
         ],

--- a/packs/feats/legs-of-stone.json
+++ b/packs/feats/legs-of-stone.json
@@ -48,6 +48,12 @@
                 "selector": "reflex",
                 "type": "status",
                 "value": 2
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.golemGrafterDedicationCount",
+                "value": 1
             }
         ],
         "traits": {

--- a/packs/feats/quicken-heartbeat.json
+++ b/packs/feats/quicken-heartbeat.json
@@ -15,8 +15,7 @@
         },
         "frequency": {
             "max": 1,
-            "per": "turn",
-            "value": 1
+            "per": "turn"
         },
         "level": {
             "value": 10
@@ -33,7 +32,14 @@
             "remaster": false,
             "title": "Pathfinder #153: Life's Long Shadows"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.golemGrafterDedicationCount",
+                "value": 1
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/quicken-heartbeat.json
+++ b/packs/feats/quicken-heartbeat.json
@@ -36,7 +36,7 @@
             {
                 "key": "ActiveEffectLike",
                 "mode": "add",
-                "path": "flags.pf2e.golemGrafterDedicationCount",
+                "path": "flags.pf2e.golemGrafter.featCount",
                 "value": 1
             }
         ],


### PR DESCRIPTION
Touches up the Golem Grafter Dedication feat chain and adds REs where needed.