### PR TITLE
Add automation for Erraticannon damage

### DIFF
--- a/packs/equipment-effects/effect-erraticannon-extra.json
+++ b/packs/equipment-effects/effect-erraticannon-extra.json
@@ -1,0 +1,133 @@
+{
+    "_id": "IURDAutTgGTKW1ks",
+    "img": "systems/pf2e/icons/equipment/weapons/specific-magic-weapons/erraticannon.webp",
+    "name": "Effect: Erraticannon (Extra)",
+    "system": {
+        "badge": {
+            "evaluate": true,
+            "labels": [
+                "Acid",
+                "Cold",
+                "Electricity",
+                "Fire",
+                "Sonic",
+                "Bludgeoning",
+                "Piercing",
+                "Slashing"
+            ],
+            "reevaluate": null,
+            "type": "formula",
+            "value": "1d8"
+        },
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.equipment-srd.Item.Erraticannon]</p>\n<p>The <em>erraticannon</em> deals 1d6 additional damage of a second damage type.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "level": {
+            "value": 9
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder #180: The Smoking Gun"
+        },
+        "rules": [
+            {
+                "damageType": "acid",
+                "diceNumber": 1,
+                "dieSize": "d6",
+                "key": "DamageDice",
+                "predicate": [
+                    "self:effect:erraticannon-extra:1"
+                ],
+                "selector": "erraticannon-damage"
+            },
+            {
+                "damageType": "cold",
+                "diceNumber": 1,
+                "dieSize": "d6",
+                "key": "DamageDice",
+                "predicate": [
+                    "self:effect:erraticannon-extra:2"
+                ],
+                "selector": "erraticannon-damage"
+            },
+            {
+                "damageType": "electricity",
+                "diceNumber": 1,
+                "dieSize": "d6",
+                "key": "DamageDice",
+                "predicate": [
+                    "self:effect:erraticannon-extra:3"
+                ],
+                "selector": "erraticannon-damage"
+            },
+            {
+                "damageType": "fire",
+                "diceNumber": 1,
+                "dieSize": "d6",
+                "key": "DamageDice",
+                "predicate": [
+                    "self:effect:erraticannon-extra:4"
+                ],
+                "selector": "erraticannon-damage"
+            },
+            {
+                "damageType": "sonic",
+                "diceNumber": 1,
+                "dieSize": "d6",
+                "key": "DamageDice",
+                "predicate": [
+                    "self:effect:erraticannon-extra:5"
+                ],
+                "selector": "erraticannon-damage"
+            },
+            {
+                "damageType": "bludgeoning",
+                "diceNumber": 1,
+                "dieSize": "d6",
+                "key": "DamageDice",
+                "predicate": [
+                    "self:effect:erraticannon-extra:6"
+                ],
+                "selector": "erraticannon-damage"
+            },
+            {
+                "damageType": "piercing",
+                "diceNumber": 1,
+                "dieSize": "d6",
+                "key": "DamageDice",
+                "predicate": [
+                    "self:effect:erraticannon-extra:7"
+                ],
+                "selector": "erraticannon-damage"
+            },
+            {
+                "damageType": "slashing",
+                "diceNumber": 1,
+                "dieSize": "d6",
+                "key": "DamageDice",
+                "predicate": [
+                    "self:effect:erraticannon-extra:8"
+                ],
+                "selector": "erraticannon-damage"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": false
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/equipment-effects/effect-erraticannon.json
+++ b/packs/equipment-effects/effect-erraticannon.json
@@ -1,0 +1,141 @@
+{
+    "_id": "wmrINlK6twqfbJjo",
+    "img": "systems/pf2e/icons/equipment/weapons/specific-magic-weapons/erraticannon.webp",
+    "name": "Effect: Erraticannon",
+    "system": {
+        "badge": {
+            "evaluate": true,
+            "labels": [
+                "Acid",
+                "Cold",
+                "Electricity",
+                "Fire",
+                "Sonic",
+                "Bludgeoning",
+                "Piercing",
+                "Slashing"
+            ],
+            "reevaluate": null,
+            "type": "formula",
+            "value": "1d8"
+        },
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.equipment-srd.Item.Erraticannon]</p>\n<p>Each time you attack with the weapon, roll to determine the damage type of the Strike.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "level": {
+            "value": 9
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder #180: The Smoking Gun"
+        },
+        "rules": [
+            {
+                "key": "DamageDice",
+                "override": {
+                    "damageType": "acid"
+                },
+                "predicate": [
+                    "self:effect:erraticannon:1"
+                ],
+                "selector": "erraticannon-damage"
+            },
+            {
+                "key": "DamageDice",
+                "override": {
+                    "damageType": "cold"
+                },
+                "predicate": [
+                    "self:effect:erraticannon:2"
+                ],
+                "selector": "erraticannon-damage"
+            },
+            {
+                "key": "DamageDice",
+                "override": {
+                    "damageType": "electricity"
+                },
+                "predicate": [
+                    "self:effect:erraticannon:3"
+                ],
+                "selector": "erraticannon-damage"
+            },
+            {
+                "key": "DamageDice",
+                "override": {
+                    "damageType": "fire"
+                },
+                "predicate": [
+                    "self:effect:erraticannon:4"
+                ],
+                "selector": "erraticannon-damage"
+            },
+            {
+                "key": "DamageDice",
+                "override": {
+                    "damageType": "sonic"
+                },
+                "predicate": [
+                    "self:effect:erraticannon:5"
+                ],
+                "selector": "erraticannon-damage"
+            },
+            {
+                "key": "DamageDice",
+                "override": {
+                    "damageType": "bludgeoning"
+                },
+                "predicate": [
+                    "self:effect:erraticannon:6"
+                ],
+                "selector": "erraticannon-damage"
+            },
+            {
+                "key": "DamageDice",
+                "override": {
+                    "damageType": "piercing"
+                },
+                "predicate": [
+                    "self:effect:erraticannon:7"
+                ],
+                "selector": "erraticannon-damage"
+            },
+            {
+                "key": "DamageDice",
+                "override": {
+                    "damageType": "slashing"
+                },
+                "predicate": [
+                    "self:effect:erraticannon:8"
+                ],
+                "selector": "erraticannon-damage"
+            },
+            {
+                "key": "GrantItem",
+                "onDeleteActions": {
+                    "grantee": "cascade",
+                    "granter": "cascade"
+                },
+                "uuid": "Compendium.pf2e.equipment-effects.Item.Effect: Erraticannon (Extra)"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/equipment/erraticannon.json
+++ b/packs/equipment/erraticannon.json
@@ -21,7 +21,7 @@
             "die": "d6"
         },
         "description": {
-            "value": "<p>This <em>+1 striking @UUID[Compendium.pf2e.equipment-srd.Item.Hand Cannon]</em> is festooned with so many add-ons and modifications it's barely recognizable as a firearm. A large hopper at the top of the gun allows any type of ammunition (including arrows, bolts, stone bullets, and firearm rounds) to be fed into the machine, which converts the ammunition into blasts of raw, destructive energy. Each time you attack with the weapon, roll [[/r 1d8]] to determine the damage type of the Strike—all of the <em>erraticannon</em>'s weapon damage is converted to that damage type for the Strike. Additionally, roll another d8, and the <em>erraticannon</em> deals [[/r 1d6]] additional damage of this second damage type.</p>\n<table class=\"pf2e\">\n<thead>\n<tr>\n<th><strong>d8</strong></th>\n<th><strong>Damage Type</strong></th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>1</td>\n<td>Acid</td>\n</tr>\n<tr>\n<td>2</td>\n<td>Cold</td>\n</tr>\n<tr>\n<td>3</td>\n<td>Electricity</td>\n</tr>\n<tr>\n<td>4</td>\n<td>Fire</td>\n</tr>\n<tr>\n<td>5</td>\n<td>Sonic</td>\n</tr>\n<tr>\n<td>6</td>\n<td>Bludgeoning</td>\n</tr>\n<tr>\n<td>7</td>\n<td>Piercing</td>\n</tr>\n<tr>\n<td>8</td>\n<td>Slashing</td>\n</tr>\n</tbody>\n</table>\n<hr />\n<p><strong>Activate</strong> <span class=\"action-glyph\">2</span></p>\n<p><strong>Frequency</strong> once per day</p>\n<p><strong>Effect</strong> You set the <em>erraticannon</em> to maximum power and unleash a blast that deals @Damage[1d6[acid],1d6[cold],1d6[electricity],1d6[fire],1d6[sonic],1d6[bludgeoning],1d6[piercing],1d6[slashing]]{1d6 acid, 1d6 cold, 1d6 electricity, 1d6 fire, 1d6 sonic, 1d6 bludgeoning, 1d6 piercing, and 1d6 slashing} damage to all creatures in a @Template[type:cone|distance:30] (@Check[type:reflex|dc:25|basic:true] save).</p>"
+            "value": "<p>This <em>+1 striking @UUID[Compendium.pf2e.equipment-srd.Item.Hand Cannon]</em> is festooned with so many add-ons and modifications it's barely recognizable as a firearm. A large hopper at the top of the gun allows any type of ammunition (including arrows, bolts, stone bullets, and firearm rounds) to be fed into the machine, which converts the ammunition into blasts of raw, destructive energy. Each time you attack with the weapon, roll 1d8 to determine the damage type of the Strike—all of the <em>erraticannon</em>'s weapon damage is converted to that damage type for the Strike. Additionally, roll another d8, and the <em>erraticannon</em> deals 1d6 additional damage of this second damage type.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Erraticannon]</p>\n<table class=\"pf2e\">\n<thead>\n<tr>\n<th><strong>d8</strong></th>\n<th><strong>Damage Type</strong></th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>1</td>\n<td>Acid</td>\n</tr>\n<tr>\n<td>2</td>\n<td>Cold</td>\n</tr>\n<tr>\n<td>3</td>\n<td>Electricity</td>\n</tr>\n<tr>\n<td>4</td>\n<td>Fire</td>\n</tr>\n<tr>\n<td>5</td>\n<td>Sonic</td>\n</tr>\n<tr>\n<td>6</td>\n<td>Bludgeoning</td>\n</tr>\n<tr>\n<td>7</td>\n<td>Piercing</td>\n</tr>\n<tr>\n<td>8</td>\n<td>Slashing</td>\n</tr>\n</tbody>\n</table>\n<hr />\n<p><strong>Activate</strong> <span class=\"action-glyph\">2</span></p>\n<p><strong>Frequency</strong> once per day</p>\n<p><strong>Effect</strong> You set the <em>erraticannon</em> to maximum power and unleash a blast that deals @Damage[1d6[acid],1d6[cold],1d6[electricity],1d6[fire],1d6[sonic],1d6[bludgeoning],1d6[piercing],1d6[slashing]]{1d6 acid, 1d6 cold, 1d6 electricity, 1d6 fire, 1d6 sonic, 1d6 bludgeoning, 1d6 piercing, and 1d6 slashing} damage to all creatures in a @Template[type:cone|distance:30] (@Check[type:reflex|dc:25|basic:true] save).</p>"
         },
         "group": "firearm",
         "hardness": 0,
@@ -51,7 +51,14 @@
         "reload": {
             "value": "1"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "Note",
+                "selector": "{item|id}-attack",
+                "text": "PF2E.SpecificRule.Equipment.Erraticannon.Note",
+                "title": "{item|name}"
+            }
+        ],
         "runes": {
             "potency": 1,
             "property": [],

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2015,6 +2015,9 @@
                         "SecretLabel": "Moderate Eagle Eye Elixir (To Find Secret Doors or Traps)"
                     }
                 },
+                "Erraticannon": {
+                    "Note": "Each time you attack with the weapon, roll to determine the damage type of the Strike. @UUID[Compendium.pf2e.equipment-effects.Item.wmrINlK6twqfbJjo]{Effect: Erraticannon}"
+                },
                 "FightersFork": {
                     "FluidLengthLabel": "Fighter's Fork — Fluid Length"
                 },


### PR DESCRIPTION
Implemented as two formula-type effects. The primary "Effect: Erraticannon" grants the second "Effect: Erraticannon (Extra)".