### PR TITLE
Handle resized actors when dropping from compendium

### DIFF
--- a/src/module/actor/creature/data.ts
+++ b/src/module/actor/creature/data.ts
@@ -14,7 +14,7 @@ import type {
 import type { ActorSizePF2e } from "@actor/data/size.ts";
 import type { DamageDicePF2e, ModifierPF2e, RawModifier, StatisticModifier } from "@actor/modifiers.ts";
 import type { AttributeString, MovementType, SaveType, SkillAbbreviation, SkillLongForm } from "@actor/types.ts";
-import type { LabeledNumber, ValueAndMax, ZeroToThree } from "@module/data.ts";
+import type { LabeledNumber, Size, ValueAndMax, ZeroToThree } from "@module/data.ts";
 import type { ArmorClassTraceData } from "@system/statistic/index.ts";
 import type { PerceptionTraceData } from "@system/statistic/perception.ts";
 import type { CreatureActorType, CreatureTrait, Language, SenseAcuity, SenseType, SpecialVisionType } from "./types.ts";
@@ -119,6 +119,8 @@ type Abilities = Record<AttributeString, AbilityData>;
 
 interface CreatureTraitsData extends Required<CreatureTraitsSource> {
     size: ActorSizePF2e;
+    /** Temporary variable that holds pre-equipment resize data */
+    naturalSize?: Size;
 }
 interface CreatureDetails extends Required<CreatureDetailsSource> {}
 

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -1070,12 +1070,10 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
                 itemSource.system.equipped.carryType = "worn";
             }
             // If the item is from a compendium, adjust the size to be appropriate to the creature's
-            const resizeItem =
-                data?.uuid?.startsWith("Compendium") &&
-                itemSource.type !== "treasure" &&
-                !["med", "sm"].includes(actor.size) &&
-                actor.isOfType("creature");
-            if (resizeItem) itemSource.system.size = actor.size;
+            if (data?.uuid?.startsWith("Compendium") && itemSource.type !== "treasure" && actor.isOfType("creature")) {
+                const sourceSize = actor.system.traits?.naturalSize ?? actor.size;
+                itemSource.system.size = sourceSize === "sm" ? "med" : sourceSize;
+            }
         }
 
         // Creating a new item: clear the _id via cloning it

--- a/src/module/rules/rule-element/creature-size.ts
+++ b/src/module/rules/rule-element/creature-size.ts
@@ -129,6 +129,9 @@ class CreatureSizeRuleElement extends RuleElementPF2e<CreatureSizeRuleSchema> {
                     item.system.size = this.decrementSize(item.size, Math.abs(sizeDifference));
                 }
             }
+
+            // Update natural size so auto-scaling targets the original size, but only once per data preparation.
+            actor.system.traits.naturalSize = actor.system.traits.naturalSize ?? originalSize.value;
         }
     }
 


### PR DESCRIPTION
This prevents dropped longswords becoming Huge on Medium actors enlarged to Large.

Closes https://github.com/foundryvtt/pf2e/issues/2840