### PR TITLE
Fix identification of mystified mundane items

### DIFF
--- a/src/module/actor/sheet/popups/identify-popup.ts
+++ b/src/module/actor/sheet/popups/identify-popup.ts
@@ -48,7 +48,11 @@ export class IdentifyItemPopup extends FormApplication<PhysicalItemPF2e> {
             const item = this.object;
             const identifiedName = item.system.identification.identified.name;
             const dcs: Record<string, number> = this.dcs;
-            const action = item.isMagical ? "identify-magic" : item.isAlchemical ? "identify-alchemy" : null;
+            const action = item.isMagical
+                ? "identify-magic"
+                : item.isAlchemical
+                  ? "identify-alchemy"
+                  : "recall-knowledge";
 
             const content = await renderTemplate("systems/pf2e/templates/actors/identify-item-chat-skill-checks.hbs", {
                 identifiedName,

--- a/src/module/item/identification.ts
+++ b/src/module/item/identification.ts
@@ -69,10 +69,8 @@ function getItemIdentificationDCs(
     const dc = adjustDCByRarity(baseDC, rarity);
     if (item.isMagical) {
         return getIdentifyMagicDCs(item, dc, notMatchingTraditionModifier);
-    } else if (item.isAlchemical) {
-        return { crafting: dc };
     } else {
-        return { dc: dc };
+        return { crafting: dc };
     }
 }
 


### PR DESCRIPTION
Fall back to using a recall knowledge action for appraising non-magical and non-alchemical items.