### PR TITLE
Fix damage dialog rollmode display

### DIFF
--- a/src/module/system/damage/damage.ts
+++ b/src/module/system/damage/damage.ts
@@ -20,7 +20,8 @@ export class DamagePF2e {
     ): Promise<Rolled<DamageRoll> | null> {
         const outcome = context.outcome ?? null;
 
-        context.rollMode ??= (context.secret ? "blindroll" : undefined) ?? game.settings.get("core", "rollMode");
+        context.rollMode = context.secret ? "blindroll" : context.rollMode ?? game.settings.get("core", "rollMode");
+
         context.createMessage ??= true;
 
         // Change default roll mode to blind GM roll if the "secret" option is specified

--- a/src/module/system/damage/damage.ts
+++ b/src/module/system/damage/damage.ts
@@ -20,8 +20,7 @@ export class DamagePF2e {
     ): Promise<Rolled<DamageRoll> | null> {
         const outcome = context.outcome ?? null;
 
-        context.rollMode = context.secret ? "blindroll" : context.rollMode ?? game.settings.get("core", "rollMode");
-
+        context.rollMode ??= (context.secret ? "blindroll" : undefined) ?? game.settings.get("core", "rollMode");
         context.createMessage ??= true;
 
         // Change default roll mode to blind GM roll if the "secret" option is specified

--- a/src/module/system/damage/dialog.ts
+++ b/src/module/system/damage/dialog.ts
@@ -141,7 +141,7 @@ class DamageModifierDialog extends Application {
             " + ",
         );
 
-        const currentRollMode = game.settings.get("core", "rollMode");
+        const currentRollMode = this.context?.rollMode ?? game.settings.get("core", "rollMode");
 
         type DamageDicePF2eWithOverride = DamageDicePF2e & { override: NonNullable<DamageDicePF2e["override"]> };
 

--- a/src/module/system/damage/dialog.ts
+++ b/src/module/system/damage/dialog.ts
@@ -141,6 +141,8 @@ class DamageModifierDialog extends Application {
             " + ",
         );
 
+        const currentRollMode = game.settings.get("core", "rollMode");
+
         type DamageDicePF2eWithOverride = DamageDicePF2e & { override: NonNullable<DamageDicePF2e["override"]> };
 
         return {
@@ -216,7 +218,7 @@ class DamageModifierDialog extends Application {
                 R.pick(CONFIG.PF2E.damageCategories, Array.from(DAMAGE_CATEGORIES_UNIQUE)),
             ),
             rollModes: CONFIG.Dice.rollModes,
-            rollMode: this.context?.rollMode,
+            rollMode: currentRollMode,
             showDamageDialogs: game.user.settings.showDamageDialogs,
             formula: formulaTemplate,
         };

--- a/src/module/system/damage/dialog.ts
+++ b/src/module/system/damage/dialog.ts
@@ -141,8 +141,6 @@ class DamageModifierDialog extends Application {
             " + ",
         );
 
-        const currentRollMode = this.context?.rollMode ?? game.settings.get("core", "rollMode");
-
         type DamageDicePF2eWithOverride = DamageDicePF2e & { override: NonNullable<DamageDicePF2e["override"]> };
 
         return {

--- a/src/module/system/damage/dialog.ts
+++ b/src/module/system/damage/dialog.ts
@@ -218,7 +218,7 @@ class DamageModifierDialog extends Application {
                 R.pick(CONFIG.PF2E.damageCategories, Array.from(DAMAGE_CATEGORIES_UNIQUE)),
             ),
             rollModes: CONFIG.Dice.rollModes,
-            rollMode: currentRollMode,
+            rollMode: this.context?.rollMode ?? game.settings.get("core", "rollMode"),
             showDamageDialogs: game.user.settings.showDamageDialogs,
             formula: formulaTemplate,
         };


### PR DESCRIPTION
Closes #14439

This sets the initial roll mode of Damage Rolls from undefined to the current user default. Undefined was falling back on the current user default anyway but displaying as Public Roll, leading to assumptions from users.

~~Also changes the secret rollMode handling a bit in damage.ts to compensate for undefined no longer being the default pass-through.~~