### PR TITLE
Add missing _id properties to spells

### DIFF
--- a/packs/spells/falling-stars.json
+++ b/packs/spells/falling-stars.json
@@ -56,6 +56,7 @@
         },
         "overlays": {
             "3Ifk4ND7o6QBAYMp": {
+                "_id": "3Ifk4ND7o6QBAYMp",
                 "name": "Falling Stars (Plasma)",
                 "overlayType": "override",
                 "sort": 4,
@@ -96,6 +97,7 @@
                 }
             },
             "8dtcJWTSeGlvDAUL": {
+                "_id": "8dtcJWTSeGlvDAUL",
                 "name": "Falling Stars (Airbursts)",
                 "overlayType": "override",
                 "sort": 1,
@@ -139,6 +141,7 @@
                 }
             },
             "TPSUk7tUquDQhIu3": {
+                "_id": "TPSUk7tUquDQhIu3",
                 "name": "Falling Stars (Comets)",
                 "overlayType": "override",
                 "sort": 3,
@@ -179,6 +182,7 @@
                 }
             },
             "UizWQQABRIkwrOZj": {
+                "_id": "UizWQQABRIkwrOZj",
                 "name": "Falling Stars (Asteroids)",
                 "overlayType": "override",
                 "sort": 2,

--- a/packs/spells/gouging-claw.json
+++ b/packs/spells/gouging-claw.json
@@ -50,6 +50,7 @@
         },
         "overlays": {
             "URQWpedXx9fB1fR7": {
+                "_id": "URQWpedXx9fB1fR7",
                 "name": "Gouging Claw (Piercing)",
                 "overlayType": "override",
                 "sort": 1,

--- a/packs/spells/spiritual-armament.json
+++ b/packs/spells/spiritual-armament.json
@@ -40,6 +40,7 @@
         },
         "overlays": {
             "NYYzPXYkV0V917XF": {
+                "_id": "NYYzPXYkV0V917XF",
                 "name": "Spiritual Armament (Spirit)",
                 "overlayType": "override",
                 "sort": 4,
@@ -57,6 +58,7 @@
                 }
             },
             "OTj254xSoTgGQJlU": {
+                "_id": "OTj254xSoTgGQJlU",
                 "name": "Spiritual Armament (Slashing)",
                 "overlayType": "override",
                 "sort": 3,
@@ -74,6 +76,7 @@
                 }
             },
             "TqI3B4hFxajOSIm3": {
+                "_id": "TqI3B4hFxajOSIm3",
                 "name": "Spiritual Armament (Bludgeoning)",
                 "overlayType": "override",
                 "sort": 1,
@@ -91,6 +94,7 @@
                 }
             },
             "WIvpqh0pSKKC4t0F": {
+                "_id": "WIvpqh0pSKKC4t0F",
                 "name": "Spiritual Armament (Piercing)",
                 "overlayType": "override",
                 "sort": 2,

--- a/packs/spells/sun-blade.json
+++ b/packs/spells/sun-blade.json
@@ -40,6 +40,7 @@
         },
         "overlays": {
             "CuGW0j3SYzsrf89R": {
+                "_id": "CuGW0j3SYzsrf89R",
                 "name": "Sun Blade",
                 "overlayType": "override",
                 "sort": 1,
@@ -58,6 +59,7 @@
                 }
             },
             "zkpyb1D8OCsASYRi": {
+                "_id": "zkpyb1D8OCsASYRi",
                 "name": "Sun Blade (Bright Natural Sunlight)",
                 "overlayType": "override",
                 "sort": 2,


### PR DESCRIPTION
Fixes #12926
_id property was missing in 11 places on the spells _falling stars_, _gouging claw_, _spiritual armament_, and _sun blade_.
The missing property seemed to cause no issues in the system itself, but broke certain macros that relied on the id existing.