### PR TITLE
Correct Caustic Blast persistent damage

### DIFF
--- a/packs/iconics/ezren-level-1.json
+++ b/packs/iconics/ezren-level-1.json
@@ -1273,7 +1273,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>You fling a large glob of acid that immediately detonates, spraying nearby creatures. Creatures in the area take 1d8 acid damage with a basic Reflex save; on a critical failure, the creature also takes @Damage[(floor(@item.level/2)+1)[persistent,acid]] damage.</p>\n<hr />\n<p><strong>Heightened (+2)</strong> The initial damage increases by 1d8, and the persistent damage on a critical failure increases by 1.</p>"
+                    "value": "<p>You fling a large glob of acid that immediately detonates, spraying nearby creatures. Creatures in the area take 1d8 acid damage with a basic Reflex save; on a critical failure, the creature also takes @Damage[(1+floor((@item.rank -1)/2))[persistent,acid]] damage.</p>\n<hr />\n<p><strong>Heightened (+2)</strong> The initial damage increases by 1d8, and the persistent damage on a critical failure increases by 1.</p>"
                 },
                 "duration": {
                     "sustained": false,

--- a/packs/spells/caustic-blast.json
+++ b/packs/spells/caustic-blast.json
@@ -30,7 +30,7 @@
             }
         },
         "description": {
-            "value": "<p>You fling a large glob of acid that immediately detonates, spraying nearby creatures. Creatures in the area take 1d8 acid damage with a basic Reflex save; on a critical failure, the creature also takes @Damage[(floor(@item.level/2)+1)[persistent,acid]] damage.</p>\n<hr />\n<p><strong>Heightened (+2)</strong> The initial damage increases by 1d8, and the persistent damage on a critical failure increases by 1.</p>"
+            "value": "<p>You fling a large glob of acid that immediately detonates, spraying nearby creatures. Creatures in the area take 1d8 acid damage with a basic Reflex save; on a critical failure, the creature also takes @Damage[(1+floor((@item.rank -1)/2))[persistent,acid]] damage.</p>\n<hr />\n<p><strong>Heightened (+2)</strong> The initial damage increases by 1d8, and the persistent damage on a critical failure increases by 1.</p>"
         },
         "duration": {
             "sustained": false,


### PR DESCRIPTION
Persistent damage was incorrectly set to increase starting from the second rank.
Maybe it would be convenient to have something like `@item.heightening` - a read-only property that essentially evaluated to `@item.rank - @item.baseRank`.