### PR TITLE
Add GrantItem REs and Feat links in some Backgrounds

### DIFF
--- a/packs/backgrounds/bookish-providence.json
+++ b/packs/backgrounds/bookish-providence.json
@@ -36,7 +36,13 @@
             "remaster": false,
             "title": "Pathfinder: Stolen Fate Player's Guide"
         },
-        "rules": [],
+        "rules": [
+            {
+                "allowDuplicate": false,
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.actionspf2e.Item.Recall Under Pressure"
+            }
+        ],
         "trainedLore": "",
         "trainedSkills": {
             "value": []

--- a/packs/backgrounds/chosen-one.json
+++ b/packs/backgrounds/chosen-one.json
@@ -22,7 +22,7 @@
             }
         },
         "description": {
-            "value": "<p>Your birth has fulfilled a prediction, and people close to you are counting on you to do great things. There's intense pressure on you to be up to the task, and the fickle nature of prophecy complicates your path.</p>\n<p>Choose two ability boosts. One must be to <strong>Strength</strong> or <strong>Charisma</strong>, and one is a free ability boost.</p>\n<p>Decide with your GM the basics of the prophecy in which you're meant to play a major part. You're trained in one skill related to the prophecy, and the Fortune-Telling Lore skill. You gain the Prophecy's Pawn free action.</p>\n<hr />\n<p><em>Note: You must select the skill manually and add the Prophecy's Pawn action</em></p>"
+            "value": "<p>Your birth has fulfilled a prediction, and people close to you are counting on you to do great things. There's intense pressure on you to be up to the task, and the fickle nature of prophecy complicates your path.</p>\n<p>Choose two ability boosts. One must be to <strong>Strength</strong> or <strong>Charisma</strong>, and one is a free ability boost.</p>\n<p>Decide with your GM the basics of the prophecy in which you're meant to play a major part. You're trained in one skill related to the prophecy, and the Fortune-Telling Lore skill. You gain the @UUID[Compendium.pf2e.actionspf2e.Item.Prophecy's Pawn] free action.</p>\n<hr />\n<p><em>Note: You must select the skill manually and add the Prophecy's Pawn action</em></p>"
         },
         "items": {},
         "publication": {
@@ -30,7 +30,13 @@
             "remaster": false,
             "title": "Pathfinder Secrets of Magic"
         },
-        "rules": [],
+        "rules": [
+            {
+                "allowDuplicate": false,
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.actionspf2e.Item.Prophecy's Pawn"
+            }
+        ],
         "trainedLore": "Fortune-Telling Lore",
         "trainedSkills": {
             "value": []

--- a/packs/backgrounds/free-spirit.json
+++ b/packs/backgrounds/free-spirit.json
@@ -22,7 +22,7 @@
             }
         },
         "description": {
-            "value": "<p>You've always lived your life straying from the path laid before you. Like a leaf blowing in the wind, your journey takes you where it will, providing you with a lifestyle free from the bonds of expectation. While you might have friends and family in specific towns or cities, you've chosen not to put down roots in favor of going wherever—and doing whatever—you want.</p>\n<p>Choose two ability boosts. One must be to <strong>Wisdom</strong> or <strong>Charisma</strong>, and one is a free ability boost.</p>\n<p>You are trained in the Survival skill and a Lore skill about a specific settlement or terrain you have traveled through. You gain the Forager skill feat.</p>"
+            "value": "<p>You've always lived your life straying from the path laid before you. Like a leaf blowing in the wind, your journey takes you where it will, providing you with a lifestyle free from the bonds of expectation. While you might have friends and family in specific towns or cities, you've chosen not to put down roots in favor of going wherever—and doing whatever—you want.</p>\n<p>Choose two ability boosts. One must be to <strong>Wisdom</strong> or <strong>Charisma</strong>, and one is a free ability boost.</p>\n<p>You are trained in the Survival skill and a Lore skill about a specific settlement or terrain you have traveled through. You gain the @UUID[Compendium.pf2e.feats-srd.Item.Forager] skill feat.</p>"
         },
         "items": {
             "OzGrH": {

--- a/packs/backgrounds/genie-blessed.json
+++ b/packs/backgrounds/genie-blessed.json
@@ -21,7 +21,7 @@
             }
         },
         "description": {
-            "value": "<p>You've sought out a powerful genie and requested their blessing, hoping to increase your fortune. Your wish was vague, but fortune and the genie favored you with a more powerful effect than an ordinary wish, granting you bits of wish-twisted luck throughout the rest of your life. Meanwhile, other genies of the same kind recognize you as one blessed by one of their most powerful nobles, and might treat you with greater respect or envy.</p>\n<p>Choose two ability boosts. One must be to <strong>Charisma</strong>, and one is a free ability boost.</p>\n<p>You're trained in the Diplomacy skill and the Genie Lore skill. You gain the Wish for Luck free action.</p>\n<hr />\n<p><em>Note: You must add the Wish for Luck free action</em></p>"
+            "value": "<p>You've sought out a powerful genie and requested their blessing, hoping to increase your fortune. Your wish was vague, but fortune and the genie favored you with a more powerful effect than an ordinary wish, granting you bits of wish-twisted luck throughout the rest of your life. Meanwhile, other genies of the same kind recognize you as one blessed by one of their most powerful nobles, and might treat you with greater respect or envy.</p>\n<p>Choose two ability boosts. One must be to <strong>Charisma</strong>, and one is a free ability boost.</p>\n<p>You're trained in the Diplomacy skill and the Genie Lore skill. You gain the @UUID[Compendium.pf2e.actionspf2e.Item.Wish for Luck] free action.</p>"
         },
         "items": {},
         "publication": {
@@ -29,7 +29,13 @@
             "remaster": false,
             "title": "Pathfinder Secrets of Magic"
         },
-        "rules": [],
+        "rules": [
+            {
+                "allowDuplicate": false,
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.actionspf2e.Item.Wish for Luck"
+            }
+        ],
         "trainedLore": "Genie Lore",
         "trainedSkills": {
             "custom": "",

--- a/packs/backgrounds/hammered-by-fate.json
+++ b/packs/backgrounds/hammered-by-fate.json
@@ -36,7 +36,13 @@
             "remaster": false,
             "title": "Pathfinder: Stolen Fate Player's Guide"
         },
-        "rules": [],
+        "rules": [
+            {
+                "allowDuplicate": false,
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.actionspf2e.Item.Harrow the Fiend"
+            }
+        ],
         "trainedLore": "",
         "trainedSkills": {
             "value": []

--- a/packs/backgrounds/keys-to-destiny.json
+++ b/packs/backgrounds/keys-to-destiny.json
@@ -36,7 +36,13 @@
             "remaster": false,
             "title": "Pathfinder: Stolen Fate Player's Guide"
         },
-        "rules": [],
+        "rules": [
+            {
+                "allowDuplicate": false,
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.actionspf2e.Item.Lucky Break"
+            }
+        ],
         "trainedLore": "",
         "trainedSkills": {
             "value": []

--- a/packs/backgrounds/pathfinder-recruiter.json
+++ b/packs/backgrounds/pathfinder-recruiter.json
@@ -22,7 +22,7 @@
             }
         },
         "description": {
-            "value": "<p>The Pathfinder Society's always on the lookout for talent, but that talent rarely just stumbles into the Grand Lodge. Whether you're professionally trained to encourage new recruits or the Society's own scouts identified your potential and raised you from childhood, you're committed to expanding the Society's roster.</p>\n<p>Choose two ability boosts. One must be to <strong>Wisdom</strong> or <strong>Charisma</strong>, and one is a free ability boost.</p>\n<p>You're trained in the Diplomacy skill and a Lore skill related to one city you've visited often. You gain the Group Impression skill feat.</p>"
+            "value": "<p>The Pathfinder Society's always on the lookout for talent, but that talent rarely just stumbles into the Grand Lodge. Whether you're professionally trained to encourage new recruits or the Society's own scouts identified your potential and raised you from childhood, you're committed to expanding the Society's roster.</p>\n<p>Choose two ability boosts. One must be to <strong>Wisdom</strong> or <strong>Charisma</strong>, and one is a free ability boost.</p>\n<p>You're trained in the Diplomacy skill and a Lore skill related to one city you've visited often. You gain the @UUID[Compendium.pf2e.feats-srd.Item.Group Impression] skill feat.</p>"
         },
         "items": {
             "2dltm": {

--- a/packs/backgrounds/runner.json
+++ b/packs/backgrounds/runner.json
@@ -22,7 +22,7 @@
             }
         },
         "description": {
-            "value": "<p>You served as a messenger for a specific faction, guild, house, or individual, often running those messages on a short timeline. Finding the quickest path from point A to point B is your specialty and you've learned to make the most of your athleticism and navigational skill.</p>\n<p>Choose two ability boosts. One must be to <strong>Strength</strong> or <strong>Intelligence</strong>, and one is a free ability boost.</p>\n<p>You are trained in the Athletics skill and a Lore skill for the city in which you were a messenger. You gain the Quick Jump skill feat.</p>"
+            "value": "<p>You served as a messenger for a specific faction, guild, house, or individual, often running those messages on a short timeline. Finding the quickest path from point A to point B is your specialty and you've learned to make the most of your athleticism and navigational skill.</p>\n<p>Choose two ability boosts. One must be to <strong>Strength</strong> or <strong>Intelligence</strong>, and one is a free ability boost.</p>\n<p>You are trained in the Athletics skill and a Lore skill for the city in which you were a messenger. You gain the @UUID[Compendium.pf2e.feats-srd.Item.Quick Jump] skill feat.</p>"
         },
         "items": {
             "imRX1": {

--- a/packs/backgrounds/shielded-fortune.json
+++ b/packs/backgrounds/shielded-fortune.json
@@ -29,7 +29,18 @@
             "remaster": false,
             "title": "Pathfinder: Stolen Fate Player's Guide"
         },
-        "rules": [],
+        "rules": [
+            {
+                "allowDuplicate": false,
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.feats-srd.Item.Toughness"
+            },
+            {
+                "allowDuplicate": false,
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.actionspf2e.Item.Fated Not to Die"
+            }
+        ],
         "trainedLore": "",
         "trainedSkills": {
             "value": []

--- a/packs/backgrounds/sun-dancer.json
+++ b/packs/backgrounds/sun-dancer.json
@@ -22,7 +22,7 @@
             }
         },
         "description": {
-            "value": "<p>You've been taught the Burning Mother's blessings could be invited through dances done under its presence, such as in welcoming the first rays of warmth in the spring. You could have been the apprentice of some primal caster who wished to harness the sun's power for their incantations or lived in a community who reveres the Daughter of the Cosmic Caravan through displays of veneration for the sun. Whatever the case, you developed a supernatural connection to the sun.</p>\n<p>Choose two ability boosts. One must be to Charisma or Dexterity, and one is a free ability boost.</p>\n<p>You're trained in Performance. You gain the Fascinating Performance skill feat. If you use this feat outdoors in direct sunlight, you gain a +1 circumstance bonus to the skill check.</p>"
+            "value": "<p>You've been taught the Burning Mother's blessings could be invited through dances done under its presence, such as in welcoming the first rays of warmth in the spring. You could have been the apprentice of some primal caster who wished to harness the sun's power for their incantations or lived in a community who reveres the Daughter of the Cosmic Caravan through displays of veneration for the sun. Whatever the case, you developed a supernatural connection to the sun.</p>\n<p>Choose two ability boosts. One must be to Charisma or Dexterity, and one is a free ability boost.</p>\n<p>You're trained in Performance. You gain the @UUID[Compendium.pf2e.feats-srd.Item.Fascinating Performance] skill feat. If you use this feat outdoors in direct sunlight, you gain a +1 circumstance bonus to the skill check.</p>"
         },
         "items": {
             "CC8hhkrq4zPv6VWG": {

--- a/packs/backgrounds/thrill-seeker.json
+++ b/packs/backgrounds/thrill-seeker.json
@@ -22,7 +22,7 @@
             }
         },
         "description": {
-            "value": "<p>You once survived a life-or-death situation and found it surprisingly exhilarating, so now you chase that feeling of invincibility you only get when dancing with death. Your desire for exhilaration has you scaling buildings, leaping off rooftops, jumping chasms, and performing other deathdefying stunts.</p>\n<p>Choose two ability boosts. One must be to <strong>Strength</strong> or <strong>Constitution</strong>, and one is a free ability boost.</p>\n<p>You are trained in the Athletics skill and the Engineering Lore skill. You gain the Combat Climber skill feat.</p>"
+            "value": "<p>You once survived a life-or-death situation and found it surprisingly exhilarating, so now you chase that feeling of invincibility you only get when dancing with death. Your desire for exhilaration has you scaling buildings, leaping off rooftops, jumping chasms, and performing other deathdefying stunts.</p>\n<p>Choose two ability boosts. One must be to <strong>Strength</strong> or <strong>Constitution</strong>, and one is a free ability boost.</p>\n<p>You are trained in the Athletics skill and the Engineering Lore skill. You gain the @UUID[Compendium.pf2e.feats-srd.Item.Combat Climber] skill feat.</p>"
         },
         "items": {
             "OciPK": {

--- a/packs/backgrounds/unremarkable.json
+++ b/packs/backgrounds/unremarkable.json
@@ -22,7 +22,7 @@
             }
         },
         "description": {
-            "value": "<p>Your face is particularly unremarkable, even if your presence or actions may not be. You know how to use this to your advantage, making it difficult for people to identify and collect information about you.</p>\n<p>Choose two ability boosts. One must be to <strong>Wisdom</strong> or <strong>Charisma</strong>, and one is a free ability boost.</p>\n<p>You are trained in the Deception skill and the Acting Lore skill. You gain the Lengthy Diversion skill feat.</p>"
+            "value": "<p>Your face is particularly unremarkable, even if your presence or actions may not be. You know how to use this to your advantage, making it difficult for people to identify and collect information about you.</p>\n<p>Choose two ability boosts. One must be to <strong>Wisdom</strong> or <strong>Charisma</strong>, and one is a free ability boost.</p>\n<p>You are trained in the Deception skill and the Acting Lore skill. You gain the @UUID[Compendium.pf2e.feats-srd.Item.Lengthy Diversion] skill feat.</p>"
         },
         "items": {
             "8ocYQ": {

--- a/packs/backgrounds/writ-in-the-stars.json
+++ b/packs/backgrounds/writ-in-the-stars.json
@@ -36,7 +36,13 @@
             "remaster": false,
             "title": "Pathfinder: Stolen Fate Player's Guide"
         },
-        "rules": [],
+        "rules": [
+            {
+                "allowDuplicate": false,
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.actionspf2e.Item.A Quick Glimpse Beyond"
+            }
+        ],
         "trainedLore": "Fortune-Telling Lore",
         "trainedSkills": {
             "value": []


### PR DESCRIPTION
A pass over Backgrounds to grant the appropriate feats and actions, along with adding missing links to Feats in the text.