### PR TITLE
Fix parsing damage rolls with `MathTerms` and remove deprecated `async` option for roll evaluation

### DIFF
--- a/roll-grammar.peggy
+++ b/roll-grammar.peggy
@@ -49,14 +49,14 @@ Term = head:TermOperand tail:(_ ("*" / "/") _ TermOperand)* {
   }, head);
 };
 
-TermOperand = DiceTerm / MathTerm / Grouping / FlavoredNumber / Number;
+TermOperand = DiceTerm / FunctionTerm / Grouping / FlavoredNumber / Number;
 
-MathTerm = fn:Identifier "(" _ head:Expression? _ tail:(_ "," _ @Expression)* _ ")" {
+FunctionTerm = fn:Identifier "(" _ head:Expression? _ tail:(_ "," _ @Expression)* _ ")" {
   const terms = head !== null
     ? [head, ...tail].map((t) => typeof t === "number" ? t.toString() : t.formula)
     : [];
   return {
-    class: "MathTerm",
+    class: "FunctionTerm",
     formula: text(),
     fn,
     terms,
@@ -64,7 +64,7 @@ MathTerm = fn:Identifier "(" _ head:Expression? _ tail:(_ "," _ @Expression)* _ 
   };
 };
 
-DiceTerm = number:(Grouping / MathTerm / Number)? [dD] faces:(Grouping / MathTerm / Number / Identifier) modifiers:Modifiers? flavor:Flavor? {
+DiceTerm = number:(Grouping / FunctionTerm / Number)? [dD] faces:(Grouping / FunctionTerm / Number / Identifier) modifiers:Modifiers? flavor:Flavor? {
   const obj =
     number instanceof Object || faces instanceof Object
       ? {

--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -995,7 +995,7 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
             await Promise.all(
                 damageDice.map(async (dice) => {
                     const formula = `${dice.diceNumber}${dice.dieSize}[${dice.label}]`;
-                    const roll = await new Roll(formula).evaluate({ async: true });
+                    const roll = await new Roll(formula).evaluate();
                     roll._formula = `${dice.diceNumber}${dice.dieSize}`; // remove the label from the main formula
                     await roll.toMessage({
                         flags: { pf2e: { suppressDamageButtons: true } },

--- a/src/module/actor/party/kingdom/model.ts
+++ b/src/module/actor/party/kingdom/model.ts
@@ -120,7 +120,7 @@ class Kingdom extends DataModel<PartyPF2e, KingdomSchema> implements PartyCampai
     /** Perform the collection portion of the upkeep phase */
     async collect(): Promise<void> {
         const { formula, commodities } = calculateKingdomCollectionData(this);
-        const roll = await new Roll(formula).evaluate({ async: true });
+        const roll = await new Roll(formula).evaluate();
         await roll.toMessage(
             {
                 flavor: game.i18n.localize("PF2E.Kingmaker.Kingdom.Resources.Points"),

--- a/src/module/apps/sidebar/chat-log.ts
+++ b/src/module/apps/sidebar/chat-log.ts
@@ -118,7 +118,7 @@ class ChatLogPF2e extends ChatLog<ChatMessagePF2e> {
                     return new Roll(formula, rollData);
                 }
             })();
-            rolls.push(await roll.evaluate({ async: true }));
+            rolls.push(await roll.evaluate());
         }
         chatData.type = CONST.CHAT_MESSAGE_TYPES.ROLL;
         chatData.rolls = rolls.map((r) => r.toJSON());

--- a/src/module/item/effect/document.ts
+++ b/src/module/item/effect/document.ts
@@ -119,7 +119,7 @@ class EffectPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ab
         const actor = this.actor;
         if (!actor) throw ErrorPF2e("A formula badge can only be evaluated if part of an embedded effect");
 
-        const roll = await new Roll(badge.value, this.getRollData()).evaluate({ async: true });
+        const roll = await new Roll(badge.value, this.getRollData()).evaluate();
         const initial = initialValue ?? roll.total;
         const reevaluate = badge.reevaluate ? { event: badge.reevaluate, formula: badge.value, initial } : null;
         const token = actor.getActiveTokens(false, true).shift();

--- a/src/module/rules/rule-element/fast-healing.ts
+++ b/src/module/rules/rule-element/fast-healing.ts
@@ -82,7 +82,7 @@ class FastHealingRuleElement extends RuleElementPF2e<FastHealingRuleSchema> {
         const postFlavor = `<div data-visibility="owner">${this.details ?? this.getReducedLabel()}</div>`;
         const flavor = `<div>${receivedMessage}</div>${postFlavor}`;
 
-        const roll = (await new DamageRoll(`{(${value})[healing]}`).evaluate({ async: true })).toJSON();
+        const roll = (await new DamageRoll(`{(${value})[healing]}`).evaluate()).toJSON();
         const rollMode = this.actor.hasPlayerOwner ? "publicroll" : "gmroll";
         const speaker = ChatMessagePF2e.getSpeaker({ actor: this.actor, token: this.token });
         ChatMessagePF2e.create({ flavor, speaker, type: CONST.CHAT_MESSAGE_TYPES.ROLL, rolls: [roll] }, { rollMode });

--- a/src/module/scene/token-document/document.ts
+++ b/src/module/scene/token-document/document.ts
@@ -49,7 +49,7 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
     ): TrackedAttributesDescription {
         // This method is being called with no associated actor: fill from the models
         if (_path.length === 0 && Object.keys(data).length === 0) {
-            for (const [type, model] of Object.entries(game.system.model.Actor)) {
+            for (const [type, model] of Object.entries(game.model.Actor)) {
                 if (!["character", "npc"].includes(type)) continue;
                 fu.mergeObject(data, model);
             }

--- a/src/module/system/action-macros/crafting/repair.ts
+++ b/src/module/system/action-macros/crafting/repair.ts
@@ -132,7 +132,7 @@ async function onRepairChatCardEvent(
         });
         await ChatMessage.create({ content, speaker });
     } else if (repair === "roll-damage") {
-        const roll = await Roll.create("2d6").evaluate({ async: true });
+        const roll = await Roll.create("2d6").evaluate();
         const templatePath = "systems/pf2e/templates/system/actions/repair/roll-damage-chat-message.hbs";
         const flavor = await renderTemplate(templatePath, {
             damage: {

--- a/src/module/system/check/check.ts
+++ b/src/module/system/check/check.ts
@@ -178,7 +178,7 @@ class CheckPF2e {
         };
 
         const totalModifierPart = signedInteger(check.totalModifier, { emptyStringZero: true });
-        const roll = await new CheckRoll(`${dice}${totalModifierPart}`, {}, options).evaluate({ async: true });
+        const roll = await new CheckRoll(`${dice}${totalModifierPart}`, {}, options).evaluate();
 
         // Combine all degree of success adjustments into a single record. Some may be overridden, but that should be
         // rare--and there are no rules for selecting among multiple adjustments.
@@ -484,7 +484,7 @@ class CheckPF2e {
         );
 
         // Evaluate the new roll and call a second hook allowing the roll to be altered
-        const newRoll = await unevaluatedNewRoll.evaluate({ async: true });
+        const newRoll = await unevaluatedNewRoll.evaluate();
         Hooks.callAll("pf2e.reroll", Roll.fromJSON(JSON.stringify(oldRoll.toJSON())), newRoll, heroPoint, keep);
 
         // Keep the new roll by default; Old roll is discarded

--- a/src/module/system/check/roll.ts
+++ b/src/module/system/check/roll.ts
@@ -34,7 +34,7 @@ class CheckRoll extends Roll {
     }
 
     override async render(this: Rolled<CheckRoll>, options: RollRenderOptions = {}): Promise<string> {
-        if (!this._evaluated) await this.evaluate({ async: true });
+        if (!this._evaluated) await this.evaluate();
         const { isPrivate, flavor, template } = options;
         const { type, identifier, action, damaging } = this.options;
         const canRollDamage = !!(damaging && identifier && (this.roller === game.user || game.user.isGM));

--- a/src/module/system/damage/damage.ts
+++ b/src/module/system/damage/damage.ts
@@ -156,7 +156,7 @@ export class DamagePF2e {
         const roll = await (() => {
             const damage = data.damage;
             if (damage.roll) {
-                return damage.roll.evaluate({ async: true });
+                return damage.roll.evaluate();
             }
 
             const formula = fu.deepClone(damage.formula[outcome ?? "success"]);
@@ -183,7 +183,7 @@ export class DamagePF2e {
                 showBreakdown,
             };
 
-            return new DamageRoll(formula, {}, options).evaluate({ async: true });
+            return new DamageRoll(formula, {}, options).evaluate();
         })();
 
         if (roll === null) return null;
@@ -275,7 +275,7 @@ export class DamagePF2e {
             const rolls: RollJSON[] = [];
             for (const splash of splashInstances) {
                 const formula = `(${splash.total}[splash])[${splash.damageType}]`;
-                const roll = await new DamageRoll(formula).evaluate({ async: true });
+                const roll = await new DamageRoll(formula).evaluate();
                 roll.options.splashOnly = true;
                 rolls.push(roll.toJSON());
             }

--- a/src/module/system/damage/helpers.ts
+++ b/src/module/system/damage/helpers.ts
@@ -210,7 +210,7 @@ function extractBaseDamage(roll: DamageRoll): BaseDamageData[] {
         }
 
         // Resolve deterministic expressions and terms normally, everything is allowed
-        // This handles NumericTerm, and ArithmeticTerm and MathTerm that don't have dice
+        // This handles NumericTerm, and ArithmeticTerm and FunctionTerm that don't have dice
         if (expression.isDeterministic) {
             return [{ dice: null, modifier: DamageInstance.getValue(expression, "expected"), category }];
         }

--- a/src/module/system/damage/roll.ts
+++ b/src/module/system/damage/roll.ts
@@ -244,7 +244,7 @@ class DamageRoll extends AbstractDamageRoll {
             return super.render({ flavor, template, isPrivate });
         }
 
-        if (!this._evaluated) await this.evaluate({ async: true });
+        if (!this._evaluated) await this.evaluate();
         const formula = isPrivate ? "???" : (await Promise.all(instances.map((i) => i.render()))).join(" + ");
         const total = this.total ?? NaN;
         const damageKinds = this.kinds;

--- a/src/module/system/damage/terms.ts
+++ b/src/module/system/damage/terms.ts
@@ -173,7 +173,7 @@ class ArithmeticExpression extends terms.RollTerm<ArithmeticExpressionData> {
     ): Promise<Evaluated<this>> {
         for (const operand of this.operands) {
             if (!operand._evaluated) {
-                await operand.evaluate({ async: true, ...options });
+                await operand.evaluate(options);
             }
         }
         this._evaluated = true;
@@ -311,7 +311,7 @@ class Grouping extends terms.RollTerm<GroupingData> {
         options: { minimize?: boolean; maximize?: boolean } = {},
     ): Promise<Evaluated<this>> {
         if (!this.term._evaluated) {
-            await this.term.evaluate({ async: true, ...options });
+            await this.term.evaluate(options);
         }
         this._evaluated = true;
 
@@ -448,17 +448,17 @@ class IntermediateDie extends terms.RollTerm<IntermediateDieData> {
     protected override async _evaluate(): Promise<Evaluated<this>>;
     protected override async _evaluate(): Promise<this> {
         if (typeof this.number !== "number") {
-            this.number = (await this.number.evaluate({ async: true })).total;
+            this.number = (await this.number.evaluate()).total;
         }
         if (typeof this.faces !== "number") {
-            this.faces = (await this.faces.evaluate({ async: true })).total;
+            this.faces = (await this.faces.evaluate()).total;
         }
 
         this.die = await new terms.Die({
             number: this.number,
             faces: this.faces,
             options: this.options,
-        }).evaluate({ async: true });
+        }).evaluate();
         this._evaluated = true;
 
         return this;

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -747,10 +747,10 @@ class TextEditorPF2e extends TextEditor {
         const traits = ((): string[] => {
             const fromParams = rawParams.traits?.split(",").flatMap((t) => t.trim() || []) ?? [];
             const fromItem = item?.system.traits?.value ?? [];
-            return overrideTraits ? fromParams : R.uniq([...fromParams, ...fromItem]);
+            return overrideTraits ? fromParams : R.unique([...fromParams, ...fromItem]);
         })();
 
-        const extraRollOptions = R.compact(rawParams.options?.split(",").map((t) => t.trim()) ?? []);
+        const extraRollOptions = R.filter(rawParams.options?.split(",").map((t) => t.trim()) ?? [], R.isTruthy);
 
         const result = await augmentInlineDamageRoll(rawParams.formula, {
             skipDialog: true,
@@ -913,7 +913,7 @@ async function augmentInlineDamageRoll(
 
         const domains = immutable
             ? []
-            : R.compact(
+            : R.filter(
                   [
                       kinds,
                       kinds.map((k) => `inline-${k}`),
@@ -921,6 +921,7 @@ async function augmentInlineDamageRoll(
                       item ? kinds.map((k) => `${sluggify(item.slug ?? item.name)}-inline-${k}`) : null,
                       options.domains,
                   ].flat(),
+                  R.isTruthy,
               );
 
         const rollOptions = new Set([

--- a/src/scripts/dice.ts
+++ b/src/scripts/dice.ts
@@ -88,7 +88,7 @@ class DicePF2e {
             )
                 rollParts.splice(rollParts.indexOf("@circumstanceBonus"), 1);
             // Execute the roll and send it to chat
-            const roll = await new Roll(rollParts.join("+"), data).roll({ async: true });
+            const roll = await new Roll(rollParts.join("+"), data).roll();
             const origin = item ? { uuid: item.uuid, type: item.type } : null;
             roll.toMessage(
                 {

--- a/src/scripts/macros/encouraging-words.ts
+++ b/src/scripts/macros/encouraging-words.ts
@@ -36,7 +36,7 @@ export function encouragingWords(options: ActionDefaultOptions): void {
                     successLabel = localize("CritFailure");
                 }
                 if (healFormula) {
-                    const healRoll = await new Roll(healFormula).roll({ async: true });
+                    const healRoll = await new Roll(healFormula).roll();
                     const rollType = degreeOfSuccess > 1 ? localize("Recovery") : localize("Damage");
                     const token = actor.getActiveTokens().shift()?.document ?? null;
 

--- a/src/scripts/macros/treat-wounds.ts
+++ b/src/scripts/macros/treat-wounds.ts
@@ -165,14 +165,14 @@ async function treat(
                     flags: message.toObject().flags,
                     type: CONST.CHAT_MESSAGE_TYPES.ROLL,
                     flavor: `<strong>${game.i18n.localize("PF2E.Actions.TreatWounds.Rolls.RiskySurgery")}</strong>`,
-                    rolls: [(await new DamageRoll("{1d8[slashing]}").roll({ async: true })).toJSON()],
+                    rolls: [(await new DamageRoll("{1d8[slashing]}").roll()).toJSON()],
                     speaker,
                 });
             }
 
             if (healFormula) {
                 const formulaModifier = outcome === "criticalFailure" ? "" : "[healing]";
-                const healRoll = await new DamageRoll(`{(${healFormula})${formulaModifier}}`).roll({ async: true });
+                const healRoll = await new DamageRoll(`{(${healFormula})${formulaModifier}}`).roll();
                 const rollType =
                     outcome !== "criticalFailure"
                         ? game.i18n.localize("PF2E.Actions.TreatWounds.Rolls.TreatWounds")

--- a/types/foundry/client/game.d.ts
+++ b/types/foundry/client/game.d.ts
@@ -205,6 +205,9 @@ declare global {
         /** A convenient reference to the currently active canvas tool */
         get activeTool(): string;
 
+        /** An alias for the structured data model organized by document class and type. */
+        get model(): Record<"Actor" | "Card" | "Cards" | "Item" | "JournalEntryPage", object>;
+
         /**
          * Toggle the pause state of the game
          * Trigger the `pauseGame` Hook when the paused state changes

--- a/types/foundry/client/roll-term/base.d.ts
+++ b/types/foundry/client/roll-term/base.d.ts
@@ -54,37 +54,9 @@ export abstract class RollTerm<TTermData extends RollTermData = RollTermData> {
      * @param [options={}]             Options which modify how the RollTerm is evaluated
      * @param [options.minimize=false] Minimize the result, obtaining the smallest possible value.
      * @param [options.maximize=false] Maximize the result, obtaining the largest possible value.
-     * @param [options.async=false]    Evaluate the term asynchronously, receiving a Promise as the returned value.
-     *                                 This will become the default behavior in version 10.x
      * @returns The evaluated RollTerm
      */
-    evaluate({
-        minimize,
-        maximize,
-        async,
-    }?: {
-        minimize?: boolean;
-        maximize?: boolean;
-        async?: false;
-    }): Evaluated<this>;
-    evaluate({
-        minimize,
-        maximize,
-        async,
-    }: {
-        minimize?: boolean;
-        maximize?: boolean;
-        async: true;
-    }): Promise<Evaluated<this>>;
-    evaluate({
-        minimize,
-        maximize,
-        async,
-    }?: {
-        minimize?: boolean;
-        maximize?: boolean;
-        async?: boolean;
-    }): Evaluated<this> | Promise<Evaluated<this>>;
+    evaluate({ minimize, maximize }?: { minimize?: boolean; maximize?: boolean }): Promise<Evaluated<this>>;
 
     /**
      * Evaluate the term.

--- a/types/foundry/client/roll-term/function-term.d.ts
+++ b/types/foundry/client/roll-term/function-term.d.ts
@@ -66,7 +66,7 @@ declare global {
         | "safeEval";
 
     interface FunctionTermData<TFunctionName extends MathFunctionName = MathFunctionName> extends RollTermData {
-        class?: "MathTerm";
+        class?: "FunctionTerm";
         fn?: TFunctionName;
         terms?: RollTerm[];
     }

--- a/types/foundry/client/roll.d.ts
+++ b/types/foundry/client/roll.d.ts
@@ -107,8 +107,6 @@ declare global {
          * @param [options={}] Options which inform how the Roll is evaluated
          * @param [options.minimize=false] Minimize the result, obtaining the smallest possible value.
          * @param [options.maximize=false] Maximize the result, obtaining the largest possible value.
-         * @param [options.async=true]     Evaluate the roll asynchronously, receiving a Promise as the returned value.
-         *                                 This will become the default behavior in version 10.x
          * @returns The evaluated Roll instance
          *
          * @example
@@ -117,9 +115,7 @@ declare global {
          * console.log(r.result); // 5 + 4 + 2
          * console.log(r.total);  // 11
          */
-        evaluate({ minimize, maximize, async }: EvaluateRollParams & { async?: false }): Rolled<this>;
-        evaluate({ minimize, maximize, async }: EvaluateRollParams & { async: true }): Promise<Rolled<this>>;
-        evaluate({ minimize, maximize, async }: EvaluateRollParams): Rolled<this> | Promise<Rolled<this>>;
+        evaluate({ minimize, maximize }?: EvaluateRollParams): Rolled<this> | Promise<Rolled<this>>;
 
         /**
          * Evaluate the roll asynchronously.
@@ -143,9 +139,7 @@ declare global {
          * Alias for evaluate.
          * @see {Roll#evaluate}
          */
-        roll({ minimize, maximize, async }: EvaluateRollParams & { async?: false }): Rolled<this>;
-        roll({ minimize, maximize, async }: EvaluateRollParams & { async: true }): Promise<Rolled<this>>;
-        roll({ minimize, maximize, async }: EvaluateRollParams): Rolled<this> | Promise<Rolled<this>>;
+        roll({ minimize, maximize }?: EvaluateRollParams): Promise<Rolled<this>>;
 
         /**
          * Create a new Roll object using the original provided formula and data.
@@ -153,9 +147,7 @@ declare global {
          * @param [options={}] Evaluation options passed to Roll#evaluate
          * @return A new Roll object, rolled using the same formula and data
          */
-        reroll({ minimize, maximize, async }: EvaluateRollParams & { async?: false }): Rolled<this>;
-        reroll({ minimize, maximize, async }: EvaluateRollParams & { async: true }): Promise<Rolled<this>>;
-        reroll({ minimize, maximize, async }: EvaluateRollParams): Rolled<this> | Promise<Rolled<this>>;
+        reroll({ minimize, maximize }?: EvaluateRollParams): Promise<Rolled<this>>;
 
         /* -------------------------------------------- */
         /*  Static Class Methods                        */
@@ -464,7 +456,6 @@ declare global {
     interface EvaluateRollParams {
         minimize?: boolean;
         maximize?: boolean;
-        async?: boolean;
     }
 
     // Empty extended interface that can be expanded by the system without polluting Math itself

--- a/types/foundry/common/packages/base-system.d.ts
+++ b/types/foundry/common/packages/base-system.d.ts
@@ -26,9 +26,6 @@ export default class BaseSystem extends packages.BasePackage<BaseSystemSchema> {
 
     /** An alias for the raw template JSON loaded from the game System. */
     get template(): object;
-
-    /** An alias for the structured data model organized by document class and type. */
-    get model(): Record<"Actor" | "Card" | "Cards" | "Item" | "JournalEntryPage", object>;
 }
 
 export default interface BaseSystem


### PR DESCRIPTION
I've slipped in a minor change to fix an error with default token settings but they are still broken on the foundry side until the next release anyway.