### PR TITLE
Brush up Cleric feats

### DIFF
--- a/packs/feat-effects/effect-channeling-block.json
+++ b/packs/feat-effects/effect-channeling-block.json
@@ -1,0 +1,50 @@
+{
+    "_id": "Rzg3c7hfkvTlxPDp",
+    "img": "icons/magic/defensive/shield-barrier-glowing-triangle-green.webp",
+    "name": "Effect: Channeling Block",
+    "system": {
+        "badge": {
+            "evaluate": true,
+            "reevaluate": null,
+            "type": "formula",
+            "value": "(@item.level)d8"
+        },
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Channeling Block]</p>\n<p>Roll 1d8 for each rank of the @UUID[Compendium.pf2e.spells-srd.Item.Heal] or @UUID[Compendium.pf2e.spells-srd.Item.Harm] spell, and increase the shield's Hardness by the total for this block.</p>"
+        },
+        "duration": {
+            "expiry": "turn-end",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 0
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Player Core"
+        },
+        "rules": [
+            {
+                "itemType": "shield",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "property": "hardness",
+                "value": "@item.badge.value"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feat-effects/effect-deitys-protection.json
+++ b/packs/feat-effects/effect-deitys-protection.json
@@ -4,7 +4,7 @@
     "name": "Effect: Deity's Protection",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Deity's Protection]</p>\n<p>You gain resistance to all damage.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Deity's Protection]</p>\n<p>You gain resistance to all damage until the start of your next turn.</p>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -22,129 +22,9 @@
         },
         "rules": [
             {
-                "adjustName": false,
-                "choices": [
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.First",
-                        "value": 1
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Second",
-                        "predicate": [
-                            {
-                                "gte": [
-                                    "self:level",
-                                    3
-                                ]
-                            }
-                        ],
-                        "value": 2
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Third",
-                        "predicate": [
-                            {
-                                "gte": [
-                                    "self:level",
-                                    5
-                                ]
-                            }
-                        ],
-                        "value": 3
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Fourth",
-                        "predicate": [
-                            {
-                                "gte": [
-                                    "self:level",
-                                    7
-                                ]
-                            }
-                        ],
-                        "value": 4
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Fifth",
-                        "predicate": [
-                            {
-                                "gte": [
-                                    "self:level",
-                                    9
-                                ]
-                            }
-                        ],
-                        "value": 5
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Sixth",
-                        "predicate": [
-                            {
-                                "gte": [
-                                    "self:level",
-                                    11
-                                ]
-                            }
-                        ],
-                        "value": 6
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Seventh",
-                        "predicate": [
-                            {
-                                "gte": [
-                                    "self:level",
-                                    13
-                                ]
-                            }
-                        ],
-                        "value": 7
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Eighth",
-                        "predicate": [
-                            {
-                                "gte": [
-                                    "self:level",
-                                    15
-                                ]
-                            }
-                        ],
-                        "value": 8
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Ninth",
-                        "predicate": [
-                            {
-                                "gte": [
-                                    "self:level",
-                                    17
-                                ]
-                            }
-                        ],
-                        "value": 9
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Tenth",
-                        "predicate": [
-                            {
-                                "gte": [
-                                    "self:level",
-                                    19
-                                ]
-                            }
-                        ],
-                        "value": 10
-                    }
-                ],
-                "flag": "deitysProtectionRank",
-                "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.SpellRank.Prompt"
-            },
-            {
                 "key": "Resistance",
                 "type": "all-damage",
-                "value": "{item|flags.pf2e.rulesSelections.deitysProtectionRank}"
+                "value": "@item.level"
             }
         ],
         "start": {

--- a/packs/feat-effects/effect-prayer-touched-weapon.json
+++ b/packs/feat-effects/effect-prayer-touched-weapon.json
@@ -4,7 +4,7 @@
     "name": "Effect: Prayer-Touched Weapon",
     "system": {
         "description": {
-            "value": "<p>The chosen weapon deals an extra 1d6 vitality damage.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Prayer-Touched Weapon]</p>\n<p>The chosen weapon deals an extra 1d6 vitality damage.</p>"
         },
         "duration": {
             "expiry": "turn-end",

--- a/packs/feat-effects/effect-premonition-of-clarity.json
+++ b/packs/feat-effects/effect-premonition-of-clarity.json
@@ -1,0 +1,47 @@
+{
+    "_id": "YIpFCMT8AKKhgbAF",
+    "img": "icons/magic/holy/prayer-hands-glowing-yellow.webp",
+    "name": "Effect: Premonition of Clarity",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Premonition of Clarity]</p>\n<p>Reroll the triggering saving throw with a +2 circumstance bonus.</p>"
+        },
+        "duration": {
+            "expiry": null,
+            "sustained": false,
+            "unit": "unlimited",
+            "value": -1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "item:trait:mental"
+                ],
+                "removeAfterRoll": true,
+                "selector": "saving-throw",
+                "type": "circumstance",
+                "value": 2
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feat-effects/effect-raise-symbol.json
+++ b/packs/feat-effects/effect-raise-symbol.json
@@ -41,6 +41,18 @@
                     }
                 ],
                 "selector": "saving-throw"
+            },
+            {
+                "key": "GrantItem",
+                "predicate": [
+                    {
+                        "or": [
+                            "self:effect:emblazon-armament-shield",
+                            "shield-religious-symbol"
+                        ]
+                    }
+                ],
+                "uuid": "Compendium.pf2e.equipment-effects.Item.Effect: Raise a Shield"
             }
         ],
         "start": {

--- a/packs/feat-effects/effect-restorative-strike.json
+++ b/packs/feat-effects/effect-restorative-strike.json
@@ -4,7 +4,7 @@
     "name": "Effect: Restorative Strike",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Restorative Strike]</p>\n<p>If you make this Strike with your deity's favored weapon, you gain a +1 status bonus to the attack roll.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Restorative Strike]</p>\n<p>Cast a 1-action @UUID[Compendium.pf2e.spells-srd.Item.Harm] or @UUID[Compendium.pf2e.spells-srd.Item.Heal] spell to heal yourself, expending the spell normally. It loses the manipulate trait when cast this way. Then make a melee Strike. If you make this Strike with your deity's favored weapon, you gain a +1 status bonus to the attack roll.</p>\n<p>If the Strike hits, you can target a second willing creature to heal the same amount from the spell. This creature can be outside of the spell's range, provided it's adjacent to the enemy you hit.</p>"
         },
         "duration": {
             "expiry": "turn-end",
@@ -22,6 +22,22 @@
         },
         "rules": [
             {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "remove",
+                "predicate": [
+                    "item:cast:actions:1",
+                    {
+                        "or": [
+                            "item:slug:harm",
+                            "item:slug:heal"
+                        ]
+                    }
+                ],
+                "property": "traits",
+                "value": "manipulate"
+            },
+            {
                 "key": "FlatModifier",
                 "predicate": [
                     "item:deity-favored"
@@ -30,6 +46,16 @@
                 "selector": "strike-attack-roll",
                 "type": "status",
                 "value": 1
+            },
+            {
+                "key": "Note",
+                "outcome": [
+                    "success",
+                    "criticalSuccess"
+                ],
+                "selector": "strike-attack-roll",
+                "text": "PF2E.SpecificRule.Cleric.RestorativeStrike.Note",
+                "title": "{item|name}"
             }
         ],
         "start": {

--- a/packs/feats/channeling-block.json
+++ b/packs/feats/channeling-block.json
@@ -28,7 +28,37 @@
             "remaster": true,
             "title": "Pathfinder Player Core"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "RollOption",
+                "option": "channeling-block",
+                "toggleable": true
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "override",
+                "predicate": [
+                    "channeling-block",
+                    {
+                        "or": [
+                            "item:slug:heal",
+                            "item:slug:harm"
+                        ]
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Cleric.ChannelingBlock.Description",
+                        "title": "{item|name}"
+                    },
+                    {
+                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Channeling Block]"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/dance-of-intercession.json
+++ b/packs/feats/dance-of-intercession.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p><strong>Frequency</strong> three times a day</p>\n<hr />\n<p>You either performed in or stood witness to the dance used to invoke the Celestial Dragon and can harness a sliver of their power. You Stride in a dance up to half your Speed, attempting a @Check[type:performance|dc:35] check. You can perform this dance up to three times per day. The second time you do so in the same day, use the degree of success one worse than your actual roll on the Performance check. The third time in a day, use the degree of success two lower than your actual roll.</p>\n<hr />\n<p><strong>Critical Success</strong> You perform the movements of the Dance of Intercession so gracefully that you evoke a glimmer of the memory of the Celestial Dragon's awesome power. You cast the 3-action version of either 9th-rank harm or heal at any point during your Stride. This does not use any spell slots.</p>\n<p><strong>Success</strong> As critical success, but the spell is 7th rank instead of 9th as you stumble through the movements.</p>\n<p><strong>Failure</strong> As critical success, but the spell is 5th rank instead of 9th as you stumble through the movements.</p>\n<p><strong>Critical Failure</strong> You fail to remember the steps of the dance. You gain no additional effect beyond Striding half your Speed, and you can't attempt the Dance of Intercession again until your next daily preparations.</p>"
+            "value": "<p><strong>Frequency</strong> three times a day</p>\n<hr />\n<p>You either performed in or stood witness to the dance used to invoke the Celestial Dragon and can harness a sliver of their power. You Stride in a dance up to half your Speed, attempting a @Check[type:performance|dc:35] check. You can perform this dance up to three times per day. The second time you do so in the same day, use the degree of success one worse than your actual roll on the Performance check. The third time in a day, use the degree of success two lower than your actual roll.</p>\n<hr />\n<p><strong>Critical Success</strong> You perform the movements of the Dance of Intercession so gracefully that you evoke a glimmer of the memory of the Celestial Dragon's awesome power. You cast the 3-action version of either 9th-rank @UUID[Compendium.pf2e.spells-srd.Item.Harm] or @UUID[Compendium.pf2e.spells-srd.Item.Heal] at any point during your Stride. This does not use any spell slots.</p>\n<p><strong>Success</strong> As critical success, but the spell is 7th rank instead of 9th as you stumble through the movements.</p>\n<p><strong>Failure</strong> As critical success, but the spell is 5th rank instead of 9th as you stumble through the movements.</p>\n<p><strong>Critical Failure</strong> You fail to remember the steps of the dance. You gain no additional effect beyond Striding half your Speed, and you can't attempt the Dance of Intercession again until your next daily preparations.</p>"
         },
         "frequency": {
             "max": 3,
@@ -32,7 +32,34 @@
             "remaster": false,
             "title": "Pathfinder #168: King of the Mountain"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "RollOption",
+                "option": "dance-of-intercession:{item|frequency.value}"
+            },
+            {
+                "adjustment": {
+                    "all": "one-degree-worse"
+                },
+                "key": "AdjustDegreeOfSuccess",
+                "predicate": [
+                    "action:dance-of-intercession",
+                    "dance-of-intercession:2"
+                ],
+                "selector": "performance"
+            },
+            {
+                "adjustment": {
+                    "all": "two-degrees-worse"
+                },
+                "key": "AdjustDegreeOfSuccess",
+                "predicate": [
+                    "action:dance-of-intercession",
+                    "dance-of-intercession:1"
+                ],
+                "selector": "performance"
+            }
+        ],
         "traits": {
             "rarity": "uncommon",
             "value": [

--- a/packs/feats/deitys-protection.json
+++ b/packs/feats/deitys-protection.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>When you call upon your deity's power to fulfill the promise of their domain, you gain divine protection. After you cast a domain spell, you gain resistance to all damage until the start of your next turn. The amount of resistance is equal to the rank of the domain spell you cast.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Deity's Protection]</p>"
+            "value": "<p>When you call upon your deity's power to fulfill the promise of their domain, you gain divine protection. After you cast a domain spell, you gain resistance to all damage until the start of your next turn. The amount of resistance is equal to the rank of the domain spell you cast.</p>"
         },
         "level": {
             "value": 14
@@ -28,7 +28,26 @@
             "remaster": true,
             "title": "Pathfinder Player Core"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:trait:focus",
+                    "item:trait:cleric"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Cleric.DeitysProtection.Description"
+                    },
+                    {
+                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Deity's Protection]"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/panic-the-dead.json
+++ b/packs/feats/panic-the-dead.json
@@ -24,7 +24,17 @@
             "remaster": true,
             "title": "Pathfinder Player Core"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "Note",
+                "predicate": [
+                    "item:slug:heal"
+                ],
+                "selector": "spell-damage",
+                "text": "{item|description}",
+                "title": "{item|name}"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/premonition-of-clarity.json
+++ b/packs/feats/premonition-of-clarity.json
@@ -28,24 +28,11 @@
             "remaster": true,
             "title": "Pathfinder Player Core"
         },
-        "rules": [
-            {
-                "domain": "saving-throw",
-                "key": "RollOption",
-                "option": "premonition-of-clarity",
-                "toggleable": true
-            },
-            {
-                "key": "FlatModifier",
-                "predicate": [
-                    "premonition-of-clarity",
-                    "mental"
-                ],
-                "selector": "saving-throw",
-                "type": "circumstance",
-                "value": 2
-            }
-        ],
+        "rules": [],
+        "selfEffect": {
+            "name": "Effect: Premonition of Clarity",
+            "uuid": "Compendium.pf2e.feat-effects.Item.Effect: Premonition of Clarity"
+        },
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/raise-symbol.json
+++ b/packs/feats/raise-symbol.json
@@ -24,7 +24,21 @@
             "remaster": true,
             "title": "Pathfinder Player Core"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Cleric.RaiseSymbol.RollOptionLabel",
+                "option": "shield-religious-symbol",
+                "predicate": [
+                    "self:shield:equipped",
+                    {
+                        "not": "self:effect:emblazon-armament-shield"
+                    }
+                ],
+                "toggleable": true,
+                "value": true
+            }
+        ],
         "selfEffect": {
             "name": "Effect: Raise Symbol",
             "uuid": "Compendium.pf2e.feat-effects.Item.Effect: Raise Symbol"

--- a/packs/feats/raise-symbol.json
+++ b/packs/feats/raise-symbol.json
@@ -35,8 +35,7 @@
                         "not": "self:effect:emblazon-armament-shield"
                     }
                 ],
-                "toggleable": true,
-                "value": true
+                "toggleable": true
             }
         ],
         "selfEffect": {

--- a/packs/feats/sap-life.json
+++ b/packs/feats/sap-life.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>ou draw the life force out of your enemies. When you cast a @UUID[Compendium.pf2e.spells-srd.Item.Harm] spell and damage at least one living creature, you regain Hit Points equal to the spell rank of your <em>harm</em> spell. If you aren't a living creature, you gain no benefit from this feat.</p>"
+            "value": "<p>You draw the life force out of your enemies. When you cast a @UUID[Compendium.pf2e.spells-srd.Item.Harm] spell and damage at least one living creature, you regain Hit Points equal to the spell rank of your <em>harm</em> spell. If you aren't a living creature, you gain no benefit from this feat.</p>"
         },
         "level": {
             "value": 2

--- a/packs/feats/shared-clarity.json
+++ b/packs/feats/shared-clarity.json
@@ -28,7 +28,17 @@
             "remaster": true,
             "title": "Pathfinder Player Core"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "Note",
+                "predicate": [
+                    "self:effect:premonition-of-clarity"
+                ],
+                "selector": "saving-throw",
+                "text": "{item|description}",
+                "title": "{item|name}"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -1798,11 +1798,17 @@
                 "CastigatingWeapon": {
                     "Note": "After you deal spirit damage due to Divine Castigation, your weapon or unarmed Strikes gain your holy or unholy trait and deal additional spirit damage until the end of your turn. @UUID[Compendium.pf2e.feat-effects.Item.BTI4obxa5UmNltyU]{Effect: Castigating Weapon}"
                 },
+                "ChannelingBlock": {
+                    "Description": "You pour divine energy into a desperate block. When you Shield Block, you can expend a harm or heal spell. Roll 1d8 for each rank of the spell, and increase the shield's Hardness by the total for this block."
+                },
                 "CommunalHealing": {
                     "Note": "When you cast the <em>heal</em> spell to heal a single creature, choose another willing living creature within range of your <em>heal</em> to regain @Damage[@item.rank[vitality,healing]|shortLabel] Hit Points."
                 },
                 "CremateUndead": {
                     "Note": "When you use a <em>heal</em> spell to damage undead, each undead that takes damage also takes @Damage[(@item.rank)[persistent,fire]]."
+                },
+                "DeitysProtection": {
+                    "Description": "After you cast a domain spell, you gain resistance to all damage until the start of your next turn. The amount of resistance is equal to the rank of the domain spell you cast."
                 },
                 "DirectedChannel": {
                     "ItemAlterationNote": "You can make the area a @Template[type:cone|distance:60] instead of an emanation."
@@ -1822,8 +1828,14 @@
                     "AllowedDrops": "1st-level cleric class feature",
                     "Prompt": "Select a doctrine."
                 },
+                "RaiseSymbol": {
+                    "RollOptionLabel": "Wielding shield as a religious symbol"
+                },
                 "ReplenishmentOfWar": {
                     "Note": "When you damage a creature with a Strike using your deity's favored weapon, you gain a number of temporary Hit Points equal to half your level, or equal to your level if the Strike was a critical hit. @UUID[Compendium.pf2e.feat-effects.Item.BJc494USeyM011p3]{Effect: Replenishment of War}"
+                },
+                "RestorativeStrike": {
+                    "Note": "You can target a second willing creature to heal the same amount from the spell. This creature can be outside of the spell's range, provided it's adjacent to the enemy you hit."
                 },
                 "SacredGround": {
                     "Harmful": "A creature that remains in the area for the entire 10 minutes regains @Damage[(@actor.level)[void,healing]]{Hit Points} equal to your level. This activity has the healing and void traits and heals undead creatures (or other creatures with void healing).",


### PR DESCRIPTION
- Add note to Panic the Dead.
- Grant Raise a Shield effect along with Raise Symbol when shield is a religious symbol.
- Remove manipulate trait from 1-action heal when using Restorative Strike and add Note rule element.
- Automate Channeling Block.
- Append Deity's Protection effect to cleric domain spells.
- Make Premonition of Clarity a self-applied effect.
- Add note rule element to Shared Clarity
- Adjust degree of success of Dance of Intercessions' performance check based on remaining uses.

And a couple of very minor things: Fix typo in Sap Life's description, Add description to Prayer-Touched Weapon's effect