### PR TITLE
Fix highlighting for cone and custom circle templates

### DIFF
--- a/src/module/canvas/helpers.ts
+++ b/src/module/canvas/helpers.ts
@@ -169,7 +169,6 @@ function highlightGrid({
     object,
     colors,
     document,
-    snappingMode = CONST.GRID_SNAPPING_MODES.CENTER,
     collisionType = "move",
     preview = false,
 }: HighlightGridParams): void {
@@ -193,7 +192,10 @@ function highlightGrid({
 
     const minAngle = (360 + ((direction - angle * 0.5) % 360)) % 360;
     const maxAngle = (360 + ((direction + angle * 0.5) % 360)) % 360;
-    const snappedOrigin = canvas.grid.getSnappedPoint({ x: document.x, y: document.y }, { mode: snappingMode });
+    const snappedOrigin =
+        "snappingMode" in object
+            ? canvas.grid.getSnappedPoint({ x: document.x, y: document.y }, { mode: object.snappingMode })
+            : object.center;
     const withinAngle = (min: number, max: number, value: number) => {
         min = (360 + (min % 360)) % 360;
         max = (360 + (max % 360)) % 360;

--- a/src/module/canvas/measured-template.ts
+++ b/src/module/canvas/measured-template.ts
@@ -25,9 +25,22 @@ class MeasuredTemplatePF2e<
         return this.document.areaShape;
     }
 
-    /** Set the template layer's grid precision appropriately for this measured template's shape. */
-    snapForShape(): void {
-        this.layer.snapFor(this.areaShape);
+    /**
+     * Returns the snapping for this template's highlight.
+     * Note that circle templates created via the canvas controls are neither bursts nor emanations, and thus can go in either position.
+     */
+    get snappingMode(): number {
+        const M = CONST.GRID_SNAPPING_MODES;
+        switch (this.areaShape) {
+            case "burst":
+                return M.CORNER;
+            case "emanation":
+                return M.CENTER;
+            case "cone":
+                return M.CENTER | M.CORNER | M.SIDE_MIDPOINT;
+            default:
+                return M.CENTER | M.CORNER;
+        }
     }
 
     override highlightGrid(): void {
@@ -43,24 +56,13 @@ class MeasuredTemplatePF2e<
             return;
         }
 
-        this.snapForShape();
         highlightGrid({
             areaShape: this.areaShape,
             object: this,
             document: this.document,
             colors: { border: Number(this.document.borderColor), fill: Number(this.document.fillColor) },
             preview: true,
-            snappingMode: this.layer.snappingMode,
         });
-    }
-
-    /* -------------------------------------------- */
-    /*  Event Handlers                              */
-    /* -------------------------------------------- */
-
-    protected override async _onDragLeftDrop(event: PlaceablesLayerPointerEvent<this>): Promise<void | TDocument[]> {
-        this.snapForShape();
-        return super._onDragLeftDrop(event);
     }
 }
 

--- a/types/foundry/client/pixi/layers/base/placeables-layer.d.ts
+++ b/types/foundry/client/pixi/layers/base/placeables-layer.d.ts
@@ -46,9 +46,6 @@ declare global {
         /** Obtain a reference to the PlaceableObject class definition which represents the Document type in this layer. */
         static get placeableClass(): ConstructorOf<PlaceableObject>;
 
-        /** Return the precision relative to the Scene grid with which Placeable objects should be snapped */
-        get gridPrecision(): number;
-
         /** If objects on this PlaceableLayer have a HUD UI, provide a reference to its instance */
         get hud(): BasePlaceableHUD<TObject> | null;
 
@@ -74,6 +71,26 @@ declare global {
 
         /** Track whether "highlight all objects" is currently active */
         highlightObjects: boolean;
+
+        /**
+         * Get the maximum sort value of all placeables.
+         * @returns    The maximum sort value (-Infinity if there are no objects)
+         */
+        getMaxSort(): number;
+
+        /**
+         * Send the controlled objects of this layer to the back or bring them to the front.
+         * @param front         Bring to front instead of send to back?
+         * @returns            Returns true if the layer has sortable object, and false otherwise
+         */
+        protected _sendToBackOrBringToFront(front: boolean): boolean;
+
+        /**
+         * Snaps the given point to grid. The layer defines the snapping behavior.
+         * @param point    The point that is to be snapped
+         * @returns        The snapped point
+         */
+        getSnappedPoint(point: Point): Point;
 
         /* -------------------------------------------- */
         /*  Rendering                                   */


### PR DESCRIPTION
It doesn't fix the templates center-point not snapping properly (which is apparently on purpose for smoother behavior), but it does fix the highlight when placed at a corner for a circle template created directly from canvas controls. It also restores mid edge placements for cones going in a lateral direction.