### PR TITLE
Restrict elemental blast to chosen elements (effect traits only) instead of any element trait.

### DIFF
--- a/build/run-migration.ts
+++ b/build/run-migration.ts
@@ -28,6 +28,7 @@ import { Migration922SwashbucklerFinishers } from "@module/migration/migrations/
 import { Migration923KineticistRestructure } from "@module/migration/migrations/923-kineticist-restructure.ts";
 import { Migration924JiuHuanDoa } from "@module/migration/migrations/924-jiu-huan-dao.ts";
 import { Migration925TouchOfCorruption } from "@module/migration/migrations/925-touch-of-corruption.ts";
+import { Migration926SeparateBlastInfusion } from "@module/migration/migrations/926-separate-infusion.ts";
 // ^^^ don't let your IDE use the index in these imports. you need to specify the full path ^^^
 
 const { window } = new JSDOM();
@@ -52,6 +53,7 @@ const migrations: MigrationBase[] = [
     new Migration923KineticistRestructure(),
     new Migration924JiuHuanDoa(),
     new Migration925TouchOfCorruption(),
+    new Migration926SeparateBlastInfusion(),
 ];
 
 const packsDataPath = path.resolve(process.cwd(), "packs");

--- a/packs/feat-effects/effect-weapon-infusion.json
+++ b/packs/feat-effects/effect-weapon-infusion.json
@@ -24,7 +24,7 @@
             {
                 "key": "ActiveEffectLike",
                 "mode": "override",
-                "path": "flags.pf2e.kineticist.elementalBlast.infusion",
+                "path": "flags.pf2e.kineticist.blastInfusion",
                 "predicate": [
                     "self:effect:weapon-infusion"
                 ],
@@ -40,7 +40,7 @@
                 "key": "ActiveEffectLike",
                 "merge": true,
                 "mode": "override",
-                "path": "flags.pf2e.kineticist.elementalBlast.infusion",
+                "path": "flags.pf2e.kineticist.blastInfusion",
                 "predicate": [
                     "weapon-infusion:melee:agile"
                 ],
@@ -56,7 +56,7 @@
                 "key": "ActiveEffectLike",
                 "merge": true,
                 "mode": "override",
-                "path": "flags.pf2e.kineticist.elementalBlast.infusion",
+                "path": "flags.pf2e.kineticist.blastInfusion",
                 "predicate": [
                     "weapon-infusion:melee:backswing"
                 ],
@@ -72,7 +72,7 @@
                 "key": "ActiveEffectLike",
                 "merge": true,
                 "mode": "override",
-                "path": "flags.pf2e.kineticist.elementalBlast.infusion",
+                "path": "flags.pf2e.kineticist.blastInfusion",
                 "predicate": [
                     "weapon-infusion:melee:forceful"
                 ],
@@ -88,7 +88,7 @@
                 "key": "ActiveEffectLike",
                 "merge": true,
                 "mode": "override",
-                "path": "flags.pf2e.kineticist.elementalBlast.infusion",
+                "path": "flags.pf2e.kineticist.blastInfusion",
                 "predicate": [
                     "weapon-infusion:melee:reach"
                 ],
@@ -104,7 +104,7 @@
                 "key": "ActiveEffectLike",
                 "merge": true,
                 "mode": "override",
-                "path": "flags.pf2e.kineticist.elementalBlast.infusion",
+                "path": "flags.pf2e.kineticist.blastInfusion",
                 "predicate": [
                     "weapon-infusion:melee:sweep"
                 ],
@@ -120,7 +120,7 @@
                 "key": "ActiveEffectLike",
                 "merge": true,
                 "mode": "override",
-                "path": "flags.pf2e.kineticist.elementalBlast.infusion",
+                "path": "flags.pf2e.kineticist.blastInfusion",
                 "predicate": [
                     "weapon-infusion:ranged:volley-30"
                 ],
@@ -139,7 +139,7 @@
                 "key": "ActiveEffectLike",
                 "merge": true,
                 "mode": "override",
-                "path": "flags.pf2e.kineticist.elementalBlast.infusion",
+                "path": "flags.pf2e.kineticist.blastInfusion",
                 "predicate": [
                     "weapon-infusion:ranged:propulsive"
                 ],
@@ -158,7 +158,7 @@
                 "key": "ActiveEffectLike",
                 "merge": true,
                 "mode": "override",
-                "path": "flags.pf2e.kineticist.elementalBlast.infusion",
+                "path": "flags.pf2e.kineticist.blastInfusion",
                 "predicate": [
                     "weapon-infusion:ranged:thrown"
                 ],

--- a/src/module/actor/character/attack-popouts.ts
+++ b/src/module/actor/character/attack-popouts.ts
@@ -1,4 +1,4 @@
-import type { ElementTrait } from "@scripts/config/traits.ts";
+import { ActionTrait as EffectTrait } from "@item/ability/index.ts";
 import { ErrorPF2e, htmlClosest, htmlQuery } from "@util";
 import type { CharacterStrike } from "./data.ts";
 import type { CharacterPF2e } from "./document.ts";
@@ -10,7 +10,7 @@ class AttackPopout<TActor extends CharacterPF2e> extends CharacterSheetPF2e<TAct
     #strikeItemId = "";
     #strikeSlug = "";
     #strike?: CharacterStrike;
-    #elementTrait?: ElementTrait;
+    #blastTrait?: EffectTrait;
     #blasts: ElementalBlastConfig[] = [];
 
     override get template(): string {
@@ -21,7 +21,7 @@ class AttackPopout<TActor extends CharacterPF2e> extends CharacterSheetPF2e<TAct
         const id = super.id;
         return this.type === "strike"
             ? `${id}-strike-${this.#strikeItemId}-${this.#strikeSlug}`
-            : `${id}-blast-${this.#elementTrait}`;
+            : `${id}-blast-${this.#blastTrait}`;
     }
 
     static override get defaultOptions(): ActorSheetOptions {
@@ -53,7 +53,7 @@ class AttackPopout<TActor extends CharacterPF2e> extends CharacterSheetPF2e<TAct
             if (!options.elementTrait) {
                 throw ErrorPF2e('AttackPopout of type "blast" is missing mandatory "elementalTrait" option.');
             }
-            this.#elementTrait = options.elementTrait;
+            this.#blastTrait = options.elementTrait;
         } else {
             if (!options.strikeSlug) {
                 throw ErrorPF2e('AttackPopout of type "strike" is missing mandatory "strikeSlug" option.');
@@ -71,7 +71,7 @@ class AttackPopout<TActor extends CharacterPF2e> extends CharacterSheetPF2e<TAct
         const base = await super.getData(options);
 
         if (this.type === "blast") {
-            base.elementalBlasts = this.#blasts = base.elementalBlasts.filter((b) => b.element === this.#elementTrait);
+            base.elementalBlasts = this.#blasts = base.elementalBlasts.filter((b) => b.element === this.#blastTrait);
             base.data.actions = [];
             base.toggles.actions = base.toggles.actions?.filter((t) => t.domain === "elemental-blast") ?? [];
         } else {
@@ -123,7 +123,7 @@ interface StrikePopoutOptions extends BaseAttackPopoutOptions {
 
 interface BlastPopoutOptions extends BaseAttackPopoutOptions {
     type: "blast";
-    elementTrait?: ElementTrait;
+    elementTrait?: EffectTrait;
 }
 
 type AttackPopoutOptions = StrikePopoutOptions | BlastPopoutOptions;

--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -1244,7 +1244,6 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
 
     #activateBlastListeners(panel: HTMLElement | null): void {
         const blastList = htmlQuery(panel, "ol[data-elemental-blasts]");
-        const { elementTraits, damageTypes } = CONFIG.PF2E;
         const selectors = ["roll-attack", "roll-damage", "set-damage-type"]
             .map((s) => `button[data-action=${s}]`)
             .join(",");
@@ -1258,10 +1257,10 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
             const blast = new ElementalBlast(this.actor);
             const { element } = blastRow.dataset;
             const damageType = button.value || blastRow.dataset.damageType;
-            if (!objectHasKey(elementTraits, element)) {
-                throw ErrorPF2e("Unexpected error retrieve element");
+            if (!objectHasKey(CONFIG.PF2E.effectTraits, element)) {
+                throw ErrorPF2e("Unexpected error retrieving elemental blast: invalid trait");
             }
-            if (!objectHasKey(damageTypes, damageType)) {
+            if (!objectHasKey(CONFIG.PF2E.damageTypes, damageType)) {
                 throw ErrorPF2e("Unexpected error retrieving damage type");
             }
             const melee = button.dataset.melee === "true";

--- a/src/module/migration/migrations/926-separate-infusion.ts
+++ b/src/module/migration/migrations/926-separate-infusion.ts
@@ -1,0 +1,13 @@
+import { ItemSourcePF2e } from "@item/base/data/index.ts";
+import { recursiveReplaceString } from "@util";
+import { MigrationBase } from "../base.ts";
+
+export class Migration926SeparateBlastInfusion extends MigrationBase {
+    static override version = 0.926;
+
+    override async updateItem(source: ItemSourcePF2e): Promise<void> {
+        source.system.rules = recursiveReplaceString(source.system.rules, (s) =>
+            s.replaceAll("flags.pf2e.kineticist.elementalBlast.infusion", "flags.pf2e.kineticist.blastInfusion"),
+        );
+    }
+}

--- a/src/module/migration/migrations/index.ts
+++ b/src/module/migration/migrations/index.ts
@@ -291,3 +291,4 @@ export { Migration922SwashbucklerFinishers } from "./922-swashbuckler-finisher-s
 export { Migration923KineticistRestructure } from "./923-kineticist-restructure.ts";
 export { Migration924JiuHuanDoa } from "./924-jiu-huan-dao.ts";
 export { Migration925TouchOfCorruption } from "./925-touch-of-corruption.ts";
+export { Migration926SeparateBlastInfusion } from "./926-separate-infusion.ts";

--- a/src/module/migration/runner/base.ts
+++ b/src/module/migration/runner/base.ts
@@ -14,7 +14,7 @@ interface CollectionDiff<T extends foundry.documents.ActiveEffectSource | ItemSo
 export class MigrationRunnerBase {
     migrations: MigrationBase[];
 
-    static LATEST_SCHEMA_VERSION = 0.925;
+    static LATEST_SCHEMA_VERSION = 0.926;
 
     static MINIMUM_SAFE_VERSION = 0.634;
 

--- a/src/module/system/settings/homebrew/data.ts
+++ b/src/module/system/settings/homebrew/data.ts
@@ -21,7 +21,7 @@ const HOMEBREW_TRAIT_KEYS = [
 const TRAIT_PROPAGATIONS = {
     creatureTraits: ["ancestryTraits"],
     equipmentTraits: ["armorTraits", "consumableTraits"],
-    featTraits: ["actionTraits"],
+    featTraits: ["actionTraits", "effectTraits"],
     weaponTraits: ["npcAttackTraits"],
 } as const;
 


### PR DESCRIPTION
Also refactors to use a data model.

The properties are still referred to as element, but they're no longer restricted via specific element traits, leaving behind `"element": "void"` as a shame on you. It now restricts by the elements that the kineticist currently possesses (and also restricts those to be effect traits).