### PR TITLE
Prevent erroneous triggering of sheet handlers

### DIFF
--- a/static/templates/actors/character/tabs/proficiencies.hbs
+++ b/static/templates/actors/character/tabs/proficiencies.hbs
@@ -21,7 +21,7 @@
                         >
                             {{> "systems/pf2e/templates/actors/character/partials/proficiencylevels-dropdown.hbs" proflevel=skill.rank}}
                         </select>
-                        <button class="hover" data-tooltip-content="#{{@root.options.id}}-{{skill.slug}}-modifiers">
+                        <button type="button" class="hover" data-tooltip-content="#{{@root.options.id}}-{{skill.slug}}-modifiers">
                             {{localize "PF2E.ModifiersTitle"}}
                         </button>
                     </div>
@@ -154,7 +154,7 @@
                     <span class="name">{{classDC.label}}</span>
                     <div class="button-group stacked">
                         <span class="pf-rank" data-rank="{{classDC.rank}}">{{lookup @root.numberToRank classDC.rank}}</span>
-                        <button class="hover" data-tooltip-content="#{{../options.id}}-{{classDC.slug}}-modifiers">
+                        <button type="button" class="hover" data-tooltip-content="#{{../options.id}}-{{classDC.slug}}-modifiers">
                             {{localize "PF2E.ModifiersTitle"}}
                         </button>
                     </div>

--- a/static/templates/actors/character/tabs/spellcasting.hbs
+++ b/static/templates/actors/character/tabs/spellcasting.hbs
@@ -103,7 +103,7 @@
 
 
     {{#if @root.editable}}
-        <button class="blue create-entry" data-action="spellcasting-create">
+        <button type="button" class="blue create-entry" data-action="spellcasting-create">
             <i class="fa-solid fa-plus"></i>{{localize "PF2E.AddSpellcastingEntryTitle"}}
         </button>
     {{/if}}


### PR DESCRIPTION
Some buttons on character sheet were missing `type="button"`. This caused a click event on them to be triggered via implicit submission if enter was pressed on the keyboard while within one of a sheet's text inputs.