### PR TITLE
Add button to show item roll options in item sheet

### DIFF
--- a/src/module/item/base/sheet/sheet.ts
+++ b/src/module/item/base/sheet/sheet.ts
@@ -20,6 +20,7 @@ import {
     TagSelectorBasic,
 } from "@system/tag-selector/index.ts";
 import {
+    createHTMLElement,
     ErrorPF2e,
     fontAwesomeIcon,
     htmlClosest,
@@ -344,6 +345,18 @@ class ItemSheetPF2e<TItem extends ItemPF2e> extends ItemSheet<TItem, ItemSheetOp
         const ruleElementSelect = htmlQuery<HTMLSelectElement>(rulesPanel, "select[data-action=select-rule-element]");
         ruleElementSelect?.addEventListener("change", () => {
             this.#selectedRuleElementType = ruleElementSelect.value;
+        });
+
+        // Add implementation for viewing an item's roll options
+        const viewRollOptionsElement = htmlQuery(rulesPanel, "a[data-action=view-roll-options]");
+        viewRollOptionsElement?.addEventListener("click", async () => {
+            const rollOptions = R.sortBy(this.item.getRollOptions("item").sort(), (o) => o.includes(":"));
+            const content = await renderTemplate("systems/pf2e/templates/items/roll-options.hbs", { rollOptions });
+            game.tooltip.dismissLockedTooltips();
+            game.tooltip.activate(viewRollOptionsElement, {
+                content: createHTMLElement("div", { innerHTML: content }),
+                locked: true,
+            });
         });
 
         for (const anchor of htmlQueryAll(rulesPanel, "a[data-action=add-rule-element]")) {

--- a/src/styles/item/_rules.scss
+++ b/src/styles/item/_rules.scss
@@ -38,6 +38,13 @@
                 margin-right: 0.5em;
             }
         }
+
+        a[data-action] {
+            flex: 0 0 auto;
+            line-height: 1.75em;
+            height: 1.75em;
+            margin-left: auto;
+        }
     }
 
     .rules {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2437,12 +2437,14 @@
                 "Hint": {
                     "Slug": "A stable, human-readable identifier: if set, it will remain in place even if the item is renamed.",
                     "SourceId": "The UUID of the original compendium item",
-                    "UUID": "A universally unique identifier for this item"
+                    "UUID": "A universally unique identifier for this item",
+                    "RollOptions": "An item roll option's prefix depends on its usage. <em>item:</em> is used most of the time, but <em>parent:</em> is used for the item containing the rule element."
                 },
                 "New": "New Rule Element",
                 "RegenerateSlug": "(Re)generate Slug",
                 "Remove": "Remove Rule Element",
-                "Tab": "Rules"
+                "Tab": "Rules",
+                "ViewRollOptions": "View Roll Options"
             },
             "Shield": {
                 "Base": {

--- a/static/templates/items/roll-options.hbs
+++ b/static/templates/items/roll-options.hbs
@@ -1,0 +1,6 @@
+<p>{{{localize "PF2E.Item.Rules.Hint.RollOptions"}}}</p>
+<ul>
+    {{#each rollOptions as |option|}}
+        <li>{{option}}</li>
+    {{/each}}
+</ul>

--- a/static/templates/items/rules-panel.hbs
+++ b/static/templates/items/rules-panel.hbs
@@ -41,6 +41,12 @@
                     <a data-action="regenerate-slug" data-tooltip="PF2E.Item.Rules.RegenerateSlug"><i class="fa-solid fa-fw fa-sync-alt"></i></a>
                 </div>
             </div>
+            <div class="form-group">
+                <a data-action="view-roll-options" data-tooltip-class="pf2e roll-options" data-tooltip-direction="RIGHT">
+                    {{localize "PF2E.Item.Rules.ViewRollOptions"}}
+                    <i class="fa-solid fa-circle-info"></i>
+                </a>
+            </div>
         </div>
         <div class="rule-element-forms">
             {{#each rules.elements as |form|}}


### PR DESCRIPTION
![image](https://github.com/foundryvtt/pf2e/assets/1286721/8aeb966a-dcf7-4965-bfc8-3bbc96f84ee1)

Requires V12 first due to locked tooltip bugfixes.