### PR TITLE
Restore surface cantrips for Psi Development archetype psychics

### DIFF
--- a/packs/classfeatures/the-distant-grasp.json
+++ b/packs/classfeatures/the-distant-grasp.json
@@ -272,6 +272,13 @@
                             }
                         ],
                         "value": "telekinetic-projectile"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.TelekineticRend",
+                        "predicate": [
+                            "feat:psi-development"
+                        ],
+                        "value": "telekinetic-rend"
                     }
                 ]
             },

--- a/packs/classfeatures/the-infinite-eye.json
+++ b/packs/classfeatures/the-infinite-eye.json
@@ -224,6 +224,13 @@
                             }
                         ],
                         "value": "guidance"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.GlimpseWeakness",
+                        "predicate": [
+                            "feat:psi-development"
+                        ],
+                        "value": "glimpse-weakness"
                     }
                 ]
             },

--- a/packs/classfeatures/the-oscillating-wave.json
+++ b/packs/classfeatures/the-oscillating-wave.json
@@ -340,6 +340,13 @@
                             }
                         ],
                         "value": "frostbite"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.ThermalStasis",
+                        "predicate": [
+                            "feat:psi-development"
+                        ],
+                        "value": "thermal-stasis"
                     }
                 ]
             },

--- a/packs/classfeatures/the-silent-whisper.json
+++ b/packs/classfeatures/the-silent-whisper.json
@@ -216,6 +216,13 @@
                             }
                         ],
                         "value": "message"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.ForbiddenThought",
+                        "predicate": [
+                            "feat:psi-development"
+                        ],
+                        "value": "forbidden-thought"
                     }
                 ]
             },

--- a/packs/classfeatures/the-tangible-dream.json
+++ b/packs/classfeatures/the-tangible-dream.json
@@ -202,6 +202,13 @@
                             }
                         ],
                         "value": "shield"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.ImaginaryWeapon",
+                        "predicate": [
+                            "feat:psi-development"
+                        ],
+                        "value": "imaginary-weapon"
                     }
                 ]
             },

--- a/packs/classfeatures/the-unbound-step.json
+++ b/packs/classfeatures/the-unbound-step.json
@@ -220,6 +220,13 @@
                             }
                         ],
                         "value": "warp-step"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Psychic.PsiCantripLabels.DistortionLens",
+                        "predicate": [
+                            "feat:psi-development"
+                        ],
+                        "value": "distortion-lens"
                     }
                 ]
             },


### PR DESCRIPTION
Reverting #14344, closes #14476
Now the original implementation works as intended thanks to #14579.