### PR TITLE
Set grid manifest settings to the new v12 format

### DIFF
--- a/static/system.json
+++ b/static/system.json
@@ -27,6 +27,11 @@
     "styles": [
         "styles/pf2e.css"
     ],
+    "grid": {
+        "distance": 5,
+        "units": "ft",
+        "diagonals": 4
+    },
     "packs": [
         {
             "name": "abomination-vaults-bestiary",
@@ -1301,8 +1306,6 @@
     ],
     "socket": true,
     "initiative": "1d20 + @attributes.perception.value + (@abilities.wis.value / 100)",
-    "gridDistance": 5,
-    "gridUnits": "ft",
     "primaryTokenAttribute": "attributes.hp",
     "url": "https://github.com/foundryvtt/pf2e",
     "bugs": "https://github.com/foundryvtt/pf2e/issues",


### PR DESCRIPTION
diagonals 4 sets it to 1/2/1 (internally referred as CONST.GRID_DIAGONALS.ALTERNATING_1)