### PR TITLE
Correct Glimpse Weakness scaling and fix other data errors

### DIFF
--- a/packs/feats/settlement-scholastics.json
+++ b/packs/feats/settlement-scholastics.json
@@ -30,6 +30,11 @@
             "title": "Pathfinder Advanced Player's Guide"
         },
         "rules": [],
+        "subfeatures": {
+            "languages": {
+                "slots": 1
+            }
+        },
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/pathfinder-monster-core/shining-child.json
+++ b/packs/pathfinder-monster-core/shining-child.json
@@ -410,6 +410,80 @@
             "type": "spell"
         },
         {
+            "_id": "9rJk8tf3FsjKzXUn",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.Item.VlNcjmYyu95vOUe8"
+                }
+            },
+            "img": "icons/magic/symbols/ring-circle-smoke-blue.webp",
+            "name": "Translocate",
+            "sort": 700000,
+            "system": {
+                "area": null,
+                "cost": {
+                    "value": ""
+                },
+                "counteraction": false,
+                "damage": {},
+                "defense": null,
+                "description": {
+                    "value": "<p>You instantly transport yourself and any items you're wearing and holding from your current space to an unoccupied space within range you can see. If this would bring another creature with you—even if you're carrying it in an extradimensional container—the spell is lost.</p>\n<hr />\n<p><strong>Heightened (5th)</strong> The range increases to 1 mile. You don't need to be able to see your destination, as long as you have been there in the past and know its relative location and distance from you. You are then temporarily immune for 1 hour.</p>"
+                },
+                "duration": {
+                    "sustained": false,
+                    "value": ""
+                },
+                "heightening": {
+                    "levels": {
+                        "5": {
+                            "range": {
+                                "value": "1 mile"
+                            }
+                        }
+                    },
+                    "type": "fixed"
+                },
+                "level": {
+                    "value": 4
+                },
+                "location": {
+                    "heightenedLevel": 5,
+                    "value": "S5TEXAbFO5yNQ9JP"
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
+                },
+                "range": {
+                    "value": "120 feet"
+                },
+                "requirements": "",
+                "rules": [],
+                "slug": "translocate",
+                "target": {
+                    "value": ""
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traits": {
+                    "rarity": "common",
+                    "traditions": [
+                        "arcane",
+                        "occult"
+                    ],
+                    "value": [
+                        "concentrate",
+                        "manipulate",
+                        "teleportation"
+                    ]
+                }
+            },
+            "type": "spell"
+        },
+        {
             "_id": "Y8h8sSbCLYWIjTO6",
             "flags": {
                 "core": {
@@ -418,7 +492,7 @@
             },
             "img": "icons/magic/symbols/ring-circle-smoke-blue.webp",
             "name": "Translocate (At Will)",
-            "sort": 700000,
+            "sort": 800000,
             "system": {
                 "area": null,
                 "cost": {
@@ -492,7 +566,7 @@
             },
             "img": "systems/pf2e/icons/spells/dispel-magic.webp",
             "name": "Dispel Magic",
-            "sort": 800000,
+            "sort": 900000,
             "system": {
                 "area": null,
                 "cost": {
@@ -557,7 +631,7 @@
             },
             "img": "systems/pf2e/icons/spells/illusory-object.webp",
             "name": "Illusory Object (At Will)",
-            "sort": 900000,
+            "sort": 1000000,
             "system": {
                 "area": {
                     "type": "burst",
@@ -625,7 +699,7 @@
             },
             "img": "systems/pf2e/icons/spells/light.webp",
             "name": "Light",
-            "sort": 1000000,
+            "sort": 1100000,
             "system": {
                 "area": null,
                 "cost": {
@@ -686,7 +760,7 @@
             "_id": "v2MAVdLprfTUs4jh",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Fist",
-            "sort": 1100000,
+            "sort": 1200000,
             "system": {
                 "attack": {
                     "value": ""
@@ -741,7 +815,7 @@
             "_id": "pWMLYiykJTfDP0Lf",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Fire Ray",
-            "sort": 1200000,
+            "sort": 1300000,
             "system": {
                 "attack": {
                     "value": ""
@@ -803,7 +877,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Telepathy 120 feet",
-            "sort": 1300000,
+            "sort": 1400000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -837,7 +911,7 @@
             "_id": "DYRACVN0h19oKZpk",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Radiance Dependence",
-            "sort": 1400000,
+            "sort": 1500000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -867,7 +941,7 @@
             "_id": "RLXxZqgZH5Ym4SGI",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Blinding Aura",
-            "sort": 1500000,
+            "sort": 1600000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -921,7 +995,7 @@
             "_id": "98fcfAaERbR2T29q",
             "img": "systems/pf2e/icons/actions/Reaction.webp",
             "name": "Overwhelming Light",
-            "sort": 1600000,
+            "sort": 1700000,
             "system": {
                 "actionType": {
                     "value": "reaction"
@@ -953,7 +1027,7 @@
             "_id": "SAXjNvkB5u3mDySh",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Arcana",
-            "sort": 1700000,
+            "sort": 1800000,
             "system": {
                 "description": {
                     "value": ""
@@ -979,7 +1053,7 @@
             "_id": "AgvAk209TualyCKs",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Deception",
-            "sort": 1800000,
+            "sort": 1900000,
             "system": {
                 "description": {
                     "value": ""
@@ -1005,7 +1079,7 @@
             "_id": "ELu1SQJerQo19sxN",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Diplomacy",
-            "sort": 1900000,
+            "sort": 2000000,
             "system": {
                 "description": {
                     "value": ""
@@ -1031,7 +1105,7 @@
             "_id": "3mRAtXuyAeLzYAwV",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Intimidation",
-            "sort": 2000000,
+            "sort": 2100000,
             "system": {
                 "description": {
                     "value": ""
@@ -1057,7 +1131,7 @@
             "_id": "9QpINfxJmDLr8hH7",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Occultism",
-            "sort": 2100000,
+            "sort": 2200000,
             "system": {
                 "description": {
                     "value": ""

--- a/packs/season-of-ghosts-bestiary/heh-shan-bao.json
+++ b/packs/season-of-ghosts-bestiary/heh-shan-bao.json
@@ -30,8 +30,8 @@
                 "slots": {},
                 "slug": null,
                 "spelldc": {
-                    "dc": 0,
-                    "value": 0
+                    "dc": 28,
+                    "value": 20
                 },
                 "tradition": {
                     "value": "occult"

--- a/packs/spell-effects/spell-effect-glimpse-weakness.json
+++ b/packs/spell-effects/spell-effect-glimpse-weakness.json
@@ -30,8 +30,9 @@
             },
             {
                 "category": "precision",
-                "diceNumber": "@item.level",
+                "diceNumber": "ceil(@item.level / 2)",
                 "dieSize": "d4",
+                "hideIfDisabled": true,
                 "key": "DamageDice",
                 "predicate": [
                     "parent:origin:item:tag:amped"
@@ -40,13 +41,13 @@
             },
             {
                 "key": "AdjustModifier",
-                "mode": "add",
+                "mode": "downgrade",
                 "predicate": [
                     "parent:origin:item:tag:amped"
                 ],
                 "selector": "strike-damage",
                 "slug": "glimpse-weakness",
-                "value": -1
+                "value": "ceil(@item.level / 2)"
             }
         ],
         "start": {

--- a/packs/spells/winters-breath.json
+++ b/packs/spells/winters-breath.json
@@ -5,7 +5,7 @@
     "system": {
         "area": null,
         "cost": {
-            "value": ""
+            "value": "15 gp"
         },
         "counteraction": false,
         "damage": {},
@@ -26,16 +26,16 @@
             "title": "Pathfinder #197: Let the Leaves Fall"
         },
         "range": {
-            "value": ""
+            "value": "40 feet"
         },
         "requirements": "",
         "ritual": {
             "primary": {
-                "check": ""
+                "check": "Cooking Lore or Tea Lore (expert)"
             },
             "secondary": {
-                "casters": 0,
-                "checks": ""
+                "casters": 1,
+                "checks": "Diplomacy or Society"
             }
         },
         "rules": [],


### PR DESCRIPTION
- Add language slot to Settlement Scholastics (Closes #14402)
- Add missing spell to Monster Core's Shining Child (Partially addresses #14358, as the other missing spell doesn't exist)
- Correct DC and spell attack of Season of Ghosts NPC (Closes #14410)
- Add missing ritual data to Winters Breath (Closes #14416)
- Correct Glimpse Weakness' effect's amp heightening (Closes #14421)