### PR TITLE
Fix skirmisher army level

### DIFF
--- a/packs/kingmaker-bestiary/armies/basic-skirmishers.json
+++ b/packs/kingmaker-bestiary/armies/basic-skirmishers.json
@@ -10,7 +10,7 @@
     "system": {
         "ac": {
             "potency": 0,
-            "value": 35
+            "value": 20
         },
         "attributes": {
             "hp": {
@@ -25,7 +25,7 @@
             "blurb": "",
             "description": "<p>Skirmishers are lightly armored, but their ability to move quickly and to focus on individual tactics rather than working as a unit make them more resilient in other ways. A skirmisher army’s AC is two lower than normal for its level, but its Maneuver and Morale are two higher than normal for its level.</p>",
             "level": {
-                "value": 15
+                "value": 5
             }
         },
         "recruitmentDC": 20,
@@ -39,10 +39,10 @@
             }
         },
         "saves": {
-            "maneuver": 31,
-            "morale": 25
+            "maneuver": 17,
+            "morale": 11
         },
-        "scouting": 26,
+        "scouting": 12,
         "traits": {
             "rarity": "common",
             "size": {


### PR DESCRIPTION
Skirmishers are a level 5 army not 15 (typo I think)

![image](https://github.com/foundryvtt/pf2e/assets/195053/5933c07a-22f5-40c5-916e-94d7b143a709)
