### PR TITLE
Grant Deadly Simplicity with Warpriest's First Doctrine

### DIFF
--- a/packs/classfeatures/first-doctrine-warpriest.json
+++ b/packs/classfeatures/first-doctrine-warpriest.json
@@ -58,6 +58,10 @@
                     "feature:divine-defense"
                 ],
                 "value": 2
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.feats-srd.Item.Deadly Simplicity"
             }
         ],
         "subfeatures": {


### PR DESCRIPTION
While technically wrong on some deities we can't grant based on the category without a larger rewrite of deity items and the feat will simply do nothing on deities that don't qualify anyways.