### PR TITLE
Fix sense details for several NPCs

### DIFF
--- a/packs/age-of-ashes-bestiary/xotani-the-firebleeder.json
+++ b/packs/age-of-ashes-bestiary/xotani-the-firebleeder.json
@@ -725,9 +725,14 @@
             "statistic": "perception"
         },
         "perception": {
-            "details": "blindsight (precise) 120 feet",
+            "details": "",
             "mod": 39,
             "senses": [
+                {
+                    "acuity": "precise",
+                    "range": 120,
+                    "type": "blindsight"
+                },
                 {
                     "type": "darkvision"
                 }

--- a/packs/blood-lords-bestiary/vampire-taviah.json
+++ b/packs/blood-lords-bestiary/vampire-taviah.json
@@ -1371,9 +1371,12 @@
             "statistic": "perception"
         },
         "perception": {
-            "details": "thoughtsense",
+            "details": "",
             "mod": 23,
             "senses": [
+                {
+                    "type": "thoughtsense"
+                },
                 {
                     "type": "darkvision"
                 }

--- a/packs/gatewalkers-bestiary/protosoul.json
+++ b/packs/gatewalkers-bestiary/protosoul.json
@@ -980,9 +980,13 @@
             "statistic": "perception"
         },
         "perception": {
-            "details": "lifesense",
+            "details": "",
             "mod": 19,
-            "senses": []
+            "senses": [
+                {
+                    "type": "lifesense"
+                }
+            ]
         },
         "resources": {
             "focus": {

--- a/packs/rage-of-elements-bestiary/blustering-gale.json
+++ b/packs/rage-of-elements-bestiary/blustering-gale.json
@@ -459,9 +459,13 @@
             "statistic": "perception"
         },
         "perception": {
-            "details": "darkvison",
+            "details": "",
             "mod": 20,
-            "senses": []
+            "senses": [
+                {
+                    "type": "darkvision"
+                }
+            ]
         },
         "resources": {},
         "saves": {

--- a/packs/season-of-ghosts-bestiary/stone-spider.json
+++ b/packs/season-of-ghosts-bestiary/stone-spider.json
@@ -913,9 +913,13 @@
             "statistic": "perception"
         },
         "perception": {
-            "details": "darkvison",
+            "details": "",
             "mod": 14,
-            "senses": []
+            "senses": [
+                {
+                    "type": "darkvision"
+                }
+            ]
         },
         "resources": {},
         "saves": {


### PR DESCRIPTION
- Moved blindsight from details to sences for Xotani The Firebleeder
- Moved thoughtsense from details to sences for Vampire Taviah
- Moved thoughtsense from details to sences for Protosoul
- Moved Darkvision from details to sences for Blustering Gale
- Moved Darkvision from details to sences for Stone Spider