### PR TITLE
Append healing note to spells under moderate Curse of Outpouring Life

### DIFF
--- a/packs/feat-effects/effect-curse-of-outpouring-life.json
+++ b/packs/feat-effects/effect-curse-of-outpouring-life.json
@@ -101,6 +101,28 @@
                 "domain": "all",
                 "key": "RollOption",
                 "option": "oracular-curse:stage:{item|badge.value}"
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    {
+                        "gte": [
+                            "parent:badge:value",
+                            2
+                        ]
+                    },
+                    {
+                        "not": "cantrip"
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.OracleCurses.Life.DescriptionModerate"
+                    }
+                ]
             }
         ],
         "start": {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -884,6 +884,7 @@
                 "Moderate": "Moderate"
             },
             "Life": {
+                "DescriptionModerate": "Whenever you finish casting a non-cantrip spell, you restore [[/r (@item.level)[healing,vitality]]]{Hit Points} equal to the spell rank to your choice of either one target of the spell or the creature nearest to you. You can't heal yourself in this way. This healing has the healing, necromancy, and vitality traits, as well as the tradition trait of the spell.",
                 "ToggleLabel": "All targets of Heal are living creatures"
             },
             "Time": {


### PR DESCRIPTION
Testing out the waters, first time using this new feature of Item Alteration