### PR TITLE
Add saving throws to the proficiencies tab and remove the proficiency rank from saving throws in the sidebar

### DIFF
--- a/static/templates/actors/character/partials/sidebar.hbs
+++ b/static/templates/actors/character/partials/sidebar.hbs
@@ -264,7 +264,6 @@
     {{#each data.saves as |save slug|}}
         <li class="roll-data" data-save="{{slug}}">
             <h2 class="sidebar_label">{{localize save.label}}</h2>
-            <span class="pf-rank" data-rank="{{save.rank}}">{{lookup @root.numberToRank save.rank}}</span>
 
             <div class="save-roll">
                 <a class="roll-icon" data-action="roll-check" data-statistic="{{save.slug}}">

--- a/static/templates/actors/character/tabs/proficiencies.hbs
+++ b/static/templates/actors/character/tabs/proficiencies.hbs
@@ -116,6 +116,25 @@
         {{/each}}
     </ul>
 
+    {{!-- Saving Throws --}}
+    <header class="saving-throws">
+        {{localize "PF2E.Actor.Character.Proficiency.SavingThrow.Title"}}
+    </header>
+    <ul class="proficiencies-list combat-list">
+        {{#each data.saves as |save slug|}}
+            <li data-slug="{{slug}}">
+                <span class="modifier" data-tooltip="{{save.breakdown}}">{{numberFormat save.totalModifier decimals=0 sign=true}}</span>
+                <span class="name">{{localize save.label}}</span>
+                <div class="button-group stacked">
+                    <span class="pf-rank" data-rank="{{save.rank}}">{{lookup @root.numberToRank save.rank}}</span>
+                    <button type="button" class="hover" data-tooltip-content="#{{@root.options.id}}-{{slug}}-modifiers">
+                        {{localize "PF2E.ModifiersTitle"}}
+                    </button>
+                </div>
+            </li>
+        {{/each}}
+    </ul>
+
     {{!-- Spellcasting --}}
     {{#if hasNormalSpellcasting}}
         <header>{{localize "PF2E.Item.Spell.Plural"}}</header>


### PR DESCRIPTION
I added the saving throws to the proficiency tab below the defenses section. Like the section for class DCs, you have a button for modifiers and can see a breakdown of the value by hovering over it. I didn't add the ability to roll the saving throw from the section as I figured you'd probably want to keep doing that from the sidebar and that saves some clutter.
Speaking of the sidebar, I removed the proficiency rank element for the saving throws there to make that area a tiny bit less packed.
![SavingThrowsSection](https://github.com/foundryvtt/pf2e/assets/7766914/a2c40bbc-881e-4bcb-8bb4-301494a18bfc)
![Sidebar](https://github.com/foundryvtt/pf2e/assets/7766914/7cf8c3e7-6bf9-4bae-ab91-960812e1dae3)
