### PR TITLE
Fix Mummy Dedication ChoiceSet activating

### DIFF
--- a/packs/feats/mummy-dedication.json
+++ b/packs/feats/mummy-dedication.json
@@ -97,11 +97,6 @@
             },
             {
                 "key": "Weakness",
-                "predicate": [
-                    {
-                        "not": "feat:sealed-poppet"
-                    }
-                ],
                 "type": "fire",
                 "value": "floor(@actor.level/2)"
             }

--- a/packs/feats/mummy-dedication.json
+++ b/packs/feats/mummy-dedication.json
@@ -45,6 +45,31 @@
                 "uuid": "Compendium.pf2e.ancestryfeatures.Item.Basic Undead Benefits"
             },
             {
+                "adjustName": true,
+                "choices": [
+                    {
+                        "label": "PF2E.SpecificRule.Mummy.Terrain.Arctic",
+                        "value": "arctic"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Mummy.Terrain.Desert",
+                        "value": "desert"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Mummy.Terrain.Mountain",
+                        "value": "mountain"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Mummy.Terrain.Swamp",
+                        "value": "swamp"
+                    }
+                ],
+                "flag": "terrain",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Mummy.Terrain.Prompt",
+                "rollOption": "mummy:bound-terrain"
+            },
+            {
                 "fist": true,
                 "key": "Strike"
             },
@@ -69,31 +94,6 @@
                 "mode": "remove",
                 "property": "weapon-traits",
                 "value": "nonlethal"
-            },
-            {
-                "adjustName": true,
-                "choices": [
-                    {
-                        "label": "PF2E.SpecificRule.Mummy.Terrain.Arctic",
-                        "value": "arctic"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Mummy.Terrain.Desert",
-                        "value": "desert"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Mummy.Terrain.Mountain",
-                        "value": "mountain"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Mummy.Terrain.Swamp",
-                        "value": "swamp"
-                    }
-                ],
-                "flag": "terrain",
-                "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.Mummy.Terrain.Prompt",
-                "rollOption": "mummy:bound-terrain"
             },
             {
                 "key": "Weakness",


### PR DESCRIPTION
Applying the Mummy Dedication to a character triggers a wall of warnings in the console regarding an ignored RuleElement and fails to trigger the ChoiceSet prompt.

Simply moving the ChoiceSet up the list of REs resolves the issue and allows the ChoiceSet to trigger.