### PR TITLE
Lock configuration of certain core grid settings

### DIFF
--- a/src/scripts/hooks/index.ts
+++ b/src/scripts/hooks/index.ts
@@ -15,6 +15,7 @@ import { RenderCombatTrackerConfig } from "./render-combat-tracker-config.ts";
 import { RenderDialog } from "./render-dialog.ts";
 import { RenderJournalPageSheet } from "./render-journal-page-sheet.ts";
 import { RenderJournalTextPageSheet } from "./render-journal-text-page-sheet.ts";
+import { RenderSettingsConfig } from "./render-settings-config.ts";
 import { RenderSettings } from "./render-settings.ts";
 import { RenderTokenHUD } from "./render-token-hud.ts";
 import { Setup } from "./setup.ts";
@@ -42,6 +43,7 @@ export const HooksPF2e = {
             RenderJournalPageSheet,
             RenderJournalTextPageSheet,
             RenderSettings,
+            RenderSettingsConfig,
             RenderTokenHUD,
             Setup,
             TargetToken,

--- a/src/scripts/hooks/ready.ts
+++ b/src/scripts/hooks/ready.ts
@@ -29,6 +29,11 @@ export const Ready = {
             console.log("PF2e System | Starting Pathfinder 2nd Edition System");
             console.debug(`PF2e System | Build mode: ${BUILD_MODE}`);
 
+            // Enforce certain grid settings (if the settings are the same, onChange isn't triggered)
+            game.settings.set("core", "gridDiagonals", 4);
+            game.settings.set("core", "gridTemplates", false);
+            game.settings.set("core", "coneTemplateType", "round");
+
             // Some of game.pf2e must wait until the ready phase
             SetGamePF2e.onReady();
 

--- a/src/scripts/hooks/render-settings-config.ts
+++ b/src/scripts/hooks/render-settings-config.ts
@@ -1,0 +1,29 @@
+import { createHTMLElement, htmlQuery } from "@util";
+
+/**
+ * Remove certain core grid settings to manage it ourselves.
+ * Implementation was suggested by https://github.com/foundryvtt/foundryvtt/issues/10683
+ */
+export const RenderSettingsConfig = {
+    listen: (): void => {
+        Hooks.on("renderSettingsConfig", (_app, $html) => {
+            const html = $html[0];
+            const lockedSettings = ["core.gridDiagonals", "core.gridTemplates", "core.coneTemplateType"];
+            for (const locked of lockedSettings) {
+                const element = htmlQuery(html, `div[data-setting-id="${locked}"]`);
+                if (!element) continue;
+
+                const controlElement = htmlQuery<HTMLInputElement | HTMLSelectElement>(element, "select, input");
+                if (controlElement) {
+                    controlElement.disabled = true;
+                    controlElement.dataset.tooltip = "PF2E.SETTINGS.Core.ManagedBySystem";
+                }
+
+                const label = htmlQuery(element, "label");
+                const lock = createHTMLElement("i", { classes: ["fa-solid", "fa-lock", "fa-fw"] });
+                lock.dataset.tooltip = "PF2E.SETTINGS.Core.ManagedBySystem";
+                label?.append(" ", lock);
+            }
+        });
+    },
+};

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -3204,6 +3204,9 @@
                 "ShowUnknownSources": "Do not filter entries with unknown sources.",
                 "SourcesListHeader": "Specified Sources"
             },
+            "Core": {
+                "ManagedBySystem": "Managed and locked by the PF2e System"
+            },
             "CritRule": {
                 "Choices": {
                     "Doubledamage": "Double the damage",

--- a/types/foundry/client/core/hooks.d.ts
+++ b/types/foundry/client/core/hooks.d.ts
@@ -87,6 +87,7 @@ declare global {
         static on(...args: HookParamsRender<ItemDirectory<Item<null>>, "ItemDirectory">): number;
         static on(...args: HookParamsRender<SceneControls, "SceneControls">): number;
         static on(...args: HookParamsRender<Settings, "Settings">): number;
+        static on(...args: HookParamsRender<SettingsConfig, "SettingsConfig">): number;
         static on(...args: HookParamsRender<TokenHUD, "TokenHUD">): number;
         static on(
             ...args: HookParamsRender<JournalPageSheet<JournalEntryPage<JournalEntry | null>>, "JournalPageSheet">


### PR DESCRIPTION
We handle the grid ourselves, so letting users configure these would lead to confusion

![image](https://github.com/foundryvtt/pf2e/assets/1286721/cc4124b3-2fa3-49b5-b246-85fe072a0b64)
