### PR TITLE
Make priority tooltip a tiny bit clearer

### DIFF
--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -1471,7 +1471,7 @@
                 "Opacity": "Opacity",
                 "Predicate": "Predicate",
                 "Primitive": "Primitive",
-                "PriorityHint": "Priority determines the order in which rule elements are executed. Rule elements with lower priority values are executed first.",
+                "PriorityHint": "Priority determines the order in which rule elements are executed within the same phase. Rule elements with lower priority values are executed first.",
                 "Range": "Range",
                 "Remove": "Remove",
                 "Selector": "Selector",


### PR DESCRIPTION
I think this might reduce some of the confusion regarding this prop, but let me know if I'm wrong.

It will add new confusion about what constitutes a "phase", but that's better than a false assurance that priority is the end-all-be-all.