### PR TITLE
Add Forceful Trait Weapon Damage Modifiers

### DIFF
--- a/src/module/system/damage/weapon.ts
+++ b/src/module/system/damage/weapon.ts
@@ -365,6 +365,26 @@ class WeaponDamagePF2e {
             );
         }
 
+        // Forceful trait
+        if (weaponTraits.some((t) => t === "forceful") && weapon.isOfType("weapon")) {
+            modifiers.push(
+                new ModifierPF2e({
+                    slug: "forceful-second",
+                    label: "PF2E.TraitForcefulSecond",
+                    modifier: weapon._source.system.damage.dice + strikingDice,
+                    type: "circumstance",
+                    ignored: true,
+                }),
+                new ModifierPF2e({
+                    slug: "forceful-third",
+                    label: "PF2E.TraitForcefulThird",
+                    modifier: 2 * (weapon._source.system.damage.dice + strikingDice),
+                    type: "circumstance",
+                    ignored: true,
+                }),
+            );
+        }
+
         // Add roll notes to the context
         const runeNotes = propertyRunes.flatMap((r) => {
             const data = RUNE_DATA.weapon.property[r].damage?.notes ?? [];

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -4220,6 +4220,8 @@
         "TraitFoldaway": "Foldaway",
         "TraitForce": "Force",
         "TraitForceful": "Forceful",
+        "TraitForcefulSecond": "Forceful 2nd Attack",
+        "TraitForcefulThird": "Forceful 3rd+ Attack",
         "TraitFormian": "Formian",
         "TraitFortune": "Fortune",
         "TraitFreeHand": "Free-Hand",


### PR DESCRIPTION
Adds options for adding extra damage for forceful weapons. The addition of the `_source` dice and `strikingDice` allows for it to account for both striking rune and runic weapon changes. 

I believe this will resolve #5974.

The only thing I'm unsure about is if I have add the language template changes in the right place.
