### PR TITLE
Fix variable-cost action glyphs in Spell Compendium

### DIFF
--- a/src/module/apps/compendium-browser/tabs/spell.ts
+++ b/src/module/apps/compendium-browser/tabs/spell.ts
@@ -81,6 +81,9 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
                         isRitual ? "ritual" : null,
                     ]);
 
+                    // format casting time (before value is sluggified)
+                    const actionGlyph = getActionGlyph(spellData.system.time.value);
+
                     // recording casting times
                     const time: unknown = spellData.system.time.value;
                     if (time && typeof time === "string") {
@@ -90,9 +93,6 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
                         times.add(normalizedTime);
                         spellData.system.time.value = normalizedTime;
                     }
-
-                    // format casting time
-                    const actionGlyph = getActionGlyph(spellData.system.time.value);
 
                     // Prepare publication source
                     const { system } = spellData;


### PR DESCRIPTION
The helper was being called with sluggified action costs and failing. An alternative fix is to modify `getActionGlyph(..)` to support sluggified input but I'm not convinced we need that.

Before v After:
![spell-compendium-action-glyph](https://github.com/foundryvtt/pf2e/assets/4469633/4dcb2c5b-b222-4bb4-9513-106ea3b2ad9f)
