### PR TITLE
Add Witch's Cauldron Crafting Entry

### DIFF
--- a/packs/feats/cauldron.json
+++ b/packs/feats/cauldron.json
@@ -24,7 +24,30 @@
             "remaster": true,
             "title": "Pathfinder Player Core"
         },
-        "rules": [],
+        "rules": [
+            {
+                "craftableItems": [
+                    {
+                        "or": [
+                            "item:trait:oil",
+                            "item:trait:potion"
+                        ]
+                    }
+                ],
+                "isDailyPrep": true,
+                "key": "CraftingEntry",
+                "label": "PF2E.SpecificRule.Witch.Cauldron.CraftingEntry",
+                "maxSlots": 1,
+                "selector": "cauldron"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "system.crafting.entries.cauldron.maxSlots",
+                "phase": "beforeDerived",
+                "value": "ternary(eq(@actor.system.proficiencies.spellcasting.rank,4),3,ternary(eq(@actor.system.proficiencies.spellcasting.rank,3),2,1))"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -3223,6 +3223,9 @@
                 "Success": "You temporarily recover an expended spell slot of a spell level chosen randomly among your top three levels of spell slots (or all your levels of spell slots if you have fewer than three). The slot lasts 3 rounds instead of 1 minute, otherwise you experience a @UUID[Compendium.pf2e.rollable-tables.RollTable.N0pDFNCffTe2Du39]{Wellspring Surge}."
             },
             "Witch": {
+                "Cauldron":{
+                    "CraftingEntry": "Cauldron"
+                },
                 "Patron": {
                     "Prompt": "Select a patron."
                 },


### PR DESCRIPTION
Closes #11595

RAW the feat doesn't seem to limit the level of the item, so I didn't include that in the RE. It also seems like the follow up feat [Double, Double](https://app.demiplane.com/nexus/pathfinder2e/feats/double-double-rm) isn't possible to implement right now, unless I'm missing something.