### PR TITLE
Fix `DamageDice` with critical set to `false` being included in critical damage

### DIFF
--- a/src/module/system/damage/formula.ts
+++ b/src/module/system/damage/formula.ts
@@ -93,7 +93,7 @@ function createDamageFormula(
     const BONUS_BASE_LABELS = ["PF2E.ConditionTypePersistent"].map((l) => game.i18n.localize(l));
 
     // Test that a damage modifier or dice partial is compatible with the prior check result
-    const outcomeMatches = (m: { critical: boolean | null }): boolean => critical || m.critical !== true;
+    const outcomeMatches = (m: { critical: boolean | null }): boolean => m.critical === null || m.critical === critical;
 
     // Add damage dice. Dice always stack
     for (const dice of damage.dice.filter((d) => d.enabled && outcomeMatches(d))) {


### PR DESCRIPTION
> True means the dice are added to critical without doubling; false means the dice are never added to critical damage; omitted means add to normal damage and double on critical damage.

The image shows: true, false, null


![image](https://github.com/foundryvtt/pf2e/assets/41452412/c14bde80-c3ed-4191-aa5f-8e628b3614b9)
