### PR TITLE
Correct precision damage getting halved by critical success

### DIFF
--- a/src/module/system/damage/iwr.ts
+++ b/src/module/system/damage/iwr.ts
@@ -60,7 +60,7 @@ function applyIWR(actor: ActorPF2e, roll: Rolled<DamageRoll>, rollOptions: Set<s
             // (or untriple) the total.
             const critImmunity = immunities.find((i) => i.type === "critical-hits");
             const isCriticalSuccess = roll.options.degreeOfSuccess === DEGREE_OF_SUCCESS.CRITICAL_SUCCESS;
-            const critImmuneTotal = isCriticalSuccess ? instance.critImmuneTotal : instanceTotal;
+            const critImmuneTotal = critImmunity && isCriticalSuccess ? instance.critImmuneTotal : instanceTotal;
 
             const instanceApplications: IWRApplication[] = [];
 


### PR DESCRIPTION
Previously, a critical success would always generate a <critImmuneTotal> value as it would not check whether critImmunity was applied. This change adds the critImmunity check to the calculation for critImmuneTotal, therefore not later halving precision damage by assuming that crit immunity was already applied.