### PR TITLE
Add save type alteration in mindshift toggle

### DIFF
--- a/packs/feats/violent-unleash.json
+++ b/packs/feats/violent-unleash.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p><strong>Trigger</strong> You Unleash your Psyche.</p>\n<hr />\n<p>The force of your mind unleashing itself wracks your enemies with a violent shockwave. You deal @Damage[ceil(@actor.level/2)d6[force]|options:area-damage] damage to all creatures in a @Template[type:emanation|distance:20], with a @Check[type:reflex|basic:true]{basic Reflex save}. This explosion is taxing, making you @UUID[Compendium.pf2e.conditionitems.Item.Stunned]{Stunned 1}. At 5th level and every 2 levels thereafter, the damage increases by 1d6.</p>"
+            "value": "<p><strong>Trigger</strong> You Unleash your Psyche.</p>\n<hr />\n<p>The force of your mind unleashing itself wracks your enemies with a violent shockwave. You deal @Damage[ceil(@actor.level/2)d6[force]|options:area-damage] damage to all creatures in a @Template[type:emanation|distance:20], with a @Check[type:reflex|dc:resolve(@actor.system.attributes.spellDC.value)|basic:true]. This explosion is taxing, making you @UUID[Compendium.pf2e.conditionitems.Item.Stunned]{Stunned 1}. At 5th level and every 2 levels thereafter, the damage increases by 1d6.</p>"
         },
         "level": {
             "value": 4

--- a/src/module/item/ability/trait-toggles.ts
+++ b/src/module/item/ability/trait-toggles.ts
@@ -1,5 +1,6 @@
 import type { AbilityItemPF2e, FeatPF2e } from "@item";
 import { DamageAlteration } from "@module/rules/rule-element/damage-alteration/alteration.ts";
+import { CheckAlteration } from "@module/system/text-editor.ts";
 import * as R from "remeda";
 
 /** A helper class to handle toggleable ability traits */
@@ -53,18 +54,6 @@ class AbilityTraitToggles {
             : [];
     }
 
-    getTraitAlterations(): TraitAlteration[] {
-        return this.mindshift?.selected
-            ? [
-                  {
-                      mode: "add",
-                      slug: "mindshift",
-                      value: "mental",
-                  }
-              ]
-            : [];
-    }
-
     getSheetData(): TraitToggleViewData[] {
         return R.compact(
             (["mindshift"] as const).map((t) => {
@@ -98,20 +87,6 @@ interface TraitToggleViewData {
     icon: string;
     classes: string;
     tooltip: string;
-}
-
-// I should do a proper rule like DamageAlteration, right? Or if not, where should I put this type?
-interface CheckAlteration {
-    mode: "override";
-    property: "type";
-    slug: string;
-    value: string;
-}
-
-interface TraitAlteration {
-    mode: "add" | "remove";
-    slug: string;
-    value: string;
 }
 
 export { AbilityTraitToggles, type TraitToggleViewData };

--- a/src/module/item/ability/trait-toggles.ts
+++ b/src/module/item/ability/trait-toggles.ts
@@ -49,7 +49,7 @@ class AbilityTraitToggles {
                       property: "type",
                       slug: "mindshift",
                       value: "will",
-                  }
+                  },
               ]
             : [];
     }

--- a/src/module/item/ability/trait-toggles.ts
+++ b/src/module/item/ability/trait-toggles.ts
@@ -40,6 +40,31 @@ class AbilityTraitToggles {
             : [];
     }
 
+    getCheckAlterations(): CheckAlteration[] {
+        return this.mindshift?.selected
+            ? [
+                  {
+                      mode: "override",
+                      property: "type",
+                      slug: "mindshift",
+                      value: "will",
+                  }
+              ]
+            : [];
+    }
+
+    getTraitAlterations(): TraitAlteration[] {
+        return this.mindshift?.selected
+            ? [
+                  {
+                      mode: "add",
+                      slug: "mindshift",
+                      value: "mental",
+                  }
+              ]
+            : [];
+    }
+
     getSheetData(): TraitToggleViewData[] {
         return R.compact(
             (["mindshift"] as const).map((t) => {
@@ -73,6 +98,20 @@ interface TraitToggleViewData {
     icon: string;
     classes: string;
     tooltip: string;
+}
+
+// I should do a proper rule like DamageAlteration, right? Or if not, where should I put this type?
+interface CheckAlteration {
+    mode: "override";
+    property: "type";
+    slug: string;
+    value: string;
+}
+
+interface TraitAlteration {
+    mode: "add" | "remove";
+    slug: string;
+    value: string;
 }
 
 export { AbilityTraitToggles, type TraitToggleViewData };

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -570,6 +570,7 @@ class TextEditorPF2e extends TextEditor {
         const params: CheckLinkParams = {
             ...rawParams,
             type,
+            baseType: type,
             basic,
             dc: rawParams.dc?.trim() || null,
             defense: rawParams.defense?.trim() || null,
@@ -628,6 +629,8 @@ class TextEditorPF2e extends TextEditor {
     }
 
     static #createSingleCheck({ params, item, actor, inlineLabel }: CreateSingleCheckOptions): HTMLSpanElement | null {
+        const result = augmentCheck({ params, item, actor });
+        params = result;
         // Get the icon
         const icon = ((): HTMLElement => {
             switch (params.type) {
@@ -688,7 +691,7 @@ class TextEditorPF2e extends TextEditor {
             createHTMLElement("span", { classes: ["label"], innerHTML: content });
 
         const anchor = createHTMLElement("a", {
-            classes: ["inline-check"],
+            classes: R.compact(["inline-check", params.baseType !== params.type ? "altered" : null]),
             children: [icon, createLabel(label)],
             dataset: {
                 pf2Traits: params.traits.toString() || null,
@@ -1032,6 +1035,24 @@ async function augmentInlineDamageRoll(
     }
 }
 
+/** Given a check options, augments its type depending on item and actor status */
+function augmentCheck(
+    options: AugmentCheckOptions,
+): CheckLinkParams {
+    const { params, item } = options;
+
+    const resultParams: CheckLinkParams = {
+        ...params
+    };
+
+    const checkAlterations = item?.isOfType("action", "feat") ? item.system.traits.toggles.getCheckAlterations() : [];
+    for (const alteration of checkAlterations) {
+        resultParams[alteration.property] = alteration.value;
+    }
+
+    return resultParams;
+}
+
 interface EnrichmentOptionsPF2e extends EnrichmentOptions {
     rollData?: RollDataPF2e;
     /** Whether to run the enriched string through `UserVisibility.process` */
@@ -1064,6 +1085,8 @@ interface ConvertXMLNodeOptions {
 
 interface CheckLinkParams {
     type: string;
+    /** Original type in case of alteration */
+    baseType: string;
     dc?: Maybe<string>;
     defense?: Maybe<string>;
     basic: boolean;
@@ -1085,6 +1108,12 @@ interface CreateSingleCheckOptions {
     item?: ItemPF2e | null;
     actor?: ActorPF2e | null;
     inlineLabel?: string;
+}
+
+interface AugmentCheckOptions {
+    params: CheckLinkParams;
+    item?: ItemPF2e | null;
+    actor?: ActorPF2e | null;
 }
 
 interface AugmentInlineDamageOptions {

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -1036,18 +1036,22 @@ async function augmentInlineDamageRoll(
 }
 
 /** Given a check options, augments its type depending on item and actor status */
-function augmentCheck(
-    options: AugmentCheckOptions,
-): CheckLinkParams {
+function augmentCheck(options: AugmentCheckOptions): CheckLinkParams {
     const { params, item } = options;
 
     const resultParams: CheckLinkParams = {
-        ...params
+        ...params,
     };
 
     const checkAlterations = item?.isOfType("action", "feat") ? item.system.traits.toggles.getCheckAlterations() : [];
     for (const alteration of checkAlterations) {
-        resultParams[alteration.property] = alteration.value;
+        switch (alteration.mode) {
+            case "override":
+                resultParams[alteration.property] = alteration.value;
+                break;
+            default:
+                break;
+        }
     }
 
     return resultParams;

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -1116,6 +1116,13 @@ interface AugmentCheckOptions {
     actor?: ActorPF2e | null;
 }
 
+interface CheckAlteration {
+    mode: "override";
+    property: "type";
+    slug: string;
+    value: string;
+}
+
 interface AugmentInlineDamageOptions {
     skipDialog: boolean;
     /** Refrain from adding domains to the damage roll. */
@@ -1130,4 +1137,4 @@ interface AugmentInlineDamageOptions {
     extraRollOptions: string[];
 }
 
-export { TextEditorPF2e, type EnrichmentOptionsPF2e };
+export { TextEditorPF2e, type EnrichmentOptionsPF2e, type CheckAlteration };

--- a/src/styles/_globals.scss
+++ b/src/styles/_globals.scss
@@ -175,6 +175,10 @@ a.content-link {
     color: var(--color-text-dark-improved);
 }
 
+.inline-check.altered {
+    color: var(--color-text-dark-improved);
+}
+
 /* ----------------------------------------- */
 /* PF2E Action Custom Element                */
 /* ----------------------------------------- */


### PR DESCRIPTION
Closes #14166

Adds simple logic for changing save types in text description to use with trait toggle. Also changed Violent Unleash feature description to be consistent with other mindshift feats.