### PR TITLE
Add support for inline /act syntax for using actions

### DIFF
--- a/src/scripts/hooks/init.ts
+++ b/src/scripts/hooks/init.ts
@@ -153,6 +153,14 @@ export const Init = {
                 enricher: (match, options) => game.pf2e.TextEditor.enrichString(match, options),
             });
 
+            CONFIG.TextEditor.enrichers.push({
+                pattern: new RegExp(
+                    /\[\[\/(act) (?<slug>[-a-z]+)(\s+)?(?<options>[^\]]+)*]](?:{(?<label>[^}]+)})?/,
+                    "g",
+                ),
+                enricher: (match, options) => game.pf2e.TextEditor.enrichString(match, options),
+            });
+
             // Soft-set system-preferred core settings until they've been explicitly set by the GM
             // const schema = foundry.data.PrototypeToken.schema;
             // schema.displayName.default = schema.displayBars.default = CONST.TOKEN_DISPLAY_MODES.OWNER_HOVER;

--- a/src/styles/_globals.scss
+++ b/src/styles/_globals.scss
@@ -141,6 +141,10 @@ a.content-link {
     &:has(i.fa-sparkles) {
         font-style: italic;
     }
+
+    & > span.fa-stack {
+        width: 1.25em;
+    }
 }
 
 #tooltip a.content-link {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1585,6 +1585,17 @@
         "InitiativeHeader": "Initiative bonus",
         "InitiativeLabel": "Initiative",
         "InitiativeWithSkill": "Initiative: {skillName}",
+        "InlineAction": {
+            "Check": {
+                "DC": "DC {dc}",
+                "StatisticVsDefense": "{statistic} vs {defense}",
+                "VsDefense": "vs {defense}"
+            },
+            "Warning": {
+                "InvalidAction": "Invalid Action: {slug}",
+                "UnresolvableAction": "Unresolvable Action: {slug}"
+            }
+        },
         "InlineCheck": {
             "BasicWithSave": "Basic {save}",
             "DCWithName": "{name} DC",


### PR DESCRIPTION
Add support for inline slash-style syntax, specifically `/act`, for actions.

Also give priority to the action objects instead of the old action functions when using both the old HTML syntax and the new slash syntax.
### Examples

`[[/act administer-first-aid variant=stop-bleeding dc=25]]`

`[[/act escape statistic=acrobatics dc=fortitude]]`

`[[/act grapple]]`

<img width="288" alt="Examples" src="https://github.com/foundryvtt/pf2e/assets/6374503/9019d448-af4b-46fe-b47b-1fb6d5286d3e">

~~Depends on https://github.com/foundryvtt/pf2e/pull/13043 and https://github.com/foundryvtt/pf2e/pull/13047~~