### PR TITLE
Make available roll options of effect origins' originating items

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -497,6 +497,7 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
                         token: origin.token.uuid,
                         item: null,
                         spellcasting: null,
+                        rollOptions: [],
                     },
                     roll: null,
                 };

--- a/src/module/chat-message/data.ts
+++ b/src/module/chat-message/data.ts
@@ -19,6 +19,7 @@ export interface ItemOriginFlag {
     castRank?: number;
     messageId?: string;
     variant?: { overlays: string[] };
+    rollOptions?: string[];
 }
 
 type ChatMessageFlagsPF2e = ChatMessageFlags & {

--- a/src/module/item/abstract-effect/data.ts
+++ b/src/module/item/abstract-effect/data.ts
@@ -66,6 +66,7 @@ interface EffectContextData {
         token: TokenDocumentUUID | null;
         item: ItemUUID | null;
         spellcasting: EffectContextSpellcastingData | null;
+        rollOptions: string[];
     };
     target: {
         actor: ActorUUID;

--- a/src/module/item/abstract-effect/document.ts
+++ b/src/module/item/abstract-effect/document.ts
@@ -76,20 +76,25 @@ abstract class AbstractEffectPF2e<TParent extends ActorPF2e | null = ActorPF2e |
     abstract decrease(): Promise<void>;
 
     override getRollOptions(prefix = this.type): string[] {
-        const { origin } = this;
-        // Safety check: this effect's owning actor may be getting initialized during game setup and before its origin
-        // has been initialized
-        const originIsInitialized = !!origin?.flags?.pf2e?.rollOptions;
-        // If this effect came from another actor, get that actor's roll options as well
-        const originRollOptions = originIsInitialized
-            ? origin.getSelfRollOptions("origin").map((o) => `${prefix}:${o}`) ?? []
-            : [];
-        const { badge } = this;
-        const itemOrigin = this.grantedBy?.getRollOptions(`${prefix}:granter`) ?? [];
+        const originRollOptions =
+            this.system.context?.origin.rollOptions.map((o) => `${prefix}:${o}`) ??
+            ((): string[] => {
+                const origin = this.origin;
+                // Safety check: this effect's owning actor may be getting initialized during game setup and before its origin
+                // has been initialized
+                const originIsInitialized = !!origin?.flags?.pf2e?.rollOptions;
+                // If this effect came from another actor, get that actor's roll options as well
+                return originIsInitialized
+                    ? origin.getSelfRollOptions("origin").map((o) => `${prefix}:${o}`) ?? []
+                    : [];
+            })();
+
+        const grantingItem = this.grantedBy?.getRollOptions(`${prefix}:granter`) ?? [];
+        const badge = this.badge;
 
         return [
             ...super.getRollOptions(prefix),
-            ...itemOrigin,
+            ...grantingItem,
             ...Object.entries({
                 [`badge:type:${badge?.type}`]: !!badge,
                 [`badge:value:${badge?.value}`]: !!badge,

--- a/src/module/item/effect/document.ts
+++ b/src/module/item/effect/document.ts
@@ -1,4 +1,4 @@
-import { ActorPF2e } from "@actor";
+import type { ActorPF2e } from "@actor";
 import { EffectBadge, EffectBadgeSource } from "@item/abstract-effect/data.ts";
 import { AbstractEffectPF2e, EffectBadgeFormulaSource, EffectBadgeValueSource } from "@item/abstract-effect/index.ts";
 import { reduceItemName } from "@item/helpers.ts";
@@ -38,7 +38,7 @@ class EffectPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ab
     override prepareBaseData(): void {
         super.prepareBaseData();
 
-        const { system } = this;
+        const system = this.system;
         if (["unlimited", "encounter"].includes(system.duration.unit)) {
             system.duration.expiry = null;
         } else {
@@ -46,7 +46,7 @@ class EffectPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ab
         }
         system.expired = this.remainingDuration.expired;
 
-        const { badge } = this.system;
+        const badge = system.badge;
         if (badge) {
             if (badge.type === "formula") {
                 badge.label = null;
@@ -107,7 +107,7 @@ class EffectPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ab
      * @returns The resulting value badge
      */
     private async evaluateFormulaBadge(badge: EffectBadgeFormulaSource): Promise<EffectBadgeValueSource> {
-        const { actor } = this;
+        const actor = this.actor;
         if (!actor) throw ErrorPF2e("A formula badge can only be evaluated if part of an embedded effect");
 
         const roll = await new Roll(badge.value, this.getRollData()).evaluate({ async: true });

--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -1047,6 +1047,9 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
         if (this.isVariant && this.appliedOverlays) {
             flag.variant = { overlays: [...this.appliedOverlays.values()] };
         }
+        flag.rollOptions = R.compact(
+            [this.actor?.getSelfRollOptions("origin"), this.getRollOptions("origin:item")].flat(),
+        );
 
         return flag;
     }

--- a/src/scripts/system/dragstart-handler.ts
+++ b/src/scripts/system/dragstart-handler.ts
@@ -50,6 +50,7 @@ export function extendDragData(): void {
                         token: token?.uuid ?? null,
                         item: originItem?.uuid ?? null,
                         spellcasting,
+                        rollOptions: message.flags.pf2e.origin?.rollOptions ?? [],
                     },
                     target: target ? { actor: target.actor.uuid, token: target.token.uuid } : null,
                     roll: roll


### PR DESCRIPTION
A bit nutty, but useful!
![image](https://github.com/foundryvtt/pf2e/assets/106829671/5f71cb51-faff-447d-a3a3-851bee60c252)
