### PR TITLE
Add description alteration for Dragons Breath

### DIFF
--- a/packs/ancestryfeatures/draconic-exemplar.json
+++ b/packs/ancestryfeatures/draconic-exemplar.json
@@ -109,6 +109,16 @@
                 "mode": "override",
                 "path": "flags.pf2e.draconicExemplar.damageType",
                 "value": "{item|flags.pf2e.rulesSelections.draconicExemplar.damageType}"
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:kobold-breath"
+                ],
+                "property": "traits",
+                "value": "{item|flags.pf2e.rulesSelections.draconicExemplar.damageType}"
             }
         ],
         "traits": {

--- a/packs/feats/dragons-breath.json
+++ b/packs/feats/dragons-breath.json
@@ -11,7 +11,7 @@
         },
         "category": "ancestry",
         "description": {
-            "value": "<p>You can put more effort into your Kobold Breath to channel greater draconic power, though it takes more out of you. When you use Kobold Breath, you can increase the damage dice to @Damage[ceil(@actor.level/2)d8[@actor.flags.pf2e.draconicExemplar.damageType]|traits:area-damage] and increase the area to @Template[type:line|distance:60]{60 feet} for a line breath weapon or @Template[type:cone|distance:30]{30 feet} for a cone. If you do, you can't use Kobold Breath again for 1 hour.</p>"
+            "value": "<p>You can put more effort into your Kobold Breath to channel greater draconic power, though it takes more out of you. When you use Kobold Breath, you can increase the damage dice to d8s and increase the area to 60 feet for a line breath weapon or 30 feet for a cone. If you do, you can't use Kobold Breath again for 1 hour.</p>"
         },
         "level": {
             "value": 9

--- a/packs/feats/dragons-breath.json
+++ b/packs/feats/dragons-breath.json
@@ -11,7 +11,7 @@
         },
         "category": "ancestry",
         "description": {
-            "value": "<p>You can put more effort into your Kobold Breath to channel greater draconic power, though it takes more out of you. When you use Kobold Breath, you can increase the damage dice to d8s and increase the area to @Template[type:line|distance:60]{60 feet} for a line breath weapon or @Template[type:cone|distance:30]{30 feet} for a cone. If you do, you can't use Kobold Breath again for 1 hour.</p>\n<p>@Damage[ceil(@actor.level/2)d8[@actor.flags.pf2e.draconicExemplar.damageType|traits:area-damage]]{Leveled damage}</p>"
+            "value": "<p>You can put more effort into your Kobold Breath to channel greater draconic power, though it takes more out of you. When you use Kobold Breath, you can increase the damage dice to @Damage[ceil(@actor.level/2)d8[@actor.flags.pf2e.draconicExemplar.damageType]|traits:area-damage] and increase the area to @Template[type:line|distance:60]{60 feet} for a line breath weapon or @Template[type:cone|distance:30]{30 feet} for a cone. If you do, you can't use Kobold Breath again for 1 hour.</p>"
         },
         "level": {
             "value": 9
@@ -28,7 +28,32 @@
             "remaster": false,
             "title": "Pathfinder Advanced Player's Guide"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "RollOption",
+                "option": "dragons-breath",
+                "toggleable": true
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "override",
+                "predicate": [
+                    "item:slug:kobold-breath",
+                    "dragons-breath"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "divider": true,
+                        "text": "PF2E.SpecificRule.Kobold.DragonsBreath.DescriptionAlteration"
+                    },
+                    {
+                        "text": "@Check[type:fortitude|dc:resolve(@actor.attributes.classOrSpellDC.value)|basic:true] @Check[type:reflex|dc:resolve(@actor.attributes.classOrSpellDC.value)|basic:true]"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2800,6 +2800,9 @@
                     "StrongjawKobold": "Strongjaw Kobold",
                     "VenomtailKobold": "Venomtail Kobold"
                 },
+                "DragonsBreath": {
+                    "DescriptionAlteration": "You channel your draconic exemplar's power into a gout of energy that manifests as a @Template[type:line|distance:60] or a @Template[type:cone|distance:30], dealing @Damage[ceil(@actor.level/2)d8[@actor.flags.pf2e.draconicExemplar.damageType]|traits:area-damage] damage. Each creature in the area must attempt a basic saving throw against the higher of your class DC or spell DC. You can't use this ability again for 1 hour."
+                },
                 "DragonsPresence": {
                     "Note": "When you roll a success on a saving throw against a fear effect, you get a critical success instead. When you roll a failure against a fear effect, you get a critical failure instead."
                 }


### PR DESCRIPTION
also add the appropriate trait to the Kobold Breath action and fix a typo in Dragon's Breath inline damage.