### PR TITLE
Fix "consumAmmo" in an Omit type

### DIFF
--- a/src/module/system/rolls.ts
+++ b/src/module/system/rolls.ts
@@ -44,7 +44,7 @@ interface AttackRollParams extends RollParameters {
     rollTwice?: RollTwiceOption;
 }
 
-interface DamageRollParams extends Omit<AttackRollParams, "consumAmmo" | "rollTwice"> {
+interface DamageRollParams extends Omit<AttackRollParams, "consumeAmmo" | "rollTwice"> {
     mapIncreases?: Maybe<ZeroToTwo>;
     checkContext?: Maybe<CheckContextChatFlag>;
 }


### PR DESCRIPTION
Looking at the "consumeAmmo" AttackRollParams, I noticed a likely typo in DamageRollParams's Omit type.