### PR TITLE
Make minor updates to BB data entry for compatibility with Remaster

### DIFF
--- a/packs/menace-under-otari-bestiary/animated-armor-bb.json
+++ b/packs/menace-under-otari-bestiary/animated-armor-bb.json
@@ -271,7 +271,16 @@
                 "temp": 0,
                 "value": 20
             },
-            "immunities": [],
+            "immunities": [
+                {
+                    "exceptions": [],
+                    "type": "vitality"
+                },
+                {
+                    "exceptions": [],
+                    "type": "void"
+                }
+            ],
             "speed": {
                 "otherSpeeds": [],
                 "value": 20

--- a/packs/menace-under-otari-bestiary/gargoyle-bb.json
+++ b/packs/menace-under-otari-bestiary/gargoyle-bb.json
@@ -302,6 +302,12 @@
                 "temp": 0,
                 "value": 40
             },
+            "immunities": [
+                {
+                    "exceptions": [],
+                    "type": "bleed"
+                }
+            ],
             "resistances": [
                 {
                     "type": "bludgeoning",

--- a/packs/menace-under-otari-bestiary/ghost-commoner-bb.json
+++ b/packs/menace-under-otari-bestiary/ghost-commoner-bb.json
@@ -292,10 +292,16 @@
             },
             "immunities": [
                 {
+                    "exceptions": [],
                     "type": "poison"
                 },
                 {
+                    "exceptions": [],
                     "type": "unconscious"
+                },
+                {
+                    "exceptions": [],
+                    "type": "bleed"
                 }
             ],
             "resistances": [

--- a/packs/menace-under-otari-bestiary/ghoul-bb.json
+++ b/packs/menace-under-otari-bestiary/ghoul-bb.json
@@ -383,10 +383,20 @@
             },
             "immunities": [
                 {
+                    "exceptions": [],
                     "type": "poison"
                 },
                 {
+                    "exceptions": [],
                     "type": "unconscious"
+                },
+                {
+                    "exceptions": [],
+                    "type": "bleed"
+                },
+                {
+                    "exceptions": [],
+                    "type": "void"
                 }
             ],
             "speed": {

--- a/packs/menace-under-otari-bestiary/hell-hound-bb.json
+++ b/packs/menace-under-otari-bestiary/hell-hound-bb.json
@@ -328,8 +328,10 @@
         "details": {
             "blurb": "",
             "languages": {
-                "details": "",
-                "value": []
+                "details": "(can't speak)",
+                "value": [
+                    "diabolic"
+                ]
             },
             "level": {
                 "value": 3

--- a/packs/menace-under-otari-bestiary/shadow-bb.json
+++ b/packs/menace-under-otari-bestiary/shadow-bb.json
@@ -326,10 +326,20 @@
             },
             "immunities": [
                 {
+                    "exceptions": [],
                     "type": "poison"
                 },
                 {
+                    "exceptions": [],
                     "type": "unconscious"
+                },
+                {
+                    "exceptions": [],
+                    "type": "bleed"
+                },
+                {
+                    "exceptions": [],
+                    "type": "void"
                 }
             ],
             "resistances": [

--- a/packs/menace-under-otari-bestiary/skeletal-giant-bb.json
+++ b/packs/menace-under-otari-bestiary/skeletal-giant-bb.json
@@ -453,10 +453,20 @@
             },
             "immunities": [
                 {
+                    "exceptions": [],
                     "type": "poison"
                 },
                 {
+                    "exceptions": [],
                     "type": "unconscious"
+                },
+                {
+                    "exceptions": [],
+                    "type": "bleed"
+                },
+                {
+                    "exceptions": [],
+                    "type": "void"
                 }
             ],
             "resistances": [

--- a/packs/menace-under-otari-bestiary/skeleton-guard-bb.json
+++ b/packs/menace-under-otari-bestiary/skeleton-guard-bb.json
@@ -514,10 +514,20 @@
             },
             "immunities": [
                 {
+                    "exceptions": [],
                     "type": "poison"
                 },
                 {
+                    "exceptions": [],
                     "type": "unconscious"
+                },
+                {
+                    "exceptions": [],
+                    "type": "bleed"
+                },
+                {
+                    "exceptions": [],
+                    "type": "void"
                 }
             ],
             "resistances": [

--- a/packs/menace-under-otari-bestiary/zombie-shambler-bb.json
+++ b/packs/menace-under-otari-bestiary/zombie-shambler-bb.json
@@ -255,10 +255,20 @@
             },
             "immunities": [
                 {
+                    "exceptions": [],
                     "type": "poison"
                 },
                 {
+                    "exceptions": [],
                     "type": "unconscious"
+                },
+                {
+                    "exceptions": [],
+                    "type": "bleed"
+                },
+                {
+                    "exceptions": [],
+                    "type": "void"
                 }
             ],
             "speed": {

--- a/packs/menace-under-otari-bestiary/zombie-shambler-bb.json
+++ b/packs/menace-under-otari-bestiary/zombie-shambler-bb.json
@@ -3,10 +3,52 @@
     "img": "systems/pf2e/icons/default-icons/npc.svg",
     "items": [
         {
+            "_id": "eEcfWUzLnhbIXHZe",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.conditionitems.Item.xYTAsEpcJE1Ccni3"
+                }
+            },
+            "img": "systems/pf2e/icons/conditions/slowed.webp",
+            "name": "Slowed",
+            "sort": 100000,
+            "system": {
+                "description": {
+                    "value": "<p>You have fewer actions. Slowed always includes a value. When you regain your actions, reduce the number of actions regained by your slowed value. Because you regain actions at the start of your turn, you don't immediately lose actions if you become slowed during your turn.</p>"
+                },
+                "duration": {
+                    "expiry": null,
+                    "unit": "unlimited",
+                    "value": 0
+                },
+                "group": null,
+                "overrides": [],
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
+                },
+                "references": {
+                    "children": [],
+                    "immunityFrom": [],
+                    "overriddenBy": [],
+                    "overrides": []
+                },
+                "rules": [],
+                "slug": "slowed",
+                "traits": {},
+                "value": {
+                    "isValued": true,
+                    "value": 1
+                }
+            },
+            "type": "condition"
+        },
+        {
             "_id": "wOkHQN8ELSDh7T1f",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Fist",
-            "sort": 100000,
+            "sort": 200000,
             "system": {
                 "attack": {
                     "value": ""
@@ -50,7 +92,7 @@
             "_id": "v90WRjELLiKF57vr",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Jaws",
-            "sort": 200000,
+            "sort": 300000,
             "system": {
                 "attack": {
                     "value": ""
@@ -97,7 +139,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Darkvision",
-            "sort": 300000,
+            "sort": 400000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -127,7 +169,7 @@
             "_id": "eulyI60JHNUYs39w",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Slow",
-            "sort": 400000,
+            "sort": 500000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -162,7 +204,7 @@
             },
             "img": "systems/pf2e/icons/actions/OneAction.webp",
             "name": "Grab",
-            "sort": 500000,
+            "sort": 600000,
             "system": {
                 "actionType": {
                     "value": "action"
@@ -192,7 +234,7 @@
             "_id": "3WEDMCeiWeexqO8U",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Athletics",
-            "sort": 600000,
+            "sort": 700000,
             "system": {
                 "description": {
                     "value": ""

--- a/packs/menace-under-otari-bestiary/zombie-shambler-bb.json
+++ b/packs/menace-under-otari-bestiary/zombie-shambler-bb.json
@@ -3,52 +3,10 @@
     "img": "systems/pf2e/icons/default-icons/npc.svg",
     "items": [
         {
-            "_id": "eEcfWUzLnhbIXHZe",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.conditionitems.Item.xYTAsEpcJE1Ccni3"
-                }
-            },
-            "img": "systems/pf2e/icons/conditions/slowed.webp",
-            "name": "Slowed",
-            "sort": 100000,
-            "system": {
-                "description": {
-                    "value": "<p>You have fewer actions. Slowed always includes a value. When you regain your actions, reduce the number of actions regained by your slowed value. Because you regain actions at the start of your turn, you don't immediately lose actions if you become slowed during your turn.</p>"
-                },
-                "duration": {
-                    "expiry": null,
-                    "unit": "unlimited",
-                    "value": 0
-                },
-                "group": null,
-                "overrides": [],
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core"
-                },
-                "references": {
-                    "children": [],
-                    "immunityFrom": [],
-                    "overriddenBy": [],
-                    "overrides": []
-                },
-                "rules": [],
-                "slug": "slowed",
-                "traits": {},
-                "value": {
-                    "isValued": true,
-                    "value": 1
-                }
-            },
-            "type": "condition"
-        },
-        {
             "_id": "wOkHQN8ELSDh7T1f",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Fist",
-            "sort": 200000,
+            "sort": 100000,
             "system": {
                 "attack": {
                     "value": ""
@@ -92,7 +50,7 @@
             "_id": "v90WRjELLiKF57vr",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Jaws",
-            "sort": 300000,
+            "sort": 200000,
             "system": {
                 "attack": {
                     "value": ""
@@ -139,7 +97,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Darkvision",
-            "sort": 400000,
+            "sort": 300000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -169,7 +127,7 @@
             "_id": "eulyI60JHNUYs39w",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Slow",
-            "sort": 500000,
+            "sort": 400000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -186,7 +144,13 @@
                     "remaster": false,
                     "title": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "inMemoryOnly": true,
+                        "key": "GrantItem",
+                        "uuid": "Compendium.pf2e.conditionitems.Item.Slowed"
+                    }
+                ],
                 "slug": null,
                 "traits": {
                     "rarity": "common",
@@ -204,7 +168,7 @@
             },
             "img": "systems/pf2e/icons/actions/OneAction.webp",
             "name": "Grab",
-            "sort": 600000,
+            "sort": 500000,
             "system": {
                 "actionType": {
                     "value": "action"
@@ -234,7 +198,7 @@
             "_id": "3WEDMCeiWeexqO8U",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Athletics",
-            "sort": 700000,
+            "sort": 600000,
             "system": {
                 "description": {
                     "value": ""

--- a/packs/pathfinder-bestiary/zombie-brute.json
+++ b/packs/pathfinder-bestiary/zombie-brute.json
@@ -3,49 +3,10 @@
     "img": "systems/pf2e/icons/default-icons/npc.svg",
     "items": [
         {
-            "_id": "9j9kz8bv8i4ae8b7",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.conditionitems.Item.xYTAsEpcJE1Ccni3"
-                }
-            },
-            "img": "systems/pf2e/icons/conditions/slowed.webp",
-            "name": "Slowed",
-            "sort": 100000,
-            "system": {
-                "description": {
-                    "value": "<p>You have fewer actions. Slowed always includes a value. When you regain your actions at the start of your turn, reduce the number of actions you regain by your slowed value. Because slowed has its effect at the start of your turn, you don't immediately lose actions if you become slowed during your turn.</p>"
-                },
-                "duration": {
-                    "value": 0
-                },
-                "group": null,
-                "overrides": [],
-                "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
-                },
-                "references": {
-                    "children": [],
-                    "immunityFrom": [],
-                    "overriddenBy": [],
-                    "overrides": []
-                },
-                "rules": [],
-                "slug": "slowed",
-                "value": {
-                    "isValued": true,
-                    "value": 1
-                }
-            },
-            "type": "condition"
-        },
-        {
             "_id": "wdsdNrRHG7tMUw5P",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Fist",
-            "sort": 200000,
+            "sort": 100000,
             "system": {
                 "attack": {
                     "value": ""
@@ -96,7 +57,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Darkvision",
-            "sort": 300000,
+            "sort": 200000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -126,7 +87,7 @@
             "_id": "TtcFIJZjrZ4Vaaml",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Slow",
-            "sort": 400000,
+            "sort": 300000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -143,7 +104,13 @@
                     "remaster": false,
                     "title": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "inMemoryOnly": true,
+                        "key": "GrantItem",
+                        "uuid": "Compendium.pf2e.conditionitems.Item.Slowed"
+                    }
+                ],
                 "slug": null,
                 "traits": {
                     "rarity": "common",
@@ -161,7 +128,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Void Healing",
-            "sort": 500000,
+            "sort": 400000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -203,7 +170,7 @@
             },
             "img": "systems/pf2e/icons/actions/FreeAction.webp",
             "name": "Improved Push 5 feet",
-            "sort": 600000,
+            "sort": 500000,
             "system": {
                 "actionType": {
                     "value": "free"
@@ -233,7 +200,7 @@
             "_id": "WHbE7viCeLXEGocR",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Athletics",
-            "sort": 700000,
+            "sort": 600000,
             "system": {
                 "description": {
                     "value": ""

--- a/packs/pathfinder-bestiary/zombie-shambler.json
+++ b/packs/pathfinder-bestiary/zombie-shambler.json
@@ -3,49 +3,10 @@
     "img": "systems/pf2e/icons/default-icons/npc.svg",
     "items": [
         {
-            "_id": "qiyu0aoav4y0v7tf",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.conditionitems.Item.xYTAsEpcJE1Ccni3"
-                }
-            },
-            "img": "systems/pf2e/icons/conditions/slowed.webp",
-            "name": "Slowed",
-            "sort": 100000,
-            "system": {
-                "description": {
-                    "value": "<p>You have fewer actions. Slowed always includes a value. When you regain your actions at the start of your turn, reduce the number of actions you regain by your slowed value. Because slowed has its effect at the start of your turn, you don't immediately lose actions if you become slowed during your turn.</p>"
-                },
-                "duration": {
-                    "value": 0
-                },
-                "group": null,
-                "overrides": [],
-                "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
-                },
-                "references": {
-                    "children": [],
-                    "immunityFrom": [],
-                    "overriddenBy": [],
-                    "overrides": []
-                },
-                "rules": [],
-                "slug": "slowed",
-                "value": {
-                    "isValued": true,
-                    "value": 1
-                }
-            },
-            "type": "condition"
-        },
-        {
             "_id": "wOkHQN8ELSDh7T1f",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Fist",
-            "sort": 200000,
+            "sort": 100000,
             "system": {
                 "attack": {
                     "value": ""
@@ -89,7 +50,7 @@
             "_id": "v90WRjELLiKF57vr",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Jaws",
-            "sort": 300000,
+            "sort": 200000,
             "system": {
                 "attack": {
                     "value": ""
@@ -136,7 +97,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Darkvision",
-            "sort": 400000,
+            "sort": 300000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -166,7 +127,7 @@
             "_id": "eulyI60JHNUYs39w",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Slow",
-            "sort": 500000,
+            "sort": 400000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -183,7 +144,13 @@
                     "remaster": false,
                     "title": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "inMemoryOnly": true,
+                        "key": "GrantItem",
+                        "uuid": "Compendium.pf2e.conditionitems.Item.Slowed"
+                    }
+                ],
                 "slug": null,
                 "traits": {
                     "rarity": "common",
@@ -201,7 +168,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Void Healing",
-            "sort": 600000,
+            "sort": 500000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -243,7 +210,7 @@
             },
             "img": "systems/pf2e/icons/actions/OneAction.webp",
             "name": "Grab",
-            "sort": 700000,
+            "sort": 600000,
             "system": {
                 "actionType": {
                     "value": "action"
@@ -273,7 +240,7 @@
             "_id": "3WEDMCeiWeexqO8U",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Athletics",
-            "sort": 800000,
+            "sort": 700000,
             "system": {
                 "description": {
                     "value": ""


### PR DESCRIPTION
Even without a remaster to the BB, we can infer some changes from recent publications which can (hopefully uncontroversially) be retroactively applied to the BB creatures and allow them to be used with less friction in the latest system versions. These include things like the removal of alignment (previously applied by system update) and (in this PR) some changes to the way that immunities and resistances are listed for undead creatures. 

This PR adds bleed & void immunity to undead creatures, updates the Hellhound's languages, and similar small tweaks.

One of the changes was less clear-cut- adding the Slowed condition to the zombie shambler. I think this is harmless and just makes the system a bit easier to learn, but I've included it in a separate commit so that it can be excluded easily if you don't agree.