### PR TITLE
Move inline link handlers to separate methods

### DIFF
--- a/static/system.json
+++ b/static/system.json
@@ -5,8 +5,8 @@
     "version": "5.15.2",
     "license": "./LICENSE",
     "compatibility": {
-        "minimum": "11.315",
-        "verified": "11.315",
+        "minimum": "12.320",
+        "verified": "12.321",
         "maximum": "12"
     },
     "authors": [


### PR DESCRIPTION
This is preparation for eventually handling the listeners globally. This only moves them, so that future changes are easier to see.

Done in V12 since master is mostly no touchy for now.