### PR TITLE
Add inline spell attack rolls to Shadow Signet

### DIFF
--- a/packs/equipment/shadow-signet.json
+++ b/packs/equipment/shadow-signet.json
@@ -9,7 +9,7 @@
         },
         "containerId": "null",
         "description": {
-            "value": "<p>This obsidian ring allows you to partially warp your spells through the Shadow Plane, allowing them to strike directly at a target's body.</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">f</span> (concentrate, spellshape)</p>\n<hr />\n<p><strong>Effect</strong> If your next action is to Cast a Spell that requires a spell attack roll against Armor Class, choose Fortitude DC or Reflex DC. You make your spell attack roll against that defense instead of AC. If the spell has multiple targets, the choice of DC applies to all of them.</p>"
+            "value": "<p>This obsidian ring allows you to partially warp your spells through the Shadow Plane, allowing them to strike directly at a target's body.</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">f</span> (concentrate, spellshape)</p>\n<hr />\n<p><strong>Effect</strong> If your next action is to Cast a Spell that requires a spell attack roll against Armor Class, choose @Check[type:spell-attack|defense:fortitude]{Fortitude DC} or @Check[type:spell-attack|defense:reflex]{Reflex DC}. You make your spell attack roll against that defense instead of AC. If the spell has multiple targets, the choice of DC applies to all of them.</p>"
         },
         "hardness": 0,
         "hp": {


### PR DESCRIPTION
I'm sure the system is doing something more elegant in the future, but in the meantime I think this is a decent stopgap.