### PR TITLE
Handle dropping persistent damage links on character and NPC Sheets

### DIFF
--- a/src/module/actor/creature/sheet.ts
+++ b/src/module/actor/creature/sheet.ts
@@ -363,8 +363,6 @@ abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends ActorSheet
             }
         }
 
-        console.log(data);
-
         return super._onDropItem(event, data);
     }
 


### PR DESCRIPTION
Closes #7223

Intercepts the drop at the creature level so both characters and NPCs benefit from the fix.