### PR TITLE
Fix status effect title bar and base image opacity in token HUD

### DIFF
--- a/src/module/canvas/status-effects.ts
+++ b/src/module/canvas/status-effects.ts
@@ -128,7 +128,7 @@ export class StatusEffects {
             const picture = document.createElement("picture");
             picture.classList.add("effect-control");
             picture.dataset.statusId = icon.dataset.statusId;
-            picture.title = icon.title;
+            picture.title = icon.dataset.tooltip ?? "";
             const iconSrc = icon.getAttribute("src") as ImageFilePath;
             picture.setAttribute("src", iconSrc);
             const newIcon = document.createElement("img");

--- a/src/styles/ui/_token-hud.scss
+++ b/src/styles/ui/_token-hud.scss
@@ -8,7 +8,7 @@
             color: var(--color-text-dark-1);
             cursor: pointer;
             height: 36px;
-            opacity: 0.75;
+            opacity: 0.5;
             position: relative;
             width: 36px;
 
@@ -58,6 +58,7 @@
 
         .title-bar {
             background: rgba(0, 0, 0, 0.6);
+            color: var(--color-text-light-0);
             border-radius: inherit;
             border: inherit;
             box-shadow: inherit;


### PR DESCRIPTION
![image](https://github.com/foundryvtt/pf2e/assets/41452412/a9fa0818-5fc4-44fd-85bf-be64a960bbc9)
