### PR TITLE
Add PF2e menu to prosemirror editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
                 "pixi.js": "7.2.4",
                 "prettier": "3.2.5",
                 "prompts": "^2.4.2",
+                "prosemirror-commands": "^1.5.2",
                 "prosemirror-view": "1.32.5",
                 "sass": "^1.71.0",
                 "socket.io": "4.6.2",
@@ -6937,10 +6938,21 @@
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
             "peer": true
         },
+        "node_modules/prosemirror-commands": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.5.2.tgz",
+            "integrity": "sha512-hgLcPaakxH8tu6YvVAaILV2tXYsW3rAdDR8WNkeKGcgeMVQg3/TMhPdVoh7iAmfgVjZGtcOSjKiQaoeKjzd2mQ==",
+            "dev": true,
+            "dependencies": {
+                "prosemirror-model": "^1.0.0",
+                "prosemirror-state": "^1.0.0",
+                "prosemirror-transform": "^1.0.0"
+            }
+        },
         "node_modules/prosemirror-model": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.20.0.tgz",
-            "integrity": "sha512-q7AY7vMjKYqDCeoedgUiAgrLabliXxndJuuFmcmc2+YU1SblvnOiG2WEACF2lwAZsMlfLpiAilA3L+TWlDqIsQ==",
+            "version": "1.21.0",
+            "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.21.0.tgz",
+            "integrity": "sha512-zLpS1mVCZLA7VTp82P+BfMiYVPcX1/z0Mf3gsjKZtzMWubwn2pN7CceMV0DycjlgE5JeXPR7UF4hJPbBV98oWA==",
             "dev": true,
             "dependencies": {
                 "orderedmap": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
         "pixi.js": "7.2.4",
         "prettier": "3.2.5",
         "prompts": "^2.4.2",
+        "prosemirror-commands": "^1.5.2",
         "prosemirror-view": "1.32.5",
         "sass": "^1.71.0",
         "socket.io": "4.6.2",

--- a/src/module/item/base/sheet/sheet.ts
+++ b/src/module/item/base/sheet/sheet.ts
@@ -274,6 +274,13 @@ class ItemSheetPF2e<TItem extends ItemPF2e> extends ItemSheet<TItem, ItemSheetOp
                 }
             }
 
+            // Remove other edit button. Will be restored by editor save rerender
+            if (name === "system.description.value") {
+                htmlQuery(html, "a[data-action=add-gm-notes]")?.remove();
+            } else if (name === "system.description.gm") {
+                htmlQuery(html, "a.editor-edit")?.remove();
+            }
+
             htmlQuery(html, ".tab.description")?.classList.add("editing");
         }
 

--- a/src/scripts/hooks/index.ts
+++ b/src/scripts/hooks/index.ts
@@ -9,6 +9,7 @@ import { I18nInit } from "./i18n-init.ts";
 import { Init } from "./init.ts";
 import { LightingRefresh } from "./lighting-refresh.ts";
 import { Load } from "./load.ts";
+import { GetProseMirrorMenuDropDowns } from "./prosemirror-menu.ts";
 import { Ready } from "./ready.ts";
 import { RenderChatPopout } from "./render-chat-popout.ts";
 import { RenderCombatTrackerConfig } from "./render-combat-tracker-config.ts";
@@ -32,6 +33,7 @@ export const HooksPF2e = {
             DiceSoNiceReady,
             DiceSoNiceRollStart,
             DropCanvasData,
+            GetProseMirrorMenuDropDowns,
             GetSceneControlButtons,
             I18nInit,
             Init,

--- a/src/scripts/hooks/prosemirror-menu.ts
+++ b/src/scripts/hooks/prosemirror-menu.ts
@@ -1,0 +1,103 @@
+export const GetProseMirrorMenuDropDowns = {
+    listen: (): void => {
+        Hooks.on("getProseMirrorMenuDropDowns", (menu, items) => {
+            const toggleMark = foundry.prosemirror.commands.toggleMark;
+            const wrapIn = foundry.prosemirror.commands.wrapIn;
+            if ("format" in items) {
+                items.format.entries.push({
+                    action: "pf2e",
+                    title: "PF2e",
+                    children: [
+                        {
+                            action: "action-glyph",
+                            title: "Icons 1 2 3 F R",
+                            mark: menu.schema.marks.span,
+                            attrs: { class: "action-glyph" },
+                            cmd: toggleMark(menu.schema.marks.span, { _preserve: { class: "action-glyph" } }),
+                        },
+                        {
+                            action: "inline-header",
+                            title: "Inline Header",
+                            class: "level4",
+                            node: menu.schema.nodes.heading,
+                            attrs: { class: "inline-header", level: 4 },
+                            cmd: () => {
+                                menu._toggleTextBlock(menu.schema.nodes.heading, {
+                                    attrs: { _preserve: { class: "inline-header" }, level: 4 },
+                                });
+                                return true;
+                            },
+                        },
+                        {
+                            action: "info-block",
+                            title: "Info Block",
+                            node: menu.schema.nodes.section,
+                            attrs: { class: "info" },
+                            cmd: () => {
+                                menu._toggleBlock(menu.schema.nodes.section, wrapIn, {
+                                    attrs: { _preserve: { class: "info" } },
+                                });
+                                return true;
+                            },
+                        },
+                        {
+                            action: "stat-block",
+                            title: "Stat Block",
+                            node: menu.schema.nodes.section,
+                            attrs: { class: "statblock" },
+                            cmd: () => {
+                                menu._toggleBlock(menu.schema.nodes.section, wrapIn, {
+                                    attrs: { _preserve: { class: "statblock" } },
+                                });
+                                return true;
+                            },
+                        },
+                        {
+                            action: "traits",
+                            title: "Trait",
+                            node: menu.schema.nodes.section,
+                            attrs: { class: "traits" },
+                            cmd: () => {
+                                menu._toggleBlock(menu.schema.nodes.section, wrapIn, {
+                                    attrs: { _preserve: { class: "traits" } },
+                                });
+                                return true;
+                            },
+                        },
+                        {
+                            action: "written-note",
+                            title: "Written Note",
+                            node: menu.schema.nodes.paragraph,
+                            attrs: { class: "message" },
+                            cmd: () => {
+                                menu._toggleTextBlock(menu.schema.nodes.paragraph, {
+                                    attrs: { _preserve: { class: "message" } },
+                                });
+                                return true;
+                            },
+                        },
+                        {
+                            action: "gm-text-block",
+                            title: "GM Text Block",
+                            node: menu.schema.nodes.div,
+                            attrs: { "data-visibility": "gm" },
+                            cmd: () => {
+                                menu._toggleBlock(menu.schema.nodes.div, wrapIn, {
+                                    attrs: { _preserve: { "data-visibility": "gm" } },
+                                });
+                                return true;
+                            },
+                        },
+                        {
+                            action: "gm-text-inline",
+                            title: "GM Text Inline",
+                            mark: menu.schema.marks.span,
+                            attrs: { "data-visibility": "gm" },
+                            cmd: toggleMark(menu.schema.marks.span, { _preserve: { "data-visibility": "gm" } }),
+                        },
+                    ],
+                });
+            }
+        });
+    },
+};

--- a/types/foundry/client/apps/form.d.ts
+++ b/types/foundry/client/apps/form.d.ts
@@ -140,6 +140,17 @@ declare global {
         /** Activate a TinyMCE editor instance present within the form */
         protected _activateEditor(div: JQuery | HTMLElement): void;
 
+        /**
+         * Configure ProseMirror plugins for this sheet.
+         * @param name                   The name of the editor.
+         * @param [options]              Additional options to configure the plugins.
+         * @param [options.remove=true]  Whether the editor should destroy itself on save.
+         */
+        protected _configureProseMirrorPlugins(
+            name: string,
+            options?: { remove?: boolean },
+        ): Record<string, ProseMirror.Plugin>;
+
         /** Activate a FilePicker instance present within the form */
         protected _activateFilePicker(button: JQuery | HTMLElement): void;
 

--- a/types/foundry/common/prosemirror/menu.d.ts
+++ b/types/foundry/common/prosemirror/menu.d.ts
@@ -34,7 +34,7 @@ export class ProseMirrorMenu extends ProseMirrorPlugin {
     /** Additional options to configure the plugin's behaviour. */
     options: ProseMirrorMenuOptions;
 
-    static build(schema: ProseMirror.Schema, options?: ProseMirrorMenuOptions): ProseMirrorMenu;
+    static build(schema: ProseMirror.Schema, options?: ProseMirrorMenuOptions): ProseMirror.Plugin;
 
     /** Render the menu's HTML. */
     render(): this;
@@ -132,10 +132,10 @@ export class ProseMirrorMenu extends ProseMirrorPlugin {
      * @param  [options]               Additional options to configure behaviour.
      * @param  [options.attrs]         Attributes for the node.
      */
-    protected _toggleBlock(
-        node: Node,
-        wrap: (node: Node, attrs?: object | null) => ProseMirror.Command,
-        options?: { attrs?: Record<string, string> | null },
+    _toggleBlock(
+        node: ProseMirror.NodeType,
+        wrap: (node: ProseMirror.NodeType, attrs?: object | null) => ProseMirror.Command,
+        options?: { attrs?: Record<string, unknown> | null },
     ): void;
 
     /**
@@ -144,7 +144,7 @@ export class ProseMirrorMenu extends ProseMirrorPlugin {
      * @param  [options]        Additional options to configure behaviour.
      * @param  [options.attrs]  Attributes for the node.
      */
-    protected _toggleTextBlock(node: Node, options?: { attrs?: Record<string, string> | null }): void;
+    _toggleTextBlock(node: ProseMirror.NodeType, options?: { attrs?: Record<string, unknown> | null }): void;
 }
 
 declare global {
@@ -171,11 +171,11 @@ declare global {
         /** The menu item's icon HTML. */
         icon?: string;
         /** The mark to apply to the selected text. */
-        mark?: string;
+        mark?: ProseMirror.MarkType;
         /** The node to wrap the selected text in. */
-        node?: unknown; // NodeType
+        node?: ProseMirror.NodeType;
         /** An object of attributes for the node or mark. */
-        attrs?: Record<string, string>;
+        attrs?: Record<string, unknown>;
         /**
          * Entries with the same group number will be grouped together in the drop-down.
          * Lower-numbered groups appear higher in the list.
@@ -187,7 +187,7 @@ declare global {
          */
         priority?: number;
         /** The command to run when the menu item is clicked. */
-        cmd?: unknown; // ProseMirrorCommand
+        cmd?: ProseMirror.Command;
         /** Whether the current item is active under the given selection or cursor. Default: false */
         active?: boolean;
     }

--- a/types/foundry/common/prosemirror/module.d.ts
+++ b/types/foundry/common/prosemirror/module.d.ts
@@ -1,3 +1,9 @@
+import type * as Commands from "prosemirror-commands";
+
 export * from "./dropdown.ts";
 export * from "./menu.ts";
 export * from "./plugin.ts";
+export const commands: typeof Commands;
+export const defaultSchema: ProseMirror.Schema;
+export const defaultPlugins: Record<string, ProseMirror.Plugin>;
+export const Plugin: ConstructorOf<ProseMirror.Plugin>;

--- a/types/foundry/common/prosemirror/plugin.d.ts
+++ b/types/foundry/common/prosemirror/plugin.d.ts
@@ -16,5 +16,5 @@ export abstract class ProseMirrorPlugin {
      * @returns {Plugin}
      * @abstract
      */
-    static build(schema: ProseMirror.Schema, options: object): ProseMirrorPlugin;
+    static build(schema: ProseMirror.Schema, options: object): ProseMirror.Plugin;
 }

--- a/types/foundry/scripts/prose-mirror.d.ts
+++ b/types/foundry/scripts/prose-mirror.d.ts
@@ -9,6 +9,9 @@ declare global {
         type EditorView = View.EditorView;
         type EditorState = State.EditorState;
         type Schema = Model.Schema;
+        type Node = Model.Node;
+        type MarkType = Model.MarkType;
+        type NodeType = Model.NodeType;
         type Plugin = State.Plugin;
         type Step = Transform.Step;
     }


### PR DESCRIPTION
This removes `protected` from two methods in `ProseMirrorMenu` that are needed to make the menu work. The alternative is subclassing it, which also would make the hook unnecessary.

Using `{ _preserve: { class: "action-glyph" } }` is currently the only way to add a class attribute to the prosemirror elements. It uses an internal property added by Foundry and circumvents prosemirror schema validation. This is not officially part of the API and might break without notice.

![image](https://github.com/foundryvtt/pf2e/assets/41452412/bb6a6d1b-3630-4a3c-b568-5ceccefa491e)

The menu could also be added as a top-level dropdown:
![image](https://github.com/foundryvtt/pf2e/assets/41452412/4b83d182-8060-4f64-92b4-697f82074d35)
