### PR TITLE
Add automation for the Mechanical Symbiosis background

### DIFF
--- a/packs/backgrounds/mechanical-symbiosis.json
+++ b/packs/backgrounds/mechanical-symbiosis.json
@@ -129,8 +129,7 @@
                     "entity-is-aiding"
                 ],
                 "selector": "{item|flags.pf2e.rulesSelections.entitySkill}",
-                "text": "You become @UUID[Compendium.pf2e.conditionitems.Item.Stunned]{Stunned 1}",
-                "title": "Mechanical Symbiosis (Failure):"
+                "text": "PF2E.SpecificRule.MechanicalSymbiosis.FailureNote"
             },
             {
                 "key": "Note",
@@ -141,8 +140,7 @@
                     "entity-is-aiding"
                 ],
                 "selector": "{item|flags.pf2e.rulesSelections.entitySkill}",
-                "text": "You become @UUID[Compendium.pf2e.conditionitems.Item.Stunned]{Stunned 2}",
-                "title": "Mechanical Symbiosis (Critical Failure)"
+                "text": "PF2E.SpecificRule.MechanicalSymbiosis.CriticalFailureNote"
             }
         ],
         "trainedLore": "",

--- a/packs/backgrounds/mechanical-symbiosis.json
+++ b/packs/backgrounds/mechanical-symbiosis.json
@@ -96,7 +96,7 @@
                 ],
                 "flag": "entitySkill",
                 "key": "ChoiceSet",
-                "prompt": "GM-Selected Skill"
+                "prompt": "PF2E.SpecificRule.Prompt.Skill"
             },
             {
                 "key": "ActiveEffectLike",

--- a/packs/backgrounds/mechanical-symbiosis.json
+++ b/packs/backgrounds/mechanical-symbiosis.json
@@ -30,7 +30,121 @@
             "remaster": false,
             "title": "Pathfinder Guns & Gears"
         },
-        "rules": [],
+        "rules": [
+            {
+                "choices": [
+                    {
+                        "label": "PF2E.SkillAcr",
+                        "value": "acrobatics"
+                    },
+                    {
+                        "label": "PF2E.SkillAth",
+                        "value": "athletics"
+                    },
+                    {
+                        "label": "PF2E.SkillCra",
+                        "value": "crafting"
+                    },
+                    {
+                        "label": "PF2E.SkillDec",
+                        "value": "deception"
+                    },
+                    {
+                        "label": "PF2E.SkillDip",
+                        "value": "diplomacy"
+                    },
+                    {
+                        "label": "PF2E.SkillItm",
+                        "value": "intimidation"
+                    },
+                    {
+                        "label": "PF2E.SkillMed",
+                        "value": "medicine"
+                    },
+                    {
+                        "label": "PF2E.SkillNat",
+                        "value": "nature"
+                    },
+                    {
+                        "label": "PF2E.SkillOcc",
+                        "value": "occultism"
+                    },
+                    {
+                        "label": "PF2E.SkillPrf",
+                        "value": "performance"
+                    },
+                    {
+                        "label": "PF2E.SkillRel",
+                        "value": "religion"
+                    },
+                    {
+                        "label": "PF2E.SkillSoc",
+                        "value": "society"
+                    },
+                    {
+                        "label": "PF2E.SkillSte",
+                        "value": "stealth"
+                    },
+                    {
+                        "label": "PF2E.SkillSur",
+                        "value": "survival"
+                    },
+                    {
+                        "label": "PF2E.SkillThi",
+                        "value": "thievery"
+                    }
+                ],
+                "flag": "entitySkill",
+                "key": "ChoiceSet",
+                "prompt": "GM-Selected Skill"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "system.skills.{item|flags.pf2e.rulesSelections.entitySkill}.rank",
+                "value": 1
+            },
+            {
+                "domain": "skill-check",
+                "key": "RollOption",
+                "option": "entity-is-aiding",
+                "toggleable": true
+            },
+            {
+                "key": "FlatModifier",
+                "label": "Mechanical Symbiosis",
+                "predicate": [
+                    "entity-is-aiding"
+                ],
+                "selector": "{item|flags.pf2e.rulesSelections.entitySkill}",
+                "type": "circumstance",
+                "value": 1
+            },
+            {
+                "key": "Note",
+                "outcome": [
+                    "failure"
+                ],
+                "predicate": [
+                    "entity-is-aiding"
+                ],
+                "selector": "{item|flags.pf2e.rulesSelections.entitySkill}",
+                "text": "You become @UUID[Compendium.pf2e.conditionitems.Item.Stunned]{Stunned 1}",
+                "title": "Mechanical Symbiosis (Failure):"
+            },
+            {
+                "key": "Note",
+                "outcome": [
+                    "criticalFailure"
+                ],
+                "predicate": [
+                    "entity-is-aiding"
+                ],
+                "selector": "{item|flags.pf2e.rulesSelections.entitySkill}",
+                "text": "You become @UUID[Compendium.pf2e.conditionitems.Item.Stunned]{Stunned 2}",
+                "title": "Mechanical Symbiosis (Critical Failure)"
+            }
+        ],
         "trainedLore": "",
         "trainedSkills": {
             "custom": "",

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -3061,6 +3061,10 @@
                 "SimpleMartialBows": "Simple & Martial Bows",
                 "SimpleMartialTwoHandedMeleeWeapons": "Simple & Martial Two-Handed Melee Weapons"
             },
+			"MechanicalSymbiosis": {
+				"FailureNote": "You become @UUID[Compendium.pf2e.conditionitems.Item.dfCMdR4wnpbYNTix]{Stunned 1}",
+				"CriticalFailureNote": "You become @UUID[Compendium.pf2e.conditionitems.Item.dfCMdR4wnpbYNTix]{Stunned 2}"
+			},
             "MechanicalTorch": {
                 "Label": "Mechanical Torch is lit",
                 "LitCone": "Cone",


### PR DESCRIPTION
Added a choice set for all skills other than Arcana, added a toggleable roll option for the +1 circumstance bonus to said skill, and added notes with linked Stunned x conditions for failure and crit failure of checks for selected skill.