### PR TITLE
Add roll options for spellcasting traditions

### DIFF
--- a/src/module/actor/creature/document.ts
+++ b/src/module/actor/creature/document.ts
@@ -393,10 +393,6 @@ abstract class CreaturePF2e<
         const { attributes, rollOptions } = this;
 
         // Add creature-specific self: roll options
-        if (this.isSpellcaster) {
-            rollOptions.all["self:caster"] = true;
-        }
-
         if (this.hitPoints.negativeHealing) {
             rollOptions.all["self:negative-healing"] = true;
         }

--- a/src/module/item/spellcasting-entry/document.ts
+++ b/src/module/item/spellcasting-entry/document.ts
@@ -135,6 +135,11 @@ class SpellcastingEntryPF2e<TParent extends ActorPF2e | null = ActorPF2e | null>
                 4,
             ) as OneToFour;
         }
+
+        if ((this.spells?.size ?? 0) > 0) {
+            actor.rollOptions.all["self:caster"] = true;
+            actor.rollOptions.all[`self:caster:tradition:${this.tradition}`] = true;
+        }
     }
 
     /** Prepares the statistic for this spellcasting entry */


### PR DESCRIPTION
When an actor can cast spells it currently gets a roll option named "self:caster" (or "target:caster", etc. depending on context).

Extend this with "self:caster:divine", etc. for whatever tradition(s) the actor has.  "self:caster" is still there if any traditions are known.

Like the existing isSpellcaster() check, the tradition doesn't count unless it actually has spells.

The motiviation is to be able to add automation for things like Divine Disharmony, which triggers on, amongst other things, "...  creature with divine spells." Or Robe of the Archmagi, which "benefit only characters who can cast arcane spells."