### PR TITLE
Add suboption for Hidden to wisp's Go Dark

### DIFF
--- a/packs/abomination-vaults-bestiary/dread-wisp.json
+++ b/packs/abomination-vaults-bestiary/dread-wisp.json
@@ -79,11 +79,13 @@
                             }
                         ],
                         "value": {
+                            "alpha": 0.2,
                             "animation": {
                                 "intensity": 4,
                                 "speed": 1,
                                 "type": "torch"
                             },
+                            "bright": 0,
                             "color": "#9b7337",
                             "dim": 20,
                             "shadows": 0.1
@@ -251,6 +253,16 @@
                         "domain": "all",
                         "key": "RollOption",
                         "option": "go-dark",
+                        "suboptions": [
+                            {
+                                "label": "PF2E.ConditionTypeInvisible",
+                                "value": "Compendium.pf2e.conditionitems.Item.Invisible"
+                            },
+                            {
+                                "label": "PF2E.ConditionTypeHidden",
+                                "value": "Compendium.pf2e.conditionitems.Item.Hidden"
+                            }
+                        ],
                         "toggleable": true
                     },
                     {
@@ -259,7 +271,7 @@
                         "predicate": [
                             "go-dark"
                         ],
-                        "uuid": "Compendium.pf2e.conditionitems.Item.Invisible"
+                        "uuid": "{item|flags.pf2e.rulesSelections.goDark}"
                     }
                 ],
                 "slug": null,

--- a/packs/abomination-vaults-bestiary/dune-candle.json
+++ b/packs/abomination-vaults-bestiary/dune-candle.json
@@ -79,13 +79,15 @@
                             }
                         ],
                         "value": {
+                            "alpha": 0.2,
                             "animation": {
                                 "intensity": 1,
                                 "speed": 3,
                                 "type": "pulse"
                             },
                             "bright": 20,
-                            "color": "#fff9a3"
+                            "color": "#fff9a3",
+                            "dim": 0
                         }
                     }
                 ],
@@ -156,6 +158,16 @@
                         "domain": "all",
                         "key": "RollOption",
                         "option": "heat-mirage",
+                        "suboptions": [
+                            {
+                                "label": "PF2E.ConditionTypeInvisible",
+                                "value": "Compendium.pf2e.conditionitems.Item.Invisible"
+                            },
+                            {
+                                "label": "PF2E.ConditionTypeHidden",
+                                "value": "Compendium.pf2e.conditionitems.Item.Hidden"
+                            }
+                        ],
                         "toggleable": true
                     },
                     {
@@ -164,7 +176,7 @@
                         "predicate": [
                             "heat-mirage"
                         ],
-                        "uuid": "Compendium.pf2e.conditionitems.Item.Invisible"
+                        "uuid": "{item|flags.pf2e.rulesSelections.heatMirage}"
                     }
                 ],
                 "slug": null,

--- a/packs/abomination-vaults-bestiary/groetan-candle.json
+++ b/packs/abomination-vaults-bestiary/groetan-candle.json
@@ -77,13 +77,15 @@
                             }
                         ],
                         "value": {
+                            "alpha": 0.2,
                             "animation": {
                                 "intensity": 1,
                                 "speed": 3,
                                 "type": "pulse"
                             },
                             "bright": 20,
-                            "color": "#fff9a3"
+                            "color": "#fff9a3",
+                            "dim": 0
                         }
                     }
                 ],
@@ -186,6 +188,16 @@
                         "domain": "all",
                         "key": "RollOption",
                         "option": "go-dark",
+                        "suboptions": [
+                            {
+                                "label": "PF2E.ConditionTypeInvisible",
+                                "value": "Compendium.pf2e.conditionitems.Item.Invisible"
+                            },
+                            {
+                                "label": "PF2E.ConditionTypeHidden",
+                                "value": "Compendium.pf2e.conditionitems.Item.Hidden"
+                            }
+                        ],
                         "toggleable": true
                     },
                     {
@@ -194,7 +206,7 @@
                         "predicate": [
                             "go-dark"
                         ],
-                        "uuid": "Compendium.pf2e.conditionitems.Item.Invisible"
+                        "uuid": "{item|flags.pf2e.rulesSelections.goDark}"
                     }
                 ],
                 "slug": null,

--- a/packs/abomination-vaults-bestiary/sacuishu.json
+++ b/packs/abomination-vaults-bestiary/sacuishu.json
@@ -1617,13 +1617,15 @@
                             }
                         ],
                         "value": {
+                            "alpha": 0.2,
                             "animation": {
                                 "intensity": 1,
                                 "speed": 3,
                                 "type": "pulse"
                             },
                             "bright": 20,
-                            "color": "#c6fba5"
+                            "color": "#c6fba5",
+                            "dim": 0
                         }
                     }
                 ],
@@ -1726,6 +1728,16 @@
                         "domain": "all",
                         "key": "RollOption",
                         "option": "go-dark",
+                        "suboptions": [
+                            {
+                                "label": "PF2E.ConditionTypeInvisible",
+                                "value": "Compendium.pf2e.conditionitems.Item.Invisible"
+                            },
+                            {
+                                "label": "PF2E.ConditionTypeHidden",
+                                "value": "Compendium.pf2e.conditionitems.Item.Hidden"
+                            }
+                        ],
                         "toggleable": true
                     },
                     {
@@ -1734,7 +1746,7 @@
                         "predicate": [
                             "go-dark"
                         ],
-                        "uuid": "Compendium.pf2e.conditionitems.Item.Invisible"
+                        "uuid": "{item|flags.pf2e.rulesSelections.goDark}"
                     }
                 ],
                 "slug": null,

--- a/packs/abomination-vaults-bestiary/spellvoid.json
+++ b/packs/abomination-vaults-bestiary/spellvoid.json
@@ -77,13 +77,15 @@
                             }
                         ],
                         "value": {
+                            "alpha": 0.2,
                             "animation": {
                                 "intensity": 1,
                                 "speed": 3,
                                 "type": "pulse"
                             },
                             "bright": 20,
-                            "color": "#fff9a3"
+                            "color": "#fff9a3",
+                            "dim": 0
                         }
                     }
                 ],
@@ -186,6 +188,16 @@
                         "domain": "all",
                         "key": "RollOption",
                         "option": "go-dark",
+                        "suboptions": [
+                            {
+                                "label": "PF2E.ConditionTypeInvisible",
+                                "value": "Compendium.pf2e.conditionitems.Item.Invisible"
+                            },
+                            {
+                                "label": "PF2E.ConditionTypeHidden",
+                                "value": "Compendium.pf2e.conditionitems.Item.Hidden"
+                            }
+                        ],
                         "toggleable": true
                     },
                     {
@@ -194,7 +206,7 @@
                         "predicate": [
                             "go-dark"
                         ],
-                        "uuid": "Compendium.pf2e.conditionitems.Item.Invisible"
+                        "uuid": "{item|flags.pf2e.rulesSelections.goDark}"
                     }
                 ],
                 "slug": null,

--- a/packs/abomination-vaults-bestiary/will-o-the-deep.json
+++ b/packs/abomination-vaults-bestiary/will-o-the-deep.json
@@ -77,13 +77,15 @@
                             }
                         ],
                         "value": {
+                            "alpha": 0.2,
                             "animation": {
                                 "intensity": 1,
                                 "speed": 3,
                                 "type": "pulse"
                             },
                             "bright": 20,
-                            "color": "#fff9a3"
+                            "color": "#fff9a3",
+                            "dim": 0
                         }
                     }
                 ],
@@ -239,6 +241,16 @@
                         "domain": "all",
                         "key": "RollOption",
                         "option": "go-dark",
+                        "suboptions": [
+                            {
+                                "label": "PF2E.ConditionTypeInvisible",
+                                "value": "Compendium.pf2e.conditionitems.Item.Invisible"
+                            },
+                            {
+                                "label": "PF2E.ConditionTypeHidden",
+                                "value": "Compendium.pf2e.conditionitems.Item.Hidden"
+                            }
+                        ],
                         "toggleable": true
                     },
                     {
@@ -247,7 +259,7 @@
                         "predicate": [
                             "go-dark"
                         ],
-                        "uuid": "Compendium.pf2e.conditionitems.Item.Invisible"
+                        "uuid": "{item|flags.pf2e.rulesSelections.goDark}"
                     }
                 ],
                 "slug": null,

--- a/packs/agents-of-edgewatch-bestiary/gloaming-will-o-wisp.json
+++ b/packs/agents-of-edgewatch-bestiary/gloaming-will-o-wisp.json
@@ -77,11 +77,13 @@
                             }
                         ],
                         "value": {
+                            "alpha": 0.2,
                             "animation": {
                                 "intensity": 1,
                                 "speed": 3,
                                 "type": "pulse"
                             },
+                            "bright": 0,
                             "color": "#fff9a3",
                             "dim": 30,
                             "shadows": 0.1
@@ -202,6 +204,16 @@
                         "domain": "all",
                         "key": "RollOption",
                         "option": "go-dark",
+                        "suboptions": [
+                            {
+                                "label": "PF2E.ConditionTypeInvisible",
+                                "value": "Compendium.pf2e.conditionitems.Item.Invisible"
+                            },
+                            {
+                                "label": "PF2E.ConditionTypeHidden",
+                                "value": "Compendium.pf2e.conditionitems.Item.Hidden"
+                            }
+                        ],
                         "toggleable": true
                     },
                     {
@@ -210,7 +222,7 @@
                         "predicate": [
                             "go-dark"
                         ],
-                        "uuid": "Compendium.pf2e.conditionitems.Item.Invisible"
+                        "uuid": "{item|flags.pf2e.rulesSelections.goDark}"
                     }
                 ],
                 "slug": null,

--- a/packs/kingmaker-bestiary/ancient-wisp.json
+++ b/packs/kingmaker-bestiary/ancient-wisp.json
@@ -80,13 +80,15 @@
                             }
                         ],
                         "value": {
+                            "alpha": 0.2,
                             "animation": {
                                 "intensity": 1,
                                 "speed": 3,
                                 "type": "pulse"
                             },
                             "bright": 20,
-                            "color": "#fff9a3"
+                            "color": "#fff9a3",
+                            "dim": 0
                         }
                     },
                     {
@@ -214,6 +216,16 @@
                         "domain": "all",
                         "key": "RollOption",
                         "option": "go-dark",
+                        "suboptions": [
+                            {
+                                "label": "PF2E.ConditionTypeInvisible",
+                                "value": "Compendium.pf2e.conditionitems.Item.Invisible"
+                            },
+                            {
+                                "label": "PF2E.ConditionTypeHidden",
+                                "value": "Compendium.pf2e.conditionitems.Item.Hidden"
+                            }
+                        ],
                         "toggleable": true
                     },
                     {
@@ -222,7 +234,7 @@
                         "predicate": [
                             "go-dark"
                         ],
-                        "uuid": "Compendium.pf2e.conditionitems.Item.Invisible"
+                        "uuid": "{item|flags.pf2e.rulesSelections.goDark}"
                     }
                 ],
                 "slug": null,

--- a/packs/kingmaker-bestiary/spirit-of-stisshak.json
+++ b/packs/kingmaker-bestiary/spirit-of-stisshak.json
@@ -413,13 +413,15 @@
                             }
                         ],
                         "value": {
+                            "alpha": 0.2,
                             "animation": {
                                 "intensity": 1,
                                 "speed": 3,
                                 "type": "pulse"
                             },
                             "bright": 20,
-                            "color": "#fff9a3"
+                            "color": "#fff9a3",
+                            "dim": 0
                         }
                     }
                 ],
@@ -522,6 +524,16 @@
                         "domain": "all",
                         "key": "RollOption",
                         "option": "go-dark",
+                        "suboptions": [
+                            {
+                                "label": "PF2E.ConditionTypeInvisible",
+                                "value": "Compendium.pf2e.conditionitems.Item.Invisible"
+                            },
+                            {
+                                "label": "PF2E.ConditionTypeHidden",
+                                "value": "Compendium.pf2e.conditionitems.Item.Hidden"
+                            }
+                        ],
                         "toggleable": true
                     },
                     {
@@ -530,7 +542,7 @@
                         "predicate": [
                             "go-dark"
                         ],
-                        "uuid": "Compendium.pf2e.conditionitems.Item.Invisible"
+                        "uuid": "{item|flags.pf2e.rulesSelections.goDark}"
                     }
                 ],
                 "slug": null,

--- a/packs/pathfinder-bestiary/will-o-wisp.json
+++ b/packs/pathfinder-bestiary/will-o-wisp.json
@@ -77,13 +77,15 @@
                             }
                         ],
                         "value": {
+                            "alpha": 0.2,
                             "animation": {
                                 "intensity": 1,
                                 "speed": 3,
                                 "type": "pulse"
                             },
                             "bright": 20,
-                            "color": "#fff9a3"
+                            "color": "#fff9a3",
+                            "dim": 0
                         }
                     }
                 ],
@@ -186,6 +188,16 @@
                         "domain": "all",
                         "key": "RollOption",
                         "option": "go-dark",
+                        "suboptions": [
+                            {
+                                "label": "PF2E.ConditionTypeInvisible",
+                                "value": "Compendium.pf2e.conditionitems.Item.Invisible"
+                            },
+                            {
+                                "label": "PF2E.ConditionTypeHidden",
+                                "value": "Compendium.pf2e.conditionitems.Item.Hidden"
+                            }
+                        ],
                         "toggleable": true
                     },
                     {
@@ -194,7 +206,7 @@
                         "predicate": [
                             "go-dark"
                         ],
-                        "uuid": "Compendium.pf2e.conditionitems.Item.Invisible"
+                        "uuid": "{item|flags.pf2e.rulesSelections.goDark}"
                     }
                 ],
                 "slug": null,

--- a/packs/pathfinder-monster-core/will-o-wisp.json
+++ b/packs/pathfinder-monster-core/will-o-wisp.json
@@ -77,13 +77,15 @@
                             }
                         ],
                         "value": {
+                            "alpha": 0.2,
                             "animation": {
                                 "intensity": 1,
                                 "speed": 3,
                                 "type": "pulse"
                             },
                             "bright": 20,
-                            "color": "#fff9a3"
+                            "color": "#fff9a3",
+                            "dim": 0
                         }
                     }
                 ],
@@ -186,6 +188,16 @@
                         "domain": "all",
                         "key": "RollOption",
                         "option": "go-dark",
+                        "suboptions": [
+                            {
+                                "label": "PF2E.ConditionTypeInvisible",
+                                "value": "Compendium.pf2e.conditionitems.Item.Invisible"
+                            },
+                            {
+                                "label": "PF2E.ConditionTypeHidden",
+                                "value": "Compendium.pf2e.conditionitems.Item.Hidden"
+                            }
+                        ],
                         "toggleable": true
                     },
                     {
@@ -194,7 +206,7 @@
                         "predicate": [
                             "go-dark"
                         ],
-                        "uuid": "Compendium.pf2e.conditionitems.Item.Invisible"
+                        "uuid": "{item|flags.pf2e.rulesSelections.goDark}"
                     }
                 ],
                 "slug": null,

--- a/packs/pfs-season-2-bestiary/urkhas-3-4.json
+++ b/packs/pfs-season-2-bestiary/urkhas-3-4.json
@@ -82,13 +82,15 @@
                             }
                         ],
                         "value": {
+                            "alpha": 0.2,
                             "animation": {
                                 "intensity": 1,
                                 "speed": 3,
                                 "type": "pulse"
                             },
                             "bright": 20,
-                            "color": "#ddc4ff"
+                            "color": "#ddc4ff",
+                            "dim": 0
                         }
                     }
                 ],
@@ -191,6 +193,16 @@
                         "domain": "all",
                         "key": "RollOption",
                         "option": "go-dark",
+                        "suboptions": [
+                            {
+                                "label": "PF2E.ConditionTypeInvisible",
+                                "value": "Compendium.pf2e.conditionitems.Item.Invisible"
+                            },
+                            {
+                                "label": "PF2E.ConditionTypeHidden",
+                                "value": "Compendium.pf2e.conditionitems.Item.Hidden"
+                            }
+                        ],
                         "toggleable": true
                     },
                     {
@@ -199,7 +211,7 @@
                         "predicate": [
                             "go-dark"
                         ],
-                        "uuid": "Compendium.pf2e.conditionitems.Item.Invisible"
+                        "uuid": "{item|flags.pf2e.rulesSelections.goDark}"
                     }
                 ],
                 "slug": null,

--- a/packs/pfs-season-2-bestiary/urkhas-5-6.json
+++ b/packs/pfs-season-2-bestiary/urkhas-5-6.json
@@ -82,13 +82,15 @@
                             }
                         ],
                         "value": {
+                            "alpha": 0.2,
                             "animation": {
                                 "intensity": 1,
                                 "speed": 3,
                                 "type": "pulse"
                             },
                             "bright": 20,
-                            "color": "#ddc4ff"
+                            "color": "#ddc4ff",
+                            "dim": 0
                         }
                     }
                 ],
@@ -191,6 +193,16 @@
                         "domain": "all",
                         "key": "RollOption",
                         "option": "go-dark",
+                        "suboptions": [
+                            {
+                                "label": "PF2E.ConditionTypeInvisible",
+                                "value": "Compendium.pf2e.conditionitems.Item.Invisible"
+                            },
+                            {
+                                "label": "PF2E.ConditionTypeHidden",
+                                "value": "Compendium.pf2e.conditionitems.Item.Hidden"
+                            }
+                        ],
                         "toggleable": true
                     },
                     {
@@ -199,7 +211,7 @@
                         "predicate": [
                             "go-dark"
                         ],
-                        "uuid": "Compendium.pf2e.conditionitems.Item.Invisible"
+                        "uuid": "{item|flags.pf2e.rulesSelections.goDark}"
                     }
                 ],
                 "slug": null,


### PR DESCRIPTION
All of these monsters have conditions under which they become temporarily Hidden instead of Invisible (such as Feed on Fear). Their light is also too bright in my opinion, so I toned them down, but I'm open to leaving it alone if people disagree.