### PR TITLE
Show prepared values instead of source in token config when RBV is enabled

### DIFF
--- a/src/module/scene/helpers.ts
+++ b/src/module/scene/helpers.ts
@@ -1,4 +1,8 @@
+import type { CreaturePF2e } from "@actor/creature/document.ts";
+import { PrototypeTokenPF2e } from "@actor/data/base.ts";
 import type { ScenePF2e, TokenDocumentPF2e } from "@scene";
+import { LightLevels } from "./data.ts";
+import { DetectionModeEntry } from "./token-document/data.ts";
 
 // Prevent concurrent executions of this method in case of network latency
 let auraCheckLock = Promise.resolve();
@@ -43,4 +47,56 @@ const checkAuras = foundry.utils.debounce(async function (this: ScenePF2e): Prom
     }
 }, 100);
 
-export { checkAuras };
+/** Assigns detection modes and sight settings for either a token or prototype token assuming RBV is enabled. */
+function computeSightAndDetectionForRBV(token: TokenDocumentPF2e | PrototypeTokenPF2e<CreaturePF2e>): void {
+    const actor = token.actor;
+    const scene = "scene" in token ? token.scene : null;
+    if (!actor?.isOfType("creature")) return;
+
+    // Reset detection modes if using rules-based vision
+    const hasVision = !!actor.perception?.hasVision;
+    const lightPerception: DetectionModeEntry = { id: "lightPerception", enabled: hasVision, range: null };
+    const basicSight: DetectionModeEntry = { id: "basicSight", enabled: hasVision, range: 0 };
+    token.detectionModes = [lightPerception, basicSight];
+
+    // Reset sight defaults and set vision mode.
+    // Unlike detection modes, there can only be one, and it decides how the player is currently seeing.
+    const visionMode = actor.hasDarkvision ? "darkvision" : "basic";
+    token.sight.attenuation = 0.1;
+    token.sight.brightness = 0;
+    token.sight.contrast = 0;
+    token.sight.range = 0;
+    token.sight.saturation = 0;
+    token.sight.visionMode = visionMode;
+
+    const visionModeDefaults = CONFIG.Canvas.visionModes[visionMode].vision.defaults;
+    token.sight.brightness = visionModeDefaults.brightness ?? 0;
+    token.sight.saturation = visionModeDefaults.saturation ?? 0;
+
+    // Update basic sight and adjust saturation based on darkvision or light levels
+    if (visionMode === "darkvision" || (scene && scene.lightLevel > LightLevels.DARKNESS)) {
+        token.sight.range = basicSight.range = null;
+
+        if (actor.isOfType("character") && actor.flags.pf2e.colorDarkvision) {
+            token.sight.saturation = 1;
+        } else if (!game.user.settings.monochromeDarkvision) {
+            token.sight.saturation = 0;
+        }
+    }
+
+    if (actor.perception.senses.has("see-invisibility")) {
+        token.detectionModes.push({ id: "seeInvisibility", enabled: true, range: null });
+    }
+
+    const tremorsense = actor.perception.senses.get("tremorsense");
+    if (tremorsense) {
+        token.detectionModes.push({ id: "feelTremor", enabled: true, range: tremorsense.range });
+    }
+
+    if (!actor.hasCondition("deafened")) {
+        const range = scene?.flags.pf2e.hearingRange ?? null;
+        token.detectionModes.push({ id: "hearing", enabled: true, range });
+    }
+}
+
+export { computeSightAndDetectionForRBV, checkAuras };

--- a/src/module/scene/token-document/sheet.ts
+++ b/src/module/scene/token-document/sheet.ts
@@ -2,8 +2,12 @@ import { ActorPF2e } from "@actor";
 import { SIZE_LINKABLE_ACTOR_TYPES } from "@actor/values.ts";
 import { ErrorPF2e, fontAwesomeIcon, htmlQuery } from "@util";
 import type { TokenDocumentPF2e } from "./index.ts";
+import * as R from "remeda";
+import { computeSightAndDetectionForRBV } from "@scene/helpers.ts";
 
 class TokenConfigPF2e<TDocument extends TokenDocumentPF2e> extends TokenConfig<TDocument> {
+    #sightInputNames = ["angle", "brightness", "range", "saturation", "visionMode"].map((n) => `sight.${n}`);
+
     static override get defaultOptions(): DocumentSheetOptions {
         return {
             ...super.defaultOptions,
@@ -25,9 +29,27 @@ class TokenConfigPF2e<TDocument extends TokenDocumentPF2e> extends TokenConfig<T
         }[actorSize];
     }
 
+    get rulesBasedVision(): boolean {
+        const isCreature = !!this.actor?.isOfType("creature");
+        return isCreature && (this.token.rulesBasedVision || (this.isPrototype && game.pf2e.settings.rbv));
+    }
+
     override async getData(options?: DocumentSheetOptions): Promise<TokenConfigDataPF2e<TDocument>> {
+        const data = await super.getData(options);
+
+        // If RBV is enabled, override will-be-disabled inputs with prepared values for transparency.
+        // If this is a prototype token, also compute sight and detection modes to reflect what will occur when placed
+        if (this.rulesBasedVision) {
+            if (this.isPrototype) {
+                computeSightAndDetectionForRBV(this.token);
+            }
+            fu.mergeObject(data, {
+                object: fu.expandObject(R.mapToObj(this.#sightInputNames, (n) => [n, fu.getProperty(this.token, n)])),
+            });
+        }
+
         return {
-            ...(await super.getData(options)),
+            ...data,
             sizeLinkable: !!this.actor && SIZE_LINKABLE_ACTOR_TYPES.has(this.actor.type),
             linkToSizeTitle: this.token.flags.pf2e.linkToActorSize ? "Unlink" : "Link",
             autoscaleTitle: this.token.flags.pf2e.autoscale ? "Unlink" : "Link",
@@ -99,15 +121,11 @@ class TokenConfigPF2e<TDocument extends TokenDocumentPF2e> extends TokenConfig<T
     }
 
     #disableVisionInputs(html: HTMLElement): void {
-        const isCreature = !!this.actor?.isOfType("creature");
-        const rulesBasedVision =
-            isCreature && (this.token.rulesBasedVision || (this.isPrototype && game.pf2e.settings.rbv));
-        if (!rulesBasedVision) return;
+        if (!this.rulesBasedVision) return;
 
-        const sightInputNames = ["angle", "brightness", "range", "saturation", "visionMode"].map((n) => `sight.${n}`);
         const sightInputs = Array.from(
             html.querySelectorAll<HTMLInputElement | HTMLSelectElement>(
-                sightInputNames.map((n) => `[name="${n}"]`).join(", "),
+                this.#sightInputNames.map((n) => `[name="${n}"]`).join(", "),
             ),
         );
 


### PR DESCRIPTION
![image](https://github.com/foundryvtt/pf2e/assets/1286721/0ba6135d-83e9-4202-ab37-8dc3495c1a84)
![image](https://github.com/foundryvtt/pf2e/assets/1286721/322a3040-6929-4c42-8d0e-d5793f64d6cd)

Also stealthily changes more maxR fallbacks to null (since null is now infinity)
