### PR TITLE
Use `CompendiumIndexData.uuid` instead of constructing it manually in `CompendiumBrowserTab#loadData`

### DIFF
--- a/src/module/apps/compendium-browser/tabs/action.ts
+++ b/src/module/apps/compendium-browser/tabs/action.ts
@@ -63,7 +63,7 @@ export class CompendiumBrowserActionTab extends CompendiumBrowserTab {
                         type: actionData.type,
                         name: actionData.name,
                         img: actionData.img,
-                        uuid: `Compendium.${pack.collection}.${actionData._id}`,
+                        uuid: actionData.uuid,
                         traits: actionData.system.traits.value.map((t: string) => t.replace(/^hb_/, "")),
                         actionType: actionData.system.actionType.value,
                         category: actionData.system.category,

--- a/src/module/apps/compendium-browser/tabs/bestiary.ts
+++ b/src/module/apps/compendium-browser/tabs/bestiary.ts
@@ -57,7 +57,7 @@ export class CompendiumBrowserBestiaryTab extends CompendiumBrowserTab {
                     type: actorData.type,
                     name: actorData.name,
                     img: actorData.img,
-                    uuid: `Compendium.${pack.collection}.${actorData._id}`,
+                    uuid: actorData.uuid,
                     level: actorData.system.details.level.value,
                     actorSize: actorData.system.traits.size.value,
                     traits: actorData.system.traits.value.map((t: string) => t.replace(/^hb_/, "")),

--- a/src/module/apps/compendium-browser/tabs/campaign-feature.ts
+++ b/src/module/apps/compendium-browser/tabs/campaign-feature.ts
@@ -58,7 +58,7 @@ export class CompendiumBrowserCampaignFeaturesTab extends CompendiumBrowserTab {
                     type: featData.type,
                     name: featData.name,
                     img: featData.img,
-                    uuid: `Compendium.${pack.collection}.${featData._id}`,
+                    uuid: featData.uuid,
                     level: featData.system.level?.value,
                     category: featData.system.category,
                     traits: featData.system.traits.value.map((t: string) => t.replace(/^hb_/, "")),

--- a/src/module/apps/compendium-browser/tabs/equipment.ts
+++ b/src/module/apps/compendium-browser/tabs/equipment.ts
@@ -109,7 +109,7 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
                         type: itemData.type,
                         name: itemData.name,
                         img: itemData.img,
-                        uuid: `Compendium.${pack.collection}.${itemData._id}`,
+                        uuid: itemData.uuid,
                         level: itemData.system.level?.value ?? 0,
                         category: itemData.system.category ?? "",
                         group: itemData.system.group ?? "",

--- a/src/module/apps/compendium-browser/tabs/feat.ts
+++ b/src/module/apps/compendium-browser/tabs/feat.ts
@@ -106,7 +106,7 @@ export class CompendiumBrowserFeatTab extends CompendiumBrowserTab {
                         type: featData.type,
                         name: featData.name,
                         img: featData.img,
-                        uuid: `Compendium.${pack.collection}.Item.${featData._id}`,
+                        uuid: featData.uuid,
                         level: featData.system.level.value,
                         category: featData.system.category,
                         skills: [...skills],

--- a/src/module/apps/compendium-browser/tabs/hazard.ts
+++ b/src/module/apps/compendium-browser/tabs/hazard.ts
@@ -58,7 +58,7 @@ export class CompendiumBrowserHazardTab extends CompendiumBrowserTab {
                     type: actorData.type,
                     name: actorData.name,
                     img: actorData.img,
-                    uuid: `Compendium.${pack.collection}.${actorData._id}`,
+                    uuid: actorData.uuid,
                     level: actorData.system.details.level.value,
                     complexity: actorData.system.details.isComplex ? "complex" : "simple",
                     traits: actorData.system.traits.value,

--- a/src/module/apps/compendium-browser/tabs/spell.ts
+++ b/src/module/apps/compendium-browser/tabs/spell.ts
@@ -104,7 +104,7 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
                         type: spellData.type,
                         name: spellData.name,
                         img: spellData.img,
-                        uuid: `Compendium.${pack.collection}.${spellData._id}`,
+                        uuid: spellData.uuid,
                         rank: spellData.system.level.value,
                         categories,
                         time: spellData.system.time,


### PR DESCRIPTION
The system is still constructing the compendium pack entries `uuid` manually in `CompendiumBrowserTab#loadData`, this PR will switch to using the one "now" provided by foundry directly which also will make them have the v11 format.