### PR TITLE
Fix visibility of `hidden`, `undetected` or `unnoticed` tokens and ambient darkness luminosity in new scenes

### DIFF
--- a/src/module/canvas/perception/modes.ts
+++ b/src/module/canvas/perception/modes.ts
@@ -21,6 +21,39 @@ const darkvision = new VisionMode({
     },
 });
 
+class LightPerceptionMode extends DetectionModeLightPerception {
+    constructor() {
+        super({
+            id: "lightPerception",
+            label: "DETECTION.LightPerception",
+            type: DetectionMode.DETECTION_TYPES.SIGHT,
+        });
+    }
+
+    protected override _canDetect(visionSource: PointVisionSourcePF2e, target: PlaceableObject): boolean {
+        if (target instanceof PlaceableObject && target.document.hidden) return false;
+        if (target instanceof TokenPF2e && target.actor?.hasCondition("hidden", "undetected", "unnoticed")) {
+            return false;
+        }
+
+        return super._canDetect(visionSource, target);
+    }
+
+    /** Potentially short-circuit range test */
+    protected override _testRange(
+        visionSource: PointVisionSourcePF2e,
+        mode: TokenDetectionMode,
+        target: PlaceableObject<CanvasDocument>,
+        test: CanvasVisibilityTest,
+    ): boolean {
+        return (
+            mode.range === null ||
+            mode.range >= canvas.dimensions.maxR ||
+            super._testRange(visionSource, mode, target, test)
+        );
+    }
+}
+
 class VisionDetectionMode extends DetectionModeBasicSight {
     constructor() {
         super({
@@ -46,7 +79,11 @@ class VisionDetectionMode extends DetectionModeBasicSight {
         target: PlaceableObject<CanvasDocument>,
         test: CanvasVisibilityTest,
     ): boolean {
-        return mode.range >= canvas.dimensions.maxR || super._testRange(visionSource, mode, target, test);
+        return (
+            mode.range === null ||
+            mode.range >= canvas.dimensions.maxR ||
+            super._testRange(visionSource, mode, target, test)
+        );
     }
 }
 
@@ -113,7 +150,11 @@ class HearingDetectionMode extends DetectionMode {
         target: PlaceableObject<CanvasDocument>,
         test: CanvasVisibilityTest,
     ): boolean {
-        return mode.range >= canvas.dimensions.maxR || super._testRange(visionSource, mode, target, test);
+        return (
+            mode.range === null ||
+            mode.range >= canvas.dimensions.maxR ||
+            super._testRange(visionSource, mode, target, test)
+        );
     }
 }
 
@@ -156,6 +197,7 @@ class DetectionModeTremorPF2e extends DetectionModeTremor {
 function setPerceptionModes(): void {
     CONFIG.Canvas.visionModes.darkvision = darkvision;
     CONFIG.Canvas.detectionModes.basicSight = new VisionDetectionMode();
+    CONFIG.Canvas.detectionModes.lightPerception = new LightPerceptionMode();
     CONFIG.Canvas.detectionModes.hearing = new HearingDetectionMode();
     CONFIG.Canvas.detectionModes.feelTremor = new DetectionModeTremorPF2e();
 }

--- a/src/module/canvas/token/object.ts
+++ b/src/module/canvas/token/object.ts
@@ -548,7 +548,6 @@ class TokenPF2e<TDocument extends TokenDocumentPF2e = TokenDocumentPF2e> extends
 
         if (["undetected", "unnoticed"].includes(statusId)) {
             canvas.perception.update({ refreshVision: true, refreshLighting: true }, true);
-            this.mesh.refresh();
         }
     }
 

--- a/src/module/scene/document.ts
+++ b/src/module/scene/document.ts
@@ -130,6 +130,17 @@ class ScenePF2e extends Scene {
             canvas.perception.update({ initializeLighting: true, initializeVision: true });
         }
     }
+
+    protected override async _preCreate(
+        data: this["_source"],
+        options: DocumentModificationContext<null>,
+        user: User,
+    ): Promise<boolean | void> {
+        // Override core luminosity of -0.5 which makes tokens nearly invisible in dark scenes
+        this.updateSource({ "environment.dark": { luminosity: 0 } });
+
+        return super._preCreate(data, options, user);
+    }
 }
 
 interface ScenePF2e extends Scene {

--- a/types/foundry/client/pixi/perception/detection-mode.d.ts
+++ b/types/foundry/client/pixi/perception/detection-mode.d.ts
@@ -188,8 +188,10 @@ declare global {
         id: string;
         /** Whether or not this detection mode is presently enabled */
         enabled: boolean;
-        /** The maximum range in distance units at which this mode can detect targets */
-        range: number;
+        /** The maximum range in distance units at which this mode can detect targets.
+         *  If null, the detection range is unlimited.
+         */
+        range: number | null;
     }
 
     type DetectionType = (typeof DetectionMode.DETECTION_TYPES)[keyof typeof DetectionMode.DETECTION_TYPES];


### PR DESCRIPTION
Closes #14710 and #14711

Luminosity -0.5:
![image](https://github.com/foundryvtt/pf2e/assets/41452412/9c0dba3b-8b20-498f-a44e-d0bf01fb7117)

Luminosity 0:
![image](https://github.com/foundryvtt/pf2e/assets/41452412/7b856671-a5a5-45e1-8604-7c184e643e94)
