### PR TITLE
Hide merchant coins and empty loot sections from players

### DIFF
--- a/src/module/actor/loot/sheet.ts
+++ b/src/module/actor/loot/sheet.ts
@@ -1,5 +1,6 @@
 import type { LootPF2e } from "@actor";
-import { ActorSheetDataPF2e } from "@actor/sheet/data-types.ts";
+import type { ActorSheetDataPF2e, InventoryItem, SheetInventory } from "@actor/sheet/data-types.ts";
+import type { PhysicalItemPF2e } from "@item";
 import { htmlClosest, htmlQuery } from "@util";
 import { ActorSheetPF2e } from "../sheet/base.ts";
 import { LootNPCsPopup } from "../sheet/loot/loot-npcs-popup.ts";
@@ -54,6 +55,27 @@ export class LootSheetPF2e<TActor extends LootPF2e> extends ActorSheetPF2e<TActo
                 }
             }
         });
+    }
+
+    protected override prepareInventory(): SheetInventory {
+        const preparedInventory = super.prepareInventory();
+
+        // Hide empty sections for non-owners
+        if (!this.actor.isOwner) {
+            preparedInventory.sections = preparedInventory.sections.filter(
+                (s) => s.items.length && s.items.some((i) => !i.hidden),
+            );
+        }
+
+        return preparedInventory;
+    }
+
+    /** Hide coin item rows in merchant actors */
+    protected override prepareInventoryItem(item: PhysicalItemPF2e): InventoryItem {
+        const isMerchant = this.actor.system.lootSheetType === "Merchant";
+        const data = super.prepareInventoryItem(item);
+        data.hidden = isMerchant && item.isOfType("treasure") && item.isCoinage && !item.container;
+        return data;
     }
 }
 

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -216,12 +216,9 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
         const itemSize = new ActorSizePF2e({ value: item.size });
         const sizeDifference = itemSize.difference(actorSize, { smallIsMedium: true });
 
-        const canBeEquipped = !item.isInContainer;
-
         return {
             item,
-            canBeEquipped,
-            editable,
+            canBeEquipped: !item.isInContainer,
             hasCharges: item.isOfType("consumable") && item.system.uses.max > 0,
             heldItems,
             isContainer: item.isOfType("backpack"),
@@ -229,6 +226,7 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
             isSellable: editable && item.isOfType("treasure") && !item.isCoinage,
             itemSize: sizeDifference !== 0 ? itemSize : null,
             unitBulk: actor.isOfType("loot") ? createBulkPerLabel(item) : null,
+            hidden: false,
         };
     }
 

--- a/src/module/actor/sheet/data-types.ts
+++ b/src/module/actor/sheet/data-types.ts
@@ -10,7 +10,6 @@ export interface InventoryItem<TItem extends PhysicalItemPF2e = PhysicalItemPF2e
     item: TItem;
     /** Item size if it causes any weight difference relative to the actor */
     itemSize?: ActorSizePF2e | null;
-    editable: boolean;
     isContainer: boolean;
     canBeEquipped: boolean;
     /** Bulk for each item is shown on an individual basis from merchant sheets */
@@ -20,6 +19,8 @@ export interface InventoryItem<TItem extends PhysicalItemPF2e = PhysicalItemPF2e
     hasCharges: boolean;
     heldItems?: InventoryItem[];
     notifyInvestment?: boolean;
+    /** Whether the item should be hidden if the user isn't the owner */
+    hidden: boolean;
 }
 
 interface CoinDisplayData {

--- a/src/styles/actor/loot/_index.scss
+++ b/src/styles/actor/loot/_index.scss
@@ -190,6 +190,12 @@
                     }
                 }
             }
+
+            li.hidden-item {
+                background: var(--visibility-gm-bg);
+                outline: 1px dotted rgba(75, 74, 68, 0.5);
+                opacity: 0.9;
+            }
         }
     }
 }

--- a/static/templates/actors/loot/inventory.hbs
+++ b/static/templates/actors/loot/inventory.hbs
@@ -1,5 +1,9 @@
 <section class="sheet-body content sheet-content-loot inventory">
-    {{> "systems/pf2e/templates/actors/partials/coinage.hbs" owner=owner}}
+    {{#if (or document.isOwner isLoot)}}
+        {{> "systems/pf2e/templates/actors/partials/coinage.hbs" owner=owner}}
+    {{/if}}
     {{> "systems/pf2e/templates/actors/partials/inventory.hbs"}}
-    {{> "systems/pf2e/templates/actors/partials/total-bulk.hbs"}}
+    {{#if (or document.isOwner isLoot)}}
+        {{> "systems/pf2e/templates/actors/partials/total-bulk.hbs"}}
+    {{/if}}
 </section>

--- a/static/templates/actors/partials/inventory.hbs
+++ b/static/templates/actors/partials/inventory.hbs
@@ -41,7 +41,9 @@
         </header>
         <ul class="items" data-item-list data-item-types="{{section.types}}"{{#if @root.isLootSheet}} data-loot{{/if}}>
             {{#each section.items as |rowData|}}
-                {{> "systems/pf2e/templates/actors/partials/item-line.hbs" this=rowData}}
+                {{#if (or (not rowData.hidden) @root.document.isOwner)}}
+                    {{> "systems/pf2e/templates/actors/partials/item-line.hbs" this=rowData}}
+                {{/if}}
             {{/each}}
         </ul>
     {{/each}}

--- a/static/templates/actors/partials/item-line.hbs
+++ b/static/templates/actors/partials/item-line.hbs
@@ -2,6 +2,7 @@
     {{#if isSubitem}}data-subitem-id{{else}}data-item-id{{/if}}="{{item.id}}"
     {{#if isContainer}}data-is-container{{/if}}
     {{#if item.isInContainer}}data-item-type="{{item.type}}"{{/if}}
+    {{#if hidden}}class="hidden-item"{{/if}}
 >
     <div class="data{{#if item.isTemporary}} temporary-item{{/if}}">
         <div class="item-name{{#if (and (ne @root.actor.type "loot") (not @root.owner))}} long{{/if}}">


### PR DESCRIPTION
GM view
![image](https://github.com/foundryvtt/pf2e/assets/1286721/ca40a07b-04f3-4b74-87c7-73a533d7a586)

Player View
![image](https://github.com/foundryvtt/pf2e/assets/1286721/6c06a44f-045c-45ca-bae2-ce3fa5656104)

Coins in containers are purposefully not hidden as it would cause strange behavior if the container itself as sold (and if it also sold what was inside the container, which it should.....)