### PR TITLE
Remove redundant retrieval of actor in `getCheckDC` inline roll links helper

### DIFF
--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -879,8 +879,8 @@ function getCheckDC({
 
     if (base) {
         const getStatisticValue = (selectors: string[]): string => {
-            if (item?.actor && params.immutable !== "true") {
-                const { actor } = item;
+            actor ??= item?.actor ?? null;
+            if (actor && params.immutable !== "true") {
                 const { synthetics } = actor;
                 const modifier = new ModifierPF2e({
                     slug: "base",

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -879,7 +879,7 @@ function getCheckDC({
 
     if (base) {
         const getStatisticValue = (selectors: string[]): string => {
-            if (actor && params.immutable !== "true") {
+            if (actor && params.immutable === undefined) {
                 const { synthetics } = actor;
                 const modifier = new ModifierPF2e({
                     slug: "base",

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -879,7 +879,6 @@ function getCheckDC({
 
     if (base) {
         const getStatisticValue = (selectors: string[]): string => {
-            actor ??= item?.actor ?? null;
             if (actor && params.immutable !== "true") {
                 const { synthetics } = actor;
                 const modifier = new ModifierPF2e({


### PR DESCRIPTION
This will allow the PFS modules to implement Influence Statblocks without excessive duplication, but I'm sure there could be other uses.

I've checked to make sure that the Journal and Chat are not affected by this in any way.