### PR TITLE
Update effect for Scout's Warning to removeAfterRoll

### DIFF
--- a/packs/classes/barbarian.json
+++ b/packs/classes/barbarian.json
@@ -82,7 +82,7 @@
                 "uuid": "Compendium.pf2e.classfeatures.Item.Reflex Expertise"
             },
             "blnv0": {
-                "img": "systems/pf2e/icons/features/classes/heightened-senses.webp",
+                "img": "icons/creatures/eyes/human-single-brown.webp",
                 "level": 17,
                 "name": "Heightened Senses",
                 "uuid": "Compendium.pf2e.classfeatures.Item.Heightened Senses"

--- a/packs/classfeatures/heightened-senses.json
+++ b/packs/classfeatures/heightened-senses.json
@@ -1,6 +1,6 @@
 {
     "_id": "7MhzrbOyue5GQsck",
-    "img": "systems/pf2e/icons/features/classes/heightened-senses.webp",
+    "img": "icons/creatures/eyes/human-single-brown.webp",
     "name": "Heightened Senses",
     "system": {
         "actionType": {

--- a/packs/feat-effects/effect-scouts-warning.json
+++ b/packs/feat-effects/effect-scouts-warning.json
@@ -1,10 +1,10 @@
 {
     "_id": "RxDDXK52lwyHXl7v",
-    "img": "systems/pf2e/icons/features/classes/heightened-senses.webp",
+    "img": "icons/creatures/eyes/human-single-brown.webp",
     "name": "Effect: Scout's Warning",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Scout's Warning].</p>\n<p>You gain a +1 circumstance bonus to your initiative roll.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Scout's Warning]</p>\n<p>You gain a +1 circumstance bonus to your initiative roll.</p>"
         },
         "duration": {
             "expiry": "turn-end",
@@ -16,13 +16,14 @@
             "value": 4
         },
         "publication": {
-            "license": "OGL",
-            "remaster": false,
-            "title": "Pathfinder Core Rulebook"
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
         },
         "rules": [
             {
                 "key": "FlatModifier",
+                "removeAfterRoll": true,
                 "selector": "initiative",
                 "type": "circumstance",
                 "value": 1

--- a/packs/iconics/amiri-level-1.json
+++ b/packs/iconics/amiri-level-1.json
@@ -1713,7 +1713,7 @@
                         "uuid": "Compendium.pf2e.classfeatures.Item.Reflex Expertise"
                     },
                     "blnv0": {
-                        "img": "systems/pf2e/icons/features/classes/heightened-senses.webp",
+                        "img": "icons/creatures/eyes/human-single-brown.webp",
                         "level": 17,
                         "name": "Heightened Senses",
                         "uuid": "Compendium.pf2e.classfeatures.Item.Heightened Senses"

--- a/packs/iconics/amiri-level-3.json
+++ b/packs/iconics/amiri-level-3.json
@@ -2285,7 +2285,7 @@
                         "uuid": "Compendium.pf2e.classfeatures.Item.Reflex Expertise"
                     },
                     "blnv0": {
-                        "img": "systems/pf2e/icons/features/classes/heightened-senses.webp",
+                        "img": "icons/creatures/eyes/human-single-brown.webp",
                         "level": 17,
                         "name": "Heightened Senses",
                         "uuid": "Compendium.pf2e.classfeatures.Item.Heightened Senses"

--- a/packs/iconics/amiri-level-5.json
+++ b/packs/iconics/amiri-level-5.json
@@ -2645,7 +2645,7 @@
                         "uuid": "Compendium.pf2e.classfeatures.Item.Reflex Expertise"
                     },
                     "blnv0": {
-                        "img": "systems/pf2e/icons/features/classes/heightened-senses.webp",
+                        "img": "icons/creatures/eyes/human-single-brown.webp",
                         "level": 17,
                         "name": "Heightened Senses",
                         "uuid": "Compendium.pf2e.classfeatures.Item.Heightened Senses"

--- a/packs/kingmaker-bestiary/amiri-level-1-kingmaker.json
+++ b/packs/kingmaker-bestiary/amiri-level-1-kingmaker.json
@@ -1790,7 +1790,7 @@
                         "uuid": "Compendium.pf2e.classfeatures.Item.Reflex Expertise"
                     },
                     "blnv0": {
-                        "img": "systems/pf2e/icons/features/classes/heightened-senses.webp",
+                        "img": "icons/creatures/eyes/human-single-brown.webp",
                         "level": 17,
                         "name": "Heightened Senses",
                         "uuid": "Compendium.pf2e.classfeatures.Item.Heightened Senses"

--- a/packs/kingmaker-bestiary/amiri-level-11-kingmaker.json
+++ b/packs/kingmaker-bestiary/amiri-level-11-kingmaker.json
@@ -2849,7 +2849,7 @@
                         "uuid": "Compendium.pf2e.classfeatures.Item.Reflex Expertise"
                     },
                     "blnv0": {
-                        "img": "systems/pf2e/icons/features/classes/heightened-senses.webp",
+                        "img": "icons/creatures/eyes/human-single-brown.webp",
                         "level": 17,
                         "name": "Heightened Senses",
                         "uuid": "Compendium.pf2e.classfeatures.Item.Heightened Senses"

--- a/packs/paizo-pregens/popcorn-level-4.json
+++ b/packs/paizo-pregens/popcorn-level-4.json
@@ -1337,7 +1337,7 @@
                         "uuid": "Compendium.pf2e.classfeatures.Item.Reflex Expertise"
                     },
                     "blnv0": {
-                        "img": "systems/pf2e/icons/features/classes/heightened-senses.webp",
+                        "img": "icons/creatures/eyes/human-single-brown.webp",
                         "level": 17,
                         "name": "Heightened Senses",
                         "uuid": "Compendium.pf2e.classfeatures.Item.Heightened Senses"

--- a/packs/paizo-pregens/popcorn.json
+++ b/packs/paizo-pregens/popcorn.json
@@ -1173,7 +1173,7 @@
                         "uuid": "Compendium.pf2e.classfeatures.Item.Reflex Expertise"
                     },
                     "blnv0": {
-                        "img": "systems/pf2e/icons/features/classes/heightened-senses.webp",
+                        "img": "icons/creatures/eyes/human-single-brown.webp",
                         "level": 17,
                         "name": "Heightened Senses",
                         "uuid": "Compendium.pf2e.classfeatures.Item.Heightened Senses"


### PR DESCRIPTION
Also replace lower-resolution system icon with identical core icon