### PR TITLE
Propagate real inline damage traits like holy to item:trait:X options to support IWR

### DIFF
--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -947,7 +947,8 @@ async function augmentInlineDamageRoll(
         const rollOptions = new Set([
             ...(actor?.getRollOptions(domains) ?? []),
             ...(item?.getRollOptions("item") ?? []),
-            ...(traits ?? []),
+            ...traits,
+            ...traits.filter((t) => t in CONFIG.PF2E.actionTraits).map((t) => `item:trait:${t}`),
             ...(extraRollOptions ?? []),
             ...actionOptions,
         ]);


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/14403

Mostly supercedes https://github.com/foundryvtt/pf2e/pull/14506. That said, this one doesn't handle area damage nor fix the typo.