### PR TITLE
Fix Kineticist Dedication wrongly granting Base Kinesis

### DIFF
--- a/packs/classfeatures/impulses.json
+++ b/packs/classfeatures/impulses.json
@@ -38,6 +38,9 @@
             },
             {
                 "key": "GrantItem",
+                "predicate": [
+                    "class:kineticist"
+                ],
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Base Kinesis"
             },
             {

--- a/packs/feats/base-kinesis.json
+++ b/packs/feats/base-kinesis.json
@@ -28,7 +28,12 @@
             "remaster": true,
             "title": "Pathfinder Rage of Elements"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.actionspf2e.Item.Base Kinesis"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [


### PR DESCRIPTION
Closes #13066
Also makes the Base Kinesis grant the corresponding impulse action.