### PR TITLE
Fix level of Ranger's Perception Legend feature

### DIFF
--- a/packs/classes/ranger.json
+++ b/packs/classes/ranger.json
@@ -131,7 +131,7 @@
             },
             "epJL1": {
                 "img": "systems/pf2e/icons/features/classes/incredible-sense.webp",
-                "level": 13,
+                "level": 15,
                 "name": "Perception Legend",
                 "uuid": "Compendium.pf2e.classfeatures.Item.Perception Legend"
             },


### PR DESCRIPTION
Addresses #12752 

<img width="523" alt="Screenshot 2024-01-04 at 3 06 09 PM" src="https://github.com/foundryvtt/pf2e/assets/43155846/bf6a9f10-c316-40d2-80df-4065572f48ab">
