### PR TITLE
Convert more select helpers to selectOptions

### DIFF
--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -366,11 +366,6 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
             ),
         ) as Record<SkillAbbreviation, CharacterSkillData>;
 
-        sheetData.initiativeOptions = {
-            perception: "PF2E.PerceptionLabel",
-            ...Object.fromEntries(Object.values(sheetData.data.skills).map((s) => [s.slug, s.label])),
-        };
-
         sheetData.tabVisibility = fu.deepClone(actor.flags.pf2e.sheetTabs);
 
         // Enrich content
@@ -1650,7 +1645,6 @@ interface CharacterSheetData<TActor extends CharacterPF2e = CharacterPF2e> exten
     hasStamina: boolean;
     /** This actor has actual containers for stowing, rather than just containers serving as a UI convenience */
     hasRealContainers: boolean;
-    initiativeOptions: Record<string, string>;
     languages: LanguageSheetData[];
     magicTraditions: Record<MagicTradition, string>;
     martialProficiencies: Record<"attacks" | "defenses", Record<string, MartialProficiency>>;

--- a/src/module/actor/creature/sheet.ts
+++ b/src/module/actor/creature/sheet.ts
@@ -37,6 +37,8 @@ abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends ActorSheet
                   .sort((a, b) => a.label.localeCompare(b.label, game.i18n.lang));
 
         sheetData.data.perception.senses = R.sortBy(sheetData.data.perception.senses, (a) => a.label ?? "");
+        const initiativeOptions = [{ value: "perception", label: "PF2E.PerceptionLabel" }];
+        initiativeOptions.push(...Object.values(sheetData.data.skills).map((s) => ({ value: s.slug, label: s.label })));
 
         return {
             ...sheetData,
@@ -45,6 +47,7 @@ abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends ActorSheet
             rarity: CONFIG.PF2E.rarityTraits,
             frequencies: CONFIG.PF2E.frequencies,
             pfsFactions: CONFIG.PF2E.pfsFactions,
+            initiativeOptions,
             dying: {
                 maxed: actor.attributes.dying.value >= actor.attributes.dying.max,
                 remainingDying: Math.max(actor.attributes.dying.max - actor.attributes.dying.value),
@@ -489,6 +492,7 @@ interface CreatureSheetData<TActor extends CreaturePF2e> extends ActorSheetDataP
     frequencies: typeof CONFIG.PF2E.frequencies;
     pfsFactions: typeof CONFIG.PF2E.pfsFactions;
     languages: { slug: Language | null; label: string }[];
+    initiativeOptions: FormSelectOption[];
     dying: {
         maxed: boolean;
         remainingDying: number;

--- a/src/module/actor/hazard/types.ts
+++ b/src/module/actor/hazard/types.ts
@@ -6,8 +6,8 @@ import type { AbilityItemPF2e } from "@item";
 
 interface HazardSheetData extends ActorSheetDataPF2e<HazardPF2e> {
     actions: HazardActionSheetData;
-    complexityOptions: { value: string; label: string }[];
-    emitsSoundOptions: { value: string; label: string }[];
+    complexityOptions: FormSelectOption[];
+    emitsSoundOptions: FormSelectOption[];
     editing: boolean;
     actorTraits: TraitViewData[];
     rarity: Record<string, string>;

--- a/src/module/actor/loot/sheet.ts
+++ b/src/module/actor/loot/sheet.ts
@@ -88,5 +88,5 @@ export class LootSheetPF2e<TActor extends LootPF2e> extends ActorSheetPF2e<TActo
 
 interface LootSheetDataPF2e<TActor extends LootPF2e> extends ActorSheetDataPF2e<TActor> {
     isLoot: boolean;
-    lootSheetTypeOptions: { value: string; label: string }[];
+    lootSheetTypeOptions: FormSelectOption[];
 }

--- a/src/module/actor/party/kingdom/builder.ts
+++ b/src/module/actor/party/kingdom/builder.ts
@@ -171,6 +171,10 @@ class KingdomBuilder extends FormApplication<Kingdom> {
             skillLabels: KINGDOM_SKILL_LABELS,
             build: this.#prepareAbilityBuilder(),
             finished,
+            aspirationOptions: [
+                { value: "fame", label: "PF2E.Kingmaker.Kingdom.Aspiration.fame" },
+                { value: "infamy", label: "PF2E.Kingmaker.Kingdom.Aspiration.infamy" },
+            ],
         };
     }
 
@@ -370,6 +374,7 @@ interface KingdomBuilderSheetData {
     skillLabels: Record<string, string>;
     build: KingdomAbilityBuilderData;
     finished: boolean;
+    aspirationOptions: FormSelectOption[];
 }
 
 interface CategorySheetData {

--- a/src/module/actor/party/kingdom/sheet.ts
+++ b/src/module/actor/party/kingdom/sheet.ts
@@ -214,6 +214,10 @@ class KingdomSheetPF2e extends ActorSheetPF2e<PartyPF2e> {
             settlementTypes: KINGDOM_SETTLEMENT_TYPE_LABELS,
             abilityLabels: KINGDOM_ABILITY_LABELS,
             skillLabels: KINGDOM_SKILL_LABELS,
+            proficiencyOptions: Object.values(CONFIG.PF2E.proficiencyRanks).map((label, i) => ({
+                value: i.toString(),
+                label,
+            })),
         };
     }
 
@@ -722,6 +726,7 @@ interface KingdomSheetData extends ActorSheetDataPF2e<PartyPF2e> {
     settlementTypes: Record<string, string>;
     abilityLabels: Record<string, string>;
     skillLabels: Record<string, string>;
+    proficiencyOptions: FormSelectOption[];
 }
 
 interface ArmySheetData {

--- a/src/module/actor/sheet/data-types.ts
+++ b/src/module/actor/sheet/data-types.ts
@@ -60,7 +60,7 @@ interface ActorSheetDataPF2e<TActor extends ActorPF2e> extends ActorSheetData<TA
     totalWealthGold: string;
     traits: SheetOptions;
     user: { isGM: boolean };
-    publicationLicenses: { value: string; label: string }[];
+    publicationLicenses: FormSelectOption[];
 }
 
 interface AbilityViewData {

--- a/src/module/actor/vehicle/sheet.ts
+++ b/src/module/actor/vehicle/sheet.ts
@@ -68,6 +68,11 @@ export class VehicleSheetPF2e extends ActorSheetPF2e<VehiclePF2e> {
                     this.actor._source.system.saves.fortitude.value,
                 ),
             },
+            emitsSoundOptions: [
+                { value: "true", label: "PF2E.Actor.Hazard.EmitsSound.True" },
+                { value: "false", label: "PF2E.Actor.Hazard.EmitsSound.False" },
+                { value: "encounter", label: "PF2E.Actor.Hazard.EmitsSound.Encounter" },
+            ],
         };
     }
 
@@ -115,6 +120,7 @@ interface VehicleSheetData extends ActorSheetDataPF2e<VehiclePF2e> {
     ac: AdjustedValue;
     frequencies: typeof CONFIG.PF2E.frequencies;
     saves: { fortitude: AdjustedValue };
+    emitsSoundOptions: FormSelectOption[];
 }
 
 type ActionsSheetData = Record<"action" | "reaction" | "free", { label: string; actions: ActionSheetData[] }>;

--- a/src/module/item/affliction/sheet.ts
+++ b/src/module/item/affliction/sheet.ts
@@ -35,6 +35,12 @@ class AfflictionSheetPF2e extends ItemSheetPF2e<AfflictionPF2e> {
             onsetUnits: R.omit(CONFIG.PF2E.timeUnits, ["encounter", "unlimited"]),
             saves: CONFIG.PF2E.saves,
             stages: await this.prepareStages(),
+            stageOptions: Object.fromEntries(
+                Array.fromRange(this.item.maxStage).map((s) => [
+                    s.toString(),
+                    game.i18n.format("PF2E.Item.Affliction.Stage", { stage: s }),
+                ]),
+            ),
         };
     }
 
@@ -227,6 +233,7 @@ interface AfflictionSheetData extends ItemSheetDataPF2e<AfflictionPF2e> {
     onsetUnits: Omit<ConfigPF2e["PF2E"]["timeUnits"], "unlimited" | "encounter">;
     saves: ConfigPF2e["PF2E"]["saves"];
     stages: Record<string, AfflictionStageSheetData>;
+    stageOptions: Record<string, string>;
 }
 
 interface AfflictionStageSheetData extends AfflictionStageData {

--- a/src/module/item/ancestry/sheet.ts
+++ b/src/module/item/ancestry/sheet.ts
@@ -23,6 +23,11 @@ class AncestrySheetPF2e extends ABCSheetPF2e<AncestryPF2e> {
             sizes: createSheetOptions(CONFIG.PF2E.actorSizes, { value: [itemData.system.size] }),
             languages: createSheetTags(CONFIG.PF2E.languages, itemData.system.languages),
             additionalLanguages: createSheetTags(CONFIG.PF2E.languages, itemData.system.additionalLanguages),
+            visionTypeOptions: [
+                { value: "normal", label: "PF2E.Item.Ancestry.Vision.Normal" },
+                { value: "low-light-vision", label: "PF2E.Actor.Creature.Sense.Type.LowLightVision" },
+                { value: "darkvision", label: "PF2E.Actor.Creature.Sense.Type.Darkvision" },
+            ],
         };
     }
 }
@@ -33,6 +38,7 @@ interface AncestrySheetData extends ABCSheetData<AncestryPF2e> {
     sizes: SheetOptions;
     languages: SheetOptions;
     additionalLanguages: SheetOptions;
+    visionTypeOptions: FormSelectOption[];
 }
 
 export { AncestrySheetPF2e };

--- a/src/module/item/base/sheet/sheet.ts
+++ b/src/module/item/base/sheet/sheet.ts
@@ -675,7 +675,7 @@ interface ItemSheetDataPF2e<TItem extends ItemPF2e> extends ItemSheetData<TItem>
             template: string;
         }[];
     };
-    publicationLicenses: { label: string; value: string }[];
+    publicationLicenses: FormSelectOption[];
     /** Lore only, will be removed later */
     proficiencyRanks: typeof CONFIG.PF2E.proficiencyLevels;
 }

--- a/src/module/item/consumable/sheet.ts
+++ b/src/module/item/consumable/sheet.ts
@@ -25,6 +25,10 @@ class ConsumableSheetPF2e extends PhysicalItemSheetPF2e<ConsumablePF2e> {
             canHaveHealing,
             categories: sortStringRecord(CONFIG.PF2E.consumableCategories),
             damageTypes: sortStringRecord(CONFIG.PF2E.damageTypes),
+            damageKindOptions: [
+                { value: "damage", label: "PF2E.DamageLabel" },
+                { value: "healing", label: "PF2E.TraitHealing" },
+            ],
             materialEffects: createSheetTags(CONFIG.PF2E.materialDamageEffects, item.system.material.effects),
             otherTags: createSheetTags(CONFIG.PF2E.otherConsumableTags, item.system.traits.otherTags),
             stackGroups: this.item.isAmmo ? R.omit(CONFIG.PF2E.stackGroups, ["coins", "gems"]) : null,
@@ -61,6 +65,7 @@ interface ConsumableSheetData extends PhysicalItemSheetData<ConsumablePF2e> {
     canHaveDamageOrHealing: boolean;
     canHaveHealing: boolean;
     categories: Record<ConsumableCategory, string>;
+    damageKindOptions: FormSelectOption[];
     damageTypes: Record<DamageType, string>;
     materialEffects: SheetOptions;
     otherTags: SheetOptions;

--- a/src/module/item/physical/sheet.ts
+++ b/src/module/item/physical/sheet.ts
@@ -237,8 +237,8 @@ interface PhysicalItemSheetData<TItem extends PhysicalItemPF2e> extends ItemShee
     frequencies: typeof CONFIG.PF2E.frequencies;
     sizes: Omit<typeof CONFIG.PF2E.actorSizes, "sm">;
     usages: typeof CONFIG.PF2E.usages;
-    usageOptions: { label: string; value: string }[];
-    identificationStatusOptions: { label: string; value: string }[];
+    usageOptions: FormSelectOption[];
+    identificationStatusOptions: FormSelectOption[];
     bulkDisabled: boolean;
     activations: {
         action: ItemActivation;

--- a/src/module/item/weapon/sheet.ts
+++ b/src/module/item/weapon/sheet.ts
@@ -211,7 +211,7 @@ interface WeaponSheetData extends PhysicalItemSheetData<WeaponPF2e> {
     mandatoryRanged: boolean;
     meleeGroups: typeof CONFIG.PF2E.meleeWeaponGroups;
     meleeUsage: ComboWeaponMeleeUsage | undefined;
-    meleeUsageBaseDamage: { label: string; value: string }[];
+    meleeUsageBaseDamage: FormSelectOption[];
     meleeUsageTraits: SheetOptions;
     otherTags: SheetOptions;
     preciousMaterials: MaterialSheetData;

--- a/static/templates/actors/character/partials/proficiencylevels-dropdown.hbs
+++ b/static/templates/actors/character/partials/proficiencylevels-dropdown.hbs
@@ -1,4 +1,4 @@
-{{#unless excludeUntrained}}<option value="0" {{#if (eq proflevel 0)}}selected{{/if}}>{{localize "PF2E.ProficiencyLevel0"}}</option>{{/unless}}
+<option value="0" {{#if (eq proflevel 0)}}selected{{/if}}>{{localize "PF2E.ProficiencyLevel0"}}</option>
 <option value="1" {{#if (eq proflevel 1)}}selected{{/if}}>{{localize "PF2E.ProficiencyLevel1"}}</option>
 <option value="2" {{#if (eq proflevel 2)}}selected{{/if}}>{{localize "PF2E.ProficiencyLevel2"}}</option>
 <option value="3" {{#if (eq proflevel 3)}}selected{{/if}}>{{localize "PF2E.ProficiencyLevel3"}}</option>

--- a/static/templates/actors/character/partials/sidebar.hbs
+++ b/static/templates/actors/character/partials/sidebar.hbs
@@ -244,7 +244,7 @@
         {{numberFormat data.initiative.totalModifier decimals=0 sign=true}}
     </a>
     <select name="system.initiative.statistic">
-        {{selectOptions initiativeOptions localize=true}}
+        {{selectOptions initiativeOptions selected=data.initiative.statistic localize=true sort=true}}
     </select>
 </section>
 {{#with data.initiative}}

--- a/static/templates/actors/npc/partials/sidebar.hbs
+++ b/static/templates/actors/npc/partials/sidebar.hbs
@@ -138,12 +138,7 @@
 
     <div class="side-bar-section-content">
         <select name="system.initiative.statistic">
-            {{#select data.initiative.statistic}}
-                <option value="perception">{{localize "PF2E.PerceptionLabel"}}</option>
-                {{#each data.skills as |skill|}}
-                    <option value="{{skill.slug}}">{{skill.label}}</option>
-                {{/each}}
-            {{/select}}
+            {{selectOptions initiativeOptions selected=data.initiative.statistic localize=true sort=true}}
         </select>
     </div>
 </div>

--- a/static/templates/actors/npc/tabs/spells.hbs
+++ b/static/templates/actors/npc/tabs/spells.hbs
@@ -57,22 +57,6 @@
                                 />
                             {{/if}}
                         </div>
-                        <div class="attribute inline-field">
-                            {{#if entry.isEphemeral}}
-                                <span class="attribute">{{entry.attribute}}</span>
-                            {{else}}
-                                <select data-base-property="data.items.{{eid}}.system.ability.value">
-                                    {{#select entry.attribute}}
-                                        <option value="str">{{localize "PF2E.AbilityId.str"}}</option>
-                                        <option value="dex">{{localize "PF2E.AbilityId.dex"}}</option>
-                                        <option value="con">{{localize "PF2E.AbilityId.con"}}</option>
-                                        <option value="int">{{localize "PF2E.AbilityId.int"}}</option>
-                                        <option value="wis">{{localize "PF2E.AbilityId.wis"}}</option>
-                                        <option value="cha">{{localize "PF2E.AbilityId.cha"}}</option>
-                                    {{/select}}
-                                </select>
-                            {{/if}}
-                        </div>
                     {{/unless}}
 
                     {{#if (and ../editable (not entry.isEphemeral))}}

--- a/static/templates/actors/party/kingdom/builder.hbs
+++ b/static/templates/actors/party/kingdom/builder.hbs
@@ -92,10 +92,7 @@
                             <label class="aspiration">
                                 {{localize "PF2E.Kingmaker.KingdomBuilder.Aspiration"}}
                                 <select name="aspiration">
-                                    {{#select kingdom.aspiration}}
-                                        <option value="fame">{{localize "PF2E.Kingmaker.Kingdom.Aspiration.fame"}}</option>
-                                        <option value="infamy">{{localize "PF2E.Kingmaker.Kingdom.Aspiration.infamy"}}</option>
-                                    {{/select}}
+                                    {{selectOptions @root.aspirationOptions selected=kingdom.aspiration localize=true}}
                                 </select>
                             </label>
                             <label>

--- a/static/templates/actors/party/kingdom/partials/settlement.hbs
+++ b/static/templates/actors/party/kingdom/partials/settlement.hbs
@@ -4,11 +4,7 @@
             <h4 class="drag-handle" data-drag-handle><i class="fa-solid fa-bars"></i></h4>
             <input class="name" type="text" value="{{settlement.name}}" name="settlements.{{settlement.id}}.name" placeholder="{{localize "PF2E.Kingmaker.Settlement.Name"}}" />
             <select class="type" name="settlements.{{settlement.id}}.type" data-dtype="String">
-                {{#select settlement.type}}
-                    {{#each @root.settlementTypes as |label value|}}
-                        <option value="{{value}}">{{localize label}}</option>
-                    {{/each}}
-                {{/select}}
+                {{selectOptions @root.settlementTypes selected=settlement.type localize=true}}
             </select>
         {{else}}
             <h4 class="name drag-handle" data-drag-handle><a data-action="toggle-summary">{{settlement.name}}</a></h4>

--- a/static/templates/actors/party/kingdom/tabs/activities.hbs
+++ b/static/templates/actors/party/kingdom/tabs/activities.hbs
@@ -92,13 +92,7 @@
 {{#*inline "proficiencySelect"}}
     {{#if @root.editable}}
         <select data-property="{{property}}" class="proficiency" data-rank="{{rank}}">
-            {{#select rank}}
-                {{#if (not excludeUntrained)}}<option value="0" {{#if (eq proflevel 0)}}selected{{/if}}>{{localize "PF2E.ProficiencyLevel0"}}</option>{{/if}}
-                <option value="1">{{localize "PF2E.ProficiencyLevel1"}}</option>
-                <option value="2">{{localize "PF2E.ProficiencyLevel2"}}</option>
-                <option value="3">{{localize "PF2E.ProficiencyLevel3"}}</option>
-                <option value="4">{{localize "PF2E.ProficiencyLevel4"}}</option>
-            {{/select}}
+            {{selectOptions @root.proficiencyOptions selected=rank localize=true}}
         </select>
     {{else}}
         <span class="proficiency" data-rank="{{rank}}">

--- a/static/templates/actors/vehicle/sidebar.hbs
+++ b/static/templates/actors/vehicle/sidebar.hbs
@@ -121,11 +121,7 @@
         </h2>
     </header>
     <select name="system.attributes.emitsSound">
-        {{#select data.attributes.emitsSound}}
-            <option value="false">{{localize "PF2E.Actor.Vehicle.EmitsSound.False"}}</option>
-            <option value="true">{{localize "PF2E.Actor.Vehicle.EmitsSound.True"}}</option>
-            <option value="encounter">{{localize "PF2E.Actor.Vehicle.EmitsSound.Encounter"}}</option>
-        {{/select}}
+        {{selectOptions emitsSoundOptions selected=data.attributes.emitsSound localize=true}}
     </select>
 </section>
 

--- a/static/templates/actors/vehicle/vehicle-header.hbs
+++ b/static/templates/actors/vehicle/vehicle-header.hbs
@@ -5,19 +5,11 @@
         </h1>
         <div class="tags">
             <select class="rarity rarity-select {{data.traits.rarity}}" name="system.traits.rarity" data-dtype="String">
-                {{#select data.traits.rarity}}
-                    {{#each actorRarities as |label key|}}
-                        <option value="{{key}}">{{localize label}}</option>
-                    {{/each}}
-                {{/select}}
+                {{selectOptions actorRarities selected=data.traits.rarity localize=true}}
             </select>
 
             <select class="size size-select" name="system.traits.size.value" data-dtype="String">
-                {{#select data.traits.size.value}}
-                    {{#each actorSizes as |label size|}}
-                        <option value="{{size}}">{{localize label}}</option>
-                    {{/each}}
-                {{/select}}
+                {{selectOptions actorSizes selected=data.traits.size.value localize=true}}
             </select>
         </div>
     </div>

--- a/static/templates/chat/check-modifiers-dialog.hbs
+++ b/static/templates/chat/check-modifiers-dialog.hbs
@@ -78,11 +78,7 @@
         <label class="roll-mode">
             {{localize "PF2E.RollModeLabel"}}
             <select name="rollmode">
-                {{#select rollMode}}
-                    {{#each rollModes as |label key|}}
-                        <option value="{{key}}">{{localize label}}</option>
-                    {{/each}}
-                {{/select}}
+                {{selectOptions rollModes selected=rollMode localize=true}}
             </select>
         </label>
         <label data-tooltip="PF2E.Roll.Dialog.ShowDefaultHint">

--- a/static/templates/chat/damage/damage-modifier-dialog.hbs
+++ b/static/templates/chat/damage/damage-modifier-dialog.hbs
@@ -93,11 +93,7 @@
         <label class="roll-mode">
             {{localize "PF2E.RollModeLabel"}}
             <select name="rollmode">
-                {{#select rollMode}}
-                    {{#each rollModes as |label key|}}
-                        <option value="{{key}}">{{localize label}}</option>
-                    {{/each}}
-                {{/select}}
+                {{selectOptions rollModes selected=rollMode localize=true}}
             </select>
         </label>
         <label data-tooltip="PF2E.Roll.Dialog.ShowDefaultHint">

--- a/static/templates/chat/roll-dialog.hbs
+++ b/static/templates/chat/roll-dialog.hbs
@@ -14,11 +14,7 @@
     <div class="form-group">
         <label>{{localize "PF2E.RollModeLabel"}}</label>
         <select name="rollMode">
-            {{#select rollMode}}
-                {{#each rollModes as |label mode|}}
-                    <option value="{{mode}}">{{localize label}}</option>
-                {{/each}}
-            {{/select}}
+            {{selectOptions rollModes selected=rollMode localize=true}}
         </select>
     </div>
 </form>

--- a/static/templates/compendium-browser/filters.hbs
+++ b/static/templates/compendium-browser/filters.hbs
@@ -5,11 +5,7 @@
             <dt>{{localize "PF2E.BrowserSortyByLabel"}}:</dt>
             <dd>
                 <select class="order">
-                    {{#select filterData.order.by}}
-                        {{#each filterData.order.options as |label type|}}
-                            <option value="{{type}}">{{localize label}}</option>
-                        {{/each}}
-                    {{/select}}
+                    {{selectOptions filterData.order.options selected=filterData.order.by localize=true}}
                 </select>
                 <a class="direction" data-type="alpha" data-direction="{{filterData.order.direction}}">
                     {{#if (eq filterData.order.direction "asc")}}
@@ -32,12 +28,7 @@
             <dl class="{{type}}">
                 <dt>{{localize selectData.label}}:</dt>
                 <dd><select name="{{type}}">
-                    {{#select selectData.selected}}
-                        <option value="">-</option>
-                        {{#each selectData.options as |option key|}}
-                            <option value="{{key}}">{{option}}</option>
-                        {{/each}}
-                    {{/select}}
+                    {{selectOptions selectData.options selected=selectData.selected blank="-"}}
                 </select></dd>
             </dl>
         {{/each}}

--- a/static/templates/items/activation-panel.hbs
+++ b/static/templates/items/activation-panel.hbs
@@ -36,19 +36,11 @@
             <div class="form-fields">
                 <div class="form-fields activation-time">
                     <select name="{{base}}.actionCost.type" data-dtype="String">
-                        {{#select action.actionCost.type}}
-                            {{#each @root.actionTypes as |name type|}}
-                                <option value="{{type}}">{{localize name}}</option>
-                            {{/each}}
-                        {{/select}}
+                        {{selectOptions @root.actionTypes selected=action.actionCost.type localize=true}}
                     </select>
                     {{#if (eq action.actionCost.type "action")}}
                         <select name="{{base}}.actionCost.value" data-dtype="Number">
-                            {{#select action.actionCost.value}}
-                                {{#each @root.actionsNumber as |name type|}}
-                                    <option value="{{type}}">{{localize name}}</option>
-                                {{/each}}
-                            {{/select}}
+                            {{selectOptions @root.actionsNumber selected=action.actionCost.value localize=true}}
                         </select>
                     {{/if}}
                 </div>
@@ -58,11 +50,7 @@
                         <input type="number" name="{{base}}.frequency.max" value="{{action.frequency.max}}" data-dtype="Number"/>
                         <span>{{localize "PF2E.Frequency.per"}}</span>
                         <select name="{{base}}.frequency.per" data-dtype="String">
-                            {{#select action.frequency.per}}
-                                {{#each @root.frequencies as |name type|}}
-                                    <option value="{{type}}">{{localize name}}</option>
-                                {{/each}}
-                            {{/select}}
+                            {{selectOptions@root.frequencies selected=action.frequency.per localize=true}}
                         </select>
                         <a data-action="activation-frequency-delete"><i class="fa-solid fa-times"></i></a>
                     </div>

--- a/static/templates/items/affliction-details.hbs
+++ b/static/templates/items/affliction-details.hbs
@@ -4,11 +4,7 @@
         <div class="form-fields">
             <input type="number" name="system.save.value" value="{{data.save.value}}">
             <select name="system.save.type">
-                {{#select data.save.type}}
-                    {{#each saves as |ability a|}}
-                        <option value="{{a}}">{{localize ability}}</option>
-                    {{/each}}
-                {{/select}}
+                {{selectOptions saves selected=data.save.type localize=true}}
             </select>
         </div>
     </div>
@@ -36,19 +32,10 @@
                     <div class="formula-row">
                         <input type="text" name="system.stages.{{stageId}}.damage.{{id}}.formula" value="{{damage.formula}}" placeholder="{{localize "PF2E.Formula"}}" />
                         <select name="system.stages.{{stageId}}.damage.{{id}}.category">
-                            {{#select damage.category}}
-                                <option></option>
-                                {{#each @root.damageCategories as |name type|}}
-                                    <option value="{{type}}">{{localize name}}</option>
-                                {{/each}}
-                            {{/select}}
+                            {{selectOptions @root.damageCategories selected=damage.category blank="" localize=true}}
                         </select>
                         <select name="system.stages.{{stageId}}.damage.{{id}}.type">
-                            {{#select damage.type}}
-                                {{#each @root.damageTypes as |name type|}}
-                                    <option value="{{type}}">{{localize name}}</option>
-                                {{/each}}
-                            {{/select}}
+                            {{selectOptions @root.damageTypes selected=damage.type localize=true}}
                         </select>
                         <div class="item-controls">
                             <a data-action="damage-delete" data-id="{{id}}"><i class="fa-solid fa-fw fa-times"></i></a>
@@ -69,11 +56,7 @@
                 {{#each stage.conditions as |condition key|}}
                     <div class="form-fields stage-condition" data-condition-id="{{key}}">
                         <select name="system.stages.{{stageId}}.conditions.{{key}}.slug">
-                            {{#select condition.slug}}
-                                {{#each @root.conditionTypes as |label slug|}}
-                                    <option value="{{slug}}">{{localize label}}</option>
-                                {{/each}}
-                            {{/select}}
+                            {{selectOptions @root.conditionTypes selected=condition.slug localize=true}}
                         </select>
                         {{#if condition.document.system.value.isValued}}
                             <input type="number" name="system.stages.{{stageId}}.conditions.{{key}}.value" value="{{condition.value}}" />

--- a/static/templates/items/affliction-sidebar.hbs
+++ b/static/templates/items/affliction-sidebar.hbs
@@ -40,14 +40,11 @@
     <div class="form-group">
         <label>{{localize "PF2E.Item.Affliction.StageLabel"}}</label>
         <select name="system.stage" data-dtype="Number" {{disabled (not item.actor)}}>
-            {{#select item.stage}}
-                {{#if item.onsetDuration}}
-                    <option value="0">{{localize "PF2E.Item.Affliction.OnsetLabel"}}</option>
-                {{/if}}
-                {{#times item.maxStage as |idx|}}
-                    <option value="{{add idx 1}}">{{localize "PF2E.Item.Affliction.Stage" stage=(add idx 1)}}</option>
-                {{/times}}
-            {{/select}}
+            {{#if item.onsetDuration}}
+                {{selectOptions @root.stageOptions selected=item.stage}}
+            {{else}}
+                {{selectOptions (omit @root.stageOptions "0") selected=item.stage}}
+            {{/if}}
         </select>
     </div>
 

--- a/static/templates/items/ancestry-sidebar.hbs
+++ b/static/templates/items/ancestry-sidebar.hbs
@@ -22,11 +22,7 @@
     <div class="form-group">
         <label>{{localize "PF2E.Item.Ancestry.Vision.Label"}}</label>
         <select name="system.vision">
-            {{#select data.vision}}
-                <option value="normal">{{localize "PF2E.Item.Ancestry.Vision.Normal"}}</option>
-                <option value="low-light-vision">{{localize "PF2E.Actor.Creature.Sense.Type.LowLightVision"}}</option>
-                <option value="darkvision">{{localize "PF2E.Actor.Creature.Sense.Type.Darkvision"}}</option>
-            {{/select}}
+            {{selectOptions visionTypeOptions selected=data.vision localize=true}}
         </select>
     </div>
 </div>

--- a/static/templates/items/armor-details.hbs
+++ b/static/templates/items/armor-details.hbs
@@ -142,21 +142,13 @@
             <div class="form-group">
                 <label for="{{fieldIdPrefix}}rune-potency">{{localize "PF2E.PotencyRuneLabel"}}</label>
                 <select name="system.runes.potency" id="{{fieldIdPrefix}}rune-potency" data-dtype="Number">
-                    {{#select data.runes.potency}}
-                        {{#each runeTypes.potency as |data number|}}
-                            <option value="{{number}}">{{localize (coalesce data.name "")}}</option>
-                        {{/each}}
-                    {{/select}}
+                    {{selectOptions (omit runeTypes.potency 0) selected=data.runes.potency labelAttr="name" blank="" localize=true}}
                 </select>
             </div>
             <div class="form-group">
                 <label for="{{fieldIdPrefix}}rune-resilient">{{localize "PF2E.Item.Armor.Rune.Resilient.Label"}}</label>
                 <select name="system.runes.resilient" id="{{fieldIdPrefix}}rune-resilient" data-dtype="Number">
-                    {{#select data.runes.resilient}}
-                        {{#each runeTypes.resilient as |data number|}}
-                            <option value="{{number}}">{{localize (coalesce data.name "")}}</option>
-                        {{/each}}
-                    {{/select}}
+                    {{selectOptions (omit runeTypes.resilient 0) selected=data.runes.resilient labelAttr="name" blank="" localize=true}}
                 </select>
             </div>
         {{/unless}}

--- a/static/templates/items/backpack-details.hbs
+++ b/static/templates/items/backpack-details.hbs
@@ -3,11 +3,7 @@
 <div class="form-group">
     <label for="{{fieldIdPrefix}}bulk-held-stowed">{{localize "PF2E.Item.Physical.Bulk.HeldOrStowed"}}</label>
     <select name="system.bulk.heldOrStowed" id="{{fieldIdPrefix}}bulk-held-stowed" data-dtype="Number">
-        {{#select item._source.system.bulk.heldOrStowed}}
-            {{#each bulks as |bulk|}}
-                <option value="{{bulk.value}}">{{bulk.label}}</option>
-            {{/each}}
-        {{/select}}
+        {{selectOptions bulks selected=item._source.system.bulk.heldOrStowed}}
     </select>
 </div>
 

--- a/static/templates/items/campaign-feature-sidebar.hbs
+++ b/static/templates/items/campaign-feature-sidebar.hbs
@@ -9,11 +9,7 @@
     <div class="form-group">
         <label>{{localize "PF2E.Category"}}</label>
         <select name="system.category" {{disabled document.parent}}>
-            {{#select data.category}}
-                {{#each categories as |label type|}}
-                    <option value="{{type}}">{{localize label}}</option>
-                {{/each}}
-            {{/select}}
+            {{selectOptions categories selected=data.category localize=true}}
         </select>
     </div>
 

--- a/static/templates/items/consumable-details.hbs
+++ b/static/templates/items/consumable-details.hbs
@@ -1,11 +1,7 @@
 <div class="form-group">
     <label>{{localize "PF2E.Category"}}</label>
     <select name="system.category">
-        {{#select data.category}}
-            {{#each categories as |name type|}}
-                <option value="{{type}}">{{localize name}}</option>
-            {{/each}}
-        {{/select}}
+        {{selectOptions categories selected=data.category localize=true}}
     </select>
 </div>
 
@@ -30,17 +26,10 @@
             <div class="form-fields">
                 <input type="text" name="system.damage.formula" id="{{fieldIdPrefix}}damage" value="{{data.damage.formula}}" />
                 <select name="system.damage.type">
-                    {{#select data.damage.type}}
-                        {{#each @root.damageTypes as |name type|}}
-                            <option value="{{type}}">{{localize name}}</option>
-                        {{/each}}
-                    {{/select}}
+                     {{selectOptions @root.damageTypes selected=data.damage.type localize=true}}
                 </select>
                 <select class="kinds" name="system.damage.kind" {{disabled (not canHaveHealing)}}>
-                    {{#select data.damage.kind}}
-                        <option value="damage">{{localize "PF2E.DamageLabel"}}</option>
-                        <option value="healing">{{localize "PF2E.TraitHealing"}}</option>
-                    {{/select}}
+                    {{selectOptions @root.damageKindOptions selected=data.damage.kind localize=true}}
                 </select>
                 <a data-action="remove-damage" data-tooltip="PF2E.DeleteShortLabel"><i class="fa-solid fa-trash"></i></a>
             </div>


### PR DESCRIPTION
- The `excludeUntrained` value for proficiency levels only existed in the templates so I removed it.
- The key attribute dropdown in the NPC spellcasting tab was non-functional and redundant so I removed it.

Untested because unsued (I think):
- "systems/pf2e/templates/items/activation-panel.hbs"
- "systems/pf2e/templates/items/affliction-details.hbs"
- "systems/pf2e/templates/items/affliction-sidebar.hbs"
