### PR TITLE
Fix 'wind touch' damage in Unshadowed Haibram

### DIFF
--- a/packs/strength-of-thousands-bestiary/unshadowed-haibram.json
+++ b/packs/strength-of-thousands-bestiary/unshadowed-haibram.json
@@ -2958,7 +2958,7 @@
                     },
                     {
                         "diceNumber": 2,
-                        "dieSize": "d8",
+                        "dieSize": "d10",
                         "key": "DamageDice",
                         "predicate": [
                             "wind-touch"


### PR DESCRIPTION
The text states: 

> Haibram imbues a weapon he's holding with the power of the wind until the start of his next turn. The wind's power allows Haibram to swing and hurl the weapon with great force, causing the weapon to deal an additional 2d10 damage. 

This fixes the extra damage to match. 