### PR TITLE
Move general amp-related REs to Psi Cantrips and Amps class feature

### DIFF
--- a/packs/classfeatures/conscious-mind.json
+++ b/packs/classfeatures/conscious-mind.json
@@ -39,37 +39,6 @@
             {
                 "key": "GrantItem",
                 "uuid": "{item|flags.pf2e.rulesSelections.consciousMind}"
-            },
-            {
-                "domain": "all",
-                "key": "RollOption",
-                "label": "PF2E.SpecificRule.Psychic.Amp.Toggle",
-                "option": "amp-spell",
-                "placement": "spellcasting",
-                "toggleable": true
-            },
-            {
-                "itemType": "spell",
-                "key": "ItemAlteration",
-                "mode": "add",
-                "predicate": [
-                    "item:trait:cantrip",
-                    "item:trait:psychic"
-                ],
-                "priority": 19,
-                "property": "other-tags",
-                "value": "psi-cantrip"
-            },
-            {
-                "itemType": "spell",
-                "key": "ItemAlteration",
-                "mode": "add",
-                "predicate": [
-                    "amp-spell",
-                    "item:tag:psi-cantrip"
-                ],
-                "property": "focus-point-cost",
-                "value": 1
             }
         ],
         "traits": {

--- a/packs/classfeatures/psi-cantrips-and-amps.json
+++ b/packs/classfeatures/psi-cantrips-and-amps.json
@@ -11,7 +11,7 @@
         },
         "category": "classfeature",
         "description": {
-            "value": "<p>The magic of your mind manifests as psi cantrips, which you can modify by spending Focus Points. Like other cantrips, you can cast psi cantrips as often as you like, and they are automatically heightened to half your level rounded up. Your psi cantrips are in addition to the cantrips you choose from the occult list as part of your psychic spellcasting. Generally, only feats can give you more psi cantrips. Unlike other cantrips, you can't swap out psi cantrips gained from psychic feats at a later level, unless you swap out the specific feat via retraining. At 1st level, you learn three psi cantrips determined by your choice of conscious mind; one is a unique psi cantrip and two are common cantrips, typically from the occult spellcasting tradition, that you always cast as psi cantrips. You automatically gain more psi cantrips as you progress in your career as a psychic.</p>\n<p>You start with a focus pool of 2 Focus Points. However, unlike other spellcasters, you don't gain focus spells that cost Focus Points to cast. Instead, you use your Focus Points to boost or modify your psi cantrips by applying amps- specialized thoughtforms that alter the expression of your psychic power. Each of your psi cantrips has a special amp heading. Whenever you cast a psi cantrip, you can amp it by spending 1 Focus Point to add the amp effect. You can also gain additional amps through feats, allowing you to substitute a psi cantrip's normal amp effect for another one. You choose which amp to use, if you choose to use any, each time you cast a psi cantrip. Unless otherwise noted, you can apply only one amp to a given psi cantrip.</p>\n<p>You refill your focus pool during your daily preparations, and you can regain Focus Points by spending 10 minutes using the @UUID[Compendium.pf2e.actionspf2e.Item.Refocus] activity to explore your mind, whether via meditation, practicing a craft or activity that gives you the mental space to self-reflect, or talking through your thoughts and feelings with yourself or another. If you've spent Focus Points only to amp psi cantrips or fuel psychic abilities since the last time you Refocused, you regain 2 Focus Points when you Refocus, up to your maximum of 2. If you've spent Focus Points on focus spells or abilities other than those from the psychic class (for instance, to cast a focus spell you gained from an archetype), you regain only 1 Focus Point.</p>"
+            "value": "<p>The magic of your mind manifests as psi cantrips, which you can modify by spending Focus Points. Like other cantrips, you can cast psi cantrips as often as you like, and they are automatically heightened to half your level rounded up. Your psi cantrips are in addition to the cantrips you choose from the occult list as part of your psychic spellcasting. Generally, only feats can give you more psi cantrips. Unlike other cantrips, you can't swap out psi cantrips gained from psychic feats at a later level, unless you swap out the specific feat via retraining. At 1st level, you learn three psi cantrips determined by your choice of conscious mind; one is a unique psi cantrip and two are common cantrips, typically from the occult spellcasting tradition, that you always cast as psi cantrips. You automatically gain more psi cantrips as you progress in your career as a psychic.</p>\n<p>You start with a focus pool of 2 Focus Points. However, unlike other spellcasters, you don't gain focus spells that cost Focus Points to cast. Instead, you use your Focus Points to boost or modify your psi cantrips by applying amps—specialized thoughtforms that alter the expression of your psychic power. Each of your psi cantrips has a special amp heading. Whenever you cast a psi cantrip, you can amp it by spending 1 Focus Point to add the amp effect. You can also gain additional amps through feats, allowing you to substitute a psi cantrip's normal amp effect for another one. You choose which amp to use, if you choose to use any, each time you cast a psi cantrip. Unless otherwise noted, you can apply only one amp to a given psi cantrip.</p>\n<p>You refill your focus pool during your daily preparations, and you can regain Focus Points by spending 10 minutes using the @UUID[Compendium.pf2e.actionspf2e.Item.Refocus] activity to explore your mind, whether via meditation, practicing a craft or activity that gives you the mental space to self-reflect, or talking through your thoughts and feelings with yourself or another. If you've spent Focus Points only to amp psi cantrips or fuel psychic abilities since the last time you Refocused, you regain 2 Focus Points when you Refocus, up to your maximum of 2. If you've spent Focus Points on focus spells or abilities other than those from the psychic class (for instance, to cast a focus spell you gained from an archetype), you regain only 1 Focus Point.</p>"
         },
         "level": {
             "value": 1
@@ -31,6 +31,48 @@
                 "path": "system.resources.focus.max",
                 "priority": 10,
                 "value": 2
+            },
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Psychic.Amp.Toggle",
+                "option": "amp-spell",
+                "placement": "spellcasting",
+                "toggleable": true
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:trait:cantrip",
+                    "item:trait:psychic"
+                ],
+                "priority": 19,
+                "property": "other-tags",
+                "value": "psi-cantrip"
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "amp-spell",
+                    "item:tag:psi-cantrip"
+                ],
+                "property": "other-tags",
+                "value": "amped"
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "amp-spell",
+                    "item:tag:psi-cantrip"
+                ],
+                "property": "focus-point-cost",
+                "value": 1
             }
         ],
         "traits": {


### PR DESCRIPTION
Also throw in spell otherTag of "amped"