### PR TITLE
Fix Ruffian Rogue armor proficiency

### DIFF
--- a/packs/classfeatures/ruffian.json
+++ b/packs/classfeatures/ruffian.json
@@ -104,7 +104,7 @@
                 "predicate": [
                     "feature:light-armor-mastery"
                 ]
-            }
+            },
             {
                 "key": "CriticalSpecialization",
                 "predicate": [

--- a/packs/classfeatures/ruffian.json
+++ b/packs/classfeatures/ruffian.json
@@ -91,21 +91,20 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.proficiencies.defenses.medium.rank",
-                "value": {
-                    "brackets": [
-                        {
-                            "start": 2,
-                            "end": 2,
-                            "value": 2
-                        },
-                        {
-                            "start": 3,
-                            "value": 3
-                        }
-                    ],
-                    "field": "actor|system.proficiencies.defenses.light.rank"
-                }
+                "value": 2,
+                "predicate": [
+                    "feature:light-armor-expertise"
+                ]
             },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "system.proficiencies.defenses.medium.rank",
+                "value": 3,
+                "predicate": [
+                    "feature:light-armor-mastery"
+                ]
+            }
             {
                 "key": "CriticalSpecialization",
                 "predicate": [

--- a/packs/classfeatures/ruffian.json
+++ b/packs/classfeatures/ruffian.json
@@ -88,6 +88,25 @@
                 "value": 1
             },
             {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "system.proficiencies.defenses.medium.rank",
+                "value": {
+                    "brackets": [
+                        {
+                            "start": 2,
+                            "end": 2,
+                            "value": 2
+                        },
+                        {
+                            "start": 3,
+                            "value": 3
+                        }
+                    ],
+                    "field": "actor|system.proficiencies.defenses.light.rank"
+                }
+            },
+            {
                 "key": "CriticalSpecialization",
                 "predicate": [
                     "target:condition:off-guard",


### PR DESCRIPTION
> When you gain light armor expertise, you also gain expert proficiency in medium armor, and when you gain light armor mastery, you also gain master proficiency in medium armor.

The wording is identical in Core Rulebook / Player Core 1, so I guess it's just a long standing data bug.

Works on my local install and I can't think of any feats that would 'break' the logic, but would definitely appreciate someone else having a look!