### PR TITLE
Allow AdjustModifier REs to affect resilient rune modifier

### DIFF
--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -840,9 +840,15 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
 
             // Add resilient bonuses for wearing armor with a resilient rune.
             if (wornArmor?.system.runes.resilient && wornArmor.isInvested) {
-                const value = wornArmor.system.runes.resilient;
+                const slug = "resilient";
                 modifiers.push(
-                    new ModifierPF2e({ slug: "resilient", label: wornArmor.name, type: "item", modifier: value }),
+                    new ModifierPF2e({
+                        slug,
+                        type: "item",
+                        label: wornArmor.name,
+                        modifier: wornArmor.system.runes.resilient,
+                        adjustments: extractModifierAdjustments(this.synthetics.modifierAdjustments, selectors, slug),
+                    }),
                 );
             }
 


### PR DESCRIPTION
When the modifier for a resilient rune is created, the adjustments weren't also extracted and added to it.  The result is that AdjustModifier REs can't change the resilient bonus.

This extracts the adjustments, in the same way as, e.g., the Bulwark trait.  Items like Robe of the Archmagi that only supply their resilient benefit if the owner has certain traits can be automated using an AdjustModifier RE.