### PR TITLE
Add foundational framework for effect spinoff rule elements

### DIFF
--- a/src/module/actor/actions/types.ts
+++ b/src/module/actor/actions/types.ts
@@ -1,10 +1,10 @@
 import type { ActorPF2e } from "@actor";
+import type { ActionTrait } from "@item/ability/index.ts";
+import type { ProficiencyRank } from "@item/base/data/index.ts";
 import type { TokenPF2e } from "@module/canvas/index.ts";
 import type { ChatMessagePF2e } from "@module/chat-message/document.ts";
-import type { ActionTrait } from "@item/ability/index.ts";
-import { ProficiencyRank } from "@item/base/data/index.ts";
 
-const ACTION_COSTS = ["free", "reaction", 1, 2, 3] as const;
+const ACTION_COSTS = ["free", "reaction", 0, 1, 2, 3] as const;
 type ActionCost = (typeof ACTION_COSTS)[number];
 
 const ACTION_SECTIONS = ["basic", "skill", "specialty-basic"] as const;

--- a/src/module/item/consumable/document.ts
+++ b/src/module/item/consumable/document.ts
@@ -7,7 +7,6 @@ import { RawItemChatData } from "@item/base/data/index.ts";
 import { TrickMagicItemEntry } from "@item/spellcasting-entry/trick.ts";
 import type { SpellcastingEntry } from "@item/spellcasting-entry/types.ts";
 import type { ValueAndMax } from "@module/data.ts";
-import type { RuleElementPF2e } from "@module/rules/index.ts";
 import type { ItemAlterationRuleElement } from "@module/rules/rule-element/item-alteration/index.ts";
 import type { UserPF2e } from "@module/user/document.ts";
 import { DamageRoll } from "@system/damage/roll.ts";
@@ -73,16 +72,6 @@ class ConsumablePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extend
                 break;
             }
         }
-    }
-
-    /** Rule elements cannot be executed from consumable items, but they can be used to generate effects */
-    override prepareRuleElements(): RuleElementPF2e[] {
-        const rules = super.prepareRuleElements();
-        for (const rule of rules) {
-            rule.ignored = true;
-        }
-
-        return rules;
     }
 
     override async getChatData(

--- a/src/module/rules/index.ts
+++ b/src/module/rules/index.ts
@@ -17,6 +17,7 @@ import { CritSpecRuleElement } from "./rule-element/crit-spec.ts";
 import { DamageAlterationRuleElement } from "./rule-element/damage-alteration/rule-element.ts";
 import { DamageDiceRuleElement } from "./rule-element/damage-dice.ts";
 import { DexterityModifierCapRuleElement } from "./rule-element/dexterity-modifier-cap.ts";
+import { EffectSpinoffRuleElement } from "./rule-element/effect-spinoff/rule-element.ts";
 import { EphemeralEffectRuleElement } from "./rule-element/ephemeral-effect.ts";
 import { FastHealingRuleElement } from "./rule-element/fast-healing.ts";
 import { FixedProficiencyRuleElement } from "./rule-element/fixed-proficiency.ts";
@@ -68,6 +69,7 @@ class RuleElements {
         DamageAlteration: DamageAlterationRuleElement,
         DamageDice: DamageDiceRuleElement,
         DexterityModifierCap: DexterityModifierCapRuleElement,
+        EffectSpinoff: EffectSpinoffRuleElement,
         EphemeralEffect: EphemeralEffectRuleElement,
         FastHealing: FastHealingRuleElement,
         FixedProficiency: FixedProficiencyRuleElement,

--- a/src/module/rules/rule-element/base.ts
+++ b/src/module/rules/rule-element/base.ts
@@ -72,7 +72,7 @@ abstract class RuleElementPF2e<TSchema extends RuleElementSchema = RuleElementSc
             : item.name;
 
         if (item.isOfType("physical")) {
-            this.requiresEquipped = !!(source.requiresEquipped ?? true);
+            this.requiresEquipped ??= true;
             this.requiresInvestment =
                 item.isInvested === null ? null : !!(source.requiresInvestment ?? this.requiresEquipped);
 
@@ -87,6 +87,9 @@ abstract class RuleElementPF2e<TSchema extends RuleElementSchema = RuleElementSc
             this.requiresEquipped = null;
             this.requiresInvestment = null;
         }
+
+        // Spinoff composition rules are always inactive
+        if (this.spinoff) this.ignored = true;
     }
 
     static override defineSchema(): RuleElementSchema {
@@ -107,6 +110,7 @@ abstract class RuleElementPF2e<TSchema extends RuleElementSchema = RuleElementSc
             predicate: new PredicateField(),
             requiresEquipped: new fields.BooleanField({ required: false, nullable: true, initial: undefined }),
             requiresInvestment: new fields.BooleanField({ required: false, nullable: true, initial: undefined }),
+            spinoff: new SlugField({ required: false, nullable: false, initial: undefined }),
         };
     }
 

--- a/src/module/rules/rule-element/data.ts
+++ b/src/module/rules/rule-element/data.ts
@@ -44,6 +44,8 @@ type RuleElementSchema = {
     requiresEquipped: BooleanField<boolean, boolean, false, true, false>;
     /** Whether the rule element requires that the parent item (if physical) be invested */
     requiresInvestment: BooleanField<boolean, boolean, false, true, false>;
+    /** A grouping slug to mark a rule as a part of a spinoff effect, which some item types can compose */
+    spinoff: SlugField<false, false, false>;
 };
 
 class ResolvableValueField<

--- a/src/module/rules/rule-element/effect-spinoff/rule-element.ts
+++ b/src/module/rules/rule-element/effect-spinoff/rule-element.ts
@@ -1,0 +1,135 @@
+import type { ActorPF2e } from "@actor";
+import type { PhysicalItemPF2e } from "@item";
+import { SlugField } from "@system/schema-data-fields.ts";
+import type { ArrayField, NumberField, SchemaField, StringField } from "types/foundry/common/data/fields.d.ts";
+import { RuleElementOptions, RuleElementPF2e } from "../base.ts";
+import type { ModelPropsFromRESchema, RuleElementSchema, RuleElementSource } from "../data.ts";
+import { EffectSpinoff } from "./spinoff.ts";
+
+class EffectSpinoffRuleElement extends RuleElementPF2e<EffectSpinoffSchema> {
+    constructor(source: RuleElementSource, options: RuleElementOptions) {
+        super(source, options);
+
+        if (!this.parent.isOfType("physical")) {
+            this.failValidation("parent: must be a physical item");
+        }
+    }
+
+    static override defineSchema(): EffectSpinoffSchema {
+        const fields = foundry.data.fields;
+
+        return {
+            ...super.defineSchema(),
+            slug: new SlugField({ required: true, nullable: false, initial: undefined }),
+            activation: new fields.SchemaField(
+                {
+                    label: new fields.StringField({ required: true, blank: false, nullable: true, initial: null }),
+                    time: new fields.SchemaField({
+                        value: new fields.NumberField({
+                            required: true,
+                            integer: true,
+                            positive: true,
+                            min: 1,
+                            nullable: false,
+                            initial: 1,
+                        }),
+                        unit: new fields.StringField({
+                            required: true,
+                            choices: ["actions", "reaction", "minutes", "hours"],
+                            initial: undefined,
+                        }),
+                    }),
+                    traits: new fields.ArrayField(
+                        new fields.StringField({
+                            required: true,
+                            nullable: false,
+                            choices: ["concentrate", "manipulate"],
+                            initial: undefined,
+                        }),
+                        { initial: ["manipulate"] },
+                    ),
+                    details: new fields.StringField({ required: false, blank: false, nullable: true, initial: null }),
+                },
+                {
+                    required: true,
+                    nullable: true,
+                    initial: {
+                        label: null,
+                        time: { value: 1, unit: "actions" },
+                        traits: ["manipulate"],
+                        details: null,
+                    },
+                },
+            ),
+            description: new fields.StringField({ required: false, blank: false, nullable: true, initial: null }),
+        };
+    }
+
+    /** Allow an effect spinoff to be available even if its parent is an unequipped physical item. */
+    protected override _initialize(options?: Record<string, unknown> | undefined): void {
+        super._initialize(options);
+
+        if (this.parent.isOfType("physical")) {
+            this.requiresEquipped = false;
+        }
+    }
+
+    override afterPrepareData(): void {
+        if (!this.test()) return;
+        const item = this.item;
+
+        if (this.label === item.name) {
+            this.label = `Effect: ${this.label}`;
+        }
+
+        if (item.isOfType("physical") && item.effectSpinoffs) {
+            item.effectSpinoffs.set(this.slug, new EffectSpinoff(this));
+        }
+    }
+}
+
+interface EffectSpinoffRuleElement
+    extends RuleElementPF2e<EffectSpinoffSchema>,
+        ModelPropsFromRESchema<EffectSpinoffSchema> {
+    slug: string;
+
+    get item(): PhysicalItemPF2e<ActorPF2e>;
+}
+
+type ActivateTimeUnit = "actions" | "reaction" | "minutes" | "hours";
+type ActivationTrait = "concentrate" | "manipulate";
+
+type ActivationSchema = SchemaField<
+    {
+        label: StringField<string, string, true, true, true>;
+        time: SchemaField<{
+            value: NumberField<number, number, true, false, true>;
+            unit: StringField<ActivateTimeUnit, ActivateTimeUnit, true, false, false>;
+        }>;
+        traits: ArrayField<StringField<"concentrate" | "manipulate", "concentrate" | "manipulate", true, false, false>>;
+        details: StringField<string, string, false, true, true>;
+    },
+    {
+        label: string | null;
+        time: { value: number; unit: ActivateTimeUnit };
+        details: string | null;
+        traits: ActivationTrait[];
+    },
+    {
+        label: string | null;
+        time: { value: number; unit: ActivateTimeUnit };
+        details: string | null;
+        traits: ActivationTrait[];
+    },
+    true,
+    true,
+    true
+>;
+
+type EffectSpinoffSchema = Omit<RuleElementSchema, "slug"> & {
+    slug: SlugField<true, false, false>;
+    activation: ActivationSchema;
+    description: StringField<string, string, false, true, true>;
+};
+
+export { EffectSpinoffRuleElement };

--- a/src/module/rules/rule-element/effect-spinoff/spinoff.ts
+++ b/src/module/rules/rule-element/effect-spinoff/spinoff.ts
@@ -1,0 +1,95 @@
+import type { ActorPF2e } from "@actor";
+import type { TraitViewData } from "@actor/data/base.ts";
+import { EffectPF2e, type PhysicalItemPF2e } from "@item";
+import type { EffectTrait } from "@item/abstract-effect/types.ts";
+import type { EffectSource } from "@item/effect/data.ts";
+import type { PhysicalItemTrait } from "@item/physical/types.ts";
+import { getActionGlyph, traitSlugToObject } from "@util";
+import type { EffectSpinoffRuleElement } from "./rule-element.ts";
+
+class EffectSpinoff {
+    item: PhysicalItemPF2e<ActorPF2e>;
+
+    slug: string;
+
+    label: string;
+
+    img: ImageFilePath;
+
+    activation: SpinoffActivationData | null;
+
+    description: { value: string; markdown: boolean };
+
+    constructor(rule: EffectSpinoffRuleElement) {
+        this.item = rule.item;
+        this.label = rule.label;
+        this.img = this.item.img;
+        this.slug = rule.slug;
+        this.description = {
+            value: rule.description ?? this.item.description,
+            markdown: !!rule.description,
+        };
+
+        const unit = rule.activation?.time.unit ?? "";
+        if (rule.activation?.time && ["actions", "reaction"].includes(rule.activation.time.unit)) {
+            const glyph = unit === "reaction" ? "R" : getActionGlyph(rule.activation.time.value);
+            const activationTraits = rule.activation.traits;
+            this.activation = {
+                label: rule.activation.label,
+                glyph,
+                details: rule.activation.details,
+                get traits(): TraitViewData[] {
+                    return activationTraits.map((t) => traitSlugToObject(t, CONFIG.PF2E.actionTraits)) ?? [];
+                },
+            };
+        } else {
+            this.activation = null;
+        }
+    }
+
+    createEffect(): EffectSource {
+        const composingRules = this.item.rules
+            .filter((r) => r.spinoff === this.slug && !r.invalid)
+            .map((r) => r.toObject());
+
+        const item = this.item;
+        const actor = item.actor;
+        const traits = item.system.traits.value.filter(
+            (t): t is PhysicalItemTrait & EffectTrait => t in EffectPF2e.validTraits,
+        );
+
+        const source: PreCreate<EffectSource> = {
+            type: "effect",
+            name: this.label,
+            img: this.img,
+            system: {
+                slug: this.slug,
+                rules: composingRules,
+                description: this.description,
+                traits: { value: traits },
+                context: {
+                    origin: {
+                        actor: actor.uuid,
+                        token: actor.getActiveTokens(true, true).at(0)?.uuid ?? null,
+                        item: item.uuid,
+                        spellcasting: null,
+                        rollOptions: item.getOriginData().rollOptions,
+                    },
+                    target: null,
+                    roll: null,
+                },
+            },
+        };
+
+        return new EffectPF2e(source).toObject();
+    }
+}
+
+interface SpinoffActivationData {
+    label: string | null;
+    glyph: string;
+    traits: TraitViewData[];
+    details: string | null;
+}
+
+export { EffectSpinoff };

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -714,7 +714,7 @@
                     "Wolf": "Wolf",
                     "WolfDire": "Dire Wolf"
                 },
-                "Label": "Current Form" 
+                "Label": "Current Form"
             },
             "Charge": {
                 "AtLeastTen": "Moved at Least 10 feet"
@@ -1356,6 +1356,7 @@
             "DamageAlteration": "Damage Alteration",
             "DamageDice": "Damage Dice",
             "DexterityModifierCap": "Dexterity Modifier Cap",
+            "EffectSpinoff": "Effect Spinoff",
             "EphemeralEffect": "Ephemeral Effect",
             "FastHealing": "Fast Healing/Regeneration",
             "FixedProficiency": "Fixed Proficiency",


### PR DESCRIPTION
No UI exposure yet: just the RE itself and populating `PhysicalItemPF2e#effectSpinoffs`