### PR TITLE
Refresh Bronze Bull Pendant

### DIFF
--- a/packs/equipment-effects/effect-bronze-bull-pendant.json
+++ b/packs/equipment-effects/effect-bronze-bull-pendant.json
@@ -1,10 +1,10 @@
 {
     "_id": "Cxa7MdgMCUoMqbKm",
-    "img": "systems/pf2e/icons/equipment/consumables/talismans/bronze-bull-pendant.webp",
+    "img": "icons/equipment/neck/necklace-hook-brown.webp",
     "name": "Effect: Bronze Bull Pendant",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.equipment-srd.Item.Bronze Bull Pendant]</p>\n<p>When you activate the pendant, attempt an Athletics check to @UUID[Compendium.pf2e.actionspf2e.Item.Shove] with a +1 item bonus to check. Increase the distance you Shove your target to 10 feet on a success or 20 feet on a critical success.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.equipment-srd.Item.Bronze Bull Pendant]</p>\n<p>When you activate the pendant, attempt an Athletics check to Shove with a +1 item bonus to check.</p>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -16,9 +16,9 @@
             "value": 2
         },
         "publication": {
-            "license": "OGL",
-            "remaster": false,
-            "title": "Pathfinder Core Rulebook"
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder GM Core"
         },
         "rules": [
             {
@@ -26,6 +26,7 @@
                 "predicate": [
                     "action:shove"
                 ],
+                "removeAfterRoll": true,
                 "selector": "athletics",
                 "type": "item",
                 "value": 1

--- a/packs/equipment/bronze-bull-pendant.json
+++ b/packs/equipment/bronze-bull-pendant.json
@@ -1,6 +1,6 @@
 {
     "_id": "nXStoLxPrrP2b6WB",
-    "img": "systems/pf2e/icons/equipment/consumables/talismans/bronze-bull-pendant.webp",
+    "img": "icons/equipment/neck/necklace-hook-brown.webp",
     "name": "Bronze Bull Pendant",
     "system": {
         "baseItem": null,
@@ -11,7 +11,7 @@
         "containerId": null,
         "damage": null,
         "description": {
-            "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> (concentrate)</p>\n<p><strong>Trigger</strong> You attempt an Athletics check to Shove, but you haven't rolled yet</p>\n<hr />\n<p>This pendant is forged from grainy steel and depicts a snorting bull's face. The pendant must be attached to the chest area or on a shoulder guard. When you activate the pendant, attempt an Athletics check to @UUID[Compendium.pf2e.actionspf2e.Item.Shove] with a +1 item bonus to check. Increase the distance you Shove your target to 10 feet on a success or 20 feet on a critical success.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Bronze Bull Pendant]</p>"
+            "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> (concentrate)</p>\n<hr />\n<p>This pendant is forged from grainy steel and depicts a snorting bull's face. The pendant must be attached to the chest area or on a shoulder guard. When you activate the pendant, attempt an Athletics check to @UUID[Compendium.pf2e.actionspf2e.Item.Shove] with a +1 item bonus to check. Increase the distance you Shove your target to 10 feet on a success or 20 feet on a critical success.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Bronze Bull Pendant]</p>"
         },
         "hardness": 0,
         "hp": {

--- a/packs/rollable-tables/2nd-level-consumables.json
+++ b/packs/rollable-tables/2nd-level-consumables.json
@@ -141,7 +141,7 @@
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "nXStoLxPrrP2b6WB",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/talismans/bronze-bull-pendant.webp",
+            "img": "icons/equipment/neck/necklace-hook-brown.webp",
             "range": [
                 52,
                 57


### PR DESCRIPTION
Remove extraneous Trigger text
Replace lower-resolution system icon with identical core icon
Make effect removeAfterRoll

Closes https://github.com/foundryvtt/pf2e/issues/14082