### PR TITLE
Change Litany of Depravity's target per the remaster errata

### DIFF
--- a/packs/spells/litany-of-depravity.json
+++ b/packs/spells/litany-of-depravity.json
@@ -31,7 +31,7 @@
         "requirements": "",
         "rules": [],
         "target": {
-            "value": "1 creature who isn't unholy"
+            "value": "1 creature that isn't unholy"
         },
         "time": {
             "value": "1"

--- a/packs/spells/litany-of-depravity.json
+++ b/packs/spells/litany-of-depravity.json
@@ -31,7 +31,7 @@
         "requirements": "",
         "rules": [],
         "target": {
-            "value": "1 good creature"
+            "value": "1 creature who isn't unholy"
         },
         "time": {
             "value": "1"


### PR DESCRIPTION
> Page 228: In the litany of depravity focus spell, replace the Targets line "1 good creature" with "1 creature that isn't unholy" and replace "weakness 7 to evil" with "weakness 7 to unholy".