### PR TITLE
Fix overlapping images in compendium browser

### DIFF
--- a/src/styles/packs/_tab.scss
+++ b/src/styles/packs/_tab.scss
@@ -135,7 +135,7 @@
             > * {
                 align-items: center;
                 display: flex;
-                height: 2rem;
+                min-height: 2rem;
                 justify-content: center;
             }
 
@@ -147,6 +147,10 @@
                 gap: 0.25em;
                 flex-basis: 6ch;
                 justify-content: start;
+            }
+
+            > .tags {
+                margin-bottom: 0;
             }
 
             > .level {

--- a/src/styles/packs/_tab.scss
+++ b/src/styles/packs/_tab.scss
@@ -150,6 +150,7 @@
             }
 
             > .tags {
+                padding: 0.25em 0.05em;
                 margin-bottom: 0;
             }
 


### PR DESCRIPTION
Also slightly reduces padding and removes unnecessary margin from rarity tags in compendium browser to keep within 2em height.

Before:
<img width="752" alt="Screenshot 2024-01-07 at 3 59 06 PM" src="https://github.com/foundryvtt/pf2e/assets/43155846/6fa17d3f-c3d3-48eb-8c35-5f9220cceb79">

After
<img width="762" alt="Screenshot 2024-01-07 at 4 01 15 PM" src="https://github.com/foundryvtt/pf2e/assets/43155846/71e8d9a5-d624-4259-8291-6dc29fa07b23">


Could also set `aspect-ratio: 1/1;` and `object-fit: contain;` on the image itself if keeping a uniform height across all rows is desired, though some images will be hard to see.
<img width="749" alt="Screenshot 2024-01-07 at 4 03 18 PM" src="https://github.com/foundryvtt/pf2e/assets/43155846/75a331ca-3907-4cfe-aa38-29f296c38753">
