### PR TITLE
Add cursebound trait to spells cast with Mystery Conduit on

### DIFF
--- a/packs/feats/mystery-conduit.json
+++ b/packs/feats/mystery-conduit.json
@@ -48,6 +48,7 @@
                         "not": "cantrip"
                     }
                 ],
+                "priority": 119,
                 "property": "traits",
                 "value": "cursebound"
             },

--- a/packs/feats/mystery-conduit.json
+++ b/packs/feats/mystery-conduit.json
@@ -26,10 +26,38 @@
         },
         "rules": [
             {
+                "key": "RollOption",
+                "option": "mystery-conduit",
+                "placement": "spellcasting",
+                "toggleable": true
+            },
+            {
                 "itemType": "spell",
                 "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
+                    "mystery-conduit",
+                    "item:duration:0",
+                    {
+                        "lte": [
+                            "item:rank",
+                            5
+                        ]
+                    },
+                    {
+                        "not": "cantrip"
+                    }
+                ],
+                "property": "traits",
+                "value": "cursebound"
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "mystery-conduit",
+                    "item:duration:0",
                     {
                         "lte": [
                             "item:rank",


### PR DESCRIPTION
which in turn will post the appropriate curse advancement to chat.