### PR TITLE
Rerender token vision when RBV setting is changed

### DIFF
--- a/src/module/scene/sheet.ts
+++ b/src/module/scene/sheet.ts
@@ -28,8 +28,8 @@ export class SceneConfigPF2e<TDocument extends ScenePF2e> extends SceneConfig<TD
                     value: "",
                     label: game.i18n.format("PF2E.SETTINGS.EnabledDisabled.Default", { worldDefault }),
                 },
-                { value: "true", label: "PF2E.SETTINGS.EnabledDisabled.Enabled" },
-                { value: "false", label: "PF2E.SETTINGS.EnabledDisabled.Disabled" },
+                { value: "true", label: game.i18n.localize("PF2E.SETTINGS.EnabledDisabled.Enabled") },
+                { value: "false", label: game.i18n.localize("PF2E.SETTINGS.EnabledDisabled.Disabled") },
             ];
             const templates = await renderTemplate(hbsPath, { scene: this.scene, rbvOptions });
 

--- a/src/module/system/settings/automation.ts
+++ b/src/module/system/settings/automation.ts
@@ -23,10 +23,12 @@ export class AutomationSettings extends SettingsMenuPF2e {
                 hint: CONFIG.PF2E.SETTINGS.automation.rulesBasedVision.hint,
                 default: true,
                 type: Boolean,
-                requiresReload: true,
                 onChange: (value) => {
                     game.pf2e.settings.rbv = !!value;
-                    canvas.perception.update({ initializeVision: true }, true);
+                    for (const token of canvas.scene?.tokens ?? []) {
+                        token.reset();
+                    }
+                    canvas.perception.update({ initializeLighting: true, initializeVision: true }, true);
                 },
             },
             iwr: {

--- a/static/templates/scene/sheet-partials.hbs
+++ b/static/templates/scene/sheet-partials.hbs
@@ -8,7 +8,7 @@
             <label for="{{scene.uuid}}-rules-based-vision">{{localize "PF2E.SETTINGS.Automation.RulesBasedVision.Name"}}</label>
             <div class="form-fields">
                 <select id="{{scene.uuid}}-rules-based-vision" name="flags.pf2e.rulesBasedVision">
-                    {{selectOptions rbvOptions selected=scene.flags.pf2e.rulesBasedVision localize=true}}
+                    {{selectOptions rbvOptions selected=scene.flags.pf2e.rulesBasedVision}}
                 </select>
 
                 <button type="button" class="automation-settings" data-action="world-rbv-setting"


### PR DESCRIPTION
This issue also exists in v11. requiresReload does not work for any of our split off settings menus, but even then the canvas refresh didn't work because token detection modes weren't reset.

Also sneakily fixes `World Default (undefined)` for v12. I haven't dug into why selectOptions was doing that when localizing though.