### PR TITLE
Update Poltergeist Telekinetic Object and Telekinetic Storm

### DIFF
--- a/packs/age-of-ashes-bestiary/saggorak-poltergeist.json
+++ b/packs/age-of-ashes-bestiary/saggorak-poltergeist.json
@@ -272,27 +272,67 @@
                 "damageRolls": {
                     "9i9jkoq251cos6qcgcp3": {
                         "damage": "4d12",
-                        "damageType": "bludgeoning"
+                        "damageType": "untyped"
                     }
                 },
                 "description": {
-                    "value": ""
+                    "value": "<p>Damage type depends on object thrown</p>"
                 },
                 "publication": {
                     "license": "OGL",
                     "remaster": false,
                     "title": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "alwaysActive": true,
+                        "domain": "damage",
+                        "key": "RollOption",
+                        "option": "telekinetic-object",
+                        "suboptions": [
+                            {
+                                "label": "PF2E.TraitBludgeoning",
+                                "value": "bludgeoning"
+                            },
+                            {
+                                "label": "PF2E.TraitPiercing",
+                                "value": "piercing"
+                            },
+                            {
+                                "label": "PF2E.TraitSlashing",
+                                "value": "slashing"
+                            }
+                        ],
+                        "toggleable": true,
+                        "value": true
+                    },
+                    {
+                        "key": "DamageDice",
+                        "override": {
+                            "damageType": "{item|flags.pf2e.rulesSelections.telekineticObject}"
+                        },
+                        "selector": "{item|id}-damage"
+                    },
+                    {
+                        "key": "DamageAlteration",
+                        "mode": "override",
+                        "predicate": [
+                            "item:slug:telekinetic-storm"
+                        ],
+                        "property": "damage-type",
+                        "selectors": [
+                            "inline-damage"
+                        ],
+                        "value": "{item|flags.pf2e.rulesSelections.telekineticObject}"
+                    }
+                ],
                 "slug": null,
                 "traits": {
                     "rarity": "common",
                     "value": [
                         "magical",
                         "occult",
-                        "range-increment-60",
-                        "versatile-p",
-                        "versatile-s"
+                        "range-increment-60"
                     ]
                 },
                 "weaponType": {
@@ -484,7 +524,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The poltergeist telekinetically throws numerous small and jagged chunks of stone rubble, either spreading them out among multiple foes or directing them at one target.</p>\n<ul>\n<li>When this effect is spread out among multiple foes, the poltergeist makes a telekinetic object Strike at a -2 penalty against each creature within 30 feet. These count as one attack for the poltergeist's multiple attack penalty, and the penalty doesn't increase until after all the attacks.</li>\n<li>When this effect has only one target, the poltergeist makes a telekinetic object Strike against the target, and the damage increases to 6d12. It deals [[/r 2d12 #Telekinetic Storm Failure]]{2d12 damage} on a failure, and no damage on a critical failure.</li>\n</ul>"
+                    "value": "<p>The poltergeist telekinetically throws numerous small and jagged chunks of stone rubble, either spreading them out among multiple foes or directing them at one target.</p>\n<ul>\n<li>When this effect is spread out among multiple foes, the poltergeist makes a telekinetic object Strike at a -2 penalty against each creature within @Template[type:emanation|distance:30]{30 feet}. These count as one attack for the poltergeist's multiple attack penalty, and the penalty doesn't increase until after all the attacks.</li>\n<li>When this effect has only one target, the poltergeist makes a telekinetic object Strike against the target, and the damage increases to 6d12. It deals @Damage[2d12[untyped]] damage on a failure, and no damage on a critical failure.</li>\n</ul>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -513,20 +553,20 @@
                         "predicate": [
                             "telekinetic-storm:multi"
                         ],
-                        "selector": "attack",
+                        "selector": "telekinetic-object-attack",
                         "value": -2
                     },
                     {
-                        "diceNumber": 1,
+                        "diceNumber": 2,
                         "dieSize": "d12",
                         "key": "DamageDice",
                         "predicate": [
                             "telekinetic-storm:single"
                         ],
-                        "selector": "damage"
+                        "selector": "telekinetic-object-damage"
                     }
                 ],
-                "slug": null,
+                "slug": "telekinetic-storm",
                 "traits": {
                     "rarity": "common",
                     "value": [

--- a/packs/fists-of-the-ruby-phoenix-bestiary/watchtower-poltergeist.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/watchtower-poltergeist.json
@@ -193,27 +193,67 @@
                 "damageRolls": {
                     "afw854mi4ui6f02xhxld": {
                         "damage": "3d12+10",
-                        "damageType": "bludgeoning"
+                        "damageType": "untyped"
                     }
                 },
                 "description": {
-                    "value": ""
+                    "value": "<p>Damage type depends on object thrown</p>"
                 },
                 "publication": {
                     "license": "OGL",
                     "remaster": false,
                     "title": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "alwaysActive": true,
+                        "domain": "damage",
+                        "key": "RollOption",
+                        "option": "telekinetic-object",
+                        "suboptions": [
+                            {
+                                "label": "PF2E.TraitBludgeoning",
+                                "value": "bludgeoning"
+                            },
+                            {
+                                "label": "PF2E.TraitPiercing",
+                                "value": "piercing"
+                            },
+                            {
+                                "label": "PF2E.TraitSlashing",
+                                "value": "slashing"
+                            }
+                        ],
+                        "toggleable": true,
+                        "value": true
+                    },
+                    {
+                        "key": "DamageDice",
+                        "override": {
+                            "damageType": "{item|flags.pf2e.rulesSelections.telekineticObject}"
+                        },
+                        "selector": "{item|id}-damage"
+                    },
+                    {
+                        "key": "DamageAlteration",
+                        "mode": "override",
+                        "predicate": [
+                            "item:slug:telekinetic-storm"
+                        ],
+                        "property": "damage-type",
+                        "selectors": [
+                            "inline-damage"
+                        ],
+                        "value": "{item|flags.pf2e.rulesSelections.telekineticObject}"
+                    }
+                ],
                 "slug": null,
                 "traits": {
                     "rarity": "common",
                     "value": [
                         "magical",
                         "occult",
-                        "range-increment-60",
-                        "versatile-p",
-                        "versatile-s"
+                        "range-increment-60"
                     ]
                 },
                 "weaponType": {
@@ -271,7 +311,7 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p>A poltergeist is naturally invisible. It becomes visible only when it uses Frighten.</p>"
+                    "value": "<p>A poltergeist is naturally @UUID[Compendium.pf2e.conditionitems.Item.Invisible]. It becomes visible only when it uses Frighten.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -369,7 +409,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p><strong>Requirements</strong> The poltergeist must be invisible.</p>\n<hr />\n<p><strong>Effect</strong> The poltergeist becomes visible, appearing as a skeletal, ghostlike humanoid. Each creature within 30 feet must attempt a @Check[type:will|dc:33] save, becoming @UUID[Compendium.pf2e.conditionitems.Item.Frightened]{Frightened 2} on a failure. On a critical failure, it's also @UUID[Compendium.pf2e.conditionitems.Item.Fleeing] for as long as it's frightened. On a success, the creature is temporarily immune for 1 minute. At the start of its next turn, the poltergeist becomes invisible again.</p>"
+                    "value": "<p><strong>Requirements</strong> The poltergeist must be @UUID[Compendium.pf2e.conditionitems.Item.Invisible].</p>\n<hr />\n<p><strong>Effect</strong> The poltergeist becomes visible, appearing as a skeletal, ghostlike humanoid. Each creature within 30 feet must attempt a @Check[type:will|dc:33] save, becoming @UUID[Compendium.pf2e.conditionitems.Item.Frightened]{Frightened 2} on a failure. On a critical failure, it's also @UUID[Compendium.pf2e.conditionitems.Item.Fleeing] for as long as it's frightened. On a success, the creature is temporarily immune for 1 minute. At the start of its next turn, the poltergeist becomes invisible again.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -405,7 +445,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The poltergeist telekinetically throws numerous small objects, such as dozens of pieces of silverware or books, either spreading them out among multiple foes or directing them at one target. When this effect is spread out among multiple foes, the poltergeist makes a telekinetic object Strike at a -2 penalty against each creature within 30 feet. These count as one attack for the poltergeist's multiple attack penalty, and the penalty doesn't increase until after all the attacks. When this effect has only one target, the poltergeist makes a telekinetic object Strike against the target, and the damage increases to [[/r {4d12+15}]]{4d12+15 damage}. It deals [[/r {2d12}]]{2d12 damage} on a failure, and no damage on a critical failure.</p>"
+                    "value": "<p>The poltergeist telekinetically throws numerous small objects, such as dozens of pieces of silverware or books, either spreading them out among multiple foes or directing them at one target. When this effect is spread out among multiple foes, the poltergeist makes a telekinetic object Strike at a -2 penalty against each creature within @Template[type:emanation|distance:30]{30 feet}. These count as one attack for the poltergeist's multiple attack penalty, and the penalty doesn't increase until after all the attacks. When this effect has only one target, the poltergeist makes a telekinetic object Strike against the target, and the damage increases to 4d12+15. It deals @Damage[2d12[untyped]] damage on a failure, and no damage on a critical failure.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -434,7 +474,7 @@
                         "predicate": [
                             "telekinetic-storm:multi"
                         ],
-                        "selector": "attack",
+                        "selector": "telekinetic-object-attack",
                         "value": -2
                     },
                     {
@@ -444,10 +484,18 @@
                         "predicate": [
                             "telekinetic-storm:single"
                         ],
-                        "selector": "damage"
+                        "selector": "telekinetic-object-damage"
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "predicate": [
+                            "telekinetic-storm:single"
+                        ],
+                        "selector": "telekinetic-object-damage",
+                        "value": 5
                     }
                 ],
-                "slug": null,
+                "slug": "telekinetic-storm",
                 "traits": {
                     "rarity": "common",
                     "value": [

--- a/packs/pathfinder-bestiary/poltergeist.json
+++ b/packs/pathfinder-bestiary/poltergeist.json
@@ -194,14 +194,13 @@
         {
             "_id": "1cbIF1wUJSF3WWPk",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "Telekinetic Object (Bludgeoning)",
+            "name": "Telekinetic Object",
             "sort": 400000,
             "system": {
                 "attack": {
                     "value": ""
                 },
                 "attackEffects": {
-                    "custom": "",
                     "value": []
                 },
                 "bonus": {
@@ -210,7 +209,7 @@
                 "damageRolls": {
                     "afw854mi4ui6f02xhxld": {
                         "damage": "2d12",
-                        "damageType": "bludgeoning"
+                        "damageType": "untyped"
                     }
                 },
                 "description": {
@@ -221,97 +220,49 @@
                     "remaster": false,
                     "title": ""
                 },
-                "rules": [],
-                "slug": null,
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "magical",
-                        "occult",
-                        "range-increment-60"
-                    ]
-                },
-                "weaponType": {
-                    "value": "ranged"
-                }
-            },
-            "type": "melee"
-        },
-        {
-            "_id": "Zi3UHzrDTQBgI0SW",
-            "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "Telekinetic Object (Piercing)",
-            "sort": 500000,
-            "system": {
-                "attack": {
-                    "value": ""
-                },
-                "attackEffects": {
-                    "value": []
-                },
-                "bonus": {
-                    "value": 13
-                },
-                "damageRolls": {
-                    "ynxgba28x199hot96m5u": {
-                        "damage": "2d12",
-                        "damageType": "piercing"
+                "rules": [
+                    {
+                        "alwaysActive": true,
+                        "domain": "damage",
+                        "key": "RollOption",
+                        "option": "telekinetic-object",
+                        "suboptions": [
+                            {
+                                "label": "PF2E.TraitBludgeoning",
+                                "value": "bludgeoning"
+                            },
+                            {
+                                "label": "PF2E.TraitPiercing",
+                                "value": "piercing"
+                            },
+                            {
+                                "label": "PF2E.TraitSlashing",
+                                "value": "slashing"
+                            }
+                        ],
+                        "toggleable": true,
+                        "value": true
+                    },
+                    {
+                        "key": "DamageDice",
+                        "override": {
+                            "damageType": "{item|flags.pf2e.rulesSelections.telekineticObject}"
+                        },
+                        "selector": "{item|id}-damage"
+                    },
+                    {
+                        "key": "DamageAlteration",
+                        "mode": "override",
+                        "predicate": [
+                            "item:slug:telekinetic-storm"
+                        ],
+                        "property": "damage-type",
+                        "selectors": [
+                            "inline-damage"
+                        ],
+                        "value": "{item|flags.pf2e.rulesSelections.telekineticObject}"
                     }
-                },
-                "description": {
-                    "value": "<p>Damage type depends on object thrown</p>"
-                },
-                "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
-                },
-                "rules": [],
-                "slug": null,
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "magical",
-                        "occult",
-                        "range-increment-60"
-                    ]
-                },
-                "weaponType": {
-                    "value": "ranged"
-                }
-            },
-            "type": "melee"
-        },
-        {
-            "_id": "AuhMdlvvBkXqKNG8",
-            "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "Telekinetic Object (Slashing)",
-            "sort": 600000,
-            "system": {
-                "attack": {
-                    "value": ""
-                },
-                "attackEffects": {
-                    "value": []
-                },
-                "bonus": {
-                    "value": 13
-                },
-                "damageRolls": {
-                    "riye3uel21mu1dieuy2m": {
-                        "damage": "2d12",
-                        "damageType": "slashing"
-                    }
-                },
-                "description": {
-                    "value": "<p>Damage type depends on object thrown</p>"
-                },
-                "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
-                },
-                "rules": [],
+                ],
                 "slug": null,
                 "traits": {
                     "rarity": "common",
@@ -331,7 +282,7 @@
             "_id": "Yi4K7PbKaZWlXxWj",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Site Bound",
-            "sort": 700000,
+            "sort": 500000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -361,7 +312,7 @@
             "_id": "smEk0yh1Pe95Nvsc",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Natural Invisibility",
-            "sort": 800000,
+            "sort": 600000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -391,7 +342,7 @@
             "_id": "pvdHMw62l3uanob8",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Rejuvenation",
-            "sort": 900000,
+            "sort": 700000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -424,7 +375,7 @@
             "_id": "KZ4sC23Z3r4PS4V6",
             "img": "systems/pf2e/icons/actions/Reaction.webp",
             "name": "Telekinetic Defense",
-            "sort": 1000000,
+            "sort": 800000,
             "system": {
                 "actionType": {
                     "value": "reaction"
@@ -454,7 +405,7 @@
             "_id": "v8X1W0LmbkWRpOS6",
             "img": "systems/pf2e/icons/actions/OneAction.webp",
             "name": "Frighten",
-            "sort": 1100000,
+            "sort": 900000,
             "system": {
                 "actionType": {
                     "value": "action"
@@ -490,7 +441,7 @@
             "_id": "RJlLjrzqdXREWyPR",
             "img": "systems/pf2e/icons/actions/TwoActions.webp",
             "name": "Telekinetic Storm",
-            "sort": 1200000,
+            "sort": 1000000,
             "system": {
                 "actionType": {
                     "value": "action"
@@ -500,7 +451,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The poltergeist telekinetically throws numerous small objects, such as dozens of pieces of silverware or books, either spreading them out among multiple foes or directing them at one target.</p>\n<ul>\n<li>When this effect is spread out among multiple foes, the poltergeist makes a telekinetic object Strike at a -2 penalty against each creature within @Template[type:emanation|distance:30]{30 feet}. These count as one attack for the poltergeist's multiple attack penalty, and the penalty doesn't increase until after all the attacks.</li>\n<li>When this effect has only one target, the poltergeist makes a telekinetic object Strike against the target, and the damage increases to [[/r {3d12}]]{3d12 damage}. It deals [[/r {1d12}]]{1d12 damage} on a failure, and no damage on a critical failure.</li>\n</ul>"
+                    "value": "<p>The poltergeist telekinetically throws numerous small objects, such as dozens of pieces of silverware or books, either spreading them out among multiple foes or directing them at one target.</p>\n<ul>\n<li>When this effect is spread out among multiple foes, the poltergeist makes a telekinetic object Strike at a -2 penalty against each creature within @Template[type:emanation|distance:30]{30 feet}. These count as one attack for the poltergeist's multiple attack penalty, and the penalty doesn't increase until after all the attacks.</li>\n<li>When this effect has only one target, the poltergeist makes a telekinetic object Strike against the target, and the damage increases to 3d12. It deals @Damage[1d12[untyped]] damage on a failure, and no damage on a critical failure.</li>\n</ul>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -529,7 +480,7 @@
                         "predicate": [
                             "telekinetic-storm:multi"
                         ],
-                        "selector": "attack",
+                        "selector": "telekinetic-object-attack",
                         "value": -2
                     },
                     {
@@ -539,10 +490,10 @@
                         "predicate": [
                             "telekinetic-storm:single"
                         ],
-                        "selector": "damage"
+                        "selector": "telekinetic-object-damage"
                     }
                 ],
-                "slug": null,
+                "slug": "telekinetic-storm",
                 "traits": {
                     "rarity": "common",
                     "value": [
@@ -557,7 +508,7 @@
             "_id": "J3tQ8tcSm16AM3H0",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Acrobatics",
-            "sort": 1300000,
+            "sort": 1100000,
             "system": {
                 "description": {
                     "value": ""
@@ -582,7 +533,7 @@
             "_id": "dtrQvP8y05cBe6dj",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Intimidation",
-            "sort": 1400000,
+            "sort": 1200000,
             "system": {
                 "description": {
                     "value": ""
@@ -607,7 +558,7 @@
             "_id": "i5BbyyHPPgn7NssZ",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Stealth",
-            "sort": 1500000,
+            "sort": 1300000,
             "system": {
                 "description": {
                     "value": ""

--- a/packs/pfs-season-3-bestiary/poltergeist-holy-hand.json
+++ b/packs/pfs-season-3-bestiary/poltergeist-holy-hand.json
@@ -174,14 +174,13 @@
         {
             "_id": "1cbIF1wUJSF3WWPk",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "Telekinetic Object (Bludgeoning)",
+            "name": "Telekinetic Object",
             "sort": 400000,
             "system": {
                 "attack": {
                     "value": ""
                 },
                 "attackEffects": {
-                    "custom": "",
                     "value": []
                 },
                 "bonus": {
@@ -190,7 +189,7 @@
                 "damageRolls": {
                     "afw854mi4ui6f02xhxld": {
                         "damage": "2d10",
-                        "damageType": "bludgeoning"
+                        "damageType": "untyped"
                     },
                     "tukgkrwngoemy7mdbf6t": {
                         "damage": "1d6",
@@ -205,107 +204,49 @@
                     "remaster": false,
                     "title": ""
                 },
-                "rules": [],
-                "slug": null,
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "magical",
-                        "occult",
-                        "range-increment-60",
-                        "unholy"
-                    ]
-                },
-                "weaponType": {
-                    "value": "ranged"
-                }
-            },
-            "type": "melee"
-        },
-        {
-            "_id": "Zi3UHzrDTQBgI0SW",
-            "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "Telekinetic Object (Piercing)",
-            "sort": 500000,
-            "system": {
-                "attack": {
-                    "value": ""
-                },
-                "attackEffects": {
-                    "value": []
-                },
-                "bonus": {
-                    "value": 13
-                },
-                "damageRolls": {
-                    "ynxgba28x199hot96m5u": {
-                        "damage": "2d10",
-                        "damageType": "piercing"
+                "rules": [
+                    {
+                        "alwaysActive": true,
+                        "domain": "damage",
+                        "key": "RollOption",
+                        "option": "telekinetic-object",
+                        "suboptions": [
+                            {
+                                "label": "PF2E.TraitBludgeoning",
+                                "value": "bludgeoning"
+                            },
+                            {
+                                "label": "PF2E.TraitPiercing",
+                                "value": "piercing"
+                            },
+                            {
+                                "label": "PF2E.TraitSlashing",
+                                "value": "slashing"
+                            }
+                        ],
+                        "toggleable": true,
+                        "value": true
                     },
-                    "gk7iygnxzcpm166y6ugz": {
-                        "damage": "1d6",
-                        "damageType": "spirit"
-                    }
-                },
-                "description": {
-                    "value": "<p>Damage type depends on object thrown</p>"
-                },
-                "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
-                },
-                "rules": [],
-                "slug": null,
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "magical",
-                        "occult",
-                        "range-increment-60",
-                        "unholy"
-                    ]
-                },
-                "weaponType": {
-                    "value": "ranged"
-                }
-            },
-            "type": "melee"
-        },
-        {
-            "_id": "AuhMdlvvBkXqKNG8",
-            "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "Telekinetic Object (Slashing)",
-            "sort": 600000,
-            "system": {
-                "attack": {
-                    "value": ""
-                },
-                "attackEffects": {
-                    "value": []
-                },
-                "bonus": {
-                    "value": 13
-                },
-                "damageRolls": {
-                    "riye3uel21mu1dieuy2m": {
-                        "damage": "2d10",
-                        "damageType": "slashing"
+                    {
+                        "key": "DamageDice",
+                        "override": {
+                            "damageType": "{item|flags.pf2e.rulesSelections.telekineticObject}"
+                        },
+                        "selector": "{item|id}-damage"
                     },
-                    "sqeww7yufpubcrvn1q9r": {
-                        "damage": "1d6",
-                        "damageType": "spirit"
+                    {
+                        "key": "DamageAlteration",
+                        "mode": "override",
+                        "predicate": [
+                            "item:slug:telekinetic-storm"
+                        ],
+                        "property": "damage-type",
+                        "selectors": [
+                            "inline-damage"
+                        ],
+                        "value": "{item|flags.pf2e.rulesSelections.telekineticObject}"
                     }
-                },
-                "description": {
-                    "value": "<p>Damage type depends on object thrown</p>"
-                },
-                "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
-                },
-                "rules": [],
+                ],
                 "slug": null,
                 "traits": {
                     "rarity": "common",
@@ -326,7 +267,7 @@
             "_id": "Yi4K7PbKaZWlXxWj",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Site Bound",
-            "sort": 700000,
+            "sort": 500000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -356,7 +297,7 @@
             "_id": "smEk0yh1Pe95Nvsc",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Natural Invisibility",
-            "sort": 800000,
+            "sort": 600000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -386,7 +327,7 @@
             "_id": "pvdHMw62l3uanob8",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Rejuvenation",
-            "sort": 900000,
+            "sort": 700000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -419,7 +360,7 @@
             "_id": "KZ4sC23Z3r4PS4V6",
             "img": "systems/pf2e/icons/actions/Reaction.webp",
             "name": "Telekinetic Defense",
-            "sort": 1000000,
+            "sort": 800000,
             "system": {
                 "actionType": {
                     "value": "reaction"
@@ -449,7 +390,7 @@
             "_id": "v8X1W0LmbkWRpOS6",
             "img": "systems/pf2e/icons/actions/OneAction.webp",
             "name": "Frighten",
-            "sort": 1100000,
+            "sort": 900000,
             "system": {
                 "actionType": {
                     "value": "action"
@@ -485,7 +426,7 @@
             "_id": "RJlLjrzqdXREWyPR",
             "img": "systems/pf2e/icons/actions/TwoActions.webp",
             "name": "Telekinetic Storm",
-            "sort": 1200000,
+            "sort": 1000000,
             "system": {
                 "actionType": {
                     "value": "action"
@@ -495,7 +436,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The poltergeist telekinetically throws numerous small objects, such as dozens of pieces of silverware or books, either spreading them out among multiple foes or directing them at one target.</p>\n<ul>\n<li>When this effect is spread out among multiple foes, the poltergeist makes a telekinetic object Strike at a -2 penalty against each creature within @Template[type:emanation|distance:30]{30 feet}. These count as one attack for the poltergeist's multiple attack penalty, and the penalty doesn't increase until after all the attacks.</li>\n<li>When this effect has only one target, the poltergeist makes a telekinetic object Strike against the target, and the damage increases to [[/r {3d12}]]{3d12 damage}. It deals [[/r {1d12}]]{1d12 damage} on a failure, and no damage on a critical failure.</li>\n</ul>"
+                    "value": "<p>The poltergeist telekinetically throws numerous small objects, such as dozens of pieces of silverware or books, either spreading them out among multiple foes or directing them at one target.</p>\n<ul>\n<li>When this effect is spread out among multiple foes, the poltergeist makes a telekinetic object Strike at a -2 penalty against each creature within @Template[type:emanation|distance:30]{30 feet}. These count as one attack for the poltergeist's multiple attack penalty, and the penalty doesn't increase until after all the attacks.</li>\n<li>When this effect has only one target, the poltergeist makes a telekinetic object Strike against the target, and the damage increases to 3d12. It deals @Damage[1d12[untyped]] damage on a failure, and no damage on a critical failure.</li>\n</ul>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -524,7 +465,7 @@
                         "predicate": [
                             "telekinetic-storm:multi"
                         ],
-                        "selector": "attack",
+                        "selector": "telekinetic-object-attack",
                         "value": -2
                     },
                     {
@@ -534,10 +475,10 @@
                         "predicate": [
                             "telekinetic-storm:single"
                         ],
-                        "selector": "damage"
+                        "selector": "telekinetic-object-damage"
                     }
                 ],
-                "slug": null,
+                "slug": "telekinetic-storm",
                 "traits": {
                     "rarity": "common",
                     "value": [
@@ -552,7 +493,7 @@
             "_id": "J3tQ8tcSm16AM3H0",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Acrobatics",
-            "sort": 1300000,
+            "sort": 1100000,
             "system": {
                 "description": {
                     "value": ""
@@ -577,7 +518,7 @@
             "_id": "dtrQvP8y05cBe6dj",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Intimidation",
-            "sort": 1400000,
+            "sort": 1200000,
             "system": {
                 "description": {
                     "value": ""
@@ -602,7 +543,7 @@
             "_id": "i5BbyyHPPgn7NssZ",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Stealth",
-            "sort": 1500000,
+            "sort": 1300000,
             "system": {
                 "description": {
                     "value": ""


### PR DESCRIPTION
Use RollOption with suboptions for damage type
Use DamageAlteration to automate Telekinetic Storm inline damage type
Use proper selectors
Fix Saggorak and Watchtower Poltergeists' Telekinetic Storm extra damage