### PR TITLE
Update Weapon Proficiency Feat for the remaster

### DIFF
--- a/packs/feats/weapon-proficiency.json
+++ b/packs/feats/weapon-proficiency.json
@@ -34,7 +34,11 @@
             }
         ],
         "subfeatures": {
-            "proficiencies": {}
+            "proficiencies": {
+                "martial": {
+                    "rank": 1
+                }
+            }
         },
         "traits": {
             "rarity": "common",

--- a/packs/feats/weapon-proficiency.json
+++ b/packs/feats/weapon-proficiency.json
@@ -30,7 +30,15 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.proficiencies.attacks.martial.rank",
-                "value": "ternary(gte(@actor.level,11),2,1)"
+                "predicate": [
+                    {
+                        "gte": [
+                            "actor:level",
+                            11
+                        ]
+                    }
+                ],
+                "value": 2
             }
         ],
         "subfeatures": {

--- a/packs/feats/weapon-proficiency.json
+++ b/packs/feats/weapon-proficiency.json
@@ -16,6 +16,7 @@
         "level": {
             "value": 1
         },
+        "maxTakable": null,
         "prerequisites": {
             "value": []
         },
@@ -29,15 +30,11 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.proficiencies.attacks.martial.rank",
-                "value": "min(1,@actor.system.proficiencies.attacks.simple.rank)"
+                "value": "ternary(gte(@actor.level,11),2,1)"
             }
         ],
         "subfeatures": {
-            "proficiencies": {
-                "simple": {
-                    "rank": 1
-                }
-            }
+            "proficiencies": {}
         },
         "traits": {
             "rarity": "common",


### PR DESCRIPTION
Closes #12674

Weapon Prof in the remaster can be taken repeatedly, so made sure that was reflected as well.