### PR TITLE
Add outcomes to the bravery note RE

### DIFF
--- a/packs/classfeatures/bravery.json
+++ b/packs/classfeatures/bravery.json
@@ -28,8 +28,7 @@
             {
                 "key": "Note",
                 "outcome": [
-                    "success",
-                    "criticalSuccess"
+                    "success"
                 ],
                 "predicate": [
                     "fear"

--- a/packs/classfeatures/bravery.json
+++ b/packs/classfeatures/bravery.json
@@ -27,6 +27,10 @@
         "rules": [
             {
                 "key": "Note",
+                "outcome": [
+                    "success",
+                    "criticalSuccess"
+                ],
                 "predicate": [
                     "fear"
                 ],


### PR DESCRIPTION
Not sure "success" needs to be in there because the RE upgrades to Critical Success automatically, but left it in just in case.