### PR TITLE
Allow ItemAlteration Hardness to use non-integer alteration values

### DIFF
--- a/src/module/rules/rule-element/item-alteration/alteration.ts
+++ b/src/module/rules/rule-element/item-alteration/alteration.ts
@@ -236,7 +236,7 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
                     const system = data.item.system;
                     const value = data.alteration.value;
                     const newValue = AELikeRuleElement.getNewValue(this.mode, system.hardness, value);
-                    system.hardness = Math.max(Math.floor(newValue), 0);
+                    system.hardness = Math.max(Math.trunc(newValue), 0);
                     this.#adjustCreatureShieldData(data.item);
                 }
                 return;

--- a/src/module/rules/rule-element/item-alteration/alteration.ts
+++ b/src/module/rules/rule-element/item-alteration/alteration.ts
@@ -235,8 +235,8 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
                 if (validator.isValid(data)) {
                     const system = data.item.system;
                     const value = data.alteration.value;
-                    const newValue = Math.floor(AELikeRuleElement.getNewValue(this.mode, system.hardness, value));
-                    system.hardness = Math.max(newValue, 0);
+                    const newValue = AELikeRuleElement.getNewValue(this.mode, system.hardness, value);
+                    system.hardness = Math.max(Math.trunc(newValue), 0);
                     this.#adjustCreatureShieldData(data.item);
                 }
                 return;

--- a/src/module/rules/rule-element/item-alteration/alteration.ts
+++ b/src/module/rules/rule-element/item-alteration/alteration.ts
@@ -235,7 +235,7 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
                 if (validator.isValid(data)) {
                     const system = data.item.system;
                     const value = data.alteration.value;
-                    const newValue = AELikeRuleElement.getNewValue(this.mode, system.hardness, value);
+                    const newValue = Math.floor(AELikeRuleElement.getNewValue(this.mode, system.hardness, value));
                     system.hardness = Math.max(newValue, 0);
                     this.#adjustCreatureShieldData(data.item);
                 }

--- a/src/module/rules/rule-element/item-alteration/alteration.ts
+++ b/src/module/rules/rule-element/item-alteration/alteration.ts
@@ -236,7 +236,7 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
                     const system = data.item.system;
                     const value = data.alteration.value;
                     const newValue = AELikeRuleElement.getNewValue(this.mode, system.hardness, value);
-                    system.hardness = Math.max(Math.trunc(newValue), 0);
+                    system.hardness = Math.max(Math.floor(newValue), 0);
                     this.#adjustCreatureShieldData(data.item);
                 }
                 return;

--- a/src/module/rules/rule-element/item-alteration/schemas.ts
+++ b/src/module/rules/rule-element/item-alteration/schemas.ts
@@ -292,7 +292,7 @@ const ITEM_ALTERATION_VALIDATORS = {
             required: true,
             choices: ["add", "downgrade", "multiply", "override", "remove", "subtract", "upgrade"],
         }),
-        value: new fields.NumberField({ required: true, nullable: false, min: 0 } as const),
+        value: new fields.NumberField({ required: true, nullable: false, min: -20, max: 20 } as const),
     }),
     "hp-max": new ItemAlterationValidator({
         itemType: new fields.StringField({ required: true, choices: Array.from(PHYSICAL_ITEM_TYPES) }),

--- a/src/module/rules/rule-element/item-alteration/schemas.ts
+++ b/src/module/rules/rule-element/item-alteration/schemas.ts
@@ -292,7 +292,7 @@ const ITEM_ALTERATION_VALIDATORS = {
             required: true,
             choices: ["add", "downgrade", "multiply", "override", "remove", "subtract", "upgrade"],
         }),
-        value: new fields.NumberField({ required: true, integer: true, nullable: false, positive: true } as const),
+        value: new fields.NumberField({ required: true, integer: false, nullable: false, positive: true } as const),
     }),
     "hp-max": new ItemAlterationValidator({
         itemType: new fields.StringField({ required: true, choices: Array.from(PHYSICAL_ITEM_TYPES) }),

--- a/src/module/rules/rule-element/item-alteration/schemas.ts
+++ b/src/module/rules/rule-element/item-alteration/schemas.ts
@@ -292,7 +292,7 @@ const ITEM_ALTERATION_VALIDATORS = {
             required: true,
             choices: ["add", "downgrade", "multiply", "override", "remove", "subtract", "upgrade"],
         }),
-        value: new fields.NumberField({ required: true, integer: false, nullable: false, positive: true } as const),
+        value: new fields.NumberField({ required: true, nullable: false, min: 0 } as const),
     }),
     "hp-max": new ItemAlterationValidator({
         itemType: new fields.StringField({ required: true, choices: Array.from(PHYSICAL_ITEM_TYPES) }),


### PR DESCRIPTION
Closes #13910 

Uses Math.trunc() to ensure Hardness is always an integer and abides by the round down rule.