### PR TITLE
Update Character Sidebar's Shield Max HP label's width

### DIFF
--- a/src/styles/actor/character/_sidebar.scss
+++ b/src/styles/actor/character/_sidebar.scss
@@ -463,7 +463,7 @@ aside {
                         margin-bottom: var(--space-4);
                         text-align: center;
                         white-space: normal;
-                        width: 5em;
+                        width: 6em;
                     }
 
                     .data-value {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -703,7 +703,7 @@
                             "Elemental": "Wood Elemental",
                             "Medium": "Medium Wood Elemental",
                             "Small": "Small Wood Elemental"
-                        }                     
+                        }
                     },
                     "Faydhaan": "Faydhaan",
                     "Fish": "Fish",
@@ -1446,7 +1446,7 @@
             "Aid": "To Aid",
             "AttemptToFascinateOutdoorsInBrightSun": "Using Fascinating Performance Outdoors in Bright Sun",
             "Blacksmithing": "For Blacksmithing",
-            "BloodOrWater": "In Blood of Water",
+            "BloodOrWater": "In Blood or Water",
             "BoundHome": "Within Bound Home",
             "Buried": "Buried",
             "CanClearlyIdentifyTheStars": "Can Clearly Identify the Stars",
@@ -1866,7 +1866,7 @@
             },
             "Champion": {
                 "AuraOfFaith": {
-                    "Toggle": "First Stike against an unholy creature this round"
+                    "Toggle": "First Strike against an unholy creature this round"
                 },
                 "BladeAllyRune": "Select a property rune for your blade ally.",
                 "DivineSmite": {


### PR DESCRIPTION
This increases the width of the Max HP label from `5em` to `6em`.
The reason for this change is due to (Brazilian Portuguese) localization not fitting into the box and requiring custom CSS styling to fix it.

![image](https://github.com/foundryvtt/pf2e/assets/5288872/150a9ee3-abad-43c5-a4fa-e998ac9e0973) ![image](https://github.com/foundryvtt/pf2e/assets/5288872/4c6b887d-9368-4e72-ad79-5cca88ca3e29)
