### PR TITLE
Add Effects for Sanguine Mutagen

### DIFF
--- a/packs/equipment-effects/effect-sanguine-mutagen-greater.json
+++ b/packs/equipment-effects/effect-sanguine-mutagen-greater.json
@@ -1,0 +1,96 @@
+{
+    "_id": "FtBfE4yrbg9fxtxr",
+    "img": "icons/consumables/potions/potion-bottle-labeled-medicine-capped-red-black.webp",
+    "name": "Effect: Sanguine Mutagen (Greater)",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.equipment-srd.Item.Sanguine Mutagen (Greater)]</p>\n<p><strong>Benefit</strong> You gain a +3 item bonus to Fortitude and Reflex saves. This bonus improves to +4 when you attempt a save against an effect that has the disease trait, poison trait, or would give you the <a class=\"content-link\" draggable=\"true\" data-uuid=\"Compendium.pf2e.conditionitems.Item.HL2l2VRSaQHu9lUw\" data-id=\"HL2l2VRSaQHu9lUw\" data-type=\"Item\" data-pack=\"pf2e.conditionitems\" data-tooltip=\"Condition Item\">Fatigued</a> condition.</p>\n<p>When you roll a success on a save against a disease, poison, or effect that would give you the Fatigued condition, you get a critical success instead.</p>\n<p><strong>Drawback</strong> Whenever you take piercing or slashing damage, you take <a class=\"inline-roll roll\" draggable=\"true\" data-formula=\"{1d6[bleed,persistent]}\" data-base-formula=\"1d6[bleed]\" data-damage-roll=\"1d6[bleed]\" data-traits=\"alchemical,consumable,elixir,mutagen,polymorph\" data-item-id=\"eSrMw2thqHGUMneF\" data-persistent=\"true\">1d6 bleed</a>.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "hours",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Treasure Vault"
+        },
+        "rules": [
+            {
+                "hideIfDisabled": true,
+                "key": "FlatModifier",
+                "selector": [
+                    "fortitude",
+                    "reflex"
+                ],
+                "type": "item",
+                "value": 3
+            },
+            {
+                "key": "FlatModifier",
+                "label": "PF2E.Mutagens.SanguineMutagen.GreaterVariantSaveLabel",
+                "predicate": [
+                    {
+                        "or": [
+                            "disease",
+                            "poison",
+                            "inflicts:fatigued"
+                        ]
+                    }
+                ],
+                "selector": [
+                    "fortitude",
+                    "reflex"
+                ],
+                "type": "item",
+                "value": 4
+            },
+            {
+                "key": "Note",
+                "predicate": [
+                    {
+                        "or": [
+                            "item:damage:type:piercing",
+                            "item:damage:type:slashing"
+                        ]
+                    }
+                ],
+                "selector": "damage-received",
+                "text": "Whenever you take piercing or slashing damage, you take @Damage[1d6[bleed]].",
+                "title": "{item|name}"
+            },
+            {
+                "adjustment": {
+                    "success": "one-degree-better"
+                },
+                "key": "AdjustDegreeOfSuccess",
+                "predicate": [
+                    {
+                        "or": [
+                            "poison",
+                            "disease",
+                            "inflicts:fatigued"
+                        ]
+                    }
+                ],
+                "selector": "saving-throw"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/equipment-effects/effect-sanguine-mutagen-lesser.json
+++ b/packs/equipment-effects/effect-sanguine-mutagen-lesser.json
@@ -1,0 +1,80 @@
+{
+    "_id": "5VI5NCEhuorERXTi",
+    "img": "icons/consumables/potions/potion-bottle-labeled-medicine-capped-red-black.webp",
+    "name": "Effect: Sanguine Mutagen (Lesser)",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.equipment-srd.Item.Sanguine Mutagen (Lesser)]</p>\n<p><strong>Benefit</strong> You gain a +1 item bonus to Fortitude and Reflex saves. This bonus improves to +2 when you attempt a save against an effect that has the disease trait, poison trait, or would give you the <a class=\"content-link\" draggable=\"true\" data-uuid=\"Compendium.pf2e.conditionitems.Item.HL2l2VRSaQHu9lUw\" data-id=\"HL2l2VRSaQHu9lUw\" data-type=\"Item\" data-pack=\"pf2e.conditionitems\" data-tooltip=\"Condition Item\">Fatigued</a> condition.</p>\n<p><strong>Drawback</strong> Whenever you take piercing or slashing damage, you take <a class=\"inline-roll roll\" draggable=\"true\" data-formula=\"{1d6[bleed,persistent]}\" data-base-formula=\"1d6[bleed]\" data-damage-roll=\"1d6[bleed]\" data-traits=\"alchemical,consumable,elixir,mutagen,polymorph\" data-item-id=\"eSrMw2thqHGUMneF\" data-persistent=\"true\">1d6 bleed</a>.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "minutes",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Treasure Vault"
+        },
+        "rules": [
+            {
+                "hideIfDisabled": true,
+                "key": "FlatModifier",
+                "selector": [
+                    "fortitude",
+                    "reflex"
+                ],
+                "type": "item",
+                "value": 1
+            },
+            {
+                "key": "FlatModifier",
+                "label": "PF2E.Mutagens.SanguineMutagen.LesserVariantSaveLabel",
+                "predicate": [
+                    {
+                        "or": [
+                            "disease",
+                            "poison",
+                            "inflicts:fatigued"
+                        ]
+                    }
+                ],
+                "selector": [
+                    "fortitude",
+                    "reflex"
+                ],
+                "type": "item",
+                "value": 2
+            },
+            {
+                "key": "Note",
+                "predicate": [
+                    {
+                        "or": [
+                            "item:damage:type:piercing",
+                            "item:damage:type:slashing"
+                        ]
+                    }
+                ],
+                "selector": "damage-received",
+                "text": "Whenever you take piercing or slashing damage, you take @Damage[1d6[bleed]].",
+                "title": "{item|name}"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/equipment-effects/effect-sanguine-mutagen-major.json
+++ b/packs/equipment-effects/effect-sanguine-mutagen-major.json
@@ -1,0 +1,78 @@
+{
+    "_id": "yY8vPNmDdQQ5d7n6",
+    "img": "icons/consumables/potions/potion-bottle-labeled-medicine-capped-red-black.webp",
+    "name": "Effect: Sanguine Mutagen (Major)",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.equipment-srd.Item.Sanguine Mutagen (Major)]</p>\n<p><strong>Benefit</strong> You gain a +4 item bonus to Fortitude and Reflex saves. When you roll a success on a save against a disease, poison, or effect that would give you the <a class=\"content-link\" draggable=\"true\" data-uuid=\"Compendium.pf2e.conditionitems.Item.HL2l2VRSaQHu9lUw\" data-id=\"HL2l2VRSaQHu9lUw\" data-type=\"Item\" data-pack=\"pf2e.conditionitems\" data-tooltip=\"Condition Item\">Fatigued</a> condition, you get a critical success instead and your critical failures on such saves become failures instead.</p>\n<p><strong>Drawback</strong> Whenever you take piercing or slashing damage, you take <a class=\"inline-roll roll\" draggable=\"true\" data-formula=\"{1d6[bleed,persistent]}\" data-base-formula=\"1d6[bleed]\" data-damage-roll=\"1d6[bleed]\" data-traits=\"alchemical,consumable,elixir,mutagen,polymorph\" data-item-id=\"eSrMw2thqHGUMneF\" data-persistent=\"true\">1d6 bleed</a>.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "hours",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Treasure Vault"
+        },
+        "rules": [
+            {
+                "hideIfDisabled": true,
+                "key": "FlatModifier",
+                "selector": [
+                    "fortitude",
+                    "reflex"
+                ],
+                "type": "item",
+                "value": 4
+            },
+            {
+                "key": "Note",
+                "predicate": [
+                    {
+                        "or": [
+                            "item:damage:type:piercing",
+                            "item:damage:type:slashing"
+                        ]
+                    }
+                ],
+                "selector": "damage-received",
+                "text": "Whenever you take piercing or slashing damage, you take @Damage[1d6[bleed]].",
+                "title": "{item|name}"
+            },
+            {
+                "adjustment": {
+                    "criticalFailure": "one-degree-better",
+                    "success": "one-degree-better"
+                },
+                "key": "AdjustDegreeOfSuccess",
+                "predicate": [
+                    {
+                        "or": [
+                            "poison",
+                            "disease",
+                            "inflicts:fatigued"
+                        ]
+                    }
+                ],
+                "selector": "saving-throw"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/equipment-effects/effect-sanguine-mutagen-moderate.json
+++ b/packs/equipment-effects/effect-sanguine-mutagen-moderate.json
@@ -1,0 +1,80 @@
+{
+    "_id": "sZPXKQACna6YDsVX",
+    "img": "icons/consumables/potions/potion-bottle-labeled-medicine-capped-red-black.webp",
+    "name": "Effect: Sanguine Mutagen (Moderate)",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.equipment-srd.Item.Sanguine Mutagen (Moderate)]</p>\n<p><strong>Benefit</strong> You gain a +2 item bonus to Fortitude and Reflex saves. This bonus improves to +3 when you attempt a save against an effect that has the disease trait, poison trait, or would give you the <a class=\"content-link\" draggable=\"true\" data-uuid=\"Compendium.pf2e.conditionitems.Item.HL2l2VRSaQHu9lUw\" data-id=\"HL2l2VRSaQHu9lUw\" data-type=\"Item\" data-pack=\"pf2e.conditionitems\" data-tooltip=\"Condition Item\">Fatigued</a> condition.</p>\n<p><strong>Drawback</strong> Whenever you take piercing or slashing damage, you take <a class=\"inline-roll roll\" draggable=\"true\" data-formula=\"{1d6[bleed,persistent]}\" data-base-formula=\"1d6[bleed]\" data-damage-roll=\"1d6[bleed]\" data-traits=\"alchemical,consumable,elixir,mutagen,polymorph\" data-item-id=\"eSrMw2thqHGUMneF\" data-persistent=\"true\">1d6 bleed</a>.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "minutes",
+            "value": 10
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Treasure Vault"
+        },
+        "rules": [
+            {
+                "hideIfDisabled": true,
+                "key": "FlatModifier",
+                "selector": [
+                    "fortitude",
+                    "reflex"
+                ],
+                "type": "item",
+                "value": 2
+            },
+            {
+                "key": "FlatModifier",
+                "label": "PF2E.Mutagens.SanguineMutagen.ModerateVariantSaveLabel",
+                "predicate": [
+                    {
+                        "or": [
+                            "disease",
+                            "poison",
+                            "inflicts:fatigued"
+                        ]
+                    }
+                ],
+                "selector": [
+                    "fortitude",
+                    "reflex"
+                ],
+                "type": "item",
+                "value": 3
+            },
+            {
+                "key": "Note",
+                "predicate": [
+                    {
+                        "or": [
+                            "item:damage:type:piercing",
+                            "item:damage:type:slashing"
+                        ]
+                    }
+                ],
+                "selector": "damage-received",
+                "text": "Whenever you take piercing or slashing damage, you take @Damage[1d6[bleed]].",
+                "title": "{item|name}"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -610,6 +610,12 @@
         "Mutagens": {
             "BestialMutagen": {
                 "FeralPrompt": "Increase penalty to AC to increase damage dice size?"
+            },
+            "SanguineMutagen":{
+                "DamageNote":"Whenever you take piercing or slashing damage, you take @Damage[1d6[bleed]].",
+                "LesserVariantSaveLabel":"Sanguine Mutagen (Lesser) vs Disease, Poison, Fatigue",
+                "ModerateVariantSaveLabel":"Sanguine Mutagen (Moderate) vs Disease, Poison, Fatigue",
+                "GreaterVariantSaveLabel":"Sanguine Mutagen (Greater) vs Disease, Poison, Fatigue"
             }
         },
         "NPCAbility": {


### PR DESCRIPTION
I didn't localize the Damage Note text because it doesn't appear to work for Damage Chat Cards - it just printed out the string name instead of the localized text.