### PR TITLE
Update Thaumaturge Features

### DIFF
--- a/packs/classfeatures/amulet.json
+++ b/packs/classfeatures/amulet.json
@@ -27,6 +27,10 @@
         "rules": [
             {
                 "key": "GrantItem",
+                "predicate": [
+                    "parent:tag:thaumaturge-implement-initiate"
+                ],
+                "reevaluateOnUpdate": true,
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Amulet's Abeyance"
             }
         ],

--- a/packs/classfeatures/bell.json
+++ b/packs/classfeatures/bell.json
@@ -27,6 +27,10 @@
         "rules": [
             {
                 "key": "GrantItem",
+                "predicate": [
+                    "parent:tag:thaumaturge-implement-initiate"
+                ],
+                "reevaluateOnUpdate": true,
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Ring Bell"
             }
         ],

--- a/packs/classfeatures/chalice.json
+++ b/packs/classfeatures/chalice.json
@@ -27,6 +27,10 @@
         "rules": [
             {
                 "key": "GrantItem",
+                "predicate": [
+                    "parent:tag:thaumaturge-implement-initiate"
+                ],
+                "reevaluateOnUpdate": true,
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Drink from the Chalice"
             }
         ],

--- a/packs/classfeatures/first-implement-and-esoterica.json
+++ b/packs/classfeatures/first-implement-and-esoterica.json
@@ -37,16 +37,17 @@
                 "prompt": "PF2E.SpecificRule.Prompt.FirstImplement"
             },
             {
+                "alterations": [
+                    {
+                        "itemId": "{item|flags.pf2e.itemGrants.firstImplement.id}",
+                        "mode": "add",
+                        "property": "other-tags",
+                        "value": "thaumaturge-implement-initiate"
+                    }
+                ],
                 "flag": "firstImplement",
                 "key": "GrantItem",
                 "uuid": "{item|flags.pf2e.rulesSelections.implement}"
-            },
-            {
-                "itemId": "{item|flags.pf2e.itemGrants.firstImplement.id}",
-                "key": "ItemAlteration",
-                "mode": "add",
-                "property": "other-tags",
-                "value": "thaumaturge-implement-initiate"
             }
         ],
         "traits": {

--- a/packs/classfeatures/first-implement-and-esoterica.json
+++ b/packs/classfeatures/first-implement-and-esoterica.json
@@ -37,8 +37,16 @@
                 "prompt": "PF2E.SpecificRule.Prompt.FirstImplement"
             },
             {
+                "flag": "firstImplement",
                 "key": "GrantItem",
                 "uuid": "{item|flags.pf2e.rulesSelections.implement}"
+            },
+            {
+                "itemId": "{item|flags.pf2e.itemGrants.firstImplement.id}",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "property": "other-tags",
+                "value": "thaumaturge-implement-initiate"
             }
         ],
         "traits": {

--- a/packs/classfeatures/first-implement-and-esoterica.json
+++ b/packs/classfeatures/first-implement-and-esoterica.json
@@ -39,7 +39,6 @@
             {
                 "alterations": [
                     {
-                        "itemId": "{item|flags.pf2e.itemGrants.firstImplement.id}",
                         "mode": "add",
                         "property": "other-tags",
                         "value": "thaumaturge-implement-initiate"

--- a/packs/classfeatures/mirror.json
+++ b/packs/classfeatures/mirror.json
@@ -27,6 +27,10 @@
         "rules": [
             {
                 "key": "GrantItem",
+                "predicate": [
+                    "parent:tag:thaumaturge-implement-initiate"
+                ],
+                "reevaluateOnUpdate": true,
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Mirror's Reflection"
             }
         ],

--- a/packs/classfeatures/second-implement.json
+++ b/packs/classfeatures/second-implement.json
@@ -37,16 +37,17 @@
                 "prompt": "PF2E.SpecificRule.Prompt.SecondImplement"
             },
             {
+                "alterations": [
+                    {
+                        "itemId": "{item|flags.pf2e.itemGrants.secondImplement.id}",
+                        "mode": "add",
+                        "property": "other-tags",
+                        "value": "thaumaturge-implement-initiate"
+                    }
+                ],
                 "flag": "secondImplement",
                 "key": "GrantItem",
                 "uuid": "{item|flags.pf2e.rulesSelections.implement}"
-            },
-            {
-                "itemId": "{item|flags.pf2e.itemGrants.secondImplement.id}",
-                "key": "ItemAlteration",
-                "mode": "add",
-                "property": "other-tags",
-                "value": "thaumaturge-implement-initiate"
             }
         ],
         "traits": {

--- a/packs/classfeatures/second-implement.json
+++ b/packs/classfeatures/second-implement.json
@@ -37,8 +37,16 @@
                 "prompt": "PF2E.SpecificRule.Prompt.SecondImplement"
             },
             {
+                "flag": "secondImplement",
                 "key": "GrantItem",
                 "uuid": "{item|flags.pf2e.rulesSelections.implement}"
+            },
+            {
+                "itemId": "{item|flags.pf2e.itemGrants.secondImplement.id}",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "property": "other-tags",
+                "value": "thaumaturge-implement-initiate"
             }
         ],
         "traits": {

--- a/packs/classfeatures/second-implement.json
+++ b/packs/classfeatures/second-implement.json
@@ -39,7 +39,6 @@
             {
                 "alterations": [
                     {
-                        "itemId": "{item|flags.pf2e.itemGrants.secondImplement.id}",
                         "mode": "add",
                         "property": "other-tags",
                         "value": "thaumaturge-implement-initiate"

--- a/packs/classfeatures/third-implement.json
+++ b/packs/classfeatures/third-implement.json
@@ -37,16 +37,17 @@
                 "prompt": "PF2E.SpecificRule.Prompt.ThirdImplement"
             },
             {
+                "alterations": [
+                    {
+                        "itemId": "{item|flags.pf2e.itemGrants.thirdImplement.id}",
+                        "mode": "add",
+                        "property": "other-tags",
+                        "value": "thaumaturge-implement-initiate"
+                    }
+                ],
                 "flag": "thirdImplement",
                 "key": "GrantItem",
                 "uuid": "{item|flags.pf2e.rulesSelections.implement}"
-            },
-            {
-                "itemId": "{item|flags.pf2e.itemGrants.thirdImplement.id}",
-                "key": "ItemAlteration",
-                "mode": "add",
-                "property": "other-tags",
-                "value": "thaumaturge-implement-initiate"
             }
         ],
         "traits": {

--- a/packs/classfeatures/third-implement.json
+++ b/packs/classfeatures/third-implement.json
@@ -37,8 +37,16 @@
                 "prompt": "PF2E.SpecificRule.Prompt.ThirdImplement"
             },
             {
+                "flag": "thirdImplement",
                 "key": "GrantItem",
                 "uuid": "{item|flags.pf2e.rulesSelections.implement}"
+            },
+            {
+                "itemId": "{item|flags.pf2e.itemGrants.thirdImplement.id}",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "property": "other-tags",
+                "value": "thaumaturge-implement-initiate"
             }
         ],
         "traits": {

--- a/packs/classfeatures/third-implement.json
+++ b/packs/classfeatures/third-implement.json
@@ -39,7 +39,6 @@
             {
                 "alterations": [
                     {
-                        "itemId": "{item|flags.pf2e.itemGrants.thirdImplement.id}",
                         "mode": "add",
                         "property": "other-tags",
                         "value": "thaumaturge-implement-initiate"

--- a/packs/classfeatures/wand.json
+++ b/packs/classfeatures/wand.json
@@ -27,6 +27,10 @@
         "rules": [
             {
                 "key": "GrantItem",
+                "predicate": [
+                    "parent:tag:thaumaturge-implement-initiate"
+                ],
+                "reevaluateOnUpdate": true,
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Fling Magic"
             }
         ],

--- a/packs/classfeatures/weapon.json
+++ b/packs/classfeatures/weapon.json
@@ -27,6 +27,10 @@
         "rules": [
             {
                 "key": "GrantItem",
+                "predicate": [
+                    "parent:tag:thaumaturge-implement-initiate"
+                ],
+                "reevaluateOnUpdate": true,
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Implement's Interruption"
             }
         ],

--- a/packs/feats/implement-initiate.json
+++ b/packs/feats/implement-initiate.json
@@ -28,7 +28,15 @@
             "remaster": false,
             "title": "Pathfinder Dark Archive"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemId": "{actor|flags.pf2e.thaumaturgeDedicationImplement}",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "property": "other-tags",
+                "value": "thaumaturge-implement-initiate"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/thaumaturge-dedication.json
+++ b/packs/feats/thaumaturge-dedication.json
@@ -46,14 +46,10 @@
                 "uuid": "{item|flags.pf2e.rulesSelections.implement}"
             },
             {
-                "itemId": "{item|flags.pf2e.itemGrants.firstImplement.id}",
-                "key": "ItemAlteration",
-                "mode": "add",
-                "predicate": [
-                    "feat:implement-initiate"
-                ],
-                "property": "other-tags",
-                "value": "thaumaturge-implement-initiate"
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.thaumaturgeDedicationImplement",
+                "value": "{item|flags.pf2e.itemGrants.firstImplement.id}"
             },
             {
                 "adjustName": false,

--- a/packs/feats/thaumaturge-dedication.json
+++ b/packs/feats/thaumaturge-dedication.json
@@ -31,6 +31,32 @@
         "rules": [
             {
                 "adjustName": false,
+                "choices": {
+                    "filter": [
+                        "item:tag:thaumaturge-implement"
+                    ]
+                },
+                "flag": "implement",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.FirstImplement"
+            },
+            {
+                "flag": "firstImplement",
+                "key": "GrantItem",
+                "uuid": "{item|flags.pf2e.rulesSelections.implement}"
+            },
+            {
+                "itemId": "{item|flags.pf2e.itemGrants.firstImplement.id}",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "feat:implement-initiate"
+                ],
+                "property": "other-tags",
+                "value": "thaumaturge-implement-initiate"
+            },
+            {
+                "adjustName": false,
                 "choices": [
                     {
                         "label": "PF2E.SkillArc",


### PR DESCRIPTION
This adds the `thaumaturge-implement-initiate` otherTag. 

While not inherently or necessarily important for the Thaumaturge class, it allows implement features that have grantItem features the ability to predicate on the tag - this means that the Thaumaturge Dedication doesn't grant these actions unless they also take the Implement Initiate feat.

The Thaumaturge Dedication is also given a choiceSet to choose an implement, and the `thaumaturge-implement-initiate` otherTag is granted only when the Implement Initiate feat is granted.