### PR TITLE
Update PC languages, speed, and traits styling

### DIFF
--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -337,6 +337,27 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
             sheetData.elementalBlasts = [];
         }
 
+        // Speed
+        const speedIcons = {
+            land: "person-running",
+            swim: "person-swimming",
+            climb: "mountain",
+            fly: "feather-pointed",
+            burrow: "water-ladder",
+        };
+        sheetData.speeds = R.keys.strict(speedIcons).map((slug): SpeedSheetData => {
+            const speed = this.actor.system.attributes.speed;
+            const data = slug === "land" ? speed : speed.otherSpeeds.find((s) => s.type === slug);
+            return {
+                slug,
+                icon: fontAwesomeIcon(speedIcons[slug]).outerHTML,
+                action: ["swim", "climb"].includes(slug) && !data?.total ? slug : null,
+                label: slug === "land" ? "PF2E.SpeedTypesLand" : CONFIG.PF2E.speedTypes[slug],
+                value: data?.total ?? null,
+                breakdown: slug === "land" ? speed.breakdown : null,
+            };
+        });
+
         // Return data for rendering
         return sheetData;
     }
@@ -1588,6 +1609,16 @@ interface CharacterSheetData<TActor extends CharacterPF2e = CharacterPF2e> exten
     feats: FeatGroup[];
     elementalBlasts: ElementalBlastSheetConfig[];
     senses: Sense[];
+    speeds: SpeedSheetData[];
+}
+
+interface SpeedSheetData {
+    slug: string;
+    icon: string;
+    action: string | null;
+    label: string;
+    value: number | null;
+    breakdown: string | null;
 }
 
 interface ActionSheetData {

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -481,8 +481,17 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
                 const element = htmlClosest(anchor, "[data-item-id], [data-action-index]") ?? htmlClosest(anchor, "li");
                 if (element) return this.itemRenderer.toggleSummary(element);
             },
-            "use-action": async (event) => {
-                const itemId = htmlClosest(event.target, "[data-item-id]")?.dataset.itemId;
+            "use-action": async (event, anchor) => {
+                const actionSlug = htmlClosest(anchor, "[data-action-slug]")?.dataset.actionSlug;
+                if (actionSlug) {
+                    const action = game.pf2e.actions[actionSlug ?? ""];
+                    if (!action) {
+                        throw ErrorPF2e(`Unexpecteed error retrieving action ${actionSlug}`);
+                    }
+                    return action({ event });
+                }
+
+                const itemId = htmlClosest(anchor, "[data-item-id]")?.dataset.itemId;
                 const item = this.actor.items.get(itemId, { strict: true });
                 if (item.isOfType("action", "feat")) {
                     await createSelfEffectMessage(item, eventToRollMode(event));

--- a/src/styles/actor/character/_character.scss
+++ b/src/styles/actor/character/_character.scss
@@ -13,46 +13,6 @@
         margin: 10px 6px 10px 0;
     }
 
-    .pc h3 {
-        align-items: center;
-        background-color: rgba($text-dark-color, 0.1);
-        border: none;
-        color: var(--text-dark);
-        display: flex;
-        font: 700 var(--font-size-14) / 1em var(--body-serif);
-        margin: 0;
-        padding: 0.5em 0.25em;
-        position: relative;
-        width: calc(100% - 0.5em);
-
-        &.has-emblem {
-            border-radius: 0 0.75rem 0.75rem 0;
-        }
-
-        span.value {
-            flex-basis: 100%;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            white-space: nowrap;
-        }
-
-        .emblem {
-            position: relative;
-            flex: 0 0 1.75rem;
-            margin-left: 0.25rem;
-            margin-right: -0.3755rem;
-            img {
-                position: absolute;
-                @include brown-border;
-                top: -0.875rem;
-                left: 0;
-                border-radius: 50%;
-                height: 1.75rem;
-                width: 1.75rem;
-            }
-        }
-    }
-
     .character-details {
         align-items: start;
         display: grid;
@@ -64,12 +24,18 @@
         .image-container {
             display: flex;
             grid-area: img;
+            flex: 0 0 8rem;
             z-index: 3;
+            position: relative;
+            max-height: 10.5rem;
+
+            display: flex;
+            flex-direction: column;
 
             .actor-image {
                 @include brown-border;
                 border-radius: 0;
-                max-height: 11rem;
+                max-height: 10.5rem;
                 object-fit: cover;
                 object-position: top;
                 width: 100%;
@@ -77,20 +43,66 @@
         }
 
         .abcd {
-            grid-area: details;
+            flex: 1;
             display: grid;
-            grid-template-columns: repeat(2, 13em);
+            grid-template-columns: repeat(2, 1fr);
             grid-row-gap: 0.5rem;
             justify-content: start;
             padding-left: 0.75rem;
 
-            > * {
+            .detail {
                 display: flex;
                 flex-wrap: wrap;
                 gap: 2px;
                 .details-label {
                     flex-basis: 100%;
                 }
+
+                h3 {
+                    align-items: center;
+                    background-color: rgba($text-dark-color, 0.1);
+                    border: none;
+                    color: var(--text-dark);
+                    display: flex;
+                    font: 700 var(--font-size-14) / 1em var(--body-serif);
+                    margin: 0;
+                    padding: 0.5em 0.25em;
+                    position: relative;
+                    width: calc(100% - 0.5em);
+
+                    &.has-emblem {
+                        border-radius: 0 0.75rem 0.75rem 0;
+                    }
+
+                    span.value {
+                        flex-basis: 100%;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                        white-space: nowrap;
+                    }
+
+                    .emblem {
+                        position: relative;
+                        flex: 0 0 1.75rem;
+                        margin-left: 0.25rem;
+                        margin-right: -0.3755rem;
+                        img {
+                            position: absolute;
+                            @include brown-border;
+                            top: -0.875rem;
+                            left: 0;
+                            border-radius: 50%;
+                            height: 1.75rem;
+                            width: 1.75rem;
+                        }
+                    }
+                }
+            }
+
+            .traits {
+                grid-column: span 2;
+                margin: -4px 0 0 -2px;
+                padding: 0;
             }
 
             .deity {
@@ -148,67 +160,66 @@
         }
     }
 
-    .character-traits {
+    .character-languages {
         display: flex;
         flex-wrap: wrap;
+        gap: 0.25rem;
+        margin-bottom: 0.5rem;
+    }
 
-        .tags {
-            width: 100%;
-        }
-
-        .pc {
+    .character-speeds {
+        display: flex;
+        margin-bottom: 0.5rem;
+        .speed {
+            align-items: center;
             display: flex;
             flex-direction: column;
-            justify-content: start;
-            align-items: start;
-            flex: 20%;
-            margin-bottom: 0.5rem;
+            flex: 1 0 0;
+            text-align: center;
 
-            span {
-                width: 100%;
+            & + .speed {
+                border-left: 1px solid #d3ccbc;
             }
 
-            span.speed {
-                * {
-                    width: 50%;
+            .label {
+                color: var(--color-pf-alternate-dark);
+                font: 500 var(--font-size-14) var(--sans-serif);
+                font-variant: small-caps;
+                position: relative;
+            }
+
+            .value {
+                align-items: baseline;
+                color: var(--color-text-dark-2);
+                display: flex;
+                font: 500 var(--font-size-18) / 1 var(--serif);
+                gap: 0.25ch;
+                padding: 0.25rem;
+                padding-bottom: 0;
+                position: relative;
+
+                i {
+                    color: var(--color-pf-alternate-dark);
+                    font-size: var(--font-size-13);
+                    opacity: 0.85;
                 }
-            }
 
-            &_land-speed,
-            &_size {
-                flex: 50%;
-            }
+                .unit {
+                    font-size: var(--font-size-14);
+                }
 
-            &_speed-types {
-                flex: 50%;
-            }
-
-            &_traits {
-                flex: 50%;
-                margin-bottom: 0;
-            }
-
-            &_languages {
-                flex: 100%;
-                margin-bottom: 0;
-            }
-
-            label,
-            h4 {
-                margin: 0;
-                white-space: nowrap;
-            }
-
-            .tags {
-                margin: 0;
-                padding: 0;
-            }
-
-            .tags,
-            select,
-            input,
-            h3 {
-                margin-top: 0.25rem;
+                &.rollable {
+                    svg {
+                        width: 1rem;
+                        height: 1rem;
+                        path {
+                            fill: var(--color-text-dark-2);
+                        }
+                    }
+                    &:hover svg {
+                        @include die-spin;
+                    }
+                }
             }
         }
     }

--- a/static/templates/actors/character/tabs/character.hbs
+++ b/static/templates/actors/character/tabs/character.hbs
@@ -10,20 +10,33 @@
             <a class="hover-icon" data-action="show-image" data-tooltip="SIDEBAR.CharArt"><i class="fa-solid fa-image fa-fw"></i></a>
         </div>
 
-         <div class="abcd">
-            <div class="pc ancestry">
+        <div class="abcd">
+            <ul class="tags traits paizo-style">
+                {{#if ancestry}}
+                    <li class="tag size">{{localize (lookup actorSizes data.traits.size.value)}}</li>
+                {{/if}}
+                {{#each traits as |trait slug|}}
+                    <li class="tag tag_alt" data-slug="{{slug}}">{{trait.label}}</li>
+                {{/each}}
+            </ul>
+
+            <div class="detail ancestry">
                 {{> detailItem item=ancestry type="ancestry" compendium="pf2e.ancestries" }}
             </div>
-            <div class="pc heritage">
+
+            <div class="detail heritage">
                 {{> detailItem item=heritage type="heritage" compendium="pf2e.heritages" }}
             </div>
-            <div class="pc background">
+
+            <div class="detail background">
                 {{> detailItem item=background type="background" compendium="pf2e.backgrounds" }}
             </div>
-            <div class="pc class">
+
+            <div class="detail class">
                 {{> detailItem item=class type="class" compendium="pf2e.classes" }}
             </div>
-            <div class="pc deity">
+
+            <div class="detail deity">
                 {{> detailItem item=deity type="deity" compendium="pf2e.deities" showEmblem=true }}
             </div>
         </div>
@@ -49,72 +62,47 @@
         </label>
     </section>
 
-    <hr />
-    <section class="character-traits">
-        <div class="pc pc_land-speed">
-            <span class="details-label">{{localize "PF2E.Speed"}}</span>
-            <span>
-                <h3 data-tooltip="{{data.attributes.speed.breakdown}}">{{data.attributes.speed.total}} {{localize "PF2E.TravelSpeed.FeetAcronym"}}</h3>
-            </span>
-        </div>
-        <div class="pc pc_size">
-            <span class="details-label">{{localize "PF2E.Size"}}</span>
-            <span>
-            <h3>{{localize (lookup actorSizes data.traits.size.value)}}</h3>
-            </span>
-        </div>
+    <header>
+        {{localize "PF2E.Languages"}}
+        {{#if @root.options.editable}}
+            <button type="button" class="crb-tag-selector" data-tag-selector="basic" data-title="PF2E.Languages" data-config-types="languages" data-property="system.traits.languages">
+                <i class="fa-solid fa-fw fa-edit"></i>{{localize "PF2E.Edit"}}
+            </button>
+        {{/if}}
+    </header>
+    <section class="character-languages tags">
+        {{#each languages as |language slug|}}
+            <span class="tag tag_alt" data-slug="{{slug}}">{{language.label}}</span>
+        {{/each}}
+    </section>
 
-        <div class="break-column"></div>
-
-        <div class="character-traits">
-            <div class="pc pc_speed-types">
-                <span class="details-label">{{localize "PF2E.SpeedTypes"}}</span>
-                <ol class="tags">
-                    {{#each data.attributes.speed.otherSpeeds as |speed|}}
-                        <li class="tag tag_alt" data-slug="{{speed.type}}" data-tooltip="{{speed.breakdown}}">{{speed.label}} ({{speed.total}})</li>
-                    {{/each}}
-                    {{#if @root.options.editable}}
-                        <li class="tag tag_secondary edit-btn">
-                            <a class="crb-tag-selector" data-tag-selector="speed-types">
-                                {{> "systems/pf2e/templates/actors/character/icons/plus.hbs"}}
-                            </a>
-                        </li>
-                    {{/if}}
-                </ol>
+    <header>
+        {{localize "PF2E.Speed"}}
+        {{#if @root.options.editable}}
+            <button type="button" class="crb-tag-selector" data-tag-selector="speed-types">
+                <i class="fa-solid fa-fw fa-edit"></i>{{localize "PF2E.Edit"}}
+            </button>
+        {{/if}}
+    </header>
+    <section class="character-speeds">
+        {{#each speeds as |speed|}}
+            <div class="speed">
+                <div class="label">
+                    {{localize speed.label}}
+                </div>
+                {{#if speed.value}}
+                    <div class="value" data-tooltip="{{speed.breakdown}}">
+                        {{{icon}}}
+                        <span class="number">{{speed.value}}</span>
+                        <span class="unit">{{localize "PF2E.TravelSpeed.FeetAcronym"}}</span>
+                    </div>
+                {{else if speed.action}}
+                    <a class="value rollable" data-action="use-action" data-action-slug="{{speed.action}}">{{> "systems/pf2e/templates/actors/character/icons/d20.hbs"}}</a>
+                {{else}}
+                    <div class="value empty">&mdash;</div>
+                {{/if}}
             </div>
-
-            <div class="pc pc_traits">
-                <span class="details-label">{{localize "PF2E.Traits"}}</span>
-                <ul class="tags">
-                    {{#each traits as |trait slug|}}
-                        <li class="tag tag_alt" data-slug="{{slug}}">{{trait.label}}</li>
-                    {{/each}}
-                    {{#if @root.options.editable}}
-                        <li class="tag tag_secondary edit-btn">
-                            <a class="crb-tag-selector" data-tag-selector="basic" data-config-types="creatureTraits" data-property="system.traits">
-                                {{> "systems/pf2e/templates/actors/character/icons/plus.hbs"}}
-                            </a>
-                        </li>
-                    {{/if}}
-                </ul>
-            </div>
-
-            <div class="pc pc_languages">
-                <span class="details-label">{{localize "PF2E.Languages"}}</span>
-                <ul class="tags">
-                    {{#each languages as |language slug|}}
-                        <li class="tag tag_alt" data-slug="{{slug}}">{{language.label}}</li>
-                    {{/each}}
-                    {{#if @root.options.editable}}
-                        <li class="tag tag_secondary edit-btn">
-                            <a class="crb-tag-selector" data-tag-selector="basic" data-title="PF2E.Languages" data-config-types="languages" data-property="system.traits.languages">
-                                {{> "systems/pf2e/templates/actors/character/icons/plus.hbs"}}
-                            </a>
-                        </li>
-                    {{/if}}
-                </ul>
-            </div>
-        </div>
+        {{/each}}
     </section>
 
     <!-- Attributes -->


### PR DESCRIPTION
The simpler tag styling languages had in the screenshot is not an available global tag styling, and I'll have to come up with a name and perhaps a tweak, since those were actually meant for the party sheet. The one in this current PR uses the normal tags. I'll think on all that later.

![image](https://github.com/foundryvtt/pf2e/assets/1286721/005fe9c3-dc47-4022-8e24-ca6634465fb9)
