### PR TITLE
(In3luki) Avoid prosemirror detecting inline header as h4

### DIFF
--- a/src/module/system/prosemirror-menu.ts
+++ b/src/module/system/prosemirror-menu.ts
@@ -22,10 +22,9 @@ class ProseMirrorMenuPF2e extends foundry.prosemirror.ProseMirrorMenu {
                     {
                         action: "pf2e-inline-header",
                         title: "Inline Header",
-                        class: "level4",
                         node: this.schema.nodes.heading,
                         attrs: { _preserve: { class: "inline-header" }, level: 4 },
-                        priority: 1,
+                        priority: 0,
                         cmd: () => {
                             this._toggleTextBlock(this.schema.nodes.heading, {
                                 attrs: { _preserve: { class: "inline-header" }, level: 4 },


### PR DESCRIPTION
A piece of https://github.com/foundryvtt/pf2e/pull/14709 I think we can go ahead with right now.