### PR TITLE
Add Metagame Setting to ignore the Secret Trait on Checks

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -143,7 +143,7 @@ interface GamePF2e
             metagame: {
                 breakdowns: boolean;
                 dcs: boolean;
-                ignoreSecretTrait: boolean;
+                showSecretTrait: boolean;
                 partyStats: boolean;
                 partyVision: boolean;
                 results: boolean;
@@ -280,7 +280,7 @@ declare global {
         get(module: "pf2e", setting: "metagame_showPartyStats"): boolean;
         get(module: "pf2e", setting: "metagame_showResults"): boolean;
         get(module: "pf2e", setting: "metagame_tokenSetsNameVisibility"): boolean;
-        get(module: "pf2e", setting: "metagame_ignoreSecretTrait"): boolean;
+        get(module: "pf2e", setting: "metagame_showSecretTrait"): boolean;
 
         get(module: "pf2e", setting: "tokens.autoscale"): boolean;
 

--- a/src/global.ts
+++ b/src/global.ts
@@ -143,7 +143,7 @@ interface GamePF2e
             metagame: {
                 breakdowns: boolean;
                 dcs: boolean;
-                showSecretTrait: boolean;
+                secretChecks: boolean;
                 partyStats: boolean;
                 partyVision: boolean;
                 results: boolean;
@@ -280,7 +280,7 @@ declare global {
         get(module: "pf2e", setting: "metagame_showPartyStats"): boolean;
         get(module: "pf2e", setting: "metagame_showResults"): boolean;
         get(module: "pf2e", setting: "metagame_tokenSetsNameVisibility"): boolean;
-        get(module: "pf2e", setting: "metagame_showSecretTrait"): boolean;
+        get(module: "pf2e", setting: "metagame_secretChecks"): boolean;
 
         get(module: "pf2e", setting: "tokens.autoscale"): boolean;
 

--- a/src/global.ts
+++ b/src/global.ts
@@ -143,6 +143,7 @@ interface GamePF2e
             metagame: {
                 breakdowns: boolean;
                 dcs: boolean;
+                ignoreSecretTrait: boolean;
                 partyStats: boolean;
                 partyVision: boolean;
                 results: boolean;
@@ -279,6 +280,7 @@ declare global {
         get(module: "pf2e", setting: "metagame_showPartyStats"): boolean;
         get(module: "pf2e", setting: "metagame_showResults"): boolean;
         get(module: "pf2e", setting: "metagame_tokenSetsNameVisibility"): boolean;
+        get(module: "pf2e", setting: "metagame_ignoreSecretTrait"): boolean;
 
         get(module: "pf2e", setting: "tokens.autoscale"): boolean;
 

--- a/src/module/system/check/check.ts
+++ b/src/module/system/check/check.ts
@@ -68,7 +68,9 @@ class CheckPF2e {
         }
 
         // Figure out the default roll mode (if not already set by the event)
-        if (rollOptions.has("secret")) context.rollMode ??= game.user.isGM ? "gmroll" : "blindroll";
+        // ignore the secret trait if the ignoreSecretTrait setting is enabled
+        if (rollOptions.has("secret") && !game.pf2e.settings.metagame.ignoreSecretTrait)
+            context.rollMode ??= game.user.isGM ? "gmroll" : "blindroll";
         context.rollMode ??= "roll";
 
         if (rollOptions.size > 0 && !context.isReroll) {

--- a/src/module/system/check/check.ts
+++ b/src/module/system/check/check.ts
@@ -69,8 +69,9 @@ class CheckPF2e {
 
         // Figure out the default roll mode (if not already set by the event)
         // ignore the secret trait if the ignoreSecretTrait setting is enabled
-        if (rollOptions.has("secret") && !game.pf2e.settings.metagame.secretChecks)
+        if (rollOptions.has("secret") && !game.pf2e.settings.metagame.secretChecks) {
             context.rollMode ??= game.user.isGM ? "gmroll" : "blindroll";
+        }
         context.rollMode ??= "roll";
 
         if (rollOptions.size > 0 && !context.isReroll) {

--- a/src/module/system/check/check.ts
+++ b/src/module/system/check/check.ts
@@ -69,7 +69,7 @@ class CheckPF2e {
 
         // Figure out the default roll mode (if not already set by the event)
         // ignore the secret trait if the ignoreSecretTrait setting is enabled
-        if (rollOptions.has("secret") && !game.pf2e.settings.metagame.showSecretTrait)
+        if (rollOptions.has("secret") && !game.pf2e.settings.metagame.secretChecks)
             context.rollMode ??= game.user.isGM ? "gmroll" : "blindroll";
         context.rollMode ??= "roll";
 

--- a/src/module/system/check/check.ts
+++ b/src/module/system/check/check.ts
@@ -69,7 +69,7 @@ class CheckPF2e {
 
         // Figure out the default roll mode (if not already set by the event)
         // ignore the secret trait if the ignoreSecretTrait setting is enabled
-        if (rollOptions.has("secret") && !game.pf2e.settings.metagame.ignoreSecretTrait)
+        if (rollOptions.has("secret") && !game.pf2e.settings.metagame.showSecretTrait)
             context.rollMode ??= game.user.isGM ? "gmroll" : "blindroll";
         context.rollMode ??= "roll";
 

--- a/src/module/system/settings/metagame.ts
+++ b/src/module/system/settings/metagame.ts
@@ -87,14 +87,14 @@ const MetagameSettingsConfig = {
             }
         },
     },
-    ignoreSecretTrait: {
+    showSecretTrait: {
         prefix: "metagame_",
-        name: "PF2E.SETTINGS.Metagame.IgnoreSecretTrait.Name",
-        hint: "PF2E.SETTINGS.Metagame.IgnoreSecretTrait.Hint",
+        name: "PF2E.SETTINGS.Metagame.ShowSecretTrait.Name",
+        hint: "PF2E.SETTINGS.Metagame.ShowSecretTrait.Hint",
         default: false,
         type: Boolean,
         onChange: (value: unknown) => {
-            game.pf2e.settings.metagame.ignoreSecretTrait = !!value;
+            game.pf2e.settings.metagame.showSecretTrait = !!value;
         },
     },
 } satisfies Record<string, PartialSettingsData>;

--- a/src/module/system/settings/metagame.ts
+++ b/src/module/system/settings/metagame.ts
@@ -87,6 +87,16 @@ const MetagameSettingsConfig = {
             }
         },
     },
+    ignoreSecretTrait: {
+        prefix: "metagame_",
+        name: "PF2E.SETTINGS.Metagame.IgnoreSecretTrait.Name",
+        hint: "PF2E.SETTINGS.Metagame.IgnoreSecretTrait.Hint",
+        default: false,
+        type: Boolean,
+        onChange: (value: unknown) => {
+            game.pf2e.settings.metagame.ignoreSecretTrait = !!value;
+        },
+    },
 } satisfies Record<string, PartialSettingsData>;
 
 class MetagameSettings extends SettingsMenuPF2e {

--- a/src/module/system/settings/metagame.ts
+++ b/src/module/system/settings/metagame.ts
@@ -87,14 +87,14 @@ const MetagameSettingsConfig = {
             }
         },
     },
-    showSecretTrait: {
+    secretChecks: {
         prefix: "metagame_",
-        name: "PF2E.SETTINGS.Metagame.ShowSecretTrait.Name",
-        hint: "PF2E.SETTINGS.Metagame.ShowSecretTrait.Hint",
+        name: "PF2E.SETTINGS.Metagame.SecretChecks.Name",
+        hint: "PF2E.SETTINGS.Metagame.SecretChecks.Hint",
         default: false,
         type: Boolean,
         onChange: (value: unknown) => {
-            game.pf2e.settings.metagame.showSecretTrait = !!value;
+            game.pf2e.settings.metagame.secretChecks = !!value;
         },
     },
 } satisfies Record<string, PartialSettingsData>;

--- a/src/scripts/set-game-pf2e.ts
+++ b/src/scripts/set-game-pf2e.ts
@@ -120,7 +120,7 @@ export const SetGamePF2e = {
             metagame: {
                 breakdowns: game.settings.get("pf2e", "metagame_showBreakdowns"),
                 dcs: game.settings.get("pf2e", "metagame_showDC"),
-                ignoreSecretTrait: game.settings.get("pf2e", "metagame_ignoreSecretTrait"),
+                showSecretTrait: game.settings.get("pf2e", "metagame_showSecretTrait"),
                 partyStats: game.settings.get("pf2e", "metagame_showPartyStats"),
                 partyVision: game.settings.get("pf2e", "metagame_partyVision"),
                 results: game.settings.get("pf2e", "metagame_showResults"),

--- a/src/scripts/set-game-pf2e.ts
+++ b/src/scripts/set-game-pf2e.ts
@@ -120,6 +120,7 @@ export const SetGamePF2e = {
             metagame: {
                 breakdowns: game.settings.get("pf2e", "metagame_showBreakdowns"),
                 dcs: game.settings.get("pf2e", "metagame_showDC"),
+                ignoreSecretTrait: game.settings.get("pf2e", "metagame_ignoreSecretTrait"),
                 partyStats: game.settings.get("pf2e", "metagame_showPartyStats"),
                 partyVision: game.settings.get("pf2e", "metagame_partyVision"),
                 results: game.settings.get("pf2e", "metagame_showResults"),

--- a/src/scripts/set-game-pf2e.ts
+++ b/src/scripts/set-game-pf2e.ts
@@ -120,7 +120,7 @@ export const SetGamePF2e = {
             metagame: {
                 breakdowns: game.settings.get("pf2e", "metagame_showBreakdowns"),
                 dcs: game.settings.get("pf2e", "metagame_showDC"),
-                showSecretTrait: game.settings.get("pf2e", "metagame_showSecretTrait"),
+                secretChecks: game.settings.get("pf2e", "metagame_secretChecks"),
                 partyStats: game.settings.get("pf2e", "metagame_showPartyStats"),
                 partyVision: game.settings.get("pf2e", "metagame_partyVision"),
                 results: game.settings.get("pf2e", "metagame_showResults"),

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -3285,8 +3285,8 @@
                 "Hint": "Limit what kinds of metagame information your players have access to.",
                 "Label": "Limit Metagame Information",
                 "Name": "Metagame Information",
-                "ShowSecretTrait": {
-                    "Hint": "Shows Secret rolls, allowing players to see normally hidden checks.",
+                "SecretChecks": {
+                    "Hint": "Players can see rolls with the Secret trait in chat.",
                     "Name": "Show Secret Trait"
                 },
                 "ShowDC": {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -3287,7 +3287,7 @@
                 "Name": "Metagame Information",
                 "SecretChecks": {
                     "Hint": "Players can see rolls with the Secret trait in chat.",
-                    "Name": "Show Secret Trait"
+                    "Name": "Show Secret Checks"
                 },
                 "ShowDC": {
                     "Hint": "Players can see DCs of checks made against NPCs and other non-player-owned sources.",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -3285,6 +3285,10 @@
                 "Hint": "Limit what kinds of metagame information your players have access to.",
                 "Label": "Limit Metagame Information",
                 "Name": "Metagame Information",
+                "IgnoreSecretTrait": {
+                    "Hint": "Suppresses the Secret Trait on rolls, allowing players to see normally hidden checks.",
+                    "Name": "Ignore Secret Trait on Rolls"
+                },
                 "ShowDC": {
                     "Hint": "Players can see DCs of checks made against NPCs and other non-player-owned sources.",
                     "Name": "Show Check DCs"

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -3286,7 +3286,7 @@
                 "Label": "Limit Metagame Information",
                 "Name": "Metagame Information",
                 "IgnoreSecretTrait": {
-                    "Hint": "Suppresses the Secret Trait on rolls, allowing players to see normally hidden checks.",
+                    "Hint": "Ignores the Secret Trait on rolls, allowing players to see normally hidden checks.",
                     "Name": "Ignore Secret Trait on Rolls"
                 },
                 "ShowDC": {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -3285,9 +3285,9 @@
                 "Hint": "Limit what kinds of metagame information your players have access to.",
                 "Label": "Limit Metagame Information",
                 "Name": "Metagame Information",
-                "IgnoreSecretTrait": {
-                    "Hint": "Ignores the Secret Trait on rolls, allowing players to see normally hidden checks.",
-                    "Name": "Ignore Secret Trait on Rolls"
+                "ShowSecretTrait": {
+                    "Hint": "Shows Secret rolls, allowing players to see normally hidden checks.",
+                    "Name": "Show Secret Trait"
                 },
                 "ShowDC": {
                     "Hint": "Players can see DCs of checks made against NPCs and other non-player-owned sources.",


### PR DESCRIPTION
Closes #9544, closes #2262

Toggling this alters the default roll type for Secret actions to Public. It doesn't remove the trait from the roll.