### PR TITLE
Fix aura RE form error

### DIFF
--- a/src/module/item/base/sheet/rule-element-form/aura.ts
+++ b/src/module/item/base/sheet/rule-element-form/aura.ts
@@ -130,8 +130,8 @@ class AuraForm extends RuleElementForm<AuraRuleElementSource, AuraRuleElement> {
                 ...e,
                 item: fromUuidSync(e.uuid),
             })),
-            borderColor: border?.color === "user-color" ? userColor : border?.color ?? null,
-            highlightColor: highlight.color === "user-color" ? userColor : highlight?.color,
+            borderColor: border?.color === "user-color" ? userColor : border?.color?.toString() ?? null,
+            highlightColor: highlight.color === "user-color" ? userColor : highlight?.color?.toString(),
             saveTypes: CONFIG.PF2E.saves,
             isImageFile: isImageFilePath(this.rule.appearance?.texture?.src),
         };


### PR DESCRIPTION
The color picker elements are not working correctly so the rule element data gets bricked when the form is used until the next core version. But this fixes a type error introduced by #14497