### PR TITLE
Set default level in party check level-based DC's to average party level.

### DIFF
--- a/src/scripts/macros/check-prompt/prompt.ts
+++ b/src/scripts/macros/check-prompt/prompt.ts
@@ -14,7 +14,7 @@ interface CheckPromptDialogOptions extends ApplicationOptions {
 interface CheckPromptDialogData {
     proficiencyRanks: SelectData[];
     dcAdjustments: SelectData[];
-    averageLevel: number;
+    partyLevel: number | null;
 }
 
 interface SelectData {
@@ -51,13 +51,10 @@ class CheckPromptDialog extends Application<CheckPromptDialogOptions> {
         this.#actions = await getActions();
         this.#lores = loreSkillsFromActors(this.options.actors ?? game.actors.party?.members ?? []);
 
-        const actors = this.options.actors ?? game.actors.party?.members ?? [];
-        const averageLevel = actors.reduce((acc, actor) => acc + actor.level, 0) / actors.length;
-
         return {
             proficiencyRanks: this.#prepareProficiencyRanks(),
             dcAdjustments: this.#prepareDCAdjustments(),
-            averageLevel: Math.round(averageLevel),
+            partyLevel: game.actors.party?.level ?? null,
         };
     }
 

--- a/src/scripts/macros/check-prompt/prompt.ts
+++ b/src/scripts/macros/check-prompt/prompt.ts
@@ -14,6 +14,7 @@ interface CheckPromptDialogOptions extends ApplicationOptions {
 interface CheckPromptDialogData {
     proficiencyRanks: SelectData[];
     dcAdjustments: SelectData[];
+    averageLevel: number;
 }
 
 interface SelectData {
@@ -50,9 +51,13 @@ class CheckPromptDialog extends Application<CheckPromptDialogOptions> {
         this.#actions = await getActions();
         this.#lores = loreSkillsFromActors(this.options.actors ?? game.actors.party?.members ?? []);
 
+        const actors = this.options.actors ?? game.actors.party?.members ?? [];
+        const averageLevel = actors.reduce((acc, actor) => acc + actor.level, 0) / actors.length;
+
         return {
             proficiencyRanks: this.#prepareProficiencyRanks(),
             dcAdjustments: this.#prepareDCAdjustments(),
+            averageLevel: Math.round(averageLevel),
         };
     }
 

--- a/static/templates/gm/check-prompt.hbs
+++ b/static/templates/gm/check-prompt.hbs
@@ -33,7 +33,7 @@
             <section class="tab active" data-tab="level-dc">
                 <div class="form-group">
                     <label for="check-prompt-level-dc">{{localize "PF2E.LevelLabel"}}</label>
-                    <input type="number" id="check-prompt-level-dc" name="level-dc" value="{{averageLevel}}" />
+                    <input type="number" id="check-prompt-level-dc" name="level-dc" value="{{partyLevel}}" />
                 </div>
             </section>
         </section>

--- a/static/templates/gm/check-prompt.hbs
+++ b/static/templates/gm/check-prompt.hbs
@@ -33,7 +33,7 @@
             <section class="tab active" data-tab="level-dc">
                 <div class="form-group">
                     <label for="check-prompt-level-dc">{{localize "PF2E.LevelLabel"}}</label>
-                    <input type="number" id="check-prompt-level-dc" name="level-dc" />
+                    <input type="number" id="check-prompt-level-dc" name="level-dc" value="{{averageLevel}}" />
                 </div>
             </section>
         </section>


### PR DESCRIPTION
splitting PR from #14450 to include only default level feature request

Potentially Closes #11664 
  - I did not like the idea of extra clicks to prefill the default value, so I went with the most common occurrence to use the party level as the default value automatically rather than have to push an extra button to do so.  I believe this will be a better user experience than a separate level button. 
  - I think this can close the request, but that depends if you see value in the request for the option to have a button(s) for levels of creatures and hazards on the scene. Practically speaking I am not sure why you would be using a level based DC from Creature's/Hazards rather than the party level. 