### PR TITLE
Set RecordField as unresolved if anything was unresolved

### DIFF
--- a/src/module/system/schema-data-fields.ts
+++ b/src/module/system/schema-data-fields.ts
@@ -403,6 +403,7 @@ class RecordField<
             }
         }
         if (failures.elements.length) {
+            failures.unresolved = failures.elements.some((e) => e.failure.unresolved);
             return failures;
         }
     }


### PR DESCRIPTION
This causes thrown exceptions in strict mode if any key or value in RecordField has unresolved errors. This causes https://github.com/foundryvtt/pf2e/pull/13927 to behave correctly, *but* it is an incredibly fundamental change that may have repercussions to rule elements.