### PR TITLE
Normalize search queries with diacritics in compendium sidebar and browser

### DIFF
--- a/src/module/apps/compendium-browser/tabs/base.ts
+++ b/src/module/apps/compendium-browser/tabs/base.ts
@@ -70,7 +70,9 @@ export abstract class CompendiumBrowserTab {
                     return null;
                 }
                 return Array.from(wordSegmenter.segment(term))
-                    .map((t) => t.segment.toLocaleLowerCase(game.i18n.lang).replace(/['"]/g, ""))
+                    .map((t) =>
+                        SearchFilter.cleanQuery(t.segment.toLocaleLowerCase(game.i18n.lang)).replace(/['"]/g, ""),
+                    )
                     .filter((t) => t.length > 1);
             },
             storeFields: this.storeFields,
@@ -104,7 +106,7 @@ export abstract class CompendiumBrowserTab {
         }
 
         this.currentIndex = (() => {
-            const searchText = this.filterData.search.text;
+            const searchText = SearchFilter.cleanQuery(this.filterData.search.text);
             if (searchText) {
                 const searchResult = this.searchEngine.search(searchText);
                 return this.sortResult(searchResult.filter(this.filterIndexData.bind(this)));

--- a/src/module/apps/sidebar/compendium-directory.ts
+++ b/src/module/apps/sidebar/compendium-directory.ts
@@ -30,7 +30,9 @@ class CompendiumDirectoryPF2e extends CompendiumDirectory {
                     return null;
                 }
                 return Array.from(wordSegmenter.segment(term))
-                    .map((t) => t.segment.toLocaleLowerCase(game.i18n.lang).replace(/['"]/g, ""))
+                    .map((t) =>
+                        SearchFilter.cleanQuery(t.segment.toLocaleLowerCase(game.i18n.lang)).replace(/['"]/g, ""),
+                    )
                     .filter((t) => t.length > 1);
             },
             searchOptions: { combineWith: "AND", prefix: true },

--- a/types/foundry/client/core/searchfilter.d.ts
+++ b/types/foundry/client/core/searchfilter.d.ts
@@ -49,4 +49,12 @@ declare class SearchFilter {
     });
 
     bind(html: HTMLElement): void;
+
+    /**
+     * Clean a query term to standardize it for matching.
+     * See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize
+     * @param   query    An input string which may contain leading/trailing spaces or diacritics
+     * @returns          A cleaned string of ASCII characters for comparison
+     */
+    static cleanQuery(query: string): string;
 }


### PR DESCRIPTION
I'm not sure if this is a bugfix or an enhancement.

![image](https://github.com/foundryvtt/pf2e/assets/41452412/61fdf0fd-64ab-4667-9163-7c43ddc036b8)

![image](https://github.com/foundryvtt/pf2e/assets/41452412/ff0e2777-1c05-4e6a-ad31-ff520f254e12)

Closes #14601