### PR TITLE
Fix damage type of Hero's Defiance, Life Siphon, Soothing Spring, and Wholeness of Body

### DIFF
--- a/packs/spells/heros-defiance.json
+++ b/packs/spells/heros-defiance.json
@@ -10,18 +10,19 @@
         "counteraction": false,
         "damage": {
             "0": {
+                "applyMod": false,
                 "category": null,
                 "formula": "10d4+20",
                 "kinds": [
                     "healing"
                 ],
                 "materials": [],
-                "type": "healing"
+                "type": "vitality"
             }
         },
         "defense": null,
         "description": {
-            "value": "<p><strong>Trigger</strong> An attack would bring you to 0 Hit Points.</p>\n<hr />\n<p>You shout in defiance, filling you with a sudden burst of healing. Just before applying the attack's damage, you recover 10d4+20 Hit Points. If this is enough to prevent the attack from bringing you to 0 Hit Points, you don't become @UUID[Compendium.pf2e.conditionitems.Item.Unconscious] or @UUID[Compendium.pf2e.conditionitems.Item.Dying]. Either way, cheating death is difficult, and you can't use hero's defiance again until you Refocus or the next time you prepare. Hero's defiance cannot be used against effects with the death trait or that would leave no remains, such as disintegrate.</p>"
+            "value": "<p><strong>Trigger</strong> An attack would bring you to 0 Hit Points.</p>\n<hr />\n<p>You shout in defiance, filling you with a sudden burst of healing. Just before applying the attack's damage, you recover 10d4+20 Hit Points. If this is enough to prevent the attack from bringing you to 0 Hit Points, you don't become @UUID[Compendium.pf2e.conditionitems.Item.Unconscious] or @UUID[Compendium.pf2e.conditionitems.Item.Dying]. Either way, cheating death is difficult, and you can't use <em>hero's defiance</em> again until you Refocus or the next time you prepare. <em>Hero's defiance</em> cannot be used against effects with the death trait or that would leave no remains, such as @UUID[Compendium.pf2e.spells-srd.Item.Disintegrate].</p>"
         },
         "duration": {
             "sustained": false,

--- a/packs/spells/life-siphon.json
+++ b/packs/spells/life-siphon.json
@@ -10,13 +10,14 @@
         "counteraction": false,
         "damage": {
             "0": {
+                "applyMod": false,
                 "category": null,
                 "formula": "1d8",
                 "kinds": [
                     "healing"
                 ],
                 "materials": [],
-                "type": "healing"
+                "type": "untyped"
             }
         },
         "defense": null,

--- a/packs/spells/soothing-spring.json
+++ b/packs/spells/soothing-spring.json
@@ -16,7 +16,7 @@
                 "kinds": [
                     "healing"
                 ],
-                "type": "healing"
+                "type": "vitality"
             }
         },
         "defense": null,

--- a/packs/spells/wholeness-of-body.json
+++ b/packs/spells/wholeness-of-body.json
@@ -10,13 +10,14 @@
         "counteraction": true,
         "damage": {
             "0": {
+                "applyMod": false,
                 "category": null,
                 "formula": "8",
                 "kinds": [
                     "healing"
                 ],
                 "materials": [],
-                "type": "healing"
+                "type": "vitality"
             }
         },
         "defense": null,


### PR DESCRIPTION
I assumed that spells with the vitality trait did vitality healing