### PR TITLE
Move leveled force damage to main `@Damage` links in Psi Burst and Violent Unleash

### DIFF
--- a/packs/classfeatures/the-oscillating-wave.json
+++ b/packs/classfeatures/the-oscillating-wave.json
@@ -214,12 +214,10 @@
                     },
                     {
                         "label": "PF2E.SpecificRule.Psychic.OscillatingWave.RemoveEnergy",
-                        "selected": false,
                         "value": "cold"
                     }
                 ],
-                "toggleable": true,
-                "value": true
+                "toggleable": true
             },
             {
                 "key": "DamageDice",
@@ -243,6 +241,39 @@
                     }
                 ],
                 "selector": "spell-damage"
+            },
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Psychic.OscillatingWave.Mindshift",
+                "option": "mindshift:add-remove-energy",
+                "toggleable": true
+            },
+            {
+                "key": "DamageAlteration",
+                "mode": "override",
+                "predicate": [
+                    "item:tag:mindshifted",
+                    "mindshift:add-remove-energy"
+                ],
+                "property": "damage-type",
+                "value": "{item|flags.pf2e.rulesSelections.conservationOfEnergy}",
+                "selectors": [
+                    "inline-damage"
+                ]
+            },
+            {
+                "key": "DamageAlteration",
+                "mode": "override",
+                "predicate": [
+                    "dice:slug:mindshift",
+                    "dice:damage:type:mental",
+                    "mindshift:add-remove-energy"
+                ],
+                "property": "damage-type",
+                "selectors": [
+                    "strike-damage"
+                ],
+                "value": "{item|flags.pf2e.rulesSelections.conservationOfEnergy}"
             }
         ],
         "traits": {

--- a/packs/feat-effects/effect-psi-strikes.json
+++ b/packs/feat-effects/effect-psi-strikes.json
@@ -34,7 +34,23 @@
                 "diceNumber": 1,
                 "dieSize": "d6",
                 "key": "DamageDice",
+                "predicate": [
+                    {
+                        "not": "parent:origin:item:tag:mindshifted"
+                    }
+                ],
                 "selector": "{item|flags.pf2e.rulesSelections.weapon}-damage"
+            },
+            {
+                "damageType": "mental",
+                "diceNumber": 1,
+                "dieSize": "d6",
+                "key": "DamageDice",
+                "predicate": [
+                    "parent:origin:item:tag:mindshifted"
+                ],
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-damage",
+                "slug": "mindshift"
             }
         ],
         "start": {

--- a/packs/feats/psi-burst.json
+++ b/packs/feats/psi-burst.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p><strong>Frequency</strong> once per round</p>\n<hr />\n<p>With a passing thought, you direct violent psychic energies at a nearby creature. Target one creature within 30 feet. It takes @Damage[1d4[bludgeoning]] damage with a @Check[type:reflex|dc:resolve(@actor.attributes.spellDC.value)|basic:true]. At 3rd level and every 2 levels thereafter, the damage increases by 1d4.</p>\n<p>[[/r (ceil(@actor.level/2)d4)[bludgeoning]]]{Leveled bludgeoning damage}</p>"
+            "value": "<p><strong>Frequency</strong> once per round</p>\n<hr />\n<p>With a passing thought, you direct violent psychic energies at a nearby creature. Target one creature within 30 feet. It takes @Damage[(ceil(@actor.level/2)d4)[bludgeoning]] damage with a @Check[type:reflex|dc:resolve(@actor.attributes.spellDC.value)|basic:true]. At 3rd level and every 2 levels thereafter, the damage increases by 1d4.</p>"
         },
         "frequency": {
             "max": 1,

--- a/packs/feats/violent-unleash.json
+++ b/packs/feats/violent-unleash.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p><strong>Trigger</strong> You Unleash your Psyche.</p>\n<hr />\n<p>The force of your mind unleashing itself wracks your enemies with a violent shockwave. You deal @Damage[2d6[force]|traits:area-damage] damage to all creatures in a @Template[type:emanation|distance:20], with a @Check[type:reflex|basic:true]{basic Reflex save}. This explosion is taxing, making you @UUID[Compendium.pf2e.conditionitems.Item.Stunned]{Stunned 1}. At 5th level and every 2 levels thereafter, the damage increases by 1d6.</p>\n<p>@Damage[(ceil(@actor.level/2)d6)[force]|traits:area-damage]{Leveled force damage}</p>"
+            "value": "<p><strong>Trigger</strong> You Unleash your Psyche.</p>\n<hr />\n<p>The force of your mind unleashing itself wracks your enemies with a violent shockwave. You deal @Damage[ceil(@actor.level/2)d6[force]|options:area-damage] damage to all creatures in a @Template[type:emanation|distance:20], with a @Check[type:reflex|basic:true]{basic Reflex save}. This explosion is taxing, making you @UUID[Compendium.pf2e.conditionitems.Item.Stunned]{Stunned 1}. At 5th level and every 2 levels thereafter, the damage increases by 1d6.</p>"
         },
         "level": {
             "value": 4

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -3025,6 +3025,7 @@
                 "OscillatingWave": {
                     "AddEnergy": "Add Energy",
                     "ConservationOfEnergyLabel": "Conservation of Energy",
+                    "Mindshift": "Mindshift: Add/Remove Energy",
                     "RemoveEnergy": "Remove Energy"
                 },
                 "SpellModification": {


### PR DESCRIPTION
Also add rule elements to conditionally change damage type of psi strikes