### PR TITLE
Add Protection aura spell effect

### DIFF
--- a/packs/spell-effects/aura-protection.json
+++ b/packs/spell-effects/aura-protection.json
@@ -1,0 +1,51 @@
+{
+	"_id": "FS02HRZmg4yIDLFw",
+	"img": "systems/pf2e/icons/spells/protection.webp",
+	"name": "Aura: Protection",
+	"system": {
+		"description": {
+			"value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Protection]</p>\n<p>The target gains a +1 status bonus to Armor Class and saving throws.</p>"
+		},
+		"rules": [
+			{
+				"key": "Aura",
+				"radius": 10,
+				"level": 3,
+				"effects": [
+					{
+						"affects": "allies",
+						"uuid": "Compendium.pf2e.spell-effects.Item.Spell Effect: Protection"
+					}
+				]
+			}
+		],
+		"traits": {
+			"otherTags": [],
+			"value": [],
+			"rarity": "common"
+		},
+		"publication": {
+			"title": "Pathfinder Player Core",
+			"authors": "",
+			"license": "ORC",
+			"remaster": true
+		},
+		"level": {
+			"value": 3
+		},
+		"duration": {
+			"value": 1,
+			"unit": "minutes",
+			"expiry": "turn-start",
+			"sustained": false
+		},
+		"start": {
+			"value": 0,
+			"initiative": null
+		},
+		"tokenIcon": {
+			"show": true
+		}
+	},
+	"type": "effect"
+}

--- a/packs/spells/protection.json
+++ b/packs/spells/protection.json
@@ -11,7 +11,7 @@
         "damage": {},
         "defense": null,
         "description": {
-            "value": "<p>You ward a creature against harm. The target gains a +1 status bonus to Armor Class and saving throws.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You can choose to have the benefits also affect all your allies in a @Template[type:emanation|distance:10] around the target.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Protection]</p>"
+            "value": "<p>You ward a creature against harm. The target gains a +1 status bonus to Armor Class and saving throws.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You can choose to have the benefits also affect all your allies in a @Template[type:emanation|distance:10] around the target.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Protection]</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Aura: Protection]</p>"
         },
         "duration": {
             "sustained": false,


### PR DESCRIPTION
- Adds `Aura: Protection` spell effect for Protection heightened to rank 3+
- Adjusts the Protection spell to link the aura as well