### PR TITLE
Update Grabble Forden's Poison Conversion to use DamageAlteration

### DIFF
--- a/packs/agents-of-edgewatch-bestiary/grabble-forden.json
+++ b/packs/agents-of-edgewatch-bestiary/grabble-forden.json
@@ -3120,6 +3120,14 @@
                             "poison-conversion",
                             {
                                 "or": [
+                                    "damage:type:acid",
+                                    "damage:type:cold",
+                                    "damage:type:electricity",
+                                    "damage:type:fire"
+                                ]
+                            },
+                            {
+                                "or": [
                                     "item:trait:cantrip",
                                     {
                                         "lte": [
@@ -3143,6 +3151,14 @@
                         "mode": "add",
                         "predicate": [
                             "poison-conversion",
+                            {
+                                "or": [
+                                    "item:damage:type:acid",
+                                    "item:damage:type:cold",
+                                    "item:damage:type:electricity",
+                                    "item:damage:type:fire"
+                                ]
+                            },
                             {
                                 "or": [
                                     "item:trait:cantrip",

--- a/packs/agents-of-edgewatch-bestiary/grabble-forden.json
+++ b/packs/agents-of-edgewatch-bestiary/grabble-forden.json
@@ -3113,10 +3113,9 @@
                         "toggleable": true
                     },
                     {
-                        "key": "DamageDice",
-                        "override": {
-                            "damageType": "poison"
-                        },
+                        "itemType": "spell",
+                        "key": "DamageAlteration",
+                        "mode": "override",
                         "predicate": [
                             "poison-conversion",
                             {
@@ -3131,7 +3130,12 @@
                                 ]
                             }
                         ],
-                        "selector": "spell-damage"
+                        "property": "damage-type",
+                        "selectors": [
+                            "spell-damage",
+                            "inline-damage"
+                        ],
+                        "value": "poison"
                     },
                     {
                         "itemType": "spell",


### PR DESCRIPTION
This allows inline damage links to also be overridden.