### PR TITLE
Add slugs to FlatModifier REs targeted by AdjustModifier REs

### DIFF
--- a/packs/classfeatures/catharsis-emotion-love.json
+++ b/packs/classfeatures/catharsis-emotion-love.json
@@ -31,6 +31,7 @@
                     "self:effect:emotional-fervor"
                 ],
                 "selector": "will",
+                "slug": "catharsis-emotion-love",
                 "type": "status",
                 "value": 1
             },

--- a/packs/equipment/kinburis-sandals-of-bounding.json
+++ b/packs/equipment/kinburis-sandals-of-bounding.json
@@ -52,6 +52,7 @@
                     }
                 ],
                 "selector": "athletics",
+                "slug": "kinburis-sandals-of-bounding",
                 "type": "item",
                 "value": 1
             },

--- a/packs/feats/dragonslayer-oath.json
+++ b/packs/feats/dragonslayer-oath.json
@@ -37,6 +37,7 @@
                     "target:trait:dragon"
                 ],
                 "selector": "strike-damage",
+                "slug": "dragonslayer-oath",
                 "type": "circumstance",
                 "value": 4
             },

--- a/packs/feats/esoteric-oath.json
+++ b/packs/feats/esoteric-oath.json
@@ -37,6 +37,7 @@
                     "target:trait:aberration"
                 ],
                 "selector": "strike-damage",
+                "slug": "esoteric-oath",
                 "type": "circumstance",
                 "value": 4
             },

--- a/packs/feats/fiendsbane-oath.json
+++ b/packs/feats/fiendsbane-oath.json
@@ -37,6 +37,7 @@
                     "target:trait:fiend"
                 ],
                 "selector": "strike-damage",
+                "slug": "fiendsbane-oath",
                 "type": "circumstance",
                 "value": 4
             },

--- a/packs/feats/intimidating-prowess.json
+++ b/packs/feats/intimidating-prowess.json
@@ -44,6 +44,7 @@
                     }
                 ],
                 "selector": "intimidation",
+                "slug": "intimidating-prowess",
                 "type": "circumstance",
                 "value": 1
             },

--- a/packs/feats/ravenings-desperation.json
+++ b/packs/feats/ravenings-desperation.json
@@ -43,6 +43,7 @@
                     "survival",
                     "stealth"
                 ],
+                "slug": "ravenings-desperation",
                 "type": "circumstance",
                 "value": 1
             },

--- a/packs/feats/shining-oath.json
+++ b/packs/feats/shining-oath.json
@@ -37,6 +37,7 @@
                     "target:mode:undead"
                 ],
                 "selector": "strike-damage",
+                "slug": "shining-oath",
                 "type": "circumstance",
                 "value": 4
             },

--- a/packs/kingmaker-bestiary/amiri-level-11-kingmaker.json
+++ b/packs/kingmaker-bestiary/amiri-level-11-kingmaker.json
@@ -2561,6 +2561,7 @@
                             }
                         ],
                         "selector": "intimidation",
+                        "slug": "intimidating-prowess",
                         "type": "circumstance",
                         "value": {
                             "brackets": [

--- a/packs/kingmaker-bestiary/valerie-level-9.json
+++ b/packs/kingmaker-bestiary/valerie-level-9.json
@@ -2239,6 +2239,7 @@
                             }
                         ],
                         "selector": "intimidation",
+                        "slug": "intimidating-prowess",
                         "type": "circumstance",
                         "value": {
                             "brackets": [


### PR DESCRIPTION
Shouldn't be a need to check for empty string as empty slug auto-nulls on item card update. #14212 