### PR TITLE
Restore surface cantrip for Psi Development psychics

### DIFF
--- a/packs/classfeatures/the-distant-grasp.json
+++ b/packs/classfeatures/the-distant-grasp.json
@@ -248,32 +248,35 @@
             },
             {
                 "key": "ActiveEffectLike",
-                "mode": "override",
+                "mode": "add",
                 "path": "flags.pf2e.psychic.dedication.psiCantrips",
                 "predicate": [
-                    "feat:psychic-dedication"
+                    "feat:psychic-dedication",
+                    {
+                        "not": "selected-psi-cantrip:telekinetic-hand"
+                    }
                 ],
                 "priority": 10,
-                "value": [
+                "value": {
+                    "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.TelekineticHand",
+                    "value": "telekinetic-hand"
+                }
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.psychic.dedication.psiCantrips",
+                "predicate": [
+                    "feat:psychic-dedication",
                     {
-                        "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.TelekineticHand",
-                        "predicate": [
-                            {
-                                "not": "selected-psi-cantrip:telekinetic-hand"
-                            }
-                        ],
-                        "value": "telekinetic-hand"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.TelekineticProjectile",
-                        "predicate": [
-                            {
-                                "not": "selected-psi-cantrip:telekinetic-projectile"
-                            }
-                        ],
-                        "value": "telekinetic-projectile"
+                        "not": "selected-psi-cantrip:telekinetic-projectile"
                     }
-                ]
+                ],
+                "priority": 10,
+                "value": {
+                    "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.TelekineticProjectile",
+                    "value": "telekinetic-projectile"
+                }
             },
             {
                 "adjustName": false,

--- a/packs/classfeatures/the-infinite-eye.json
+++ b/packs/classfeatures/the-infinite-eye.json
@@ -200,32 +200,35 @@
             },
             {
                 "key": "ActiveEffectLike",
-                "mode": "override",
+                "mode": "add",
                 "path": "flags.pf2e.psychic.dedication.psiCantrips",
                 "predicate": [
-                    "feat:psychic-dedication"
+                    "feat:psychic-dedication",
+                    {
+                        "not": "selected-psi-cantrip:detect-magic"
+                    }
                 ],
                 "priority": 10,
-                "value": [
+                "value": {
+                    "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.DetectMagic",
+                    "value": "detect-magic"
+                }
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.psychic.dedication.psiCantrips",
+                "predicate": [
+                    "feat:psychic-dedication",
                     {
-                        "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.DetectMagic",
-                        "predicate": [
-                            {
-                                "not": "selected-psi-cantrip:detect-magic"
-                            }
-                        ],
-                        "value": "detect-magic"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.Guidance",
-                        "predicate": [
-                            {
-                                "not": "selected-psi-cantrip:guidance"
-                            }
-                        ],
-                        "value": "guidance"
+                        "not": "selected-psi-cantrip:guidance"
                     }
-                ]
+                ],
+                "priority": 10,
+                "value": {
+                    "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.Guidance",
+                    "value": "guidance"
+                }
             },
             {
                 "adjustName": false,

--- a/packs/classfeatures/the-oscillating-wave.json
+++ b/packs/classfeatures/the-oscillating-wave.json
@@ -316,32 +316,35 @@
             },
             {
                 "key": "ActiveEffectLike",
-                "mode": "override",
+                "mode": "add",
                 "path": "flags.pf2e.psychic.dedication.psiCantrips",
                 "predicate": [
-                    "feat:psychic-dedication"
+                    "feat:psychic-dedication",
+                    {
+                        "not": "selected-psi-cantrip:ignition"
+                    }
                 ],
                 "priority": 10,
-                "value": [
+                "value": {
+                    "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.Ignition",
+                    "value": "ignition"
+                }
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.psychic.dedication.psiCantrips",
+                "predicate": [
+                    "feat:psychic-dedication",
                     {
-                        "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.Ignition",
-                        "predicate": [
-                            {
-                                "not": "selected-psi-cantrip:ignition"
-                            }
-                        ],
-                        "value": "ignition"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.Frostbite",
-                        "predicate": [
-                            {
-                                "not": "selected-psi-cantrip:frostbite"
-                            }
-                        ],
-                        "value": "frostbite"
+                        "not": "selected-psi-cantrip:frostbite"
                     }
-                ]
+                ],
+                "priority": 10,
+                "value": {
+                    "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.Frostbite",
+                    "value": "frostbite"
+                }
             },
             {
                 "adjustName": false,

--- a/packs/classfeatures/the-silent-whisper.json
+++ b/packs/classfeatures/the-silent-whisper.json
@@ -192,32 +192,35 @@
             },
             {
                 "key": "ActiveEffectLike",
-                "mode": "override",
+                "mode": "add",
                 "path": "flags.pf2e.psychic.dedication.psiCantrips",
                 "predicate": [
-                    "feat:psychic-dedication"
+                    "feat:psychic-dedication",
+                    {
+                        "not": "selected-psi-cantrip:daze"
+                    }
                 ],
                 "priority": 10,
-                "value": [
+                "value": {
+                    "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.Daze",
+                    "value": "daze"
+                }
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.psychic.dedication.psiCantrips",
+                "predicate": [
+                    "feat:psychic-dedication",
                     {
-                        "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.Daze",
-                        "predicate": [
-                            {
-                                "not": "selected-psi-cantrip:daze"
-                            }
-                        ],
-                        "value": "daze"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.Message",
-                        "predicate": [
-                            {
-                                "not": "selected-psi-cantrip:message"
-                            }
-                        ],
-                        "value": "message"
+                        "not": "selected-psi-cantrip:message"
                     }
-                ]
+                ],
+                "priority": 10,
+                "value": {
+                    "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.Message",
+                    "value": "message"
+                }
             },
             {
                 "adjustName": false,

--- a/packs/classfeatures/the-tangible-dream.json
+++ b/packs/classfeatures/the-tangible-dream.json
@@ -178,32 +178,35 @@
             },
             {
                 "key": "ActiveEffectLike",
-                "mode": "override",
+                "mode": "add",
                 "path": "flags.pf2e.psychic.dedication.psiCantrips",
                 "predicate": [
-                    "feat:psychic-dedication"
+                    "feat:psychic-dedication",
+                    {
+                        "not": "selected-psi-cantrip:figment"
+                    }
                 ],
                 "priority": 10,
-                "value": [
+                "value": {
+                    "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.Figment",
+                    "value": "figment"
+                }
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.psychic.dedication.psiCantrips",
+                "predicate": [
+                    "feat:psychic-dedication",
                     {
-                        "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.Figment",
-                        "predicate": [
-                            {
-                                "not": "selected-psi-cantrip:figment"
-                            }
-                        ],
-                        "value": "figment"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.Shield",
-                        "predicate": [
-                            {
-                                "not": "selected-psi-cantrip:shield"
-                            }
-                        ],
-                        "value": "shield"
+                        "not": "selected-psi-cantrip:shield"
                     }
-                ]
+                ],
+                "priority": 10,
+                "value": {
+                    "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.Shield",
+                    "value": "shield"
+                }
             },
             {
                 "adjustName": false,

--- a/packs/classfeatures/the-unbound-step.json
+++ b/packs/classfeatures/the-unbound-step.json
@@ -196,32 +196,35 @@
             },
             {
                 "key": "ActiveEffectLike",
-                "mode": "override",
+                "mode": "add",
                 "path": "flags.pf2e.psychic.dedication.psiCantrips",
                 "predicate": [
-                    "feat:psychic-dedication"
+                    "feat:psychic-dedication",
+                    {
+                        "not": "selected-psi-cantrip:phase-bolt"
+                    }
                 ],
                 "priority": 10,
-                "value": [
+                "value": {
+                    "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.PhaseBolt",
+                    "value": "phase-bolt"
+                }
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.psychic.dedication.psiCantrips",
+                "predicate": [
+                    "feat:psychic-dedication",
                     {
-                        "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.PhaseBolt",
-                        "predicate": [
-                            {
-                                "not": "selected-psi-cantrip:phase-bolt"
-                            }
-                        ],
-                        "value": "phase-bolt"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.WarpStep",
-                        "predicate": [
-                            {
-                                "not": "selected-psi-cantrip:warp-step"
-                            }
-                        ],
-                        "value": "warp-step"
+                        "not": "selected-psi-cantrip:warp-step"
                     }
-                ]
+                ],
+                "priority": 10,
+                "value": {
+                    "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.WarpStep",
+                    "value": "warp-step"
+                }
             },
             {
                 "adjustName": false,

--- a/packs/feats/psi-development.json
+++ b/packs/feats/psi-development.json
@@ -37,6 +37,84 @@
                 "value": 1
             },
             {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.psychic.dedication.psiCantrips",
+                "predicate": [
+                    "feature:the-distant-grasp"
+                ],
+                "priority": 10,
+                "value": {
+                    "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.TelekineticRend",
+                    "value": "telekinetic-rend"
+                }
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.psychic.dedication.psiCantrips",
+                "predicate": [
+                    "feature:the-infinite-eye"
+                ],
+                "priority": 10,
+                "value": {
+                    "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.GlimpseWeakness",
+                    "value": "glimpse-weakness"
+                }
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.psychic.dedication.psiCantrips",
+                "predicate": [
+                    "feature:the-oscillating-wave"
+                ],
+                "priority": 10,
+                "value": {
+                    "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.ThermalStasis",
+                    "value": "thermal-stasis"
+                }
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.psychic.dedication.psiCantrips",
+                "predicate": [
+                    "feature:the-silent-whisper"
+                ],
+                "priority": 10,
+                "value": {
+                    "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.ForbiddenThought",
+                    "value": "forbidden-thought"
+                }
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.psychic.dedication.psiCantrips",
+                "predicate": [
+                    "feature:the-tangible-dream"
+                ],
+                "priority": 10,
+                "value": {
+                    "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.ImaginaryWeapon",
+                    "value": "imaginary-weapon"
+                }
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.psychic.dedication.psiCantrips",
+                "predicate": [
+                    "feature:the-unbound-step"
+                ],
+                "priority": 10,
+                "value": {
+                    "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.DistortionLens",
+                    "value": "distortion-lens"
+                }
+            },
+            {
                 "adjustName": false,
                 "choices": "flags.pf2e.psychic.dedication.psiCantrips",
                 "flag": "dedicationCantrip",

--- a/packs/feats/psychic-dedication.json
+++ b/packs/feats/psychic-dedication.json
@@ -42,6 +42,13 @@
                 "value": 1
             },
             {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.psychic.dedication.psiCantrips",
+                "priority": 10,
+                "value": []
+            },
+            {
                 "key": "GrantItem",
                 "uuid": "Compendium.pf2e.classfeatures.Item.Conscious Mind"
             },


### PR DESCRIPTION
Closes #14476

The Choice Sets in each conscious mind and Psi Development were not checking if the predicates set in `flags.pf2e.psychic.dedication.psiCantrips` were satisfied. I've opted for a different approach, where Psychic Dedication sets up the previously mentioned flag as an empty array, and then each conscious mind adds its standard cantrips to this array depending on whether or not they've been chosen before. Then, Psi Development will also add to this array depending on your choice of conscious mind.

After testing, this works as expected, with the user having the choice of two standard cantrips when they take the dedication, and then when they take Psi Development they can choose between the surface cantrip and the standard cantrip they didn't take initially.