### PR TITLE
Restore heightened signature spell background color

### DIFF
--- a/src/styles/actor/_index.scss
+++ b/src/styles/actor/_index.scss
@@ -202,7 +202,6 @@
         .sheet-body {
             grid-area: content;
             position: relative;
-            z-index: 0;
 
             ol {
                 list-style: none;

--- a/src/styles/actor/_index.scss
+++ b/src/styles/actor/_index.scss
@@ -202,6 +202,7 @@
         .sheet-body {
             grid-area: content;
             position: relative;
+            z-index: 0;
 
             ol {
                 list-style: none;

--- a/src/styles/actor/_spell-collection.scss
+++ b/src/styles/actor/_spell-collection.scss
@@ -216,16 +216,7 @@ ol.spell-list {
 
     &[data-category="spontaneous"] {
         .virtual {
-            position: relative;
-            &::before {
-                background-color: #0005ff1d;
-                content: "";
-                height: 100%;
-                mix-blend-mode: saturation;
-                pointer-events: none;
-                position: absolute;
-                width: 100%;
-            }
+            backdrop-filter: blur(8px) hue-rotate(210deg) saturate(2);
         }
 
         .item:not(.virtual) + .virtual {


### PR DESCRIPTION
Closes #13012

Restores `z-index: 0` removed in #12936, long text still works.

<img width="501" alt="Screenshot 2024-01-13 at 9 27 15 PM" src="https://github.com/foundryvtt/pf2e/assets/43155846/b22bec49-a48a-4a97-ae11-6ca585c461ae">
