### PR TITLE
Add spell effect for Everlight

### DIFF
--- a/packs/spell-effects/spell-effect-everlight.json
+++ b/packs/spell-effects/spell-effect-everlight.json
@@ -1,0 +1,50 @@
+{
+    "_id": "hpbCDbDOoVyhOmck",
+    "img": "icons/magic/light/torch-fire-orange.webp",
+    "name": "Spell Effect: Everlight",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Everlight]</p>\n<p>The gemstone you touch glows, spreading bright light with a color of your choice in a 20-foot radius (and dim light for the next 20 feet).</p>"
+        },
+        "duration": {
+            "expiry": null,
+            "sustained": false,
+            "unit": "unlimited",
+            "value": -1
+        },
+        "level": {
+            "value": 2
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "rules": [
+            {
+                "key": "TokenLight",
+                "value": {
+                    "animation": {
+                        "speed": 1,
+                        "type": "starlight"
+                    },
+                    "attenuation": 0.4,
+                    "bright": 20,
+                    "color": "#ffdf3d",
+                    "dim": 40
+                }
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/spell-effects/spell-effect-everlight.json
+++ b/packs/spell-effects/spell-effect-everlight.json
@@ -4,7 +4,7 @@
     "name": "Spell Effect: Everlight",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Everlight]</p>\n<p>The gemstone you touch glows, spreading bright light with a color of your choice in a 20-foot radius (and dim light for the next 20 feet).</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Everlight]</p>\n<p>The gemstone you touch glows, spreading bright light in a 20-foot radius (and dim light for the next 20 feet).</p>"
         },
         "duration": {
             "expiry": null,

--- a/packs/spells/everlight.json
+++ b/packs/spells/everlight.json
@@ -11,7 +11,7 @@
         "damage": {},
         "defense": null,
         "description": {
-            "value": "<p>The gemstone you touch glows, spreading bright light with a color of your choice in a 20-foot radius (and dim light for the next 20 feet). The spell ends immediately if the gemstone is broken.</p>"
+            "value": "<p>The gemstone you touch glows, spreading bright light with a color of your choice in a 20-foot radius (and dim light for the next 20 feet). The spell ends immediately if the gemstone is broken.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Everlight]</p>"
         },
         "duration": {
             "sustained": false,


### PR DESCRIPTION
While Everlight doesn't technically affect a creature, this will handle the common use-case.