### PR TITLE
Add fallback for browsers lacking `Intl.Segmenter`

### DIFF
--- a/src/module/apps/compendium-browser/tabs/base.ts
+++ b/src/module/apps/compendium-browser/tabs/base.ts
@@ -53,11 +53,19 @@ export abstract class CompendiumBrowserTab {
         await this.loadData();
 
         // Initialize MiniSearch
-        const wordSegmenter = new Intl.Segmenter(game.i18n.lang, { granularity: "word" });
+        const wordSegmenter =
+            "Segmenter" in Intl
+                ? new Intl.Segmenter(game.i18n.lang, { granularity: "word" })
+                : // Firefox >:(
+                  {
+                      segment(term: string): { segment: string }[] {
+                          return [{ segment: term }];
+                      },
+                  };
         this.searchEngine = new MiniSearch({
             fields: this.searchFields,
             idField: "uuid",
-            processTerm: (term) => {
+            processTerm: (term): string[] | null => {
                 if (term.length <= 1 || CompendiumDirectoryPF2e.STOP_WORDS.has(term)) {
                     return null;
                 }

--- a/src/module/apps/sidebar/compendium-directory.ts
+++ b/src/module/apps/sidebar/compendium-directory.ts
@@ -13,11 +13,19 @@ class CompendiumDirectoryPF2e extends CompendiumDirectory {
     constructor(options?: Partial<ApplicationOptions>) {
         super(options);
 
-        const wordSegmenter = new Intl.Segmenter(game.i18n.lang, { granularity: "word" });
+        const wordSegmenter =
+            "Segmenter" in Intl
+                ? new Intl.Segmenter(game.i18n.lang, { granularity: "word" })
+                : // Firefox >:(
+                  {
+                      segment(term: string): { segment: string }[] {
+                          return [{ segment: term }];
+                      },
+                  };
         this.#searchEngine = new MiniSearch({
             fields: ["name"],
             idField: "uuid",
-            processTerm: (term) => {
+            processTerm: (term): string[] | null => {
                 if (term.length <= 1 || CompendiumDirectoryPF2e.STOP_WORDS.has(term)) {
                     return null;
                 }


### PR DESCRIPTION
![image](https://github.com/foundryvtt/pf2e/assets/106829671/8ee104dc-d798-4978-8243-a0d1aa268a8c)
