### PR TITLE
Remove inline damage links from Timber

### DIFF
--- a/packs/rage-of-elements-bestiary/ardande-gardener.json
+++ b/packs/rage-of-elements-bestiary/ardande-gardener.json
@@ -603,7 +603,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>You create a small dead tree in your space that falls over on anyone in its path, then immediately decomposes. Any creature in the area takes @Damage[2d4[bludgeoning]] damage, with a basic Reflex saving throw. A creature that critically fails its save is knocked for a loop, making it @UUID[Compendium.pf2e.conditionitems.Item.Dazzled] until the end of its next turn.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The initial damage increases by [[/r 1d4]].</p>"
+                    "value": "<p>You create a small dead tree in your space that falls over on anyone in its path, then immediately decomposes. Any creature in the area takes 2d4 bludgeoning damage, with a basic Reflex saving throw. A creature that critically fails its save is knocked for a loop, making it @UUID[Compendium.pf2e.conditionitems.Item.Dazzled] until the end of its next turn.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The initial damage increases by 1d4.</p>"
                 },
                 "duration": {
                     "sustained": false,

--- a/packs/spells/timber.json
+++ b/packs/spells/timber.json
@@ -30,7 +30,7 @@
             }
         },
         "description": {
-            "value": "<p>You create a small dead tree in your space that falls over on anyone in its path, then immediately decomposes. Any creature in the area takes @Damage[2d4[bludgeoning]] damage, with a basic Reflex saving throw. A creature that critically fails its save is knocked for a loop, making it @UUID[Compendium.pf2e.conditionitems.Item.Dazzled] until the end of its next turn.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The initial damage increases by [[/r 1d4]].</p>"
+            "value": "<p>You create a small dead tree in your space that falls over on anyone in its path, then immediately decomposes. Any creature in the area takes 2d4 bludgeoning damage, with a basic Reflex saving throw. A creature that critically fails its save is knocked for a loop, making it @UUID[Compendium.pf2e.conditionitems.Item.Dazzled] until the end of its next turn.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The initial damage increases by 1d4.</p>"
         },
         "duration": {
             "sustained": false,


### PR DESCRIPTION
Also refresh all copies