### PR TITLE
Process user visibility and register inline roll links for expanded descriptions

### DIFF
--- a/src/module/chat-message/listeners/cards.ts
+++ b/src/module/chat-message/listeners/cards.ts
@@ -8,6 +8,8 @@ import { EffectSource } from "@item/effect/data.ts";
 import { CoinsPF2e } from "@item/physical/helpers.ts";
 import { elementTraits } from "@scripts/config/traits.ts";
 import { eventToRollParams } from "@scripts/sheet-util.ts";
+import { InlineRollLinks } from "@scripts/ui/inline-roll-links.ts";
+import { UserVisibilityPF2e } from "@scripts/ui/user-visibility.ts";
 import { onRepairChatCardEvent } from "@system/action-macros/crafting/repair.ts";
 import { CheckRoll } from "@system/check/index.ts";
 import {
@@ -182,8 +184,10 @@ class ChatCards {
                     if (element) {
                         element.innerHTML = await TextEditor.enrichHTML(description, {
                             async: true,
-                            rollData: actor.getRollData(),
+                            rollData: item.getRollData(),
                         });
+                        UserVisibilityPF2e.process(element, { message });
+                        InlineRollLinks.listen(element, message);
                         element.scrollIntoView({ behavior: "smooth", block: "center" });
                     }
                     break;


### PR DESCRIPTION
At a later date I wish to move inline roll registration to TextEditor#activateListeners(), which should improve performance very slightly and remove these bugs from happening.