### PR TITLE
Fix Party's Hexploration Speed missing localization

### DIFF
--- a/static/templates/actors/party/regions/exploration.hbs
+++ b/static/templates/actors/party/regions/exploration.hbs
@@ -6,7 +6,7 @@
                 <div class="summary-data">
                     <div>
                         <label>{{localize "PF2E.TravelSpeed.Label"}}</label>
-                        <span class="value">{{explorationSummary.speed}} {{localize "PF2E.Feet"}}</span>
+                        <span class="value">{{explorationSummary.speed}} {{localize "PF2E.Foot.Plural"}}</span>
                     </div>
                     <div>
                         <label>{{localize "PF2E.TravelSpeed.HexplorationActivities"}}</label>


### PR DESCRIPTION
Hexploration's Travel Speed was using the old loc string for Feet.