### PR TITLE
Move overdrive fire damage to weapon innovation class feature

### DIFF
--- a/packs/classfeatures/weapon-innovation.json
+++ b/packs/classfeatures/weapon-innovation.json
@@ -163,6 +163,27 @@
                     "class:inventor"
                 ],
                 "uuid": "{item|flags.pf2e.rulesSelections.initialModification}"
+            },
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Inventor.Overdrive.FireDamage",
+                "option": "overdrive-fire-damage",
+                "predicate": [
+                    "self:effect:overdrive"
+                ],
+                "selector": "strike-damage",
+                "toggleable": true
+            },
+            {
+                "damageType": "fire",
+                "key": "AdjustModifier",
+                "mode": "add",
+                "predicate": [
+                    "overdrive-fire-damage"
+                ],
+                "selector": "strike-damage",
+                "slug": "overdrive",
+                "value": 0
             }
         ],
         "traits": {

--- a/packs/feat-effects/effect-overdrive.json
+++ b/packs/feat-effects/effect-overdrive.json
@@ -108,27 +108,6 @@
                 "predicate": [
                     "overdrive:critical-success"
                 ]
-            },
-            {
-                "key": "RollOption",
-                "label": "PF2E.SpecificRule.Inventor.Overdrive.FireDamage",
-                "option": "overdrive-fire-damage",
-                "predicate": [
-                    "feature:weapon-innovation"
-                ],
-                "selector": "strike-damage",
-                "toggleable": true
-            },
-            {
-                "damageType": "fire",
-                "key": "AdjustModifier",
-                "mode": "add",
-                "predicate": [
-                    "overdrive-fire-damage"
-                ],
-                "selector": "strike-damage",
-                "slug": "overdrive",
-                "value": 0
             }
         ],
         "start": {


### PR DESCRIPTION
To make the selection persist since last time it was applied