### PR TITLE
Remove damage partial from Life's Flowing River and add inline damage links

### DIFF
--- a/packs/spells/lifes-flowing-river.json
+++ b/packs/spells/lifes-flowing-river.json
@@ -8,18 +8,7 @@
             "value": ""
         },
         "counteraction": false,
-        "damage": {
-            "FIkUEzSt5nqmYDL5": {
-                "applyMod": false,
-                "category": null,
-                "formula": "4d6",
-                "kinds": [
-                    "damage"
-                ],
-                "materials": [],
-                "type": "mental"
-            }
-        },
+        "damage": {},
         "defense": {
             "save": {
                 "basic": false,
@@ -27,11 +16,14 @@
             }
         },
         "description": {
-            "value": "<p>You create a volume of faint shimmering light that resembles a flowing river and sheds dim light for 10 feet on each side. The river begins in an adjacent square to you and extends in a straight 5-foot path to its maximum range or until it hits a solid wall, whichever comes first. A creature that begins its turn in the river or enters one of the river's spaces must attempt a Will save.</p>\n<hr />\n<p><strong>Critical Success</strong> The creature ignores the river's effects until the start of its next turn.</p>\n<p><strong>Success</strong> The creature treats all squares occupied by the river as difficult terrain until the start of its next turn. If the creature is undead or a nindoru fiend, it takes 2d6 mental damage.</p>\n<p><strong>Failure</strong> As success, but the creature is also knocked @UUID[Compendium.pf2e.conditionitems.Item.Prone]. If the creature is undead or a nindoru fiend, it takes 4d6 mental damage.</p>\n<p><strong>Critical Failure</strong> As failure, but the creature is pushed 20 feet along the river's path in the direction of flow. If the creature is undead or a nindoru fiend, it takes 8d6 mental damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The mental damage increases by 1d6.</p>"
+            "value": "<p>You create a volume of faint shimmering light that resembles a flowing river and sheds dim light for 10 feet on each side. The river begins in an adjacent square to you and extends in a straight 5-foot path to its maximum range or until it hits a solid wall, whichever comes first. A creature that begins its turn in the river or enters one of the river's spaces must attempt a Will save.</p>\n<hr />\n<p><strong>Critical Success</strong> The creature ignores the river's effects until the start of its next turn.</p>\n<p><strong>Success</strong> The creature treats all squares occupied by the river as difficult terrain until the start of its next turn. If the creature is undead or a nindoru fiend, it takes @Damage[(@item.level -2)d6[mental]] damage.</p>\n<p><strong>Failure</strong> As success, but the creature is also knocked @UUID[Compendium.pf2e.conditionitems.Item.Prone]. If the creature is undead or a nindoru fiend, it takes @Damage[(@item.level)d6[mental]] damage.</p>\n<p><strong>Critical Failure</strong> As failure, but the creature is pushed 20 feet along the river's path in the direction of flow. If the creature is undead or a nindoru fiend, it takes @Damage[(@item.level+4)d6[mental]] damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The mental damage increases by 1d6.</p>"
         },
         "duration": {
             "sustained": false,
             "value": "1 minute"
+        },
+        "heightening": {
+            "damage": {}
         },
         "level": {
             "value": 4


### PR DESCRIPTION
It's not a basic saving throw, and the language doesn't indicate that the damage is doubled or halved.

By my interpretation that means a +1 heightened Critical Failure should do 9d6 mental rather than 10d6.