### PR TITLE
Fix `TokenLayerPF2e#cycleStack`

### DIFF
--- a/src/module/canvas/layer/token.ts
+++ b/src/module/canvas/layer/token.ts
@@ -6,23 +6,20 @@ export class TokenLayerPF2e<TToken extends TokenPF2e = TokenPF2e> extends TokenL
         const hovered = this.hover;
         if (!hovered) return false;
 
-        const stack = this.placeables
-            .filter((t) => hovered.distanceTo(t) === 0 && hovered.document.elevation === t.document.elevation)
-            .sort((a, b) => a.mesh.sort - b.mesh.sort);
+        const stack = [...this.quadtree.getObjects(hovered.bounds)]
+            .filter((t) => hovered.document.elevation === t.document.elevation)
+            .sort((a, b) => a.document.sort - b.document.sort);
         if (stack.length < 2) return false;
 
         const first = stack.shift()!;
         stack.push(first);
 
+        const updates: { _id: string; sort: number }[] = [];
         for (let sort = stack.length - 1; sort >= 0; sort--) {
             const token = stack[sort];
-            token.document.sort = sort;
-            token.mesh.initialize({ sort });
-            if (sort === stack.length - 1) {
-                token.emitHoverIn(new PointerEvent("pointerenter"));
-                this.hover = token;
-            }
+            updates.push({ _id: token.document.id, sort });
         }
+        canvas.scene?.updateEmbeddedDocuments("Token", updates);
 
         return true;
     }

--- a/src/module/canvas/status-effects.ts
+++ b/src/module/canvas/status-effects.ts
@@ -146,7 +146,7 @@ export class StatusEffects {
             if (hideIcon) picture.style.display = "none";
 
             const affecting = affectingConditions.filter((c) => c.slug === slug);
-            if (affecting.length > 0 || (iconSrc === deathIcon && token.actor?.isDead)) {
+            if (affecting.length > 0 || (iconSrc === deathIcon && token.actor?.statuses.has("dead"))) {
                 picture.classList.add("active");
             }
 


### PR DESCRIPTION
Also fixes a small error in the status effects HUD. `token.actor.isDead` always returns `true` for creatures at 0 hp so we need to check for the status.