### PR TITLE
Fix token config `Infinity` warning

### DIFF
--- a/src/module/canvas/perception/point-vision-source.ts
+++ b/src/module/canvas/perception/point-vision-source.ts
@@ -5,12 +5,6 @@ class PointVisionSourcePF2e<TObject extends TokenPF2e = TokenPF2e> extends found
     .PointVisionSource<TObject> {
     hearing?: PointSourcePolygon;
 
-    // Fix https://github.com/foundryvtt/foundryvtt/issues/10731
-    // todo: remove after next release
-    static override blindedColorRGB(): number[] {
-        return CONFIG.Canvas.visionModes.blindness.vision.defaults.color?.rgb ?? (Color.from(0) as Color).rgb;
-    }
-
     protected override _createShapes(): void {
         super._createShapes();
 

--- a/src/module/scene/token-document/data.ts
+++ b/src/module/scene/token-document/data.ts
@@ -1,3 +1,5 @@
+import type { TokenSchema } from "types/foundry/common/documents/token.d.ts";
+
 type TokenFlagsPF2e = DocumentFlags & {
     pf2e: {
         [key: string]: unknown;
@@ -7,4 +9,6 @@ type TokenFlagsPF2e = DocumentFlags & {
     [key: string]: Record<string, unknown>;
 };
 
-export type { TokenFlagsPF2e };
+type DetectionModeEntry = ModelPropsFromSchema<TokenSchema>["detectionModes"][number];
+
+export type { DetectionModeEntry, TokenFlagsPF2e };

--- a/src/module/scene/token-document/document.ts
+++ b/src/module/scene/token-document/document.ts
@@ -273,7 +273,6 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
         this.sight.visionMode = visionMode;
 
         const visionModeDefaults = CONFIG.Canvas.visionModes[visionMode].vision.defaults;
-        const maxRadius = scene.dimensions.maxR;
         this.sight.brightness = visionModeDefaults.brightness ?? 0;
         this.sight.saturation = visionModeDefaults.saturation ?? 0;
 

--- a/src/module/scene/token-document/document.ts
+++ b/src/module/scene/token-document/document.ts
@@ -288,6 +288,7 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
             }
         }
 
+        const maxRadius = scene.dimensions.maxR;
         if (actor.perception.senses.has("see-invisibility")) {
             this.detectionModes.push({ id: "seeInvisibility", enabled: true, range: maxRadius });
         }

--- a/src/module/scene/token-document/document.ts
+++ b/src/module/scene/token-document/document.ts
@@ -9,7 +9,7 @@ import * as R from "remeda";
 import { LightLevels } from "../data.ts";
 import type { ScenePF2e } from "../document.ts";
 import { TokenAura } from "./aura/index.ts";
-import { TokenFlagsPF2e } from "./data.ts";
+import { DetectionModeEntry, TokenFlagsPF2e } from "./data.ts";
 import type { TokenConfigPF2e } from "./sheet.ts";
 
 class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> extends TokenDocument<TParent> {
@@ -257,8 +257,9 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
         }
 
         // Reset detection modes if using rules-based vision
-        const lightPerception = { id: "lightPerception", enabled: !!actor.perception?.hasVision, range: null };
-        const basicSight = { id: "basicSight", enabled: !!actor.perception?.hasVision, range: 0 };
+        const hasVision = !!actor.perception?.hasVision;
+        const lightPerception: DetectionModeEntry = { id: "lightPerception", enabled: hasVision, range: null };
+        const basicSight: DetectionModeEntry = { id: "basicSight", enabled: hasVision, range: 0 };
         this.detectionModes = [lightPerception, basicSight];
 
         // Reset sight defaults and set vision mode.
@@ -272,12 +273,13 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
         this.sight.visionMode = visionMode;
 
         const visionModeDefaults = CONFIG.Canvas.visionModes[visionMode].vision.defaults;
+        const maxRadius = scene.dimensions.maxR;
         this.sight.brightness = visionModeDefaults.brightness ?? 0;
         this.sight.saturation = visionModeDefaults.saturation ?? 0;
 
         // Update basic sight and adjust saturation based on darkvision or light levels
         if (visionMode === "darkvision" || scene.lightLevel > LightLevels.DARKNESS) {
-            this.sight.range = basicSight.range = Infinity;
+            this.sight.range = basicSight.range = null;
 
             if (actor.isOfType("character") && actor.flags.pf2e.colorDarkvision) {
                 this.sight.saturation = 1;
@@ -286,7 +288,6 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
             }
         }
 
-        const maxRadius = scene.dimensions.maxR;
         if (actor.perception.senses.has("see-invisibility")) {
             this.detectionModes.push({ id: "seeInvisibility", enabled: true, range: maxRadius });
         }


### PR DESCRIPTION
I think `maxR` should be equivalent to `Infinity`.

Also removes override for an issue that was fixed in build 320.