### PR TITLE
Use full width in spell collection summary expando

### DIFF
--- a/src/styles/actor/_spell-collection.scss
+++ b/src/styles/actor/_spell-collection.scss
@@ -212,6 +212,7 @@ ol.spell-list {
             display: block;
             grid-column: span 5;
             padding: var(--space-4) 0 var(--space-8);
+            width: 100%;
         }
     }
 


### PR DESCRIPTION
Spells with really brief descriptions weren't pushing the summary card to match the normal width.

Example of the issue before fix:
![image](https://github.com/foundryvtt/pf2e/assets/4469633/9159f281-5bc4-4bb3-9519-7603c2141c2b)
