### PR TITLE
Support Babele's `originalName` property in compendium browser search

### DIFF
--- a/src/module/apps/compendium-browser/tabs/action.ts
+++ b/src/module/apps/compendium-browser/tabs/action.ts
@@ -1,7 +1,7 @@
-import * as R from "remeda";
 import { getActionIcon, sluggify } from "@util";
-import { CompendiumBrowser } from "../index.ts";
+import * as R from "remeda";
 import { ContentTabName } from "../data.ts";
+import { CompendiumBrowser } from "../index.ts";
 import { CompendiumBrowserTab } from "./base.ts";
 import { ActionFilters, CompendiumBrowserIndexData } from "./data.ts";
 
@@ -11,7 +11,7 @@ export class CompendiumBrowserActionTab extends CompendiumBrowserTab {
     templatePath = "systems/pf2e/templates/compendium-browser/partials/action.hbs";
 
     /* MiniSearch */
-    override searchFields = ["name"];
+    override searchFields = ["name", "originalName"];
     override storeFields = ["type", "name", "img", "uuid", "traits", "source", "category", "actionType"];
 
     constructor(browser: CompendiumBrowser) {
@@ -62,6 +62,7 @@ export class CompendiumBrowserActionTab extends CompendiumBrowserTab {
                     actions.push({
                         type: actionData.type,
                         name: actionData.name,
+                        originalName: actionData.originalName, // Added by Babele
                         img: actionData.img,
                         uuid: actionData.uuid,
                         traits: actionData.system.traits.value.map((t: string) => t.replace(/^hb_/, "")),

--- a/src/module/apps/compendium-browser/tabs/bestiary.ts
+++ b/src/module/apps/compendium-browser/tabs/bestiary.ts
@@ -18,7 +18,7 @@ export class CompendiumBrowserBestiaryTab extends CompendiumBrowserTab {
     ];
 
     /* MiniSearch */
-    override searchFields = ["name"];
+    override searchFields = ["name", "originalName"];
     override storeFields = ["type", "name", "img", "uuid", "level", "actorSize", "traits", "rarity", "source"];
 
     constructor(browser: CompendiumBrowser) {
@@ -56,6 +56,7 @@ export class CompendiumBrowserBestiaryTab extends CompendiumBrowserTab {
                 bestiaryActors.push({
                     type: actorData.type,
                     name: actorData.name,
+                    originalName: actorData.originalName, // Added by Babele
                     img: actorData.img,
                     uuid: actorData.uuid,
                     level: actorData.system.details.level.value,

--- a/src/module/apps/compendium-browser/tabs/campaign-feature.ts
+++ b/src/module/apps/compendium-browser/tabs/campaign-feature.ts
@@ -11,7 +11,7 @@ export class CompendiumBrowserCampaignFeaturesTab extends CompendiumBrowserTab {
     templatePath = "systems/pf2e/templates/compendium-browser/partials/feat.hbs";
 
     /* MiniSearch */
-    override searchFields = ["name"];
+    override searchFields = ["name", "originalName"];
     override storeFields = ["type", "name", "img", "uuid", "level", "category", "traits", "source"];
 
     constructor(browser: CompendiumBrowser) {
@@ -57,6 +57,7 @@ export class CompendiumBrowserCampaignFeaturesTab extends CompendiumBrowserTab {
                 feats.push({
                     type: featData.type,
                     name: featData.name,
+                    originalName: featData.originalName, // Added by Babele
                     img: featData.img,
                     uuid: featData.uuid,
                     level: featData.system.level?.value,

--- a/src/module/apps/compendium-browser/tabs/equipment.ts
+++ b/src/module/apps/compendium-browser/tabs/equipment.ts
@@ -13,7 +13,7 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
     templatePath = "systems/pf2e/templates/compendium-browser/partials/equipment.hbs";
 
     /* MiniSearch */
-    override searchFields = ["name"];
+    override searchFields = ["name", "originalName"];
     override storeFields = [
         "type",
         "name",
@@ -108,6 +108,7 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
                     inventoryItems.push({
                         type: itemData.type,
                         name: itemData.name,
+                        originalName: itemData.originalName, // Added by Babele
                         img: itemData.img,
                         uuid: itemData.uuid,
                         level: itemData.system.level?.value ?? 0,

--- a/src/module/apps/compendium-browser/tabs/feat.ts
+++ b/src/module/apps/compendium-browser/tabs/feat.ts
@@ -10,7 +10,7 @@ export class CompendiumBrowserFeatTab extends CompendiumBrowserTab {
     templatePath = "systems/pf2e/templates/compendium-browser/partials/feat.hbs";
 
     /* MiniSearch */
-    override searchFields = ["name"];
+    override searchFields = ["name", "originalName"];
     override storeFields = ["type", "name", "img", "uuid", "level", "category", "skills", "traits", "rarity", "source"];
 
     #creatureTraits = CONFIG.PF2E.creatureTraits;
@@ -105,6 +105,7 @@ export class CompendiumBrowserFeatTab extends CompendiumBrowserTab {
                     feats.push({
                         type: featData.type,
                         name: featData.name,
+                        originalName: featData.originalName, // Added by Babele
                         img: featData.img,
                         uuid: featData.uuid,
                         level: featData.system.level.value,

--- a/src/module/apps/compendium-browser/tabs/hazard.ts
+++ b/src/module/apps/compendium-browser/tabs/hazard.ts
@@ -10,7 +10,7 @@ export class CompendiumBrowserHazardTab extends CompendiumBrowserTab {
     templatePath = "systems/pf2e/templates/compendium-browser/partials/hazard.hbs";
 
     /* MiniSearch */
-    override searchFields = ["name"];
+    override searchFields = ["name", "originalName"];
     override storeFields = ["type", "name", "img", "uuid", "level", "complexity", "traits", "rarity", "source"];
 
     protected index = ["img", "system.details.level.value", "system.details.isComplex", "system.traits"];
@@ -57,6 +57,7 @@ export class CompendiumBrowserHazardTab extends CompendiumBrowserTab {
                 hazardActors.push({
                     type: actorData.type,
                     name: actorData.name,
+                    originalName: actorData.originalName, // Added by Babele
                     img: actorData.img,
                     uuid: actorData.uuid,
                     level: actorData.system.details.level.value,

--- a/src/module/apps/compendium-browser/tabs/spell.ts
+++ b/src/module/apps/compendium-browser/tabs/spell.ts
@@ -12,7 +12,7 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
     templatePath = "systems/pf2e/templates/compendium-browser/partials/spell.hbs";
 
     /* MiniSearch */
-    override searchFields = ["name"];
+    override searchFields = ["name", "originalName"];
     override storeFields = [
         "type",
         "name",
@@ -103,6 +103,7 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
                     spells.push({
                         type: spellData.type,
                         name: spellData.name,
+                        originalName: spellData.originalName, // Added by Babele
                         img: spellData.img,
                         uuid: spellData.uuid,
                         rank: spellData.system.level.value,


### PR DESCRIPTION
Babele adds the `originalName` property when a compendium index entry was translated.

Closes #14068 