### PR TITLE
Predicate on effect's roll option instead of badge value for Bones Oracle REs

### DIFF
--- a/packs/feat-effects/effect-curse-of-living-death.json
+++ b/packs/feat-effects/effect-curse-of-living-death.json
@@ -10,6 +10,7 @@
                 "Major",
                 "Extreme"
             ],
+            "loop": false,
             "type": "counter",
             "value": 1
         },
@@ -36,7 +37,7 @@
                 "predicate": [
                     {
                         "gte": [
-                            "parent:badge:value",
+                            "self:effect:curse-of-living-death",
                             2
                         ]
                     },
@@ -102,7 +103,7 @@
                 "predicate": [
                     {
                         "gte": [
-                            "parent:badge:value",
+                            "self:effect:curse-of-living-death",
                             3
                         ]
                     },
@@ -125,7 +126,7 @@
                 "predicate": [
                     {
                         "gte": [
-                            "parent:badge:value",
+                            "self:effect:curse-of-living-death",
                             2
                         ]
                     },


### PR DESCRIPTION
Closes #14394 
For some reason `parent:badge:value` is not being satisfied as a predicate for Flat Modifier and Adjust Modifier rule elements. I'm not sure if this is bug in and of itself, but regardless using the equivalent roll option setup by the effect itself works.