### PR TITLE
Fix predicating parent roll options in modifier clones

### DIFF
--- a/src/module/actor/modifiers.ts
+++ b/src/module/actor/modifiers.ts
@@ -239,7 +239,7 @@ class ModifierPF2e implements RawModifier {
 
     /** Return a copy of this ModifierPF2e instance */
     clone(data: Partial<ModifierObjectParams> = {}, options: { test?: Set<string> | string[] } = {}): ModifierPF2e {
-        const clone = new ModifierPF2e(fu.mergeObject({ ...this, modifier: this.#originalValue, ...data }));
+        const clone = new ModifierPF2e({ ...this, modifier: this.#originalValue, rule: this.rule, ...data });
         if (options.test) clone.test(options.test);
 
         return clone;


### PR DESCRIPTION
This is the true cause behind https://github.com/foundryvtt/pf2e/issues/14394. Rule isn't enumerable and must be copied separately.

I don't understand why there is a mergeObject without arguments though. It was introduced in https://github.com/CarlosFdez/pf2e/commit/1f9ae8ea0e2244936453f6d8f7297c1d7eee2c2a . I kept it in just in case but my guess is that it should probably be removed.