### PR TITLE
Add Defense to spell description headers

### DIFF
--- a/src/styles/legacy/_chat.scss
+++ b/src/styles/legacy/_chat.scss
@@ -58,6 +58,12 @@
         p {
             margin: var(--space-4) 0;
             min-height: unset;
+
+            &.spell-defense-duration {
+                display: flex;
+                flex-wrap: wrap;
+                gap: var(--space-4);
+            }
         }
     }
 

--- a/static/templates/items/partials/spell-description-prepend.hbs
+++ b/static/templates/items/partials/spell-description-prepend.hbs
@@ -9,6 +9,19 @@
         {{#if spell.system.target.value}}<strong>{{localize "PF2E.SpellTargetLabel"}}</strong> {{spell.system.target.value}}{{/if}}
     </p>
 {{/if}}
-{{#if duration}}
-    <p><strong>{{localize "PF2E.Time.Duration"}}</strong> {{duration}}</p>
+{{#if (or spell.defense duration)}}
+    <p class="spell-defense-duration">
+        {{#if spell.defense}}
+            <span>
+                <strong>{{localize "PF2E.Item.Spell.Defense.Label"}}</strong>
+                {{spell.defense.label}}
+            </span>
+        {{/if}}
+        {{#if duration}}
+            <span>
+                <strong>{{localize "PF2E.Time.Duration"}}</strong>
+                {{duration}}
+            </span>
+        {{/if}}
+    </p>
 {{/if}}


### PR DESCRIPTION
Following on from the change in #13140 this adds the `Defense [...]` label to the prepended spell descriptions.

I need input on which display we prefer though: inline or separate line to `Duration`. I prefer inline but it does mean that some spell chat cards have to wrap the Duration value if it's wordy. The current PR is the _inline_ implementation.

Comparisons:
![spell-defense-prepend](https://github.com/foundryvtt/pf2e/assets/4469633/2e79dd94-968f-40f8-aae0-657e4c7a32c0)

I also experimented with displaying a "fully complete" defense label for niche cases that have _both_ an AC and stat defense like Disintegrate but I'm not convinced it's worth the mess to implement 🤷 

Here's what one iteration looked like (note slightly fatter spell slot row):
![spell-defense-prepend-complex](https://github.com/foundryvtt/pf2e/assets/4469633/1de90a82-b10d-4694-b3a9-a41cd6e25374)

IMO it does look nice in the spell cards but not in the new Defense column, however I'm not convinced it's worth all the janky code changes vs the current PR which is a super simple template change. Happy to polish the more complete version if that's more preferable though.