### PR TITLE
Exclude alternate amps from Parallel Breakthrough

### DIFF
--- a/packs/classfeatures/the-silent-whisper.json
+++ b/packs/classfeatures/the-silent-whisper.json
@@ -100,6 +100,16 @@
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.Message.Base",
                         "title": "PF2E.TraitAmp"
+                    },
+                    {
+                        "predicate": [
+                            "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            }
+                        ],
+                        "text": "PF2E.SpecificRule.Psychic.Amp.Message.Heightened",
+                        "title": "PF2E.SpecificRule.Psychic.Amp.AmpHeightenedLabel.AmpHeightenedFourth"
                     }
                 ]
             },

--- a/packs/feats/parallel-breakthrough.json
+++ b/packs/feats/parallel-breakthrough.json
@@ -87,7 +87,10 @@
                     {
                         "predicate": [
                             "item:slug:contagious-idea",
-                            "item:tag:amped"
+                            "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            }
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.ContagiousIdea",
                         "title": "PF2E.TraitAmp"
@@ -95,6 +98,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:dancing-blade"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.DancingBlade.Base",
@@ -103,6 +109,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:dancing-blade"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.DancingBlade.Guard.Text",
@@ -111,6 +120,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:dancing-blade"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.DancingBlade.Push.Text",
@@ -125,6 +137,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:daze"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.Daze.Base",
@@ -133,6 +148,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:daze"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.Daze.Heightened",
@@ -147,6 +165,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:detect-magic"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.DetectMagic.Base",
@@ -155,6 +176,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             {
                                 "gte": [
                                     "item:rank",
@@ -169,6 +193,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:distortion-lens"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.DistortionLens",
@@ -177,7 +204,10 @@
                     {
                         "predicate": [
                             "item:slug:entropic-wheel",
-                            "item:tag:amped"
+                            "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            }
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.EntropicWheel",
                         "title": "PF2E.TraitAmp"
@@ -191,6 +221,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:figment"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.Figment",
@@ -199,6 +232,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:forbidden-thought"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.ForbiddenThought",
@@ -207,6 +243,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:foresee-the-path"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.ForeseeThePath",
@@ -221,6 +260,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:frostbite"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.Frostbite.Base",
@@ -229,6 +271,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:frostbite"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.Frostbite.Heightened",
@@ -237,6 +282,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:ghostly-shift"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.GhostlyShift.Base",
@@ -245,6 +293,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:ghostly-shift"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.GhostlyShift.Heightened",
@@ -253,6 +304,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:glimpse-weakness"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.GlimpseWeakness.Base",
@@ -261,6 +315,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:glimpse-weakness"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.GlimpseWeakness.Heightened",
@@ -275,6 +332,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:guidance"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.Guidance.Base",
@@ -283,6 +343,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:guidance"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.Guidance.BaseTwo"
@@ -290,6 +353,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             {
                                 "gte": [
                                     "item:rank",
@@ -304,6 +370,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:hologram-cage"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.HologramCage",
@@ -318,6 +387,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:ignition"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.Ignition.Base",
@@ -326,6 +398,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:ignition"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.Ignition.Heightened",
@@ -334,6 +409,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:imaginary-weapon"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.ImaginaryWeapon.Base",
@@ -342,6 +420,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:imaginary-weapon"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.ImaginaryWeapon.Heightened",
@@ -356,6 +437,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:message"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.Message.Base",
@@ -364,6 +448,20 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
+                            "item:slug:message"
+                        ],
+                        "text": "PF2E.SpecificRule.Psychic.Amp.Message.Heightened",
+                        "title": "PF2E.SpecificRule.Psychic.Amp.AmpHeightenedLabel.AmpHeightenedFourth"
+                    },
+                    {
+                        "predicate": [
+                            "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:omnidirectional-scan"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.OmnidirectionalScan.Base",
@@ -372,6 +470,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:omnidirectional-scan"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.OmnidirectionalScan.BaseTwo"
@@ -385,6 +486,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:phase-bolt"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.PhaseBolt.Base",
@@ -393,6 +497,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:phase-bolt"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.PhaseBolt.Heightened",
@@ -401,7 +508,10 @@
                     {
                         "predicate": [
                             "item:slug:redistribute-potential",
-                            "item:tag:amped"
+                            "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            }
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.RedistributePotential.Base",
                         "title": "PF2E.TraitAmp"
@@ -409,7 +519,10 @@
                     {
                         "predicate": [
                             "item:slug:redistribute-potential",
-                            "item:tag:amped"
+                            "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            }
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.RedistributePotential.Heightened",
                         "title": "PF2E.SpecificRule.Psychic.Amp.AmpHeightenedLabel.AmpHeightenedPlusOne"
@@ -417,6 +530,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:shatter-mind"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.ShatterMind",
@@ -431,6 +547,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:shield"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.Shield.Base",
@@ -439,6 +558,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:shield"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.Shield.BaseTwo"
@@ -452,6 +574,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:telekinetic-hand"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.TelekineticHand.Base",
@@ -460,6 +585,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             {
                                 "gte": [
                                     "item:rank",
@@ -480,6 +608,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:telekinetic-projectile"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.TelekineticProjectile.Base",
@@ -488,6 +619,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:telekinetic-projectile"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.TelekineticProjectile.Heightened",
@@ -496,6 +630,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:telekinetic-rend"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.TelekineticRend.Base",
@@ -504,6 +641,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:telekinetic-rend"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.TelekineticRend.Heightened",
@@ -512,6 +652,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:tesseract-tunnel"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.TesseractTunnel",
@@ -520,7 +663,10 @@
                     {
                         "predicate": [
                             "item:slug:thermal-stasis",
-                            "item:tag:amped"
+                            "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            }
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.ThermalStasis",
                         "title": "PF2E.TraitAmp"
@@ -528,6 +674,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:vector-screen"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.VectorScreen",
@@ -542,6 +691,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             "item:slug:warp-step"
                         ],
                         "text": "PF2E.SpecificRule.Psychic.Amp.WarpStep.Base",
@@ -550,6 +702,9 @@
                     {
                         "predicate": [
                             "item:tag:amped",
+                            {
+                                "not": "alternate-amp"
+                            },
                             {
                                 "gte": [
                                     "item:rank",


### PR DESCRIPTION
and add Message's missing heightened amp entry on the relevant Item Alterations.