### PR TITLE
Add darkvision subfeature to Visual Fidelity

### DIFF
--- a/packs/feats/visual-fidelity.json
+++ b/packs/feats/visual-fidelity.json
@@ -25,6 +25,11 @@
             "title": "Pathfinder Guns & Gears"
         },
         "rules": [],
+        "subfeatures": {
+            "senses": {
+                "darkvision": {}
+            }
+        },
         "traits": {
             "rarity": "common",
             "value": [


### PR DESCRIPTION
Didn't include low-light vision since darkvision supercedes it in the system, but if there's a good reason to include it anyway I'm happy to do so