### PR TITLE
Fix status effect icons

### DIFF
--- a/src/module/active-effect.ts
+++ b/src/module/active-effect.ts
@@ -1,18 +1,15 @@
 import type { ActorPF2e } from "@actor";
 import type { ItemPF2e } from "@item";
 
-/** Disable Active Effects */
 export class ActiveEffectPF2e<TParent extends ActorPF2e | ItemPF2e | null> extends ActiveEffect<TParent> {
-    constructor(
-        data: DeepPartial<foundry.documents.ActiveEffectSource>,
-        context?: DocumentConstructionContext<TParent>,
-    ) {
-        data.disabled = true;
-        data.transfer = false;
-        super(data, context);
-    }
+    protected override async _preCreate(
+        data: this["_source"],
+        options: DocumentModificationContext<TParent>,
+        user: User,
+    ): Promise<boolean | void> {
+        // Only allow the death overlay effect
+        if (!data.statuses.includes("dead")) return false;
 
-    static override async createDocuments<T extends foundry.abstract.Document>(this: ConstructorOf<T>): Promise<T[]> {
-        return [];
+        return super._preCreate(data, options, user);
     }
 }

--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -249,10 +249,7 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
     }
 
     get isDead(): boolean {
-        const deathIcon = game.settings.get("pf2e", "deathIcon");
-        if (this.token) return this.token.overlayEffect === deathIcon;
-        const tokens = this.getActiveTokens(true, true);
-        return tokens.length > 0 && tokens.every((t) => t.overlayEffect === deathIcon);
+        return this.statuses.has("dead");
     }
 
     get modeOfBeing(): ModeOfBeing {
@@ -312,7 +309,7 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
 
         return R.uniqueBy(
             [super.temporaryEffects, fromConditions, fromEffects, this.synthetics.tokenEffectIcons].flat(),
-            (e) => e.icon,
+            (e) => e.img,
         );
     }
 

--- a/src/module/actor/creature/document.ts
+++ b/src/module/actor/creature/document.ts
@@ -146,9 +146,7 @@ abstract class CreaturePF2e<
         if (hitPoints.max > 0 && hitPoints.value === 0 && !this.hasCondition("dying", "unconscious")) {
             return true;
         }
-
-        const token = this.token ?? this.getActiveTokens(false, true).shift();
-        return !!token?.hasStatusEffect("dead");
+        return this.statuses.has("dead");
     }
 
     /** Whether the creature emits sound: overridable by AE-like */

--- a/src/module/actor/token-effect.ts
+++ b/src/module/actor/token-effect.ts
@@ -29,8 +29,16 @@ export class TokenEffect implements TemporaryEffect {
         return this.#effect.name;
     }
 
-    get icon(): ImageFilePath {
+    get img(): ImageFilePath {
         return this.#effect.img;
+    }
+
+    get type(): string {
+        return this.#effect.type;
+    }
+
+    get system(): AbstractEffectPF2e["system"] {
+        return this.#effect.system;
     }
 
     get changes(): never[] {
@@ -76,6 +84,10 @@ export class TokenEffect implements TemporaryEffect {
 
     get origin(): ItemUUID {
         return this.#effect.uuid;
+    }
+
+    get _stats(): AbstractEffectPF2e["_stats"] {
+        return this.#effect._stats;
     }
 
     getFlag(scope: string, flag: string): unknown {

--- a/src/module/canvas/status-effects.ts
+++ b/src/module/canvas/status-effects.ts
@@ -95,15 +95,15 @@ export class StatusEffects {
     static #updateStatusIcons(): void {
         const iconTheme = game.settings.get("pf2e", "statusEffectType");
         const directory = iconTheme === "default" ? "conditions" : "conditions-2";
-        CONFIG.statusEffects = Object.entries(CONFIG.PF2E.statusEffects.conditions).map(([id, label]) => ({
+        CONFIG.statusEffects = Object.entries(CONFIG.PF2E.statusEffects.conditions).map(([id, name]) => ({
             id,
-            label,
-            icon: `systems/pf2e/icons/${directory}/${id}.webp` as const,
+            name,
+            img: `systems/pf2e/icons/${directory}/${id}.webp` as const,
         }));
         CONFIG.statusEffects.push({
             id: "dead",
-            label: "PF2E.Actor.Dead",
-            icon: CONFIG.controlIcons.defeated,
+            name: "PF2E.Actor.Dead",
+            img: CONFIG.controlIcons.defeated,
         });
     }
 
@@ -121,6 +121,7 @@ export class StatusEffects {
         iconGrid.append(titleBar);
 
         const statusIcons = iconGrid.querySelectorAll<HTMLImageElement>(".effect-control");
+        const deathIcon = game.settings.get("pf2e", "deathIcon");
 
         for (const icon of statusIcons) {
             // Replace the img element with a picture element, which can display ::after content
@@ -145,7 +146,7 @@ export class StatusEffects {
             if (hideIcon) picture.style.display = "none";
 
             const affecting = affectingConditions.filter((c) => c.slug === slug);
-            if (affecting.length > 0 || iconSrc === token.document.overlayEffect) {
+            if (affecting.length > 0 || (iconSrc === deathIcon && token.actor?.isDead)) {
                 picture.classList.add("active");
             }
 
@@ -220,9 +221,10 @@ export class StatusEffects {
             return;
         }
 
-        const tokensAndActors = R.uniqBy(
-            R.compact(
+        const tokensAndActors = R.uniqueBy(
+            R.filter(
                 canvas.tokens.controlled.map((t): [TokenPF2e, ActorPF2e] | null => (t.actor ? [t, t.actor] : null)),
+                R.isTruthy,
             ),
             ([, a]) => a,
         );
@@ -269,9 +271,6 @@ export class StatusEffects {
             return;
         }
 
-        const imgElement = control.querySelector("img");
-        const iconSrc = imgElement?.getAttribute("src") as ImageFilePath | null | undefined;
-
         const affecting = actor?.conditions
             .bySlug(slug, { active: true, temporary: false })
             .find((c) => !c.system.references.parent);
@@ -281,16 +280,14 @@ export class StatusEffects {
             if (objectHasKey(CONFIG.PF2E.conditionTypes, slug)) {
                 const newCondition = game.pf2e.ConditionManager.getCondition(slug).toObject();
                 await token.actor?.createEmbeddedDocuments("Item", [newCondition]);
-            } else if (iconSrc && (event.shiftKey || control.dataset.statusId === "dead")) {
-                await token.toggleEffect(iconSrc, { overlay: true, active: true });
+            } else if (slug === "dead") {
+                await token.actor?.toggleStatusEffect(slug, { overlay: true });
             }
         } else if (event.type === "contextmenu") {
             if (affecting) conditionIds.push(affecting.id);
 
             if (conditionIds.length > 0) {
                 await token.actor?.deleteEmbeddedDocuments("Item", conditionIds);
-            } else if (token.document.overlayEffect === iconSrc) {
-                await token.document.update({ overlayEffect: "" });
             }
         }
     }

--- a/src/module/encounter/combatant.ts
+++ b/src/module/encounter/combatant.ts
@@ -179,10 +179,7 @@ class CombatantPF2e<
 
         await this.update({ defeated: to });
         if (overlayIcon) {
-            await this.token?.object?.toggleEffect(game.settings.get("pf2e", "deathIcon"), {
-                active: to,
-                overlay: true,
-            });
+            await this.token?.actor?.toggleStatusEffect("dead", { overlay: true });
         }
 
         /** Remove this combatant's token as a target if it died */

--- a/src/module/scene/token-document/document.ts
+++ b/src/module/scene/token-document/document.ts
@@ -29,7 +29,7 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
 
     /** Check actor for effects found in `CONFIG.specialStatusEffects` */
     override hasStatusEffect(statusId: string): boolean {
-        if (statusId === "dead") return this.overlayEffect === CONFIG.controlIcons.defeated;
+        if (statusId === "dead") return !!this.actor?.statuses.has("dead");
 
         const actor = this.actor;
         if (!actor || !game.pf2e.settings.rbv) {

--- a/types/foundry/client/config.d.ts
+++ b/types/foundry/client/config.d.ts
@@ -601,8 +601,8 @@ declare global {
 
     interface StatusEffect {
         id: string;
-        label: string;
-        icon: ImageFilePath | VideoFilePath;
+        name: string;
+        img: ImageFilePath | VideoFilePath;
     }
 
     interface FontFamilyDefinition {

--- a/types/foundry/client/data/documents/actor.d.ts
+++ b/types/foundry/client/data/documents/actor.d.ts
@@ -137,6 +137,23 @@ declare global {
         }): Promise<Combat | null>;
 
         /**
+         * Toggle a configured status effect for the Actor.
+         * @param   statusId                A status effect ID defined in CONFIG.statusEffects
+         * @param   [options={}]            Additional options which modify how the effect is created
+         * @param   [options.active]        Force the effect to be active or inactive regardless of its current state
+         * @param   [options.overlay=false] Display the toggled effect as an overlay
+         * @returns A promise which resolves to one of the following values:
+         *                                 - ActiveEffect if a new effect need to be created
+         *                                 - true if was already an existing effect
+         *                                 - false if an existing effect needed to be removed
+         *                                 - undefined if no changes need to be made
+         */
+        toggleStatusEffect(
+            statusId: string,
+            options?: { active?: boolean; overlay?: boolean },
+        ): Promise<ActiveEffect<this> | boolean | void>;
+
+        /**
          * Request wildcard token images from the server and return them.
          * @param actorId   The actor whose prototype token contains the wildcard image path.
          * @param [options]

--- a/types/foundry/client/pixi/placeables/token.d.ts
+++ b/types/foundry/client/pixi/placeables/token.d.ts
@@ -482,23 +482,6 @@ declare global {
         toggleCombat(combat?: Combat): Promise<this>;
 
         /**
-         * Toggle an active effect by its texture path.
-         * Copy the existing Array in order to ensure the update method detects the data as changed.
-         * @param effect  The texture file-path of the effect icon to toggle on the Token.
-         * @param [options]      Additional optional arguments which configure how the effect is handled.
-         * @param [options.active]    Force a certain active state for the effect
-         * @param [options.overlay]   Whether to set the effect as the overlay effect?
-         * @return Was the texture applied (true) or removed (false)
-         */
-        toggleEffect(
-            effect: StatusEffect | ImageFilePath,
-            { active, overlay }?: { active?: boolean; overlay?: boolean },
-        ): Promise<boolean>;
-
-        /** A helper function to toggle the overlay status icon on the Token */
-        protected _toggleOverlayEffect(texture: ImageFilePath, { active }: { active: boolean }): Promise<this>;
-
-        /**
          * Toggle the visibility state of any Tokens in the currently selected set
          * @return A Promise which resolves to the updated Token documents
          */

--- a/types/foundry/common/documents/active-effect.d.ts
+++ b/types/foundry/common/documents/active-effect.d.ts
@@ -1,6 +1,6 @@
 import type { Document, DocumentMetadata } from "../abstract/module.d.ts";
-import type { BaseActor, BaseCombat, BaseItem, BaseUser } from "./module.d.ts";
 import type * as fields from "../data/fields.d.ts";
+import type { BaseActor, BaseItem, BaseUser } from "./module.d.ts";
 
 /**
  * The ActiveEffect document model.
@@ -66,6 +66,8 @@ type ActiveEffectSchema = {
             priority: fields.NumberField;
         }>
     >;
+    system: fields.TypeDataField;
+    type: fields.StringField<string, string, false, true, true>;
     disabled: fields.BooleanField;
     duration: fields.SchemaField<{
         startTime: fields.NumberField<number, number, false, true, true>;
@@ -77,12 +79,13 @@ type ActiveEffectSchema = {
         startTurn: fields.NumberField;
     }>;
     description: fields.HTMLField;
-    icon: fields.FilePathField<ImageFilePath>;
+    img: fields.FilePathField<ImageFilePath>;
     origin: fields.StringField<ActorUUID | ItemUUID, ActorUUID | ItemUUID, false, true, true>;
     tint: fields.ColorField;
     transfer: fields.BooleanField;
     statuses: fields.SetField<fields.StringField<string, string, true, false, false>>;
     flags: fields.ObjectField<DocumentFlags>;
+    _stats: fields.DocumentStatsField;
 };
 
 export type ActiveEffectSource = SourceFromSchema<ActiveEffectSchema>;

--- a/types/foundry/common/documents/token.d.ts
+++ b/types/foundry/common/documents/token.d.ts
@@ -75,8 +75,6 @@ type TokenSchema = {
     effects: fields.ArrayField<
         fields.FilePathField<ImageFilePath | VideoFilePath, ImageFilePath | VideoFilePath, true, false>
     >;
-    /** A single icon path which is displayed as an overlay on the Token */
-    overlayEffect: fields.StringField<ImageFilePath | VideoFilePath | "">;
     /** The opacity of the token image */
     alpha: fields.AlphaField;
     /** Is the Token currently hidden from player view? */


### PR DESCRIPTION
Allows the creation of active effects that carry the "dead" status only. This could be relaxed to allow all statuses registered in `CONFIG.statusEffects` as long as the `overlay` flag is set.
A positive side effect of this change should be that modules that rely on `actor.statuses.has("dead")` should work out of the box now.