### PR TITLE
Remove colored border on disabled `Cast` buttons in spellcasting entries

### DIFF
--- a/src/styles/actor/_spell-collection.scss
+++ b/src/styles/actor/_spell-collection.scss
@@ -28,6 +28,7 @@ ol.spell-list {
 
             button.cast-spell {
                 background: var(--color-disabled);
+                border-color: transparent;
                 box-shadow: inset 0 0 0 1px rgba(white, 0.5);
                 cursor: not-allowed;
 


### PR DESCRIPTION
The border remaining blue kinda looks deceptively like a lingering selection highlight IMO.

![spell-cast-button](https://github.com/foundryvtt/pf2e/assets/4469633/37c86557-2d00-4428-a816-8d4d58d5e0a3)
