### PR TITLE
Fix outdated ancestry sheet low-light-vision value

### DIFF
--- a/static/templates/items/ancestry-sidebar.hbs
+++ b/static/templates/items/ancestry-sidebar.hbs
@@ -28,7 +28,7 @@
         <select name="system.vision">
             {{#select data.vision}}
                 <option value="normal">{{localize "PF2E.Item.Ancestry.Vision.Normal"}}</option>
-                <option value="lowLightVision">{{localize "PF2E.Actor.Creature.Sense.Type.LowLightVision"}}</option>
+                <option value="low-light-vision">{{localize "PF2E.Actor.Creature.Sense.Type.LowLightVision"}}</option>
                 <option value="darkvision">{{localize "PF2E.Actor.Creature.Sense.Type.Darkvision"}}</option>
             {{/select}}
         </select>


### PR DESCRIPTION
Fixes #12835 

option had old value `lowLightVision` and would throw the following error.
<img width="653" alt="Screenshot 2024-01-07 at 10 25 17 PM" src="https://github.com/foundryvtt/pf2e/assets/43155846/8149d418-2c5a-48de-84f8-50275c9a80f0">


After:
<img width="228" alt="Screenshot 2024-01-07 at 10 25 33 PM" src="https://github.com/foundryvtt/pf2e/assets/43155846/dd34934b-07ad-4d7c-90c3-a8aefd032194">
