### PR TITLE
Fix display of Master name in Familiar sheet when User is an `Observer`

### DIFF
--- a/src/module/actor/familiar/sheet.ts
+++ b/src/module/actor/familiar/sheet.ts
@@ -33,8 +33,7 @@ export class FamiliarSheetPF2e<TActor extends FamiliarPF2e> extends CreatureShee
 
         // Get all potential masters of the familiar (always include current master regardless of User permissions)
         const masters = game.actors.filter(
-            (a): a is CharacterPF2e<null> =>
-                a.type === "character" && (a.testUserPermission(game.user, "OWNER") || this.actor.master?.id === a.id),
+            (a): a is CharacterPF2e<null> => a.type === "character" && (a.isOwner || a.id === familiar.master?.id),
         );
 
         // list of abilities that can be selected as spellcasting ability

--- a/src/module/actor/familiar/sheet.ts
+++ b/src/module/actor/familiar/sheet.ts
@@ -30,9 +30,11 @@ export class FamiliarSheetPF2e<TActor extends FamiliarPF2e> extends CreatureShee
     override async getData(options?: ActorSheetOptions): Promise<FamiliarSheetData<TActor>> {
         const sheetData = await super.getData(options);
         const familiar = this.actor;
-        // Get all potential masters of the familiar
+
+        // Get all potential masters of the familiar (always include current master regardless of User permissions)
         const masters = game.actors.filter(
-            (a): a is CharacterPF2e<null> => a.type === "character" && a.testUserPermission(game.user, "OWNER"),
+            (a): a is CharacterPF2e<null> =>
+                a.type === "character" && (a.testUserPermission(game.user, "OWNER") || this.actor.master?.id === a.id),
         );
 
         // list of abilities that can be selected as spellcasting ability

--- a/static/templates/actors/familiar/sheet.hbs
+++ b/static/templates/actors/familiar/sheet.hbs
@@ -27,13 +27,9 @@
                     <select id="{{document.uuid}}-master" name="system.master.id">
                         {{#select master.id}}
                             <option value="">{{localize "PF2E.Familiar.SelectMaster"}}</option>
-                            {{#if document.limited}}
-                                {{#if master}}<option value="{{master.id}}" selected>{{master.name}}</option>{{/if}}
-                            {{else}}
-                                {{#each masters as |eligible idx|}}
-                                    <option value="{{eligible.id}}">{{eligible.name}}</option>
-                                {{/each}}
-                            {{/if}}
+                            {{#each masters as |eligible idx|}}
+                                <option value="{{eligible.id}}">{{eligible.name}}</option>
+                            {{/each}}
                         {{/select}}
                     </select>
                 </div>

--- a/static/templates/actors/familiar/sheet.hbs
+++ b/static/templates/actors/familiar/sheet.hbs
@@ -27,7 +27,7 @@
                     <select id="{{document.uuid}}-master" name="system.master.id">
                         {{#select master.id}}
                             <option value="">{{localize "PF2E.Familiar.SelectMaster"}}</option>
-                            {{#each masters as |eligible idx|}}
+                            {{#each masters as |eligible|}}
                                 <option value="{{eligible.id}}">{{eligible.name}}</option>
                             {{/each}}
                         {{/select}}


### PR DESCRIPTION
Previously the `masters` array would be empty for non-Owner users and not show the Master's name.

This also lets us simplify the messy template code that I just added for handling the Limited sheet view since the familiar Master, if set, will always be available in the `<select>` (I had confirmed it was an existing bug while working on the Limited sheet).