### PR TITLE
Add Failure Note to Pernicious Spore Bomb

### DIFF
--- a/packs/equipment/pernicious-spore-bomb-greater.json
+++ b/packs/equipment/pernicious-spore-bomb-greater.json
@@ -60,18 +60,13 @@
             {
                 "key": "Note",
                 "outcome": [
-                    "success"
+                    "success",
+                    "criticalSuccess",
+                    "failure"
                 ],
-                "selector": "{item|_id}-damage",
-                "text": "PF2E.BombNotes.PerniciousSporeBomb.Greater.success"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "{item|_id}-damage",
-                "text": "PF2E.BombNotes.PerniciousSporeBomb.Greater.criticalSuccess"
+                "selector": "{item|_id}-attack",
+                "text": "PF2E.BombNotes.PerniciousSporeBomb.Terrain",
+                "title": "{item|name}"
             }
         ],
         "runes": {
@@ -94,6 +89,7 @@
             ]
         },
         "usage": {
+            "canBeAmmo": false,
             "value": "held-in-one-hand"
         }
     },

--- a/packs/equipment/pernicious-spore-bomb-lesser.json
+++ b/packs/equipment/pernicious-spore-bomb-lesser.json
@@ -60,18 +60,13 @@
             {
                 "key": "Note",
                 "outcome": [
+                    "criticalSuccess",
+                    "failure",
                     "success"
                 ],
-                "selector": "{item|_id}-damage",
-                "text": "PF2E.BombNotes.PerniciousSporeBomb.Lesser.success"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "{item|_id}-damage",
-                "text": "PF2E.BombNotes.PerniciousSporeBomb.Lesser.criticalSuccess"
+                "selector": "{item|id}-attack",
+                "text": "PF2E.BombNotes.PerniciousSporeBomb.Terrain",
+                "title": "{item|name}"
             }
         ],
         "runes": {
@@ -94,6 +89,7 @@
             ]
         },
         "usage": {
+            "canBeAmmo": false,
             "value": "held-in-one-hand"
         }
     },

--- a/packs/equipment/pernicious-spore-bomb-major.json
+++ b/packs/equipment/pernicious-spore-bomb-major.json
@@ -60,18 +60,13 @@
             {
                 "key": "Note",
                 "outcome": [
-                    "success"
+                    "success",
+                    "criticalSuccess",
+                    "failure"
                 ],
-                "selector": "{item|_id}-damage",
-                "text": "PF2E.BombNotes.PerniciousSporeBomb.Major.success"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "{item|_id}-damage",
-                "text": "PF2E.BombNotes.PerniciousSporeBomb.Major.criticalSuccess"
+                "selector": "{item|_id}-attack",
+                "text": "PF2E.BombNotes.PerniciousSporeBomb.TerrainMajor",
+                "title": "{item|name}"
             }
         ],
         "runes": {
@@ -94,6 +89,7 @@
             ]
         },
         "usage": {
+            "canBeAmmo": false,
             "value": "held-in-one-hand"
         }
     },

--- a/packs/equipment/pernicious-spore-bomb-moderate.json
+++ b/packs/equipment/pernicious-spore-bomb-moderate.json
@@ -60,18 +60,13 @@
             {
                 "key": "Note",
                 "outcome": [
-                    "success"
+                    "success",
+                    "criticalSuccess",
+                    "failure"
                 ],
-                "selector": "{item|_id}-damage",
-                "text": "PF2E.BombNotes.PerniciousSporeBomb.Moderate.success"
-            },
-            {
-                "key": "Note",
-                "outcome": [
-                    "criticalSuccess"
-                ],
-                "selector": "{item|_id}-damage",
-                "text": "PF2E.BombNotes.PerniciousSporeBomb.Moderate.criticalSuccess"
+                "selector": "{item|id}-attack",
+                "text": "PF2E.BombNotes.PerniciousSporeBomb.Terrain",
+                "title": "{item|name}"
             }
         ],
         "runes": {
@@ -94,6 +89,7 @@
             ]
         },
         "usage": {
+            "canBeAmmo": false,
             "value": "held-in-one-hand"
         }
     },

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -382,22 +382,8 @@
                 }
             },
             "PerniciousSporeBomb": {
-                "Greater": {
-                    "criticalSuccess": "<strong>Effect</strong> The bomb also deals [[/r (2*3d4)[persistent,piercing]]] and [[/r (3[splash])[poison]]]{3 poison splash damage}. The bomb's splash area is coated in vegetation, becoming difficult terrain for 1 round.",
-                    "success": "<strong>Effect</strong> The bomb also deals [[/r 3d4[persistent,piercing]]] and [[/r (3[splash])[poison]]]{3 poison splash damage}. The bomb's splash area is coated in vegetation, becoming difficult terrain for 1 round."
-                },
-                "Lesser": {
-                    "criticalSuccess": "<strong>Effect</strong> The bomb also deals [[/r (2*1d4)[persistent,piercing]]] and [[/r (1[splash])[poison]]]{1 poison splash damage}. The bomb's splash area is coated in vegetation, becoming difficult terrain for 1 round.",
-                    "success": "<strong>Effect</strong> The bomb also deals [[/r 1d4[persistent,piercing]]] and [[/r (1[splash])[poison]]]{1 poison splash damage}. The bomb's splash area is coated in vegetation, becoming difficult terrain for 1 round."
-                },
-                "Major": {
-                    "criticalSuccess": "<strong>Effect</strong> The bomb also deals [[/r (2*4d4)[persistent,piercing]]] and [[/r (4[splash])[poison]]]{4 poison splash damage}. The bomb's splash area is coated in vegetation, becoming difficult terrain for 1 minute.",
-                    "success": "<strong>Effect</strong> The bomb also deals [[/r 4d4[persistent,piercing]]] and [[/r (4[splash])[poison]]]{4 poison splash damage}. The bomb's splash area is coated in vegetation, becoming difficult terrain for 1 minute."
-                },
-                "Moderate": {
-                    "criticalSuccess": "<strong>Effect</strong> The bomb also deals [[/r (2*2d4)[persistent,piercing]]] and [[/r (2[splash])[poison]]]{2 poison splash damage}. The bomb's splash area is coated in vegetation, becoming difficult terrain for 1 round.",
-                    "success": "<strong>Effect</strong> The bomb also deals [[/r 2d4[persistent,piercing]]] and [[/r (2[splash])[poison]]]{2 poison splash damage}. The bomb's splash area is coated in vegetation, becoming difficult terrain for 1 round."
-                }
+                "Terrain": "Except on a critical failure, the bomb's splash area is coated in vegetation, becoming difficult terrain for 1 round.",
+                "TerrainMajor": "Except on a critical failure, the bomb's splash area is coated in vegetation, becoming difficult terrain for 1 minute."
             },
             "PeshspineGrenade": {
                 "Greater": {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -382,6 +382,22 @@
                 }
             },
             "PerniciousSporeBomb": {
+                "Greater": {
+                    "criticalSuccess": "<strong>Effect</strong> The bomb also deals [[/r (2*3d4)[persistent,piercing]]] and [[/r (3[splash])[poison]]]{3 poison splash damage}. The bomb's splash area is coated in vegetation, becoming difficult terrain for 1 round.",
+                    "success": "<strong>Effect</strong> The bomb also deals [[/r 3d4[persistent,piercing]]] and [[/r (3[splash])[poison]]]{3 poison splash damage}. The bomb's splash area is coated in vegetation, becoming difficult terrain for 1 round."
+                },
+                "Lesser": {
+                    "criticalSuccess": "<strong>Effect</strong> The bomb also deals [[/r (2*1d4)[persistent,piercing]]] and [[/r (1[splash])[poison]]]{1 poison splash damage}. The bomb's splash area is coated in vegetation, becoming difficult terrain for 1 round.",
+                    "success": "<strong>Effect</strong> The bomb also deals [[/r 1d4[persistent,piercing]]] and [[/r (1[splash])[poison]]]{1 poison splash damage}. The bomb's splash area is coated in vegetation, becoming difficult terrain for 1 round."
+                },
+                "Major": {
+                    "criticalSuccess": "<strong>Effect</strong> The bomb also deals [[/r (2*4d4)[persistent,piercing]]] and [[/r (4[splash])[poison]]]{4 poison splash damage}. The bomb's splash area is coated in vegetation, becoming difficult terrain for 1 minute.",
+                    "success": "<strong>Effect</strong> The bomb also deals [[/r 4d4[persistent,piercing]]] and [[/r (4[splash])[poison]]]{4 poison splash damage}. The bomb's splash area is coated in vegetation, becoming difficult terrain for 1 minute."
+                },
+                "Moderate": {
+                    "criticalSuccess": "<strong>Effect</strong> The bomb also deals [[/r (2*2d4)[persistent,piercing]]] and [[/r (2[splash])[poison]]]{2 poison splash damage}. The bomb's splash area is coated in vegetation, becoming difficult terrain for 1 round.",
+                    "success": "<strong>Effect</strong> The bomb also deals [[/r 2d4[persistent,piercing]]] and [[/r (2[splash])[poison]]]{2 poison splash damage}. The bomb's splash area is coated in vegetation, becoming difficult terrain for 1 round."
+                },
                 "Terrain": "Except on a critical failure, the bomb's splash area is coated in vegetation, becoming difficult terrain for 1 round.",
                 "TerrainMajor": "Except on a critical failure, the bomb's splash area is coated in vegetation, becoming difficult terrain for 1 minute."
             },


### PR DESCRIPTION
Removes the unnecessary current Notes and adds the special Terrain-specific note to the _attack roll_ instead of damage, so it can show on Failure as well.

Closes #2128 