### PR TITLE
Begin converting deprecated select handlebars helper to selectOptions

### DIFF
--- a/static/templates/actors/character/tabs/pfs.hbs
+++ b/static/templates/actors/character/tabs/pfs.hbs
@@ -17,11 +17,7 @@
     <section class="faction">
         <label class="details-label" for="{{options.id}}-pfs-current-faction">{{localize "PF2E.PFS.CurrentFaction"}}</label>
         <select id="{{options.id}}-pfs-current-faction" name="system.pfs.currentFaction">
-            {{#select data.pfs.currentFaction}}
-                {{#each pfsFactions as |label key|}}
-                    <option value="{{key}}">{{localize label}}</option>
-                {{/each}}
-            {{/select}}
+            {{selectOptions pfsFactions selected=data.pfs.currentFaction localize=true}}
         </select>
     </section>
     <section class="reputations">

--- a/static/templates/actors/familiar/sheet.hbs
+++ b/static/templates/actors/familiar/sheet.hbs
@@ -25,12 +25,12 @@
                 <div>
                     <label for="{{document.uuid}}-master"><strong>{{localize "PF2E.Familiar.Master"}}</strong></label>
                     <select id="{{document.uuid}}-master" name="system.master.id">
-                        {{#select master.id}}
-                            <option value="">{{localize "PF2E.Familiar.SelectMaster"}}</option>
-                            {{#each masters as |eligible|}}
-                                <option value="{{eligible.id}}">{{eligible.name}}</option>
-                            {{/each}}
-                        {{/select}}
+                        {{selectOptions
+                            masters
+                            selected=master.id
+                            valueAttr="id"
+                            labelAttr="name"
+                            blank=(localize "PF2E.Familiar.SelectMaster")}}
                     </select>
                 </div>
             </div>
@@ -183,11 +183,7 @@
                         <div class="detail">
                             <label for="{{document.uuid}}-attribute">{{localize "PF2E.Familiar.MasterSpellcastingAbility"}}</label>
                             <select id="{{document.uuid}}-attribute" name="system.master.ability">
-                                {{#select data.master.ability}}
-                                    {{#each attributes as |label slug|}}
-                                        <option value="{{slug}}">{{localize label}}</option>
-                                    {{/each}}
-                                {{/select}}
+                                {{selectOptions attributes selected=data.master.ability localize=true}}
                             </select>
                         </div>
                     </div>

--- a/static/templates/actors/hazard/partials/header.hbs
+++ b/static/templates/actors/hazard/partials/header.hbs
@@ -24,11 +24,7 @@
         {{#if editing}}
             <template class="traits-extra">
                 <select class="tag rarity" name="system.traits.rarity" value="{{data.traits.rarity}}">
-                    {{#select data.traits.rarity}}
-                        {{#each rarity as |label key|}}
-                            <option value="{{key}}">{{localize label}}</option>
-                        {{/each}}
-                    {{/select}}
+                    {{selectOptions rarity selected=data.traits.rarity localize=true}}
                 </select>
                 <select class="tag" name="system.details.isComplex" data-dtype="Boolean">
                     {{#select data.details.isComplex}}

--- a/static/templates/actors/npc/partials/header.hbs
+++ b/static/templates/actors/npc/partials/header.hbs
@@ -26,19 +26,11 @@
         <div class="tags paizo-style">
             {{!-- TRAITS --}}
             <select class="tag rarity {{data.traits.rarity}}" data-property="system.traits.rarity">
-                {{#select data.traits.rarity}}
-                    {{#each rarity as |label key|}}
-                        <option value="{{key}}">{{localize label}}</option>
-                    {{/each}}
-                {{/select}}
+                {{selectOptions rarity selected=data.traits.rarity localize=true}}
             </select>
 
             <select class="tag size" data-property="system.traits.size.value">
-                {{#select data.traits.size.value}}
-                    {{#each actorSizes as |label key|}}
-                        <option value="{{key}}">{{localize label}}</option>
-                    {{/each}}
-                {{/select}}
+                {{selectOptions actorSizes selected=data.traits.size.value localize=true}}
             </select>
         </div>
         {{#if editable}}

--- a/static/templates/actors/npc/simple-sheet.hbs
+++ b/static/templates/actors/npc/simple-sheet.hbs
@@ -167,18 +167,10 @@
             <div class="flexrow">
                 <div class="flexrow tags paizo-style">
                     <select class="rarity-select traits-list-item tag rarity {{data.traits.rarity}}" data-property="system.traits.rarity">
-                        {{#select data.traits.rarity}}
-                            {{#each rarity as |label key|}}
-                                <option value="{{key}}">{{localize label}}</option>
-                            {{/each}}
-                        {{/select}}
+                        {{selectOptions rarity selected=data.traits.rarity localize=true}}
                     </select>
                     <select class="size-select traits-list-item tag size" data-property="system.traits.size.value">
-                        {{#select data.traits.size.value}}
-                            {{#each actorSizes as |label key|}}
-                                <option value="{{key}}">{{localize label}}</option>
-                            {{/each}}
-                        {{/select}}
+                        {{selectOptions actorSizes selected=data.traits.size.value localize=true}}
                     </select>
                 </div>
             </div>

--- a/static/templates/items/action-sidebar.hbs
+++ b/static/templates/items/action-sidebar.hbs
@@ -2,12 +2,7 @@
     <div class="form-group">
         <label>{{localize "PF2E.Category"}}</label>
         <select name="system.category">
-            {{#select data.category}}
-                <option value="">{{localize "PF2E.Item.Action.Category.None"}}</option>
-                {{#each categories as |name type|}}
-                    <option value="{{type}}">{{localize name}}</option>
-                {{/each}}
-            {{/select}}
+            {{selectOptions categories selected=data.category blank="PF2E.Item.Action.Category.None" localize=true}}
         </select>
     </div>
 </div>

--- a/static/templates/items/ancestry-sidebar.hbs
+++ b/static/templates/items/ancestry-sidebar.hbs
@@ -7,11 +7,7 @@
     <div class="form-group">
         <label>{{localize "PF2E.SizeLabel"}}</label>
         <select name="system.size">
-            {{#select data.size}}
-                {{#each sizes}}
-                    <option value="{{@key}}">{{localize this.label}}</option>
-                {{/each}}
-            {{/select}}
+            {{selectOptions sizes selected=data.size labelAttr="label" localize=true}}
         </select>
     </div>
 

--- a/static/templates/items/armor-details.hbs
+++ b/static/templates/items/armor-details.hbs
@@ -4,11 +4,7 @@
     <div class="form-group">
         <label for="{{fieldIdPrefix}}category">{{localize "PF2E.Category"}}</label>
         <select id="{{fieldIdPrefix}}category" data-property="system.category">
-            {{#select data.category}}
-                {{#each categories as |name type|}}
-                    <option value="{{type}}">{{localize name}}</option>
-                {{/each}}
-            {{/select}}
+            {{selectOptions categories selected=data.category localize=true}}
         </select>
     </div>
 
@@ -16,24 +12,14 @@
         <div class="form-group">
             <label for="{{fieldIdPrefix}}group">{{localize "PF2E.ArmorGroupLabel"}}</label>
             <select id="{{fieldIdPrefix}}group" data-property="system.group">
-                {{#select item.group}}
-                    <option value=""></option>
-                    {{#each groups as |name type|}}
-                        <option value="{{type}}">{{localize name}}</option>
-                    {{/each}}
-                {{/select}}
+                {{selectOptions groups selected=item.group blank="" localize=true}}
             </select>
         </div>
 
         <div class="form-group">
             <label for="{{fieldIdPrefix}}base">{{localize "PF2E.Item.Physical.Base"}}</label>
             <select id="{{fieldIdPrefix}}base" data-property="system.baseItem">
-                {{#select item.baseType}}
-                    <option value=""></option>
-                    {{#each baseTypes as |name slug|}}
-                        <option value="{{slug}}">{{localize name}}</option>
-                    {{/each}}
-                {{/select}}
+                {{selectOptions baseTypes selected=item.baseType blank="" localize=true}}
             </select>
         </div>
     {{/unless}}
@@ -200,12 +186,13 @@
                     {{disabled slot.disabled}}
                     {{#if slot.readOnly}}class="readonly"{{/if}}
                 >
-                    {{#select slot.slug}}
-                        <option value=""></option>
-                        {{#each @root.runeTypes.property as |rune|}}
-                            <option value="{{rune.slug}}">{{localize rune.name}}</option>
-                        {{/each}}
-                    {{/select}}
+                    {{selectOptions
+                        @root.runeTypes.property
+                        selected=slot.slug
+                        valueAttr="slug"
+                        labelAttr="name"
+                        blank=""
+                        localize=true}}
                 </select>
             </div>
         {{/each}}

--- a/static/templates/items/physical-sidebar.hbs
+++ b/static/templates/items/physical-sidebar.hbs
@@ -22,11 +22,7 @@
         <div class="form-group">
             <label for="{{fieldIdPrefix}}usage">{{localize "PF2E.Usage"}}</label>
             <select name="system.usage.value" id="{{fieldIdPrefix}}usage">
-                {{#select data.usage.value}}
-                    {{#each usages as |label key|}}
-                        <option value="{{key}}">{{localize label}}</option>
-                    {{/each}}
-                {{/select}}
+                {{selectOptions usages selected=data.usage.value localize=true}}
             </select>
         </div>
     {{/if}}
@@ -43,22 +39,14 @@
             data-dtype="Number"
             {{disabled bulkDisabled}}
         >
-            {{#select data.bulk.value}}
-                {{#each bulks as |bulk|}}
-                    <option value="{{bulk.value}}">{{bulk.label}}</option>
-                {{/each}}
-            {{/select}}
+            {{selectOptions bulks selected=data.bulk.value valueAttr="value" labelAttr="label"}}
         </select>
     </div>
 
     <div class="form-group">
         <label for="{{fieldIdPrefix}}size">{{localize "PF2E.Size"}}</label>
         <select id="{{fieldIdPrefix}}size" data-property="system.size">
-            {{#select data.size}}
-                {{#each sizes as |name value|}}
-                    <option value="{{value}}">{{localize name}}</option>
-                {{/each}}
-            {{/select}}
+            {{selectOptions sizes selected=data.size localize=true}}
         </select>
     </div>
 
@@ -88,12 +76,7 @@
         <div class="form-group">
             <label for="{{fieldIdPrefix}}stack-group">{{localize "PF2E.StackGroupLabel"}}</label>
             <select name="system.stackGroup" id="{{filedIdPrefix}}stack-group">
-                {{#select data.stackGroup}}
-                    <option value="">{{localize "None"}}</option>
-                    {{#each stackGroups as |name type|}}
-                        <option value="{{type}}">{{localize name}}</option>
-                    {{/each}}
-                {{/select}}
+                {{selectOptions stackGroups selected=data.stackGroup blank="None" localize=true}}
             </select>
         </div>
     {{/if}}
@@ -123,9 +106,9 @@
 
     {{#if otherTags}}
         <ol class="item-tags tags">
-                {{#each otherTags as |tag|}}
-                    <li class="tag tag_transparent">{{tag.label}}</li>
-                {{/each}}
+            {{#each otherTags as |tag|}}
+                <li class="tag tag_transparent">{{tag.label}}</li>
+            {{/each}}
         </ol>
     {{/if}}
 </div>

--- a/static/templates/items/rules-panel.hbs
+++ b/static/templates/items/rules-panel.hbs
@@ -49,11 +49,7 @@
         </div>
         <div class="create-rule-element">
             <select data-action="select-rule-element">
-                {{#select rules.selection.selected}}
-                    {{#each rules.selection.types as |value key|}}
-                        <option value="{{key}}">{{value}}</option>
-                    {{/each}}
-                {{/select}}
+                {{selectOptions rules.selection.types selected=rules.selection.selected}}
             </select>
             <a data-action="add-rule-element"><i class="fa-solid fa-plus"></i> {{localize "PF2E.Item.Rules.New"}}</a>
         </div>

--- a/static/templates/items/sheet.hbs
+++ b/static/templates/items/sheet.hbs
@@ -38,11 +38,7 @@
             <template class="traits-extra">
                 {{#if item.rarity}}
                     <select class="tag rarity {{item.rarity}}" data-property="system.traits.rarity">
-                        {{#select item.rarity}}
-                            {{#each rarities as |label key|}}
-                                <option value="{{key}}">{{localize label}}</option>
-                            {{/each}}
-                        {{/select}}
+                        {{selectOptions rarities selected=item.rarity localize=true}}
                     </select>
                 {{/if}}
             </template>

--- a/static/templates/items/weapon-details.hbs
+++ b/static/templates/items/weapon-details.hbs
@@ -4,33 +4,19 @@
     <div class="form-group">
         <label for="{{fieldIdPrefix}}category">{{localize "PF2E.Category"}}</label>
         <select name="system.category" id="{{fieldIdPrefix}}category">
-            {{#select data.category}}
-                {{#each categories as |label slug|}}
-                    <option value="{{slug}}">{{label}}</option>
-                {{/each}}
-            {{/select}}
+            {{selectOptions categories selected=data.category}}
         </select>
     </div>
     <div class="form-group">
         <label for="{{fieldIdPrefix}}group">{{localize "PF2E.WeaponGroupLabel"}}</label>
         <select name="system.group" id="{{fieldIdPrefix}}group">
-            {{#select data.group}}
-                <option value=""></option>
-                {{#each groups as |name type|}}
-                    <option value="{{type}}">{{localize name}}</option>
-                {{/each}}
-            {{/select}}
+            {{selectOptions groups selected=data.group blank="" localize=true}}
         </select>
     </div>
     <div class="form-group">
         <label for="{{fieldIdPrefix}}base">{{localize "PF2E.WeaponBaseLabel"}}</label>
         <select id="{{fieldIdPrefix}}base" data-property="system.baseItem">
-            {{#select data.baseItem}}
-                <option value=""></option>
-                {{#each baseTypes as |label slug|}}
-                    <option value="{{slug}}">{{label}}</option>
-                {{/each}}
-            {{/select}}
+            {{selectOptions baseTypes selected=data.baseItem blank=""}}
         </select>
     </div>
     <div class="form-group">
@@ -53,12 +39,7 @@
         <div class="form-group">
             <label for="{{fieldIdPrefix}}reload">{{localize "PF2E.WeaponReloadLabel"}}</label>
             <select name="system.reload.value" id="{{fieldIdPrefix}}reload">
-                {{#select data.reload.value}}
-                    <option value=""></option>
-                    {{#each weaponReload as |name type|}}
-                        <option value="{{type}}">{{localize name}}</option>
-                    {{/each}}
-                {{/select}}
+                {{selectOptions weaponReload selected=data.reload.value blank="" localize=true}}
             </select>
         </div>
     {{/if}}
@@ -135,12 +116,13 @@
                     {{disabled slot.disabled}}
                     {{#if @root.item.isSpecific}}class="readonly"{{/if}}
                 >
-                    {{#select slot.slug}}
-                        <option value=""></option>
-                        {{#each @root.runeTypes.property as |rune|}}
-                            <option value="{{rune.slug}}">{{localize rune.name}}</option>
-                        {{/each}}
-                    {{/select}}
+                    {{selectOptions
+                        @root.runeTypes.property
+                        selected=slot.slug
+                        valueAttr="slug"
+                        labelAttr="name"
+                        blank=""
+                        localize=true}}
                 </select>
             </div>
         {{/each}}
@@ -182,12 +164,7 @@
                 value="{{data.damage.dice}}"
             />
             <select data-property="system.damage.die">
-                {{#select data.damage.die}}
-                    <option value=""></option>
-                    {{#each damageDie as |name type|}}
-                        <option value="{{type}}">{{localize name}}</option>
-                    {{/each}}
-                {{/select}}
+                {{selectOptions damageDie selected=data.damage.die blank="" localize=true}}
             </select>
 
             <select data-property="system.damage.damageType">


### PR DESCRIPTION
It doesn't seem possible to directly convert all of them. The ones that are arrays (Proficiency ranks for example) require an Object.entries() first (see https://github.com/foundryvtt/foundryvtt/issues/10691). The ones that have additional non-blank option entries cannot be converted, and neither can those that have hardcoded select options or labels generated at render time.

There are more that can be converted now though rather than just these.