### PR TITLE
Migrate ki spells and monk feats for ki spell proficiency

### DIFF
--- a/build/run-migration.ts
+++ b/build/run-migration.ts
@@ -13,8 +13,6 @@ import * as R from "remeda";
 import "./lib/foundry-utils.ts";
 import { getFilesRecursively } from "./lib/helpers.ts";
 
-import { Migration911CoinBulk } from "@module/migration/migrations/911-coin-bulk.ts";
-import { Migration912RmFocusTraitFocusCantrips } from "@module/migration/migrations/912-rm-focus-trait-focus-cantrips.ts";
 import { Migration913SpellSustainedText } from "@module/migration/migrations/913-spell-sustained-text.ts";
 import { Migration914MovePerceptionSenses } from "@module/migration/migrations/914-move-perception-senses.ts";
 import { Migration915MoveLanguages } from "@module/migration/migrations/915-move-languages.ts";
@@ -29,6 +27,7 @@ import { Migration923KineticistRestructure } from "@module/migration/migrations/
 import { Migration924JiuHuanDoa } from "@module/migration/migrations/924-jiu-huan-dao.ts";
 import { Migration925TouchOfCorruption } from "@module/migration/migrations/925-touch-of-corruption.ts";
 import { Migration926RemoveVisionFeatureLinks } from "@module/migration/migrations/926-remove-vision-feature-links.ts";
+import { Migration927KiSpells } from "@module/migration/migrations/927-ki-spells.ts";
 // ^^^ don't let your IDE use the index in these imports. you need to specify the full path ^^^
 
 const { window } = new JSDOM();
@@ -38,8 +37,6 @@ globalThis.HTMLParagraphElement = window.HTMLParagraphElement;
 globalThis.Text = window.Text;
 
 const migrations: MigrationBase[] = [
-    new Migration911CoinBulk(),
-    new Migration912RmFocusTraitFocusCantrips(),
     new Migration913SpellSustainedText(),
     new Migration914MovePerceptionSenses(),
     new Migration915MoveLanguages(),
@@ -54,6 +51,7 @@ const migrations: MigrationBase[] = [
     new Migration924JiuHuanDoa(),
     new Migration925TouchOfCorruption(),
     new Migration926RemoveVisionFeatureLinks(),
+    new Migration927KiSpells(),
 ];
 
 const packsDataPath = path.resolve(process.cwd(), "packs");

--- a/src/module/migration/migrations/927-ki-spells.ts
+++ b/src/module/migration/migrations/927-ki-spells.ts
@@ -1,0 +1,92 @@
+import { ItemSourcePF2e } from "@item/base/data/index.ts";
+import type { AELikeSource } from "@module/rules/rule-element/ae-like.ts";
+import type { RollOptionSource } from "@module/rules/rule-element/roll-option/rule-element.ts";
+import { sluggify } from "@util/misc.ts";
+import { MigrationBase } from "../base.ts";
+
+export class Migration927KiSpells extends MigrationBase {
+    static override version = 0.927;
+
+    /**
+     * All KI Spell Feats. Includes those with pre-requisites.
+     * Even if a pre-requisite is skipped, the monk should still be treated as having ki spells (because they do).
+     */
+    #KI_SPELL_FEATS = new Set([
+        "ki-rush",
+        "ki-strike",
+        "wholeness-of-body",
+        "abundant-step",
+        "ki-blast",
+        "ki-cutting-sight",
+        "clinging-shadow-stance",
+        "wild-winds-initiate",
+        "wind-jump",
+        "wronged-monks-wrath",
+        "speaking-sky",
+        "shadows-web",
+        "medusas-wrath",
+        "quivering-palm",
+        "empty-body",
+        "ki-form",
+        "irori-moderate-boon",
+    ]);
+
+    override async updateItem(source: ItemSourcePF2e): Promise<void> {
+        const slug = source.system.slug ?? sluggify(source.name);
+
+        if (source.type === "class" && slug === "monk") {
+            if (!hasSpellcastingRE(source)) {
+                source.system.rules.push({
+                    key: "ActiveEffectLike",
+                    mode: "upgrade",
+                    path: "system.proficiencies.spellcasting.rank",
+                    predicate: ["qi-spell"],
+                    priority: 51,
+                    value: 1,
+                } as AELikeSource);
+            }
+        }
+
+        if (source.type !== "feat") return;
+
+        if (this.#KI_SPELL_FEATS.has(slug)) {
+            const hasKiOption = source.system.rules.some(
+                (r) => r.key === "RollOption" && "option" in r && r.option === "qi-spell",
+            );
+            if (!hasKiOption) {
+                source.system.rules.push({
+                    key: "RollOption",
+                    option: "qi-spell",
+                } as RollOptionSource);
+            }
+        } else if (slug === "monk-expertise") {
+            if (!hasSpellcastingRE(source)) {
+                source.system.rules.push({
+                    key: "ActiveEffectLike",
+                    mode: "upgrade",
+                    path: "system.proficiencies.spellcasting.rank",
+                    predicate: ["qi-spell"],
+                    priority: 51,
+                    value: 2,
+                } as AELikeSource);
+            }
+        } else if (slug === "graceful-legend") {
+            if (!hasSpellcastingRE(source)) {
+                source.system.rules.push({
+                    key: "ActiveEffectLike",
+                    mode: "upgrade",
+                    path: "system.proficiencies.spellcasting.rank",
+                    predicate: ["qi-spell"],
+                    priority: 51,
+                    value: 3,
+                } as AELikeSource);
+            }
+        }
+    }
+}
+
+function hasSpellcastingRE(source: ItemSourcePF2e) {
+    return source.system.rules.some(
+        (r) => r.key === "ActiveEffectLike" && "path" in r && r.path === "system.proficiencies.spellcasting.rank",
+    );
+}

--- a/src/module/migration/migrations/index.ts
+++ b/src/module/migration/migrations/index.ts
@@ -292,3 +292,4 @@ export { Migration923KineticistRestructure } from "./923-kineticist-restructure.
 export { Migration924JiuHuanDoa } from "./924-jiu-huan-dao.ts";
 export { Migration925TouchOfCorruption } from "./925-touch-of-corruption.ts";
 export { Migration926RemoveVisionFeatureLinks } from "./926-remove-vision-feature-links.ts";
+export { Migration927KiSpells } from "./927-ki-spells.ts";

--- a/src/module/migration/runner/base.ts
+++ b/src/module/migration/runner/base.ts
@@ -14,7 +14,7 @@ interface CollectionDiff<T extends foundry.documents.ActiveEffectSource | ItemSo
 export class MigrationRunnerBase {
     migrations: MigrationBase[];
 
-    static LATEST_SCHEMA_VERSION = 0.926;
+    static LATEST_SCHEMA_VERSION = 0.927;
 
     static MINIMUM_SAFE_VERSION = 0.634;
 

--- a/src/module/rules/rule-element/roll-option/rule-element.ts
+++ b/src/module/rules/rule-element/roll-option/rule-element.ts
@@ -413,3 +413,4 @@ interface RollOptionSource extends RuleElementSource {
 }
 
 export { RollOptionRuleElement };
+export type { RollOptionSource };


### PR DESCRIPTION
The actual items themselves have been updated by https://github.com/foundryvtt/pf2e/pull/14624, this migration takes care of the actors and any imported items. Also fixes a trivial bug with an older migration (beneath notice).