### PR TITLE
Add Magical Trait to Strikes granted by Morph spell effects

### DIFF
--- a/packs/spell-effects/spell-effect-animal-feature-claws.json
+++ b/packs/spell-effects/spell-effect-animal-feature-claws.json
@@ -38,6 +38,7 @@
                 "traits": [
                     "agile",
                     "finesse",
+                    "magical",
                     "unarmed"
                 ]
             }

--- a/packs/spell-effects/spell-effect-animal-feature-jaws.json
+++ b/packs/spell-effects/spell-effect-animal-feature-jaws.json
@@ -36,6 +36,7 @@
                 "label": "PF2E.Weapon.Base.jaws",
                 "range": null,
                 "traits": [
+                    "magical",
                     "unarmed"
                 ]
             }

--- a/packs/spell-effects/spell-effect-dragon-claws.json
+++ b/packs/spell-effects/spell-effect-dragon-claws.json
@@ -36,6 +36,7 @@
                 "range": null,
                 "slug": "dragon-claw",
                 "traits": [
+                    "magical",
                     "unarmed",
                     "finesse"
                 ]

--- a/packs/spell-effects/spell-effect-gluttons-jaw.json
+++ b/packs/spell-effects/spell-effect-gluttons-jaw.json
@@ -36,6 +36,7 @@
                 "range": null,
                 "traits": [
                     "forceful",
+                    "magical",
                     "unarmed"
                 ]
             },

--- a/packs/spell-effects/spell-effect-mantle-of-the-frozen-heart-icy-claws.json
+++ b/packs/spell-effects/spell-effect-mantle-of-the-frozen-heart-icy-claws.json
@@ -38,7 +38,8 @@
                 "traits": [
                     "unarmed",
                     "agile",
-                    "finesse"
+                    "finesse",
+                    "magical"
                 ]
             },
             {

--- a/packs/spell-effects/spell-effect-mantle-of-the-magma-heart-fiery-grasp.json
+++ b/packs/spell-effects/spell-effect-mantle-of-the-magma-heart-fiery-grasp.json
@@ -35,7 +35,8 @@
                 "label": "PF2E.BattleForm.Attack.LavaFist",
                 "range": null,
                 "traits": [
-                    "unarmed"
+                    "unarmed",
+                    "magical"
                 ]
             },
             {

--- a/packs/spell-effects/spell-effect-mantle-of-the-unwavering-heart.json
+++ b/packs/spell-effects/spell-effect-mantle-of-the-unwavering-heart.json
@@ -147,7 +147,8 @@
                 "range": null,
                 "slug": "grasping-branch",
                 "traits": [
-                    "unarmed"
+                    "unarmed",
+                    "magical"
                 ]
             },
             {

--- a/packs/spell-effects/spell-effect-moon-frenzy.json
+++ b/packs/spell-effects/spell-effect-moon-frenzy.json
@@ -50,7 +50,8 @@
                 "label": "PF2E.BattleForm.Attack.Fangs",
                 "slug": "moon-frenzy-fangs",
                 "traits": [
-                    "unarmed"
+                    "unarmed",
+                    "magical"
                 ]
             },
             {
@@ -70,7 +71,8 @@
                 "traits": [
                     "agile",
                     "finesse",
-                    "unarmed"
+                    "unarmed",
+                    "magical"
                 ]
             },
             {

--- a/packs/spell-effects/spell-effect-shifting-form.json
+++ b/packs/spell-effects/spell-effect-shifting-form.json
@@ -104,7 +104,8 @@
                 "traits": [
                     "agile",
                     "finesse",
-                    "unarmed"
+                    "unarmed",
+                    "magical"
                 ]
             },
             {

--- a/packs/spell-effects/spell-effect-untamed-shift.json
+++ b/packs/spell-effects/spell-effect-untamed-shift.json
@@ -322,7 +322,8 @@
                 "traits": [
                     "agile",
                     "finesse",
-                    "unarmed"
+                    "unarmed",
+                    "magical"
                 ]
             },
             {
@@ -344,7 +345,8 @@
                 "range": null,
                 "slug": "jaws",
                 "traits": [
-                    "unarmed"
+                    "unarmed",
+                    "magical"
                 ]
             },
             {


### PR DESCRIPTION
Morph states "Any Strikes specifically granted by a morph effect are magical."

So I added the magical trait to all Strike REs on Morph spell effects.