### PR TITLE
Fix parentheses sometimes appearing in private damage rolls

### DIFF
--- a/static/templates/dice/damage-roll.hbs
+++ b/static/templates/dice/damage-roll.hbs
@@ -10,7 +10,7 @@
                         <span class="increased-from">*</span>
                     {{~/if~}}
                 </span>
-                {{#if showTotalInstances}}
+                {{#if (and instances.length showTotalInstances)}}
                     <div class="instances">
                         (
                         {{~#each instances as |instance|~}}


### PR DESCRIPTION
Closes #13611