### PR TITLE
Add Spellcasting Proficiency to more Feats

### DIFF
--- a/packs/feats/basic-red-mantis-magic.json
+++ b/packs/feats/basic-red-mantis-magic.json
@@ -42,6 +42,13 @@
                 "value": 1
             }
         ],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 1
+                }
+            }
+        },
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/basic-summoner-spellcasting.json
+++ b/packs/feats/basic-summoner-spellcasting.json
@@ -29,6 +29,13 @@
             "title": "Pathfinder Secrets of Magic"
         },
         "rules": [],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 1
+                }
+            }
+        },
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/beast-gunner-dedication.json
+++ b/packs/feats/beast-gunner-dedication.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>You've bonded to your beast gun and unlocked the first hints of its @UUID[Compendium.pf2e.conditionitems.Item.Hidden] potential. You treat all beast guns as martial firearms when determining your proficiency with them, even beast guns that are normally advanced weapons. You can change your bonded beast gun to another beast gun you own each day during your daily preparations, as long as you've previously performed a ritual hunt associated with the new beast gun.</p>\n<p>The beast gun also acts as a conduit, drawing out and amplifying any latent or active magic power you have. You learn to cast spontaneous spells and gain the Cast a Spell activity. You gain a spell repertoire with one cantrip of your choice, from either the arcane or primal spell list. You choose this cantrip from the common spells on your chosen spell list or from other spells you have access to on the list. This cantrip must require a spell attack roll. You're trained in spell attack rolls and spell DCs for arcane or primal spells, whichever of the two traditions you chose. Your key spellcasting ability for these spells is Charisma.</p>\n<p>If you already cast arcane or primal spells from spell slots, you learn one additional cantrip from that tradition. If you're a prepared caster, you can prepare this spell in addition to your usual cantrips per day; if you're a spontaneous caster, you add this cantrip to your spell repertoire.</p>\n<p>You also gain @UUID[Compendium.pf2e.actionspf2e.Item.Spellsling].</p>\n<p><strong>Special</strong> You can't select another dedication feat until you've gained two other feats from the @UUID[Compendium.pf2e.journals.JournalEntry.vx5FGEG34AxI2dow.JournalEntryPage.jTiXRtNNvMOnsg98]{Beast Gunner} archetype.</p>"
+            "value": "<p>You've bonded to your beast gun and unlocked the first hints of its hidden potential. You treat all beast guns as martial firearms when determining your proficiency with them, even beast guns that are normally advanced weapons. You can change your bonded beast gun to another beast gun you own each day during your daily preparations, as long as you've previously performed a ritual hunt associated with the new beast gun.</p>\n<p>The beast gun also acts as a conduit, drawing out and amplifying any latent or active magic power you have. You learn to cast spontaneous spells and gain the Cast a Spell activity. You gain a spell repertoire with one cantrip of your choice, from either the arcane or primal spell list. You choose this cantrip from the common spells on your chosen spell list or from other spells you have access to on the list. This cantrip must require a spell attack roll. You're trained in spell attack rolls and spell DCs for arcane or primal spells, whichever of the two traditions you chose. Your key spellcasting ability for these spells is Charisma.</p>\n<p>If you already cast arcane or primal spells from spell slots, you learn one additional cantrip from that tradition. If you're a prepared caster, you can prepare this spell in addition to your usual cantrips per day; if you're a spontaneous caster, you add this cantrip to your spell repertoire.</p>\n<p>You also gain @UUID[Compendium.pf2e.actionspf2e.Item.Spellsling].</p>\n<p><strong>Special</strong> You can't select another dedication feat until you've gained two other feats from the @UUID[Compendium.pf2e.journals.JournalEntry.vx5FGEG34AxI2dow.JournalEntryPage.jTiXRtNNvMOnsg98]{Beast Gunner} archetype.</p>"
         },
         "level": {
             "value": 6
@@ -40,6 +40,13 @@
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Spellsling"
             }
         ],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 1
+                }
+            }
+        },
         "traits": {
             "rarity": "uncommon",
             "value": [

--- a/packs/feats/blessing-of-the-sun-gods.json
+++ b/packs/feats/blessing-of-the-sun-gods.json
@@ -30,6 +30,13 @@
             "title": "Pathfinder #172: Secrets of the Temple-City"
         },
         "rules": [],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 1
+                }
+            }
+        },
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/captivator-dedication.json
+++ b/packs/feats/captivator-dedication.json
@@ -32,6 +32,13 @@
             "title": "Pathfinder Lost Omens: The Grand Bazaar"
         },
         "rules": [],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 1
+                }
+            }
+        },
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/cathartic-mage-dedication.json
+++ b/packs/feats/cathartic-mage-dedication.json
@@ -19,7 +19,7 @@
         "prerequisites": {
             "value": [
                 {
-                    "value": "Cha 14 or ability to cast spells from spell slots"
+                    "value": "Charisma +2 or ability to cast spells from spell slots"
                 }
             ]
         },
@@ -80,6 +80,13 @@
                 "uuid": "{item|flags.pf2e.rulesSelections.catharticMageDedication}"
             }
         ],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 1
+                }
+            }
+        },
         "traits": {
             "rarity": "uncommon",
             "value": [

--- a/packs/feats/cautious-delver.json
+++ b/packs/feats/cautious-delver.json
@@ -29,6 +29,13 @@
             "title": "Pathfinder Lost Omens: Pathfinder Society Guide"
         },
         "rules": [],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 1
+                }
+            }
+        },
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/crystal-ward-spells.json
+++ b/packs/feats/crystal-ward-spells.json
@@ -29,6 +29,13 @@
             "title": "Pathfinder #148: Fires of the Haunted City"
         },
         "rules": [],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 1
+                }
+            }
+        },
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/dracomancer.json
+++ b/packs/feats/dracomancer.json
@@ -25,6 +25,13 @@
             "title": "Pathfinder Advanced Player's Guide"
         },
         "rules": [],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 1
+                }
+            }
+        },
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/eldritch-archer-dedication.json
+++ b/packs/feats/eldritch-archer-dedication.json
@@ -34,6 +34,13 @@
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Eldritch Shot"
             }
         ],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 1
+                }
+            }
+        },
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/eldritch-researcher-dedication.json
+++ b/packs/feats/eldritch-researcher-dedication.json
@@ -32,6 +32,13 @@
             "title": "Pathfinder #164: Hands of the Devil"
         },
         "rules": [],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 1
+                }
+            }
+        },
         "traits": {
             "rarity": "uncommon",
             "value": [

--- a/packs/feats/expert-beast-gunner-spellcasting.json
+++ b/packs/feats/expert-beast-gunner-spellcasting.json
@@ -29,6 +29,13 @@
             "title": "Pathfinder Guns & Gears"
         },
         "rules": [],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 2
+                }
+            }
+        },
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/expert-captivator-spellcasting.json
+++ b/packs/feats/expert-captivator-spellcasting.json
@@ -29,6 +29,13 @@
             "title": "Pathfinder Lost Omens: The Grand Bazaar"
         },
         "rules": [],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 2
+                }
+            }
+        },
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/expert-cathartic-spellcasting.json
+++ b/packs/feats/expert-cathartic-spellcasting.json
@@ -29,6 +29,13 @@
             "title": "Pathfinder Secrets of Magic"
         },
         "rules": [],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 2
+                }
+            }
+        },
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/expert-eldritch-archer-spellcasting.json
+++ b/packs/feats/expert-eldritch-archer-spellcasting.json
@@ -29,6 +29,13 @@
             "title": "Pathfinder Advanced Player's Guide"
         },
         "rules": [],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 2
+                }
+            }
+        },
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/expert-snowcasting.json
+++ b/packs/feats/expert-snowcasting.json
@@ -25,6 +25,13 @@
             "title": "Pathfinder Treasure Vault"
         },
         "rules": [],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 2
+                }
+            }
+        },
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/expert-summoner-spellcasting.json
+++ b/packs/feats/expert-summoner-spellcasting.json
@@ -32,6 +32,13 @@
             "title": "Pathfinder Secrets of Magic"
         },
         "rules": [],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 2
+                }
+            }
+        },
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/ghost-hunter-dedication.json
+++ b/packs/feats/ghost-hunter-dedication.json
@@ -29,6 +29,13 @@
             "title": "Pathfinder #163: Ruins of Gauntlight"
         },
         "rules": [],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 1
+                }
+            }
+        },
         "traits": {
             "rarity": "uncommon",
             "value": [

--- a/packs/feats/halcyon-spellcasting-adept.json
+++ b/packs/feats/halcyon-spellcasting-adept.json
@@ -32,6 +32,13 @@
             "title": "Pathfinder Lost Omens: Character Guide"
         },
         "rules": [],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 2
+                }
+            }
+        },
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/invoke-the-crimson-oath.json
+++ b/packs/feats/invoke-the-crimson-oath.json
@@ -29,6 +29,13 @@
             "title": "Pathfinder Lost Omens: Character Guide"
         },
         "rules": [],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 1
+                }
+            }
+        },
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/lore-seeker.json
+++ b/packs/feats/lore-seeker.json
@@ -29,6 +29,13 @@
             "title": "Pathfinder Lost Omens: Character Guide"
         },
         "rules": [],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 1
+                }
+            }
+        },
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/magaambyan-attendant-dedication.json
+++ b/packs/feats/magaambyan-attendant-dedication.json
@@ -32,6 +32,13 @@
             "title": "Pathfinder Lost Omens: Character Guide"
         },
         "rules": [],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 1
+                }
+            }
+        },
         "traits": {
             "rarity": "uncommon",
             "value": [

--- a/packs/feats/magic-finder.json
+++ b/packs/feats/magic-finder.json
@@ -29,6 +29,13 @@
             "title": "Pathfinder Lost Omens: Pathfinder Society Guide"
         },
         "rules": [],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 1
+                }
+            }
+        },
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/master-captivator-spellcasting.json
+++ b/packs/feats/master-captivator-spellcasting.json
@@ -29,6 +29,13 @@
             "title": "Pathfinder Lost Omens: The Grand Bazaar"
         },
         "rules": [],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 3
+                }
+            }
+        },
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/master-skysage-divination.json
+++ b/packs/feats/master-skysage-divination.json
@@ -29,6 +29,13 @@
             "title": "Pathfinder #187: The Seventh Arch"
         },
         "rules": [],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 3
+                }
+            }
+        },
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/minor-magic.json
+++ b/packs/feats/minor-magic.json
@@ -25,6 +25,13 @@
             "title": "Pathfinder Core Rulebook"
         },
         "rules": [],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 1
+                }
+            }
+        },
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/nantambu-chime-ringer-dedication.json
+++ b/packs/feats/nantambu-chime-ringer-dedication.json
@@ -32,6 +32,13 @@
             "title": "Pathfinder #170: Spoken on the Song Wind"
         },
         "rules": [],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 1
+                }
+            }
+        },
         "traits": {
             "rarity": "uncommon",
             "value": [

--- a/packs/feats/shadow-illusion.json
+++ b/packs/feats/shadow-illusion.json
@@ -29,6 +29,13 @@
             "title": "Pathfinder Advanced Player's Guide"
         },
         "rules": [],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 2
+                }
+            }
+        },
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/shadow-magic.json
+++ b/packs/feats/shadow-magic.json
@@ -29,6 +29,13 @@
             "title": "Pathfinder Advanced Player's Guide"
         },
         "rules": [],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 1
+                }
+            }
+        },
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/shadow-power.json
+++ b/packs/feats/shadow-power.json
@@ -29,6 +29,13 @@
             "title": "Pathfinder Advanced Player's Guide"
         },
         "rules": [],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 2
+                }
+            }
+        },
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/shall-not-falter-shall-not-rout.json
+++ b/packs/feats/shall-not-falter-shall-not-rout.json
@@ -29,6 +29,13 @@
             "title": "Pathfinder Lost Omens: Legends"
         },
         "rules": [],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 1
+                }
+            }
+        },
         "traits": {
             "rarity": "rare",
             "selected": {

--- a/packs/feats/suns-fury.json
+++ b/packs/feats/suns-fury.json
@@ -29,6 +29,13 @@
             "title": "Pathfinder Lost Omens: Legends"
         },
         "rules": [],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 1
+                }
+            }
+        },
         "traits": {
             "rarity": "common",
             "selected": {


### PR DESCRIPTION
Adds spellcasting training rules to a bunch of feats.

Also fixes a bad pre-requisite on Cathartic Mage and removes a link to Hidden on Beast Gunner Dedication that's not actually a reference to the condition.