### PR TITLE
Automate Keen Follower feat

### DIFF
--- a/packs/feats/keen-follower.json
+++ b/packs/feats/keen-follower.json
@@ -24,7 +24,24 @@
             "remaster": false,
             "title": "Pathfinder Advanced Player's Guide"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "AdjustModifier",
+                "mode": "upgrade",
+                "predicate": [
+                    "self:effect:follow-the-expert",
+                    {
+                        "or": [
+                            "follow-the-expert:proficiency:rank:2",
+                            "follow-the-expert:proficiency:rank:3"
+                        ]
+                    }
+                ],
+                "selector": "skill-check",
+                "slug": "follow-the-expert-circumstance",
+                "value": "@actor.flags.pf2e.followTheExpertProficiency+1"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/other-effects/effect-follow-the-expert.json
+++ b/packs/other-effects/effect-follow-the-expert.json
@@ -97,6 +97,7 @@
                 "prompt": "PF2E.SpecificRule.Prompt.Skill"
             },
             {
+                "actorFlag": true,
                 "choices": [
                     {
                         "label": "PF2E.ProficiencyLevel2",
@@ -116,7 +117,8 @@
                 ],
                 "flag": "followTheExpertProficiency",
                 "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.FollowTheExpert.Prompt"
+                "prompt": "PF2E.SpecificRule.FollowTheExpert.Prompt",
+                "rollOption": "follow-the-expert:proficiency:rank"
             },
             {
                 "key": "FlatModifier",


### PR DESCRIPTION
This will add the larger bonus when following an Expert or Master.

To get the necessary information, the Follow The Expert effect makes the ChoiceSets copy to actor flags.  The proficiency is also a roll option.

The proficiency roll option is used so the Keen Follower modifier can be disabled when it shouldn't apply, i.e. when following a trained or legendary "expert".

I also tried as an AdjustModifier, but without a relabel there's no clear indication the feat is working.  And with a relabel, the localized skill name is removed from the modifier, e.g. "Follow The Expert (Arcana)" would become "Keenly Follow The Expert".