### PR TITLE
Add item links to item transfer chat messages

### DIFF
--- a/src/module/actor/item-transfer.ts
+++ b/src/module/actor/item-transfer.ts
@@ -298,7 +298,7 @@ export class ItemTransfer implements ItemTransferData {
         const formatProperties = formatArgs[1];
         if (!formatProperties) throw ErrorPF2e("Unexpected item-transfer failure");
         formatProperties.quantity = this.quantity;
-        formatProperties.item = item.name;
+        formatProperties.item = await TextEditor.enrichHTML(item.link, { async: true });
 
         // Don't bother showing quantity if it's only 1:
         const content = await renderTemplate(this.#templatePaths.content, {

--- a/src/styles/ui/sidebar/chat/_action.scss
+++ b/src/styles/ui/sidebar/chat/_action.scss
@@ -6,6 +6,19 @@
         align-items: center;
         font-weight: normal;
 
+        a.content-link {
+            background: none;
+            border: none;
+            padding: 0;
+            text-decoration: underline;
+            white-space: unset;
+            word-break: normal;
+
+            > i {
+                margin-inline: 0.125rem;
+            }
+        }
+
         img {
             height: 2.33em;
             width: 2.33em;

--- a/static/templates/chat/action/content.hbs
+++ b/static/templates/chat/action/content.hbs
@@ -1,1 +1,1 @@
-<p class="action-content"><img src="{{imgPath}}" />{{message}}</p>
+<p class="action-content"><img src="{{imgPath}}" /><span>{{{message}}}</span></p>


### PR DESCRIPTION
Closes #13680

Inserts the item link for all of the valid A -> B item transfer chat messages.

The default item link styling was way too chunky without word wrap so I experimented with a simple underline instead. It still maintains all the clicky, hover etc effects:

![image](https://github.com/foundryvtt/pf2e/assets/4469633/f7509107-c5bf-4ba2-9fee-9a3e6c897c0c)

