### PR TITLE
Add Hero Point Deck effects

### DIFF
--- a/packs/journals/hero-point-deck.json
+++ b/packs/journals/hero-point-deck.json
@@ -13,7 +13,7 @@
             "src": null,
             "system": {},
             "text": {
-                "content": "<p>Play during your turn.</p>\n<hr />\n<p>Until the start of your next turn, you gain a +2 status bonus to checks based on the attributes that are boosted by your ancestry (ignoring free boosts). If your ancestry only grants free boosts, select one attribute to gain the bonus to instead.</p>",
+                "content": "<p>Play during your turn.</p><hr /><p>Until the start of your next turn, you gain a +2 status bonus to checks based on the attributes that are boosted by your ancestry (ignoring free boosts). If your ancestry only grants free boosts, select one attribute to gain the bonus to instead.</p><p>@UUID[Compendium.pf2e.other-effects.Item.Effect: Ancestral Might]</p>",
                 "format": 1
             },
             "title": {
@@ -34,7 +34,7 @@
             "src": null,
             "system": {},
             "text": {
-                "content": "<p>Play this after Casting a Spell from your spell slots.</p>\n<hr />\n<p>You surround yourself with an aura of residual magic power. Until the start of your next turn, you gain resistance to all damage equal to the rank of the spell that you just cast.</p>",
+                "content": "<p>Play this after Casting a Spell from your spell slots.</p><hr /><p>You surround yourself with an aura of residual magic power. Until the start of your next turn, you gain resistance to all damage equal to the rank of the spell that you just cast.</p><p>@UUID[Compendium.pf2e.other-effects.Item.Effect: Aura of Protection]</p>",
                 "format": 1
             },
             "title": {
@@ -55,7 +55,7 @@
             "src": null,
             "system": {},
             "text": {
-                "content": "<p>Play when an ally is knocked @UUID[Compendium.pf2e.conditionitems.Item.Unconscious] or when you take damage from a critical hit.</p>\n<hr />\n<p>At the start of your next turn, you enter a rage (+2 damage to melee strikes, -1 AC penalty, no concentrate actions unless they have the rage trait, or use the stats for your rage class feature if you have one). At the end of that turn, if you don't have the rage class feature, the rage ends and you are @UUID[Compendium.pf2e.conditionitems.Item.Fatigued].</p>",
+                "content": "<p>Play when an ally is knocked @UUID[Compendium.pf2e.conditionitems.Item.Unconscious] or when you take damage from a critical hit.</p><hr /><p>At the start of your next turn, you enter a rage (+2 damage to melee strikes, -1 AC penalty, no concentrate actions unless they have the rage trait, or use the stats for your rage class feature if you have one). At the end of that turn, if you don't have the rage class feature, the rage ends and you are @UUID[Compendium.pf2e.conditionitems.Item.Fatigued].</p><p>@UUID[Compendium.pf2e.other-effects.Item.Effect: Rage and Fury]</p>",
                 "format": 1
             },
             "title": {
@@ -97,7 +97,7 @@
             "src": null,
             "system": {},
             "text": {
-                "content": "<p>Play at any time.</p>\n<hr />\n<p>Give a creature you can see resistance 5 to all damage until the start of your next turn. If you are 7th level or higher, the resistance is 10, and if you are 12th level or higher, the resistance is 15.</p>",
+                "content": "<p>Play at any time.</p><hr /><p>Give a creature you can see resistance 5 to all damage until the start of your next turn. If you are 7th level or higher, the resistance is 10, and if you are 12th level or higher, the resistance is 15.</p><p>@UUID[Compendium.pf2e.other-effects.Item.Effect: Endure the Onslaught]</p>",
                 "format": 1
             },
             "title": {
@@ -139,7 +139,7 @@
             "src": null,
             "system": {},
             "text": {
-                "content": "<p>Play at the end of your turn.</p>\n<hr />\n<p>Select yourself or an ally within 30 feet. The creature you choose must have fewer than half their total Hit Points. The creature gains a number of temporary Hit Points equal to twice your level, which last until the end of the combat.</p>",
+                "content": "<p>Play at the end of your turn.</p><hr /><p>Select yourself or an ally within 30 feet. The creature you choose must have fewer than half their total Hit Points. The creature gains a number of temporary Hit Points equal to twice your level, which last until the end of the combat.</p><p>@UUID[Compendium.pf2e.other-effects.Item.Effect: Catch your Breath]</p>",
                 "format": 1
             },
             "title": {
@@ -265,7 +265,7 @@
             "src": null,
             "system": {},
             "text": {
-                "content": "<p>Play before you make a Strike.</p>\n<hr />\n<p>Designate a foe that you can see. You gain a +2 status bonus to attack rolls made against that foe, but you take a -4 status penalty to attack rolls made against any other creature. This lasts until the end of your next turn or until you critically hit the designated foe, whichever comes first.</p>",
+                "content": "<p>Play before you make a Strike.</p><hr /><p>Designate a foe that you can see. You gain a +2 status bonus to attack rolls made against that foe, but you take a -4 status penalty to attack rolls made against any other creature. This lasts until the end of your next turn or until you critically hit the designated foe, whichever comes first.</p><p>@UUID[Compendium.pf2e.other-effects.Item.Effect: Called Foe]</p>",
                 "format": 1
             },
             "title": {
@@ -286,7 +286,7 @@
             "src": null,
             "system": {},
             "text": {
-                "content": "<p>Play during your turn.</p>\n<hr />\n<p>Until the start of your next turn you gain a +2 status bonus to checks based on the key attribute of your class. If your class grants a choice for its key attribute, select one of those attributes to gain the bonus.</p>",
+                "content": "<p>Play during your turn.</p><hr /><p>Until the start of your next turn you gain a +2 status bonus to checks based on the key attribute of your class. If your class grants a choice for its key attribute, select one of those attributes to gain the bonus.</p><p>@UUID[Compendium.pf2e.other-effects.Item.Effect: Class Might]</p>",
                 "format": 1
             },
             "title": {
@@ -349,7 +349,7 @@
             "src": null,
             "system": {},
             "text": {
-                "content": "<p>Play at the start of your turn.</p>\n<hr />\n<p>For the rest of your turn, you gain a climb Speed and a swim Speed equal to half your Speed. If you make a horizontal @UUID[Compendium.pf2e.actionspf2e.Item.Leap], increase the distance jumped by 10 feet.</p>",
+                "content": "<p>Play at the start of your turn.</p><hr /><p>For the rest of your turn, you gain a climb Speed and a swim Speed equal to half your Speed. If you make a horizontal @UUID[Compendium.pf2e.actionspf2e.Item.Leap], increase the distance jumped by 10 feet.</p><p>@UUID[Compendium.pf2e.other-effects.Item.Effect: Fluid Motion]</p>",
                 "format": 1
             },
             "title": {
@@ -391,7 +391,7 @@
             "src": null,
             "system": {},
             "text": {
-                "content": "<p>Play when you have the @UUID[Compendium.pf2e.conditionitems.Item.Frightened] condition.</p>\n<hr />\n<p>You lose that condition and instead gain a +2 status bonus to attack rolls and skill checks until the end of your next turn.</p>",
+                "content": "<p>Play when you have the @UUID[Compendium.pf2e.conditionitems.Item.Frightened] condition.</p><hr /><p>You lose that condition and instead gain a +2 status bonus to attack rolls and skill checks until the end of your next turn.</p><p>@UUID[Compendium.pf2e.other-effects.Item.Effect: Spark of Courage]</p>",
                 "format": 1
             },
             "title": {
@@ -454,7 +454,7 @@
             "src": null,
             "system": {},
             "text": {
-                "content": "<p>Play when making a ranged attack, either with a Strike or a spell.</p>\n<hr />\n<p>If you're attempting a Strike, double the range increment of the weapon or unarmed attack. If you're Casting a Spell, increase the range of the spell by half.</p>",
+                "content": "<p>Play when making a ranged attack, either with a Strike or a spell.</p><hr /><p>If you're attempting a Strike, double the range increment of the weapon or unarmed attack. If you're Casting a Spell, increase the range of the spell by half.</p><p>@UUID[Compendium.pf2e.other-effects.Item.Effect: Impossible Shot]</p>",
                 "format": 1
             },
             "title": {
@@ -580,7 +580,7 @@
             "src": null,
             "system": {},
             "text": {
-                "content": "<p>Play when you or an ally are about to make a Strike.</p>\n<hr />\n<p>The target rolls twice and takes the higher result. This strike deals an extra die of damage on a hit if the attacker has fewer than half their maximum Hit Points, or two extra dice if they have fewer than one quarter their maximum Hit Points. This is a fortune effect.</p>",
+                "content": "<p>Play when you or an ally are about to make a Strike.</p><hr /><p>The target rolls twice and takes the higher result. This strike deals an extra die of damage on a hit if the attacker has fewer than half their maximum Hit Points, or two extra dice if they have fewer than one quarter their maximum Hit Points. This is a fortune effect.</p><p>@UUID[Compendium.pf2e.other-effects.Item.Effect: Strike True]</p>",
                 "format": 1
             },
             "title": {
@@ -769,7 +769,7 @@
             "src": null,
             "system": {},
             "text": {
-                "content": "<p>Play this after rolling a check.</p>\n<hr />\n<p>Reroll the check twice and take the best result. This is a fortune effect. If you still fail this check, you become @UUID[Compendium.pf2e.conditionitems.Item.Doomed]{Doomed 1}.</p>",
+                "content": "<p>Play this after rolling a check.</p><hr /><p>Reroll the check twice and take the best result. This is a fortune effect. If you still fail this check, you become @UUID[Compendium.pf2e.conditionitems.Item.Doomed]{Doomed 1}.</p><p>@UUID[Compendium.pf2e.other-effects.Item.Effect: Critical Moment]</p>",
                 "format": 1
             },
             "title": {
@@ -832,7 +832,7 @@
             "src": null,
             "system": {},
             "text": {
-                "content": "<p>Play during your turn.</p>\n<hr />\n<p>Make a Strike, ignoring the multiple attack penalty. If you roll a critical success, you get a normal success instead. If the attack fails, you release your weapon, or drop @UUID[Compendium.pf2e.conditionitems.Item.Prone] if you were using an unarmed attack or otherwise can't release your weapon.</p>",
+                "content": "<p>Play during your turn.</p><hr /><p>Make a Strike, ignoring the multiple attack penalty. If you roll a critical success, you get a normal success instead. If the attack fails, you release your weapon, or drop @UUID[Compendium.pf2e.conditionitems.Item.Prone] if you were using an unarmed attack or otherwise can't release your weapon.</p><p>@UUID[Compendium.pf2e.other-effects.Item.Effect: Desperate Swing]</p>",
                 "format": 1
             },
             "title": {
@@ -1084,7 +1084,7 @@
             "src": null,
             "system": {},
             "text": {
-                "content": "<p>Play at the start of your turn.</p>\n<hr />\n<p>Select one untrained skill. You are trained in that skill until the end of your next turn. If you use that skill before the end of your next turn and succeed at your skill check, you keep this benefit until the end of the combat, or for 1 minute if not in combat.</p>",
+                "content": "<p>Play at the start of your turn.</p><hr /><p>Select one untrained skill. You are trained in that skill until the end of your next turn. If you use that skill before the end of your next turn and succeed at your skill check, you keep this benefit until the end of the combat, or for 1 minute if not in combat.</p><p>@UUID[Compendium.pf2e.other-effects.Item.Effect: Daring Attempt]</p>",
                 "format": 1
             },
             "title": {

--- a/packs/other-effects/effect-ancestral-might.json
+++ b/packs/other-effects/effect-ancestral-might.json
@@ -87,7 +87,7 @@
                 ],
                 "flag": "secondBoost",
                 "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.HeroPointDeck.AncestralMight.SecondBoostPrompt.",
+                "prompt": "PF2E.SpecificRule.HeroPointDeck.AncestralMight.SecondBoostPrompt",
                 "rollOption": "ancestral-might"
             },
             {

--- a/packs/other-effects/effect-ancestral-might.json
+++ b/packs/other-effects/effect-ancestral-might.json
@@ -1,0 +1,125 @@
+{
+    "_id": "qKS1TilScX0SmesO",
+    "img": "icons/sundries/gaming/playing-cards-brown.webp",
+    "name": "Effect: Ancestral Might",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.quxPxuMub8k6abzN]{Ancestral Might}</p>\n<p>Until the start of your next turn, you gain a +2 status bonus to checks based on the attributes that are boosted by your ancestry (ignoring free boosts). If your ancestry only grants free boosts, select one attribute to gain the bonus to instead.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Hero Point Deck"
+        },
+        "rules": [
+            {
+                "adjustName": false,
+                "choices": [
+                    {
+                        "label": "Strength",
+                        "value": "str-based"
+                    },
+                    {
+                        "label": "Dexterity",
+                        "value": "dex-based"
+                    },
+                    {
+                        "label": "Constitution",
+                        "value": "con-based"
+                    },
+                    {
+                        "label": "Intelligence",
+                        "value": "int-based"
+                    },
+                    {
+                        "label": "Wisdom",
+                        "value": "wis-based"
+                    },
+                    {
+                        "label": "Charisma",
+                        "value": "cha-based"
+                    }
+                ],
+                "flag": "firstBoost",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.HeroPointDeck.AncestralMight.FirstBoostPrompt"
+            },
+            {
+                "adjustName": false,
+                "choices": [
+                    {
+                        "label": "Skip",
+                        "value": "skip"
+                    },
+                    {
+                        "label": "Strength",
+                        "value": "str-based"
+                    },
+                    {
+                        "label": "Dexterity",
+                        "value": "dex-based"
+                    },
+                    {
+                        "label": "Constitution",
+                        "value": "con-based"
+                    },
+                    {
+                        "label": "Intelligence",
+                        "value": "int-based"
+                    },
+                    {
+                        "label": "Wisdom",
+                        "value": "wis-based"
+                    },
+                    {
+                        "label": "Charisma",
+                        "value": "cha-based"
+                    }
+                ],
+                "flag": "secondBoost",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.HeroPointDeck.AncestralMight.SecondBoostPrompt.",
+                "rollOption": "ancestral-might"
+            },
+            {
+                "key": "FlatModifier",
+                "selector": "{item|flags.pf2e.rulesSelections.firstBoost}",
+                "slug": "ancestral-might-first",
+                "type": "status",
+                "value": 2
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    {
+                        "not": "ancestral-might:skip"
+                    }
+                ],
+                "selector": "{item|flags.pf2e.rulesSelections.secondBoost}",
+                "slug": "ancestral-might-second",
+                "type": "status",
+                "value": 2
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/other-effects/effect-ancestral-might.json
+++ b/packs/other-effects/effect-ancestral-might.json
@@ -25,27 +25,27 @@
                 "adjustName": false,
                 "choices": [
                     {
-                        "label": "Strength",
+                        "label": "PF2E.AbilityStr",
                         "value": "str-based"
                     },
                     {
-                        "label": "Dexterity",
+                        "label": "PF2E.AbilityDex",
                         "value": "dex-based"
                     },
                     {
-                        "label": "Constitution",
+                        "label": "PF2E.AbilityCon",
                         "value": "con-based"
                     },
                     {
-                        "label": "Intelligence",
+                        "label": "PF2E.AbilityInt",
                         "value": "int-based"
                     },
                     {
-                        "label": "Wisdom",
+                        "label": "PF2E.AbilityWis",
                         "value": "wis-based"
                     },
                     {
-                        "label": "Charisma",
+                        "label": "PF2E.AbilityCha",
                         "value": "cha-based"
                     }
                 ],
@@ -61,27 +61,27 @@
                         "value": "skip"
                     },
                     {
-                        "label": "Strength",
+                        "label": "PF2E.AbilityStr",
                         "value": "str-based"
                     },
                     {
-                        "label": "Dexterity",
+                        "label": "PF2E.AbilityDex",
                         "value": "dex-based"
                     },
                     {
-                        "label": "Constitution",
+                        "label": "PF2E.AbilityCon",
                         "value": "con-based"
                     },
                     {
-                        "label": "Intelligence",
+                        "label": "PF2E.AbilityInt",
                         "value": "int-based"
                     },
                     {
-                        "label": "Wisdom",
+                        "label": "PF2E.AbilityWis",
                         "value": "wis-based"
                     },
                     {
-                        "label": "Charisma",
+                        "label": "PF2E.AbilityCha",
                         "value": "cha-based"
                     }
                 ],

--- a/packs/other-effects/effect-ancestral-might.json
+++ b/packs/other-effects/effect-ancestral-might.json
@@ -57,7 +57,7 @@
                 "adjustName": false,
                 "choices": [
                     {
-                        "label": "Skip",
+                        "label": "PF2E.SpecificRule.HeroPointDeck.AncestralMight.SkipChoice",
                         "value": "skip"
                     },
                     {

--- a/packs/other-effects/effect-aura-of-protection.json
+++ b/packs/other-effects/effect-aura-of-protection.json
@@ -1,0 +1,161 @@
+{
+    "_id": "J3beTsJS9DBkJuVJ",
+    "img": "icons/sundries/gaming/playing-cards-brown.webp",
+    "name": "Effect: Aura of Protection",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.7uERHpfJplGtYf8w]{Aura of Protection}</p>\n<p>Until the start of your next turn, you gain resistance to all damage equal to the rank of the spell that you just cast.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Hero Point Deck"
+        },
+        "rules": [
+            {
+                "choices": [
+                    {
+                        "label": "PF2E.SpecificRule.SpellRank.First",
+                        "value": 1
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.SpellRank.Second",
+                        "predicate": [
+                            {
+                                "gte": [
+                                    "self:level",
+                                    3
+                                ]
+                            }
+                        ],
+                        "value": 2
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.SpellRank.Third",
+                        "predicate": [
+                            {
+                                "gte": [
+                                    "self:level",
+                                    5
+                                ]
+                            }
+                        ],
+                        "value": 3
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.SpellRank.Fourth",
+                        "predicate": [
+                            {
+                                "gte": [
+                                    "self:level",
+                                    7
+                                ]
+                            }
+                        ],
+                        "value": 4
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.SpellRank.Fifth",
+                        "predicate": [
+                            {
+                                "gte": [
+                                    "self:level",
+                                    9
+                                ]
+                            }
+                        ],
+                        "value": 5
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.SpellRank.Sixth",
+                        "predicate": [
+                            {
+                                "gte": [
+                                    "self:level",
+                                    11
+                                ]
+                            }
+                        ],
+                        "value": 6
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.SpellRank.Seventh",
+                        "predicate": [
+                            {
+                                "gte": [
+                                    "self:level",
+                                    13
+                                ]
+                            }
+                        ],
+                        "value": 7
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.SpellRank.Eight",
+                        "predicate": [
+                            {
+                                "gte": [
+                                    "self:level",
+                                    15
+                                ]
+                            }
+                        ],
+                        "value": 8
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.SpellRank.Ninth",
+                        "predicate": [
+                            {
+                                "gte": [
+                                    "self:level",
+                                    17
+                                ]
+                            }
+                        ],
+                        "value": 9
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.SpellRank.Tenth",
+                        "predicate": [
+                            {
+                                "gte": [
+                                    "self:level",
+                                    19
+                                ]
+                            }
+                        ],
+                        "value": 10
+                    }
+                ],
+                "flag": "rank",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.HeroPointDeck.AuraOfProtection.SpellRankPrompt"
+            },
+            {
+                "key": "Resistance",
+                "type": "all-damage",
+                "value": "{item|flags.pf2e.rulesSelections.rank}"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/other-effects/effect-called-foe.json
+++ b/packs/other-effects/effect-called-foe.json
@@ -1,0 +1,80 @@
+{
+    "_id": "63ia9YXlCIX7PXyp",
+    "img": "icons/sundries/gaming/playing-cards-brown.webp",
+    "name": "Effect: Called Foe",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.spzRl5CS4vnvcrm5]{Called Foe}</p>\n<p>Designate a foe that you can see. You gain a +2 status bonus to attack rolls made against that foe, but you take a -4 status penalty to attack rolls made against any other creature. This lasts until the end of your next turn or until you critically hit the designated foe, whichever comes first.</p>"
+        },
+        "duration": {
+            "expiry": "turn-end",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Hero Point Deck"
+        },
+        "rules": [
+            {
+                "key": "TokenMark",
+                "slug": "called-foe"
+            },
+            {
+                "hideIfDisabled": true,
+                "key": "FlatModifier",
+                "predicate": [
+                    "target:mark:called-foe"
+                ],
+                "removeAfterRoll": [
+                    "check:outcome:critical-success"
+                ],
+                "selector": "attack-roll",
+                "slug": "called-foe-bonus",
+                "type": "status",
+                "value": 2
+            },
+            {
+                "hideIfDisabled": true,
+                "key": "FlatModifier",
+                "predicate": [
+                    {
+                        "not": "target:mark:called-foe"
+                    }
+                ],
+                "selector": "attack-roll",
+                "slug": "called-foe-penalty",
+                "type": "status",
+                "value": -4
+            },
+            {
+                "key": "Note",
+                "outcome": [
+                    "criticalSuccess"
+                ],
+                "predicate": [
+                    "target:mark:called-foe"
+                ],
+                "selector": "attack-roll",
+                "text": "PF2E.SpecificRule.HeroPointDeck.CalledFoe.Note",
+                "title": "{item|name}"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/other-effects/effect-called-foe.json
+++ b/packs/other-effects/effect-called-foe.json
@@ -31,9 +31,6 @@
                 "predicate": [
                     "target:mark:called-foe"
                 ],
-                "removeAfterRoll": [
-                    "check:outcome:critical-success"
-                ],
                 "selector": "attack-roll",
                 "slug": "called-foe-bonus",
                 "type": "status",

--- a/packs/other-effects/effect-catch-your-breath.json
+++ b/packs/other-effects/effect-catch-your-breath.json
@@ -1,0 +1,41 @@
+{
+    "_id": "A81HpA9cBUgGRsqx",
+    "img": "icons/sundries/gaming/playing-cards-brown.webp",
+    "name": "Effect: Catch your Breath",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.LafJ1PXfnR4Ogyzh]{Catch your Breath}</p>\n<p>The creature you choose must have fewer than half their total Hit Points. The creature gains a number of temporary Hit Points equal to twice your level, which last until the end of the combat.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "encounter",
+            "value": -1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Hero Point Deck"
+        },
+        "rules": [
+            {
+                "key": "TempHP",
+                "value": "2*@actor.level"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/other-effects/effect-catch-your-breath.json
+++ b/packs/other-effects/effect-catch-your-breath.json
@@ -23,7 +23,7 @@
         "rules": [
             {
                 "key": "TempHP",
-                "value": "2*@actor.level"
+                "value": "2*@item.origin.level"
             }
         ],
         "start": {

--- a/packs/other-effects/effect-class-might.json
+++ b/packs/other-effects/effect-class-might.json
@@ -1,0 +1,43 @@
+{
+    "_id": "EBE2Oid75GC4n5vG",
+    "img": "icons/sundries/gaming/playing-cards-brown.webp",
+    "name": "Effect: Class Might",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.a68Phr1qsqVRPMVp]{Class Might}</p>\n<p>Until the start of your next turn you gain a +2 status bonus to checks based on the key attribute of your class. If your class grants a choice for its key attribute, select one of those attributes to gain the bonus.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Hero Point Deck"
+        },
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "selector": "{actor|class.system.keyAbility.selected}-based",
+                "type": "status",
+                "value": 2
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/other-effects/effect-critical-moment.json
+++ b/packs/other-effects/effect-critical-moment.json
@@ -1,0 +1,53 @@
+{
+    "_id": "NyUWMdcABrlVsSBy",
+    "img": "icons/sundries/gaming/playing-cards-brown.webp",
+    "name": "Effect: Critical Moment",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.P3mSUWRvCCwEouB0]{Critical Moment}</p>\n<p>Reroll the check twice and take the best result. This is a fortune effect. If you still fail this check, you become @UUID[Compendium.pf2e.conditionitems.Item.Doomed]{Doomed 1}.</p>"
+        },
+        "duration": {
+            "expiry": "turn-end",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Hero Point Deck"
+        },
+        "rules": [
+            {
+                "keep": "higher",
+                "key": "RollTwice",
+                "removeAfterRoll": true,
+                "selector": "check"
+            },
+            {
+                "key": "Note",
+                "outcome": [
+                    "failure",
+                    "criticalFailure"
+                ],
+                "selector": "check",
+                "text": "{item|description}",
+                "title": "{item|name}"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/other-effects/effect-critical-moment.json
+++ b/packs/other-effects/effect-critical-moment.json
@@ -34,7 +34,7 @@
                     "criticalFailure"
                 ],
                 "selector": "check",
-                "text": "{item|description}",
+                "text": "PF2E.SpecificRule.HeroPointDeck.CriticalMoment.Note",
                 "title": "{item|name}"
             }
         ],

--- a/packs/other-effects/effect-daring-attempt.json
+++ b/packs/other-effects/effect-daring-attempt.json
@@ -1,0 +1,162 @@
+{
+    "_id": "w0kwwWC7QTmytbVt",
+    "img": "icons/sundries/gaming/playing-cards-brown.webp",
+    "name": "Effect: Daring Attempt",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.jHn1m1r95YgMQSvM]{Daring Attempt}</p>\n<p>Select one untrained skill. You are trained in that skill until the end of your next turn. If you use that skill before the end of your next turn and succeed at your skill check, you keep this benefit until the end of the combat, or for 1 minute if not in combat.</p>"
+        },
+        "duration": {
+            "expiry": null,
+            "sustained": false,
+            "unit": "unlimited",
+            "value": -1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Hero Point Deck"
+        },
+        "rules": [
+            {
+                "choices": [
+                    {
+                        "label": "PF2E.SkillAcr",
+                        "predicate": [
+                            "skill:acr:rank:0"
+                        ],
+                        "value": "acrobatics"
+                    },
+                    {
+                        "label": "PF2E.SkillArc",
+                        "predicate": [
+                            "skill:arc:rank:0"
+                        ],
+                        "value": "arcana"
+                    },
+                    {
+                        "label": "PF2E.SkillAth",
+                        "predicate": [
+                            "skill:ath:rank:0"
+                        ],
+                        "value": "athletics"
+                    },
+                    {
+                        "label": "PF2E.SkillCra",
+                        "predicate": [
+                            "skill:cra:rank:0"
+                        ],
+                        "value": "crafting"
+                    },
+                    {
+                        "label": "PF2E.SkillDec",
+                        "predicate": [
+                            "skill:dec:rank:0"
+                        ],
+                        "value": "deception"
+                    },
+                    {
+                        "label": "PF2E.SkillDip",
+                        "predicate": [
+                            "skill:dip:rank:0"
+                        ],
+                        "value": "diplomacy"
+                    },
+                    {
+                        "label": "PF2E.SkillItm",
+                        "predicate": [
+                            "skill:itm:rank:0"
+                        ],
+                        "value": "intimidation"
+                    },
+                    {
+                        "label": "PF2E.SkillMed",
+                        "predicate": [
+                            "skill:med:rank:0"
+                        ],
+                        "value": "medicine"
+                    },
+                    {
+                        "label": "PF2E.SkillNat",
+                        "predicate": [
+                            "skill:nat:rank:0"
+                        ],
+                        "value": "nature"
+                    },
+                    {
+                        "label": "PF2E.SkillOcc",
+                        "predicate": [
+                            "skill:occ:rank:0"
+                        ],
+                        "value": "occultism"
+                    },
+                    {
+                        "label": "PF2E.SkillPrf",
+                        "predicate": [
+                            "skill:prf:rank:0"
+                        ],
+                        "value": "performance"
+                    },
+                    {
+                        "label": "PF2E.SkillRel",
+                        "predicate": [
+                            "skill:rel:rank:0"
+                        ],
+                        "value": "religion"
+                    },
+                    {
+                        "label": "PF2E.SkillSoc",
+                        "predicate": [
+                            "skill:soc:rank:0"
+                        ],
+                        "value": "society"
+                    },
+                    {
+                        "label": "PF2E.SkillSte",
+                        "predicate": [
+                            "skill:ste:rank:0"
+                        ],
+                        "value": "stealth"
+                    },
+                    {
+                        "label": "PF2E.SkillSur",
+                        "predicate": [
+                            "skill:sur:rank:0"
+                        ],
+                        "value": "survival"
+                    },
+                    {
+                        "label": "PF2E.SkillThi",
+                        "predicate": [
+                            "skill:thi:rank:0"
+                        ],
+                        "value": "thievery"
+                    }
+                ],
+                "flag": "daringAttempt",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.Skill"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "system.skills.{item|flags.pf2e.rulesSelections.daringAttempt}.rank",
+                "value": 1
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/other-effects/effect-desperate-swing.json
+++ b/packs/other-effects/effect-desperate-swing.json
@@ -1,0 +1,60 @@
+{
+    "_id": "Bjwlrq0mF64nZJjK",
+    "img": "icons/sundries/gaming/playing-cards-brown.webp",
+    "name": "Effect: Desperate Swing",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.d15Zjdqplmj7ZTKK]{Desperate Swing}</p>\n<p>Make a Strike, ignoring the multiple attack penalty. If you roll a critical success, you get a normal success instead. If the attack fails, you release your weapon, or drop Prone if you were using an unarmed attack or otherwise can't release your weapon.</p>"
+        },
+        "duration": {
+            "expiry": "turn-end",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Hero Point Deck"
+        },
+        "rules": [
+            {
+                "key": "AdjustModifier",
+                "selector": "strike-attack-roll",
+                "slug": "multiple-attack-penalty",
+                "suppress": true
+            },
+            {
+                "adjustment": {
+                    "criticalSuccess": "one-degree-worse"
+                },
+                "key": "AdjustDegreeOfSuccess",
+                "selector": "strike-attack-roll"
+            },
+            {
+                "key": "Note",
+                "outcome": [
+                    "failure",
+                    "criticalFailure"
+                ],
+                "selector": "strike-attack-roll",
+                "text": "PF2E.SpecificRule.HeroPointDeck.DesperateSwing.Note",
+                "title": "{item|name}"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/other-effects/effect-endure-the-onslaught.json
+++ b/packs/other-effects/effect-endure-the-onslaught.json
@@ -24,7 +24,7 @@
             {
                 "key": "Resistance",
                 "type": "all-damage",
-                "value": "ternary(gte(@actor.level,12),15,ternary(gte(@actor.level,7),10,5))"
+                "value": "ternary(gte(@item.origin.level,12),15,ternary(gte(@item.origin.level,7),10,5))"
             }
         ],
         "start": {

--- a/packs/other-effects/effect-endure-the-onslaught.json
+++ b/packs/other-effects/effect-endure-the-onslaught.json
@@ -4,7 +4,7 @@
     "name": "Effect: Endure the Onslaught",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.TU21DvdpQG7U2Q9Y]{Endure the Onslaught}</p>\n<p>Give a creature you can see resistance 5 to all damage until the start of your next turn. If you are 7th level or higher, the resistance is 10, and if you are 12th level or higher, the resistance is 15.</p>\n<hr />\n<p><em>Note: This effect assumes the user of the card and the one receiving the benefit are the same level.</em></p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.TU21DvdpQG7U2Q9Y]{Endure the Onslaught}</p>\n<p>Give a creature you can see resistance 5 to all damage until the start of your next turn. If you are 7th level or higher, the resistance is 10, and if you are 12th level or higher, the resistance is 15.</p>"
         },
         "duration": {
             "expiry": "turn-start",

--- a/packs/other-effects/effect-endure-the-onslaught.json
+++ b/packs/other-effects/effect-endure-the-onslaught.json
@@ -1,0 +1,42 @@
+{
+    "_id": "datPIlarC3SudOSd",
+    "img": "icons/sundries/gaming/playing-cards-brown.webp",
+    "name": "Effect: Endure the Onslaught",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.TU21DvdpQG7U2Q9Y]{Endure the Onslaught}</p>\n<p>Give a creature you can see resistance 5 to all damage until the start of your next turn. If you are 7th level or higher, the resistance is 10, and if you are 12th level or higher, the resistance is 15.</p>\n<hr />\n<p><em>Note: This effect assumes the user of the card and the one receiving the benefit are the same level.</em></p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Hero Point Deck"
+        },
+        "rules": [
+            {
+                "key": "Resistance",
+                "type": "all-damage",
+                "value": "ternary(gte(@actor.level,12),15,ternary(gte(@actor.level,7),10,5))"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/other-effects/effect-fluid-motion.json
+++ b/packs/other-effects/effect-fluid-motion.json
@@ -24,12 +24,12 @@
             {
                 "key": "BaseSpeed",
                 "selector": "climb",
-                "value": "5*floor(@actor.attributes.speed.total / 10)"
+                "value": "floor(@actor.attributes.speed.total/2)"
             },
             {
                 "key": "BaseSpeed",
                 "selector": "swim",
-                "value": "5*floor(@actor.attributes.speed.total / 10)"
+                "value": "floor(@actor.attributes.speed.total/2)"
             }
         ],
         "start": {

--- a/packs/other-effects/effect-fluid-motion.json
+++ b/packs/other-effects/effect-fluid-motion.json
@@ -24,12 +24,12 @@
             {
                 "key": "BaseSpeed",
                 "selector": "climb",
-                "value": "5*floor(@actor.system.attributes.speed.total / 10)"
+                "value": "5*floor(@actor.attributes.speed.total / 10)"
             },
             {
                 "key": "BaseSpeed",
                 "selector": "swim",
-                "value": "5*floor(@actor.system.attributes.speed.total / 10)"
+                "value": "5*floor(@actor.attributes.speed.total / 10)"
             }
         ],
         "start": {

--- a/packs/other-effects/effect-fluid-motion.json
+++ b/packs/other-effects/effect-fluid-motion.json
@@ -1,0 +1,47 @@
+{
+    "_id": "QjvNcjLMaDJ0ig0D",
+    "img": "icons/sundries/gaming/playing-cards-brown.webp",
+    "name": "Effect: Fluid Motion",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.D6hqfmZUksRvqNFR]{Fluid Motion}</p>\n<p>For the rest of your turn, you gain a climb Speed and a swim Speed equal to half your Speed. If you make a horizontal Leap, increase the distance jumped by 10 feet.</p>"
+        },
+        "duration": {
+            "expiry": "turn-end",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 0
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Hero Point Deck"
+        },
+        "rules": [
+            {
+                "key": "BaseSpeed",
+                "selector": "climb",
+                "value": "5*floor(@actor.system.attributes.speed.total / 10)"
+            },
+            {
+                "key": "BaseSpeed",
+                "selector": "swim",
+                "value": "5*floor(@actor.system.attributes.speed.total / 10)"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/other-effects/effect-impossible-shot.json
+++ b/packs/other-effects/effect-impossible-shot.json
@@ -28,7 +28,7 @@
                 "key": "AdjustStrike",
                 "mode": "multiply",
                 "property": "range-increment",
-                "value": 1.5
+                "value": 2
             }
         ],
         "start": {

--- a/packs/other-effects/effect-impossible-shot.json
+++ b/packs/other-effects/effect-impossible-shot.json
@@ -1,0 +1,46 @@
+{
+    "_id": "HgWSyf7jULisWIlG",
+    "img": "icons/sundries/gaming/playing-cards-brown.webp",
+    "name": "Effect: Impossible Shot",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.k0ue81dFKH4OKxed]{Impossible Shot}</p>\n<p>If you're attempting a Strike, double the range increment of the weapon or unarmed attack. If you're Casting a Spell, increase the range of the spell by half.</p>"
+        },
+        "duration": {
+            "expiry": "turn-end",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Hero Point Deck"
+        },
+        "rules": [
+            {
+                "definition": [
+                    "item:ranged"
+                ],
+                "key": "AdjustStrike",
+                "mode": "multiply",
+                "property": "range-increment",
+                "value": 1.5
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/other-effects/effect-rage-and-fury.json
+++ b/packs/other-effects/effect-rage-and-fury.json
@@ -1,0 +1,47 @@
+{
+    "_id": "B09MScCT7fhtBW5S",
+    "img": "icons/sundries/gaming/playing-cards-brown.webp",
+    "name": "Effect: Rage and Fury",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.cQH9Syl1SQpbAi5A]{Rage and Fury}</p>\n<p>At the start of your next turn, you enter a rage (+2 damage to melee strikes, -1 AC penalty).</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Hero Point Deck"
+        },
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "selector": "melee-strike-damage",
+                "value": 2
+            },
+            {
+                "key": "FlatModifier",
+                "selector": "ac",
+                "value": -1
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/other-effects/effect-spark-of-courage.json
+++ b/packs/other-effects/effect-spark-of-courage.json
@@ -1,0 +1,46 @@
+{
+    "_id": "nwSZL6EgG8KarNOT",
+    "img": "icons/sundries/gaming/playing-cards-brown.webp",
+    "name": "Effect: Spark of Courage",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.EZZxz9jeEB0N3FPZ]{Spark of Courage}</p>\n<p>You gain a +2 status bonus to attack rolls and skill checks until the end of your next turn.</p>"
+        },
+        "duration": {
+            "expiry": "turn-end",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Hero Point Deck"
+        },
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "selector": [
+                    "attack-roll",
+                    "skill-check"
+                ],
+                "type": "status",
+                "value": 2
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/other-effects/effect-strike-true.json
+++ b/packs/other-effects/effect-strike-true.json
@@ -1,0 +1,76 @@
+{
+    "_id": "l9bMRAoKnFP8vb3D",
+    "img": "icons/sundries/gaming/playing-cards-brown.webp",
+    "name": "Effect: Strike True",
+    "system": {
+        "description": {
+            "value": "<p>The target rolls twice and takes the higher result. This strike deals an extra die of damage on a hit if the attacker has fewer than half their maximum Hit Points, or two extra dice if they have fewer than one quarter their maximum Hit Points. This is a fortune effect.</p>\n<p>@UUID[Compendium.pf2e.other-effects.Item.Effect: Strike True]</p>"
+        },
+        "duration": {
+            "expiry": "turn-end",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Hero Point Deck"
+        },
+        "rules": [
+            {
+                "keep": "higher",
+                "key": "RollTwice",
+                "selector": "strike-attack-roll"
+            },
+            {
+                "diceNumber": 1,
+                "hideIfDisabled": true,
+                "key": "DamageDice",
+                "predicate": [
+                    {
+                        "gte": [
+                            "hp-percent",
+                            25
+                        ]
+                    },
+                    {
+                        "lt": [
+                            "hp-percent",
+                            50
+                        ]
+                    }
+                ],
+                "selector": "strike-damage"
+            },
+            {
+                "diceNumber": 2,
+                "hideIfDisabled": true,
+                "key": "DamageDice",
+                "predicate": [
+                    {
+                        "lt": [
+                            "hp-percent",
+                            25
+                        ]
+                    }
+                ],
+                "selector": "strike-damage"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2659,7 +2659,7 @@
             "HeroPointDeck": {
                 "AncestralMight": {
                     "FirstBoostPrompt": "Select one of your ancestry boosts, or pick any if it only had free boosts.",
-                    "SecondBoostPrompt" "Select another one of your ancestry boosts. Skip if it only had free boosts."
+                    "SecondBoostPrompt": "Select another one of your ancestry boosts. Skip if it only had free boosts."
                 },
                 "AuraofProtection": {
                     "SpellRankPrompt": "Select the rank of the spell you just cast."

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2656,6 +2656,21 @@
                 },
                 "Prompt": "Select a harrow suit."
             },
+            "HeroPointDeck": {
+                "AncestralMight": {
+                    "FirstBoostPrompt": "Select one of your ancestry boosts, or pick any if it only had free boosts.",
+                    "SecondBoostPrompt" "Select another one of your ancestry boosts. Skip if it only had free boosts."
+                },
+                "AuraofProtection": {
+                    "SpellRankPrompt": "Select the rank of the spell you just cast."
+                },
+                "CalledFoe": {
+                    "Note": "This effect lasts until the end of your next turn or until you critically hit the designated foe, whichever comes first."
+                },
+                "DesperateSwing": {
+                    "Note": "If the attack fails, you release your weapon, or drop @UUID[Compendium.pf2e.conditionitems.Item.j91X7x0XSomq8d60]{Prone} if you were using an unarmed attack or otherwise can't release your weapon."
+                }
+            },
             "Hobgoblin": {
                 "AgonizingRebuke": {
                     "Note": "When you successfully Demoralize a foe, that foe takes [[/r 1d4[mental]]]{1d4 mental damage} at the start of each of its turns as long as it remains Frightened and continues to engage in combat with you. If you have master proficiency in Intimidation, the damage increases to [[/r 2d4[mental]]]{2d4}, and if you have legendary proficiency, the damage increases to [[/r 3d4[mental]]]{3d4}."

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2659,13 +2659,17 @@
             "HeroPointDeck": {
                 "AncestralMight": {
                     "FirstBoostPrompt": "Select one of your ancestry boosts, or pick any if it only had free boosts.",
-                    "SecondBoostPrompt": "Select another one of your ancestry boosts. Skip if it only had free boosts."
+                    "SecondBoostPrompt": "Select another one of your ancestry boosts. Skip if it only had free boosts.",
+                    "SkipChoice": "Skip"
                 },
-                "AuraofProtection": {
+                "AuraOfProtection": {
                     "SpellRankPrompt": "Select the rank of the spell you just cast."
                 },
                 "CalledFoe": {
                     "Note": "This effect lasts until the end of your next turn or until you critically hit the designated foe, whichever comes first."
+                },
+                "CriticalMoment": {
+                    "Note": "If you still fail this check, you become @UUID[Compendium.pf2e.conditionitems.Item.3uh1r86TzbQvosxv]{Doomed 1}."
                 },
                 "DesperateSwing": {
                     "Note": "If the attack fails, you release your weapon, or drop @UUID[Compendium.pf2e.conditionitems.Item.j91X7x0XSomq8d60]{Prone} if you were using an unarmed attack or otherwise can't release your weapon."


### PR DESCRIPTION
~~I had to make an assumption on the Endure the Onslaught effect by assuming the user of the card and the receiver are the same level, which will be true in 99% of cases, but still noted it in the effect's description.~~

Used origin in Endure the Onslaught and Catch your Breath as suggested by Simon instead. The usual places you'll be dragging this from shouldn't have origin data as far as I know, but it will fall back on the actor's data anyway, so I figured no harm in using it here, in case modules find ways of having the actor post the effect (like Idle's Toolbelt module).