### PR TITLE
Add all present class traits in spells to actor roll options

### DIFF
--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -214,6 +214,24 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
         return this.classDCs[slug] ?? super.getStatistic(slug);
     }
 
+    override getRollOptions(domains?: string[]): string[] {
+        const options = super.getRollOptions(domains);
+
+        // Add roll options based on spells with existing class traits
+        // This can be used to predicate on the existance of things like warden spells
+        const extraOptions = new Set<string>();
+        for (const spell of this.itemTypes.spell) {
+            for (const trait of spell.system.traits.value) {
+                if (trait in CONFIG.PF2E.classTraits) {
+                    extraOptions.add(`spell-traits:${trait}`);
+                }
+            }
+        }
+
+        options.push(...extraOptions);
+        return options;
+    }
+
     async getCraftingFormulas(): Promise<CraftingFormula[]> {
         const formulas = this.system.crafting.formulas;
         formulas.sort((a, b) => (a.sort ?? 0) - (b.sort ?? 0));


### PR DESCRIPTION
This allows predication on the presence of ki spells and warden spells. However:

1) I am uncertain of the name of the roll option. spell-traits:monk could be something else. I don't mind.
2) It creates a window of opportunity where the newly created spellcasting entry is untrained until they put a ki/warden spell in that slot. Said people may complain in pf2e-system instead of adding the spell and solving their own problem.

This avoids the need to litter certain archetypes and divine boons with "I has qi spell".