### PR TITLE
Generate Check Prompt Macro updates

### DIFF
--- a/src/scripts/macros/check-prompt/prompt.ts
+++ b/src/scripts/macros/check-prompt/prompt.ts
@@ -14,6 +14,7 @@ interface CheckPromptDialogOptions extends ApplicationOptions {
 interface CheckPromptDialogData {
     proficiencyRanks: SelectData[];
     dcAdjustments: SelectData[];
+    averageLevel: number;
 }
 
 interface SelectData {
@@ -50,9 +51,13 @@ class CheckPromptDialog extends Application<CheckPromptDialogOptions> {
         this.#actions = await getActions();
         this.#lores = loreSkillsFromActors(this.options.actors ?? game.actors.party?.members ?? []);
 
+        const actors = this.options.actors ?? game.actors.party?.members ?? [];
+        const averageLevel = actors.reduce((acc, actor) => acc + actor.level, 0) / actors.length;
+
         return {
             proficiencyRanks: this.#prepareProficiencyRanks(),
             dcAdjustments: this.#prepareDCAdjustments(),
+            averageLevel: Math.round(averageLevel),
         };
     }
 

--- a/src/scripts/macros/check-prompt/prompt.ts
+++ b/src/scripts/macros/check-prompt/prompt.ts
@@ -111,7 +111,11 @@ class CheckPromptDialog extends Application<CheckPromptDialogOptions> {
 
         // Setup buttons
         htmlQuery(html, "[data-action=post]")?.addEventListener("click", async () => {
-            this.#generatePrompt();
+            this.#generatePrompt("post");
+        });
+
+        htmlQuery(html, "[data-action=copy]")?.addEventListener("click", async () => {
+            this.#generatePrompt("copy");
         });
 
         htmlQuery(html, "[data-action=cancel]")?.addEventListener("click", async () => {
@@ -119,7 +123,7 @@ class CheckPromptDialog extends Application<CheckPromptDialogOptions> {
         });
     }
 
-    #generatePrompt(): void {
+    #generatePrompt(type: string = "post"): void {
         const html = this.element[0];
         const types: string[] = [];
         const traits: string[] = [];
@@ -152,8 +156,13 @@ class CheckPromptDialog extends Application<CheckPromptDialogOptions> {
 
             const dc = this.#getDC(html);
             const content = types.map((type) => this.#constructCheck(type, dc, traits, extras)).join("");
-
-            ChatMessagePF2e.create({ user: game.user.id, flavor, content });
+            if (type === "post") {
+                ChatMessagePF2e.create({ user: game.user.id, flavor, content: `<p>${content}</p>` });
+            } else if (type === "copy") {
+                const clipText = content;
+                game.clipboard.copyPlainText(clipText);
+                ui.notifications.info(game.i18n.format("PF2E.ClipboardNotification", { clipText }));
+            }
         }
     }
 
@@ -208,7 +217,7 @@ class CheckPromptDialog extends Application<CheckPromptDialogOptions> {
         ]
             .concat(...extras)
             .filter((p) => p);
-        return `<p>@Check[${parts.join("|")}]</p>`;
+        return `@Check[${parts.join("|")}]`;
     }
 }
 

--- a/static/templates/gm/check-prompt.hbs
+++ b/static/templates/gm/check-prompt.hbs
@@ -97,6 +97,9 @@
         <button type="button" class="dialog-button post default bright" data-action="post">
             {{localize "PF2E.Actor.Party.CheckPrompt.Post"}}
         </button>
+        <button type="button" class="dialog-button copy" data-action="copy">
+            {{localize "Copy"}}
+        </button>
         <button type="button" class="dialog-button cancel" data-action="cancel">
             {{localize "Cancel"}}
         </button>

--- a/static/templates/gm/check-prompt.hbs
+++ b/static/templates/gm/check-prompt.hbs
@@ -33,7 +33,7 @@
             <section class="tab active" data-tab="level-dc">
                 <div class="form-group">
                     <label for="check-prompt-level-dc">{{localize "PF2E.LevelLabel"}}</label>
-                    <input type="number" id="check-prompt-level-dc" name="level-dc" />
+                    <input type="number" id="check-prompt-level-dc" name="level-dc" value="{{averageLevel}}" />
                 </div>
             </section>
         </section>


### PR DESCRIPTION
- (redeux) Generate Check Prompt Macro: Added button to copy to clipboard. Closes #13090 
- (redeux) Generate Check Prompt Macro: Added default level to level-based DC's, based on average party level. #11664 
  - I did not like the idea of extra clicks to prefill the default value, so I went with the most common occurrence to use the party level as the default value automatically rather than have to push an extra button to do so.  I believe this will be a better user experience than a separate level button. 
  - I think this can close the request, but that depends if you see value in the request for the option to have a button(s) for levels of creatures and hazards on the scene. Practically speaking I am not sure why you would be using a level based DC from Creature's/Hazards rather than the party level. 

This is my first system contribution outside of data entry. Thanks! 