### PR TITLE
Refactor `ChatMessagePF2e` flags

### DIFF
--- a/src/module/actor/roll-context/damage.ts
+++ b/src/module/actor/roll-context/damage.ts
@@ -1,7 +1,7 @@
 import type { ActorPF2e } from "@actor";
 import type { StrikeData } from "@actor/data/base.ts";
 import type { ItemPF2e } from "@item";
-import type { CheckContextChatFlag } from "@module/chat-message/data.ts";
+import type { CheckContextChatData } from "@module/chat-message/data.ts";
 import { CheckRoll } from "@system/check/roll.ts";
 import type { Statistic } from "@system/statistic/statistic.ts";
 import { sluggify } from "@util";
@@ -26,7 +26,7 @@ class DamageContext<
         }
     }
 
-    #findMatchingCheckContext(): CheckContextChatFlag | null {
+    #findMatchingCheckContext(): CheckContextChatData | null {
         const { origin, target } = this.unresolved;
         const item = origin?.item;
         if (this.viewOnly || !origin?.actor || !item?.isOfType("melee", "weapon") || !target?.token) {
@@ -54,7 +54,7 @@ class DamageContext<
                 );
             });
 
-        return (checkMessage?.flags.pf2e.context ?? null) as CheckContextChatFlag | null;
+        return (checkMessage?.system.context ?? null) as CheckContextChatData | null;
     }
 }
 

--- a/src/module/actor/roll-context/types.ts
+++ b/src/module/actor/roll-context/types.ts
@@ -3,7 +3,7 @@ import type { StrikeData } from "@actor/data/base.ts";
 import type { ModifierPF2e } from "@actor/modifiers.ts";
 import type { ItemPF2e } from "@item";
 import type { ActionTrait } from "@item/ability/types.ts";
-import type { CheckContextChatFlag } from "@module/chat-message/data.ts";
+import type { CheckContextChatData } from "@module/chat-message/data.ts";
 import type { TokenDocumentPF2e } from "@scene";
 import type { CheckDC, DegreeOfSuccessString } from "@system/degree-of-success.ts";
 import type { Statistic } from "@system/statistic/statistic.ts";
@@ -143,7 +143,7 @@ type DamageContextConstructorParams<
     TItem extends ItemPF2e<ActorPF2e> | null = ItemPF2e<ActorPF2e> | null,
 > = RollContextConstructorParams<TSelf, TStatistic, TItem> & {
     /** The context object of the preceding check roll */
-    checkContext: Maybe<CheckContextChatFlag>;
+    checkContext: Maybe<CheckContextChatData>;
     /**
      * An outcome of a preceding check roll:
      * This may be different than what is in the context object if the user rolled damage despite a failure

--- a/src/module/apps/sidebar/chat-log.ts
+++ b/src/module/apps/sidebar/chat-log.ts
@@ -349,7 +349,7 @@ class ChatLogPF2e extends ChatLog<ChatMessagePF2e> {
 
         const canShowRollDetails: ContextOptionCondition = ($li: JQuery): boolean => {
             const message = game.messages.get($li[0].dataset.messageId, { strict: true });
-            return game.user.isGM && !!message.flags.pf2e.context;
+            return game.user.isGM && !!message.system.context;
         };
 
         const options = super._getEntryContextOptions();

--- a/src/module/chat-message/crit-fumble-cards.ts
+++ b/src/module/chat-message/crit-fumble-cards.ts
@@ -7,7 +7,7 @@ export class CriticalHitAndFumbleCards {
 
     static handleDraw(message: ChatMessagePF2e): void {
         if (message.isAuthor && message.isContentVisible) {
-            const type = message.flags.pf2e.context?.type ?? "";
+            const type = message.system.context?.type ?? "";
             const firstDie = message.rolls.at(0)?.dice[0];
             if (firstDie && firstDie.faces === 20 && this.rollTypes.includes(type)) {
                 if (firstDie.total === 20) {
@@ -53,7 +53,7 @@ export class CriticalHitAndFumbleCards {
     static appendButtons(message: ChatMessagePF2e, $html: JQuery): void {
         this.appendButtonsOption ??= game.pf2e.settings.critFumble.buttons;
         if (this.appendButtonsOption && (message.isAuthor || game.user.isGM) && message.isContentVisible) {
-            const type = message.flags.pf2e.context?.type ?? "";
+            const type = message.system.context?.type ?? "";
             if (this.rollTypes.includes(type)) {
                 const $critButton = $(
                     `<button class="dice-total-fullDamage-btn" style="width: 22px; height:22px; font-size:10px;line-height:1px"><i class="fa-solid fa-thumbs-up" title="${game.i18n.localize(

--- a/src/module/chat-message/data.ts
+++ b/src/module/chat-message/data.ts
@@ -1,4 +1,4 @@
-import type { RawDamageDice, RawModifier } from "@actor/modifiers.ts";
+import { RawDamageDice, RawModifier } from "@actor/modifiers.ts";
 import { SpellSource } from "@item/base/data/index.ts";
 import { MagicTradition } from "@item/spell/types.ts";
 import { ZeroToTwo } from "@module/data.ts";
@@ -18,8 +18,6 @@ interface ChatMessageSystemData {
     appliedDamage?: AppliedDamageData | null;
     /** Message context data that describes the type of this chat message */
     context?: ChatMessageContext;
-    /** Origin data for this chat message */
-    origin: ChatMessageOriginData | null;
 }
 
 type ChatMessageFlagsPF2e = ChatMessageFlags & {
@@ -110,23 +108,31 @@ type ContextFlagOmission =
     | "target"
     | "token";
 
+interface BaseChatMessageContext {
+    /** Origin data for this chat message */
+    origin?: Maybe<ChatMessageOriginData>;
+}
+
 interface CheckContextChatData extends Required<Omit<CheckCheckContext, ContextFlagOmission>> {
     dosAdjustments?: DegreeAdjustmentsRecord;
     roller?: "origin" | "target";
+    origin?: Maybe<ChatMessageOriginData>;
     target: ChatMessageTargetData | null;
     altUsage?: "thrown" | "melee" | null;
     notes: RollNoteSource[];
     options: string[];
 }
 
-interface DamageDamageContextData extends Required<Omit<DamageDamageContext, ContextFlagOmission | "self">> {
+interface DamageDamageContextData
+    extends BaseChatMessageContext,
+        Required<Omit<DamageDamageContext, ContextFlagOmission | "self">> {
     mapIncreases?: ZeroToTwo;
     target: ChatMessageTargetData | null;
     notes: RollNoteSource[];
     options: string[];
 }
 
-interface SpellCastContextData {
+interface SpellCastContextData extends BaseChatMessageContext {
     type: "spell-cast";
     domains: string[];
     options: string[];
@@ -136,7 +142,7 @@ interface SpellCastContextData {
     spellcasting?: SpellcastingOriginData | null;
 }
 
-interface SelfEffectContextData {
+interface SelfEffectContextData extends BaseChatMessageContext {
     type: "self-effect";
     domains?: never;
     options?: never;
@@ -156,15 +162,11 @@ interface AppliedDamageData {
 }
 
 export type {
-    ActorTokenFlag,
     AppliedDamageData,
-    ChatContextFlag,
     ChatMessageFlagsPF2e,
     ChatMessageOriginData,
     ChatMessageSourcePF2e,
     ChatMessageSystemData,
-    CheckContextChatFlag,
-    DamageDamageContextFlag,
     DamageRollFlag,
     SpellcastingOriginData,
 };

--- a/src/module/chat-message/data.ts
+++ b/src/module/chat-message/data.ts
@@ -13,7 +13,6 @@ type ChatMessageSourcePF2e = foundry.documents.ChatMessageSource<string, ChatMes
 };
 
 interface ChatMessageSystemData {
-    rollOptions?: string[];
     /** A record of applied damage that can be undone */
     appliedDamage?: AppliedDamageData | null;
     /** Message context data that describes the type of this chat message */
@@ -163,10 +162,15 @@ interface AppliedDamageData {
 
 export type {
     AppliedDamageData,
+    ChatMessageContext,
     ChatMessageFlagsPF2e,
     ChatMessageOriginData,
     ChatMessageSourcePF2e,
     ChatMessageSystemData,
+    ChatMessageTargetData,
+    CheckContextChatData,
+    DamageDamageContextData,
     DamageRollFlag,
+    SpellCastContextData,
     SpellcastingOriginData,
 };

--- a/src/module/chat-message/document.ts
+++ b/src/module/chat-message/document.ts
@@ -10,7 +10,7 @@ import { DamageRoll } from "@system/damage/roll.ts";
 import { TextEditorPF2e } from "@system/text-editor.ts";
 import { htmlQuery, htmlQueryAll, parseHTML } from "@util";
 import { CriticalHitAndFumbleCards } from "./crit-fumble-cards.ts";
-import type { AppliedDamageData, ChatMessageFlagsPF2e, ChatMessageSourcePF2e, ChatMessageSystemData } from "./data.ts";
+import type { ChatMessageFlagsPF2e, ChatMessageSourcePF2e, ChatMessageSystemData } from "./data.ts";
 import * as Listeners from "./listeners/index.ts";
 import { RollInspector } from "./roll-inspector.ts";
 
@@ -175,10 +175,6 @@ class ChatMessagePF2e extends ChatMessage {
     static override migrateData(source: ChatMessageSourcePF2e): ChatMessageSourcePF2e {
         // Migrate old flags to system data (we need to either migrate this for real later, or drop support in a future release)
         const flags = source.flags.pf2e;
-        if (flags?.appliedDamage) {
-            source.system.appliedDamage = flags.appliedDamage as AppliedDamageData;
-            flags.appliedDamage = undefined;
-        }
         if (flags?.appliedDamage) {
             source.system.appliedDamage = flags.appliedDamage;
             flags.appliedDamage = undefined;

--- a/src/module/chat-message/listeners/cards.ts
+++ b/src/module/chat-message/listeners/cards.ts
@@ -22,7 +22,7 @@ import {
     sluggify,
     tupleHasValue,
 } from "@util";
-import { ChatMessagePF2e, CheckContextChatFlag } from "../index.ts";
+import { ChatMessagePF2e, CheckContextChatData } from "../index.ts";
 
 class ChatCards {
     static #lastClick = 0;
@@ -58,8 +58,8 @@ class ChatCards {
         const strikeAction = message._strike;
         if (strikeAction && action?.startsWith("strike-")) {
             const context = (
-                message.rolls.some((r) => r instanceof CheckRoll) ? message.flags.pf2e.context ?? null : null
-            ) as CheckContextChatFlag | null;
+                message.rolls.some((r) => r instanceof CheckRoll) ? message.system.context ?? null : null
+            ) as CheckContextChatData | null;
             const mapIncreases =
                 context && "mapIncreases" in context && tupleHasValue([0, 1, 2], context.mapIncreases)
                     ? context.mapIncreases
@@ -246,9 +246,7 @@ class ChatCards {
                     const roll = message.rolls.find(
                         (r): r is Rolled<CheckRoll> => r instanceof CheckRoll && r.options.action === "elemental-blast",
                     );
-                    const checkContext = (
-                        roll ? message.flags.pf2e.context ?? null : null
-                    ) as CheckContextChatFlag | null;
+                    const checkContext = (roll ? message.system.context ?? null : null) as CheckContextChatData | null;
                     const outcome = button.dataset.outcome === "success" ? "success" : "criticalSuccess";
                     const [element, damageType, meleeOrRanged, actionCost]: (string | undefined)[] =
                         roll?.options.identifier?.split(".") ?? [];
@@ -348,7 +346,7 @@ class ChatCards {
             const roll = message.rolls.find(
                 (r): r is Rolled<CheckRoll> => r instanceof CheckRoll && r.options.action === "army-strike",
             );
-            const checkContext = (roll ? message.flags.pf2e.context ?? null : null) as CheckContextChatFlag | null;
+            const checkContext = (roll ? message.system.context ?? null : null) as CheckContextChatData | null;
             const action = button.dataset.outcome === "success" ? "damage" : "critical";
             const strike = actor.strikes[roll?.options.identifier ?? ""];
             strike?.[action]({ checkContext, event });

--- a/src/module/chat-message/roll-inspector.ts
+++ b/src/module/chat-message/roll-inspector.ts
@@ -1,7 +1,7 @@
 import { DamageDicePF2e, ModifierPF2e, RawDamageDice, RawModifier } from "@actor/modifiers.ts";
 import { createHTMLElement, htmlQuery, htmlQueryAll, signedInteger } from "@util";
 import * as R from "remeda";
-import type { ChatContextFlag, ChatMessagePF2e } from "./index.ts";
+import type { ChatMessageContext, ChatMessagePF2e } from "./index.ts";
 
 class RollInspector extends Application {
     message: ChatMessagePF2e;
@@ -33,7 +33,7 @@ class RollInspector extends Application {
     }
 
     override getData(): ChatRollDetailsData {
-        const context = this.message.flags.pf2e.context;
+        const context = this.message.system.context;
 
         const rollOptions = R.sortBy(context?.options?.sort() ?? [], (o) => o.includes(":"));
 
@@ -115,7 +115,7 @@ class RollInspector extends Application {
 }
 
 interface ChatRollDetailsData {
-    context?: ChatContextFlag;
+    context?: ChatMessageContext;
     domains: string[];
     modifiers: PreparedModifier[];
     dice: PreparedDice[];

--- a/src/module/item/base/document.ts
+++ b/src/module/item/base/document.ts
@@ -225,9 +225,6 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
                 }),
                 content: await renderTemplate(template, templateData),
                 flags: { pf2e: {} },
-                system: {
-                    origin: this.getOriginData(),
-                },
             },
             rollMode,
         );

--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -832,6 +832,7 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
             system.context = {
                 domains: [],
                 options: [],
+                origin: this.getOriginData(),
                 type: "spell-cast",
                 rollMode,
                 spellcasting: spellcastingFlag,

--- a/src/module/scene/measured-template-document.ts
+++ b/src/module/scene/measured-template-document.ts
@@ -2,7 +2,7 @@ import { ActorPF2e } from "@actor";
 import { ItemPF2e } from "@item";
 import type { EffectAreaShape } from "@item/spell/types.ts";
 import type { MeasuredTemplatePF2e } from "@module/canvas/measured-template.ts";
-import { ItemOriginFlag } from "@module/chat-message/data.ts";
+import { ChatMessageOriginData } from "@module/chat-message/data.ts";
 import type { ChatMessagePF2e } from "@module/chat-message/document.ts";
 import { toggleClearTemplatesButton } from "@module/chat-message/helpers.ts";
 import type { ScenePF2e } from "./document.ts";
@@ -18,15 +18,16 @@ class MeasuredTemplateDocumentPF2e<
     }
 
     get item(): ItemPF2e<ActorPF2e> | null {
-        const origin = this.flags.pf2e?.origin;
-        const uuid = origin?.uuid;
+        const flags = this.flags.pf2e;
+        const origin = flags?.origin;
+        const uuid = origin?.item;
         if (!uuid) return null;
         const item = fromUuidSync(uuid as string);
         if (!(item instanceof ItemPF2e)) return null;
 
         if (item?.isOfType("spell")) {
-            const overlayIds = origin?.variant?.overlays;
-            const castRank = (origin?.castRank ?? item.rank) as number;
+            const overlayIds = flags?.variant.overlays;
+            const castRank = (flags?.castRank ?? item.rank) as number;
             const modifiedSpell = item.loadVariant({ overlayIds, castRank: castRank });
             return modifiedSpell ?? item;
         }
@@ -77,9 +78,14 @@ interface MeasuredTemplateDocumentPF2e<TParent extends ScenePF2e | null = SceneP
 
     flags: DocumentFlags & {
         pf2e: {
-            messageId?: string;
-            origin?: ItemOriginFlag;
             areaShape: EffectAreaShape | null;
+            castRank?: number;
+            messageId?: string;
+            name: string;
+            origin?: ChatMessageOriginData;
+            slug: string;
+            traits: string[];
+            variant: { overlays: string[] };
         };
     };
 }

--- a/src/module/system/check/check.ts
+++ b/src/module/system/check/check.ts
@@ -268,6 +268,7 @@ class CheckPF2e {
             identifier: context.identifier ?? null,
             dosAdjustments,
             domains: context.domains ?? [],
+            origin: extractOriginOrTargetData(context.origin),
             target: extractOriginOrTargetData(context.target),
             options: Array.from(rollOptions).sort(),
             notes: notes.map((n) => n.toObject()),
@@ -290,7 +291,6 @@ class CheckPF2e {
                 pf2e: {
                     modifierName: check.slug,
                     modifiers: check.modifiers.map((m) => m.toObject()),
-                    origin: item?.getOriginData(),
                 },
             };
 
@@ -538,12 +538,11 @@ class CheckPF2e {
 
         const newFlavor = useNewRoll
             ? await (async (): Promise<string> => {
-                  const system = message.system;
                   const parsedFlavor = document.createElement("div");
                   parsedFlavor.innerHTML = oldFlavor;
-                  const targeting = actor.uuid === system.origin?.actor;
-                  const self = targeting ? system.origin : context.target;
-                  const opposer = context.target?.actor === actor.uuid ? system.origin : context.target;
+                  const targeting = actor.uuid === context.origin?.actor;
+                  const self = targeting ? context.origin : context.target;
+                  const opposer = context.target?.actor === actor.uuid ? context.origin : context.target;
                   const targetFlavor = await this.#createResultFlavor({ degree, self, opposer, targeting });
                   if (targetFlavor) {
                       htmlQuery(parsedFlavor, ".target-dc-result")?.replaceWith(targetFlavor);
@@ -817,7 +816,7 @@ class CheckPF2e {
 
 interface CreateResultFlavorParams {
     degree: DegreeOfSuccess | null;
-    self: RollOrigin | RollTarget | ChatMessageOriginData | ChatMessageTargetData | null;
+    self?: RollOrigin | RollTarget | ChatMessageOriginData | ChatMessageTargetData | null;
     opposer?: RollOrigin | RollTarget | ChatMessageOriginData | ChatMessageTargetData | null;
     /** Whether `self` is targeting the `opposer` (or otherwise being targeted by it) */
     targeting: boolean;

--- a/src/module/system/damage/damage.ts
+++ b/src/module/system/damage/damage.ts
@@ -233,6 +233,7 @@ export class DamagePF2e {
         const contextData: DamageDamageContextData = {
             type: context.type,
             sourceType: context.sourceType,
+            origin: extractOriginOrTargetData(origin),
             target: extractOriginOrTargetData(target),
             domains: context.domains ?? [],
             options: Array.from(context.options).sort(),
@@ -261,7 +262,6 @@ export class DamagePF2e {
                     },
                     system: {
                         context: contextData,
-                        origin: extractOriginOrTargetData(origin),
                     },
                 },
                 { create: false },

--- a/src/module/system/rolls.ts
+++ b/src/module/system/rolls.ts
@@ -2,7 +2,7 @@ import type { ModifierPF2e } from "@actor/modifiers.ts";
 import type { RollOrigin, RollTarget } from "@actor/roll-context/types.ts";
 import type { ActionTrait } from "@item/ability/types.ts";
 import type { TokenPF2e } from "@module/canvas/index.ts";
-import type { CheckContextChatFlag } from "@module/chat-message/index.ts";
+import type { CheckContextChatData } from "@module/chat-message/index.ts";
 import type { ZeroToTwo } from "@module/data.ts";
 import type { RollNotePF2e, RollNoteSource } from "@module/notes.ts";
 import type { RollTwiceOption } from "./check/index.ts";
@@ -46,7 +46,7 @@ interface AttackRollParams extends RollParameters {
 
 interface DamageRollParams extends Omit<AttackRollParams, "consumeAmmo" | "rollTwice"> {
     mapIncreases?: Maybe<ZeroToTwo>;
-    checkContext?: Maybe<CheckContextChatFlag>;
+    checkContext?: Maybe<CheckContextChatData>;
 }
 
 interface BaseRollContext {

--- a/src/scripts/system/dragstart-handler.ts
+++ b/src/scripts/system/dragstart-handler.ts
@@ -52,7 +52,7 @@ export function extendDragData(): void {
                         token: token?.uuid ?? null,
                         item: originItem?.uuid ?? null,
                         spellcasting,
-                        rollOptions: message?.origin?.rollOptions ?? [],
+                        rollOptions: context?.origin?.rollOptions ?? [],
                     },
                     target: target ? { actor: target.actor.uuid, token: target.token.uuid } : null,
                     roll: roll

--- a/src/scripts/system/dragstart-handler.ts
+++ b/src/scripts/system/dragstart-handler.ts
@@ -26,7 +26,9 @@ export function extendDragData(): void {
 
             // Detect spell rank of containing element, if available
             const containerElement = htmlClosest(target, "[data-cast-rank]");
-            const castRank = Number(containerElement?.dataset.castRank) || message?.flags.pf2e.origin?.castRank || 0;
+            const context = message?.system.context;
+            const casting = context?.type === "spell-cast" ? context.spellcasting : null;
+            const castRank = Number(containerElement?.dataset.castRank) || casting?.castRank || 0;
             if (castRank > 0) data.level = castRank;
 
             if (message?.actor) {
@@ -50,7 +52,7 @@ export function extendDragData(): void {
                         token: token?.uuid ?? null,
                         item: originItem?.uuid ?? null,
                         spellcasting,
-                        rollOptions: message.flags.pf2e.origin?.rollOptions ?? [],
+                        rollOptions: message?.origin?.rollOptions ?? [],
                     },
                     target: target ? { actor: target.actor.uuid, token: target.token.uuid } : null,
                     roll: roll


### PR DESCRIPTION
Deprecations:
`ChatMessagePF2e#flags#pf2e#appliedDamage` moved to `ChatMessagePF2e#system#appliedDamage`
`ChatMessagePF2e#flags#pf2e#origin` moved to `ChatMessagePF2e#system#origin` and refactored to:
```ts
interface ChatMessageOriginData {
    actor: ActorUUID | TokenDocumentUUID | null;
    token?: TokenDocumentUUID;
    item?: ItemUUID;
    rollOptions?: string[];
    /** Is the origin the roller? */
    self?: boolean;
}
```

`ChatMessagePF2e#flags#pf2e#context#target` refactored to:
```ts
interface ChatMessageTargetData {
    actor?: ActorUUID | TokenDocumentUUID | null;
    token?: TokenDocumentUUID;
    item?: ItemUUID;
    distance: number | null;
    rangeIncrement: number | null;
}
```
`ChatMessagePF2e#flags#pf2e#context` moved to `ChatMessagePF2e#system#context` and partially refactored.

~~I've opted to move origin to top level system data to avoid having to add bogus `origin`s to `context` data that has no origin.~~
```ts
interface ChatMessageSystemData {
    /** A record of applied damage that can be undone */
    appliedDamage?: AppliedDamageData | null;
    /** Message context data that describes the type of this chat message */
    context?: ChatMessageContext;
}
```

Old messages still work thanks to `DataModel#migrateData`.