### PR TITLE
Add implementation for Advanced Breakthrough

### DIFF
--- a/packs/feats/advanced-breakthrough.json
+++ b/packs/feats/advanced-breakthrough.json
@@ -29,7 +29,37 @@
             "remaster": false,
             "title": "Pathfinder Guns & Gears"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.advancedMulticlassLevel",
+                "value": "floor(@item.system.level.taken / 2)"
+            },
+            {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        "item:category:class",
+                        "item:trait:inventor",
+                        {
+                            "lte": [
+                                "item:level",
+                                "{actor|flags.pf2e.advancedMulticlassLevel}"
+                            ]
+                        }
+                    ],
+                    "itemType": "feat"
+                },
+                "flag": "feat",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.AdvancedMulticlassFeat"
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "{item|flags.pf2e.rulesSelections.feat}"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/src/module/actor/character/feats.ts
+++ b/src/module/actor/character/feats.ts
@@ -360,7 +360,9 @@ class FeatGroup<TActor extends ActorPF2e = ActorPF2e, TItem extends FeatLike = F
 
         // If this is a new feat, create a new feat item on the actor first
         if (!alreadyHasFeat && (isFeatValidInSlot || !location)) {
-            const source = fu.mergeObject(feat.toObject(), { system: { location } });
+            const source = fu.mergeObject(feat.toObject(), {
+                system: { location, level: { taken: slot?.level ?? this.actor.level } },
+            });
             changed.push(...(await this.actor.createEmbeddedDocuments("Item", [source])));
             const label = game.i18n.localize(this.label);
             ui.notifications.info(game.i18n.format("PF2E.Item.Feat.Info.Added", { item: feat.name, category: label }));


### PR DESCRIPTION
A potential way to add the advanced multiclass archetype feats, using the level taken and an AELike (which are processed right before the choiceset runs).

An alternative approach I had considered was to support RollOption injecting into item options somehow, but the issue is that I can't think of a good way to let them inject formulas directly. Neither `{ key: "RollOption", "option": "something:{floor(formulaHere)}" }` nor `{ key: "RollOption", "option": "something", "value": "floor(formulaHere)" }` seemed clean.

Another idea was to add "maxLevel" directly to Choiceset's filter. After thinking about it this is now my preference, but I'm defaulting to the tools we already have.

Delay till after V12.