### PR TITLE
Fix styling regression in Kingdom sheet sub-nav header

### DIFF
--- a/src/styles/actor/_nav.scss
+++ b/src/styles/actor/_nav.scss
@@ -87,7 +87,7 @@ nav.sub-nav {
     display: flex;
     flex-wrap: nowrap;
     flex: 0 0 2.5rem;
-    justify-content: center;
+    justify-content: space-evenly;
     list-style: none;
     margin: 0;
     padding: 0;
@@ -100,6 +100,7 @@ nav.sub-nav {
         content: "";
         height: 1rem;
         width: 2.5rem;
+        margin: 0 1rem;
     }
 
     &::after {
@@ -111,7 +112,7 @@ nav.sub-nav {
         border-right: 1px solid rgba(black, 0.2);
         color: var(--color-pf-alternate);
         display: block;
-        flex: 0 0 25%;
+        flex: 1;
         font: 400 var(--font-size-16) var(--serif);
         text-align: center;
         text-decoration: none;


### PR DESCRIPTION
This should be a more reliable way of maintaining the centered, evenly spread sub-nav links now that we have a Kingdom sheet with more sub-nav links than the player sheet and party sheet.

![image](https://github.com/foundryvtt/pf2e/assets/4469633/cd9a58f3-d557-4a9a-adf0-31a50fd7a1b1)