### PR TITLE
Allow setting the indentation value in json handlebars helper

### DIFF
--- a/src/scripts/handlebars.ts
+++ b/src/scripts/handlebars.ts
@@ -54,8 +54,8 @@ export function registerHandlebarsHelpers(): void {
         return sluggify(String(text));
     });
 
-    Handlebars.registerHelper("json", (data: unknown): string => {
-        return JSON.stringify(data);
+    Handlebars.registerHelper("json", (data: unknown, indent: unknown): string => {
+        return JSON.stringify(data, null, Number(indent));
     });
 
     Handlebars.registerHelper("actionGlyph", (value, options: Handlebars.HelperOptions): string | null => {


### PR DESCRIPTION
This one I can actually justify though: I am displaying the value of object settings in an 'are you sure you want to reset this to default' box, currently handling the stringification in the data, would be nice to move it to the template but I need the indentation parameter. I don't think it needs more guards than this, it doesn't choke on NaN.