### PR TITLE
Disable sight for hazards on actor creation

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -596,6 +596,9 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
                     merged.prototypeToken.actorLink = true;
                     merged.prototypeToken.sight = { enabled: true };
                     break;
+                case "hazard":
+                    merged.prototypeToken.sight = { enabled: false };
+                    break;
                 case "loot":
                     // Make loot actors linked and interactable
                     merged.ownership.default = CONST.DOCUMENT_OWNERSHIP_LEVELS.LIMITED;


### PR DESCRIPTION
Now that users may wish to enable vision for NPCs via the token defaults setting, it should still be prevented for hazards so they don't get unusable vision.