### PR TITLE
Fix logic of Fury Instinct Raging Resistance

### DIFF
--- a/packs/classfeatures/fury-instinct.json
+++ b/packs/classfeatures/fury-instinct.json
@@ -78,9 +78,7 @@
                                     "item:type:weapon"
                                 ]
                             },
-                            {
-                                "not": "item:category:unarmed"
-                            }
+                            "item:category:unarmed"
                         ],
                         "label": "PF2E.IWR.Custom.NonWeapons"
                     }


### PR DESCRIPTION
```You resist physical weapon damage, but not physical damage from other sources (such as unarmed attacks).```

Unarmed attacks are exception