### PR TITLE
Relax equipped check for invested non-worn items

### DIFF
--- a/src/module/item/physical/document.ts
+++ b/src/module/item/physical/document.ts
@@ -123,7 +123,12 @@ abstract class PhysicalItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | n
     get isInvested(): boolean | null {
         const traits: Set<string> = this.traits;
         if (!traits.has("invested")) return null;
-        return this.isEquipped && this.isIdentified && this.system.equipped.invested === true;
+        return (
+            (this.isEquipped || this.system.usage.type !== "worn") &&
+            !this.isStowed &&
+            this.isIdentified &&
+            this.system.equipped.invested === true
+        );
     }
 
     get isCursed(): boolean {

--- a/src/scripts/config/traits.ts
+++ b/src/scripts/config/traits.ts
@@ -839,6 +839,7 @@ const shieldTraits = {
     "integrated-1d6-p": "PF2E.TraitIntegrated1d6P",
     "integrated-1d6-s": "PF2E.TraitIntegrated1d6S",
     "integrated-1d6-s-versatile-p": "PF2E.TraitIntegrated1d6SVersatileP",
+    invested: "PF2E.TraitInvested",
     "launching-dart": "PF2E.TraitLaunching",
     magical: "PF2E.TraitMagical",
     "shield-throw-20": "PF2E.TraitShieldThrow20",


### PR DESCRIPTION
From rudimentary testing, rule elements don't trigger on items that are invested but not in the right usage status, which I believe is what we want.