### PR TITLE
Restrict Megaton Strike to specified Strikes

### DIFF
--- a/packs/equipment/black-hole-armor.json
+++ b/packs/equipment/black-hole-armor.json
@@ -42,7 +42,7 @@
         "rules": [
             {
                 "definition": [
-                    "item:damage:category:physical",
+                    "damage:category:physical",
                     "item:ranged"
                 ],
                 "key": "Resistance",

--- a/packs/feats/megaton-strike.json
+++ b/packs/feats/megaton-strike.json
@@ -54,21 +54,52 @@
                 "value": "unstable"
             },
             {
+                "diceNumber": "ternary(gte(@actor.level, 18), 3, ternary(gte(@actor.level, 10), 2, 1))",
                 "key": "DamageDice",
                 "predicate": [
-                    "megaton:stable"
+                    "megaton:stable",
+                    {
+                        "or": [
+                            {
+                                "and": [
+                                    "feature:weapon-innovation",
+                                    "item:id:{actor|flags.pf2e.innovationId}"
+                                ]
+                            },
+                            {
+                                "and": [
+                                    "feature:armor-innovation",
+                                    "item:melee"
+                                ]
+                            }
+                        ]
+                    }
                 ],
-                "selector": "strike-damage",
-                "value": "ternary(gte(@actor.level, 18), 3, ternary(gte(@actor.level, 10), 2, 1))"
+                "selector": "strike-damage"
             },
             {
+                "diceNumber": "ternary(gte(@actor.level, 18), 4, ternary(gte(@actor.level, 10), 3, 2))",
                 "key": "DamageDice",
-                "label": "Unstable Megaton Strike",
                 "predicate": [
-                    "megaton:unstable"
+                    "megaton:unstable",
+                    {
+                        "or": [
+                            {
+                                "and": [
+                                    "feature:weapon-innovation",
+                                    "item:id:{actor|flags.pf2e.innovationId}"
+                                ]
+                            },
+                            {
+                                "and": [
+                                    "feature:armor-innovation",
+                                    "item:melee"
+                                ]
+                            }
+                        ]
+                    }
                 ],
-                "selector": "strike-damage",
-                "value": "ternary(gte(@actor.level, 18), 4, ternary(gte(@actor.level, 10), 3, 2))"
+                "selector": "strike-damage"
             }
         ],
         "traits": {

--- a/src/module/migration/migrations/916-new-pc-toys.ts
+++ b/src/module/migration/migrations/916-new-pc-toys.ts
@@ -101,16 +101,31 @@ export class Migration916NewPCToys extends MigrationBase {
                 },
                 {
                     key: "DamageDice",
-                    predicate: ["megaton:stable"],
+                    predicate: [
+                        "megaton:stable",
+                        {
+                            or: [
+                                { and: ["feature:weapon-innovation", "item:id:{actor|flags.pf2e.innovationId}"] },
+                                { and: ["feature:armor-innovation", "item:melee"] },
+                            ],
+                        },
+                    ],
                     selector: "strike-damage",
-                    value: "ternary(gte(@actor.level, 18), 3, ternary(gte(@actor.level, 10), 2, 1))",
+                    diceNumber: "ternary(gte(@actor.level, 18), 3, ternary(gte(@actor.level, 10), 2, 1))",
                 },
                 {
                     key: "DamageDice",
-                    label: "Unstable Megaton Strike",
-                    predicate: ["megaton:unstable"],
+                    predicate: [
+                        "megaton:unstable",
+                        {
+                            or: [
+                                { and: ["feature:weapon-innovation", "item:id:{actor|flags.pf2e.innovationId}"] },
+                                { and: ["feature:armor-innovation", "item:melee"] },
+                            ],
+                        },
+                    ],
                     selector: "strike-damage",
-                    value: "ternary(gte(@actor.level, 18), 4, ternary(gte(@actor.level, 10), 3, 2))",
+                    diceNumber: "ternary(gte(@actor.level, 18), 4, ternary(gte(@actor.level, 10), 3, 2))",
                 },
             ];
             source.system.rules = rules;


### PR DESCRIPTION
Also switched `value` for `diceNumber` on the rule elements, as the dice were not being added