### PR TITLE
Fix missing versatile piercing for Bestial Manifestation claw attack

### DIFF
--- a/packs/feats/bestial-manifestation.json
+++ b/packs/feats/bestial-manifestation.json
@@ -29,18 +29,22 @@
             {
                 "choices": [
                     {
+                        "img": "icons/commodities/claws/claw-bear-brown-grey.webp",
                         "label": "PF2E.BattleForm.Attack.Claw",
                         "value": "claw"
                     },
                     {
+                        "img": "icons/commodities/biological/foot-black-grey.webp",
                         "label": "PF2E.BattleForm.Attack.Hoof",
                         "value": "hoof"
                     },
                     {
+                        "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
                         "label": "PF2E.BattleForm.Attack.Jaws",
                         "value": "jaws"
                     },
                     {
+                        "img": "icons/creatures/abilities/tail-swipe-green.webp",
                         "label": "PF2E.BattleForm.Attack.Tail",
                         "value": "tail"
                     }
@@ -70,7 +74,8 @@
                 "traits": [
                     "agile",
                     "finesse",
-                    "unarmed"
+                    "unarmed",
+                    "versatile-p"
                 ]
             },
             {
@@ -83,7 +88,7 @@
                     }
                 },
                 "group": "brawling",
-                "img": "systems/pf2e/icons/unarmed-attacks/foot.webp",
+                "img": "icons/commodities/biological/foot-black-grey.webp",
                 "key": "Strike",
                 "label": "PF2E.BattleForm.Attack.Hoof",
                 "predicate": [


### PR DESCRIPTION
Also add icons to ChoiceSet and use higher-res image for hoof

Closes https://github.com/foundryvtt/pf2e/issues/13617