### PR TITLE
Show additional icons for character sheet choices

### DIFF
--- a/src/styles/actor/character/_character.scss
+++ b/src/styles/actor/character/_character.scss
@@ -86,17 +86,19 @@
                 padding: 0;
             }
 
-            .deity.selected {
-                min-width: max-content;
+            .selected {
+                &.deity {
+                    min-width: max-content;
+
+                    h3 span.value {
+                        text-overflow: unset;
+                    }
+                }
 
                 h3 {
                     border-radius: 0 var(--space-12) var(--space-12) 0;
                     flex-basis: auto;
                     gap: var(--space-4);
-
-                    span.value {
-                        text-overflow: unset;
-                    }
 
                     .emblem {
                         flex: 0 0 1.75rem;

--- a/static/templates/actors/character/tabs/character.hbs
+++ b/static/templates/actors/character/tabs/character.hbs
@@ -21,19 +21,19 @@
             </ul>
 
             <div class="detail ancestry{{#if ancestry}} selected{{/if}}">
-                {{> detailItem item=ancestry type="ancestry" compendium="pf2e.ancestries"}}
+                {{> detailItem item=ancestry type="ancestry" compendium="pf2e.ancestries" showEmblem=ancestry}}
             </div>
 
             <div class="detail heritage{{#if heritage}} selected{{/if}}">
-                {{> detailItem item=heritage type="heritage" compendium="pf2e.heritages"}}
+                {{> detailItem item=heritage type="heritage" compendium="pf2e.heritages" showEmblem=heritage}}
             </div>
 
             <div class="detail background{{#if background}} selected{{/if}}">
-                {{> detailItem item=background type="background" compendium="pf2e.backgrounds"}}
+                {{> detailItem item=background type="background" compendium="pf2e.backgrounds" showEmblem=background}}
             </div>
 
             <div class="detail class{{#if class}} selected{{/if}}">
-                {{> detailItem item=class type="class" compendium="pf2e.classes"}}
+                {{> detailItem item=class type="class" compendium="pf2e.classes" showEmblem=class}}
             </div>
 
             <div class="detail deity{{#if deity}} selected{{/if}}">


### PR DESCRIPTION
Thoughts on expanding the stylised icon that we use for deity to the other choices too?

The default icons for some of the choices are a little jarring but IMO it's still quite charming.

![show-player-ABCH-icons](https://github.com/foundryvtt/pf2e/assets/4469633/119d2e3c-5e90-412b-ae73-a80a893fada1)
