### PR TITLE
Update publication data of some PC1 class feats

### DIFF
--- a/packs/feats/dueling-parry-fighter.json
+++ b/packs/feats/dueling-parry-fighter.json
@@ -20,9 +20,9 @@
             "value": []
         },
         "publication": {
-            "license": "OGL",
-            "remaster": false,
-            "title": "Pathfinder Core Rulebook"
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
         },
         "rules": [],
         "selfEffect": {

--- a/packs/feats/slam-down.json
+++ b/packs/feats/slam-down.json
@@ -24,9 +24,9 @@
             ]
         },
         "publication": {
-            "license": "OGL",
-            "remaster": false,
-            "title": "Pathfinder Core Rulebook"
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
         },
         "rules": [],
         "traits": {

--- a/packs/feats/sneak-adept.json
+++ b/packs/feats/sneak-adept.json
@@ -24,9 +24,9 @@
             ]
         },
         "publication": {
-            "license": "OGL",
-            "remaster": false,
-            "title": "Pathfinder Core Rulebook"
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
         },
         "rules": [],
         "traits": {

--- a/packs/feats/tactical-reflexes.json
+++ b/packs/feats/tactical-reflexes.json
@@ -20,9 +20,9 @@
             "value": []
         },
         "publication": {
-            "license": "OGL",
-            "remaster": false,
-            "title": "Pathfinder Core Rulebook"
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
         },
         "rules": [],
         "traits": {


### PR DESCRIPTION
Partially addresses #13527

- Green Empathy is a duplicate of the new Plant Empathy, which Druids can get for free at level 1. It's even already listed in the Remaster Changes journal entry as being a rename. But then Green Empathy is also a prerequisite for Green Tongue. Nuke both?
- Battle Assessment is sheer chaos; it's no wonder that it didn't make it to PC1. That said, I suppose GMs can continue to indulge it if they want to.