### PR TITLE
Add `description` item alteration

### DIFF
--- a/src/module/item/abc/data.ts
+++ b/src/module/item/abc/data.ts
@@ -1,4 +1,4 @@
-import { ItemSystemSource } from "@item/base/data/system.ts";
+import { ItemSystemData, ItemSystemSource } from "@item/base/data/system.ts";
 
 interface ABCFeatureEntryData {
     uuid: string;
@@ -11,6 +11,6 @@ interface ABCSystemSource extends ItemSystemSource {
     items: Record<string, ABCFeatureEntryData>;
 }
 
-type ABCSystemData = ABCSystemSource;
+interface ABCSystemData extends Omit<ABCSystemSource, "description">, ItemSystemData {}
 
 export type { ABCFeatureEntryData, ABCSystemData, ABCSystemSource };

--- a/src/module/item/ability/data.ts
+++ b/src/module/item/ability/data.ts
@@ -36,7 +36,7 @@ interface SelfEffectReferenceSource {
     name: string;
 }
 
-interface AbilitySystemData extends AbilitySystemSource, Omit<ItemSystemData, "level" | "traits"> {
+interface AbilitySystemData extends Omit<AbilitySystemSource, "description">, Omit<ItemSystemData, "level" | "traits"> {
     frequency?: Frequency;
     /** A self-applied effect for simple actions */
     selfEffect: SelfEffectReference | null;

--- a/src/module/item/affliction/data.ts
+++ b/src/module/item/affliction/data.ts
@@ -42,7 +42,7 @@ interface AfflictionSystemSource extends AbstractEffectSystemSource {
 }
 
 interface AfflictionSystemData
-    extends Omit<AfflictionSystemSource, "fromSpell">,
+    extends Omit<AfflictionSystemSource, "description" | "fromSpell">,
         Omit<AbstractEffectSystemData, "level" | "traits"> {}
 
 interface AfflictionOnset {

--- a/src/module/item/ancestry/data.ts
+++ b/src/module/item/ancestry/data.ts
@@ -33,6 +33,8 @@ interface AncestrySystemSource extends ABCSystemSource {
     level?: never;
 }
 
-interface AncestrySystemData extends Omit<AncestrySystemSource, "items">, Omit<ABCSystemData, "level" | "traits"> {}
+interface AncestrySystemData
+    extends Omit<AncestrySystemSource, "description" | "items">,
+        Omit<ABCSystemData, "level" | "traits"> {}
 
-export type { AncestrySource, AncestrySystemData, AncestryTraits, CreatureTraits };
+export type { AncestrySource, AncestrySystemData, AncestrySystemSource, AncestryTraits, CreatureTraits };

--- a/src/module/item/armor/data.ts
+++ b/src/module/item/armor/data.ts
@@ -53,7 +53,7 @@ interface ArmorSystemData
     stackGroup: null;
 }
 
-type SourceOmission = "bulk" | "hp" | "identification" | "items" | "material" | "price" | "temporary" | "usage";
+type SourceOmission = "bulk" | "description" | "hp" | "identification" | "material" | "price" | "temporary" | "usage";
 
 interface ArmorTraits extends PhysicalItemTraits<ArmorTrait> {
     otherTags: OtherArmorTag[];

--- a/src/module/item/background/data.ts
+++ b/src/module/item/background/data.ts
@@ -18,6 +18,8 @@ interface BackgroundSystemSource extends ABCSystemSource {
 
 type BackgroundTraits = ItemTraits<BackgroundTrait>;
 
-interface BackgroundSystemData extends Omit<BackgroundSystemSource, "items">, Omit<ABCSystemData, "level" | "traits"> {}
+interface BackgroundSystemData
+    extends Omit<BackgroundSystemSource, "description" | "items">,
+        Omit<ABCSystemData, "level" | "traits"> {}
 
 export type { BackgroundSource, BackgroundSystemData };

--- a/src/module/item/base/data/system.ts
+++ b/src/module/item/base/data/system.ts
@@ -77,10 +77,7 @@ type ItemGrantDeleteAction = "cascade" | "detach" | "restrict";
 
 type ItemSystemSource = {
     level?: { value: number };
-    description: {
-        gm: string;
-        value: string;
-    };
+    description: ItemDescriptionSource;
     traits: ItemTraits | ItemTraitsNoRarity | RarityTraitAndOtherTags | OtherTagsOnly;
     rules: RuleElementSource[];
     slug: string | null;
@@ -94,9 +91,20 @@ type ItemSystemSource = {
     schema?: Readonly<{ version: number | null; lastMigration: object | null }>;
 };
 
-type ItemSystemData = ItemSystemSource;
+interface ItemDescriptionSource {
+    gm: string;
+    value: string;
+}
 
-type FrequencyInterval = keyof ConfigPF2e["PF2E"]["frequencies"];
+interface ItemSystemData extends ItemSystemSource {
+    description: ItemDescriptionData;
+}
+
+interface ItemDescriptionData extends ItemDescriptionSource {
+    addenda: string[];
+}
+
+type FrequencyInterval = keyof typeof CONFIG.PF2E.frequencies;
 
 interface FrequencySource {
     value?: number;

--- a/src/module/item/book/data.ts
+++ b/src/module/item/book/data.ts
@@ -16,8 +16,8 @@ interface BookSystemSource extends PhysicalSystemSource {
     contents: ItemUUID[];
 }
 
-interface BookSystemData extends Omit<BookSystemSource, SourceOmission>, PhysicalSystemData {}
+interface BookSystemData extends Omit<BookSystemSource, SourceOmission>, Omit<PhysicalSystemData, "traits"> {}
 
-type SourceOmission = "bulk" | "hp" | "identification" | "material" | "price" | "temporary" | "traits" | "usage";
+type SourceOmission = "bulk" | "description" | "hp" | "identification" | "material" | "price" | "temporary" | "usage";
 
 export type { BookSource, BookSystemData };

--- a/src/module/item/campaign-feature/data.ts
+++ b/src/module/item/campaign-feature/data.ts
@@ -3,6 +3,7 @@ import {
     BaseItemSourcePF2e,
     Frequency,
     FrequencySource,
+    ItemSystemData,
     ItemSystemSource,
     ItemTraits,
 } from "@item/base/data/system.ts";
@@ -35,7 +36,9 @@ interface CampaignFeatureSystemSource extends ItemSystemSource {
     frequency?: FrequencySource;
 }
 
-interface CampaignFeatureSystemData extends CampaignFeatureSystemSource {
+interface CampaignFeatureSystemData
+    extends Omit<CampaignFeatureSystemSource, "description">,
+        Omit<ItemSystemData, "traits"> {
     frequency?: Frequency;
 }
 

--- a/src/module/item/class/data.ts
+++ b/src/module/item/class/data.ts
@@ -1,5 +1,5 @@
 import { AttributeString, SaveType } from "@actor/types.ts";
-import { ABCSystemSource } from "@item/abc/data.ts";
+import { ABCSystemData, ABCSystemSource } from "@item/abc/data.ts";
 import { BaseItemSourcePF2e, RarityTraitAndOtherTags } from "@item/base/data/system.ts";
 import { ZeroToFour } from "@module/data.ts";
 
@@ -27,7 +27,7 @@ interface ClassSystemSource extends ABCSystemSource {
     level?: never;
 }
 
-type ClassSystemData = ClassSystemSource;
+interface ClassSystemData extends Omit<ClassSystemSource, "description">, Omit<ABCSystemData, "level" | "traits"> {}
 
 interface ClassAttackProficiencies {
     simple: ZeroToFour;
@@ -44,4 +44,4 @@ interface ClassDefenseProficiencies {
     heavy: ZeroToFour;
 }
 
-export type { ClassAttackProficiencies, ClassDefenseProficiencies, ClassSource, ClassSystemData };
+export type { ClassAttackProficiencies, ClassDefenseProficiencies, ClassSource, ClassSystemData, ClassSystemSource };

--- a/src/module/item/condition/data.ts
+++ b/src/module/item/condition/data.ts
@@ -34,7 +34,7 @@ interface PersistentSourceData {
 }
 
 interface ConditionSystemData
-    extends Omit<ConditionSystemSource, "fromSpell">,
+    extends Omit<ConditionSystemSource, "description" | "fromSpell">,
         Omit<AbstractEffectSystemData, "level" | "slug" | "traits"> {
     persistent?: PersistentDamageData;
     duration: DurationData;

--- a/src/module/item/consumable/data.ts
+++ b/src/module/item/consumable/data.ts
@@ -39,13 +39,11 @@ type ConsumableDamageHealing = {
 };
 
 interface ConsumableSystemData
-    extends Omit<
-            ConsumableSystemSource,
-            "bulk" | "hp" | "identification" | "material" | "price" | "temporary" | "usage"
-        >,
+    extends Omit<ConsumableSystemSource, SourceOmission>,
         Omit<PhysicalSystemData, "traits"> {
     stackGroup: AmmoStackGroup | null;
 }
+type SourceOmission = "bulk" | "description" | "hp" | "identification" | "material" | "price" | "temporary" | "usage";
 
 export type {
     ConsumableDamageHealing,

--- a/src/module/item/container/data.ts
+++ b/src/module/item/container/data.ts
@@ -28,14 +28,12 @@ interface ContainerBulkSource {
 }
 
 interface ContainerSystemData
-    extends Omit<
-            ContainerSystemSource,
-            "bulk" | "hp" | "identification" | "material" | "price" | "temporary" | "usage"
-        >,
+    extends Omit<ContainerSystemSource, SourceOmission>,
         Omit<Investable<PhysicalSystemData>, "traits"> {
     bulk: ContainerBulkData;
     stackGroup: null;
 }
+type SourceOmission = "bulk" | "description" | "hp" | "identification" | "material" | "price" | "temporary" | "usage";
 
 interface ContainerBulkData extends ContainerBulkSource, BulkData {}
 

--- a/src/module/item/deity/data.ts
+++ b/src/module/item/deity/data.ts
@@ -1,6 +1,6 @@
 import { SkillAbbreviation } from "@actor/creature/data.ts";
 import { AttributeString } from "@actor/types.ts";
-import { BaseItemSourcePF2e, ItemSystemSource, OtherTagsOnly } from "@item/base/data/system.ts";
+import { BaseItemSourcePF2e, ItemSystemData, ItemSystemSource, OtherTagsOnly } from "@item/base/data/system.ts";
 import { BaseWeaponType } from "@item/weapon/types.ts";
 import { DeityDomain, Sanctification } from "./types.ts";
 
@@ -26,6 +26,6 @@ type DeitySanctification = { modal: "can" | "must"; what: Sanctification[] };
 
 type DivineFonts = ["harm"] | ["heal"] | ["harm", "heal"] | never[];
 
-type DeitySystemData = DeitySystemSource;
+interface DeitySystemData extends Omit<DeitySystemSource, "description">, Omit<ItemSystemData, "level" | "traits"> {}
 
 export type { DeitySanctification, DeitySource, DeitySystemData, DeitySystemSource };

--- a/src/module/item/effect/data.ts
+++ b/src/module/item/effect/data.ts
@@ -40,7 +40,9 @@ interface EffectSystemSource extends AbstractEffectSystemSource {
     context: EffectContextData | null;
 }
 
-interface EffectSystemData extends Omit<EffectSystemSource, "fromSpell">, Omit<AbstractEffectSystemData, "level"> {
+interface EffectSystemData
+    extends Omit<EffectSystemSource, "description" | "fromSpell">,
+        Omit<AbstractEffectSystemData, "level"> {
     expired: boolean;
     badge: EffectBadge | null;
     remaining: string;

--- a/src/module/item/equipment/data.ts
+++ b/src/module/item/equipment/data.ts
@@ -38,7 +38,7 @@ interface EquipmentSystemData
     stackGroup: null;
 }
 
-type SourceOmission = "bulk" | "hp" | "identification" | "items" | "material" | "price" | "temporary" | "usage";
+type SourceOmission = "bulk" | "description" | "hp" | "identification" | "material" | "price" | "temporary" | "usage";
 
 interface EquipmentTraits extends PhysicalItemTraits<EquipmentTrait> {
     otherTags: OtherEquipmentTag[];

--- a/src/module/item/feat/data.ts
+++ b/src/module/item/feat/data.ts
@@ -7,6 +7,7 @@ import {
     BaseItemSourcePF2e,
     Frequency,
     FrequencySource,
+    ItemSystemData,
     ItemSystemSource,
     ItemTraits,
 } from "@item/base/data/system.ts";
@@ -51,7 +52,7 @@ interface FeatLevelSource {
     taken?: number | null;
 }
 
-interface FeatSystemData extends Omit<FeatSystemSource, "maxTaken"> {
+interface FeatSystemData extends Omit<FeatSystemSource, "description" | "maxTaken">, Omit<ItemSystemData, "traits"> {
     level: FeatLevelData;
 
     /** `null` is set to `Infinity` during data preparation */

--- a/src/module/item/heritage/data.ts
+++ b/src/module/item/heritage/data.ts
@@ -13,6 +13,8 @@ interface HeritageSystemSource extends ItemSystemSource {
     level?: never;
 }
 
-interface HeritageSystemData extends HeritageSystemSource, Omit<ItemSystemData, "level" | "traits"> {}
+interface HeritageSystemData
+    extends Omit<HeritageSystemSource, "description">,
+        Omit<ItemSystemData, "level" | "traits"> {}
 
 export type { HeritageSource, HeritageSystemData, HeritageSystemSource };

--- a/src/module/item/kit/data.ts
+++ b/src/module/item/kit/data.ts
@@ -1,5 +1,5 @@
-import { BaseItemSourcePF2e, ItemSystemSource } from "@item/base/data/system.ts";
-import { PhysicalItemTraits, PartialPrice } from "@item/physical/data.ts";
+import { BaseItemSourcePF2e, ItemSystemData, ItemSystemSource } from "@item/base/data/system.ts";
+import { PartialPrice, PhysicalItemTraits } from "@item/physical/data.ts";
 
 type KitSource = BaseItemSourcePF2e<"kit", KitSystemSource>;
 
@@ -19,6 +19,6 @@ interface KitSystemSource extends ItemSystemSource {
     level?: never;
 }
 
-type KitSystemData = KitSystemSource;
+interface KitSystemData extends Omit<KitSystemSource, "description" | "traits">, Omit<ItemSystemData, "level"> {}
 
 export type { KitEntryData, KitSource, KitSystemData, KitSystemSource };

--- a/src/module/item/lore.ts
+++ b/src/module/item/lore.ts
@@ -1,6 +1,6 @@
 import type { ActorPF2e } from "@actor";
 import { ItemPF2e, ItemSheetPF2e } from "@item";
-import { BaseItemSourcePF2e, ItemSystemSource, OtherTagsOnly } from "@item/base/data/system.ts";
+import { BaseItemSourcePF2e, ItemSystemData, ItemSystemSource, OtherTagsOnly } from "@item/base/data/system.ts";
 import { ZeroToFour } from "@module/data.ts";
 
 class LorePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends ItemPF2e<TParent> {}
@@ -20,7 +20,10 @@ interface LoreSystemSource extends ItemSystemSource {
     level?: never;
 }
 
-type LoreSystemData = LoreSystemSource;
+interface LoreSystemData extends Omit<LoreSystemSource, "description">, ItemSystemData {
+    level?: never;
+    traits: OtherTagsOnly;
+}
 
 class LoreSheetPF2e extends ItemSheetPF2e<LorePF2e> {}
 

--- a/src/module/item/melee/data.ts
+++ b/src/module/item/melee/data.ts
@@ -37,7 +37,7 @@ interface MeleeSystemSource extends ItemSystemSource {
     };
 }
 
-interface MeleeSystemData extends MeleeSystemSource, Omit<ItemSystemData, "level" | "traits"> {
+interface MeleeSystemData extends Omit<MeleeSystemSource, "description">, Omit<ItemSystemData, "level" | "traits"> {
     material: WeaponMaterialData;
     runes: { property: WeaponPropertyRuneType[] };
 }

--- a/src/module/item/physical/data.ts
+++ b/src/module/item/physical/data.ts
@@ -51,7 +51,7 @@ interface ItemMaterialSource {
     type: PreciousMaterialType | null;
 }
 
-interface PhysicalSystemData extends PhysicalSystemSource, Omit<ItemSystemData, "level"> {
+interface PhysicalSystemData extends Omit<PhysicalSystemSource, "description">, Omit<ItemSystemData, "level"> {
     hp: PhysicalItemHitPoints;
     price: Price;
     bulk: BulkData;

--- a/src/module/item/shield/data.ts
+++ b/src/module/item/shield/data.ts
@@ -53,7 +53,7 @@ interface ShieldSystemData
     stackGroup: null;
 }
 
-type SourceOmission = "bulk" | "hp" | "identification" | "items" | "material" | "price" | "temporary" | "usage";
+type SourceOmission = "bulk" | "description" | "hp" | "identification" | "material" | "price" | "temporary" | "usage";
 
 interface IntegratedWeaponData extends IntegratedWeaponSource {
     damageType: DamageType;

--- a/src/module/item/spell/data.ts
+++ b/src/module/item/spell/data.ts
@@ -97,7 +97,9 @@ interface SpellOverlayOverride {
     sort: number;
 }
 
-interface SpellSystemData extends Omit<SpellSystemSource, "damage">, Omit<ItemSystemData, "level" | "traits"> {
+interface SpellSystemData
+    extends Omit<SpellSystemSource, "damage" | "description">,
+        Omit<ItemSystemData, "level" | "traits"> {
     /** Time and resources consumed in the casting of this spell */
     cast: SpellCastData;
     damage: Record<string, SpellDamage>;

--- a/src/module/item/spellcasting-entry/data.ts
+++ b/src/module/item/spellcasting-entry/data.ts
@@ -65,7 +65,9 @@ interface SpellCollectionTypeSource {
     validItems?: "scroll" | "" | null;
 }
 
-interface SpellcastingEntrySystemData extends SpellcastingEntrySystemSource, Omit<ItemSystemData, "level" | "traits"> {
+interface SpellcastingEntrySystemData
+    extends Omit<SpellcastingEntrySystemSource, "description">,
+        Omit<ItemSystemData, "level" | "traits"> {
     prepared: SpellCollectionTypeData;
 }
 

--- a/src/module/item/weapon/data.ts
+++ b/src/module/item/weapon/data.ts
@@ -163,7 +163,7 @@ interface WeaponSystemData
     stackGroup: null;
 }
 
-type SourceOmission = "bulk" | "hp" | "identification" | "items" | "price" | "temporary";
+type SourceOmission = "bulk" | "description" | "hp" | "identification" | "price" | "temporary";
 
 type WeaponUsageDetails = UsageDetails & Required<WeaponSystemSource["usage"]>;
 

--- a/src/module/migration/migrations/742-rm-class-ability-boost-levels.ts
+++ b/src/module/migration/migrations/742-rm-class-ability-boost-levels.ts
@@ -1,5 +1,5 @@
-import { ClassSystemData } from "@item/class/data.ts";
 import { ItemSourcePF2e } from "@item/base/data/index.ts";
+import { ClassSystemSource } from "@item/class/data.ts";
 import { MigrationBase } from "../base.ts";
 
 /** Remove ability boost levels data from class items */
@@ -17,7 +17,7 @@ export class Migration742RMAbilityBoostLevels extends MigrationBase {
     }
 }
 
-interface MaybeWithAbilityBoostLevels extends ClassSystemData {
+interface MaybeWithAbilityBoostLevels extends ClassSystemSource {
     abilityBoostLevels?: unknown;
     "-=abilityBoostLevels"?: null;
 }

--- a/src/module/migration/migrations/767-convert-voluntary-flaws.ts
+++ b/src/module/migration/migrations/767-convert-voluntary-flaws.ts
@@ -1,5 +1,5 @@
 import { AttributeString } from "@actor/types.ts";
-import { AncestrySystemData } from "@item/ancestry/data.ts";
+import { AncestrySystemSource } from "@item/ancestry/data.ts";
 import { ItemSourcePF2e } from "@item/base/data/index.ts";
 import { MigrationBase } from "../base.ts";
 
@@ -41,7 +41,7 @@ interface DatumOld {
     selected: AttributeString | null;
 }
 
-interface AncestrySystemDataMaybeOld extends AncestrySystemData {
+interface AncestrySystemDataMaybeOld extends AncestrySystemSource {
     voluntaryBoosts?: Record<string, DatumOld>;
     voluntaryFlaws?: Record<string, DatumOld>;
     "-=voluntaryBoosts"?: null;

--- a/src/module/rules/rule-element/item-alteration/alteration.ts
+++ b/src/module/rules/rule-element/item-alteration/alteration.ts
@@ -22,6 +22,7 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
         "bulk",
         "category",
         "check-penalty",
+        "description",
         "dex-cap",
         "focus-point-cost",
         "hardness",
@@ -150,6 +151,13 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
                     data.alteration.value,
                 );
                 data.item.system.checkPenalty = Math.min(newValue, 0);
+                return;
+            }
+            case "description": {
+                const validator = ITEM_ALTERATION_VALIDATORS[this.property];
+                if (!validator.isValid(data)) return;
+                if (!(data.item instanceof ItemPF2e)) return;
+                data.item.system.description.addenda.push(data.alteration.value);
                 return;
             }
             case "dex-cap": {

--- a/src/module/rules/rule-element/item-alteration/schemas.ts
+++ b/src/module/rules/rule-element/item-alteration/schemas.ts
@@ -153,6 +153,20 @@ const ITEM_ALTERATION_VALIDATORS = {
             initial: undefined,
         } as const),
     }),
+    description: new ItemAlterationValidator({
+        itemType: new fields.StringField({
+            required: true,
+            nullable: false,
+            choices: () => R.keys.strict(CONFIG.PF2E.Item.documentClasses),
+            initial: undefined,
+        }),
+        mode: new fields.StringField({
+            required: true,
+            choices: ["add"],
+        }),
+        value: new fields.StringField({ required: true, blank: false, nullable: false, initial: undefined } as const),
+    }),
+
     "dex-cap": new ItemAlterationValidator({
         itemType: new fields.StringField({
             required: true,


### PR DESCRIPTION
An alternative to previously requested "item notes". This has a large types update, so I just added the alteration validator and data structure for it. Will follow up with rest of implementation if/when this PR is merged.