### PR TITLE
Update witch lessons to use otherTags

### DIFF
--- a/packs/classfeatures/lesson-of-bargains.json
+++ b/packs/classfeatures/lesson-of-bargains.json
@@ -1,6 +1,6 @@
 {
     "_id": "RcmqV0cuOLcnKQr0",
-    "img": "systems/pf2e/icons/features/classes/lesson-of-favors.webp",
+    "img": "icons/skills/social/diplomacy-handshake-yellow.webp",
     "name": "Lesson of Bargains",
     "system": {
         "actionType": {

--- a/packs/classfeatures/lesson-of-bargains.json
+++ b/packs/classfeatures/lesson-of-bargains.json
@@ -1,6 +1,6 @@
 {
     "_id": "RcmqV0cuOLcnKQr0",
-    "img": "icons/skills/social/diplomacy-handshake-yellow.webp",
+    "img": "systems/pf2e/icons/features/classes/lesson-of-favors.webp",
     "name": "Lesson of Bargains",
     "system": {
         "actionType": {
@@ -26,6 +26,9 @@
         },
         "rules": [],
         "traits": {
+            "otherTags": [
+                "witch-lesson"
+            ],
             "rarity": "common",
             "value": [
                 "witch"

--- a/packs/classfeatures/lesson-of-calamity.json
+++ b/packs/classfeatures/lesson-of-calamity.json
@@ -26,6 +26,9 @@
         },
         "rules": [],
         "traits": {
+            "otherTags": [
+                "witch-lesson"
+            ],
             "rarity": "uncommon",
             "value": [
                 "witch"

--- a/packs/classfeatures/lesson-of-death.json
+++ b/packs/classfeatures/lesson-of-death.json
@@ -26,6 +26,9 @@
         },
         "rules": [],
         "traits": {
+            "otherTags": [
+                "witch-lesson"
+            ],
             "rarity": "common",
             "value": [
                 "witch"

--- a/packs/classfeatures/lesson-of-dreams.json
+++ b/packs/classfeatures/lesson-of-dreams.json
@@ -26,6 +26,9 @@
         },
         "rules": [],
         "traits": {
+            "otherTags": [
+                "witch-lesson"
+            ],
             "rarity": "common",
             "value": [
                 "witch"

--- a/packs/classfeatures/lesson-of-elements.json
+++ b/packs/classfeatures/lesson-of-elements.json
@@ -26,6 +26,9 @@
         },
         "rules": [],
         "traits": {
+            "otherTags": [
+                "witch-lesson"
+            ],
             "rarity": "common",
             "value": [
                 "witch"

--- a/packs/classfeatures/lesson-of-favors.json
+++ b/packs/classfeatures/lesson-of-favors.json
@@ -1,6 +1,6 @@
 {
     "_id": "2IhZbkx889pATIjq",
-    "img": "icons/skills/social/diplomacy-handshake-yellow.webp",
+    "img": "systems/pf2e/icons/features/classes/lesson-of-favors.webp",
     "name": "Lesson of Favors",
     "system": {
         "actionType": {
@@ -26,6 +26,9 @@
         },
         "rules": [],
         "traits": {
+            "otherTags": [
+                "witch-lesson"
+            ],
             "rarity": "common",
             "value": [
                 "witch"

--- a/packs/classfeatures/lesson-of-favors.json
+++ b/packs/classfeatures/lesson-of-favors.json
@@ -1,6 +1,6 @@
 {
     "_id": "2IhZbkx889pATIjq",
-    "img": "systems/pf2e/icons/features/classes/lesson-of-favors.webp",
+    "img": "icons/skills/social/diplomacy-handshake-yellow.webp",
     "name": "Lesson of Favors",
     "system": {
         "actionType": {

--- a/packs/classfeatures/lesson-of-life.json
+++ b/packs/classfeatures/lesson-of-life.json
@@ -26,6 +26,9 @@
         },
         "rules": [],
         "traits": {
+            "otherTags": [
+                "witch-lesson"
+            ],
             "rarity": "common",
             "value": [
                 "witch"

--- a/packs/classfeatures/lesson-of-mischief.json
+++ b/packs/classfeatures/lesson-of-mischief.json
@@ -26,6 +26,9 @@
         },
         "rules": [],
         "traits": {
+            "otherTags": [
+                "witch-lesson"
+            ],
             "rarity": "common",
             "value": [
                 "witch"

--- a/packs/classfeatures/lesson-of-protection.json
+++ b/packs/classfeatures/lesson-of-protection.json
@@ -26,6 +26,9 @@
         },
         "rules": [],
         "traits": {
+            "otherTags": [
+                "witch-lesson"
+            ],
             "rarity": "common",
             "value": [
                 "witch"

--- a/packs/classfeatures/lesson-of-renewal.json
+++ b/packs/classfeatures/lesson-of-renewal.json
@@ -26,6 +26,9 @@
         },
         "rules": [],
         "traits": {
+            "otherTags": [
+                "witch-lesson"
+            ],
             "rarity": "common",
             "value": [
                 "witch"

--- a/packs/classfeatures/lesson-of-shadow.json
+++ b/packs/classfeatures/lesson-of-shadow.json
@@ -26,6 +26,9 @@
         },
         "rules": [],
         "traits": {
+            "otherTags": [
+                "witch-lesson"
+            ],
             "rarity": "common",
             "value": [
                 "witch"

--- a/packs/classfeatures/lesson-of-snow.json
+++ b/packs/classfeatures/lesson-of-snow.json
@@ -26,6 +26,9 @@
         },
         "rules": [],
         "traits": {
+            "otherTags": [
+                "witch-lesson"
+            ],
             "rarity": "common",
             "value": [
                 "witch"

--- a/packs/classfeatures/lesson-of-the-frozen-queen.json
+++ b/packs/classfeatures/lesson-of-the-frozen-queen.json
@@ -26,6 +26,9 @@
         },
         "rules": [],
         "traits": {
+            "otherTags": [
+                "witch-lesson"
+            ],
             "rarity": "rare",
             "value": [
                 "witch"

--- a/packs/classfeatures/lesson-of-vengeance.json
+++ b/packs/classfeatures/lesson-of-vengeance.json
@@ -26,6 +26,9 @@
         },
         "rules": [],
         "traits": {
+            "otherTags": [
+                "witch-lesson"
+            ],
             "rarity": "common",
             "value": [
                 "witch"

--- a/packs/feats/basic-lesson.json
+++ b/packs/feats/basic-lesson.json
@@ -34,26 +34,17 @@
                         "item:type:feature"
                     ]
                 },
-                "choices": [
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Lesson of Calamity"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Lesson of Dreams"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Lesson of Life"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Lesson of Protection"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Lesson of Elements"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Lesson of Vengeance"
-                    }
-                ],
+                "choices": {
+                    "filter": [
+                        "item:tag:witch-lesson",
+                        {
+                            "eq": [
+                                "item:level",
+                                2
+                            ]
+                        }
+                    ]
+                },
                 "flag": "lesson",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.Lesson"

--- a/packs/feats/greater-lesson.json
+++ b/packs/feats/greater-lesson.json
@@ -39,38 +39,17 @@
                         }
                     ]
                 },
-                "choices": [
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Lesson of Mischief"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Lesson of Shadow"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Lesson of Snow"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Lesson of Calamity"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Lesson of Dreams"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Lesson of Life"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Lesson of Protection"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Lesson of Elements"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Lesson of Vengeance"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Lesson of Favors"
-                    }
-                ],
+                "choices": {
+                    "filter": [
+                        "item:tag:witch-lesson",
+                        {
+                            "lte": [
+                                "item:level",
+                                6
+                            ]
+                        }
+                    ]
+                },
                 "flag": "lesson",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.Lesson"

--- a/packs/feats/major-lesson.json
+++ b/packs/feats/major-lesson.json
@@ -40,47 +40,17 @@
                         }
                     ]
                 },
-                "choices": [
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Lesson of Bargains"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Lesson of Death"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Lesson of Renewal"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Lesson of the Frozen Queen"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Lesson of Mischief"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Lesson of Shadow"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Lesson of Snow"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Lesson of Calamity"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Lesson of Dreams"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Lesson of Life"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Lesson of Protection"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Lesson of Elements"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Lesson of Vengeance"
-                    }
-                ],
+                "choices": {
+                    "filter": [
+                        "item:tag:witch-lesson",
+                        {
+                            "lte": [
+                                "item:level",
+                                10
+                            ]
+                        }
+                    ]
+                },
                 "flag": "lesson",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.Lesson"


### PR DESCRIPTION
Not *necessarily* needed for the Witches+ Remaster module, I could just duplicate the Basic / Greater / Major Lesson feats, but this is probably "more proper" this way.