### PR TITLE
Automate Overdrive Ally

### DIFF
--- a/packs/feat-effects/effect-overdrive-ally-shared-overdrive.json
+++ b/packs/feat-effects/effect-overdrive-ally-shared-overdrive.json
@@ -1,0 +1,42 @@
+{
+    "_id": "EEujvJ9UzzK7fvqG",
+    "img": "icons/commodities/tech/cog-large-steel-white.webp",
+    "name": "Effect: Overdrive Ally (Shared Overdrive)",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Shared Overdrive]</p>\n<p>The first time you use Overdrive Ally during a given Overdrive, the effect lasts for the remainder of the duration of your Overdrive, instead of just until the end of the target's next turn.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "minutes",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Guns & Gears"
+        },
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "selector": "strike-damage",
+                "value": "@item.origin.flags.pf2e.inventor.overdriveAlly.damage"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feat-effects/effect-overdrive-ally.json
+++ b/packs/feat-effects/effect-overdrive-ally.json
@@ -1,0 +1,42 @@
+{
+    "_id": "a4C89wVlcwV6Uxx4",
+    "img": "icons/commodities/tech/cog-brass.webp",
+    "name": "Effect: Overdrive Ally",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Overdrive Ally]</p>\n<p>Until the end of their next turn, that ally's Strikes deal additional damage equal to half your Intelligence modifier, or your full Intelligence modifier if you were in critical overdrive.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Guns & Gears"
+        },
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "selector": "strike-damage",
+                "value": "@item.origin.flags.pf2e.overdriveAlly.damage"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feat-effects/effect-overdrive-ally.json
+++ b/packs/feat-effects/effect-overdrive-ally.json
@@ -24,7 +24,7 @@
             {
                 "key": "FlatModifier",
                 "selector": "strike-damage",
-                "value": "@item.origin.flags.pf2e.overdriveAlly.damage"
+                "value": "@item.origin.flags.pf2e.inventor.overdriveAlly.damage"
             }
         ],
         "start": {

--- a/packs/feats/overdrive-ally.json
+++ b/packs/feats/overdrive-ally.json
@@ -32,7 +32,7 @@
             {
                 "key": "ActiveEffectLike",
                 "mode": "override",
-                "path": "flags.pf2e.overdriveAlly.damage",
+                "path": "flags.pf2e.inventor.overdriveAlly.damage",
                 "phase": "afterDerived",
                 "predicate": [
                     "self:effect:overdrive-success"
@@ -42,7 +42,7 @@
             {
                 "key": "ActiveEffectLike",
                 "mode": "override",
-                "path": "flags.pf2e.overdriveAlly.damage",
+                "path": "flags.pf2e.inventor.overdriveAlly.damage",
                 "phase": "afterDerived",
                 "predicate": [
                     "self:effect:overdrive-critical-success"

--- a/packs/feats/overdrive-ally.json
+++ b/packs/feats/overdrive-ally.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p><strong>Requirements</strong> You are currently in overdrive.</p>\n<hr />\n<p>You quickly fling some of your powered-up mechanisms to an ally, sharing your benefits with them briefly. Choose an ally within 30 feet. Until the end of their next turn, that ally's Strikes deal additional damage equal to half your Intelligence modifier, or your full Intelligence modifier if you were in critical overdrive. The ally doesn't gain the increased damage from expert, master, or legendary overdrive.</p>"
+            "value": "<p><strong>Requirements</strong> You are currently in overdrive.</p>\n<hr />\n<p>You quickly fling some of your powered-up mechanisms to an ally, sharing your benefits with them briefly. Choose an ally within 30 feet. Until the end of their next turn, that ally's Strikes deal additional damage equal to half your Intelligence modifier, or your full Intelligence modifier if you were in critical overdrive. The ally doesn't gain the increased damage from expert, master, or legendary overdrive.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Overdrive Ally]</p>"
         },
         "level": {
             "value": 8
@@ -28,7 +28,28 @@
             "remaster": false,
             "title": "Pathfinder Guns & Gears"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.overdriveAlly.damage",
+                "phase": "afterDerived",
+                "predicate": [
+                    "self:effect:overdrive-success"
+                ],
+                "value": "floor(@actor.system.abilities.int.mod/2)"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.overdriveAlly.damage",
+                "phase": "afterDerived",
+                "predicate": [
+                    "self:effect:overdrive-critical-success"
+                ],
+                "value": "@actor.system.abilities.int.mod"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/shared-overdrive.json
+++ b/packs/feats/shared-overdrive.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>You've experimented enough on your teammates to transfer a substantial number of powered-up gizmos to them, enabling one of your allies to benefit from the full effects and duration of your Overdrive. The first time you use Overdrive Ally during a given Overdrive, the effect lasts for the remainder of the duration of your Overdrive, instead of just until the end of the target's next turn. Any further uses of Overdrive Ally during the same Overdrive have their normal duration, per Overdrive Ally.</p>"
+            "value": "<p>You've experimented enough on your teammates to transfer a substantial number of powered-up gizmos to them, enabling one of your allies to benefit from the full effects and duration of your Overdrive. The first time you use Overdrive Ally during a given Overdrive, the effect lasts for the remainder of the duration of your Overdrive, instead of just until the end of the target's next turn. Any further uses of Overdrive Ally during the same Overdrive have their normal duration, per Overdrive Ally.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Overdrive Ally (Shared Overdrive)]</p>"
         },
         "level": {
             "value": 12


### PR DESCRIPTION
Since it seems there's no way currently to get roll options from the item's origin, I set up a flag in Overdrive Ally that could tell the effect what Overdrive degree of success the inventor has. The alternative is a Choice Set, but this seemed cleaner.

It doesn't look like there's console noise if the flag is missing (which would be the case for inventors with an old copy of the feat), but even then if they want to have the effect handy, it's likely they will get a new overdrive ally copy. If this isn't ok I'm happy to go with a Choice Set instead though.