### PR TITLE
Remove Tandem feats from Basic Synergy options

### DIFF
--- a/packs/feats/basic-synergy.json
+++ b/packs/feats/basic-synergy.json
@@ -40,6 +40,9 @@
                                 "item:level",
                                 2
                             ]
+                        },
+                        {
+                            "not": "item:trait:tandem"
                         }
                     ],
                     "itemType": "feat"


### PR DESCRIPTION
> Due to your tenuous link, you can't gain or use tandem actions.