### PR TITLE
Fix ChoiceSet labels for Effect: Deck of Destiny and Effect: Recall Under Pressure

### DIFF
--- a/packs/actions/recall-under-pressure.json
+++ b/packs/actions/recall-under-pressure.json
@@ -11,7 +11,7 @@
         },
         "category": "offensive",
         "description": {
-            "value": "<p><strong>Trigger</strong> You attempt to Recall Knowledge during a combat</p>\n<p><strong>Frequency</strong> once per day</p>\n<hr />\n<p><strong>Effect</strong> Rather than roll a different skill to Recall Knowledge during the fight, your memory flashes back to something you read in some old book. You instead attempt this Recall Knowledge check with an Academia Lore check. If the information you recall ends up being helpful and positive in an obvious way before you take your next turn, draw a random harrow card. You gain a +1 status bonus to saving throws for the remainder of the combat encounter as your morale soars or a +2 status bonus if the card you drew was from the suit of Books.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Recall Under Pressure]</p>"
+            "value": "<p><strong>Trigger</strong> You attempt to @UUID[Compendium.pf2e.actionspf2e.Item.Recall Knowledge] during a combat</p>\n<p><strong>Frequency</strong> once per day</p>\n<hr />\n<p><strong>Effect</strong> Rather than roll a different skill to Recall Knowledge during the fight, your memory flashes back to something you read in some old book. You instead attempt this Recall Knowledge check with an Academia Lore check. If the information you recall ends up being helpful and positive in an obvious way before you take your next turn, draw a random harrow card. You gain a +1 status bonus to saving throws for the remainder of the combat encounter as your morale soars or a +2 status bonus if the card you drew was from the suit of Books.</p>"
         },
         "frequency": {
             "max": 1,
@@ -23,6 +23,10 @@
             "title": "Pathfinder: Stolen Fate Player's Guide"
         },
         "rules": [],
+        "selfEffect": {
+            "name": "Effect: Recall Under Pressure",
+            "uuid": "Compendium.pf2e.feat-effects.Item.Effect: Recall Under Pressure"
+        },
         "traits": {
             "value": [
                 "fortune"

--- a/packs/equipment-effects/effect-deck-of-destiny.json
+++ b/packs/equipment-effects/effect-deck-of-destiny.json
@@ -39,11 +39,11 @@
             {
                 "choices": [
                     {
-                        "label": "UI.RuleElements.ChoiceSet.YesLabel",
+                        "label": "PF2E.UI.RuleElements.ChoiceSet.YesLabel",
                         "value": "matching-suit"
                     },
                     {
-                        "label": "UI.RuleElements.ChoiceSet.NoLabel",
+                        "label": "PF2E.UI.RuleElements.ChoiceSet.NoLabel",
                         "value": "non-matching-suit"
                     }
                 ],

--- a/packs/feat-effects/effect-recall-under-pressure.json
+++ b/packs/feat-effects/effect-recall-under-pressure.json
@@ -24,11 +24,11 @@
             {
                 "choices": [
                     {
-                        "label": "UI.RuleElements.ChoiceSet.NoLabel",
+                        "label": "PF2E.UI.RuleElements.ChoiceSet.NoLabel",
                         "value": 1
                     },
                     {
-                        "label": "UI.RuleElements.ChoiceSet.YesLabel",
+                        "label": "PF2E.UI.RuleElements.ChoiceSet.YesLabel",
                         "value": 2
                     }
                 ],
@@ -39,6 +39,7 @@
             {
                 "key": "FlatModifier",
                 "selector": "saving-throw",
+                "type": "status",
                 "value": "@item.flags.pf2e.rulesSelections.bonus"
             }
         ],


### PR DESCRIPTION
Also fix bonus type for Effect: Recall Under Pressure
Make Effect: Recall Under Pressure a self effect

Closes https://github.com/foundryvtt/pf2e/issues/14555