### PR TITLE
Update Skittish to be defensive

### DIFF
--- a/packs/pfs-season-5-bestiary/giant-er-mouse.json
+++ b/packs/pfs-season-5-bestiary/giant-er-mouse.json
@@ -48,6 +48,35 @@
             "type": "melee"
         },
         {
+            "_id": "LPLANYYvsQkWsMkb",
+            "img": "systems/pf2e/icons/default-icons/action.svg",
+            "name": "Skittish",
+            "sort": 200000,
+            "system": {
+                "actionType": {
+                    "value": "reaction"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "defensive",
+                "description": {
+                    "value": "<p><strong>Trigger</strong> The giant-er mouse is hit with a melee attack</p>\n<hr />\n<p><strong>Effect</strong> The giant-er mouse takes a step after the effects of the triggering attack are resolved.</p>"
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "value": []
+                }
+            },
+            "type": "action"
+        },
+        {
             "_id": "V7WYb14ewhEEgVUz",
             "flags": {
                 "core": {
@@ -56,7 +85,7 @@
             },
             "img": "systems/pf2e/icons/actions/OneAction.webp",
             "name": "Grab",
-            "sort": 200000,
+            "sort": 300000,
             "system": {
                 "actionType": {
                     "value": "action"
@@ -77,35 +106,6 @@
                 "slug": "grab",
                 "traits": {
                     "rarity": "common",
-                    "value": []
-                }
-            },
-            "type": "action"
-        },
-        {
-            "_id": "LPLANYYvsQkWsMkb",
-            "img": "systems/pf2e/icons/default-icons/action.svg",
-            "name": "Skittish",
-            "sort": 300000,
-            "system": {
-                "actionType": {
-                    "value": "reaction"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": null,
-                "description": {
-                    "value": "<p><strong>Trigger</strong> The giant-er mouse is hit with a melee attack</p>\n<hr />\n<p><strong>Effect</strong> The giant-er mouse takes a step after the effects of the triggering attack are resolved.</p>"
-                },
-                "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
-                },
-                "rules": [],
-                "slug": null,
-                "traits": {
                     "value": []
                 }
             },

--- a/packs/pfs-season-5-bestiary/giant-mouse.json
+++ b/packs/pfs-season-5-bestiary/giant-mouse.json
@@ -56,7 +56,7 @@
                 "actions": {
                     "value": null
                 },
-                "category": null,
+                "category": "defensive",
                 "description": {
                     "value": "<p><strong>Trigger</strong> The giant mouse is hit with a melee attack</p>\n<hr />\n<p><strong>Effect</strong> The giant mouse takes a step after the effects of the triggering attack are resolved.</p>"
                 },

--- a/packs/pfs-season-5-bestiary/weak-giant-er-mouse.json
+++ b/packs/pfs-season-5-bestiary/weak-giant-er-mouse.json
@@ -48,6 +48,35 @@
             "type": "melee"
         },
         {
+            "_id": "LPLANYYvsQkWsMkb",
+            "img": "systems/pf2e/icons/default-icons/action.svg",
+            "name": "Skittish",
+            "sort": 200000,
+            "system": {
+                "actionType": {
+                    "value": "reaction"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "defensive",
+                "description": {
+                    "value": "<p><strong>Trigger</strong> The giant-er mouse is hit with a melee attack</p>\n<hr />\n<p><strong>Effect</strong> The giant-er mouse takes a step after the effects of the triggering attack are resolved.</p>"
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "value": []
+                }
+            },
+            "type": "action"
+        },
+        {
             "_id": "V7WYb14ewhEEgVUz",
             "flags": {
                 "core": {
@@ -56,7 +85,7 @@
             },
             "img": "systems/pf2e/icons/actions/OneAction.webp",
             "name": "Grab",
-            "sort": 200000,
+            "sort": 300000,
             "system": {
                 "actionType": {
                     "value": "action"
@@ -77,35 +106,6 @@
                 "slug": "grab",
                 "traits": {
                     "rarity": "common",
-                    "value": []
-                }
-            },
-            "type": "action"
-        },
-        {
-            "_id": "LPLANYYvsQkWsMkb",
-            "img": "systems/pf2e/icons/default-icons/action.svg",
-            "name": "Skittish",
-            "sort": 300000,
-            "system": {
-                "actionType": {
-                    "value": "reaction"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": null,
-                "description": {
-                    "value": "<p><strong>Trigger</strong> The giant-er mouse is hit with a melee attack</p>\n<hr />\n<p><strong>Effect</strong> The giant-er mouse takes a step after the effects of the triggering attack are resolved.</p>"
-                },
-                "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
-                },
-                "rules": [],
-                "slug": null,
-                "traits": {
                     "value": []
                 }
             },

--- a/packs/pfs-season-5-bestiary/weak-giant-mouse.json
+++ b/packs/pfs-season-5-bestiary/weak-giant-mouse.json
@@ -56,7 +56,7 @@
                 "actions": {
                     "value": null
                 },
-                "category": null,
+                "category": "defensive",
                 "description": {
                     "value": "<p><strong>Trigger</strong> The giant mouse is hit with a melee attack</p>\n<hr />\n<p><strong>Effect</strong> The giant mouse takes a step after the effects of the triggering attack are resolved.</p>"
                 },


### PR DESCRIPTION
I assume defensive is correct, as I don't have the PDF.
```
Warning in Weak Giant Mouse: Ability item "Skittish" has no category defined!
Warning in Weak Giant-er Mouse: Ability item "Skittish" has no category defined!
Warning in Giant Mouse: Ability item "Skittish" has no category defined!
Warning in Giant-er Mouse: Ability item "Skittish" has no category defined!
```