### PR TITLE
Fix Black Smilodon rarity in Kingmaker

### DIFF
--- a/packs/kingmaker-bestiary/black-smilodon.json
+++ b/packs/kingmaker-bestiary/black-smilodon.json
@@ -331,7 +331,8 @@
                     "title": ""
                 },
                 "rules": [],
-                "slug": null
+                "slug": null,
+                "traits": {}
             },
             "type": "lore"
         },
@@ -356,7 +357,8 @@
                     "title": ""
                 },
                 "rules": [],
-                "slug": null
+                "slug": null,
+                "traits": {}
             },
             "type": "lore"
         },
@@ -381,7 +383,8 @@
                     "title": ""
                 },
                 "rules": [],
-                "slug": null
+                "slug": null,
+                "traits": {}
             },
             "type": "lore"
         }
@@ -477,7 +480,7 @@
             }
         },
         "traits": {
-            "rarity": "unique",
+            "rarity": "common",
             "size": {
                 "value": "lg"
             },


### PR DESCRIPTION
Closes #9023

Set to the same rarity as Smilodons.