### PR TITLE
Restore secondary spellcasters for rituals

### DIFF
--- a/build/run-migration.ts
+++ b/build/run-migration.ts
@@ -29,6 +29,7 @@ import { Migration923KineticistRestructure } from "@module/migration/migrations/
 import { Migration924JiuHuanDoa } from "@module/migration/migrations/924-jiu-huan-dao.ts";
 import { Migration925TouchOfCorruption } from "@module/migration/migrations/925-touch-of-corruption.ts";
 import { Migration926RemoveVisionFeatureLinks } from "@module/migration/migrations/926-remove-vision-feature-links.ts";
+import { Migration927RitualSecondaryCasters } from "@module/migration/migrations/927-ritual-secondary-casters.ts";
 // ^^^ don't let your IDE use the index in these imports. you need to specify the full path ^^^
 
 const { window } = new JSDOM();
@@ -54,6 +55,7 @@ const migrations: MigrationBase[] = [
     new Migration924JiuHuanDoa(),
     new Migration925TouchOfCorruption(),
     new Migration926RemoveVisionFeatureLinks(),
+    new Migration927RitualSecondaryCasters(),
 ];
 
 const packsDataPath = path.resolve(process.cwd(), "packs");

--- a/packs/spells/awaken-portal.json
+++ b/packs/spells/awaken-portal.json
@@ -35,7 +35,7 @@
                 "check": "Arcana or Occultism (trained)"
             },
             "secondary": {
-                "casters": "up to 5",
+                "casters": 0,
                 "checks": "Whichever is used for the primary check"
             }
         },

--- a/packs/spells/winters-breath.json
+++ b/packs/spells/winters-breath.json
@@ -5,7 +5,7 @@
     "system": {
         "area": null,
         "cost": {
-            "value": ""
+            "value": "15 gp"
         },
         "counteraction": false,
         "damage": {},
@@ -26,16 +26,16 @@
             "title": "Pathfinder #197: Let the Leaves Fall"
         },
         "range": {
-            "value": ""
+            "value": "40 feet"
         },
         "requirements": "",
         "ritual": {
             "primary": {
-                "check": ""
+                "check": "Cooking Lore or Tea Lore (expert)"
             },
             "secondary": {
                 "casters": 0,
-                "checks": ""
+                "checks": "Diplomacy or Society"
             }
         },
         "rules": [],

--- a/src/module/item/spell/data.ts
+++ b/src/module/item/spell/data.ts
@@ -123,11 +123,17 @@ interface SpellDefenseData extends SpellDefenseSource {
 type SpellOverlay = SpellOverlayOverride;
 type SpellOverlayType = SpellOverlay["overlayType"];
 
+interface RitualSecondaryCasters {
+    min: number;
+    max: number | null;
+    details: string;
+}
+
 interface RitualData {
     /** Details of the primary check for the ritual */
     primary: { check: string };
-    /** Details of the secondary check(s) for the ritual and maximum number of casters */
-    secondary: { checks: string; casters: number };
+    /** Details of the secondary check(s) for the ritual and a number of casters */
+    secondary: { checks: string; casters: RitualSecondaryCasters };
 }
 
 export type {

--- a/src/module/migration/migrations/882-spell-data-reorganization.ts
+++ b/src/module/migration/migrations/882-spell-data-reorganization.ts
@@ -269,7 +269,7 @@ export class Migration882SpellDataReorganization extends MigrationBase {
     }
 }
 
-type MaybeOldSpellSystemSource = Omit<DeepPartial<SpellSystemSource>, "traditions"> & {
+type MaybeOldSpellSystemSource = Omit<DeepPartial<SpellSystemSource>, "traditions" | "ritual"> & {
     spellType?: { value?: string };
     "-=spellType"?: null;
 
@@ -302,6 +302,8 @@ type MaybeOldSpellSystemSource = Omit<DeepPartial<SpellSystemSource>, "tradition
     "-=hasCounteractCheck"?: null;
 
     damage?: { value?: Record<string, unknown> };
+
+    ritual?: unknown;
 
     // Random legacy cruft
     "-=ability"?: null;

--- a/src/module/migration/migrations/927-ritual-secondary-casters.ts
+++ b/src/module/migration/migrations/927-ritual-secondary-casters.ts
@@ -1,0 +1,310 @@
+import { ItemSourcePF2e } from "@item/base/data/index.ts";
+import { SpellSystemSource } from "@item/spell/data.ts";
+import * as R from "remeda";
+import { MigrationBase } from "../base.ts";
+import { sluggify } from "@util";
+
+export class Migration927RitualSecondaryCasters extends MigrationBase {
+    static override version = 0.927;
+
+    #RITUALCASTERSREPLACEMENT = new Map<string, NewCasters>([
+        [
+            "demonic-pact",
+            {
+                min: 0,
+                max: 0,
+                details: "",
+            },
+        ],
+        [
+            "amity-cycle",
+            {
+                min: 3,
+                max: null,
+                details: "",
+            },
+        ],
+        [
+            "angelic-messenger",
+            {
+                min: 0,
+                max: 0,
+                details: "",
+            },
+        ],
+        [
+            "asmodean-wager",
+            {
+                min: 1,
+                max: 9,
+                details: "",
+            },
+        ],
+        [
+            "aspirational-state",
+            {
+                min: 2,
+                max: 2,
+                details: "3 for groups of 6 PCs",
+            },
+        ],
+        [
+            "atone",
+            {
+                min: 1,
+                max: 1,
+                details: "must be the ritual's target",
+            },
+        ],
+        [
+            "awaken-portal",
+            {
+                min: 0,
+                max: 5,
+                details: "",
+            },
+        ],
+        [
+            "community-repair",
+            {
+                min: 4,
+                max: null,
+                details: "",
+            },
+        ],
+        [
+            "concealments-curtain",
+            {
+                min: 3,
+                max: 3,
+                details: "",
+            },
+        ],
+        [
+            "consecrate",
+            {
+                min: 2,
+                max: 2,
+                details: "must be worshippers of your religion",
+            },
+        ],
+        [
+            "contact-friends",
+            {
+                min: 1,
+                max: null,
+                details: "",
+            },
+        ],
+        [
+            "corpse-communion",
+            {
+                min: 0,
+                max: 0,
+                details: "",
+            },
+        ],
+        [
+            "daemonic-pact",
+            {
+                min: 0,
+                max: 0,
+                details: "",
+            },
+        ],
+        [
+            "diabolic-pact",
+            {
+                min: 0,
+                max: 0,
+                details: "",
+            },
+        ],
+        [
+            "div-pact",
+            {
+                min: 0,
+                max: 0,
+                details: "",
+            },
+        ],
+        [
+            "elemental-sentinel",
+            {
+                min: 0,
+                max: 0,
+                details: "",
+            },
+        ],
+        [
+            "extract-brain",
+            {
+                min: 0,
+                max: null,
+                details: "",
+            },
+        ],
+        [
+            "harrowing",
+            {
+                min: 0,
+                max: 0,
+                details: "",
+            },
+        ],
+        [
+            "infernal-pact",
+            {
+                min: 0,
+                max: 0,
+                details: "",
+            },
+        ],
+        [
+            "inveigle",
+            {
+                min: 0,
+                max: 0,
+                details: "",
+            },
+        ],
+        [
+            "last-nights-vigil",
+            {
+                min: 0,
+                max: 0,
+                details: "",
+            },
+        ],
+        [
+            "mosquito-blight",
+            {
+                min: 0,
+                max: 0,
+                details: "",
+            },
+        ],
+        [
+            "mystic-carriage",
+            {
+                min: 1,
+                max: 1,
+                details: "",
+            },
+        ],
+        [
+            "planar-ally",
+            {
+                min: 2,
+                max: 2,
+                details: "must share your religion",
+            },
+        ],
+        [
+            "purify-soul-path",
+            {
+                min: 0,
+                max: 0,
+                details: "",
+            },
+        ],
+        [
+            "ravenous-reanimation",
+            {
+                min: 0,
+                max: 0,
+                details: "",
+            },
+        ],
+        [
+            "rite-of-repatriation",
+            {
+                min: 0,
+                max: 5,
+                details: "",
+            },
+        ],
+        [
+            "rite-of-the-red-star",
+            {
+                min: 1,
+                max: null,
+                details: "the maximum is limited only by the physical space within the ring of stones",
+            },
+        ],
+        [
+            "tattoo-whispers",
+            {
+                min: 2,
+                max: 6,
+                details: "",
+            },
+        ],
+        [
+            "the-worlds-a-stage",
+            {
+                min: 2,
+                max: 12,
+                details: "",
+            },
+        ],
+        [
+            "unfettered-mark",
+            {
+                min: 0,
+                max: 10,
+                details: "",
+            },
+        ],
+        [
+            "winters-breath",
+            {
+                min: 1,
+                max: 1,
+                details: "",
+            },
+        ],
+    ]);
+
+    #updateRitualCasters(oldCasters: number, slug: string): NewCasters {
+        if (oldCasters > 0) {
+            // If the number was greater than zero, it actually was correctly converted from the original text
+            // If it is a user-made ritual, it should transfer as-is.
+            return { min: oldCasters, max: oldCasters, details: "" };
+        }
+        const newCasters = this.#RITUALCASTERSREPLACEMENT.get(slug);
+        // If we don't have replacement values for the slug, just return default
+        return newCasters ? R.clone(newCasters) : { min: 0, max: null, details: "" };
+    }
+
+    override async updateItem(source: ItemSourcePF2e): Promise<void> {
+        if (source.type !== "spell") return;
+
+        const system: MaybeOldSpellSystemSource = source.system ?? {};
+
+        if ("ritual" in source.system && R.isObjectType(source.system.ritual)) {
+            const slug = source.system.slug ?? sluggify(source.name);
+            const ritual: MaybeOldRitualData = system.ritual ?? {};
+            if (R.isObjectType(ritual.secondary) && R.isNumber(ritual.secondary.casters)) {
+                if (slug === "concealments-curtain") ritual.secondary.checks = "Arcana, Deception, Stealth";
+                const newCasters = this.#updateRitualCasters(ritual.secondary.casters, slug);
+                source.system.ritual.secondary.casters = newCasters;
+            }
+        }
+    }
+}
+
+interface MaybeOldRitualData {
+    primary?: { check: string };
+    secondary?: { checks: string; casters: number };
+}
+
+interface NewCasters {
+    min: number;
+    max: number | null;
+    details: string;
+}
+
+type MaybeOldSpellSystemSource = Omit<DeepPartial<SpellSystemSource>, "ritual"> & {
+    ritual?: unknown;
+};

--- a/src/module/migration/migrations/927-ritual-secondary-casters.ts
+++ b/src/module/migration/migrations/927-ritual-secondary-casters.ts
@@ -9,7 +9,7 @@ export class Migration927RitualSecondaryCasters extends MigrationBase {
 
     #RITUALCASTERSREPLACEMENT = new Map<string, NewCasters>([
         [
-            "demonic-pact",
+            "abyssal-pact",
             {
                 min: 0,
                 max: 0,
@@ -106,6 +106,14 @@ export class Migration927RitualSecondaryCasters extends MigrationBase {
         ],
         [
             "daemonic-pact",
+            {
+                min: 0,
+                max: 0,
+                details: "",
+            },
+        ],
+        [
+            "demonic-pact",
             {
                 min: 0,
                 max: 0,

--- a/src/module/migration/migrations/index.ts
+++ b/src/module/migration/migrations/index.ts
@@ -292,3 +292,4 @@ export { Migration923KineticistRestructure } from "./923-kineticist-restructure.
 export { Migration924JiuHuanDoa } from "./924-jiu-huan-dao.ts";
 export { Migration925TouchOfCorruption } from "./925-touch-of-corruption.ts";
 export { Migration926RemoveVisionFeatureLinks } from "./926-remove-vision-feature-links.ts";
+export { Migration927RitualSecondaryCasters } from "./927-ritual-secondary-casters.ts";

--- a/src/module/migration/runner/base.ts
+++ b/src/module/migration/runner/base.ts
@@ -14,7 +14,7 @@ interface CollectionDiff<T extends foundry.documents.ActiveEffectSource | ItemSo
 export class MigrationRunnerBase {
     migrations: MigrationBase[];
 
-    static LATEST_SCHEMA_VERSION = 0.926;
+    static LATEST_SCHEMA_VERSION = 0.927;
 
     static MINIMUM_SAFE_VERSION = 0.634;
 

--- a/src/styles/item/_spell-sheet.scss
+++ b/src/styles/item/_spell-sheet.scss
@@ -21,6 +21,20 @@
         }
     }
 
+    fieldset.ritual .form-group .secondary-casters-data {
+        display: grid;
+        grid-template-columns: 6rem auto;
+        column-gap: 1em;
+        div {
+            display: flex;
+            align-items: center;
+        }
+
+        div.range {
+            column-gap: 0.5em;
+        }
+    }
+
     button + fieldset {
         margin-top: 0.5rem;
     }

--- a/static/templates/items/spell-details.hbs
+++ b/static/templates/items/spell-details.hbs
@@ -61,7 +61,7 @@
 </fieldset>
 
 {{#if item.isRitual}}
-    <fieldset>
+    <fieldset class="ritual">
         <legend>{{localize "PF2E.Item.Spell.Ritual.Label"}}</legend>
 
         <div class="form-group">
@@ -76,7 +76,14 @@
 
         <div class="form-group">
             <label>{{localize "PF2E.Item.Spell.Ritual.SecondaryCasters"}}</label>
-            <input type="number" name="system.ritual.secondary.casters" required min="0" max="100" value="{{data.ritual.secondary.casters}}" />
+            <div class="secondary-casters-data">
+                <div class="range">
+                    <input type="number" name="system.ritual.secondary.casters.min" required min="0" max="100" value="{{data.ritual.secondary.casters.min}}" />
+                    <span>&ndash;</span>
+                    <input type="number" name="system.ritual.secondary.casters.max" min="0" max="100" value="{{data.ritual.secondary.casters.max}}" />
+                </div>
+                <input type="text" name="system.ritual.secondary.casters.details" value="{{data.ritual.secondary.casters.details}}" />
+            </div>
         </div>
     </fieldset>
 {{else}}


### PR DESCRIPTION
After attempting to correct the number of secondary casters for Awaken Portal ritual #14043 (that PR was not enough for it to work, which I somehow forgot to check), I wanted to correct the values for other rituals.

What I figured out was that in one of the migrations this data was stripped completely, and the field expected a numerical value.
Since the system doesn't do anything with the number of secondary ritual casters at the moment (as far as I'm aware), and the values there are not as straightforward as simple numbers or ranges, I propose changing the field into string type.

The comment on the data type (about the *maximum* number of spellcasters) was also incorrect, as that was the number of required spellcasters.