### PR TITLE
Add targetOwner option to @Check syntax

### DIFF
--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -582,8 +582,8 @@ class TextEditorPF2e extends TextEditor {
                 ...(basic ? ["damaging-effect"] : []),
                 ...(rawParams.options?.split(",").map((t) => t.trim()) ?? []),
             ]).sort(),
+    targetOwner: "targetOwner" in rawParams,
         };
-        params.targetOwner = "targetOwner" in rawParams;
 
         const types = params.type.split(",");
         let adjustments = params.adjustment?.split(",") ?? ["0"];

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -583,7 +583,7 @@ class TextEditorPF2e extends TextEditor {
                 ...(rawParams.options?.split(",").map((t) => t.trim()) ?? []),
             ]).sort(),
         };
-        if ("targetSelf" in rawParams) params.targetOwner = true;
+        params.targetOwner = "targetOwner" in rawParams;
 
         const types = params.type.split(",");
         let adjustments = params.adjustment?.split(",") ?? ["0"];
@@ -698,7 +698,7 @@ class TextEditorPF2e extends TextEditor {
                 pf2Label: localize("DCWithName", { name }),
                 pf2Adjustment: Number(params.adjustment) || null,
                 pf2Roller: params.roller || null,
-                TargetOwner: params.targetOwner,
+                targetOwner: params.targetOwner,
                 pf2Check: sluggify(params.type),
             },
         });
@@ -1076,7 +1076,7 @@ interface CheckLinkParams {
     /** Refrain from adding domains to the check. */
     immutable: boolean;
     roller?: string;
-    targetOwner?: boolean;
+    targetOwner: boolean;
 }
 
 interface CreateSingleCheckOptions {

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -583,6 +583,7 @@ class TextEditorPF2e extends TextEditor {
                 ...(rawParams.options?.split(",").map((t) => t.trim()) ?? []),
             ]).sort(),
         };
+        if ("targetSelf" in rawParams) params.targetSelf = true;
 
         const types = params.type.split(",");
         let adjustments = params.adjustment?.split(",") ?? ["0"];
@@ -697,7 +698,7 @@ class TextEditorPF2e extends TextEditor {
                 pf2Label: localize("DCWithName", { name }),
                 pf2Adjustment: Number(params.adjustment) || null,
                 pf2Roller: params.roller || null,
-                pf2Target: params.target || null,
+                pf2TargetSelf: params.targetSelf,
                 pf2Check: sluggify(params.type),
             },
         });
@@ -1075,7 +1076,7 @@ interface CheckLinkParams {
     /** Refrain from adding domains to the check. */
     immutable: boolean;
     roller?: string;
-    target?: string;
+    targetSelf?: boolean;
 }
 
 interface CreateSingleCheckOptions {

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -697,6 +697,7 @@ class TextEditorPF2e extends TextEditor {
                 pf2Label: localize("DCWithName", { name }),
                 pf2Adjustment: Number(params.adjustment) || null,
                 pf2Roller: params.roller || null,
+                pf2Target: params.target || null,
                 pf2Check: sluggify(params.type),
             },
         });
@@ -1074,6 +1075,7 @@ interface CheckLinkParams {
     /** Refrain from adding domains to the check. */
     immutable: boolean;
     roller?: string;
+    target?: string;
 }
 
 interface CreateSingleCheckOptions {

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -582,7 +582,7 @@ class TextEditorPF2e extends TextEditor {
                 ...(basic ? ["damaging-effect"] : []),
                 ...(rawParams.options?.split(",").map((t) => t.trim()) ?? []),
             ]).sort(),
-    targetOwner: "targetOwner" in rawParams,
+            targetOwner: "targetOwner" in rawParams,
         };
 
         const types = params.type.split(",");

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -583,7 +583,7 @@ class TextEditorPF2e extends TextEditor {
                 ...(rawParams.options?.split(",").map((t) => t.trim()) ?? []),
             ]).sort(),
         };
-        if ("targetSelf" in rawParams) params.targetSelf = true;
+        if ("targetSelf" in rawParams) params.targetOwner = true;
 
         const types = params.type.split(",");
         let adjustments = params.adjustment?.split(",") ?? ["0"];
@@ -698,7 +698,7 @@ class TextEditorPF2e extends TextEditor {
                 pf2Label: localize("DCWithName", { name }),
                 pf2Adjustment: Number(params.adjustment) || null,
                 pf2Roller: params.roller || null,
-                pf2TargetSelf: params.targetSelf,
+                TargetOwner: params.targetOwner,
                 pf2Check: sluggify(params.type),
             },
         });
@@ -1076,7 +1076,7 @@ interface CheckLinkParams {
     /** Refrain from adding domains to the check. */
     immutable: boolean;
     roller?: string;
-    targetSelf?: boolean;
+    targetOwner?: boolean;
 }
 
 interface CreateSingleCheckOptions {

--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -100,7 +100,7 @@ export const InlineRollLinks = {
                 pf2Defense,
                 pf2Adjustment,
                 pf2Roller,
-                pf2TargetSelf,
+                targetOwner,
                 pf2RollOptions,
                 overrideTraits,
             } = link.dataset;
@@ -184,7 +184,7 @@ export const InlineRollLinks = {
                             }
 
                             const targetActor = pf2Defense
-                                ? pf2TargetSelf
+                                ? targetOwner
                                     ? parent
                                     : game.user.targets.first()?.actor
                                 : null;

--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -100,7 +100,7 @@ export const InlineRollLinks = {
                 pf2Defense,
                 pf2Adjustment,
                 pf2Roller,
-                pf2Target,
+                pf2TargetSelf,
                 pf2RollOptions,
                 overrideTraits,
             } = link.dataset;
@@ -184,7 +184,7 @@ export const InlineRollLinks = {
                             }
 
                             const targetActor = pf2Defense
-                                ? pf2Target === "self"
+                                ? pf2TargetSelf
                                     ? parent
                                     : game.user.targets.first()?.actor
                                 : null;

--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -100,6 +100,7 @@ export const InlineRollLinks = {
                 pf2Defense,
                 pf2Adjustment,
                 pf2Roller,
+                pf2Target,
                 pf2RollOptions,
                 overrideTraits,
             } = link.dataset;
@@ -182,7 +183,11 @@ export const InlineRollLinks = {
                                 continue;
                             }
 
-                            const targetActor = pf2Defense ? game.user.targets.first()?.actor : null;
+                            const targetActor = pf2Defense
+                                ? pf2Target === "self"
+                                    ? parent
+                                    : game.user.targets.first()?.actor
+                                : null;
 
                             const dcValue = (() => {
                                 const adjustment = Number(pf2Adjustment) || 0;


### PR DESCRIPTION
When target:self is defined in the @Checks params, set the target for any defense evaluation to the origin of the Check.