### PR TITLE
fix trait based RE predicates for inline DCs

### DIFF
--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -857,7 +857,7 @@ function getCheckDC({
     item?: ItemPF2e | null;
     actor?: ActorPF2e | null;
 }): string {
-    const { type } = params;
+    const { type, traits } = params;
     const dc = params.dc;
     const base = (() => {
         if (dc?.startsWith("resolve") && (item || actor)) {
@@ -887,12 +887,16 @@ function getCheckDC({
                     modifier: base - 10,
                     adjustments: extractModifierAdjustments(synthetics.modifierAdjustments, selectors, "base"),
                 });
-                const stat = new Statistic(actor, {
-                    slug: type,
-                    label: name,
-                    domains: selectors,
-                    modifiers: [modifier],
-                });
+                const stat = new Statistic(
+                    actor,
+                    {
+                        slug: type,
+                        label: name,
+                        domains: selectors,
+                        modifiers: [modifier],
+                    },
+                    { extraRollOptions: traits },
+                );
 
                 return String(stat.dc.value);
             }


### PR DESCRIPTION
follow up to #13623 I am not sure if this is the way the system wants to go, but the inline-dc selector should prevent unwanted behavior, but this might have interactions with the `perception-dc` or `all` selectors.

Note: At this time there is no need to implement this to fully support the commercial modules, it's only based on an observation of unexpected behavior while setting things up there.

enables Rule Elements for inline-dcs to use a predicate from the traits array, tested with `@Check[perception|traits:secret,concentrate,linguistic,action:discover|dc:13]`

```json
{
  "key": "FlatModifier",
  "selector": "inline-dc",
  "value": 1,
  "predicate": [
    "action:discover"
  ]
}
```