### PR TITLE
Fix disabled appearance of NPC resistances header

### DIFF
--- a/static/templates/actors/npc/partials/sidebar.hbs
+++ b/static/templates/actors/npc/partials/sidebar.hbs
@@ -191,7 +191,7 @@
 
 <div class="subsection iwr">
     <header>
-        <label{{#unless data.attributes.immunities}} class="empty"{{/unless}}>
+        <label{{#unless data.attributes.resistances}} class="empty"{{/unless}}>
             <i class="fa-solid fa-fw fa-shield-virus"></i>
             <span>{{localize "PF2E.ResistancesLabel"}}</span>
         </label>


### PR DESCRIPTION
Vampire Squid before:
<img width="158" alt="Screen Shot 2024-02-12 at 11 45 27 PM" src="https://github.com/foundryvtt/pf2e/assets/1904698/e340d907-f7c0-4f8c-8deb-8a657f708432">

After:
<img width="158" alt="Screen Shot 2024-02-12 at 11 47 53 PM" src="https://github.com/foundryvtt/pf2e/assets/1904698/678347b5-27a7-4cfd-b1f4-d8fad32e80fc">

Kasesh (Stone) before:
<img width="158" alt="Screen Shot 2024-02-12 at 11 46 04 PM" src="https://github.com/foundryvtt/pf2e/assets/1904698/fc879fdf-5490-449d-a07a-bcbf51cd84d7">

After:
<img width="153" alt="Screen Shot 2024-02-12 at 11 48 15 PM" src="https://github.com/foundryvtt/pf2e/assets/1904698/cba850a8-1778-4014-a78a-0a5b541e65ab">
