### PR TITLE
Fix duration of Guided by the Stars effect

### DIFF
--- a/packs/feat-effects/effect-guided-by-the-stars.json
+++ b/packs/feat-effects/effect-guided-by-the-stars.json
@@ -7,7 +7,7 @@
             "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Guided by the Stars]</p>\n<p>You roll twice and take the better result on your next skill check or saving throw. If it's night and you can see the stars, you gain a +1 circumstance bonus to the triggering roll.</p>"
         },
         "duration": {
-            "expiry": "turn-start",
+            "expiry": "turn-end",
             "sustained": false,
             "unit": "rounds",
             "value": 0

--- a/packs/feat-effects/effect-guided-by-the-stars.json
+++ b/packs/feat-effects/effect-guided-by-the-stars.json
@@ -7,7 +7,7 @@
             "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Guided by the Stars]</p>\n<p>You roll twice and take the better result on your next skill check or saving throw. If it's night and you can see the stars, you gain a +1 circumstance bonus to the triggering roll.</p>"
         },
         "duration": {
-            "expiry": "turn-end",
+            "expiry": "turn-start",
             "sustained": false,
             "unit": "unlimited",
             "value": -1

--- a/packs/feat-effects/effect-guided-by-the-stars.json
+++ b/packs/feat-effects/effect-guided-by-the-stars.json
@@ -9,8 +9,8 @@
         "duration": {
             "expiry": "turn-end",
             "sustained": false,
-            "unit": "rounds",
-            "value": 0
+            "unit": "unlimited",
+            "value": -1
         },
         "level": {
             "value": 1


### PR DESCRIPTION
Currently, the "Guided by the Stars" effect immediately becomes "Expired" when applied to a character and de-activates, making it impossible to use even when the game is paused.

I believe this change will cause it to persist until it is triggered (at which point `removeAfterRoll: true` should remove it?), allowing it to be applied to the next save or skill check as intended.

This is my first contribution to this community, so please let me know if I've misunderstood the way durations work, or if my PR is in some way off!