### PR TITLE
Fix broken non-land Base Speed tooltip labels in creature documents

### DIFF
--- a/src/module/actor/creature/document.ts
+++ b/src/module/actor/creature/document.ts
@@ -725,7 +725,9 @@ abstract class CreaturePF2e<
                 },
                 breakdown: {
                     get(): string {
-                        return [`${game.i18n.format("PF2E.SpeedBaseLabel", { type: speed.label })} ${speed.value}`]
+                        return [
+                            `${game.i18n.format("PF2E.Actor.Speed.BaseLabel", { type: speed.label })} ${speed.value}`,
+                        ]
                             .concat(
                                 stat.modifiers
                                     .filter((m) => m.enabled)


### PR DESCRIPTION
This label was missed when the actor base speed labels were refactored.

Noticed while doing some Familiar Sheet work 👀 