### PR TITLE
Append aura shut off reminder note to overflow impulses

### DIFF
--- a/packs/classfeatures/kinetic-aura.json
+++ b/packs/classfeatures/kinetic-aura.json
@@ -29,6 +29,21 @@
                 "allowDuplicate": false,
                 "key": "GrantItem",
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Channel Elements"
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:trait:overflow"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Kineticist.Overflow.Description",
+                        "title": "PF2E.SpecificRule.Kineticist.Overflow.Title"
+                    }
+                ]
             }
         ],
         "traits": {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2520,6 +2520,10 @@
                         "Threshold": "Select a gate's threshold."
                     },
                     "SingleGate": "Single Gate"
+                },
+                "Overflow": {
+                    "Title": "Overflow",
+                    "Description": "When you use an impulse that has the overflow trait, your kinetic aura deactivates until you revitalize it (typically with @UUID[Compendium.pf2e.actionspf2e.Item.g8QrV39TmZfkbXgE]{Channel Elements}). You can use only one overflow impulse per round, even if you reactivate your kinetic gate."
                 }
             },
             "Kobold": {


### PR DESCRIPTION
~~Feat description alterations are not posted to chat currently, so I suppose I'm drafting this until that's resolved.~~