### PR TITLE
Fix Ghostly Weapon to apply only to selected weapon

### DIFF
--- a/packs/spell-effects/spell-effect-ghostly-weapon.json
+++ b/packs/spell-effects/spell-effect-ghostly-weapon.json
@@ -4,7 +4,7 @@
     "name": "Spell Effect: Ghostly Weapon",
     "system": {
         "description": {
-            "value": "<p>Granted by <em>@UUID[Compendium.pf2e.spells-srd.Item.Ghostly Weapon]</em></p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Ghostly Weapon]</p>\n<p>The weapon gains the effects of the <em>ghost touch</em> property rune, and becomes magical if it wasn't already.</p>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -22,21 +22,33 @@
         },
         "rules": [
             {
-                "key": "AdjustStrike",
-                "mode": "add",
-                "property": "property-runes",
-                "value": "ghost-touch"
-            },
-            {
                 "choices": {
                     "ownedItems": true,
                     "types": [
                         "weapon"
                     ]
                 },
-                "flag": "weapon",
+                "flag": "spellEffectGhostlyWeapon",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
+            },
+            {
+                "definition": [
+                    "item:id:{item|flags.pf2e.rulesSelections.spellEffectGhostlyWeapon}"
+                ],
+                "key": "AdjustStrike",
+                "mode": "add",
+                "property": "property-runes",
+                "value": "ghost-touch"
+            },
+            {
+                "definition": [
+                    "item:id:{item|flags.pf2e.rulesSelections.spellEffectGhostlyWeapon}"
+                ],
+                "key": "AdjustStrike",
+                "mode": "add",
+                "property": "traits",
+                "value": "magical"
             }
         ],
         "start": {

--- a/packs/spell-effects/spell-effect-ghostly-weapon.json
+++ b/packs/spell-effects/spell-effect-ghostly-weapon.json
@@ -4,7 +4,7 @@
     "name": "Spell Effect: Ghostly Weapon",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Ghostly Weapon]</p>\n<p>The weapon gains the effects of the <em>ghost touch</em> property rune, and becomes magical if it wasn't already.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Ghostly Weapon]</p>\n<p>The weapon gains the effects of the <em>ghost touch</em> property rune and becomes magical if it wasn't already.</p>"
         },
         "duration": {
             "expiry": "turn-start",

--- a/packs/spells/ghostly-weapon.json
+++ b/packs/spells/ghostly-weapon.json
@@ -11,7 +11,7 @@
         "damage": {},
         "defense": null,
         "description": {
-            "value": "<p>The target weapon becomes translucent and ghostly, and it can affect material and incorporeal creatures and objects. It gains the effects of the <em>ghost touch</em> property rune, meaning it is magical if it wasn't already, is especially effective against incorporeal creatures, and can be wielded by a corporeal or incorporeal creature.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Ghostly Weapon]</p>"
+            "value": "<p>The target weapon becomes translucent and ghostly, and it can affect material and incorporeal creatures and objects. It gains the effects of the <em>@UUID[Compendium.pf2e.equipment-srd.Item.Ghost Touch]</em> property rune, meaning it is magical if it wasn't already, is especially effective against incorporeal creatures, and can be wielded by a corporeal or incorporeal creature.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Ghostly Weapon]</p>"
         },
         "duration": {
             "sustained": false,


### PR DESCRIPTION
Also add magical trait to weapon.

Closes https://github.com/foundryvtt/pf2e/issues/12825