### PR TITLE
Add level to Hilllock Halfling's healing received from Treat Wounds

### DIFF
--- a/packs/heritages/hillock-halfling.json
+++ b/packs/heritages/hillock-halfling.json
@@ -12,15 +12,23 @@
             "value": "<p>Accustomed to a calm life in the hills, your people find rest and relaxation especially replenishing, particularly when indulging in creature comforts. When you regain Hit Points overnight, add your level to the Hit Points regained. When anyone uses the Medicine skill to @UUID[Compendium.pf2e.actionspf2e.Item.Treat Wounds]{Treat your Wounds}, you can eat a snack to add your level to the Hit Points you regain from their treatment.</p>"
         },
         "publication": {
-            "license": "OGL",
-            "remaster": false,
-            "title": "Pathfinder Core Rulebook"
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
         },
         "rules": [
             {
                 "key": "ActiveEffectLike",
                 "mode": "add",
                 "path": "system.attributes.hp.recoveryAddend",
+                "value": "@actor.level"
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "action:treat-wounds"
+                ],
+                "selector": "healing-received",
                 "value": "@actor.level"
             }
         ],

--- a/packs/heritages/jinxed-halfling.json
+++ b/packs/heritages/jinxed-halfling.json
@@ -12,9 +12,9 @@
             "value": "<p>You were born with a strange blessing: bereft of the typical halfling luck, you can instead manipulate the fortunes of others. You can never take the @UUID[Compendium.pf2e.feats-srd.Item.Halfling Luck] feat, and you gain the @UUID[Compendium.pf2e.actionspf2e.Item.Jinx] action.</p>"
         },
         "publication": {
-            "license": "OGL",
-            "remaster": false,
-            "title": "Pathfinder Advanced Player's Guide"
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
         },
         "rules": [
             {

--- a/packs/heritages/nomadic-halfling.json
+++ b/packs/heritages/nomadic-halfling.json
@@ -12,9 +12,9 @@
             "value": "<p>Your ancestors have traveled from place to place for generations, never content to settle down. You gain two additional languages of your choice, chosen from among the common and uncommon languages available to you, and every time you take the @UUID[Compendium.pf2e.feats-srd.Item.Multilingual] feat, you gain another new language.</p>"
         },
         "publication": {
-            "license": "OGL",
-            "remaster": false,
-            "title": "Pathfinder Core Rulebook"
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
         },
         "rules": [],
         "traits": {

--- a/packs/heritages/twilight-halfling.json
+++ b/packs/heritages/twilight-halfling.json
@@ -12,9 +12,9 @@
             "value": "<p>Your ancestors performed many secret acts under the concealing cover of dusk, whether for good or ill, and over time they developed the ability to see in twilight beyond even the usual keen sight of halflings. You gain low-light vision.</p>"
         },
         "publication": {
-            "license": "OGL",
-            "remaster": false,
-            "title": "Pathfinder Core Rulebook"
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
         },
         "rules": [
             {

--- a/packs/heritages/wildwood-halfling.json
+++ b/packs/heritages/wildwood-halfling.json
@@ -12,9 +12,9 @@
             "value": "<p>You hail from deep within a jungle or forest, and you've learned how to use your small size to wriggle through undergrowth and other obstacles. You ignore any difficult terrain caused by plants and fungi, such as bushes, vines, and undergrowth.</p>"
         },
         "publication": {
-            "license": "OGL",
-            "remaster": false,
-            "title": "Pathfinder Core Rulebook"
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
         },
         "rules": [],
         "traits": {


### PR DESCRIPTION
took the chance to fix publication data from the rest of Player Core halfling heritages too