### PR TITLE
Kill the jquery in hazard sheet

### DIFF
--- a/src/styles/actor/hazard/_header.scss
+++ b/src/styles/actor/hazard/_header.scss
@@ -38,22 +38,23 @@ form > header {
         }
 
         .edit-mode-button {
-            position: absolute;
-            width: 20px;
-            height: 20px;
-            bottom: -10px;
-            left: -10px;
-            border-radius: 10px;
-            background-color: white;
-            color: var(--text-dark);
-            cursor: pointer;
             @include brown-border;
-
-            // center the icon
-            display: flex;
-            justify-content: center;
             align-items: center;
+            background-color: var(--color-text-light-0);
+            border-radius: 10px;
+            bottom: -0.625rem;
+            color: var(--text-dark);
+            display: flex;
             font-size: 1.05em;
+            height: 1.25rem;
+            justify-content: center;
+            left: -0.625rem;
+            position: absolute;
+            width: 1.25rem;
+
+            &:hover {
+                text-shadow: none;
+            }
         }
     }
 

--- a/static/templates/actors/hazard/partials/header.hbs
+++ b/static/templates/actors/hazard/partials/header.hbs
@@ -2,10 +2,14 @@
 <header>
     <div class="frame-container">
         <div class="frame image-container">
-            <img class="actor-image" alt="{{actor.name}}" src="{{actor.img}}" title="{{actor.name}}" data-edit="img" />
+            <img class="actor-image" alt="{{actor.name}}" src="{{actor.img}}" data-edit="img" />
             <a class="hover-icon" data-action="show-image" data-tooltip="SIDEBAR.CharArt"><i class="fa-solid fa-image fa-fw"></i></a>
             {{#if editable}}
-                <div class="edit-mode-button" title="{{localize "PF2E.EditHazardLabel"}}"><i class="fa-solid fa-lock{{#if editing}}-open{{/if}}"></i></div>
+                <a
+                    class="edit-mode-button"
+                    data-action="toggle-edit-mode"
+                    data-tooltip="PF2E.EditHazardLabel"
+                ><i class="fa-solid fa-lock{{#if editing}}-open{{/if}}"></i></a>
             {{/if}}
         </div>
     </div>

--- a/static/templates/actors/hazard/partials/sidebar.hbs
+++ b/static/templates/actors/hazard/partials/sidebar.hbs
@@ -34,7 +34,14 @@
             <div>
                 <div class="initiative">
                     <div class="valued-icon">
-                        <input type="text" value="{{numberFormat data.attributes.stealth.value decimals=0 sign=true}}" data-property="system.attributes.stealth.value" data-dtype="Number" placeholder="N/A" />
+                        <input
+                            type="text"
+                            value="{{numberFormat data.attributes.stealth.value sign=true}}"
+                            data-property="system.attributes.stealth.value"
+                            data-modifier
+                            data-dtype="Number"
+                            placeholder="N/A"
+                        />
                     </div>
                     <a class="roll-init{{#if @root.options.editable}} rollable{{/if}}" data-action="roll-initiative">
                         <i class="fa-solid fa-dice-d20"></i>
@@ -63,7 +70,15 @@
                             <div>{{save.label}}</div>
                         {{~/if}}
                         <span class="valued-icon">
-                            <input type="text" value="{{#if save.mod includeZero=true}}{{numberFormat save.mod decimals=0 sign=true}}{{/if}}" data-property="system.saves.{{save.type}}.value" data-dtype="Number" placeholder="N/A" />
+                            <input
+                                type="text"
+                                value="{{#if save.mod includeZero=true}}{{numberFormat save.mod sign=true}}{{/if}}"
+                                data-property="system.saves.{{save.type}}.value"
+                                data-modifier
+                                data-nullable
+                                data-dtype="Number"
+                                placeholder="N/A"
+                            />
                         </span>
                     </div>
                 {{/each}}

--- a/static/templates/actors/hazard/sheet.hbs
+++ b/static/templates/actors/hazard/sheet.hbs
@@ -1,4 +1,4 @@
-<form class="{{cssClass}}{{#if editing}} editing{{/if}}" autocomplete="off">
+<form class="{{cssClass}}{{#if editing}} editing{{/if}}" autocomplete="off" spellcheck="false" data-tooltip-class="pf2e">
     {{> "systems/pf2e/templates/actors/hazard/partials/header.hbs"}}
     <div class="container">
         {{> "systems/pf2e/templates/actors/hazard/partials/sidebar.hbs"}}


### PR DESCRIPTION
Includes updating base sheet class's `data-property` handler to accommodate nullable numeric values