### PR TITLE
Show Common-backing language and prevent it from double-counting and displaying separately

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -138,6 +138,9 @@ interface GamePF2e
             /** Encumbrance automation */
             encumbrance: boolean;
             gmVision: boolean;
+            homebrew: {
+                languageRarities: LanguageRaritiesData;
+            };
             /** Immunities, weaknesses, and resistances */
             iwr: boolean;
             metagame: {

--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -315,8 +315,8 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
 
         sheetData.abpEnabled = AutomaticBonusProgression.isEnabled(actor);
 
-        // get the backing language for common
-        const commonBackingLanguage = game.settings.get("pf2e", "homebrew.languageRarities").commonLanguage;
+        // get the backing language for common from cache
+        const commonBackingLanguage = game.pf2e.settings.homebrew.languageRarities.commonLanguage;
 
         sheetData.languages = ((): LanguageSheetData[] => {
             const languagesBuild = actor.system.build.languages;
@@ -326,10 +326,8 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
 
             // find if the backing language is present in character's languages
             // this means characters explictly selected it
-            const deductBackingLanguage = commonBackingLanguage
-                ? actor.system.details.languages.value.find((i) => i === commonBackingLanguage)
-                    ? 1
-                    : 0
+            const deductBackingLanguage = actor.system.details.languages.value.find((i) => i === commonBackingLanguage)
+                ? 1
                 : 0;
             // set the new languages max based on if the common-backing language is present
             const languageNewMax = languagesBuild.max + deductBackingLanguage;

--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -315,6 +315,8 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
 
         sheetData.abpEnabled = AutomaticBonusProgression.isEnabled(actor);
 
+        const commonLanguage = game.settings.get("pf2e", "homebrew.languageRarities").commonLanguage;
+
         sheetData.languages = ((): LanguageSheetData[] => {
             const languagesBuild = actor.system.build.languages;
             const sourceLanguages = actor._source.system.details.languages.value.filter(
@@ -323,7 +325,18 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
             const isOverMax = languagesBuild.value > languagesBuild.max;
             const languages: LanguageSheetData[] = actor.system.details.languages.value
                 .map((language) => {
-                    const label = game.i18n.localize(CONFIG.PF2E.languages[language] ?? language);
+                    const baseLanguage = game.i18n.localize(CONFIG.PF2E.languages[language] ?? language);
+
+                    const label =
+                        commonLanguage && language === "common"
+                            ? game.i18n.format("PF2E.Actor.Character.Language.CommonLabel", {
+                                  common: baseLanguage,
+                                  linkedLanguage: game.i18n.localize(
+                                      CONFIG.PF2E.languages[commonLanguage] ?? commonLanguage,
+                                  ),
+                              })
+                            : baseLanguage;
+
                     const overLimit = isOverMax && sourceLanguages.indexOf(language) + 1 > languagesBuild.max;
                     const tooltip = overLimit ? "PF2E.Actor.Character.Language.OverLimit" : null;
                     return { slug: language, label, tooltip, overLimit };

--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -359,7 +359,7 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
             );
             languages.push(...unallocatedLanguages);
 
-            return languages.filter((s) => s.slug != commonBackingLanguage);
+            return languages.filter((s) => s.slug !== commonBackingLanguage);
         })();
 
         // Sort skills by localized label

--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -325,7 +325,7 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
             );
 
             // find if the backing language is present in character's languages
-            // this means characters explictly selected it
+            // this means characters explicitly selected it
             const deductBackingLanguage = actor.system.details.languages.value.find((i) => i === commonBackingLanguage)
                 ? 1
                 : 0;
@@ -337,20 +337,18 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
                 .map((language) => {
                     const baseLanguage = game.i18n.localize(CONFIG.PF2E.languages[language] ?? language);
 
-                    const label = baseLanguage;
-
-                    // set the tooltip for common to show the backing language
-                    const commonTooltip =
+                    const label =
                         commonBackingLanguage && language === "common"
-                            ? game.i18n.localize(CONFIG.PF2E.languages[commonBackingLanguage] ?? commonBackingLanguage)
+                            ? game.i18n.format("PF2E.Actor.Character.Language.CommonLabel", {
+                                  common: baseLanguage,
+                                  linkedLanguage: game.i18n.localize(
+                                      CONFIG.PF2E.languages[commonBackingLanguage] ?? commonBackingLanguage,
+                                  ),
+                              })
                             : baseLanguage;
 
                     const overLimit = isOverMax && sourceLanguages.indexOf(language) + 1 > languageNewMax;
-                    const tooltip = overLimit
-                        ? "PF2E.Actor.Character.Language.OverLimit"
-                        : language === "common"
-                          ? commonTooltip
-                          : "";
+                    const tooltip = overLimit ? "PF2E.Actor.Character.Language.OverLimit" : "";
                     return { slug: language, label, tooltip, overLimit };
                 })
                 .sort((a, b) => a.label.localeCompare(b.label));
@@ -361,7 +359,7 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
             );
             languages.push(...unallocatedLanguages);
 
-            return languages;
+            return languages.filter((s) => s.slug != commonBackingLanguage);
         })();
 
         // Sort skills by localized label

--- a/src/module/system/tag-selector/languages.ts
+++ b/src/module/system/tag-selector/languages.ts
@@ -56,6 +56,9 @@ class LanguageSelector extends TagSelectorBasic<ActorPF2e | ItemPF2e> {
             delete sheetData.choices[language];
         }
 
+        // disable the Common-linked language so players don't double-pick
+        if (languagesByRarity.commonLanguage) sheetData.choices[languagesByRarity.commonLanguage].disabled = true;
+
         const choices = R.mapValues(sheetData.choices, (data, key): ChoiceData => {
             const slug = key as Language;
             const rarityLocKeys = { ...CONFIG.PF2E.rarityTraits, secret: "PF2E.TraitSecret" };

--- a/src/module/system/tag-selector/languages.ts
+++ b/src/module/system/tag-selector/languages.ts
@@ -56,10 +56,6 @@ class LanguageSelector extends TagSelectorBasic<ActorPF2e | ItemPF2e> {
             delete sheetData.choices[language];
         }
 
-        // disable the Common-linked language so players don't double-pick
-        if (languagesByRarity.commonLanguage && !game.user.isGM)
-            sheetData.choices[languagesByRarity.commonLanguage].disabled = true;
-
         const choices = R.mapValues(sheetData.choices, (data, key): ChoiceData => {
             const slug = key as Language;
             const rarityLocKeys = { ...CONFIG.PF2E.rarityTraits, secret: "PF2E.TraitSecret" };

--- a/src/module/system/tag-selector/languages.ts
+++ b/src/module/system/tag-selector/languages.ts
@@ -57,7 +57,7 @@ class LanguageSelector extends TagSelectorBasic<ActorPF2e | ItemPF2e> {
         }
 
         // disable the Common-linked language so players don't double-pick
-        if (languagesByRarity.commonLanguage) sheetData.choices[languagesByRarity.commonLanguage].disabled = true;
+        if (languagesByRarity.commonLanguage && !game.user.isGM) sheetData.choices[languagesByRarity.commonLanguage].disabled = true;
 
         const choices = R.mapValues(sheetData.choices, (data, key): ChoiceData => {
             const slug = key as Language;

--- a/src/module/system/tag-selector/languages.ts
+++ b/src/module/system/tag-selector/languages.ts
@@ -57,7 +57,8 @@ class LanguageSelector extends TagSelectorBasic<ActorPF2e | ItemPF2e> {
         }
 
         // disable the Common-linked language so players don't double-pick
-        if (languagesByRarity.commonLanguage && !game.user.isGM) sheetData.choices[languagesByRarity.commonLanguage].disabled = true;
+        if (languagesByRarity.commonLanguage && !game.user.isGM)
+            sheetData.choices[languagesByRarity.commonLanguage].disabled = true;
 
         const choices = R.mapValues(sheetData.choices, (data, key): ChoiceData => {
             const slug = key as Language;

--- a/src/scripts/set-game-pf2e.ts
+++ b/src/scripts/set-game-pf2e.ts
@@ -115,6 +115,9 @@ export const SetGamePF2e = {
                 cards: game.settings.get("pf2e", "drawCritFumble"),
             },
             encumbrance: game.settings.get("pf2e", "automation.encumbrance"),
+            homebrew: {
+                languageRarities: game.settings.get("pf2e", "homebrew.languageRarities"),
+            },
             gmVision: game.settings.get("pf2e", "gmVision"),
             iwr: game.settings.get("pf2e", "automation.iwr"),
             metagame: {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -211,6 +211,7 @@
                 "CreateFeat": "Create Feat",
                 "HandsOccupied": "Hands Occupied",
                 "Language": {
+                    "CommonLabel": "{common} ({linkedLanguage})",
                     "OverLimit": "This language is in excess of the number of languages this character can know.",
                     "Unallocated": {
                         "Label": "Unallocated",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -211,7 +211,6 @@
                 "CreateFeat": "Create Feat",
                 "HandsOccupied": "Hands Occupied",
                 "Language": {
-                    "CommonLabel": "{common} ({linkedLanguage})",
                     "OverLimit": "This language is in excess of the number of languages this character can know.",
                     "Unallocated": {
                         "Label": "Unallocated",


### PR DESCRIPTION
Closes #13675

GMs can still alter the common-linked language on PC sheets in case it becomes needed.