### PR TITLE
Fix padding on familiar sheet headers

### DIFF
--- a/src/styles/actor/familiar/_index.scss
+++ b/src/styles/actor/familiar/_index.scss
@@ -9,6 +9,7 @@
         display: flex;
         flex-direction: column;
         height: 100%;
+        padding: 4px 6px 0;
 
         & > hr {
             width: 100%;
@@ -40,7 +41,6 @@
     header {
         display: flex;
         flex-direction: row;
-        padding: 4px 6px 0;
 
         .image-container {
             display: flex;


### PR DESCRIPTION
The padding was placed on the header which pushed down the title bar. Moving it to the form fixes this.
Before
![image](https://github.com/foundryvtt/pf2e/assets/77904738/dd119bcd-bcdc-4ddf-bf03-79ee00914f63)
After
![image](https://github.com/foundryvtt/pf2e/assets/77904738/dbb605eb-bb20-43b0-bf27-5439a75a3611)
