### PR TITLE
Remove structured blindsight from Xotani, The Firebleeder as it's not supported

### DIFF
--- a/packs/age-of-ashes-bestiary/xotani-the-firebleeder.json
+++ b/packs/age-of-ashes-bestiary/xotani-the-firebleeder.json
@@ -725,14 +725,9 @@
             "statistic": "perception"
         },
         "perception": {
-            "details": "",
+            "details": "blindsight (precise) 120 feet",
             "mod": 39,
             "senses": [
-                {
-                    "acuity": "precise",
-                    "range": 120,
-                    "type": "blindsight"
-                },
                 {
                     "type": "darkvision"
                 }


### PR DESCRIPTION
Was added by https://github.com/foundryvtt/pf2e/pull/13087