### PR TITLE
Add `target` property to SimpleRollActionCheck options that accepts Token or Actor

### DIFF
--- a/src/module/actor/actions/single-check.ts
+++ b/src/module/actor/actions/single-check.ts
@@ -1,4 +1,4 @@
-import type { ActorPF2e } from "@actor";
+import { ActorPF2e } from "@actor";
 import { ModifierPF2e, RawModifier, StatisticModifier } from "@actor/modifiers.ts";
 import { DCSlug } from "@actor/types.ts";
 import { DC_SLUGS } from "@actor/values.ts";
@@ -16,6 +16,7 @@ import { CheckDC } from "@system/degree-of-success.ts";
 import { getActionGlyph, isObject, setHasElement } from "@util";
 import { BaseAction, BaseActionData, BaseActionVariant, BaseActionVariantData } from "./base.ts";
 import { ActionUseOptions } from "./types.ts";
+import { TokenPF2e } from "@module/canvas/index.ts";
 
 type SingleCheckActionRollNoteData = Omit<RollNoteSource, "selector"> & { selector?: string };
 function toRollNoteSource(data: SingleCheckActionRollNoteData): RollNoteSource {
@@ -155,6 +156,16 @@ class SingleCheckActionVariant extends BaseActionVariant {
                     note.selector ||= selector; // treat empty selectors as always applicable to this check
                     return note;
                 }),
+            target: () => {
+                if (options.target instanceof ActorPF2e) {
+                    return { token: null, actor: options.target };
+                } else if (options.target instanceof TokenPF2e) {
+                    return options.target.actor
+                        ? { token: options.target.document, actor: options.target.actor }
+                        : null;
+                }
+                return null;
+            },
             traits: this.traits.concat(options?.traits ?? []),
         });
 

--- a/src/module/actor/actions/types.ts
+++ b/src/module/actor/actions/types.ts
@@ -1,4 +1,5 @@
 import type { ActorPF2e } from "@actor";
+import type { TokenPF2e } from "@module/canvas/index.ts";
 import type { ChatMessagePF2e } from "@module/chat-message/document.ts";
 import type { ActionTrait } from "@item/ability/index.ts";
 import { ProficiencyRank } from "@item/base/data/index.ts";
@@ -19,6 +20,7 @@ interface ActionVariantUseOptions extends Record<string, unknown> {
     actors: ActorPF2e | ActorPF2e[];
     event: Event;
     traits: ActionTrait[];
+    target: ActorPF2e | TokenPF2e;
 }
 
 interface ActionVariant {

--- a/src/module/system/action-macros/types.ts
+++ b/src/module/system/action-macros/types.ts
@@ -86,7 +86,7 @@ interface SimpleRollActionCheckOptions<ItemType extends ItemPF2e<ActorPF2e>> {
     createMessage?: boolean;
     weaponTrait?: WeaponTrait;
     weaponTraitWithPenalty?: WeaponTrait;
-    target?: () => { token: TokenDocumentPF2e; actor: ActorPF2e } | null;
+    target?: () => { token: TokenDocumentPF2e | null; actor: ActorPF2e } | null;
 }
 
 type UnresolvedCheckDC = CheckDC | DCSlug | ((actor: ActorPF2e | null) => CheckDC | null);


### PR DESCRIPTION
The proposed change allows calling `action.use({target:token})` or `action.use({target:token.action})` and use the passed value instead of picking the first user target.

When called with an actor, the assumption is that the caller doesn't care about a specific token.

The intended use case is to call this from a macro or a module and utilize the system action checks and modifiers.