### PR TITLE
Refresh Facetbound Cascader's Aeon Stone (Orange Prism) to Amplifying

### DIFF
--- a/packs/blood-lords-bestiary/facetbound-cascader.json
+++ b/packs/blood-lords-bestiary/facetbound-cascader.json
@@ -2356,7 +2356,7 @@
                 }
             },
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/aeon-stone-orange-prism.webp",
-            "name": "Aeon Stone (Orange Prism)",
+            "name": "Aeon Stone (Amplifying)",
             "sort": 3200000,
             "system": {
                 "baseItem": null,
@@ -2365,7 +2365,7 @@
                 },
                 "containerId": null,
                 "description": {
-                    "value": "<p>An <em>orange prism aeon stone</em> must be activated to provide a benefit. The resonant power grants you a +2 item bonus to Arcana, Nature, Occultism, or Religion checks-whichever corresponds to the tradition of the last spell you enhanced with this <em>aeon stone</em>.</p>\n<hr />\n<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> envision</p>\n<hr />\n<p><strong>Effect</strong> If your next action is to Cast a Spell, that spell's rank is 1 higher (maximum 10th rank) for the purposes of counteracting and being counteracted.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Aeon Stone (Orange Prism) (Arcana)]</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Aeon Stone (Orange Prism) (Nature)]</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Aeon Stone (Orange Prism) (Occultism)]</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Aeon Stone (Orange Prism) (Religion)]</p>"
+                    "value": "<p>Over millennia, these mysterious, intricately cut gemstones have been hoarded by mystics and fanatics hoping to discover their secrets. Despite their myriad forms and functions, these stones are purportedly all fragments of crystal tools used by otherworldly entities to construct the universe in primeval times.</p>\n<p>When you invest one of these precisely shaped crystals, the stone orbits your head instead of being worn on your body. You can stow an <em>aeon stone</em> with an Interact action, and an orbiting stone can be snatched out of the air with a successful Disarm action against you. A stowed or removed stone remains invested, but its effects are suppressed until you return it to orbit your head again.</p>\n<p>There are various types of <em>aeon stones</em>, each with a different appearance and magical effect. Each <em>aeon stone</em> also gains a resonant power when slotted into a special magical item called a <em>wayfinder</em>.</p>\n<hr />\n<p>An <em>Amplifying aeon stone</em> must be activated to provide a benefit. The resonant power grants you a +2 item bonus to Arcana, Nature, Occultism, or Religion checks-whichever corresponds to the tradition of the last spell you enhanced with this <em>aeon stone</em>.</p>\n<hr />\n<p><strong>Activate—Amplify</strong> <span class=\"action-glyph\">1</span> (concentrate, spellshape)</p>\n<p><strong>Effect</strong> If your next action is to Cast a Spell, that spell's rank is 1 higher (maximum 10th rank) for the purposes of counteracting and being counteracted.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Aeon Stone Resonance (Amplifying)]</p>"
                 },
                 "equipped": {
                     "carryType": "worn",
@@ -2389,14 +2389,14 @@
                     }
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": "Pathfinder Core Rulebook"
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder GM Core"
                 },
                 "quantity": 1,
                 "rules": [],
                 "size": "med",
-                "slug": "aeon-stone-orange-prism",
+                "slug": "aeon-stone-amplifying",
                 "traits": {
                     "rarity": "uncommon",
                     "value": [

--- a/packs/rollable-tables/16th-level-permanent-items.json
+++ b/packs/rollable-tables/16th-level-permanent-items.json
@@ -398,7 +398,7 @@
                 117,
                 119
             ],
-            "text": "Aeon Stone (Orange Prism)",
+            "text": "Aeon Stone (Amplifying)",
             "type": 2,
             "weight": 3
         }


### PR DESCRIPTION
This was done in order to remove the references to the old "Effect: Aeon Stone (Orange Prism) *" effects.