### PR TITLE
Brush up some Spell Trickster automation

### DIFF
--- a/packs/feat-effects/effect-animate-net.json
+++ b/packs/feat-effects/effect-animate-net.json
@@ -1,0 +1,65 @@
+{
+    "_id": "eaKB3rIkJyfsow5H",
+    "img": "icons/tools/fishing/net-simple-brown.webp",
+    "name": "Effect: Animate Net",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Animate Net]</p>\n<p>On a success, the target is @UUID[Compendium.pf2e.conditionitems.Item.Off-Guard] and takes a -10-foot circumstance penalty to its Speeds until it Escapes; on a critical success, it's also @UUID[Compendium.pf2e.conditionitems.Item.Immobilized] until it Escapes.</p>"
+        },
+        "duration": {
+            "expiry": null,
+            "sustained": false,
+            "unit": "unlimited",
+            "value": -1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Lost Omens: The Grand Bazaar"
+        },
+        "rules": [
+            {
+                "choices": [
+                    {
+                        "label": "PF2E.Check.Result.Degree.Check.criticalSuccess",
+                        "value": "critical-success"
+                    },
+                    {
+                        "label": "PF2E.Check.Result.Degree.Check.success",
+                        "value": "success"
+                    }
+                ],
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.DegreeOfSuccess",
+                "rollOption": "animate-net"
+            },
+            {
+                "key": "FlatModifier",
+                "selector": "all-speeds",
+                "type": "circumstance",
+                "value": -10
+            },
+            {
+                "key": "GrantItem",
+                "predicate": [
+                    "animate-net:critical-success"
+                ],
+                "uuid": "Compendium.pf2e.conditionitems.Item.Immobilized"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feat-effects/effect-shining-arms.json
+++ b/packs/feat-effects/effect-shining-arms.json
@@ -1,0 +1,60 @@
+{
+    "_id": "s5OHkf1HkLwgvZT7",
+    "img": "icons/magic/light/swords-light-glowing-white.webp",
+    "name": "Effect: Shining Arms",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Shining Arms]</p>\n<p>When a creature wielding the weapon critically hits a foe, you can Dismiss the spell as a reaction, causing the foe to be @UUID[Compendium.pf2e.conditionitems.Item.Dazzled] for 1 round</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "minutes",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Lost Omens: The Grand Bazaar"
+        },
+        "rules": [
+            {
+                "choices": {
+                    "ownedItems": true,
+                    "predicate": [
+                        "item:melee"
+                    ],
+                    "types": [
+                        "weapon"
+                    ]
+                },
+                "flag": "shiningArms",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.Weapon"
+            },
+            {
+                "key": "Note",
+                "outcome": [
+                    "criticalSuccess"
+                ],
+                "selector": "{item|flags.pf2e.rulesSelections.shiningArms}-attack",
+                "text": "PF2E.SpecificRule.SpellTrickster.ShiningArms.Note",
+                "title": "PF2E.SpecificRule.SpellTrickster.ShiningArms.Label"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feats/animate-net.json
+++ b/packs/feats/animate-net.json
@@ -58,6 +58,9 @@
                 "value": [
                     {
                         "text": "PF2E.SpecificRule.SpellTrickster.AnimateNet.Description"
+                    },
+                    {
+                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Animate Net]"
                     }
                 ]
             }

--- a/packs/feats/lingering-flames.json
+++ b/packs/feats/lingering-flames.json
@@ -78,17 +78,6 @@
                     "spell-damage"
                 ],
                 "value": "2 + @spell.rank"
-            },
-            {
-                "damageCategory": "persistent",
-                "damageType": "fire",
-                "key": "FlatModifier",
-                "predicate": [
-                    "item:slug:fireball",
-                    "spell-trickster:lingering-flames"
-                ],
-                "selector": "spell-damage",
-                "value": "2*(@spell.rank - 2)"
             }
         ],
         "traits": {

--- a/packs/feats/shining-arms.json
+++ b/packs/feats/shining-arms.json
@@ -58,6 +58,9 @@
                 "value": [
                     {
                         "text": "PF2E.SpecificRule.SpellTrickster.ShiningArms.Description"
+                    },
+                    {
+                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Shining Arms]"
                     }
                 ]
             }

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -307,16 +307,16 @@
             },
             "GhostCharge": {
                 "Greater": {
-                    "success": "<strong>Effect</strong> The bomb also deals [[/r (3[splash])[vitality]]]{3 vitality splash damage} and the target that takes damage becomes @UUID[Compendium.pf2e.conditionitems.Item.MIRkyAjyBeXivMa7]{Enfeebled 2} until the start of my next turn."
+                    "success": "<strong>Effect</strong> The bomb also deals [[/r (3[splash])[vitality]]]{3 vitality splash damage} and the target that takes damage becomes @UUID[Compendium.pf2e.conditionitems.Item.MIRkyAjyBeXivMa7]{Enfeebled 2} until the start of your next turn."
                 },
                 "Lesser": {
-                    "success": "<strong>Effect</strong> The bomb also deals [[/r (1[splash])[vitality]]]{1 vitality splash damage} and the target that takes damage becomes @UUID[Compendium.pf2e.conditionitems.Item.MIRkyAjyBeXivMa7]{Enfeebled 1} until the start of my next turn."
+                    "success": "<strong>Effect</strong> The bomb also deals [[/r (1[splash])[vitality]]]{1 vitality splash damage} and the target that takes damage becomes @UUID[Compendium.pf2e.conditionitems.Item.MIRkyAjyBeXivMa7]{Enfeebled 1} until the start of your next turn."
                 },
                 "Major": {
-                    "success": "<strong>Effect</strong> The bomb also deals [[/r (4[splash])[vitality]]]{4 vitality splash damage} and the target that takes damage becomes @UUID[Compendium.pf2e.conditionitems.Item.MIRkyAjyBeXivMa7]{Enfeebled 2} until the start of my next turn."
+                    "success": "<strong>Effect</strong> The bomb also deals [[/r (4[splash])[vitality]]]{4 vitality splash damage} and the target that takes damage becomes @UUID[Compendium.pf2e.conditionitems.Item.MIRkyAjyBeXivMa7]{Enfeebled 2} until the start of your next turn."
                 },
                 "Moderate": {
-                    "success": "<strong>Effect</strong> The bomb also deals [[/r (2[splash])[vitality]]]{2 vitality splash damage} and the target that takes damage becomes @UUID[Compendium.pf2e.conditionitems.Item.MIRkyAjyBeXivMa7]{Enfeebled 1} until the start of my next turn."
+                    "success": "<strong>Effect</strong> The bomb also deals [[/r (2[splash])[vitality]]]{2 vitality splash damage} and the target that takes damage becomes @UUID[Compendium.pf2e.conditionitems.Item.MIRkyAjyBeXivMa7]{Enfeebled 1} until the start of your next turn."
                 }
             },
             "GooGrenade": {
@@ -435,19 +435,19 @@
             },
             "RedpitchBomb": {
                 "Greater": {
-                    "criticalSuccess": "<strong>Effect</strong> The bomb also deals [[/r (2*3d4)[persistent,fire]]] and [[/r (3[splash])[fire]]]{3 fire splash damage}. On a critical hit, the target is @UUID[Compendium.pf2e.conditionitems.Item.i3OJZU2nk64Df3xm]{Clumsy 2} until the start of my next turn.",
+                    "criticalSuccess": "<strong>Effect</strong> The bomb also deals [[/r (2*3d4)[persistent,fire]]] and [[/r (3[splash])[fire]]]{3 fire splash damage}. On a critical hit, the target is @UUID[Compendium.pf2e.conditionitems.Item.i3OJZU2nk64Df3xm]{Clumsy 2} until the start of your next turn.",
                     "success": "<strong>Effect</strong> The bomb also deals [[/r 3d4[persistent,fire]]] and [[/r (3[splash])[fire]]]{3 fire splash damage}."
                 },
                 "Lesser": {
-                    "criticalSuccess": "<strong>Effect</strong> The bomb also deals [[/r (2*1d4)[persistent,fire]]] and [[/r (1[splash])[fire]]]{1 fire splash damage}. On a critical hit, the target is @UUID[Compendium.pf2e.conditionitems.Item.i3OJZU2nk64Df3xm]{Clumsy 1} until the start of my next turn.",
+                    "criticalSuccess": "<strong>Effect</strong> The bomb also deals [[/r (2*1d4)[persistent,fire]]] and [[/r (1[splash])[fire]]]{1 fire splash damage}. On a critical hit, the target is @UUID[Compendium.pf2e.conditionitems.Item.i3OJZU2nk64Df3xm]{Clumsy 1} until the start of your next turn.",
                     "success": "<strong>Effect</strong> The bomb also deals [[/r 1d4[persistent,fire]]] and [[/r (1[splash])[fire]]]{1 fire splash damage}."
                 },
                 "Major": {
-                    "criticalSuccess": "<strong>Effect</strong> The bomb also deals [[/r (2*4d4)[persistent,fire]]] and [[/r (4[splash])[fire]]]{4 fire splash damage}. On a critical hit, the target is @UUID[Compendium.pf2e.conditionitems.Item.i3OJZU2nk64Df3xm]{Clumsy 3} until the start of my next turn.",
+                    "criticalSuccess": "<strong>Effect</strong> The bomb also deals [[/r (2*4d4)[persistent,fire]]] and [[/r (4[splash])[fire]]]{4 fire splash damage}. On a critical hit, the target is @UUID[Compendium.pf2e.conditionitems.Item.i3OJZU2nk64Df3xm]{Clumsy 3} until the start of your next turn.",
                     "success": "<strong>Effect</strong> The bomb also deals [[/r 4d4[persistent,fire]]] and [[/r (4[splash])[fire]]]{4 fire splash damage}."
                 },
                 "Moderate": {
-                    "criticalSuccess": "<strong>Effect</strong> The bomb also deals [[/r (2*2d4)[persistent,fire]]] and [[/r (2[splash])[fire]]]{2 fire splash damage}. On a critical hit, the target is @UUID[Compendium.pf2e.conditionitems.Item.i3OJZU2nk64Df3xm]{Clumsy 1} until the start of my next turn.",
+                    "criticalSuccess": "<strong>Effect</strong> The bomb also deals [[/r (2*2d4)[persistent,fire]]] and [[/r (2[splash])[fire]]]{2 fire splash damage}. On a critical hit, the target is @UUID[Compendium.pf2e.conditionitems.Item.i3OJZU2nk64Df3xm]{Clumsy 1} until the start of your next turn.",
                     "success": "<strong>Effect</strong> The bomb also deals [[/r 2d4[persistent,fire]]] and [[/r (2[splash])[fire]]]{2 fire splash damage}."
                 }
             },
@@ -3578,7 +3578,7 @@
                     "DescriptionHeightened": "You attune yourself to the marked target. While the spell lasts, you can spend a single action, which has the concentrate, detection, and divination traits, to attempt to locate the target, learning the direction to the target as long as you are within 1 mile of it. If the target is a creature or a creature is in possession of the target object, the creature can attempt a @Check[type:will] saving throw against your spell DC. If it succeeds, your attempt to locate the target fails and you can't attempt this again for 1 day. You can only have a single target marked with a _sigil_ modified in this way. If you Cast this Spell again on a second target, the _sigil_ spell on the first target ends, and your mark fades."
                 },
                 "ChokingSmoke": {
-                    "Description": "When you cast _fireball_ heightened to at least 6th level, you can modify the spell's standard effects as follows: Reduce the spell's damage by 6d6. Your _fireball_ leaves behind a lingering cloud of toxic smoke in its area. While it's smoke instead of mist, this cloud otherwise has the effects of @UUID[Compendium.pf2e.spells-srd.Item.GKpEcy9WId6NJvtx]{Stinking Cloud}."
+                    "Description": "When you cast _fireball_ heightened to at least 6th rank, you can modify the spell's standard effects as follows: Reduce the spell's damage by 6d6. Your _fireball_ leaves behind a lingering cloud of toxic smoke in its area. While it's smoke instead of mist, this cloud otherwise has the effects of @UUID[Compendium.pf2e.spells-srd.Item.GKpEcy9WId6NJvtx]{Stinking Cloud}."
                 },
                 "ConfoundingImage": {
                     "Description": "When you cast _mirror image_, you can modify its duration to be sustained up to 1 minute and modify its range to 30 feet. If you do, replace the spell's standard effects with the following: You create an illusory duplicate of yourself that appears in an unoccupied square within range. The image takes up space and has a reach of 5 feet, and your allies can flank with the image. It doesn't have any other attributes a creature would normally have other than an AC equal to your spell DC and saving throw modifiers equal to your spell DC - 10. If the image is hit by an attack or fails a save, or if you ever move more than 30 feet from it, the spell ends. Creatures can move through its space without hindrance. When you Sustain the Spell, you can move the image to an unoccupied square within range."
@@ -3605,16 +3605,18 @@
                     "Description": "When you cast _telekinetic hand_, you can remove its duration, modify its range to 20 feet, and modify its target to be an attended object within the spell's Bulk limit that wouldn't be time-consuming to remove. Add the following to the spell's standard effects: If the creature attending the object is willing to have you take the item, mage hand carries the item to you. If the creature is unwilling, you must attempt to [[/act steal]] the target object with a Thievery check. The usual restrictions on attempts to Steal an object apply, including the restrictions that you can't steal objects that would be extremely noticeable or time-consuming to remove (like worn shoes or armor or actively wielded objects) and you can't Steal from a creature in combat or otherwise on guard. On a successful Steal check, the mage hand carries the item to you, and on a critical failure, you can't use this modification again for 1 hour. If you're a master in Thievery, you can attempt to Steal from a creature in combat or otherwise on guard, though if you do so, the spell's casting time increases by 1 action."
                 },
                 "LingeringFlames": {
-                    "Description": "When you cast _fireball_, you can modify its effects, decreasing the base damage to 5d6 and causing it to deal 2 persistent fire damage to creatures that fail their save, doubled as normal on a critical failure. If you do, replace its heightened entry with the following.",
+                    "Description": "When you cast _fireball_, you can modify its effects, decreasing the base damage to 5d6 and causing it to deal @Damage[(2*(@item.level - 2))[fire,persistent]] damage to creatures that fail their save, doubled as normal on a critical failure. If you do, replace its heightened entry with the following.",
                     "DescriptionHeightened": "The damage is increased by 1d6 and the persistent fire damage is increased by 2."
                 },
                 "ScatteredFire": {
                     "Description": "When you cast _fireball_, you can modify its area to be two non-overlapping @Template[type:burst|distance:10]{10-foot bursts}."
                 },
                 "ShiningArms": {
-                    "Description": "When you cast _light_, you can modify its target to be 1 melee weapon, either unattended or possessed by you or a willing ally, and modify its duration to be 1 minute. If you do, add the following to its effects: When a creature wielding the weapon critically hits a foe, you can @UUID[Compendium.pf2e.actionspf2e.Item.AjLSHZSWQ90exdLo]{Dismiss} the Spell as a reaction, causing the foe to be @UUID[Compendium.pf2e.conditionitems.Item.TkIyaNPgTZFBCCuh]{Dazzled} for 1 round. After you use this reaction, you can't use this modification again for 10 minutes."
+                    "Description": "When you cast _light_, you can modify its target to be 1 melee weapon, either unattended or possessed by you or a willing ally, and modify its duration to be 1 minute. If you do, add the following to its effects: When a creature wielding the weapon critically hits a foe, you can Dismiss the Spell as a reaction, causing the foe to be @UUID[Compendium.pf2e.conditionitems.Item.TkIyaNPgTZFBCCuh]{Dazzled} for 1 round. After you use this reaction, you can't use this modification again for 10 minutes.",
+                    "Label": "Shining Arms",
+                    "Note": "When a creature wielding the weapon critically hits a foe, you can Dismiss the spell as a reaction, causing the foe to be @UUID[Compendium.pf2e.conditionitems.Item.TkIyaNPgTZFBCCuh]{Dazzled} for 1 round."
                 },
-                "SiphoningHand": {
+                "SiphoningTouch": {
                     "Description": "When you cast _vampiric feast_, you can modify its standard effects as follows: Instead of gaining the temporary Hit Points yourself, you can grant the temporary Hit Points to an ally within 30 feet. After 1 minute, the ally loses any of these temporary Hit Points that remain."
                 },
                 "SmolderingExplosion": {


### PR DESCRIPTION
- Add effect for Animate Net.
- Add effect for Shining Arms.
- Replace instance of level with rank in Choking Smoke's localization key.
- Replace Lingering Flames' persistent damage flat modifier with an inline roll, since the persistent damage only occurs on a failure and critical failure.
- Fix Siphoning Touch's name in localization file.

Also fix some Alchemical Bomb notes scarily written in the first person.