### PR TITLE
Include item options in target context clones

### DIFF
--- a/src/module/actor/roll-context/base.ts
+++ b/src/module/actor/roll-context/base.ts
@@ -221,7 +221,9 @@ abstract class RollContext<
         if (!uncloned?.actor || !otherActor) {
             return uncloned?.actor ?? null;
         }
+
         const item = this.item;
+        const itemOptions = item?.getRollOptions("item") ?? [];
 
         // Get ephemeral effects from the target that affect this actor while attacking
         const ephemeralEffects = await extractEphemeralEffects({
@@ -230,7 +232,7 @@ abstract class RollContext<
             target: unresolved.target?.actor ?? null,
             item,
             domains: this.domains,
-            options: [...this.rollOptions, ...(item?.getRollOptions("item") ?? [])],
+            options: [...this.rollOptions, ...itemOptions],
         });
 
         // Add an epehemeral effect from flanking
@@ -258,6 +260,7 @@ abstract class RollContext<
                 markOption,
                 isFlankingAttack ? `${perspectivePrefix}:flanking` : null,
                 ...actionOptions,
+                ...(which === "target" ? itemOptions : []),
             ]),
             ephemeralEffects,
         );


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/14380

Feel free to handle it a different way if this isn't correct. From my limited testing "hit the dirt" works again