### PR TITLE
Add scaling to Mountain Skin's armor proficiency

### DIFF
--- a/packs/feats/mountain-skin.json
+++ b/packs/feats/mountain-skin.json
@@ -28,7 +28,20 @@
             "remaster": false,
             "title": "Pathfinder Lost Omens: Highhelm"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "system.proficiencies.defenses.medium.rank",
+                "value": "@actor.system.proficiencies.defenses.light.rank"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "system.proficiencies.defenses.heavy.rank",
+                "value": "@actor.system.proficiencies.defenses.light.rank"
+            }
+        ],
         "subfeatures": {
             "proficiencies": {
                 "heavy": {


### PR DESCRIPTION
Closes #12980
The feat already granted medium and heavy armor proficiency over on the details tab's proficiencies. This adds upgrading with respect to light armor proficiency.