### PR TITLE
Preserve creation order in nested grants

### DIFF
--- a/src/module/rules/rule-element/grant-item/rule-element.ts
+++ b/src/module/rules/rule-element/grant-item/rule-element.ts
@@ -213,12 +213,13 @@ class GrantItemRuleElement extends RuleElementPF2e<GrantItemSchema> {
         this.#setGrantFlags(itemSource, grantedSource);
         this.#trackItem(tempGranted);
 
+        // Add to pending items before running pre-creates to preserve creation order
+        pendingItems.push(grantedSource);
+
         // Run the granted item's preCreate callbacks unless this is a pre-actor-update reevaluation
         if (!args.reevaluation) {
             await this.#runGrantedItemPreCreates(args, tempGranted, grantedSource, context);
         }
-
-        pendingItems.push(grantedSource);
     }
 
     /** Grant an item if this rule element permits it and the predicate passes */


### PR DESCRIPTION
This is more of an internal bugfix, and I don't know if anything trips this in the wild.

If you create this:
![firefox_2024-03-21_02-16-57](https://github.com/foundryvtt/pf2e/assets/1286721/ea0180f3-588d-4b92-9c79-0e2c28c61d93)
![image](https://github.com/foundryvtt/pf2e/assets/1286721/34c2315b-ff71-438a-802d-283d6c2f4bf0)

Before:
![firefox_2024-03-21_02-17-34](https://github.com/foundryvtt/pf2e/assets/1286721/08a1221a-0f6a-4374-b4ca-4f9f8c7f408e)

After:
![image](https://github.com/foundryvtt/pf2e/assets/1286721/2b1d4acc-3f5f-4c39-b669-fd724d10c5b7)
