### PR TITLE
Extend sidebar compendium search to support Babele originalName

### DIFF
--- a/src/module/apps/sidebar/compendium-directory.ts
+++ b/src/module/apps/sidebar/compendium-directory.ts
@@ -23,7 +23,7 @@ class CompendiumDirectoryPF2e extends CompendiumDirectory {
                       },
                   };
         this.#searchEngine = new MiniSearch({
-            fields: ["name"],
+            fields: ["name", "originalName"],
             idField: "uuid",
             processTerm: (term): string[] | null => {
                 if (term.length <= 1 || CompendiumDirectoryPF2e.STOP_WORDS.has(term)) {


### PR DESCRIPTION
After looking at https://github.com/foundryvtt/pf2e/pull/14121 and the recent https://github.com/foundryvtt/pf2e/pull/14603, I've tried to extend former solution to the sidebar search. This provided the desired result with no apparent side effects in an non-localized world
![image](https://github.com/foundryvtt/pf2e/assets/34245546/6c43dcdf-9547-428d-96ad-8d748029510c)
