### PR TITLE
Update Champion Smite effects to remaster errata

### DIFF
--- a/packs/feat-effects/effect-smite-evil.json
+++ b/packs/feat-effects/effect-smite-evil.json
@@ -4,7 +4,7 @@
     "name": "Effect: Smite Evil",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Smite Evil].</p>\n<p>Until the start of your next turn, your Strikes with the weapon your blade ally inhabits against that foe deal an extra 4 spirit damage, increasing to 6 if you have master proficiency with this weapon.</p>\n<p>If the foe attacks one of your allies, the duration extends to the end of that foe's next turn. If the foe continues to attack your allies each turn, the duration continues to extend.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Smite Evil].</p>\n<p>Until the start of your next turn, your Strikes with the weapon your blade ally inhabits against that foe deal an extra 4 spirit damage if the target is unholy, increasing to 6 if you have master proficiency with this weapon.</p>\n<p>If the foe attacks one of your allies, the duration extends to the end of that foe's next turn. If the foe continues to attack your allies each turn, the duration continues to extend.</p>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -22,21 +22,19 @@
         },
         "rules": [
             {
-                "domain": "damage",
-                "key": "RollOption",
-                "label": "Target is subject of your Smite Evil",
-                "option": "smite-evil",
-                "toggleable": true
+                "key": "TokenMark",
+                "slug": "smite-evil"
             },
             {
                 "damageType": "spirit",
                 "key": "FlatModifier",
                 "predicate": [
-                    "smite-evil",
+                    "target:mark:smite-evil",
+                    "target:trait:unholy",
                     {
-                        "nor": [
-                            "proficiency:master",
-                            "proficiency:legendary"
+                        "lt": [
+                            "item:proficiency:rank",
+                            3
                         ]
                     }
                 ],
@@ -48,11 +46,12 @@
                 "damageType": "spirit",
                 "key": "FlatModifier",
                 "predicate": [
-                    "smite-evil",
+                    "target:mark:smite-evil",
+                    "target:trait:unholy",
                     {
-                        "or": [
-                            "proficiency:master",
-                            "proficiency:legendary"
+                        "gte": [
+                            "item:proficiency:rank",
+                            "3"
                         ]
                     }
                 ],

--- a/packs/feat-effects/effect-smite-good.json
+++ b/packs/feat-effects/effect-smite-good.json
@@ -22,21 +22,19 @@
         },
         "rules": [
             {
-                "domain": "damage",
-                "key": "RollOption",
-                "label": "Target is subject of your Smite Good",
-                "option": "smite-good",
-                "toggleable": true
+                "key": "TokenMark",
+                "slug": "smite-good"
             },
             {
                 "damageType": "spirit",
                 "key": "FlatModifier",
                 "predicate": [
-                    "smite-good",
+                    "target:mark:smite-good",
+                    "target:trait:holy",
                     {
-                        "nor": [
-                            "proficiency:master",
-                            "proficiency:legendary"
+                        "lt": [
+                            "item:proficiency:rank",
+                            3
                         ]
                     }
                 ],
@@ -48,11 +46,12 @@
                 "damageType": "spirit",
                 "key": "FlatModifier",
                 "predicate": [
-                    "smite-good",
+                    "target:mark:smite-good",
+                    "target:trait:holy",
                     {
-                        "or": [
-                            "proficiency:master",
-                            "proficiency:legendary"
+                        "gte": [
+                            "item:proficiency:rank",
+                            "3"
                         ]
                     }
                 ],

--- a/packs/feats/smite-good.json
+++ b/packs/feats/smite-good.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>Your blade ally shares your lust for the blood of good creatures.</p>\n<p>Select one enemy you can see. Until the start of your next turn, your Strikes against that foe using the weapon your blade ally inhabits deal an extra 4 spirit damage if the target is holy, increasing to 6 if you have master proficiency with this weapon.</p>\n<p>If the chosen enemy attacks you before the start of your next turn, the duration extends to the end of that enemy's next turn. If the enemy continues to attack you each turn, the duration continues to extend.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Smite Good]</p>"
+            "value": "<p>Your blade ally shares your lust for the blood of good creatures.</p>\n<p>Select one enemy you can see. Until the start of your next turn, your Strikes against that foe using the weapon your blade ally inhabits deal an extra 4 spirit damage if the target is holy, increasing to 6 if you have master proficiency with this weapon.</p>\n<p>If the chosen enemy attacks you before the start of your next turn, the duration extends to the end of that enemy's next turn. If the enemy continues to attack you each turn, the duration continues to extend.</p>"
         },
         "level": {
             "value": 6
@@ -32,6 +32,10 @@
             "title": "Pathfinder Advanced Player's Guide"
         },
         "rules": [],
+        "selfEffect": {
+            "name": "Effect: Smite Good",
+            "uuid": "Compendium.pf2e.feat-effects.Item.Effect: Smite Good"
+        },
         "traits": {
             "rarity": "uncommon",
             "value": [


### PR DESCRIPTION
Follow up to #13867, updates the effects of Smite Evil and Good to remaster and makes Smite Good a self effect.

I tried thinking of a clever way to combine the Flat Modifiers, but not sure if it's possible to get the weapon's proficiency in a Flat Modifier resolvable format? Chime in if you got one!