### PR TITLE
Refresh copies of Hydraulic Torrent

### DIFF
--- a/packs/abomination-vaults-bestiary/deep-end-sarglagon.json
+++ b/packs/abomination-vaults-bestiary/deep-end-sarglagon.json
@@ -326,7 +326,7 @@
                     "sourceId": "Compendium.pf2e.spells-srd.Item.Y3G6Y6EDgCY0s3fq"
                 }
             },
-            "img": "systems/pf2e/icons/spells/hydraulic-torrent.webp",
+            "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
             "name": "Hydraulic Torrent",
             "sort": 600000,
             "system": {

--- a/packs/abomination-vaults-bestiary/deep-end-sarglagon.json
+++ b/packs/abomination-vaults-bestiary/deep-end-sarglagon.json
@@ -357,7 +357,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures that fail the save are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
+                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures and objects that fail are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -378,9 +378,9 @@
                     "value": "xxK8rXRDWK5Rwj9i"
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": "Pathfinder Core Rulebook"
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
                 },
                 "range": {
                     "value": ""

--- a/packs/agents-of-edgewatch-bestiary/avarek.json
+++ b/packs/agents-of-edgewatch-bestiary/avarek.json
@@ -131,6 +131,7 @@
                 "counteraction": false,
                 "damage": {
                     "0": {
+                        "applyMod": false,
                         "category": null,
                         "formula": "8d6",
                         "kinds": [
@@ -142,12 +143,12 @@
                 },
                 "defense": {
                     "save": {
-                        "basic": false,
+                        "basic": true,
                         "statistic": "fortitude"
                     }
                 },
                 "description": {
-                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures that fail the save are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
+                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures and objects that fail are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -167,9 +168,9 @@
                     "value": "x2ySAWMOcn67UNgo"
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
                 },
                 "range": {
                     "value": ""

--- a/packs/agents-of-edgewatch-bestiary/avarek.json
+++ b/packs/agents-of-edgewatch-bestiary/avarek.json
@@ -117,7 +117,7 @@
                     "sourceId": "Compendium.pf2e.spells-srd.Item.Y3G6Y6EDgCY0s3fq"
                 }
             },
-            "img": "systems/pf2e/icons/spells/hydraulic-torrent.webp",
+            "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
             "name": "Hydraulic Torrent",
             "sort": 300000,
             "system": {

--- a/packs/agents-of-edgewatch-bestiary/minchgorm.json
+++ b/packs/agents-of-edgewatch-bestiary/minchgorm.json
@@ -27,6 +27,9 @@
                     "title": ""
                 },
                 "rules": [],
+                "showSlotlessLevels": {
+                    "value": false
+                },
                 "slots": {},
                 "slug": null,
                 "spelldc": {
@@ -37,96 +40,10 @@
                 },
                 "tradition": {
                     "value": "primal"
-                }
+                },
+                "traits": {}
             },
             "type": "spellcastingEntry"
-        },
-        {
-            "_id": "yPuU1CPcqoZ2MfIt",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.Item.Y3G6Y6EDgCY0s3fq"
-                }
-            },
-            "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
-            "name": "Hydraulic Torrent",
-            "sort": 200000,
-            "system": {
-                "area": {
-                    "type": "line",
-                    "value": 60
-                },
-                "cost": {
-                    "value": ""
-                },
-                "counteraction": false,
-                "damage": {
-                    "0": {
-                        "category": null,
-                        "formula": "18d6",
-                        "kinds": [
-                            "damage"
-                        ],
-                        "materials": [],
-                        "type": "bludgeoning"
-                    }
-                },
-                "defense": {
-                    "save": {
-                        "basic": false,
-                        "statistic": "fortitude"
-                    }
-                },
-                "description": {
-                    "value": "<p>A swirling torrent of water manifests along a straight line, battering those that are its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save. Creatures that fail the save are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
-                },
-                "duration": {
-                    "sustained": false,
-                    "value": ""
-                },
-                "heightening": {
-                    "damage": {
-                        "0": "2d6"
-                    },
-                    "interval": 1,
-                    "type": "interval"
-                },
-                "level": {
-                    "value": 9
-                },
-                "location": {
-                    "value": "PvjXCmuXDpKKHSIf"
-                },
-                "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
-                },
-                "range": {
-                    "value": ""
-                },
-                "requirements": "",
-                "rules": [],
-                "slug": "hydraulic-torrent",
-                "target": {
-                    "value": ""
-                },
-                "time": {
-                    "value": "2"
-                },
-                "traits": {
-                    "rarity": "common",
-                    "traditions": [
-                        "primal"
-                    ],
-                    "value": [
-                        "concentrate",
-                        "manipulate",
-                        "water"
-                    ]
-                }
-            },
-            "type": "spell"
         },
         {
             "_id": "s73UR8DteBrsSG9X",
@@ -137,7 +54,7 @@
             },
             "img": "icons/magic/fire/explosion-flame-blue.webp",
             "name": "Control Water",
-            "sort": 300000,
+            "sort": 200000,
             "system": {
                 "area": null,
                 "cost": {
@@ -204,7 +121,7 @@
             },
             "img": "systems/pf2e/icons/spells/tongues.webp",
             "name": "Tongues (Constant)",
-            "sort": 400000,
+            "sort": 300000,
             "system": {
                 "area": null,
                 "cost": {
@@ -253,6 +170,95 @@
                     "value": [
                         "concentrate",
                         "manipulate"
+                    ]
+                }
+            },
+            "type": "spell"
+        },
+        {
+            "_id": "kxt8VP9aQgAbceZ5",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.Item.Y3G6Y6EDgCY0s3fq"
+                }
+            },
+            "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
+            "name": "Hydraulic Torrent",
+            "sort": 400000,
+            "system": {
+                "area": {
+                    "type": "line",
+                    "value": 60
+                },
+                "cost": {
+                    "value": ""
+                },
+                "counteraction": false,
+                "damage": {
+                    "0": {
+                        "applyMod": false,
+                        "category": null,
+                        "formula": "8d6",
+                        "kinds": [
+                            "damage"
+                        ],
+                        "materials": [],
+                        "type": "bludgeoning"
+                    }
+                },
+                "defense": {
+                    "save": {
+                        "basic": true,
+                        "statistic": "fortitude"
+                    }
+                },
+                "description": {
+                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures and objects that fail are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
+                },
+                "duration": {
+                    "sustained": false,
+                    "value": ""
+                },
+                "heightening": {
+                    "damage": {
+                        "0": "2d6"
+                    },
+                    "interval": 1,
+                    "type": "interval"
+                },
+                "level": {
+                    "value": 4
+                },
+                "location": {
+                    "heightenedLevel": 9,
+                    "value": "PvjXCmuXDpKKHSIf"
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
+                },
+                "range": {
+                    "value": ""
+                },
+                "requirements": "",
+                "rules": [],
+                "slug": "hydraulic-torrent",
+                "target": {
+                    "value": ""
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traits": {
+                    "rarity": "common",
+                    "traditions": [
+                        "primal"
+                    ],
+                    "value": [
+                        "concentrate",
+                        "manipulate",
+                        "water"
                     ]
                 }
             },

--- a/packs/agents-of-edgewatch-bestiary/minchgorm.json
+++ b/packs/agents-of-edgewatch-bestiary/minchgorm.json
@@ -48,7 +48,7 @@
                     "sourceId": "Compendium.pf2e.spells-srd.Item.Y3G6Y6EDgCY0s3fq"
                 }
             },
-            "img": "systems/pf2e/icons/spells/hydraulic-torrent.webp",
+            "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
             "name": "Hydraulic Torrent",
             "sort": 200000,
             "system": {

--- a/packs/agents-of-edgewatch-bestiary/tiderunner-aquamancer.json
+++ b/packs/agents-of-edgewatch-bestiary/tiderunner-aquamancer.json
@@ -546,7 +546,7 @@
                     "sourceId": "Compendium.pf2e.spells-srd.Item.Y3G6Y6EDgCY0s3fq"
                 }
             },
-            "img": "systems/pf2e/icons/spells/hydraulic-torrent.webp",
+            "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
             "name": "Hydraulic Torrent",
             "sort": 700000,
             "system": {

--- a/packs/agents-of-edgewatch-bestiary/tiderunner-aquamancer.json
+++ b/packs/agents-of-edgewatch-bestiary/tiderunner-aquamancer.json
@@ -560,6 +560,7 @@
                 "counteraction": false,
                 "damage": {
                     "0": {
+                        "applyMod": false,
                         "category": null,
                         "formula": "8d6",
                         "kinds": [
@@ -571,12 +572,12 @@
                 },
                 "defense": {
                     "save": {
-                        "basic": false,
+                        "basic": true,
                         "statistic": "fortitude"
                     }
                 },
                 "description": {
-                    "value": "<p>A swirling torrent of water manifests along a straight line, battering those that are its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save. Creatures that fail the save are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
+                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures and objects that fail are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -596,9 +597,9 @@
                     "value": "N8sxUVjIH1fEWXxu"
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
                 },
                 "range": {
                     "value": ""

--- a/packs/feats/smite-evil.json
+++ b/packs/feats/smite-evil.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>Your blade ally becomes an even more powerful tool against evildoers.</p>\n<p>Select one foe you can see. Until the start of your next turn, your Strikes with the weapon your blade ally inhabits against that foe deal an extra 4 spirit damage if the target is unholy, increasing to 6 if you have master proficiency with this weapon.</p>\n<p>If the foe attacks one of your allies, the duration extends to the end of that foe's next turn. If the foe continues to attack your allies each turn, the duration continues to extend."
+            "value": "<p>Your blade ally becomes an even more powerful tool against evildoers.</p>\n<p>Select one foe you can see. Until the start of your next turn, your Strikes with the weapon your blade ally inhabits against that foe deal an extra 4 spirit damage if the target is unholy, increasing to 6 if you have master proficiency with this weapon.</p>\n<p>If the foe attacks one of your allies, the duration extends to the end of that foe's next turn. If the foe continues to attack your allies each turn, the duration continues to extend.</p>"
         },
         "level": {
             "value": 6

--- a/packs/kingmaker-bestiary/false-priestess.json
+++ b/packs/kingmaker-bestiary/false-priestess.json
@@ -98,7 +98,7 @@
                     "sourceId": "Compendium.pf2e.spells-srd.Item.Y3G6Y6EDgCY0s3fq"
                 }
             },
-            "img": "systems/pf2e/icons/spells/hydraulic-torrent.webp",
+            "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
             "name": "Hydraulic Torrent",
             "sort": 300000,
             "system": {

--- a/packs/kingmaker-bestiary/false-priestess.json
+++ b/packs/kingmaker-bestiary/false-priestess.json
@@ -129,7 +129,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures that fail the save are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
+                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures and objects that fail are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -150,9 +150,9 @@
                     "value": "auHvPa2qajS0vG6w"
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": "Pathfinder Core Rulebook"
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
                 },
                 "range": {
                     "value": ""

--- a/packs/night-of-the-gray-death-bestiary/riekanoy.json
+++ b/packs/night-of-the-gray-death-bestiary/riekanoy.json
@@ -429,7 +429,7 @@
                     "sourceId": "Compendium.pf2e.spells-srd.Item.Y3G6Y6EDgCY0s3fq"
                 }
             },
-            "img": "systems/pf2e/icons/spells/hydraulic-torrent.webp",
+            "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
             "name": "Hydraulic Torrent",
             "sort": 700000,
             "system": {

--- a/packs/night-of-the-gray-death-bestiary/riekanoy.json
+++ b/packs/night-of-the-gray-death-bestiary/riekanoy.json
@@ -443,6 +443,7 @@
                 "counteraction": false,
                 "damage": {
                     "0": {
+                        "applyMod": false,
                         "category": null,
                         "formula": "8d6",
                         "kinds": [
@@ -454,12 +455,12 @@
                 },
                 "defense": {
                     "save": {
-                        "basic": false,
+                        "basic": true,
                         "statistic": "fortitude"
                     }
                 },
                 "description": {
-                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures that fail the save are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
+                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures and objects that fail are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -480,9 +481,9 @@
                     "value": "l6gDxpqDjpaOlxmL"
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": "Pathfinder Core Rulebook"
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
                 },
                 "range": {
                     "value": ""

--- a/packs/pathfinder-bestiary-2/adult-brine-dragon-spellcaster.json
+++ b/packs/pathfinder-bestiary-2/adult-brine-dragon-spellcaster.json
@@ -546,6 +546,7 @@
                 "counteraction": false,
                 "damage": {
                     "0": {
+                        "applyMod": false,
                         "category": null,
                         "formula": "8d6",
                         "kinds": [
@@ -557,12 +558,12 @@
                 },
                 "defense": {
                     "save": {
-                        "basic": false,
+                        "basic": true,
                         "statistic": "fortitude"
                     }
                 },
                 "description": {
-                    "value": "<p>A swirling torrent of water manifests along a straight line, battering those that are its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save. Creatures that fail the save are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
+                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures and objects that fail are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -582,9 +583,9 @@
                     "value": "zhHzZbCi9Wd6r7hj"
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
                 },
                 "range": {
                     "value": ""

--- a/packs/pathfinder-bestiary-2/adult-brine-dragon-spellcaster.json
+++ b/packs/pathfinder-bestiary-2/adult-brine-dragon-spellcaster.json
@@ -532,7 +532,7 @@
                     "sourceId": "Compendium.pf2e.spells-srd.Item.Y3G6Y6EDgCY0s3fq"
                 }
             },
-            "img": "systems/pf2e/icons/spells/hydraulic-torrent.webp",
+            "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
             "name": "Hydraulic Torrent",
             "sort": 800000,
             "system": {

--- a/packs/pathfinder-bestiary-2/adult-brine-dragon.json
+++ b/packs/pathfinder-bestiary-2/adult-brine-dragon.json
@@ -50,7 +50,7 @@
                     "sourceId": "Compendium.pf2e.spells-srd.Item.Y3G6Y6EDgCY0s3fq"
                 }
             },
-            "img": "systems/pf2e/icons/spells/hydraulic-torrent.webp",
+            "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
             "name": "Hydraulic Torrent",
             "sort": 200000,
             "system": {

--- a/packs/pathfinder-bestiary-2/adult-brine-dragon.json
+++ b/packs/pathfinder-bestiary-2/adult-brine-dragon.json
@@ -64,6 +64,7 @@
                 "counteraction": false,
                 "damage": {
                     "0": {
+                        "applyMod": false,
                         "category": null,
                         "formula": "8d6",
                         "kinds": [
@@ -75,12 +76,12 @@
                 },
                 "defense": {
                     "save": {
-                        "basic": false,
+                        "basic": true,
                         "statistic": "fortitude"
                     }
                 },
                 "description": {
-                    "value": "<p>A swirling torrent of water manifests along a straight line, battering those that are its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save. Creatures that fail the save are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
+                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures and objects that fail are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -100,9 +101,9 @@
                     "value": "zhHzZbCi9Wd6r7hj"
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
                 },
                 "range": {
                     "value": ""

--- a/packs/pathfinder-bestiary-2/ancient-brine-dragon-spellcaster.json
+++ b/packs/pathfinder-bestiary-2/ancient-brine-dragon-spellcaster.json
@@ -568,7 +568,7 @@
                     "sourceId": "Compendium.pf2e.spells-srd.Item.Y3G6Y6EDgCY0s3fq"
                 }
             },
-            "img": "systems/pf2e/icons/spells/hydraulic-torrent.webp",
+            "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
             "name": "Hydraulic Torrent",
             "sort": 800000,
             "system": {

--- a/packs/pathfinder-bestiary-2/ancient-brine-dragon-spellcaster.json
+++ b/packs/pathfinder-bestiary-2/ancient-brine-dragon-spellcaster.json
@@ -210,7 +210,8 @@
                 },
                 "tradition": {
                     "value": "primal"
-                }
+                },
+                "traits": {}
             },
             "type": "spellcastingEntry"
         },
@@ -562,93 +563,6 @@
             "type": "spell"
         },
         {
-            "_id": "CAPONuiPj7xEFjGV",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.Item.Y3G6Y6EDgCY0s3fq"
-                }
-            },
-            "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
-            "name": "Hydraulic Torrent",
-            "sort": 800000,
-            "system": {
-                "area": {
-                    "type": "line",
-                    "value": 60
-                },
-                "cost": {
-                    "value": ""
-                },
-                "counteraction": false,
-                "damage": {
-                    "0": {
-                        "category": null,
-                        "formula": "12d6",
-                        "kinds": [
-                            "damage"
-                        ],
-                        "materials": [],
-                        "type": "bludgeoning"
-                    }
-                },
-                "defense": {
-                    "save": {
-                        "basic": false,
-                        "statistic": "fortitude"
-                    }
-                },
-                "description": {
-                    "value": "<p>A swirling torrent of water manifests along a straight line, battering those that are its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save. Creatures that fail the save are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
-                },
-                "duration": {
-                    "sustained": false,
-                    "value": ""
-                },
-                "heightening": {
-                    "damage": {
-                        "0": "2d6"
-                    },
-                    "interval": 1,
-                    "type": "interval"
-                },
-                "level": {
-                    "value": 6
-                },
-                "location": {
-                    "value": "wea1MnyUIhvtedhE"
-                },
-                "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
-                },
-                "range": {
-                    "value": ""
-                },
-                "requirements": "",
-                "rules": [],
-                "slug": "hydraulic-torrent",
-                "target": {
-                    "value": ""
-                },
-                "time": {
-                    "value": "2"
-                },
-                "traits": {
-                    "rarity": "common",
-                    "traditions": [
-                        "primal"
-                    ],
-                    "value": [
-                        "concentrate",
-                        "manipulate",
-                        "water"
-                    ]
-                }
-            },
-            "type": "spell"
-        },
-        {
             "_id": "csVnnWhvJ9eXHtJR",
             "flags": {
                 "core": {
@@ -657,7 +571,7 @@
             },
             "img": "systems/pf2e/icons/spells/true-seeing.webp",
             "name": "True Seeing",
-            "sort": 900000,
+            "sort": 800000,
             "system": {
                 "area": null,
                 "cost": {
@@ -722,7 +636,7 @@
             },
             "img": "icons/magic/water/vortex-water-whirlpool.webp",
             "name": "Cone of Cold",
-            "sort": 1000000,
+            "sort": 900000,
             "system": {
                 "area": {
                     "type": "cone",
@@ -810,7 +724,7 @@
             },
             "img": "icons/magic/fire/explosion-flame-blue.webp",
             "name": "Control Water",
-            "sort": 1100000,
+            "sort": 1000000,
             "system": {
                 "area": null,
                 "cost": {
@@ -877,7 +791,7 @@
             },
             "img": "icons/magic/fire/explosion-flame-blue.webp",
             "name": "Control Water",
-            "sort": 1200000,
+            "sort": 1100000,
             "system": {
                 "area": null,
                 "cost": {
@@ -940,7 +854,7 @@
             },
             "img": "icons/magic/water/wave-water-blue.webp",
             "name": "Mariner's Curse",
-            "sort": 1300000,
+            "sort": 1200000,
             "system": {
                 "area": null,
                 "cost": {
@@ -1009,7 +923,7 @@
             },
             "img": "icons/magic/water/wave-water-blue.webp",
             "name": "Mariner's Curse",
-            "sort": 1400000,
+            "sort": 1300000,
             "system": {
                 "area": null,
                 "cost": {
@@ -1078,7 +992,7 @@
             },
             "img": "systems/pf2e/icons/spells/freedom-of-movement.webp",
             "name": "Freedom of Movement",
-            "sort": 1500000,
+            "sort": 1400000,
             "system": {
                 "area": null,
                 "cost": {
@@ -1141,7 +1055,7 @@
             },
             "img": "systems/pf2e/icons/spells/hallucinatory-terrain.webp",
             "name": "Hallucinatory Terrain",
-            "sort": 1600000,
+            "sort": 1500000,
             "system": {
                 "area": {
                     "type": "burst",
@@ -1208,7 +1122,7 @@
             },
             "img": "systems/pf2e/icons/spells/hydraulic-push.webp",
             "name": "Hydraulic Push (At Will)",
-            "sort": 1700000,
+            "sort": 1600000,
             "system": {
                 "area": null,
                 "cost": {
@@ -1272,6 +1186,95 @@
                     ],
                     "value": [
                         "attack",
+                        "concentrate",
+                        "manipulate",
+                        "water"
+                    ]
+                }
+            },
+            "type": "spell"
+        },
+        {
+            "_id": "QM8dedTMSqW1NxS0",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.Item.Y3G6Y6EDgCY0s3fq"
+                }
+            },
+            "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
+            "name": "Hydraulic Torrent",
+            "sort": 1700000,
+            "system": {
+                "area": {
+                    "type": "line",
+                    "value": 60
+                },
+                "cost": {
+                    "value": ""
+                },
+                "counteraction": false,
+                "damage": {
+                    "0": {
+                        "applyMod": false,
+                        "category": null,
+                        "formula": "8d6",
+                        "kinds": [
+                            "damage"
+                        ],
+                        "materials": [],
+                        "type": "bludgeoning"
+                    }
+                },
+                "defense": {
+                    "save": {
+                        "basic": true,
+                        "statistic": "fortitude"
+                    }
+                },
+                "description": {
+                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures and objects that fail are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
+                },
+                "duration": {
+                    "sustained": false,
+                    "value": ""
+                },
+                "heightening": {
+                    "damage": {
+                        "0": "2d6"
+                    },
+                    "interval": 1,
+                    "type": "interval"
+                },
+                "level": {
+                    "value": 4
+                },
+                "location": {
+                    "heightenedLevel": 6,
+                    "value": "wea1MnyUIhvtedhE"
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
+                },
+                "range": {
+                    "value": ""
+                },
+                "requirements": "",
+                "rules": [],
+                "slug": "hydraulic-torrent",
+                "target": {
+                    "value": ""
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traits": {
+                    "rarity": "common",
+                    "traditions": [
+                        "primal"
+                    ],
+                    "value": [
                         "concentrate",
                         "manipulate",
                         "water"

--- a/packs/pathfinder-bestiary-2/ancient-brine-dragon.json
+++ b/packs/pathfinder-bestiary-2/ancient-brine-dragon.json
@@ -39,96 +39,10 @@
                 },
                 "tradition": {
                     "value": "primal"
-                }
+                },
+                "traits": {}
             },
             "type": "spellcastingEntry"
-        },
-        {
-            "_id": "CAPONuiPj7xEFjGV",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.Item.Y3G6Y6EDgCY0s3fq"
-                }
-            },
-            "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
-            "name": "Hydraulic Torrent",
-            "sort": 200000,
-            "system": {
-                "area": {
-                    "type": "line",
-                    "value": 60
-                },
-                "cost": {
-                    "value": ""
-                },
-                "counteraction": false,
-                "damage": {
-                    "0": {
-                        "category": null,
-                        "formula": "12d6",
-                        "kinds": [
-                            "damage"
-                        ],
-                        "materials": [],
-                        "type": "bludgeoning"
-                    }
-                },
-                "defense": {
-                    "save": {
-                        "basic": false,
-                        "statistic": "fortitude"
-                    }
-                },
-                "description": {
-                    "value": "<p>A swirling torrent of water manifests along a straight line, battering those that are its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save. Creatures that fail the save are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
-                },
-                "duration": {
-                    "sustained": false,
-                    "value": ""
-                },
-                "heightening": {
-                    "damage": {
-                        "0": "2d6"
-                    },
-                    "interval": 1,
-                    "type": "interval"
-                },
-                "level": {
-                    "value": 6
-                },
-                "location": {
-                    "value": "wea1MnyUIhvtedhE"
-                },
-                "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
-                },
-                "range": {
-                    "value": ""
-                },
-                "requirements": "",
-                "rules": [],
-                "slug": "hydraulic-torrent",
-                "target": {
-                    "value": ""
-                },
-                "time": {
-                    "value": "2"
-                },
-                "traits": {
-                    "rarity": "common",
-                    "traditions": [
-                        "primal"
-                    ],
-                    "value": [
-                        "concentrate",
-                        "manipulate",
-                        "water"
-                    ]
-                }
-            },
-            "type": "spell"
         },
         {
             "_id": "Amy3IYyx3Etum3TI",
@@ -139,7 +53,7 @@
             },
             "img": "icons/magic/fire/explosion-flame-blue.webp",
             "name": "Control Water",
-            "sort": 300000,
+            "sort": 200000,
             "system": {
                 "area": null,
                 "cost": {
@@ -206,7 +120,7 @@
             },
             "img": "icons/magic/water/wave-water-blue.webp",
             "name": "Mariner's Curse",
-            "sort": 400000,
+            "sort": 300000,
             "system": {
                 "area": null,
                 "cost": {
@@ -275,7 +189,7 @@
             },
             "img": "systems/pf2e/icons/spells/hydraulic-push.webp",
             "name": "Hydraulic Push (At Will)",
-            "sort": 500000,
+            "sort": 400000,
             "system": {
                 "area": null,
                 "cost": {
@@ -339,6 +253,95 @@
                     ],
                     "value": [
                         "attack",
+                        "concentrate",
+                        "manipulate",
+                        "water"
+                    ]
+                }
+            },
+            "type": "spell"
+        },
+        {
+            "_id": "zjVKr9vZsL88g9CA",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.Item.Y3G6Y6EDgCY0s3fq"
+                }
+            },
+            "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
+            "name": "Hydraulic Torrent",
+            "sort": 500000,
+            "system": {
+                "area": {
+                    "type": "line",
+                    "value": 60
+                },
+                "cost": {
+                    "value": ""
+                },
+                "counteraction": false,
+                "damage": {
+                    "0": {
+                        "applyMod": false,
+                        "category": null,
+                        "formula": "8d6",
+                        "kinds": [
+                            "damage"
+                        ],
+                        "materials": [],
+                        "type": "bludgeoning"
+                    }
+                },
+                "defense": {
+                    "save": {
+                        "basic": true,
+                        "statistic": "fortitude"
+                    }
+                },
+                "description": {
+                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures and objects that fail are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
+                },
+                "duration": {
+                    "sustained": false,
+                    "value": ""
+                },
+                "heightening": {
+                    "damage": {
+                        "0": "2d6"
+                    },
+                    "interval": 1,
+                    "type": "interval"
+                },
+                "level": {
+                    "value": 4
+                },
+                "location": {
+                    "heightenedLevel": 6,
+                    "value": "wea1MnyUIhvtedhE"
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
+                },
+                "range": {
+                    "value": ""
+                },
+                "requirements": "",
+                "rules": [],
+                "slug": "hydraulic-torrent",
+                "target": {
+                    "value": ""
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traits": {
+                    "rarity": "common",
+                    "traditions": [
+                        "primal"
+                    ],
+                    "value": [
                         "concentrate",
                         "manipulate",
                         "water"

--- a/packs/pathfinder-bestiary-2/ancient-brine-dragon.json
+++ b/packs/pathfinder-bestiary-2/ancient-brine-dragon.json
@@ -50,7 +50,7 @@
                     "sourceId": "Compendium.pf2e.spells-srd.Item.Y3G6Y6EDgCY0s3fq"
                 }
             },
-            "img": "systems/pf2e/icons/spells/hydraulic-torrent.webp",
+            "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
             "name": "Hydraulic Torrent",
             "sort": 200000,
             "system": {

--- a/packs/pathfinder-bestiary-2/sarglagon.json
+++ b/packs/pathfinder-bestiary-2/sarglagon.json
@@ -320,6 +320,7 @@
                 "counteraction": false,
                 "damage": {
                     "0": {
+                        "applyMod": false,
                         "category": null,
                         "formula": "8d6",
                         "kinds": [
@@ -331,12 +332,12 @@
                 },
                 "defense": {
                     "save": {
-                        "basic": false,
+                        "basic": true,
                         "statistic": "fortitude"
                     }
                 },
                 "description": {
-                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures that fail the save are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
+                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures and objects that fail are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -357,9 +358,9 @@
                     "value": "xxK8rXRDWK5Rwj9i"
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": "Pathfinder Core Rulebook"
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
                 },
                 "range": {
                     "value": ""

--- a/packs/pathfinder-bestiary-2/sarglagon.json
+++ b/packs/pathfinder-bestiary-2/sarglagon.json
@@ -306,7 +306,7 @@
                     "sourceId": "Compendium.pf2e.spells-srd.Item.Y3G6Y6EDgCY0s3fq"
                 }
             },
-            "img": "systems/pf2e/icons/spells/hydraulic-torrent.webp",
+            "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
             "name": "Hydraulic Torrent",
             "sort": 600000,
             "system": {

--- a/packs/pathfinder-bestiary-2/water-yai.json
+++ b/packs/pathfinder-bestiary-2/water-yai.json
@@ -274,93 +274,6 @@
             "type": "spell"
         },
         {
-            "_id": "UK2QC8TMC5DHG3Tb",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.Item.Y3G6Y6EDgCY0s3fq"
-                }
-            },
-            "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
-            "name": "Hydraulic Torrent",
-            "sort": 500000,
-            "system": {
-                "area": {
-                    "type": "line",
-                    "value": 60
-                },
-                "cost": {
-                    "value": ""
-                },
-                "counteraction": false,
-                "damage": {
-                    "0": {
-                        "category": null,
-                        "formula": "16d6",
-                        "kinds": [
-                            "damage"
-                        ],
-                        "materials": [],
-                        "type": "bludgeoning"
-                    }
-                },
-                "defense": {
-                    "save": {
-                        "basic": false,
-                        "statistic": "fortitude"
-                    }
-                },
-                "description": {
-                    "value": "<p>A swirling torrent of water manifests along a straight line, battering those that are its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save. Creatures that fail the save are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
-                },
-                "duration": {
-                    "sustained": false,
-                    "value": ""
-                },
-                "heightening": {
-                    "damage": {
-                        "0": "2d6"
-                    },
-                    "interval": 1,
-                    "type": "interval"
-                },
-                "level": {
-                    "value": 8
-                },
-                "location": {
-                    "value": "3KyuJoHTxD577UTr"
-                },
-                "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
-                },
-                "range": {
-                    "value": ""
-                },
-                "requirements": "",
-                "rules": [],
-                "slug": "hydraulic-torrent",
-                "target": {
-                    "value": ""
-                },
-                "time": {
-                    "value": "2"
-                },
-                "traits": {
-                    "rarity": "common",
-                    "traditions": [
-                        "primal"
-                    ],
-                    "value": [
-                        "concentrate",
-                        "manipulate",
-                        "water"
-                    ]
-                }
-            },
-            "type": "spell"
-        },
-        {
             "_id": "cOqmT9M74QEp6QXX",
             "flags": {
                 "core": {
@@ -369,7 +282,7 @@
             },
             "img": "icons/magic/fire/explosion-flame-blue.webp",
             "name": "Control Water (At will)",
-            "sort": 600000,
+            "sort": 500000,
             "system": {
                 "area": null,
                 "cost": {
@@ -432,7 +345,7 @@
             },
             "img": "systems/pf2e/icons/spells/charm.webp",
             "name": "Charm",
-            "sort": 700000,
+            "sort": 600000,
             "system": {
                 "area": null,
                 "cost": {
@@ -507,7 +420,7 @@
             },
             "img": "systems/pf2e/icons/spells/darkness.webp",
             "name": "Darkness",
-            "sort": 800000,
+            "sort": 700000,
             "system": {
                 "area": {
                     "type": "burst",
@@ -561,6 +474,95 @@
                         "concentrate",
                         "darkness",
                         "manipulate"
+                    ]
+                }
+            },
+            "type": "spell"
+        },
+        {
+            "_id": "9UHRBPeenXrCAruc",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.Item.Y3G6Y6EDgCY0s3fq"
+                }
+            },
+            "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
+            "name": "Hydraulic Torrent",
+            "sort": 800000,
+            "system": {
+                "area": {
+                    "type": "line",
+                    "value": 60
+                },
+                "cost": {
+                    "value": ""
+                },
+                "counteraction": false,
+                "damage": {
+                    "0": {
+                        "applyMod": false,
+                        "category": null,
+                        "formula": "8d6",
+                        "kinds": [
+                            "damage"
+                        ],
+                        "materials": [],
+                        "type": "bludgeoning"
+                    }
+                },
+                "defense": {
+                    "save": {
+                        "basic": true,
+                        "statistic": "fortitude"
+                    }
+                },
+                "description": {
+                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures and objects that fail are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
+                },
+                "duration": {
+                    "sustained": false,
+                    "value": ""
+                },
+                "heightening": {
+                    "damage": {
+                        "0": "2d6"
+                    },
+                    "interval": 1,
+                    "type": "interval"
+                },
+                "level": {
+                    "value": 4
+                },
+                "location": {
+                    "heightenedLevel": 8,
+                    "value": "3KyuJoHTxD577UTr"
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
+                },
+                "range": {
+                    "value": ""
+                },
+                "requirements": "",
+                "rules": [],
+                "slug": "hydraulic-torrent",
+                "target": {
+                    "value": ""
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traits": {
+                    "rarity": "common",
+                    "traditions": [
+                        "primal"
+                    ],
+                    "value": [
+                        "concentrate",
+                        "manipulate",
+                        "water"
                     ]
                 }
             },

--- a/packs/pathfinder-bestiary-2/water-yai.json
+++ b/packs/pathfinder-bestiary-2/water-yai.json
@@ -280,7 +280,7 @@
                     "sourceId": "Compendium.pf2e.spells-srd.Item.Y3G6Y6EDgCY0s3fq"
                 }
             },
-            "img": "systems/pf2e/icons/spells/hydraulic-torrent.webp",
+            "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
             "name": "Hydraulic Torrent",
             "sort": 500000,
             "system": {

--- a/packs/pathfinder-bestiary-3/danava-titan.json
+++ b/packs/pathfinder-bestiary-3/danava-titan.json
@@ -670,7 +670,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures that fail the save are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
+                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures and objects that fail are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -695,9 +695,9 @@
                     "value": "t0jxVnsS6HbKkoTf"
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": "Pathfinder Core Rulebook"
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
                 },
                 "range": {
                     "value": ""

--- a/packs/pathfinder-bestiary-3/danava-titan.json
+++ b/packs/pathfinder-bestiary-3/danava-titan.json
@@ -639,7 +639,7 @@
                     "sourceId": "Compendium.pf2e.spells-srd.Item.Y3G6Y6EDgCY0s3fq"
                 }
             },
-            "img": "systems/pf2e/icons/spells/hydraulic-torrent.webp",
+            "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
             "name": "Hydraulic Torrent",
             "sort": 1000000,
             "system": {

--- a/packs/pathfinder-bestiary-3/storm-hag.json
+++ b/packs/pathfinder-bestiary-3/storm-hag.json
@@ -603,7 +603,7 @@
                             "damage"
                         ],
                         "materials": [],
-                        "type": "untyped"
+                        "type": "bludgeoning"
                     }
                 },
                 "defense": {
@@ -613,7 +613,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures that fail the save are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
+                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures and objects that fail are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -634,9 +634,9 @@
                     "value": "jAcMhmLTK9Y34bhZ"
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": "Pathfinder Core Rulebook"
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
                 },
                 "range": {
                     "value": ""

--- a/packs/pathfinder-bestiary-3/storm-hag.json
+++ b/packs/pathfinder-bestiary-3/storm-hag.json
@@ -582,7 +582,7 @@
                     "sourceId": "Compendium.pf2e.spells-srd.Item.Y3G6Y6EDgCY0s3fq"
                 }
             },
-            "img": "systems/pf2e/icons/spells/hydraulic-torrent.webp",
+            "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
             "name": "Hydraulic Torrent",
             "sort": 1000000,
             "system": {

--- a/packs/pathfinder-bestiary-3/tidehawk.json
+++ b/packs/pathfinder-bestiary-3/tidehawk.json
@@ -271,7 +271,7 @@
                     "sourceId": "Compendium.pf2e.spells-srd.Item.Y3G6Y6EDgCY0s3fq"
                 }
             },
-            "img": "systems/pf2e/icons/spells/hydraulic-torrent.webp",
+            "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
             "name": "Hydraulic Torrent",
             "sort": 500000,
             "system": {

--- a/packs/pathfinder-bestiary-3/tidehawk.json
+++ b/packs/pathfinder-bestiary-3/tidehawk.json
@@ -302,7 +302,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures that fail the save are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
+                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures and objects that fail are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -323,9 +323,9 @@
                     "value": "CMbpDKN5GasPKdEy"
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": "Pathfinder Core Rulebook"
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
                 },
                 "range": {
                     "value": ""

--- a/packs/pathfinder-bestiary/marid.json
+++ b/packs/pathfinder-bestiary/marid.json
@@ -248,7 +248,7 @@
                     "sourceId": "Compendium.pf2e.spells-srd.Item.Y3G6Y6EDgCY0s3fq"
                 }
             },
-            "img": "systems/pf2e/icons/spells/hydraulic-torrent.webp",
+            "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
             "name": "Hydraulic Torrent",
             "sort": 500000,
             "system": {

--- a/packs/pathfinder-bestiary/marid.json
+++ b/packs/pathfinder-bestiary/marid.json
@@ -279,7 +279,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures that fail the save are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
+                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures and objects that fail are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -300,9 +300,9 @@
                     "value": "EyTNAb0HgeYGoaPL"
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": "Pathfinder Core Rulebook"
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
                 },
                 "range": {
                     "value": ""

--- a/packs/quest-for-the-frozen-flame-bestiary/jesseri-the-hailstorm.json
+++ b/packs/quest-for-the-frozen-flame-bestiary/jesseri-the-hailstorm.json
@@ -378,7 +378,7 @@
                     "sourceId": "Compendium.pf2e.spells-srd.Item.Y3G6Y6EDgCY0s3fq"
                 }
             },
-            "img": "systems/pf2e/icons/spells/hydraulic-torrent.webp",
+            "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
             "name": "Hydraulic Torrent",
             "sort": 500000,
             "system": {

--- a/packs/quest-for-the-frozen-flame-bestiary/jesseri-the-hailstorm.json
+++ b/packs/quest-for-the-frozen-flame-bestiary/jesseri-the-hailstorm.json
@@ -392,6 +392,7 @@
                 "counteraction": false,
                 "damage": {
                     "0": {
+                        "applyMod": false,
                         "category": null,
                         "formula": "8d6",
                         "kinds": [
@@ -403,12 +404,12 @@
                 },
                 "defense": {
                     "save": {
-                        "basic": false,
+                        "basic": true,
                         "statistic": "fortitude"
                     }
                 },
                 "description": {
-                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures that fail the save are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
+                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures and objects that fail are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -428,9 +429,9 @@
                     "value": "EzHSNKdnJmqW9c8K"
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": "Pathfinder Core Rulebook"
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
                 },
                 "range": {
                     "value": ""

--- a/packs/rage-of-elements-bestiary/faydhaan-shuyookh.json
+++ b/packs/rage-of-elements-bestiary/faydhaan-shuyookh.json
@@ -486,7 +486,7 @@
                     "sourceId": "Compendium.pf2e.spells-srd.Item.Y3G6Y6EDgCY0s3fq"
                 }
             },
-            "img": "systems/pf2e/icons/spells/hydraulic-torrent.webp",
+            "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
             "name": "Hydraulic Torrent",
             "sort": 800000,
             "system": {

--- a/packs/rage-of-elements-bestiary/faydhaan-shuyookh.json
+++ b/packs/rage-of-elements-bestiary/faydhaan-shuyookh.json
@@ -517,7 +517,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures that fail the save are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
+                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures and objects that fail are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -538,9 +538,9 @@
                     "value": "IJA2uWllA9JMgBOG"
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": "Pathfinder Core Rulebook"
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
                 },
                 "range": {
                     "value": ""

--- a/packs/season-of-ghosts-bestiary/heh-shan-bao.json
+++ b/packs/season-of-ghosts-bestiary/heh-shan-bao.json
@@ -1038,7 +1038,7 @@
                             "sourceId": "Compendium.pf2e.spells-srd.Item.Y3G6Y6EDgCY0s3fq"
                         }
                     },
-                    "img": "systems/pf2e/icons/spells/hydraulic-torrent.webp",
+                    "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
                     "name": "Hydraulic Torrent",
                     "sort": 0,
                     "system": {

--- a/packs/season-of-ghosts-bestiary/iogaka.json
+++ b/packs/season-of-ghosts-bestiary/iogaka.json
@@ -605,7 +605,7 @@
                             "damage"
                         ],
                         "materials": [],
-                        "type": "untyped"
+                        "type": "bludgeoning"
                     }
                 },
                 "defense": {
@@ -615,7 +615,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures that fail the save are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
+                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures and objects that fail are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -636,9 +636,9 @@
                     "value": "jAcMhmLTK9Y34bhZ"
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": "Pathfinder Core Rulebook"
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
                 },
                 "range": {
                     "value": ""

--- a/packs/season-of-ghosts-bestiary/iogaka.json
+++ b/packs/season-of-ghosts-bestiary/iogaka.json
@@ -584,7 +584,7 @@
                     "sourceId": "Compendium.pf2e.spells-srd.Item.Y3G6Y6EDgCY0s3fq"
                 }
             },
-            "img": "systems/pf2e/icons/spells/hydraulic-torrent.webp",
+            "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
             "name": "Hydraulic Torrent",
             "sort": 1000000,
             "system": {

--- a/packs/spells/hydraulic-torrent.json
+++ b/packs/spells/hydraulic-torrent.json
@@ -1,6 +1,6 @@
 {
     "_id": "Y3G6Y6EDgCY0s3fq",
-    "img": "systems/pf2e/icons/spells/hydraulic-torrent.webp",
+    "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
     "name": "Hydraulic Torrent",
     "system": {
         "area": {

--- a/packs/stolen-fate-bestiary/markish-aghayarea.json
+++ b/packs/stolen-fate-bestiary/markish-aghayarea.json
@@ -759,7 +759,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures that fail the save are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
+                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures and objects that fail are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -780,9 +780,9 @@
                     "value": "LPsC4aPQJcVgNEdo"
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": "Pathfinder Core Rulebook"
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
                 },
                 "range": {
                     "value": ""

--- a/packs/stolen-fate-bestiary/markish-aghayarea.json
+++ b/packs/stolen-fate-bestiary/markish-aghayarea.json
@@ -728,7 +728,7 @@
                     "sourceId": "Compendium.pf2e.spells-srd.Item.Y3G6Y6EDgCY0s3fq"
                 }
             },
-            "img": "systems/pf2e/icons/spells/hydraulic-torrent.webp",
+            "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
             "name": "Hydraulic Torrent",
             "sort": 1200000,
             "system": {

--- a/packs/strength-of-thousands-bestiary/grouloop.json
+++ b/packs/strength-of-thousands-bestiary/grouloop.json
@@ -348,7 +348,7 @@
                     "sourceId": "Compendium.pf2e.spells-srd.Item.Y3G6Y6EDgCY0s3fq"
                 }
             },
-            "img": "systems/pf2e/icons/spells/hydraulic-torrent.webp",
+            "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
             "name": "Hydraulic Torrent",
             "sort": 500000,
             "system": {

--- a/packs/strength-of-thousands-bestiary/grouloop.json
+++ b/packs/strength-of-thousands-bestiary/grouloop.json
@@ -362,6 +362,7 @@
                 "counteraction": false,
                 "damage": {
                     "0": {
+                        "applyMod": false,
                         "category": null,
                         "formula": "8d6",
                         "kinds": [
@@ -373,12 +374,12 @@
                 },
                 "defense": {
                     "save": {
-                        "basic": false,
+                        "basic": true,
                         "statistic": "fortitude"
                     }
                 },
                 "description": {
-                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures that fail the save are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
+                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures and objects that fail are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -399,9 +400,9 @@
                     "value": "HkaLSWDV9fVv0xkG"
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": "Pathfinder Core Rulebook"
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
                 },
                 "range": {
                     "value": ""

--- a/packs/strength-of-thousands-bestiary/ssumzili.json
+++ b/packs/strength-of-thousands-bestiary/ssumzili.json
@@ -116,7 +116,7 @@
                     "sourceId": "Compendium.pf2e.spells-srd.Item.Y3G6Y6EDgCY0s3fq"
                 }
             },
-            "img": "systems/pf2e/icons/spells/hydraulic-torrent.webp",
+            "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
             "name": "Hydraulic Torrent",
             "sort": 300000,
             "system": {

--- a/packs/strength-of-thousands-bestiary/ssumzili.json
+++ b/packs/strength-of-thousands-bestiary/ssumzili.json
@@ -130,6 +130,7 @@
                 "counteraction": false,
                 "damage": {
                     "0": {
+                        "applyMod": false,
                         "category": null,
                         "formula": "8d6",
                         "kinds": [
@@ -141,12 +142,12 @@
                 },
                 "defense": {
                     "save": {
-                        "basic": false,
+                        "basic": true,
                         "statistic": "fortitude"
                     }
                 },
                 "description": {
-                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures that fail the save are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
+                    "value": "<p>A swirling torrent of water manifests along a straight line, battering creatures and unattended objects in its path and possibly pushing them away from you. The torrent deals 8d6 bludgeoning damage. Each creature in the area must attempt a basic Fortitude save; unattended objects automatically fail. Creatures and objects that fail are also knocked back 5 feet (10 feet on a critical failure).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -167,9 +168,9 @@
                     "value": "JRCZvWVw9mFwuMTN"
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": "Pathfinder Core Rulebook"
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
                 },
                 "range": {
                     "value": ""


### PR DESCRIPTION
Replace lower-resolution system icon with identical core icon
Manually replace copies for Minchgorm, Ancient Brine Dragon, Ancient Brine Dragon (Spellcaster), and Water Yai.