### PR TITLE
Fix sustained/basic save spell toggle sizing

### DIFF
--- a/src/styles/item/_index.scss
+++ b/src/styles/item/_index.scss
@@ -248,7 +248,7 @@
                         line-height: normal;
                     }
 
-                    &.no-sidebar .form-group label {
+                    &.no-sidebar .form-group > label {
                         flex: 0 0 12em;
                         white-space: wrap;
                         padding-right: 0;
@@ -303,7 +303,7 @@
                 font-weight: 600;
             }
 
-            .form-group label:first-of-type {
+            .form-group > label:first-of-type {
                 flex-basis: 11em;
             }
         }

--- a/static/templates/items/spell-details.hbs
+++ b/static/templates/items/spell-details.hbs
@@ -58,10 +58,10 @@
         <div class="form-fields">
         <input id="{{fieldIdPrefix}}duration" type="text" name="system.duration.value" value="{{data.duration.value}}" />
             {{#unless item.isRitual}}
-                <div>
-                    <label class="sustained" for="{{fieldIdPrefix}}sustained">{{localize "PF2E.Item.Spell.Sustained.Label"}}</label>
+                <label class="sustained">
+                    {{localize "PF2E.Item.Spell.Sustained.Label"}}
                     <input id="{{fieldIdPrefix}}sustained" type="checkbox" name="system.duration.sustained" {{checked data.duration.sustained}} />
-                </div>
+                </label>
             {{/unless}}
         </div>
     </div>
@@ -108,11 +108,8 @@
                         <option value="will">{{localize "PF2E.SavesWill"}}</option>
                     {{/select}}
                 </select>
-                <div>
-                    <label
-                        for="{{fieldIdPrefix}}save-basic"
-                        {{#unless data.defense.save.statistic}}class="disabled"{{/unless}}
-                    >{{localize "PF2E.Item.Spell.Defense.BasicSave"}}</label>
+                <label {{#unless data.defense.save.statistic}}class="disabled"{{/unless}}>
+                    {{localize "PF2E.Item.Spell.Defense.BasicSave"}}
                     <input
                         type="checkbox"
                         name="system.defense.save.basic"
@@ -120,7 +117,7 @@
                         {{checked data.defense.save.basic}}
                         {{disabled (not data.defense.save.statistic)}}
                     />
-                </div>
+                </label>
             </div>
         </div>
     </fieldset>


### PR DESCRIPTION
Before
![image](https://github.com/foundryvtt/pf2e/assets/1286721/89db1689-1f29-4974-a303-1499f5292f2d)


After
![image](https://github.com/foundryvtt/pf2e/assets/1286721/33837872-fd72-4432-8bac-8b0447122afe)
