### PR TITLE
Add outcome-dependent notes with effect links to Overdrive

### DIFF
--- a/packs/actions/overdrive.json
+++ b/packs/actions/overdrive.json
@@ -25,6 +25,30 @@
         "rules": [
             {
                 "key": "Note",
+                "title": "PF2E.Check.Result.Degree.Check.criticalSuccess",
+                "selector": "crafting",
+                "predicate": [
+                    "self:action:slug:overdrive"
+                ],
+                "text": "PF2E.SpecificRule.Inventor.Overdrive.CriticalSuccess",
+                "outcome": [
+                    "criticalSuccess"
+                ]
+            },
+            {
+                "key": "Note",
+                "title": "PF2E.Check.Result.Degree.Check.success",
+                "selector": "crafting",
+                "predicate": [
+                    "self:action:slug:overdrive"
+                ],
+                "text": "PF2E.SpecificRule.Inventor.Overdrive.Success",
+                "outcome": [
+                    "success"
+                ]
+            },
+            {
+                "key": "Note",
                 "outcome": [
                     "criticalFailure"
                 ],

--- a/packs/feat-effects/effect-overdrive.json
+++ b/packs/feat-effects/effect-overdrive.json
@@ -24,12 +24,42 @@
             {
                 "choices": [
                     {
-                        "label": "PF2E.Check.Result.Degree.Check.criticalSuccess",
-                        "value": "critical-success"
+                        "label": "PF2E.Check.Result.Degree.Check.success",
+                        "predicate": [
+                            {
+                                "or": [
+                                    "parent:context:check:outcome:2",
+                                    {
+                                        "not": {
+                                            "gte": [
+                                                "parent:context:check:outcome",
+                                                0
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        ],
+                        "value": "success"
                     },
                     {
-                        "label": "PF2E.Check.Result.Degree.Check.success",
-                        "value": "success"
+                        "label": "PF2E.Check.Result.Degree.Check.criticalSuccess",
+                        "predicate": [
+                            {
+                                "or": [
+                                    "parent:context:check:outcome:3",
+                                    {
+                                        "not": {
+                                            "gte": [
+                                                "parent:context:check:outcome",
+                                                0
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        ],
+                        "value": "critical-success"
                     }
                 ],
                 "flag": "baseDamage",

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2460,7 +2460,9 @@
                 },
                 "Overdrive": {
                     "CriticalFailure": "Whoops! Something explodes. You take @Damage[@actor.level[@actor.flags.pf2e.inventor.explode]|immutable|name:PF2E.SpecificRule.Inventor.Innovation.MalfunctionDamage] damage, and you can't use Overdrive again for 1 minute as your gizmos cool down and reset.",
-                    "FireDamage": "Overdrive Fire Damage"
+                    "CriticalSuccess": "Your gizmos go into a state of incredible efficiency called critical @UUID[Compendium.pf2e.feat-effects.Item.1XlJ9xLzL19GHoOL]{Overdrive}, adding great power to your attacks.",
+                    "FireDamage": "Overdrive Fire Damage",
+                    "Success": "Your gizmos go into @UUID[Compendium.pf2e.feat-effects.Item.1XlJ9xLzL19GHoOL]{Overdrive}, adding power to your attacks."
                 },
                 "Unstable": {
                     "FlatCheck": {


### PR DESCRIPTION
[Screencast from 02-05-2024 10:05:53 PM.webm](https://github.com/foundryvtt/pf2e/assets/106829671/8eb4e05e-22cd-4c87-a079-a005f7a693e7)
