### PR TITLE
Brush up Shillelagh's spell effect

### DIFF
--- a/packs/spell-effects/spell-effect-shillelagh.json
+++ b/packs/spell-effects/spell-effect-shillelagh.json
@@ -24,13 +24,21 @@
             {
                 "choices": {
                     "ownedItems": true,
+                    "predicate": [
+                        {
+                            "or": [
+                                "item:group:club",
+                                "item:group:staff"
+                            ]
+                        }
+                    ],
                     "types": [
                         "weapon"
                     ]
                 },
                 "flag": "spellEffectShillelagh",
                 "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.Prompt.Weapon"
+                "prompt": "PF2E.SpecificRule.Prompt.Shillelagh"
             },
             {
                 "key": "WeaponPotency",
@@ -39,25 +47,24 @@
             },
             {
                 "key": "Striking",
-                "label": "Shillelagh",
                 "selector": "{item|flags.pf2e.rulesSelections.spellEffectShillelagh}-damage",
                 "value": 1
             },
             {
                 "domain": "all",
                 "key": "RollOption",
-                "label": "Get third damage die from Shillelagh",
+                "label": "PF2E.SpecificRule.Shillelagh.RollOptionLabel",
                 "option": "shillelagh-third-die",
                 "toggleable": true
             },
             {
-                "key": "Striking",
-                "label": "Shillelagh bonus damage",
+                "diceNumber": 1,
+                "key": "DamageDice",
+                "label": "PF2E.SpecificRule.Shillelagh.DamageDiceLabel",
                 "predicate": [
                     "shillelagh-third-die"
                 ],
-                "selector": "{item|flags.pf2e.rulesSelections.spellEffectShillelagh}-damage",
-                "value": 2
+                "selector": "{item|flags.pf2e.rulesSelections.spellEffectShillelagh}-damage"
             }
         ],
         "start": {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2893,6 +2893,10 @@
             "ShadowSignet": {
                 "Note": "If your next action is to Cast a Spell that requires a spell attack roll against Armor Class, choose Fortitude DC or Reflex DC. You make your spell attack roll against that defense instead of AC."
             },
+            "Shillelagh": {
+                "RollOptionLabel": "Increase Shillelagh's damage dice to 3",
+                "DamageDiceLabel": "Shillelagh (increased damage)"
+            },
             "Shisk": {
                 "PiercingQuills": {
                     "Note": "Your quills unarmed attack deals @Localize[PF2E.PersistentDamage.Bleed1d4.success] on a critical hit."


### PR DESCRIPTION
Made the predicate more specific, localised the labels, and made the bonus damage die a Damage Dice rule element instead of a Striking one, since the spell doesn't technically mention the weapon becoming Greater Striking.