### PR TITLE
Set roll option for Swashbuckler's Panache-granting actions

### DIFF
--- a/packs/classfeatures/battledancer.json
+++ b/packs/classfeatures/battledancer.json
@@ -26,16 +26,6 @@
         },
         "rules": [
             {
-                "key": "FlatModifier",
-                "predicate": [
-                    "action:perform",
-                    "self:effect:panache"
-                ],
-                "selector": "performance",
-                "type": "circumstance",
-                "value": 1
-            },
-            {
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.prf.rank",
@@ -55,28 +45,20 @@
                     "criticalSuccess"
                 ],
                 "predicate": [
-                    "action:perform",
-                    {
-                        "not": "self:effect:panache"
-                    }
-                ],
-                "selector": "performance",
-                "text": "PF2E.SpecificRule.Swashbuckler.Panache",
-                "title": "{item|name}"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "success",
-                    "criticalSuccess"
-                ],
-                "predicate": [
                     "finisher",
                     "feature:exemplary-finisher"
                 ],
                 "selector": "strike-attack-roll",
                 "text": "PF2E.SpecificRule.ExemplaryFinisher.Battledancer",
                 "title": "PF2E.SpecificRule.ExemplaryFinisher.Name"
+            },
+            {
+                "key": "RollOption",
+                "option": "grants-panache",
+                "predicate": [
+                    "action:perform"
+                ],
+                "selector": "performance-check"
             }
         ],
         "traits": {

--- a/packs/classfeatures/braggart.json
+++ b/packs/classfeatures/braggart.json
@@ -26,16 +26,6 @@
         },
         "rules": [
             {
-                "key": "FlatModifier",
-                "predicate": [
-                    "action:demoralize",
-                    "self:effect:panache"
-                ],
-                "selector": "intimidation",
-                "type": "circumstance",
-                "value": 1
-            },
-            {
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.itm.rank",
@@ -51,28 +41,20 @@
                     "criticalSuccess"
                 ],
                 "predicate": [
-                    "action:demoralize",
-                    {
-                        "not": "self:effect:panache"
-                    }
-                ],
-                "selector": "intimidation",
-                "text": "PF2E.SpecificRule.Swashbuckler.Panache",
-                "title": "{item|name}"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "success",
-                    "criticalSuccess"
-                ],
-                "predicate": [
                     "finisher",
                     "feature:exemplary-finisher"
                 ],
                 "selector": "strike-attack-roll",
                 "text": "PF2E.SpecificRule.ExemplaryFinisher.Braggart",
                 "title": "PF2E.SpecificRule.ExemplaryFinisher.Name"
+            },
+            {
+                "key": "RollOption",
+                "option": "grants-panache",
+                "predicate": [
+                    "action:demoralize"
+                ],
+                "selector": "skill-check"
             }
         ],
         "traits": {

--- a/packs/classfeatures/fencer.json
+++ b/packs/classfeatures/fencer.json
@@ -26,21 +26,6 @@
         },
         "rules": [
             {
-                "key": "FlatModifier",
-                "predicate": [
-                    "self:effect:panache",
-                    {
-                        "or": [
-                            "action:feint",
-                            "action:create-a-diversion"
-                        ]
-                    }
-                ],
-                "selector": "deception",
-                "type": "circumstance",
-                "value": 1
-            },
-            {
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.dec.rank",
@@ -56,33 +41,25 @@
                     "criticalSuccess"
                 ],
                 "predicate": [
-                    {
-                        "or": [
-                            "action:feint",
-                            "action:create-a-diversion"
-                        ]
-                    },
-                    {
-                        "not": "self:effect:panache"
-                    }
-                ],
-                "selector": "deception",
-                "text": "PF2E.SpecificRule.Swashbuckler.Panache",
-                "title": "{item|name}"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "success",
-                    "criticalSuccess"
-                ],
-                "predicate": [
                     "finisher",
                     "feature:exemplary-finisher"
                 ],
                 "selector": "strike-attack-roll",
                 "text": "PF2E.SpecificRule.ExemplaryFinisher.Fencer",
                 "title": "PF2E.SpecificRule.ExemplaryFinisher.Name"
+            },
+            {
+                "key": "RollOption",
+                "option": "grants-panache",
+                "predicate": [
+                    {
+                        "or": [
+                            "action:create-a-diversion",
+                            "action:feint"
+                        ]
+                    }
+                ],
+                "selector": "skill-check"
             }
         ],
         "traits": {

--- a/packs/classfeatures/gymnast.json
+++ b/packs/classfeatures/gymnast.json
@@ -26,22 +26,6 @@
         },
         "rules": [
             {
-                "key": "FlatModifier",
-                "predicate": [
-                    "self:effect:panache",
-                    {
-                        "or": [
-                            "action:grapple",
-                            "action:shove",
-                            "action:trip"
-                        ]
-                    }
-                ],
-                "selector": "athletics",
-                "type": "circumstance",
-                "value": 1
-            },
-            {
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.ath.rank",
@@ -49,28 +33,6 @@
                     "class:swashbuckler"
                 ],
                 "value": 1
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "success",
-                    "criticalSuccess"
-                ],
-                "predicate": [
-                    {
-                        "or": [
-                            "action:grapple",
-                            "action:shove",
-                            "action:trip"
-                        ]
-                    },
-                    {
-                        "not": "self:effect:panache"
-                    }
-                ],
-                "selector": "athletics",
-                "text": "PF2E.SpecificRule.Swashbuckler.Panache",
-                "title": "{item|name}"
             },
             {
                 "hideIfDisabled": true,
@@ -90,6 +52,20 @@
                 "selector": "strike-damage",
                 "type": "circumstance",
                 "value": "2* @weapon.system.damage.dice"
+            },
+            {
+                "key": "RollOption",
+                "option": "grants-panache",
+                "predicate": [
+                    {
+                        "or": [
+                            "action:grapple",
+                            "action:shove",
+                            "action:trip"
+                        ]
+                    }
+                ],
+                "selector": "skill-check"
             }
         ],
         "traits": {

--- a/packs/classfeatures/panache.json
+++ b/packs/classfeatures/panache.json
@@ -32,14 +32,22 @@
                     "criticalSuccess"
                 ],
                 "predicate": [
-                    "action:tumble-through",
+                    "grants-panache",
                     {
                         "not": "self:effect:panache"
                     }
                 ],
-                "selector": "acrobatics",
+                "selector": "skill-check",
                 "text": "PF2E.SpecificRule.Swashbuckler.Panache",
                 "title": "{item|name}"
+            },
+            {
+                "key": "RollOption",
+                "option": "grants-panache",
+                "predicate": [
+                    "action:tumble-through"
+                ],
+                "selector": "skill-check"
             }
         ],
         "traits": {

--- a/packs/classfeatures/wit.json
+++ b/packs/classfeatures/wit.json
@@ -26,16 +26,6 @@
         },
         "rules": [
             {
-                "key": "FlatModifier",
-                "predicate": [
-                    "action:bon-mot",
-                    "self:effect:panache"
-                ],
-                "selector": "diplomacy",
-                "type": "circumstance",
-                "value": 1
-            },
-            {
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.dip.rank",
@@ -58,28 +48,20 @@
                     "criticalSuccess"
                 ],
                 "predicate": [
-                    "action:bon-mot",
-                    {
-                        "not": "self:effect:panache"
-                    }
-                ],
-                "selector": "diplomacy",
-                "text": "PF2E.SpecificRule.Swashbuckler.Panache",
-                "title": "{item|name}"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "success",
-                    "criticalSuccess"
-                ],
-                "predicate": [
                     "finisher",
                     "feature:exemplary-finisher"
                 ],
                 "selector": "strike-attack-roll",
                 "text": "PF2E.SpecificRule.ExemplaryFinisher.Wit",
                 "title": "PF2E.SpecificRule.ExemplaryFinisher.Name"
+            },
+            {
+                "key": "RollOption",
+                "option": "grants-panache",
+                "predicate": [
+                    "action:bon-mot"
+                ],
+                "selector": "skill-check"
             }
         ],
         "traits": {

--- a/packs/feat-effects/effect-panache.json
+++ b/packs/feat-effects/effect-panache.json
@@ -4,7 +4,7 @@
     "name": "Effect: Panache",
     "system": {
         "description": {
-            "value": "<p>You care as much about the way you accomplish something as whether you actually accomplish it in the first place. When you perform an action with particular bravado, you can leverage this moment of verve to perform spectacular, deadly maneuvers. This state of flair is called panache, and you are either in a state of panache or you are not.</p>\n<p>Granted by @UUID[Compendium.pf2e.classfeatures.Item.Panache]</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.classfeatures.Item.Panache]</p>\n<p>While you have panache, you gain a +5-foot status bonus to your Speeds and gain a +1 circumstance bonus to checks to Tumble Through or to take any actions that give you panache due to your style.</p>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -29,9 +29,9 @@
             {
                 "key": "FlatModifier",
                 "predicate": [
-                    "action:tumble-through"
+                    "grants-panache"
                 ],
-                "selector": "acrobatics",
+                "selector": "skill-check",
                 "type": "circumstance",
                 "value": 1
             },

--- a/packs/feats/derring-do.json
+++ b/packs/feats/derring-do.json
@@ -24,7 +24,17 @@
             "remaster": false,
             "title": "Pathfinder Advanced Player's Guide"
         },
-        "rules": [],
+        "rules": [
+            {
+                "keep": "higher",
+                "key": "RollTwice",
+                "predicate": [
+                    "panache",
+                    "grants-panache"
+                ],
+                "selector": "skill-check"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/derring-do.json
+++ b/packs/feats/derring-do.json
@@ -29,7 +29,7 @@
                 "keep": "higher",
                 "key": "RollTwice",
                 "predicate": [
-                    "panache",
+                    "self:effect:panache",
                     "grants-panache"
                 ],
                 "selector": "skill-check"


### PR DESCRIPTION
Makes things a bit cleaner, and hopefully easier for 3PP to add their own swashbuckler styles. I left feats out of this due to the way Panache and Derring-Do are worded:

Panache says
> gain a +1 circumstance bonus to checks to Tumble Through or to take any actions that give you panache due to your style

Derring-Do says
> you can roll twice and use the higher result on checks to which the circumstance bonus for having panache applies (Tumble Through and any skill actions listed in your swashbuckler's style).

Which implies that different ways to gain Panache (such as Leading Dance, One For All, and Disarming Flair) do not qualify for these benefits. For the sake of convenience, I think they're better off with their own Note for gaining Panache, if we add any. Thoughts?