### PR TITLE
Add effect for Hand of the Apprentice

### DIFF
--- a/packs/spell-effects/effect-hand-of-the-apprentice.json
+++ b/packs/spell-effects/effect-hand-of-the-apprentice.json
@@ -18,7 +18,7 @@
         "publication": {
             "license": "ORC",
             "remaster": true,
-            "title": ""
+            "title": "Pathfinder Player Core"
         },
         "rules": [
             {

--- a/packs/spell-effects/effect-hand-of-the-apprentice.json
+++ b/packs/spell-effects/effect-hand-of-the-apprentice.json
@@ -17,7 +17,7 @@
         },
         "publication": {
             "license": "ORC",
-            "remaster": false,
+            "remaster": true,
             "title": ""
         },
         "rules": [

--- a/packs/spell-effects/effect-hand-of-the-apprentice.json
+++ b/packs/spell-effects/effect-hand-of-the-apprentice.json
@@ -41,12 +41,7 @@
             {
                 "key": "CriticalSpecialization",
                 "predicate": [
-                    {
-                        "or": [
-                            "item:category:{item|flags.pf2e.rulesSelections.weapon}",
-                            "item:id:{item|flags.pf2e.rulesSelections.weapon}"
-                        ]
-                    }
+                    "item:id:{item|flags.pf2e.rulesSelections.weapon}"
                 ]
             }
         ],

--- a/packs/spell-effects/effect-hand-of-the-apprentice.json
+++ b/packs/spell-effects/effect-hand-of-the-apprentice.json
@@ -16,7 +16,7 @@
             "value": 0
         },
         "publication": {
-            "license": "OGL",
+            "license": "ORC",
             "remaster": false,
             "title": ""
         },

--- a/packs/spell-effects/effect-hand-of-the-apprentice.json
+++ b/packs/spell-effects/effect-hand-of-the-apprentice.json
@@ -35,12 +35,8 @@
             {
                 "ability": "int",
                 "key": "FlatModifier",
-                "predicate": [
-                    "item:id:{item|flags.pf2e.rulesSelections.weapon}"
-                ],
-                "selector": "strike-damage",
-                "type": "ability",
-                "value": 0
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-damage",
+                "type": "ability"
             },
             {
                 "key": "CriticalSpecialization",

--- a/packs/spell-effects/effect-hand-of-the-apprentice.json
+++ b/packs/spell-effects/effect-hand-of-the-apprentice.json
@@ -1,0 +1,69 @@
+{
+    "_id": "3pb8XJTwAjkx8l4o",
+    "img": "systems/pf2e/icons/spells/hand-of-the-apprentice.webp",
+    "name": "Effect: Hand of the Apprentice",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Hand of the Apprentice]</p>\n<p>You take advantage of one of the most fundamental lessons of magic to levitate and propel your weapon. You hurl a held melee weapon with which you are trained at the target, making a spell attack roll. On a success, you deal the weapon's damage as if you had hit with a melee Strike, but adding your spellcasting ability modifier to damage, rather than your Strength modifier. On a critical success, you deal double damage, and you add the weapon's critical specialization effect. Regardless of the outcome, the weapon flies back to you and returns to your hand.</p>\n<p> </p>"
+        },
+        "duration": {
+            "expiry": "turn-end",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 0
+        },
+        "level": {
+            "value": 0
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": ""
+        },
+        "rules": [
+            {
+                "choices": {
+                    "ownedItems": true,
+                    "types": [
+                        "weapon"
+                    ]
+                },
+                "flag": "weapon",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.Weapon"
+            },
+            {
+                "ability": "int",
+                "key": "FlatModifier",
+                "predicate": [
+                    "item:id:{item|flags.pf2e.rulesSelections.weapon}"
+                ],
+                "selector": "strike-damage",
+                "type": "ability",
+                "value": 0
+            },
+            {
+                "key": "CriticalSpecialization",
+                "predicate": [
+                    {
+                        "or": [
+                            "item:category:{item|flags.pf2e.rulesSelections.weapon}",
+                            "item:id:{item|flags.pf2e.rulesSelections.weapon}"
+                        ]
+                    }
+                ]
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/spell-effects/spell-effect-hand-of-the-apprentice.json
+++ b/packs/spell-effects/spell-effect-hand-of-the-apprentice.json
@@ -1,7 +1,7 @@
 {
     "_id": "3pb8XJTwAjkx8l4o",
     "img": "systems/pf2e/icons/spells/hand-of-the-apprentice.webp",
-    "name": "Spell Effect:  Hand of the Apprentice",
+    "name": "Spell Effect: Hand of the Apprentice",
     "system": {
         "description": {
             "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Hand of the Apprentice]</p>\n<p>You take advantage of one of the most fundamental lessons of magic to levitate and propel your weapon. You hurl a held melee weapon with which you are trained at the target, making a spell attack roll. On a success, you deal the weapon's damage as if you had hit with a melee Strike, but adding your spellcasting ability modifier to damage, rather than your Strength modifier. On a critical success, you deal double damage, and you add the weapon's critical specialization effect. Regardless of the outcome, the weapon flies back to you and returns to your hand.</p>\n<p> </p>"

--- a/packs/spell-effects/spell-effect-hand-of-the-apprentice.json
+++ b/packs/spell-effects/spell-effect-hand-of-the-apprentice.json
@@ -1,5 +1,5 @@
 {
-    "_id": "3pb8XJTwAjkx8l4o",
+    "_id": "MsXuzUrCGVuRGWK7",
     "img": "systems/pf2e/icons/spells/hand-of-the-apprentice.webp",
     "name": "Spell Effect: Hand of the Apprentice",
     "system": {

--- a/packs/spell-effects/spell-effect-hand-of-the-apprentice.json
+++ b/packs/spell-effects/spell-effect-hand-of-the-apprentice.json
@@ -1,7 +1,7 @@
 {
     "_id": "3pb8XJTwAjkx8l4o",
     "img": "systems/pf2e/icons/spells/hand-of-the-apprentice.webp",
-    "name": "Effect: Hand of the Apprentice",
+    "name": "Spell Effect:  Hand of the Apprentice",
     "system": {
         "description": {
             "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Hand of the Apprentice]</p>\n<p>You take advantage of one of the most fundamental lessons of magic to levitate and propel your weapon. You hurl a held melee weapon with which you are trained at the target, making a spell attack roll. On a success, you deal the weapon's damage as if you had hit with a melee Strike, but adding your spellcasting ability modifier to damage, rather than your Strength modifier. On a critical success, you deal double damage, and you add the weapon's critical specialization effect. Regardless of the outcome, the weapon flies back to you and returns to your hand.</p>\n<p> </p>"

--- a/packs/spells/hand-of-the-apprentice.json
+++ b/packs/spells/hand-of-the-apprentice.json
@@ -11,7 +11,7 @@
         "damage": {},
         "defense": null,
         "description": {
-            "value": "<p>You take advantage of one of the most fundamental lessons of magic to levitate and propel your weapon. You hurl a held melee weapon with which you are trained at the target, making a spell attack roll. On a success, you deal the weapon's damage as if you had hit with a melee Strike, but adding your spellcasting ability modifier to damage, rather than your Strength modifier. On a critical success, you deal double damage, and you add the weapon's critical specialization effect. Regardless of the outcome, the weapon flies back to you and returns to your hand.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Effect: Hand of the Apprentice]</p>"
+            "value": "<p>You take advantage of one of the most fundamental lessons of magic to levitate and propel your weapon. You hurl a held melee weapon with which you are trained at the target, making a spell attack roll. On a success, you deal the weapon's damage as if you had hit with a melee Strike, but adding your spellcasting ability modifier to damage, rather than your Strength modifier. On a critical success, you deal double damage, and you add the weapon's critical specialization effect. Regardless of the outcome, the weapon flies back to you and returns to your hand.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect:  Hand of the Apprentice]{Spell Effect: Hand of the Apprentice}</p>\n<p> </p>"
         },
         "duration": {
             "sustained": false,

--- a/packs/spells/hand-of-the-apprentice.json
+++ b/packs/spells/hand-of-the-apprentice.json
@@ -11,7 +11,7 @@
         "damage": {},
         "defense": null,
         "description": {
-            "value": "<p>You take advantage of one of the most fundamental lessons of magic to levitate and propel your weapon. You hurl a held melee weapon with which you are trained at the target, making a spell attack roll. On a success, you deal the weapon's damage as if you had hit with a melee Strike, but adding your spellcasting ability modifier to damage, rather than your Strength modifier. On a critical success, you deal double damage, and you add the weapon's critical specialization effect. Regardless of the outcome, the weapon flies back to you and returns to your hand.</p>"
+            "value": "<p>You take advantage of one of the most fundamental lessons of magic to levitate and propel your weapon. You hurl a held melee weapon with which you are trained at the target, making a spell attack roll. On a success, you deal the weapon's damage as if you had hit with a melee Strike, but adding your spellcasting ability modifier to damage, rather than your Strength modifier. On a critical success, you deal double damage, and you add the weapon's critical specialization effect. Regardless of the outcome, the weapon flies back to you and returns to your hand.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Effect: Hand of the Apprentice]</p>"
         },
         "duration": {
             "sustained": false,

--- a/packs/spells/hand-of-the-apprentice.json
+++ b/packs/spells/hand-of-the-apprentice.json
@@ -11,7 +11,7 @@
         "damage": {},
         "defense": null,
         "description": {
-            "value": "<p>You take advantage of one of the most fundamental lessons of magic to levitate and propel your weapon. You hurl a held melee weapon with which you are trained at the target, making a spell attack roll. On a success, you deal the weapon's damage as if you had hit with a melee Strike, but adding your spellcasting ability modifier to damage, rather than your Strength modifier. On a critical success, you deal double damage, and you add the weapon's critical specialization effect. Regardless of the outcome, the weapon flies back to you and returns to your hand.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect:  Hand of the Apprentice]{Spell Effect: Hand of the Apprentice}</p>\n<p> </p>"
+            "value": "<p>You take advantage of one of the most fundamental lessons of magic to levitate and propel your weapon. You hurl a held melee weapon with which you are trained at the target, making a spell attack roll. On a success, you deal the weapon's damage as if you had hit with a melee Strike, but adding your spellcasting ability modifier to damage, rather than your Strength modifier. On a critical success, you deal double damage, and you add the weapon's critical specialization effect. Regardless of the outcome, the weapon flies back to you and returns to your hand.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Hand of the Apprentice]</p>\n<p> </p>"
         },
         "duration": {
             "sustained": false,


### PR DESCRIPTION
Improve Hand of the Apprentice automation.

Added a spell effect that toggles the attribute modifier to intelligence and adds the critical specialization effect to the selected weapon