### PR TITLE
Show tooltip for modifier/dice roll options in inspector

### DIFF
--- a/src/styles/tooltip/_index.scss
+++ b/src/styles/tooltip/_index.scss
@@ -1,1 +1,8 @@
 @import "carry-type-menu";
+
+aside.locked-tooltip.roll-options {
+    padding-right: var(--space-8);
+    li {
+        user-select: all;
+    }
+}

--- a/src/styles/ui/sidebar/chat/_roll-inspector.scss
+++ b/src/styles/ui/sidebar/chat/_roll-inspector.scss
@@ -89,8 +89,16 @@
             }
 
             h4 {
+                align-items: baseline;
+                display: flex;
                 font-size: 1.1em;
                 margin-bottom: 0.37em;
+                gap: var(--space-4);
+
+                i {
+                    margin-left: auto;
+                    padding-left: var(--space-4);
+                }
             }
 
             & > div {

--- a/static/templates/chat/roll-inspector.hbs
+++ b/static/templates/chat/roll-inspector.hbs
@@ -37,9 +37,13 @@
                 </div>
             {{/if}}
 
-            {{#each modifiers as |m|}}
-                <div class="modifier {{disabled (not m.enabled)}}">
-                    <h4>{{m.label}} <span class="slug">({{m.slug}})</span></h4>
+            {{#each modifiers as |m idx|}}
+                <div class="modifier {{disabled (not m.enabled)}}" data-type="modifier" data-idx="{{idx}}">
+                    <h4>
+                        {{m.label}}
+                        <span class="slug">({{m.slug}})</span>
+                        <i class="fa-solid fa-circle-info"></i>
+                    </h4>
                     <div>
                         <span>{{localize (concat "PF2E.ModifierType." m.type)}} {{m.value}} {{m.damageType}} {{#if m.category}}({{m.category}}){{/if}}</span>
                         <span>{{m.critical}}</span>
@@ -47,9 +51,13 @@
                 </div>
             {{/each}}
 
-            {{#each dice as |d|}}
-                <div class="modifier {{disabled (not d.enabled)}}">
-                    <h4>{{d.label}} <span class="slug">({{d.slug}})</span></h4>
+            {{#each dice as |d idx|}}
+                <div class="modifier {{disabled (not d.enabled)}}" data-type="dice" data-idx="{{idx}}">
+                    <h4>
+                        {{d.label}}
+                        <span class="slug">({{d.slug}})</span>
+                        <i class="fa-solid fa-circle-info"></i>
+                    </h4>
                     <div>
                         <span>{{d.value}} {{d.damageType}} {{#if d.category}}({{d.category}}){{/if}}</span>
                         <span>{{d.critical}}</span>


### PR DESCRIPTION
If you can think of a good data property to replace the html query selector with for the hover, I'd appreciate it.

![image](https://github.com/foundryvtt/pf2e/assets/1286721/d6990d6e-f0c1-4625-abff-69f7e952a26c)
