### PR TITLE
Continue to improve prosemirror dropdown menu

### DIFF
--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -1340,6 +1340,7 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
         plugins.menu = ProseMirrorMenuPF2e.build(foundry.prosemirror.defaultSchema, {
             destroyOnSave: options.remove,
             onSave: () => this.saveEditor(name, options),
+            compact: true,
         });
         return plugins;
     }

--- a/src/module/item/base/sheet/sheet.ts
+++ b/src/module/item/base/sheet/sheet.ts
@@ -307,6 +307,7 @@ class ItemSheetPF2e<TItem extends ItemPF2e> extends ItemSheet<TItem, ItemSheetOp
         plugins.menu = ProseMirrorMenuPF2e.build(foundry.prosemirror.defaultSchema, {
             destroyOnSave: options.remove,
             onSave: () => this.saveEditor(name, options),
+            compact: this.options.hasSidebar,
         });
         return plugins;
     }

--- a/src/module/system/prosemirror-menu.ts
+++ b/src/module/system/prosemirror-menu.ts
@@ -5,14 +5,6 @@ class ProseMirrorMenuPF2e extends foundry.prosemirror.ProseMirrorMenu {
         const menus = super._getDropDownMenus();
         const toggleMark = foundry.prosemirror.commands.toggleMark;
         const wrapIn = foundry.prosemirror.commands.wrapIn;
-        const fonts = menus.fonts;
-
-        menus.format.entries.push({
-            action: "fonts",
-            title: fonts.title,
-            children: [...fonts.entries],
-        });
-        delete menus.fonts;
 
         if ("format" in menus) {
             menus.format.entries.push({
@@ -21,6 +13,7 @@ class ProseMirrorMenuPF2e extends foundry.prosemirror.ProseMirrorMenu {
                 children: [
                     {
                         action: "pf2e-action-glyph",
+                        class: "action-glyph",
                         title: "Icons 1 2 3 F R",
                         mark: this.schema.marks.span,
                         attrs: { _preserve: { class: "action-glyph" } },
@@ -31,6 +24,7 @@ class ProseMirrorMenuPF2e extends foundry.prosemirror.ProseMirrorMenu {
                     },
                     {
                         action: "pf2e-inline-header",
+                        class: "inline-header",
                         title: "Inline Header",
                         node: this.schema.nodes.heading,
                         attrs: { _preserve: { class: "inline-header" }, level: 4 },
@@ -44,6 +38,7 @@ class ProseMirrorMenuPF2e extends foundry.prosemirror.ProseMirrorMenu {
                     },
                     {
                         action: "pf2e-info-block",
+                        class: "info",
                         title: "Info Block",
                         node: this.schema.nodes.section,
                         attrs: { _preserve: { class: "info" } },
@@ -57,6 +52,7 @@ class ProseMirrorMenuPF2e extends foundry.prosemirror.ProseMirrorMenu {
                     },
                     {
                         action: "pf2e-stat-block",
+                        class: "statblock",
                         title: "Stat Block",
                         node: this.schema.nodes.section,
                         attrs: { _preserve: { class: "statblock" } },
@@ -70,6 +66,7 @@ class ProseMirrorMenuPF2e extends foundry.prosemirror.ProseMirrorMenu {
                     },
                     {
                         action: "pf2e-traits",
+                        class: "traits",
                         title: "Trait",
                         node: this.schema.nodes.section,
                         attrs: { _preserve: { class: "traits" } },
@@ -83,6 +80,7 @@ class ProseMirrorMenuPF2e extends foundry.prosemirror.ProseMirrorMenu {
                     },
                     {
                         action: "pf2e-written-note",
+                        class: "message",
                         title: "Written Note",
                         node: this.schema.nodes.paragraph,
                         attrs: { _preserve: { class: "message" } },
@@ -96,6 +94,7 @@ class ProseMirrorMenuPF2e extends foundry.prosemirror.ProseMirrorMenu {
                     },
                     {
                         action: "pf2e-gm-text-block",
+                        class: "visibility-gm",
                         title: "GM Text Block",
                         node: this.schema.nodes.div,
                         attrs: { _preserve: { "data-visibility": "gm" } },
@@ -109,6 +108,7 @@ class ProseMirrorMenuPF2e extends foundry.prosemirror.ProseMirrorMenu {
                     },
                     {
                         action: "pf2e-gm-text-inline",
+                        class: "visibility-gm",
                         title: "GM Text Inline",
                         mark: this.schema.marks.span,
                         attrs: { _preserve: { "data-visibility": "gm" } },

--- a/src/styles/_globals.scss
+++ b/src/styles/_globals.scss
@@ -369,6 +369,45 @@ a[href]:hover {
     @include journal-styling;
 }
 
+#prosemirror-dropdown {
+    @include journal-styling;
+
+    .info:hover {
+        color: black;
+    }
+
+    .inline-header {
+        padding: inherit;
+
+        &:hover {
+            color: black;
+        }
+    }
+
+    .statblock {
+        margin-top: unset;
+    }
+
+    li[data-action="pf2e"] {
+        li {
+            height: 1.9rem;
+            margin-bottom: var(--space-2);
+        }
+
+        .visibility-gm {
+            background: var(--visibility-gm-bg);
+            border-radius: 1px;
+            box-sizing: border-box;
+            line-height: 1em;
+            outline: 1px dotted rgba(75, 74, 68, 0.5);
+
+            &:hover {
+                background: var(--color-hover-bg);
+            }
+        }
+    }
+}
+
 .prosemirror menu {
     gap: 3px;
 }

--- a/src/styles/_globals.scss
+++ b/src/styles/_globals.scss
@@ -369,6 +369,10 @@ a[href]:hover {
     @include journal-styling;
 }
 
+.prosemirror menu {
+    gap: 3px;
+}
+
 // System theme Foundry tooltips
 #tooltip.pf2e,
 aside.locked-tooltip.pf2e {

--- a/src/styles/mixins/_typography.scss
+++ b/src/styles/mixins/_typography.scss
@@ -96,7 +96,8 @@
             }
         }
 
-        p {
+        p,
+        span {
             font-size: 0.8em;
             margin: 0;
             padding: 0 var(--space-l);
@@ -113,7 +114,8 @@
         flex-wrap: wrap;
         padding: 0;
 
-        p {
+        p,
+        span {
             display: inline-flex;
             padding: 0.16rem 0.25rem;
             margin: 0;


### PR DESCRIPTION
- Make `Font` dropdown a child of `Format` dropdown
- Fix toggling of inline header
- Reduce menu item gap by 1px

This does not fix toggling of the action glyphs and inline gm text. The problem  there is that it's using a `ProseMirror.Mark` instead of a `ProseMirror.Node` because the foundry schema has no `span` `Node` only a `Mark`.
`toggleMark` only toggles a selection so to remove the span it is necessary to select the text that should be toggled instead of just toggling it off with the menu.

![image](https://github.com/foundryvtt/pf2e/assets/41452412/763ec92d-7088-4de9-8cde-9e9ba9ad6d26)
