### PR TITLE
Add 500ms delay for Drag-n-Drop sort for touch

### DIFF
--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -402,6 +402,9 @@ const SORTABLE_BASE_OPTIONS: Sortable.Options = {
     scroll: true,
     scrollSensitivity: 30,
     scrollSpeed: 15,
+
+    delay: 500,
+    delayOnTouchOnly: true,
 };
 
 export {


### PR DESCRIPTION
Fix expand/collapse item descriptions on mobile by adding a 500ms delay to drag-n-drop sort