### PR TITLE
Refactor getDefaultVariant method on BaseAction to be synchronous

### DIFF
--- a/static/lang/action-en.json
+++ b/static/lang/action-en.json
@@ -894,7 +894,7 @@
             "Variants": {
                 "None": "Action '{action}' has no variants, but variant '{variant}' was requested.",
                 "Multiple": "Action '{action}' has multiple variants, but no variant was requested.",
-                "Nonexisting": "Specified variant '{variant}' does not exist for action '{action}'"
+                "Nonexistent": "Specified variant '{variant}' does not exist for action '{action}'"
             }
         }
     }


### PR DESCRIPTION
Change `BaseAction#getDefaultVariant` from being asynchronous to being synchronous since the asynchronicity was not necessary and future synchronous use cases are anticipated.