### PR TITLE
Prevent action glyphs from inheriting bold styling

### DIFF
--- a/src/styles/_globals.scss
+++ b/src/styles/_globals.scss
@@ -64,6 +64,7 @@ p.compact-text {
     align-self: center;
     display: inline;
     font-family: "Pathfinder2eActions", sans-serif;
+    font-weight: normal;
     letter-spacing: 0;
     margin: 0;
     padding: 0;


### PR DESCRIPTION
Most visible scenario is chat message headings:

![glyph-bold](https://github.com/foundryvtt/pf2e/assets/4469633/9c512174-9f9c-4ba1-b6ae-c122624f9687)

Another scenario is NPC actions.