### PR TITLE
Fix cases of erroneous PC language slot calculations

### DIFF
--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -492,7 +492,9 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
         }
 
         const build = this.system.build;
-        const sourceLanguages = this._source.system.details.languages.value;
+        // Remove any unrecognized languages
+        const sourceLanguages = this._source.system.details.languages.value.filter((l) => l in CONFIG.PF2E.languages);
+        build.languages.granted = build.languages.granted.filter((l) => l.slug in CONFIG.PF2E.languages);
         const grantedLanguages = build.languages.granted.map((g) => g.slug);
         build.languages.value = sourceLanguages.filter((l) => !grantedLanguages.includes(l)).length;
         build.languages.max += Math.max(this.system.abilities.int.mod, 0);

--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -301,12 +301,14 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
 
         sheetData.languages = ((): LanguageSheetData[] => {
             const languagesBuild = actor.system.build.languages;
-            const sourceLanguages = actor._source.system.details.languages.value;
+            const sourceLanguages = actor._source.system.details.languages.value.filter(
+                (l) => l in CONFIG.PF2E.languages,
+            );
+            const isOverMax = languagesBuild.value > languagesBuild.max;
             const languages: LanguageSheetData[] = actor.system.details.languages.value
                 .map((language) => {
                     const label = game.i18n.localize(CONFIG.PF2E.languages[language] ?? language);
-                    const sourceIndex = sourceLanguages.indexOf(language);
-                    const overLimit = sourceIndex + 1 > languagesBuild.max;
+                    const overLimit = isOverMax && sourceLanguages.indexOf(language) + 1 > languagesBuild.max;
                     const tooltip = overLimit ? "PF2E.Actor.Character.Language.OverLimit" : null;
                     return { slug: language, label, tooltip, overLimit };
                 })


### PR DESCRIPTION
Specifically when a language has been both manually and automatically added