### PR TITLE
Fix familiar level 0 in world actors and party errors based off initialization order

### DIFF
--- a/src/module/actor/familiar/document.ts
+++ b/src/module/actor/familiar/document.ts
@@ -100,6 +100,7 @@ class FamiliarPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e 
         };
         system.attributes.speed = {
             value: 25,
+            total: 25,
             label: CONFIG.PF2E.speedTypes.land,
             otherSpeeds: [],
         };

--- a/src/module/actor/party/document.ts
+++ b/src/module/actor/party/document.ts
@@ -80,7 +80,7 @@ class PartyPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
         return R.isEmpty(campaignDiff) ? diff : fu.mergeObject(diff, campaignDiff);
     }
 
-    /** Only prepare rule elements for non-physical items (in case campaigin items exist) */
+    /** Only prepare rule elements for non-physical items (in case campaign items exist) */
     protected override prepareRuleElements(): RuleElementPF2e<RuleElementSchema>[] {
         return this.items.contents
             .filter((item) => !item.isOfType("physical"))
@@ -105,7 +105,6 @@ class PartyPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
             .map((m) => fromUuidSync(m.uuid))
             .filter((a): a is CreaturePF2e => a instanceof ActorPF2e && a.isOfType("creature"))
             .sort((a, b) => a.name.localeCompare(b.name, game.i18n.lang));
-
         for (const member of this.members) {
             member?.parties.add(this);
         }
@@ -167,6 +166,8 @@ class PartyPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
 
     override prepareDerivedData(): void {
         super.prepareDerivedData();
+        if (!game.ready) return; // exit early if game isn't ready yet
+
         // Compute travel speed. Creature travel speed isn't implemented yet
         const travelSpeed = Math.min(...this.members.map((m) => m.attributes.speed.total));
         this.attributes.speed = { total: travelSpeed };

--- a/src/scripts/hooks/ready.ts
+++ b/src/scripts/hooks/ready.ts
@@ -127,16 +127,16 @@ export const Ready = {
             });
 
             // Now that all game data is available, Determine what actors we need to reprepare.
-            // Add actors currently in an encounter, a party, and all familiars (last)
+            // Add actors currently in an encounter, then in a party, then all familiars, then parties
+            const parties = game.actors.filter((a): a is PartyPF2e<null> => a.isOfType("party"));
             const actorsToReprepare = R.compact([
                 ...game.combats.contents.flatMap((e) => e.combatants.contents).map((c) => c.actor),
-                ...game.actors
-                    .filter((a): a is PartyPF2e<null> => a.isOfType("party"))
-                    .flatMap((p) => p.members)
-                    .filter((a) => !a.isOfType("familiar")),
+                ...parties.flatMap((p) => p.members).filter((a) => !a.isOfType("familiar")),
                 ...game.actors.filter((a) => a.type === "familiar"),
+                ...parties,
             ]);
             resetActors(new Set(actorsToReprepare), { sheets: false });
+            ui.actors.render();
 
             // Show the GM the Remaster changes journal entry if they haven't seen it already.
             if (game.user.isGM && !game.settings.get("pf2e", "seenRemasterJournalEntry")) {


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/10778

In better detail (the title is bad and I gave up coming up with a better one):
* Fixes familiars in the actor sidebar being level 0 by re-rendering after re-preparation
* Fixes certain errors that occur if the party was created after the members (there was an old issue that comes to mind, though I can't find it now)