### PR TITLE
Append note to spells under major Curse of Outpouring Life

### DIFF
--- a/packs/feat-effects/effect-curse-of-outpouring-life.json
+++ b/packs/feat-effects/effect-curse-of-outpouring-life.json
@@ -106,21 +106,41 @@
                 "itemType": "spell",
                 "key": "ItemAlteration",
                 "mode": "add",
-                "predicate": [
-                    {
-                        "gte": [
-                            "parent:badge:value",
-                            2
-                        ]
-                    },
-                    {
-                        "not": "cantrip"
-                    }
-                ],
                 "property": "description",
                 "value": [
                     {
-                        "text": "PF2E.OracleCurses.Life.DescriptionModerate"
+                        "predicate": [
+                            {
+                                "gte": [
+                                    "oracular-curse:stage",
+                                    2
+                                ]
+                            },
+                            {
+                                "not": "cantrip"
+                            }
+                        ],
+                        "text": "PF2E.OracleCurses.Life.DescriptionModerate",
+                        "title": "PF2E.OracleCurses.Label.Moderate"
+                    },
+                    {
+                        "predicate": [
+                            {
+                                "gte": [
+                                    "oracular-curse:stage",
+                                    3
+                                ]
+                            },
+                            {
+                                "gte": [
+                                    "item:rank",
+                                    5
+                                ]
+                            },
+                            "item:spell-slot"
+                        ],
+                        "text": "PF2E.OracleCurses.Life.DescriptionMajor",
+                        "title": "PF2E.OracleCurses.Label.Major"
                     }
                 ]
             }

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -884,7 +884,7 @@
                 "Moderate": "Moderate"
             },
             "Life": {
-                "DescriptionModerate": "Whenever you finish casting a non-cantrip spell, you restore [[/r (@item.level)[healing,vitality]]]{Hit Points} equal to the spell rank to your choice of either one target of the spell or the creature nearest to you. You can't heal yourself in this way. This healing has the healing, necromancy, and vitality traits, as well as the tradition trait of the spell.",
+                "DescriptionModerate": "Whenever you finish casting a non-cantrip spell, you restore [[/r @item.level[healing]]] Hit Points to your choice of either one target of the spell or the creature nearest to you. You can't heal yourself in this way. This healing has the healing, necromancy, and vitality traits, as well as the tradition trait of the spell.",
                 "DescriptionMajor": "Each time you use a spell slot to cast a 5th-rank or higher spell that takes 2 or more actions to cast, you disperse vitality energy in a @Template[type:burst|distance:30] with the effects of a 3-action @UUID[Compendium.pf2e.spells-srd.Item.rfZpqmj0AIIdkVIs]{Heal} spell with a level 4 lower than that of the spell you cast. This healing occurs immediately after you finish @UUID[Compendium.pf2e.actionspf2e.aBQ8ajvEBByv45yz]{Casting the Spell}. You don't benefit from this healing. Instead, you lose double the number of Hit Points rolled for the heal spell.",
                 "ToggleLabel": "All targets of Heal are living creatures"
             },

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -885,6 +885,7 @@
             },
             "Life": {
                 "DescriptionModerate": "Whenever you finish casting a non-cantrip spell, you restore [[/r (@item.level)[healing,vitality]]]{Hit Points} equal to the spell rank to your choice of either one target of the spell or the creature nearest to you. You can't heal yourself in this way. This healing has the healing, necromancy, and vitality traits, as well as the tradition trait of the spell.",
+                "DescriptionMajor": "Each time you use a spell slot to cast a 5th-rank or higher spell that takes 2 or more actions to cast, you disperse vitality energy in a @Template[type:burst|distance:30] with the effects of a 3-action @UUID[Compendium.pf2e.spells-srd.Item.rfZpqmj0AIIdkVIs]{Heal} spell with a level 4 lower than that of the spell you cast. This healing occurs immediately after you finish @UUID[Compendium.pf2e.actionspf2e.aBQ8ajvEBByv45yz]{Casting the Spell}. You don't benefit from this healing. Instead, you lose double the number of Hit Points rolled for the heal spell.",
                 "ToggleLabel": "All targets of Heal are living creatures"
             },
             "Time": {


### PR DESCRIPTION
For some reason `parent:badge:value` does not work correctly as a predicate for an individual line, but `oracular-curse:stage`, which denotes the same thing in this context, does.