### PR TITLE
Use underline modifiers convention for character proficiencies tab

### DIFF
--- a/src/styles/actor/character/_proficiencies.scss
+++ b/src/styles/actor/character/_proficiencies.scss
@@ -31,7 +31,7 @@
             display: flex;
             font-family: var(--serif);
             font-size: var(--font-size-16);
-            min-height: 2.5rem;
+            min-height: 2.25rem;
             padding: 0 var(--space-8) 0 var(--space-4);
 
             a.d20 {
@@ -65,42 +65,15 @@
                 width: 1.75rem;
             }
 
-            .name {
-                flex: 1;
-                line-height: 1em;
-                margin-right: var(--space-4);
+            a.hover {
+                text-decoration: underline var(--color-pf-primary-dark);
+                text-underline-offset: 0.125em;
             }
 
-            .button-group {
-                align-items: center;
-                display: flex;
-                justify-content: center;
-
-                button {
-                    @include micro;
-                    align-items: center;
-                    background: var(--sub);
-                    border-radius: 2px;
-                    border: 1px solid rgba(black, 0.5);
-                    box-shadow: inset 0 0 0 1px rgba(white, 0.15);
-                    color: var(--text-light);
-                    display: flex;
-                    font-weight: 500;
-                    justify-content: center;
-                    line-height: 1.3em;
-                    margin: 0;
-                    padding: var(--space-1) 0 0;
-                    width: 6.5em;
-
-                    &:hover {
-                        background: var(--color-pf-primary);
-                    }
-                }
-
-                &.stacked {
-                    flex-flow: column wrap;
-                    gap: var(--space-1);
-                }
+            .name {
+                flex: 1;
+                line-height: 0.9em;
+                margin-right: var(--space-4);
             }
 
             // Proficiencies added by the user
@@ -121,7 +94,7 @@
             }
         }
 
-        &.lores-list > li .button-group .item-controls {
+        &.lores-list > li .item-controls {
             font-size: var(--font-size-12);
             margin-left: var(--space-8);
         }

--- a/static/templates/actors/character/tabs/proficiencies.hbs
+++ b/static/templates/actors/character/tabs/proficiencies.hbs
@@ -8,23 +8,18 @@
                     <a class="d20" data-action="roll-check">
                         {{> "systems/pf2e/templates/actors/character/icons/d20.hbs"}}
                     </a>
-                    <a class="modifier" data-action="roll-check" data-tooltip="{{skill.breakdown}}">
+                    <a class="modifier hover" data-tooltip-content="#{{@root.options.id}}-{{skill.slug}}-modifiers" data-tooltip="{{skill.breakdown}}">
                         {{numberFormat skill.value decimals=0 sign=true}}
                     </a>
                     <div class="name">{{localize skill.label}}</div>
-                    <div class="button-group stacked">
-                        <select
-                            class="skill-proficiency pf-rank"
-                            data-property="system.skills.{{key}}.rank"
-                            data-rank="{{skill.rank}}"
-                            data-dtype="Number"
-                        >
-                            {{> "systems/pf2e/templates/actors/character/partials/proficiencylevels-dropdown.hbs" proflevel=skill.rank}}
-                        </select>
-                        <button type="button" class="hover" data-tooltip-content="#{{@root.options.id}}-{{skill.slug}}-modifiers">
-                            {{localize "PF2E.ModifiersTitle"}}
-                        </button>
-                    </div>
+                    <select
+                        class="skill-proficiency pf-rank"
+                        data-property="system.skills.{{key}}.rank"
+                        data-rank="{{skill.rank}}"
+                        data-dtype="Number"
+                    >
+                        {{> "systems/pf2e/templates/actors/character/partials/proficiencylevels-dropdown.hbs" proflevel=skill.rank}}
+                    </select>
                     {{#with skill}}
                         {{> "systems/pf2e/templates/actors/partials/modifiers-tooltip.hbs" abpEnabled=@root.abpEnabled title=label}}
                     {{/with}}
@@ -53,16 +48,14 @@
                     </a>
                     <a class="modifier" data-action="roll-check">{{numberFormat skill.value decimals=0 sign=true}}</a>
                     <input class="name" data-item-id="{{skill.itemID}}" data-item-property="name" type="text" value="{{skill.label}}" />
-                    <div class="skill-prof button-group skill-container">
-                        <select class="skill-proficiency pf-rank adjust-item-stat-select" data-item-property="system.proficient.value" data-tooltip="{{skill.breakdown}}" data-rank="{{skill.rank}}">
-                            {{> "systems/pf2e/templates/actors/character/partials/proficiencylevels-dropdown.hbs" proflevel=skill.rank}}
-                        </select>
-                        {{#if ../editable}}
-                            <div class="item-controls">
-                                <a data-action="delete-item" data-tooltip="PF2E.DeleteItemTitle"><i class="fa-solid fa-fw fa-trash"></i></a>
-                            </div>
-                        {{/if}}
-                    </div>
+                    <select class="skill-proficiency pf-rank adjust-item-stat-select" data-item-property="system.proficient.value" data-tooltip="{{skill.breakdown}}" data-rank="{{skill.rank}}">
+                        {{> "systems/pf2e/templates/actors/character/partials/proficiencylevels-dropdown.hbs" proflevel=skill.rank}}
+                    </select>
+                    {{#if ../editable}}
+                        <div class="item-controls">
+                            <a data-action="delete-item" data-tooltip="PF2E.DeleteItemTitle"><i class="fa-solid fa-fw fa-trash"></i></a>
+                        </div>
+                    {{/if}}
                 </li>
             {{/if}}
         {{/each}}
@@ -86,16 +79,14 @@
                 {{/if}}
                 <span class="modifier" data-tooltip="{{proficiency.breakdown}}">{{numberFormat proficiency.value decimals=0 sign=true}}</span>
                 <span class="name">{{localize proficiency.label}}</span>
-                <div class="button-group">
-                    <select
-                        class="skill-proficiency pf-rank{{#unless proficiency.custom}} readonly{{/unless}}"
-                        data-property="system.proficiencies.attacks.{{key}}.rank"
-                        data-rank="{{proficiency.rank}}"
-                        data-dtype="Number"
-                    >
-                        {{> "systems/pf2e/templates/actors/character/partials/proficiencylevels-dropdown.hbs" proflevel=proficiency.rank}}
-                    </select>
-                </div>
+                <select
+                    class="skill-proficiency pf-rank{{#unless proficiency.custom}} readonly{{/unless}}"
+                    data-property="system.proficiencies.attacks.{{key}}.rank"
+                    data-rank="{{proficiency.rank}}"
+                    data-dtype="Number"
+                >
+                    {{> "systems/pf2e/templates/actors/character/partials/proficiencylevels-dropdown.hbs" proflevel=proficiency.rank}}
+                </select>
             </li>
         {{/each}}
     </ul>
@@ -109,9 +100,7 @@
             <li{{#if (and @first @last)}} class="all-by-myself"{{/if}} data-slug="{{key}}">
                 <span class="modifier" data-tooltip="{{proficiency.breakdown}}">{{numberFormat proficiency.value decimals=0 sign=true}}</span>
                 <span class="name">{{localize proficiency.label}}</span>
-                <div class="button-group">
-                    <span class="pf-rank" data-rank="{{proficiency.rank}}">{{lookup @root.numberToRank proficiency.rank}}</span>
-                </div>
+                <span class="pf-rank" data-rank="{{proficiency.rank}}">{{lookup @root.numberToRank proficiency.rank}}</span>
             </li>
         {{/each}}
     </ul>
@@ -124,9 +113,7 @@
                 <li class="all-by-myself" data-slug="spellcasting">
                     <span class="modifier" data-tooltip="{{spellcasting.breakdown}}">{{numberFormat spellcasting.mod decimals=0 sign=true}}</span>
                     <span class="name">{{localize spellcasting.label}}</span>
-                    <div class="skill-prof button-group skill-container">
-                        <span class="pf-rank" data-rank="{{spellcasting.rank}}">{{lookup @root.numberToRank spellcasting.rank}}</span>
-                    </div>
+                    <span class="pf-rank" data-rank="{{spellcasting.rank}}">{{lookup @root.numberToRank spellcasting.rank}}</span>
                 </li>
             {{/with}}
         </ul>
@@ -138,14 +125,9 @@
         <ul class="proficiencies-list">
             {{#each classDCs.dcs as |classDC|}}
                 <li{{#if (and @first @last)}} class="all-by-myself"{{else if (not classDC.primary)}} class="secondary"{{/if}}>
-                    <span class="dc" data-tooltip="{{classDC.breakdown}}">{{classDC.dc}}</span>
+                    <a class="dc hover" data-tooltip-content="#{{../options.id}}-{{classDC.slug}}-modifiers" data-tooltip="{{classDC.breakdown}}">{{classDC.dc}}</a>
                     <span class="name">{{classDC.label}}</span>
-                    <div class="button-group stacked">
-                        <span class="pf-rank" data-rank="{{classDC.rank}}">{{lookup @root.numberToRank classDC.rank}}</span>
-                        <button type="button" class="hover" data-tooltip-content="#{{../options.id}}-{{classDC.slug}}-modifiers">
-                            {{localize "PF2E.ModifiersTitle"}}
-                        </button>
-                    </div>
+                    <span class="pf-rank" data-rank="{{classDC.rank}}">{{lookup @root.numberToRank classDC.rank}}</span>
                     {{#with classDC}}
                         {{> "systems/pf2e/templates/actors/partials/modifiers-tooltip.hbs" title="PF2E.Actor.Character.ClassDC.Label"}}
                     {{/with}}


### PR DESCRIPTION
Seems it went over well, so I'm confident enough to do it in the proficiencies tab as well

![image](https://github.com/foundryvtt/pf2e/assets/1286721/634e7fcb-7921-4e57-bf7a-6cb5e5db3c14)
