### PR TITLE
Finish Robe of the Archmagi automation

### DIFF
--- a/packs/equipment/robe-of-the-archmagi-greater.json
+++ b/packs/equipment/robe-of-the-archmagi-greater.json
@@ -67,6 +67,28 @@
                 "value": 10
             },
             {
+                "key": "AdjustModifier",
+                "predicate": [
+                    {
+                        "not": "self:caster:tradition:arcane"
+                    }
+                ],
+                "selector": "saving-throw",
+                "slug": "resilient",
+                "suppress": true
+            },
+            {
+                "key": "AdjustModifier",
+                "predicate": [
+                    {
+                        "not": "self:caster:tradition:arcane"
+                    }
+                ],
+                "selector": "ac",
+                "slug": "explorers-clothing",
+                "suppress": true
+            },
+            {
                 "alterations": [
                     {
                         "mode": "override",

--- a/packs/equipment/robe-of-the-archmagi.json
+++ b/packs/equipment/robe-of-the-archmagi.json
@@ -67,6 +67,28 @@
                 "value": 5
             },
             {
+                "key": "AdjustModifier",
+                "predicate": [
+                    {
+                        "not": "self:caster:tradition:arcane"
+                    }
+                ],
+                "selector": "saving-throw",
+                "slug": "resilient",
+                "suppress": true
+            },
+            {
+                "key": "AdjustModifier",
+                "predicate": [
+                    {
+                        "not": "self:caster:tradition:arcane"
+                    }
+                ],
+                "selector": "ac",
+                "slug": "explorers-clothing",
+                "suppress": true
+            },
+            {
                 "alterations": [
                     {
                         "mode": "override",


### PR DESCRIPTION
This automates most of the effects of a non-arcane caster wearing a Robe of the Archmagi (regular or plus-sized).

A Stupefied 2 condition is imposed.

The saving throw bonus is disabled.

The AC and the resilient item bonuses are supressed.  They'll appear on the character sheet with the normal +2 value, but be grayed out and not applied.

The good/neutral/evil alignment of the robe, and the robe's color, isn't part of the item.  So none of the effects consider that.