### PR TITLE
Add rule for Divine Disharmony bonus

### DIFF
--- a/packs/feats/divine-disharmony.json
+++ b/packs/feats/divine-disharmony.json
@@ -24,7 +24,29 @@
             "remaster": false,
             "title": "Pathfinder Dark Archive"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "action:divine-disharmony",
+                    {
+                        "or": [
+                            "target:trait:cleric",
+                            "target:trait:fiend",
+                            "target:trait:monitor",
+                            "target:trait:celestial",
+                            "target:caster:tradition:divine"
+                        ]
+                    }
+                ],
+                "selector": [
+                    "intimidation",
+                    "deception"
+                ],
+                "type": "circumstance",
+                "value": 2
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [


### PR DESCRIPTION
Rule for the +2 circumstance bonus to the divine disharmony action, when the target meets certain conditions.

While the text of the feat mentions GM arbitration in determining the nature of the target's faith or lack thereof, it also lists several specific traits.  The RE tests only for the extact traits listed in the text.