### PR TITLE
FIx bulk of Clan Pistol

### DIFF
--- a/packs/equipment/clan-pistol.json
+++ b/packs/equipment/clan-pistol.json
@@ -11,7 +11,7 @@
             "value": 0
         },
         "bulk": {
-            "value": 1
+            "value": 0.1
         },
         "category": "martial",
         "containerId": null,

--- a/packs/outlaws-of-alkenstar-bestiary/corrupt-shieldmarshal-clan-pistol.json
+++ b/packs/outlaws-of-alkenstar-bestiary/corrupt-shieldmarshal-clan-pistol.json
@@ -21,7 +21,7 @@
                     "value": 0
                 },
                 "bulk": {
-                    "value": 1
+                    "value": 0.1
                 },
                 "category": "martial",
                 "containerId": null,


### PR DESCRIPTION
Immolation Clan Pistol is correctly bulk 1.

Closes https://github.com/foundryvtt/pf2e/issues/13997