### PR TITLE
Run CI on pull requests for the `v12` branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,11 @@ name: PF2e System CI
 
 on:
   pull_request:
-    branches: [master]
+    branches: [master, v12]
   push:
-    branches: [master, release-v9]
+    branches: [master]
   workflow_dispatch:
-    branches: [master, release-v9]
+    branches: [master]
 
 jobs:
   build:


### PR DESCRIPTION
Also removes `release-v9` branch from CI configuration.