### PR TITLE
Add `party` as a valid roller in `StatisticCheck.roll()`

### DIFF
--- a/src/module/system/statistic/statistic.ts
+++ b/src/module/system/statistic/statistic.ts
@@ -415,7 +415,7 @@ class StatisticCheck<TParent extends Statistic = Statistic> {
 
         const isValidRoller = targetToken?.actor?.isOfType("army")
             ? self.isOfType("army")
-            : self.isOfType("creature", "hazard");
+            : self.isOfType("creature", "hazard", "party");
         if (!isValidRoller) return null;
 
         // This is required to determine the AC for attack dialogs


### PR DESCRIPTION
This fixes a regression that prevented Kingdom sheet rolls.

Fixes #14162 