### PR TITLE
Store Swashbuckler's Precise Strike value in a flag

### DIFF
--- a/packs/actions/confident-finisher.json
+++ b/packs/actions/confident-finisher.json
@@ -25,7 +25,25 @@
                     "failure"
                 ],
                 "predicate": [
-                    "finisher:confident"
+                    "finisher:confident",
+                    {
+                        "or": [
+                            "item:melee",
+                            {
+                                "and": [
+                                    "feat:flying-blade",
+                                    "item:thrown",
+                                    "target:range-increment:1"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "or": [
+                            "item:trait:agile",
+                            "item:trait:finesse"
+                        ]
+                    }
                 ],
                 "selector": "attack-roll",
                 "text": "PF2E.SpecificRule.Swashbuckler.Finisher.Confident.Note",

--- a/packs/actions/confident-finisher.json
+++ b/packs/actions/confident-finisher.json
@@ -18,7 +18,20 @@
             "remaster": false,
             "title": "Pathfinder Advanced Player's Guide"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "Note",
+                "outcome": [
+                    "failure"
+                ],
+                "predicate": [
+                    "finisher:confident"
+                ],
+                "selector": "attack-roll",
+                "text": "PF2E.SpecificRule.Swashbuckler.Finisher.Confident.Note",
+                "title": "{item|name}"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/actions/confident-finisher.json
+++ b/packs/actions/confident-finisher.json
@@ -46,7 +46,7 @@
                     }
                 ],
                 "selector": "attack-roll",
-                "text": "PF2E.SpecificRule.Swashbuckler.Finisher.Confident.Note",
+                "text": "PF2E.SpecificRule.Swashbuckler.Finisher.ConfidentNote",
                 "title": "{item|name}"
             }
         ],

--- a/packs/classfeatures/precise-strike.json
+++ b/packs/classfeatures/precise-strike.json
@@ -28,7 +28,7 @@
             {
                 "key": "ActiveEffectLike",
                 "mode": "override",
-                "path": "flags.pf2e.swashbuckler.preciseStrike.value",
+                "path": "flags.pf2e.swashbuckler.preciseStrike",
                 "predicate": [
                     "class:swashbuckler"
                 ],
@@ -155,11 +155,11 @@
                 ],
                 "selector": "strike-damage",
                 "slug": "precise-strike",
-                "value": "@actor.flags.pf2e.swashbuckler.preciseStrike.value"
+                "value": "@actor.flags.pf2e.swashbuckler.preciseStrike"
             },
             {
                 "category": "precision",
-                "diceNumber": "@actor.flags.pf2e.swashbuckler.preciseStrike.value",
+                "diceNumber": "@actor.flags.pf2e.swashbuckler.preciseStrike",
                 "dieSize": "d6",
                 "key": "DamageDice",
                 "predicate": [

--- a/packs/classfeatures/precise-strike.json
+++ b/packs/classfeatures/precise-strike.json
@@ -26,6 +26,41 @@
         },
         "rules": [
             {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.swashbuckler.preciseStrike.value",
+                "predicate": [
+                    "class:swashbuckler"
+                ],
+                "value": {
+                    "brackets": [
+                        {
+                            "end": 4,
+                            "value": 2
+                        },
+                        {
+                            "end": 8,
+                            "start": 5,
+                            "value": 3
+                        },
+                        {
+                            "end": 12,
+                            "start": 9,
+                            "value": 4
+                        },
+                        {
+                            "end": 16,
+                            "start": 13,
+                            "value": 5
+                        },
+                        {
+                            "start": 17,
+                            "value": 6
+                        }
+                    ]
+                }
+            },
+            {
                 "disabledIf": [
                     {
                         "not": "self:effect:panache"
@@ -121,7 +156,6 @@
                 "damageCategory": "precision",
                 "key": "FlatModifier",
                 "predicate": [
-                    "class:swashbuckler",
                     "self:effect:panache",
                     {
                         "or": [
@@ -147,40 +181,14 @@
                 ],
                 "selector": "strike-damage",
                 "slug": "precise-strike",
-                "value": {
-                    "brackets": [
-                        {
-                            "end": 4,
-                            "value": 2
-                        },
-                        {
-                            "end": 8,
-                            "start": 5,
-                            "value": 3
-                        },
-                        {
-                            "end": 12,
-                            "start": 9,
-                            "value": 4
-                        },
-                        {
-                            "end": 16,
-                            "start": 13,
-                            "value": 5
-                        },
-                        {
-                            "start": 17,
-                            "value": 6
-                        }
-                    ]
-                }
+                "value": "@actor.flags.pf2e.swashbuckler.preciseStrike.value"
             },
             {
                 "category": "precision",
+                "diceNumber": "@actor.flags.pf2e.swashbuckler.preciseStrike.value",
                 "dieSize": "d6",
                 "key": "DamageDice",
                 "predicate": [
-                    "class:swashbuckler",
                     "self:effect:panache",
                     "finisher",
                     {
@@ -203,44 +211,7 @@
                     }
                 ],
                 "selector": "strike-damage",
-                "slug": "finisher",
-                "value": {
-                    "brackets": [
-                        {
-                            "end": 4,
-                            "value": {
-                                "diceNumber": 2
-                            }
-                        },
-                        {
-                            "end": 8,
-                            "start": 5,
-                            "value": {
-                                "diceNumber": 3
-                            }
-                        },
-                        {
-                            "end": 12,
-                            "start": 9,
-                            "value": {
-                                "diceNumber": 4
-                            }
-                        },
-                        {
-                            "end": 16,
-                            "start": 13,
-                            "value": {
-                                "diceNumber": 5
-                            }
-                        },
-                        {
-                            "start": 17,
-                            "value": {
-                                "diceNumber": 6
-                            }
-                        }
-                    ]
-                }
+                "slug": "finisher"
             }
         ],
         "traits": {

--- a/packs/classfeatures/precise-strike.json
+++ b/packs/classfeatures/precise-strike.json
@@ -61,7 +61,7 @@
                         "value": "bleeding"
                     },
                     {
-                        "label": "PF2E.SpecificRule.Swashbuckler.Finisher.Confident.Label",
+                        "label": "PF2E.SpecificRule.Swashbuckler.Finisher.Confident",
                         "predicate": [
                             "feature:confident-finisher"
                         ],

--- a/packs/classfeatures/precise-strike.json
+++ b/packs/classfeatures/precise-strike.json
@@ -32,33 +32,7 @@
                 "predicate": [
                     "class:swashbuckler"
                 ],
-                "value": {
-                    "brackets": [
-                        {
-                            "end": 4,
-                            "value": 2
-                        },
-                        {
-                            "end": 8,
-                            "start": 5,
-                            "value": 3
-                        },
-                        {
-                            "end": 12,
-                            "start": 9,
-                            "value": 4
-                        },
-                        {
-                            "end": 16,
-                            "start": 13,
-                            "value": 5
-                        },
-                        {
-                            "start": 17,
-                            "value": 6
-                        }
-                    ]
-                }
+                "value": "ceil(@actor.level/4) + 1"
             },
             {
                 "disabledIf": [
@@ -87,7 +61,7 @@
                         "value": "bleeding"
                     },
                     {
-                        "label": "PF2E.SpecificRule.Swashbuckler.Finisher.Confident",
+                        "label": "PF2E.SpecificRule.Swashbuckler.Finisher.Confident.Label",
                         "predicate": [
                             "feature:confident-finisher"
                         ],

--- a/packs/feats/bleeding-finisher.json
+++ b/packs/feats/bleeding-finisher.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>Your blow inflicts profuse bleeding. Make a slashing or piercing Strike with a weapon or unarmed attack that allows you to add your precise strike damage.</p>\n<p>If you hit, the target also takes @Damage[(@actor.flags.pf2e.swashbuckler.preciseStrike.value)d6[persistent,bleed]]{persistent bleed damage} equal to your precise strike finisher damage.</p>"
+            "value": "<p>Your blow inflicts profuse bleeding. Make a slashing or piercing Strike with a weapon or unarmed attack that allows you to add your precise strike damage.</p>\n<p>If you hit, the target also takes @Damage[(@actor.flags.pf2e.swashbuckler.preciseStrike)d6[persistent,bleed]]{persistent bleed damage} equal to your precise strike finisher damage.</p>"
         },
         "level": {
             "value": 8
@@ -28,7 +28,7 @@
             {
                 "category": "persistent",
                 "damageType": "bleed",
-                "diceNumber": "@actor.flags.pf2e.swashbuckler.preciseStrike.value",
+                "diceNumber": "@actor.flags.pf2e.swashbuckler.preciseStrike",
                 "dieSize": "d6",
                 "key": "DamageDice",
                 "predicate": [

--- a/packs/feats/bleeding-finisher.json
+++ b/packs/feats/bleeding-finisher.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>Your blow inflicts profuse bleeding. Make a slashing or piercing Strike with a weapon or unarmed attack that allows you to add your precise strike damage.</p>\n<p>If you hit, the target also takes @UUID[Compendium.pf2e.conditionitems.Item.Persistent Damage]{Persistent Bleed Damage} equal to your precise strike finisher damage.</p>"
+            "value": "<p>Your blow inflicts profuse bleeding. Make a slashing or piercing Strike with a weapon or unarmed attack that allows you to add your precise strike damage.</p>\n<p>If you hit, the target also takes @Damage[(@actor.flags.pf2e.swashbuckler.preciseStrike.value)d6[persistent,bleed]]{persistent bleed damage} equal to your precise strike finisher damage.</p>"
         },
         "level": {
             "value": 8
@@ -24,7 +24,43 @@
             "remaster": false,
             "title": "Pathfinder Advanced Player's Guide"
         },
-        "rules": [],
+        "rules": [
+            {
+                "category": "persistent",
+                "damageType": "bleed",
+                "diceNumber": "@actor.flags.pf2e.swashbuckler.preciseStrike.value",
+                "dieSize": "d6",
+                "key": "DamageDice",
+                "predicate": [
+                    "finisher:bleeding",
+                    {
+                        "or": [
+                            "item:melee",
+                            {
+                                "and": [
+                                    "feat:flying-blade",
+                                    "item:thrown",
+                                    "target:range-increment:1"
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "or": [
+                            "item:trait:agile",
+                            "item:trait:finesse"
+                        ]
+                    },
+                    {
+                        "or": [
+                            "item:damage:type:piercing",
+                            "item:damage:type:slashing"
+                        ]
+                    }
+                ],
+                "selector": "strike-damage"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/finishing-precision.json
+++ b/packs/feats/finishing-precision.json
@@ -30,73 +30,18 @@
         },
         "rules": [
             {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.swashbuckler.preciseStrike.value",
+                "value": 1
+            },
+            {
                 "key": "GrantItem",
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Basic Finisher"
             },
             {
                 "key": "GrantItem",
                 "uuid": "Compendium.pf2e.classfeatures.Item.Precise Strike"
-            },
-            {
-                "damageCategory": "precision",
-                "key": "FlatModifier",
-                "predicate": [
-                    "self:effect:panache",
-                    {
-                        "or": [
-                            "item:melee",
-                            {
-                                "and": [
-                                    "feat:flying-blade",
-                                    "item:thrown",
-                                    "target:range-increment:1"
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "or": [
-                            "item:trait:agile",
-                            "item:trait:finesse"
-                        ]
-                    },
-                    {
-                        "not": "finisher"
-                    }
-                ],
-                "selector": "strike-damage",
-                "slug": "finishing-precision",
-                "value": 1
-            },
-            {
-                "category": "precision",
-                "diceNumber": 1,
-                "dieSize": "d6",
-                "key": "DamageDice",
-                "predicate": [
-                    "self:effect:panache",
-                    "finisher",
-                    {
-                        "or": [
-                            "item:melee",
-                            {
-                                "and": [
-                                    "feat:flying-blade",
-                                    "item:thrown",
-                                    "target:range-increment:1"
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "or": [
-                            "item:trait:agile",
-                            "item:trait:finesse"
-                        ]
-                    }
-                ],
-                "selector": "strike-damage",
-                "slug": "finishing-precision"
             }
         ],
         "traits": {

--- a/packs/feats/finishing-precision.json
+++ b/packs/feats/finishing-precision.json
@@ -32,7 +32,7 @@
             {
                 "key": "ActiveEffectLike",
                 "mode": "override",
-                "path": "flags.pf2e.swashbuckler.preciseStrike.value",
+                "path": "flags.pf2e.swashbuckler.preciseStrike",
                 "value": 1
             },
             {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -3068,10 +3068,8 @@
                 "Finisher": {
                     "Basic": "Basic",
                     "Bleeding": "Bleeding",
-                    "Confident": {
-                        "Label": "Confident",
-                        "Note": "You deal half your @Damage[((@actor.flags.pf2e.swashbuckler.preciseStrike.value)d6[precision])[@item.system.damage.damageType]]{Precise Strike damage} to the target. This damage type is that of the weapon or unarmed attack you used for the Strike."
-                    },
+                    "Confident": "Confident",
+                    "ConfidentNote": "You deal half your @Damage[((@actor.flags.pf2e.swashbuckler.preciseStrike.value)d6[precision])[@item.system.damage.damageType]]{Precise Strike damage} to the target. This damage type is that of the weapon or unarmed attack you used for the Strike.",
                     "Dual": "Dual",
                     "Impaling": "Impaling",
                     "Label": "Finisher",

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -3068,7 +3068,10 @@
                 "Finisher": {
                     "Basic": "Basic",
                     "Bleeding": "Bleeding",
-                    "Confident": "Confident",
+                    "Confident": {
+                        "Label": "Confident",
+                        "Note": "You deal half your @Damage[((@actor.flags.pf2e.swashbuckler.preciseStrike.value)d6[precision])[@item.system.damage.damageType]]{Precise Strike damage} to the target. This damage type is that of the weapon or unarmed attack you used for the Strike."
+                    },
                     "Dual": "Dual",
                     "Impaling": "Impaling",
                     "Label": "Finisher",

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -3069,7 +3069,7 @@
                     "Basic": "Basic",
                     "Bleeding": "Bleeding",
                     "Confident": "Confident",
-                    "ConfidentNote": "You deal half your @Damage[((@actor.flags.pf2e.swashbuckler.preciseStrike.value)d6[precision])[@item.system.damage.damageType]]{Precise Strike damage} to the target. This damage type is that of the weapon or unarmed attack you used for the Strike.",
+                    "ConfidentNote": "You deal half your @Damage[((@actor.flags.pf2e.swashbuckler.preciseStrike)d6[precision])[@item.system.damage.damageType]]{Precise Strike damage} to the target. This damage type is that of the weapon or unarmed attack you used for the Strike.",
                     "Dual": "Dual",
                     "Impaling": "Impaling",
                     "Label": "Finisher",


### PR DESCRIPTION
I also use the very same flag to automate Bleeding Finisher, which supports multiclass swashbucklers as well.  ~~I tried to do the same with Confident Finisher but quickly ran into the roadblock of inline precision damage...~~

Were this to be accepted I suppose it'd require to migrate existing swashbucklers for them to have the relevant flag?