### PR TITLE
Avoid always revealing actor name for inline rolls of hazard routines

### DIFF
--- a/src/module/system/damage/damage.ts
+++ b/src/module/system/damage/damage.ts
@@ -35,7 +35,9 @@ export class DamagePF2e {
             : null;
         let flavor = data.name.startsWith("<h4")
             ? data.name
-            : await renderTemplate("systems/pf2e/templates/chat/action/header.hbs", { title: data.name, subtitle });
+            : data.name || subtitle
+              ? await renderTemplate("systems/pf2e/templates/chat/action/header.hbs", { title: data.name, subtitle })
+              : "";
 
         if (context.traits) {
             interface ToTagsParams {

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -215,7 +215,7 @@ class TextEditorPF2e extends TextEditor {
                               subtitle,
                               title: item.name,
                           })
-                        : anchor.dataset.name ?? item?.name ?? actor?.name ?? "";
+                        : anchor.dataset.name ?? item?.name ?? "";
                 args.template.name = game.i18n.localize(name);
 
                 await DamagePF2e.roll(args.template, args.context);


### PR DESCRIPTION
Previously it was using the actor name as the flavor text if there was no item associated with it. But the title of the chat message is already the actor name.

Closes https://github.com/foundryvtt/pf2e/issues/14562 

![image](https://github.com/foundryvtt/pf2e/assets/1286721/4a2551d9-4f3f-41ac-9543-69fe10a15968)
