### PR TITLE
Fix centering for wrapped text in prerequisites and spellcasting

### DIFF
--- a/src/styles/actor/_spell-collection.scss
+++ b/src/styles/actor/_spell-collection.scss
@@ -22,6 +22,7 @@ ol.spell-list {
             justify-self: center;
             display: flex;
             flex-wrap: nowrap;
+            text-align: center;
         }
 
         &:nth-child(odd) {

--- a/src/styles/actor/_spell-preparation.scss
+++ b/src/styles/actor/_spell-preparation.scss
@@ -67,6 +67,7 @@
                 justify-self: center;
                 display: flex;
                 flex-wrap: nowrap;
+                text-align: center;
             }
 
             &:nth-child(odd) {

--- a/src/styles/item/_feat-sheet.scss
+++ b/src/styles/item/_feat-sheet.scss
@@ -9,7 +9,7 @@
                 color: var(--color-text-dark-2);
                 font-size: var(--font-size-12);
                 font-weight: 400;
-                padding: 0.25em 0;
+                padding: var(--space-3) var(--space-2);
             }
         }
     }

--- a/src/styles/item/_sidebar.scss
+++ b/src/styles/item/_sidebar.scss
@@ -29,6 +29,7 @@ section.sidebar {
             align-items: center;
             justify-content: center;
             width: 100%;
+            text-align: center;
         }
     }
 


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/14572

![image](https://github.com/foundryvtt/pf2e/assets/1286721/09d5db44-ec2a-4b84-a5cf-f68f16ce1024)
