### PR TITLE
Hide disabled damage dice and modifiers in Parallel Breakthrough

### DIFF
--- a/packs/feats/parallel-breakthrough.json
+++ b/packs/feats/parallel-breakthrough.json
@@ -566,6 +566,7 @@
             {
                 "diceNumber": "@spell.rank - 1",
                 "dieSize": "d6",
+                "hideIfDisabled": true,
                 "key": "DamageDice",
                 "predicate": [
                     "item:slug:{item|flags.pf2e.rulesSelections.spell}",
@@ -579,6 +580,7 @@
                 "damageType": "bludgeoning",
                 "diceNumber": "ceil(@spell.rank/2)",
                 "dieSize": "d6",
+                "hideIfDisabled": true,
                 "key": "DamageDice",
                 "predicate": [
                     "item:slug:{item|flags.pf2e.rulesSelections.spell}",
@@ -592,6 +594,7 @@
                 "damageType": "slashing",
                 "diceNumber": "ceil(@spell.rank/2)",
                 "dieSize": "d6",
+                "hideIfDisabled": true,
                 "key": "DamageDice",
                 "predicate": [
                     "item:slug:{item|flags.pf2e.rulesSelections.spell}",
@@ -602,6 +605,7 @@
                 "selector": "spell-damage"
             },
             {
+                "hideIfDisabled": true,
                 "key": "DamageDice",
                 "override": {
                     "dieSize": "d10"
@@ -614,6 +618,7 @@
                 "selector": "spell-damage"
             },
             {
+                "hideIfDisabled": true,
                 "key": "DamageDice",
                 "override": {
                     "diceNumber": "@spell.rank",
@@ -630,6 +635,7 @@
                 "selector": "spell-damage"
             },
             {
+                "hideIfDisabled": true,
                 "key": "DamageDice",
                 "override": {
                     "diceNumber": "@spell.rank",
@@ -645,6 +651,7 @@
             },
             {
                 "damageCategory": "splash",
+                "hideIfDisabled": true,
                 "key": "FlatModifier",
                 "predicate": [
                     "item:slug:{item|flags.pf2e.rulesSelections.spell}",
@@ -657,6 +664,7 @@
             {
                 "diceNumber": "@spell.rank",
                 "dieSize": "d4",
+                "hideIfDisabled": true,
                 "key": "DamageDice",
                 "predicate": [
                     "item:slug:{item|flags.pf2e.rulesSelections.spell}",
@@ -666,6 +674,7 @@
                 "selector": "spell-damage"
             },
             {
+                "hideIfDisabled": true,
                 "key": "DamageDice",
                 "override": {
                     "diceNumber": "2 * ceil(@spell.rank / 2) - 1",
@@ -681,6 +690,7 @@
             {
                 "diceNumber": "@spell.rank - 1",
                 "dieSize": "d8",
+                "hideIfDisabled": true,
                 "key": "DamageDice",
                 "predicate": [
                     "item:slug:{item|flags.pf2e.rulesSelections.spell}",
@@ -692,6 +702,7 @@
             {
                 "diceNumber": "@spell.rank - 1",
                 "dieSize": "d4",
+                "hideIfDisabled": true,
                 "key": "DamageDice",
                 "predicate": [
                     "item:slug:{item|flags.pf2e.rulesSelections.spell}",


### PR DESCRIPTION
As to avoid this
![image](https://github.com/foundryvtt/pf2e/assets/103401186/7ed3d129-5eda-4224-b1e9-64c877ab28b9)