### PR TITLE
Tweak spacing in item sidebar and spell heightening

### DIFF
--- a/src/styles/item/_sidebar.scss
+++ b/src/styles/item/_sidebar.scss
@@ -32,13 +32,12 @@ section.sidebar {
         }
     }
 
-    .inventory-details,
-    .feat-details {
+    .inventory-details {
         display: flex;
         flex-flow: column nowrap;
-        gap: 0.25rem;
+        gap: var(--space-4);
         overflow: hidden scroll;
-        padding: 0 0.25rem 0 0;
+        padding: var(--space-8) var(--space-4) 0 0;
 
         .form-group {
             margin: 0 0.125rem;

--- a/src/styles/item/_spell-sheet.scss
+++ b/src/styles/item/_spell-sheet.scss
@@ -25,10 +25,6 @@
     }
 
     fieldset.heightening {
-        display: flex;
-        flex-direction: column;
-        gap: 0.25rem;
-
         .add {
             display: grid;
             grid-template-columns: 1fr 1fr;
@@ -39,6 +35,8 @@
         }
 
         .overlay {
+            margin-top: var(--space-8);
+
             .toggle-button-list {
                 column-gap: 2px;
                 display: grid;

--- a/static/templates/items/action-details.hbs
+++ b/static/templates/items/action-details.hbs
@@ -6,5 +6,7 @@
 
 <div class="form-group">
     <label for="{{fieldIdPrefix}}death-note">{{localize "PF2E.ActionDeathNoteLabel"}}</label>
-    <input type="checkbox" name="system.deathNote" id="{{fieldIdPrefix}}death-note" {{checked data.deathNote}} />
+    <div class="form-fields">
+        <input type="checkbox" name="system.deathNote" id="{{fieldIdPrefix}}death-note" {{checked data.deathNote}} />
+    </div>
 </div>

--- a/static/templates/items/campaign-feature-sidebar.hbs
+++ b/static/templates/items/campaign-feature-sidebar.hbs
@@ -1,8 +1,4 @@
-{{#if data.requirements.value}}
-    <span class="item-summary">{{data.requirements.value}}</span>
-{{/if}}
-
-<div class="feat-details">
+<div class="inventory-details">
     <div class="form-group">
         <label>{{localize "PF2E.Item.CampaignFeature.CampaignLabel"}}</label>
         <select name="system.campaign" {{disabled document.parent}}>

--- a/static/templates/items/feat-sidebar.hbs
+++ b/static/templates/items/feat-sidebar.hbs
@@ -1,8 +1,4 @@
-{{#if data.requirements.value}}
-    <span class="item-summary">{{data.requirements.value}}</span>
-{{/if}}
-
-<div class="feat-details">
+<div class="inventory-details">
     <div class="form-group">
         <label>{{localize "PF2E.Category"}}</label>
         <select name="system.category">

--- a/static/templates/items/heritage-sidebar.hbs
+++ b/static/templates/items/heritage-sidebar.hbs
@@ -1,4 +1,4 @@
-<div class="feat-details">
+<div class="inventory-details">
     <div class="form-group required-ancestry">
         <label class="pf-title">{{localize "TYPES.Item.ancestry"}}</label>
         <div


### PR DESCRIPTION
Fixed heightening still needs better separation of ranks but its a start.

![image](https://github.com/foundryvtt/pf2e/assets/1286721/daa8a670-276b-42bf-8459-fda45c7da41f)
![image](https://github.com/foundryvtt/pf2e/assets/1286721/2d431f2a-9e4c-48b2-a2bf-1eb3f780a2db)
![image](https://github.com/foundryvtt/pf2e/assets/1286721/a9cf2d52-a85b-4a33-a81b-52ede4555c6e)


Also fixes positioning of death note checkbox.