### PR TITLE
Add automation for the Resistance group of Familiar Abilities

### DIFF
--- a/packs/familiar-abilities/greater-resistance.json
+++ b/packs/familiar-abilities/greater-resistance.json
@@ -18,7 +18,18 @@
             "remaster": false,
             "title": "Pathfinder Lost Omens: The Grand Bazaar"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "Resistance",
+                "type": "{actor|flags.pf2e.resistance.resistanceOne}",
+                "value": "3 + floor(@actor.level/2)"
+            },
+            {
+                "key": "Resistance",
+                "type": "{actor|flags.pf2e.resistance.resistanceTwo}",
+                "value": "3 + floor(@actor.level/2)"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": []

--- a/packs/familiar-abilities/major-resistance.json
+++ b/packs/familiar-abilities/major-resistance.json
@@ -11,14 +11,25 @@
         },
         "category": "familiar",
         "description": {
-            "value": "<p>Your familiar increases the resistance it gains from its resistance familiar ability to a value equal to your level. To select this you must be at least 8th level.</p>"
+            "value": "<p>Your familiar increases the resistance it gains from its @UUID[Compendium.pf2e.familiar-abilities.Item.Resistance] familiar ability to a value equal to your level. To select this you must be at least 8th level.</p>"
         },
         "publication": {
             "license": "ORC",
             "remaster": true,
             "title": "Pathfinder Player Core"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "Resistance",
+                "type": "{actor|flags.pf2e.resistance.resistanceOne}",
+                "value": "@actor.level"
+            },
+            {
+                "key": "Resistance",
+                "type": "{actor|flags.pf2e.resistance.resistanceTwo}",
+                "value": "@actor.level"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": []

--- a/packs/familiar-abilities/resistance.json
+++ b/packs/familiar-abilities/resistance.json
@@ -48,7 +48,6 @@
                 ],
                 "flag": "resistanceOne",
                 "key": "ChoiceSet",
-                "priority": 50,
                 "prompt": "PF2E.SpecificRule.Prompt.Resistance",
                 "rollOption": "resistance"
             },
@@ -111,7 +110,6 @@
                 ],
                 "flag": "resistanceTwo",
                 "key": "ChoiceSet",
-                "priority": 60,
                 "prompt": "PF2E.SpecificRule.Prompt.Resistance",
                 "rollOption": "resistance"
             },
@@ -129,14 +127,12 @@
                 "key": "ActiveEffectLike",
                 "mode": "override",
                 "path": "flags.pf2e.resistance.resistanceOne",
-                "priority": 100,
                 "value": "{item|flags.pf2e.rulesSelections.resistanceOne}"
             },
             {
                 "key": "ActiveEffectLike",
                 "mode": "override",
                 "path": "flags.pf2e.resistance.resistanceTwo",
-                "priority": 100,
                 "value": "{item|flags.pf2e.rulesSelections.resistanceTwo}"
             }
         ],

--- a/packs/familiar-abilities/resistance.json
+++ b/packs/familiar-abilities/resistance.json
@@ -18,7 +18,128 @@
             "remaster": true,
             "title": "Pathfinder Player Core"
         },
-        "rules": [],
+        "rules": [
+            {
+                "choices": [
+                    {
+                        "label": "PF2E.TraitAcid",
+                        "value": "acid"
+                    },
+                    {
+                        "label": "PF2E.TraitCold",
+                        "value": "cold"
+                    },
+                    {
+                        "label": "PF2E.TraitElectricity",
+                        "value": "electricity"
+                    },
+                    {
+                        "label": "PF2E.TraitFire",
+                        "value": "fire"
+                    },
+                    {
+                        "label": "PF2E.TraitPoison",
+                        "value": "poison"
+                    },
+                    {
+                        "label": "PF2E.TraitSonic",
+                        "value": "sonic"
+                    }
+                ],
+                "flag": "resistanceOne",
+                "key": "ChoiceSet",
+                "priority": 50,
+                "prompt": "PF2E.SpecificRule.Prompt.Resistance",
+                "rollOption": "resistance"
+            },
+            {
+                "choices": [
+                    {
+                        "label": "PF2E.TraitAcid",
+                        "predicate": [
+                            {
+                                "not": "resistance:acid"
+                            }
+                        ],
+                        "value": "acid"
+                    },
+                    {
+                        "label": "PF2E.TraitCold",
+                        "predicate": [
+                            {
+                                "not": "resistance:cold"
+                            }
+                        ],
+                        "value": "cold"
+                    },
+                    {
+                        "label": "PF2E.TraitElectricity",
+                        "predicate": [
+                            {
+                                "not": "resistance:electricity"
+                            }
+                        ],
+                        "value": "electricity"
+                    },
+                    {
+                        "label": "PF2E.TraitFire",
+                        "predicate": [
+                            {
+                                "not": "resistance:fire"
+                            }
+                        ],
+                        "value": "fire"
+                    },
+                    {
+                        "label": "PF2E.TraitPoison",
+                        "predicate": [
+                            {
+                                "not": "resistance:poison"
+                            }
+                        ],
+                        "value": "poison"
+                    },
+                    {
+                        "label": "PF2E.TraitSonic",
+                        "predicate": [
+                            {
+                                "not": "resistance:sonic"
+                            }
+                        ],
+                        "value": "sonic"
+                    }
+                ],
+                "flag": "resistanceTwo",
+                "key": "ChoiceSet",
+                "priority": 60,
+                "prompt": "PF2E.SpecificRule.Prompt.Resistance",
+                "rollOption": "resistance"
+            },
+            {
+                "key": "Resistance",
+                "type": "{item|flags.pf2e.rulesSelections.resistanceOne}",
+                "value": "max(1,floor(@actor.level/2))"
+            },
+            {
+                "key": "Resistance",
+                "type": "{item|flags.pf2e.rulesSelections.resistanceTwo}",
+                "value": "max(1,floor(@actor.level/2))"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.resistance.resistanceOne",
+                "priority": 100,
+                "value": "{item|flags.pf2e.rulesSelections.resistanceOne}"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.resistance.resistanceTwo",
+                "priority": 100,
+                "value": "{item|flags.pf2e.rulesSelections.resistanceTwo}"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": []


### PR DESCRIPTION
The rule elements for the base `Resistance` ability are a bit clunky but it gets the job done and allows for the upgrades from the other two abilities.

Happy for some tips if there's a more succinct way to do the same though.