### PR TITLE
Replace Ki Form's lawful damage with spirit

### DIFF
--- a/packs/spell-effects/spell-effect-ki-form.json
+++ b/packs/spell-effects/spell-effect-ki-form.json
@@ -56,10 +56,6 @@
                         "value": "force"
                     },
                     {
-                        "label": "PF2E.TraitLawful",
-                        "value": "lawful"
-                    },
-                    {
                         "label": "PF2E.TraitVoid",
                         "value": "void"
                     },

--- a/packs/spell-effects/spell-effect-ki-form.json
+++ b/packs/spell-effects/spell-effect-ki-form.json
@@ -56,6 +56,10 @@
                         "value": "force"
                     },
                     {
+                        "label": "PF2E.TraitSpirit",
+                        "value": "spirit"
+                    },
+                    {
                         "label": "PF2E.TraitVoid",
                         "value": "void"
                     },


### PR DESCRIPTION
Closes #12745
I've opted to replace it with spirit damage, going off Ki Strike [here](https://github.com/foundryvtt/pf2e/pull/11375). Let me know if I should just remove it instead.