### PR TITLE
Add RE to handle part of Defensive Armaments

### DIFF
--- a/packs/feats/defensive-armaments.json
+++ b/packs/feats/defensive-armaments.json
@@ -24,7 +24,29 @@
             "remaster": false,
             "title": "Pathfinder Guns & Gears"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "weapon",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    {
+                        "or": [
+                            "item:group:crossbow",
+                            "item:group:firearm"
+                        ]
+                    },
+                    {
+                        "or": [
+                            "item:usage:hands:2",
+                            "item:hands-held:2"
+                        ]
+                    }
+                ],
+                "property": "traits",
+                "value": "parry"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [


### PR DESCRIPTION
Handling of the parry bonus is a bit jank right now, so this doesn't build on top of it.

Partially addresses #13408 