### PR TITLE
Add defense column to spells tab

### DIFF
--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -56,7 +56,7 @@ import {
     SpellSystemData,
     SpellSystemSource,
 } from "./data.ts";
-import { createDescriptionPrepend, createSpellRankLabel } from "./helpers.ts";
+import { createDescriptionPrepend, createSpellRankLabel, getPassiveDefenseLabel } from "./helpers.ts";
 import { SpellOverlayCollection } from "./overlay.ts";
 import { EffectAreaSize, MagicTradition, SpellTrait } from "./types.ts";
 
@@ -131,6 +131,23 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
     get actionGlyph(): string | null {
         if (this.isRitual) return null;
         return getActionGlyph(this.system.time.value) || null;
+    }
+
+    get defense(): { slug: string; label: string } | null {
+        const defense = this.system.defense;
+        if (defense?.passive) {
+            const label = getPassiveDefenseLabel(defense.passive.statistic);
+            if (label) {
+                return { slug: defense.passive.statistic, label: game.i18n.localize(label) };
+            }
+        } else if (defense?.save) {
+            return {
+                slug: defense.save.statistic,
+                label: game.i18n.localize(CONFIG.PF2E.saves[defense.save.statistic]),
+            };
+        }
+
+        return null;
     }
 
     get spellcasting(): BaseSpellcastingEntry<NonNullable<TParent>> | null {

--- a/src/module/item/spell/helpers.ts
+++ b/src/module/item/spell/helpers.ts
@@ -39,4 +39,19 @@ async function createDescriptionPrepend(
     return rendered ? `${rendered}\n<hr />` : "";
 }
 
-export { createDescriptionPrepend, createSpellRankLabel };
+function getPassiveDefenseLabel(statistic: string): string | null {
+    switch (statistic) {
+        case "ac":
+            return "PF2E.Check.DC.Specific.armor";
+        case "fortitude-dc":
+            return "PF2E.Check.DC.Specific.fortitude";
+        case "reflex-dc":
+            return "PF2E.Check.DC.Specific.reflex";
+        case "will-dc":
+            return "PF2E.Check.DC.Specific.will";
+        default:
+            return null;
+    }
+}
+
+export { createDescriptionPrepend, createSpellRankLabel, getPassiveDefenseLabel };

--- a/src/module/item/spell/sheet.ts
+++ b/src/module/item/spell/sheet.ts
@@ -17,7 +17,7 @@ import {
     tupleHasValue,
 } from "@util";
 import * as R from "remeda";
-import { createDescriptionPrepend, createSpellRankLabel } from "./helpers.ts";
+import { createDescriptionPrepend, createSpellRankLabel, getPassiveDefenseLabel } from "./helpers.ts";
 import type {
     SpellDamageSource,
     SpellHeighteningInterval,
@@ -74,22 +74,6 @@ export class SpellSheetPF2e extends ItemSheetPF2e<SpellPF2e> {
             }))
             .sort((a, b) => a.sort - b.sort);
 
-        const passiveDefense = ((): string | null => {
-            const statistic = spell.system.defense?.passive?.statistic;
-            switch (statistic) {
-                case "ac":
-                    return "PF2E.Check.DC.Specific.armor";
-                case "fortitude-dc":
-                    return "PF2E.Check.DC.Specific.fortitude";
-                case "reflex-dc":
-                    return "PF2E.Check.DC.Specific.reflex";
-                case "will-dc":
-                    return "PF2E.Check.DC.Specific.will";
-                default:
-                    return null;
-            }
-        })();
-
         const damageKinds = R.mapValues(spell.system.damage, (damage, id) => {
             const healingDisabled = !["vitality", "void", "untyped"].includes(damage.type) || !!damage.category;
             const currentKinds = Array.from(spell.system.damage[id].kinds);
@@ -118,7 +102,7 @@ export class SpellSheetPF2e extends ItemSheetPF2e<SpellPF2e> {
         return {
             ...sheetData,
             itemType: createSpellRankLabel(this.item),
-            passiveDefense,
+            passiveDefense: getPassiveDefenseLabel(spell.system.defense?.passive?.statistic ?? ""),
             variants,
             isVariant: this.item.isVariant,
             damageTypes: sortStringRecord(CONFIG.PF2E.damageTypes),

--- a/src/styles/actor/_spell-collection.scss
+++ b/src/styles/actor/_spell-collection.scss
@@ -11,31 +11,13 @@ ol.spell-list {
         align-items: center;
         display: grid;
         gap: var(--space-8);
-        grid-template-columns: 52.5% auto fit-content(5rem) 3rem;
+        grid-template-columns: 1fr 3.75rem 5rem min-content 3rem;
         margin: 0;
 
         > * {
             align-items: center;
             display: flex;
             flex-wrap: nowrap;
-        }
-
-        &[data-slot-expended] {
-            h4 {
-                color: var(--color-disabled);
-                text-decoration: line-through;
-            }
-
-            button.cast-spell {
-                background: var(--color-disabled);
-                border-color: transparent;
-                box-shadow: inset 0 0 0 1px rgba(white, 0.5);
-                cursor: not-allowed;
-
-                &:hover {
-                    text-shadow: none;
-                }
-            }
         }
 
         &:nth-child(odd) {
@@ -80,8 +62,8 @@ ol.spell-list {
                 }
             }
 
-            .range-uses {
-                grid-column: span 2;
+            .invisible {
+                visibility: hidden;
             }
 
             .item-controls {
@@ -121,16 +103,28 @@ ol.spell-list {
             font-size: var(--font-size-13);
             padding: var(--space-3) var(--space-4);
 
+            &[data-slot-expended] {
+                h4 {
+                    color: var(--color-disabled);
+                    text-decoration: line-through;
+                }
+
+                button.cast-spell {
+                    background: var(--color-disabled);
+                    border-color: transparent;
+                    box-shadow: inset 0 0 0 1px rgba(white, 0.5);
+                    cursor: not-allowed;
+
+                    &:hover {
+                        text-shadow: none;
+                    }
+                }
+            }
+
             // The lighter background gives an illusion of larger padding: tweak slightly
             &:nth-child(even) {
                 padding: var(--space-2) var(--space-4);
             }
-        }
-
-        .level-prepared-toggle {
-            flex: 0;
-            font-size: var(--space-12);
-            color: var(--color-pf-secondary);
         }
 
         .item-name {
@@ -210,7 +204,7 @@ ol.spell-list {
             border-bottom: 1px solid var(--sub);
             border-top: 1px solid lighten($sub-color, 30);
             display: block;
-            grid-column: span 4;
+            grid-column: span 5;
             padding: var(--space-4) 0 var(--space-8);
         }
     }

--- a/src/styles/actor/_spell-preparation.scss
+++ b/src/styles/actor/_spell-preparation.scss
@@ -47,7 +47,7 @@
         }
 
         ol.spell-list > li {
-            grid-template-columns: 70% 1fr 3rem;
+            grid-template-columns: 1fr 3.75rem 4rem 3rem;
 
             .item-name .item-image {
                 display: flex;

--- a/static/templates/actors/partials/spell-collection.hbs
+++ b/static/templates/actors/partials/spell-collection.hbs
@@ -69,6 +69,10 @@
                         {{/if}}
                     </div>
 
+                    <div class="defense">
+                        {{localize "PF2E.Item.Spell.Defense.Label"}}
+                    </div>
+
                     <div class="range-uses">
                         {{~#if entry.isInnate~}}
                             {{localize "PF2E.SpellUsesLabel"}}
@@ -78,6 +82,9 @@
                     </div>
 
                     {{#if @root.editable}}
+                        {{!-- This button will get removed by the stylesheet, and only exists for sizing reasons (localization) --}}
+                        <button type="button" class="cast-spell blue invisible">{{localize "PF2E.Item.Spell.Cast"}}</button>
+
                         <div class="item-controls">
                             {{#unless entry.isPrepared}}
                                 <a
@@ -123,6 +130,8 @@
                                     {{{actionGlyph spell.system.time.value}}}
                                 </h4>
                             </div>
+
+                            <div class="defense">{{spell.defense.label}}</div>
 
                             <div class="range-uses">
                                 {{!-- Innate spells replace range for uses --}}

--- a/static/templates/actors/spell-preparation-sheet.hbs
+++ b/static/templates/actors/spell-preparation-sheet.hbs
@@ -54,6 +54,10 @@
                             </h3>
                         </div>
 
+                        <div class="defense">
+                            {{localize "PF2E.Item.Spell.Defense.Label"}}
+                        </div>
+
                         <div class="spell-range">{{localize "PF2E.SpellRangeLabel"}}</div>
                         {{#if @root.editable}}
                             <div class="item-controls">
@@ -89,6 +93,8 @@
                                     {{{actionGlyph spell.system.time.value}}}
                                 </h4>
                             </div>
+
+                            <div class="defense">{{spell.defense.label}}</div>
 
                             <div class="spell-range">{{spell.system.range.value}}</div>
 


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/12910

![image](https://github.com/foundryvtt/pf2e/assets/1286721/5b4c7b17-7df0-48f6-a954-c9cc2661d168)

![image](https://github.com/foundryvtt/pf2e/assets/1286721/80ad65c7-3ff7-48b7-abe7-7276f2701b05)

Big cast buttons still work in Russian, though the solution is a little cursed. We can introduce localization specific CSS variables instead if you prefer. Another solution is to make it part of the range cell, and right align the cast button.

![image](https://github.com/foundryvtt/pf2e/assets/1286721/4bd38db1-4e79-4067-95f3-025eb7e215a2)
