### PR TITLE
Show impulse junction note on elemental blast attack roll instead of damage roll

### DIFF
--- a/packs/classfeatures/air-gate.json
+++ b/packs/classfeatures/air-gate.json
@@ -251,9 +251,29 @@
                             2
                         ]
                     },
-                    "impulse",
                     "junction:air:impulse",
-                    "air"
+                    "self:action:trait:impulse",
+                    "self:action:trait:air"
+                ],
+                "selector": "impulse-attack-roll",
+                "text": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Air",
+                "title": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Title"
+            },
+            {
+                "key": "Note",
+                "predicate": [
+                    {
+                        "not": "self:action:slug:elemental-blast"
+                    },
+                    {
+                        "gte": [
+                            "action:cost",
+                            2
+                        ]
+                    },
+                    "junction:air:impulse",
+                    "self:action:trait:impulse",
+                    "self:action:trait:air"
                 ],
                 "selector": [
                     "impulse-damage",

--- a/packs/classfeatures/earth-gate.json
+++ b/packs/classfeatures/earth-gate.json
@@ -241,9 +241,29 @@
                             2
                         ]
                     },
-                    "impulse",
                     "junction:earth:impulse",
-                    "earth"
+                    "self:action:trait:impulse",
+                    "self:action:trait:earth"
+                ],
+                "selector": "impulse-attack-roll",
+                "text": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Earth",
+                "title": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Title"
+            },
+            {
+                "key": "Note",
+                "predicate": [
+                    {
+                        "not": "self:action:slug:elemental-blast"
+                    },
+                    {
+                        "gte": [
+                            "action:cost",
+                            2
+                        ]
+                    },
+                    "junction:earth:impulse",
+                    "self:action:trait:impulse",
+                    "self:action:trait:earth"
                 ],
                 "selector": [
                     "impulse-damage",

--- a/packs/classfeatures/metal-gate.json
+++ b/packs/classfeatures/metal-gate.json
@@ -267,9 +267,29 @@
                             2
                         ]
                     },
-                    "impulse",
                     "junction:metal:impulse",
-                    "metal"
+                    "self:action:trait:impulse",
+                    "self:action:trait:metal"
+                ],
+                "selector": "impulse-attack-roll",
+                "text": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Metal",
+                "title": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Title"
+            },
+            {
+                "key": "Note",
+                "predicate": [
+                    {
+                        "not": "self:action:slug:elemental-blast"
+                    },
+                    {
+                        "gte": [
+                            "action:cost",
+                            2
+                        ]
+                    },
+                    "junction:metal:impulse",
+                    "self:action:trait:impulse",
+                    "self:action:trait:metal"
                 ],
                 "selector": [
                     "impulse-damage",

--- a/packs/classfeatures/water-gate.json
+++ b/packs/classfeatures/water-gate.json
@@ -240,9 +240,29 @@
                             2
                         ]
                     },
-                    "impulse",
                     "junction:water:impulse",
-                    "water"
+                    "self:action:trait:impulse",
+                    "self:action:trait:water"
+                ],
+                "selector": "impulse-attack-roll",
+                "text": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Water",
+                "title": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Title"
+            },
+            {
+                "key": "Note",
+                "predicate": [
+                    {
+                        "not": "self:action:slug:elemental-blast"
+                    },
+                    {
+                        "gte": [
+                            "action:cost",
+                            2
+                        ]
+                    },
+                    "junction:water:impulse",
+                    "self:action:trait:impulse",
+                    "self:action:trait:water"
                 ],
                 "selector": [
                     "impulse-damage",

--- a/packs/classfeatures/wood-gate.json
+++ b/packs/classfeatures/wood-gate.json
@@ -244,9 +244,29 @@
                             2
                         ]
                     },
-                    "impulse",
                     "junction:wood:impulse",
-                    "wood"
+                    "self:action:trait:impulse",
+                    "self:action:trait:wood"
+                ],
+                "selector": "impulse-attack-roll",
+                "text": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Wood",
+                "title": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Title"
+            },
+            {
+                "key": "Note",
+                "predicate": [
+                    {
+                        "not": "self:action:slug:elemental-blast"
+                    },
+                    {
+                        "gte": [
+                            "action:cost",
+                            2
+                        ]
+                    },
+                    "junction:wood:impulse",
+                    "self:action:trait:impulse",
+                    "self:action:trait:wood"
                 ],
                 "selector": [
                     "impulse-damage",


### PR DESCRIPTION
```
In addition, you gain an impulse junction, a benefit that
occurs when you use an impulse of the chosen element
that takes 2 actions or more.
```
Currently, when an elemental blast attack misses, there is no roll note shown for the impulse junction effect.

After this PR:
![image](https://github.com/foundryvtt/pf2e/assets/41452412/cb14df5b-d456-4e4d-8332-12630dcbd624)
