### PR TITLE
Hide damage result cues for players with show results disabled

### DIFF
--- a/src/module/system/check/roll.ts
+++ b/src/module/system/check/roll.ts
@@ -39,7 +39,7 @@ class CheckRoll extends Roll {
         const { type, identifier, action, damaging } = this.options;
         const canRollDamage = !!(damaging && identifier && (this.roller === game.user || game.user.isGM));
         const showBreakdown = this.options.showBreakdown;
-        const showDamageCue = canRollDamage && game.pf2e.settings.metagame.results;
+        const showDamageCue = canRollDamage && (game.user.isGM || game.pf2e.settings.metagame.results);
         const tooltip = isPrivate || !(showBreakdown || game.user.isGM) ? "" : await this.getTooltip();
 
         const chatData: Record<string, unknown> = {

--- a/static/templates/chat/check/roll.hbs
+++ b/static/templates/chat/check/roll.hbs
@@ -14,16 +14,16 @@
     <div class="message-buttons" data-identifier="{{identifier}}">
         <button type="button" class="success" data-action="{{action}}-damage" data-outcome="success">
             {{localize "PF2E.DamageLabel"}}
-            {{#if (eq degree 2)}}
-                <span class="cue"{{#unless showDamageCue}} data-visibility="owner" data-whose="target"{{/unless}}>
+            {{#if (and showDamageCue (eq degree 2))}}
+                <span class="cue">
                     <i class="fa-duotone fa-bullseye-pointer fa-flip-horizontal fa-fw"></i>
                 </span>
             {{/if}}
         </button>
         <button type="button" class="critical-success" data-action="{{action}}-damage" data-outcome="critical-success">
             {{localize "PF2E.CriticalDamageLabel"}}
-            {{#if (eq degree 3)}}
-                <span class="cue"{{#unless showDamageCue}} data-visibility="owner" data-whose="target"{{/unless}}>
+            {{#if (and showDamageCue (eq degree 3))}}
+                <span class="cue">
                     <i class="fa-duotone fa-bullseye-pointer fa-flip-horizontal fa-fw"></i>
                 </span>
             {{/if}}


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/14215

Check rolls are re-rendered per player every reload, so we're good to handle it in the template like this.