### PR TITLE
Add cold damage overlay to Final Sacrifice

### DIFF
--- a/packs/blood-lords-bestiary/vice-chancellor-vikroti-stroh.json
+++ b/packs/blood-lords-bestiary/vice-chancellor-vikroti-stroh.json
@@ -1326,7 +1326,10 @@
             "name": "Final Sacrifice",
             "sort": 1700000,
             "system": {
-                "area": null,
+                "area": {
+                    "type": "emanation",
+                    "value": 20
+                },
                 "cost": {
                     "value": ""
                 },
@@ -1350,7 +1353,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>You channel disruptive energies through the bond between you and your minion, causing it to violently explode. The target is immediately slain, and the explosion deals 6d6 fire damage to creatures within 20 feet of it (basic Reflex save). If the target has the cold or water trait, the spell instead deals cold damage and gains the cold trait in place of the fire trait. If used on a creature that isn't mindless, this spell has the evil trait. Attempting to cast this spell targeting a creature that you temporarily seized control of, such as an undead commanded by @UUID[Compendium.pf2e.feats-srd.Item.Command Undead], automatically fails and breaks the controlling effect.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by @Damage[2d6[fire]] damage.</p>"
+                    "value": "<p>You channel disruptive energies through the bond between you and your minion, causing it to violently explode. The target is immediately slain, and the explosion deals 6d6 fire damage to creatures within 20 feet of it (basic Reflex save). If the target has the cold or water trait, the spell instead deals cold damage and gains the cold trait in place of the fire trait. If used on a creature that isn't mindless, this spell has the evil trait. Attempting to cast this spell targeting a creature that you temporarily seized control of, such as an undead commanded by @UUID[Compendium.pf2e.feats-srd.Item.Command Undead], automatically fails and breaks the controlling effect.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -1368,6 +1371,45 @@
                 },
                 "location": {
                     "value": "QwanxsB4SIavve0x"
+                },
+                "overlays": {
+                    "CXLBoUCDAyNLYJLa": {
+                        "name": "Final Sacrifice (Cold)",
+                        "overlayType": "override",
+                        "sort": 2,
+                        "system": {
+                            "damage": {
+                                "0": {
+                                    "category": null,
+                                    "kinds": [
+                                        "damage"
+                                    ],
+                                    "type": "cold"
+                                }
+                            },
+                            "rules": [],
+                            "traits": {
+                                "value": [
+                                    "cold",
+                                    "concentrate",
+                                    "manipulate"
+                                ]
+                            }
+                        }
+                    },
+                    "rxA3woadtvHLq4xZ": {
+                        "name": "Final Sacrifice (Fire)",
+                        "overlayType": "override",
+                        "sort": 1,
+                        "system": {
+                            "damage": {
+                                "0": {
+                                    "category": null
+                                }
+                            },
+                            "rules": []
+                        }
+                    }
                 },
                 "publication": {
                     "license": "OGL",

--- a/packs/spells/final-sacrifice.json
+++ b/packs/spells/final-sacrifice.json
@@ -30,7 +30,7 @@
             }
         },
         "description": {
-            "value": "<p>You channel disruptive energies through the bond between you and your minion, causing it to violently explode. The target is immediately slain, and the explosion deals 6d6 fire damage to creatures within 20 feet of it (basic Reflex save). If the target has the cold or water trait, the spell instead deals cold damage and gains the cold trait in place of the fire trait. If used on a creature that isn't mindless, this spell has the evil trait. Attempting to cast this spell targeting a creature that you temporarily seized control of, such as an undead commanded by @UUID[Compendium.pf2e.feats-srd.Item.Command Undead], automatically fails and breaks the controlling effect.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by @Damage[2d6[fire]] damage.</p>"
+            "value": "<p>You channel disruptive energies through the bond between you and your minion, causing it to violently explode. The target is immediately slain, and the explosion deals 6d6 fire damage to creatures within 20 feet of it (basic Reflex save). If the target has the cold or water trait, the spell instead deals cold damage and gains the cold trait in place of the fire trait. If used on a creature that isn't mindless, this spell has the evil trait. Attempting to cast this spell targeting a creature that you temporarily seized control of, such as an undead commanded by @UUID[Compendium.pf2e.feats-srd.Item.Command Undead], automatically fails and breaks the controlling effect.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by 2d6.</p>"
         },
         "duration": {
             "sustained": false,
@@ -45,6 +45,45 @@
         },
         "level": {
             "value": 2
+        },
+        "overlays": {
+            "CXLBoUCDAyNLYJLa": {
+                "name": "Final Sacrifice (Cold)",
+                "overlayType": "override",
+                "sort": 2,
+                "system": {
+                    "damage": {
+                        "0": {
+                            "category": null,
+                            "kinds": [
+                                "damage"
+                            ],
+                            "type": "cold"
+                        }
+                    },
+                    "rules": [],
+                    "traits": {
+                        "value": [
+                            "cold",
+                            "concentrate",
+                            "manipulate"
+                        ]
+                    }
+                }
+            },
+            "rxA3woadtvHLq4xZ": {
+                "name": "Final Sacrifice (Fire)",
+                "overlayType": "override",
+                "sort": 1,
+                "system": {
+                    "damage": {
+                        "0": {
+                            "category": null
+                        }
+                    },
+                    "rules": []
+                }
+            }
         },
         "publication": {
             "license": "OGL",


### PR DESCRIPTION
Cannot use alteration REs and predicate off target, since non-attack spells don't have target RollOptions.