### PR TITLE
Also show GM Notes in item summaries

### DIFF
--- a/src/module/actor/sheet/item-summary-renderer.ts
+++ b/src/module/actor/sheet/item-summary-renderer.ts
@@ -96,7 +96,6 @@ export class ItemSummaryRenderer<TActor extends ActorPF2e, TSheet extends Applic
         item: ItemPF2e<ActorPF2e>,
         chatData: RawItemChatData,
     ): Promise<void> {
-        const description = chatData.description.value;
         const isEffect = item instanceof AbstractEffectPF2e;
         const effectLinkText =
             item.isOfType("action", "feat") && item.system.selfEffect
@@ -106,7 +105,7 @@ export class ItemSummaryRenderer<TActor extends ActorPF2e, TSheet extends Applic
 
         const summary = await renderTemplate("systems/pf2e/templates/actors/partials/item-summary.hbs", {
             item,
-            description,
+            description: chatData.description,
             identified: game.user.isGM || !(item.isOfType("physical") || isEffect) || item.isIdentified,
             isCreature: item.actor?.isOfType("creature"),
             chatData,

--- a/src/styles/actor/_item-summary.scss
+++ b/src/styles/actor/_item-summary.scss
@@ -22,6 +22,13 @@
         }
     }
 
+    .gm-notes {
+        background-color: var(--visibility-gm-bg);
+        border: 1px dotted rgba(75, 74, 68, 0.5);
+        padding: 0 0.25em;
+        flex: 0 0 auto;
+    }
+
     .description {
         padding: 0 var(--space-2);
 

--- a/static/templates/actors/partials/item-summary.hbs
+++ b/static/templates/actors/partials/item-summary.hbs
@@ -25,8 +25,12 @@
     {{/if}}
 {{/if}}
 
+{{#if description.gm}}
+    <section class="gm-notes" data-tooltip-class="">{{{description.gm}}}</section>
+{{/if}}
+
 <div class="description" data-tooltip-class="">
-    {{{description}}}
+    {{{description.value}}}
     {{#if selfEffect}}<p>{{{selfEffect}}}</p>{{/if}}
 </div>
 


### PR DESCRIPTION
I'm surprised it wasn't in item summaries in the first place. Screenshot includes a AV spoilers.

![image](https://github.com/foundryvtt/pf2e/assets/1286721/bf2a380a-e181-4799-ba8e-ec3e52d7bb87)
