### PR TITLE
Fix NPC copies of Meteor Swarm

### DIFF
--- a/packs/age-of-ashes-bestiary/ilgreth.json
+++ b/packs/age-of-ashes-bestiary/ilgreth.json
@@ -201,7 +201,7 @@
                         "max": 4,
                         "prepared": [
                             {
-                                "id": "qIhk32nFzOkXfJ0U"
+                                "id": "WdEL9RlGZAsCEIDU"
                             },
                             {
                                 "id": "yke2CA9DIe7ifv4k"
@@ -223,7 +223,8 @@
                 },
                 "tradition": {
                     "value": "arcane"
-                }
+                },
+                "traits": {}
             },
             "type": "spellcastingEntry"
         },
@@ -403,7 +404,7 @@
             "type": "spell"
         },
         {
-            "_id": "qIhk32nFzOkXfJ0U",
+            "_id": "WdEL9RlGZAsCEIDU",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.Item.jrBa9deU2ULFWvSl"
@@ -413,7 +414,10 @@
             "name": "Meteor Swarm",
             "sort": 400000,
             "system": {
-                "area": null,
+                "area": {
+                    "type": "burst",
+                    "value": 40
+                },
                 "cost": {
                     "value": ""
                 },
@@ -428,6 +432,16 @@
                         ],
                         "materials": [],
                         "type": "bludgeoning"
+                    },
+                    "6BEyrCCNpDfJh5P8": {
+                        "applyMod": false,
+                        "category": null,
+                        "formula": "14d6",
+                        "kinds": [
+                            "damage"
+                        ],
+                        "materials": [],
+                        "type": "fire"
                     }
                 },
                 "defense": {
@@ -445,7 +459,8 @@
                 },
                 "heightening": {
                     "damage": {
-                        "0": "1d10"
+                        "0": "1d10",
+                        "6BEyrCCNpDfJh5P8": "2d6"
                     },
                     "interval": 1,
                     "type": "interval"

--- a/packs/age-of-ashes-bestiary/ilgreth.json
+++ b/packs/age-of-ashes-bestiary/ilgreth.json
@@ -451,7 +451,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the @Template[type:burst|distance:10] at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its @Template[type:burst|distance:40]. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>\n<p>[[/r ((@item.level*2)-4)d6[fire]]]{Leveled Fire Damage}</p>"
+                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the @Template[type:burst|distance:10] at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its @Template[type:burst|distance:40]. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,

--- a/packs/age-of-ashes-bestiary/ilgreth.json
+++ b/packs/age-of-ashes-bestiary/ilgreth.json
@@ -451,7 +451,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the 10-foot burst at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its 40-foot burst. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>"
+                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the @Template[type:burst|distance:10] at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its @Template[type:burst|distance:40]. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>\n<p>[[/r ((@item.level*2)-4)d6[fire]]]{Leveled Fire Damage}</p>"
                 },
                 "duration": {
                     "sustained": false,

--- a/packs/age-of-ashes-bestiary/mengkare.json
+++ b/packs/age-of-ashes-bestiary/mengkare.json
@@ -210,7 +210,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the 10-foot burst at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its 40-foot burst. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>"
+                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the @Template[type:burst|distance:10] at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its @Template[type:burst|distance:40]. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>\n<p>[[/r ((@item.level*2)-4)d6[fire]]]{Leveled Fire Damage}</p>"
                 },
                 "duration": {
                     "sustained": false,

--- a/packs/age-of-ashes-bestiary/mengkare.json
+++ b/packs/age-of-ashes-bestiary/mengkare.json
@@ -210,7 +210,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the @Template[type:burst|distance:10] at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its @Template[type:burst|distance:40]. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>\n<p>[[/r ((@item.level*2)-4)d6[fire]]]{Leveled Fire Damage}</p>"
+                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the @Template[type:burst|distance:10] at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its @Template[type:burst|distance:40]. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,

--- a/packs/age-of-ashes-bestiary/mengkare.json
+++ b/packs/age-of-ashes-bestiary/mengkare.json
@@ -163,7 +163,7 @@
             "type": "spell"
         },
         {
-            "_id": "BD4PnqALfvjMHLsB",
+            "_id": "C1HLjJx1GAgmpngx",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.Item.jrBa9deU2ULFWvSl"
@@ -173,7 +173,10 @@
             "name": "Meteor Swarm",
             "sort": 400000,
             "system": {
-                "area": null,
+                "area": {
+                    "type": "burst",
+                    "value": 40
+                },
                 "cost": {
                     "value": ""
                 },
@@ -188,6 +191,16 @@
                         ],
                         "materials": [],
                         "type": "bludgeoning"
+                    },
+                    "6BEyrCCNpDfJh5P8": {
+                        "applyMod": false,
+                        "category": null,
+                        "formula": "14d6",
+                        "kinds": [
+                            "damage"
+                        ],
+                        "materials": [],
+                        "type": "fire"
                     }
                 },
                 "defense": {
@@ -205,7 +218,8 @@
                 },
                 "heightening": {
                     "damage": {
-                        "0": "1d10"
+                        "0": "1d10",
+                        "6BEyrCCNpDfJh5P8": "2d6"
                     },
                     "interval": 1,
                     "type": "interval"
@@ -214,6 +228,7 @@
                     "value": 9
                 },
                 "location": {
+                    "heightenedLevel": 9,
                     "value": "pb3yDpk6Rl0BuY7j"
                 },
                 "publication": {

--- a/packs/fists-of-the-ruby-phoenix-bestiary/mafika-ayuwari.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/mafika-ayuwari.json
@@ -362,7 +362,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the @Template[type:burst|distance:10] at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its @Template[type:burst|distance:40]. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>\n<p>[[/r ((@item.level*2)-4)d6[fire]]]{Leveled Fire Damage}</p>"
+                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the @Template[type:burst|distance:10] at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its @Template[type:burst|distance:40]. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,

--- a/packs/fists-of-the-ruby-phoenix-bestiary/mafika-ayuwari.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/mafika-ayuwari.json
@@ -190,7 +190,7 @@
                                 "id": "C3SCJkplJ7UggrPO"
                             },
                             {
-                                "id": "scrjVGWBMQ3W2XbO"
+                                "id": "mYKimtCtotk2cPg8"
                             },
                             {
                                 "id": "eP7cRYieyQUu4J7g"
@@ -207,7 +207,8 @@
                 },
                 "tradition": {
                     "value": "arcane"
-                }
+                },
+                "traits": {}
             },
             "type": "spellcastingEntry"
         },
@@ -314,7 +315,7 @@
             "type": "spell"
         },
         {
-            "_id": "scrjVGWBMQ3W2XbO",
+            "_id": "mYKimtCtotk2cPg8",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.Item.jrBa9deU2ULFWvSl"
@@ -324,13 +325,17 @@
             "name": "Meteor Swarm",
             "sort": 400000,
             "system": {
-                "area": null,
+                "area": {
+                    "type": "burst",
+                    "value": 40
+                },
                 "cost": {
                     "value": ""
                 },
                 "counteraction": false,
                 "damage": {
                     "0": {
+                        "applyMod": false,
                         "category": null,
                         "formula": "6d10",
                         "kinds": [
@@ -338,6 +343,16 @@
                         ],
                         "materials": [],
                         "type": "bludgeoning"
+                    },
+                    "6BEyrCCNpDfJh5P8": {
+                        "applyMod": false,
+                        "category": null,
+                        "formula": "14d6",
+                        "kinds": [
+                            "damage"
+                        ],
+                        "materials": [],
+                        "type": "fire"
                     }
                 },
                 "defense": {
@@ -347,7 +362,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the 10-foot burst at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its 40-foot burst. The meteors' central 10-foot bursts can't overlap, and a creature takes the same amount of fire damage no matter how many overlapping explosions it's caught in. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>"
+                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the 10-foot burst at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its 40-foot burst. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -355,7 +370,8 @@
                 },
                 "heightening": {
                     "damage": {
-                        "0": "1d10"
+                        "0": "1d10",
+                        "6BEyrCCNpDfJh5P8": "2d6"
                     },
                     "interval": 1,
                     "type": "interval"

--- a/packs/fists-of-the-ruby-phoenix-bestiary/mafika-ayuwari.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/mafika-ayuwari.json
@@ -362,7 +362,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the 10-foot burst at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its 40-foot burst. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>"
+                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the @Template[type:burst|distance:10] at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its @Template[type:burst|distance:40]. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>\n<p>[[/r ((@item.level*2)-4)d6[fire]]]{Leveled Fire Damage}</p>"
                 },
                 "duration": {
                     "sustained": false,

--- a/packs/kingmaker-bestiary/avatar-of-the-lantern-king.json
+++ b/packs/kingmaker-bestiary/avatar-of-the-lantern-king.json
@@ -234,7 +234,7 @@
             "type": "spell"
         },
         {
-            "_id": "qYTpxtNsZDh3qqPf",
+            "_id": "ZwS4YLBwCuSvToVi",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.Item.jrBa9deU2ULFWvSl"
@@ -244,7 +244,10 @@
             "name": "Meteor Swarm",
             "sort": 500000,
             "system": {
-                "area": null,
+                "area": {
+                    "type": "burst",
+                    "value": 40
+                },
                 "cost": {
                     "value": ""
                 },
@@ -259,6 +262,16 @@
                         ],
                         "materials": [],
                         "type": "bludgeoning"
+                    },
+                    "6BEyrCCNpDfJh5P8": {
+                        "applyMod": false,
+                        "category": null,
+                        "formula": "14d6",
+                        "kinds": [
+                            "damage"
+                        ],
+                        "materials": [],
+                        "type": "fire"
                     }
                 },
                 "defense": {
@@ -276,7 +289,8 @@
                 },
                 "heightening": {
                     "damage": {
-                        "0": "1d10"
+                        "0": "1d10",
+                        "6BEyrCCNpDfJh5P8": "2d6"
                     },
                     "interval": 1,
                     "type": "interval"

--- a/packs/kingmaker-bestiary/avatar-of-the-lantern-king.json
+++ b/packs/kingmaker-bestiary/avatar-of-the-lantern-king.json
@@ -281,7 +281,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the 10-foot burst at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its 40-foot burst. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>"
+                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the @Template[type:burst|distance:10] at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its @Template[type:burst|distance:40]. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,

--- a/packs/pathfinder-bestiary-2/bastion-archon.json
+++ b/packs/pathfinder-bestiary-2/bastion-archon.json
@@ -104,91 +104,6 @@
             "type": "spell"
         },
         {
-            "_id": "purLutaIQJ6evyLg",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.Item.jrBa9deU2ULFWvSl"
-                }
-            },
-            "img": "icons/magic/light/projectile-beams-salvo-yellow.webp",
-            "name": "Meteor Swarm",
-            "sort": 300000,
-            "system": {
-                "area": null,
-                "cost": {
-                    "value": ""
-                },
-                "counteraction": false,
-                "damage": {
-                    "0": {
-                        "category": null,
-                        "formula": "7d10",
-                        "kinds": [
-                            "damage"
-                        ],
-                        "materials": [],
-                        "type": "bludgeoning"
-                    }
-                },
-                "defense": {
-                    "save": {
-                        "basic": true,
-                        "statistic": "reflex"
-                    }
-                },
-                "description": {
-                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the 10-foot burst at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its 40-foot burst. The meteors' central 10-foot bursts can't overlap, and a creature takes the same amount of fire damage no matter how many overlapping explosions it's caught in. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>"
-                },
-                "duration": {
-                    "sustained": false,
-                    "value": ""
-                },
-                "heightening": {
-                    "damage": {
-                        "0": "1d10"
-                    },
-                    "interval": 1,
-                    "type": "interval"
-                },
-                "level": {
-                    "value": 10
-                },
-                "location": {
-                    "value": "CFncnCOk0MBxjpim"
-                },
-                "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
-                },
-                "range": {
-                    "value": "500 feet"
-                },
-                "requirements": "",
-                "rules": [],
-                "slug": "meteor-swarm",
-                "target": {
-                    "value": ""
-                },
-                "time": {
-                    "value": "2"
-                },
-                "traits": {
-                    "rarity": "common",
-                    "traditions": [
-                        "arcane",
-                        "primal"
-                    ],
-                    "value": [
-                        "concentrate",
-                        "fire",
-                        "manipulate"
-                    ]
-                }
-            },
-            "type": "spell"
-        },
-        {
             "_id": "9lvTqGmBN1mGdrHe",
             "flags": {
                 "core": {
@@ -197,7 +112,7 @@
             },
             "img": "systems/pf2e/icons/spells/polar-ray.webp",
             "name": "Polar Ray",
-            "sort": 400000,
+            "sort": 300000,
             "system": {
                 "area": null,
                 "cost": {
@@ -278,7 +193,7 @@
             },
             "img": "systems/pf2e/icons/spells/sunburst.webp",
             "name": "Sunburst",
-            "sort": 500000,
+            "sort": 400000,
             "system": {
                 "area": {
                     "type": "burst",
@@ -368,7 +283,7 @@
             },
             "img": "systems/pf2e/icons/spells/tongues.webp",
             "name": "Tongues (Constant)",
-            "sort": 600000,
+            "sort": 500000,
             "system": {
                 "area": null,
                 "cost": {
@@ -431,7 +346,7 @@
             },
             "img": "systems/pf2e/icons/spells/true-seeing.webp",
             "name": "True Seeing (Constant)",
-            "sort": 700000,
+            "sort": 600000,
             "system": {
                 "area": null,
                 "cost": {
@@ -482,6 +397,107 @@
                         "concentrate",
                         "manipulate",
                         "revelation"
+                    ]
+                }
+            },
+            "type": "spell"
+        },
+        {
+            "_id": "5K6NWmbELFhghl55",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.Item.jrBa9deU2ULFWvSl"
+                }
+            },
+            "img": "icons/magic/light/projectile-beams-salvo-yellow.webp",
+            "name": "Meteor Swarm",
+            "sort": 700000,
+            "system": {
+                "area": {
+                    "type": "burst",
+                    "value": 40
+                },
+                "cost": {
+                    "value": ""
+                },
+                "counteraction": false,
+                "damage": {
+                    "0": {
+                        "applyMod": false,
+                        "category": null,
+                        "formula": "6d10",
+                        "kinds": [
+                            "damage"
+                        ],
+                        "materials": [],
+                        "type": "bludgeoning"
+                    },
+                    "6BEyrCCNpDfJh5P8": {
+                        "applyMod": false,
+                        "category": null,
+                        "formula": "14d6",
+                        "kinds": [
+                            "damage"
+                        ],
+                        "materials": [],
+                        "type": "fire"
+                    }
+                },
+                "defense": {
+                    "save": {
+                        "basic": true,
+                        "statistic": "reflex"
+                    }
+                },
+                "description": {
+                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the 10-foot burst at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its 40-foot burst. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>"
+                },
+                "duration": {
+                    "sustained": false,
+                    "value": ""
+                },
+                "heightening": {
+                    "damage": {
+                        "0": "1d10",
+                        "6BEyrCCNpDfJh5P8": "2d6"
+                    },
+                    "interval": 1,
+                    "type": "interval"
+                },
+                "level": {
+                    "value": 9
+                },
+                "location": {
+                    "heightenedLevel": 10,
+                    "value": "CFncnCOk0MBxjpim"
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Core Rulebook"
+                },
+                "range": {
+                    "value": "500 feet"
+                },
+                "requirements": "",
+                "rules": [],
+                "slug": "meteor-swarm",
+                "target": {
+                    "value": ""
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traits": {
+                    "rarity": "common",
+                    "traditions": [
+                        "arcane",
+                        "primal"
+                    ],
+                    "value": [
+                        "concentrate",
+                        "fire",
+                        "manipulate"
                     ]
                 }
             },

--- a/packs/pathfinder-bestiary-2/bastion-archon.json
+++ b/packs/pathfinder-bestiary-2/bastion-archon.json
@@ -450,7 +450,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the 10-foot burst at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its 40-foot burst. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>"
+                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the @Template[type:burst|distance:10] at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its @Template[type:burst|distance:40]. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,

--- a/packs/pathfinder-bestiary-2/lerritan.json
+++ b/packs/pathfinder-bestiary-2/lerritan.json
@@ -335,7 +335,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the 10-foot burst at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its 40-foot burst. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>"
+                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the @Template[type:burst|distance:10] at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its @Template[type:burst|distance:40]. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,

--- a/packs/pathfinder-bestiary-2/lerritan.json
+++ b/packs/pathfinder-bestiary-2/lerritan.json
@@ -288,7 +288,7 @@
             "type": "spell"
         },
         {
-            "_id": "EEnO5a9s4vceIrOS",
+            "_id": "cY5rvLtVuvHqtW3K",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.Item.jrBa9deU2ULFWvSl"
@@ -298,13 +298,17 @@
             "name": "Meteor Swarm",
             "sort": 400000,
             "system": {
-                "area": null,
+                "area": {
+                    "type": "burst",
+                    "value": 40
+                },
                 "cost": {
                     "value": ""
                 },
                 "counteraction": false,
                 "damage": {
                     "0": {
+                        "applyMod": false,
                         "category": null,
                         "formula": "6d10",
                         "kinds": [
@@ -312,6 +316,16 @@
                         ],
                         "materials": [],
                         "type": "bludgeoning"
+                    },
+                    "6BEyrCCNpDfJh5P8": {
+                        "applyMod": false,
+                        "category": null,
+                        "formula": "14d6",
+                        "kinds": [
+                            "damage"
+                        ],
+                        "materials": [],
+                        "type": "fire"
                     }
                 },
                 "defense": {
@@ -321,7 +335,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the 10-foot burst at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its 40-foot burst. The meteors' central 10-foot bursts can't overlap, and a creature takes the same amount of fire damage no matter how many overlapping explosions it's caught in. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>"
+                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the 10-foot burst at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its 40-foot burst. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -329,7 +343,8 @@
                 },
                 "heightening": {
                     "damage": {
-                        "0": "1d10"
+                        "0": "1d10",
+                        "6BEyrCCNpDfJh5P8": "2d6"
                     },
                     "interval": 1,
                     "type": "interval"
@@ -338,12 +353,13 @@
                     "value": 9
                 },
                 "location": {
+                    "heightenedLevel": 9,
                     "value": "ej30s3gZXMNhiGRr"
                 },
                 "publication": {
                     "license": "OGL",
                     "remaster": false,
-                    "title": ""
+                    "title": "Pathfinder Core Rulebook"
                 },
                 "range": {
                     "value": "500 feet"

--- a/packs/pathfinder-bestiary-3/elysian-titan.json
+++ b/packs/pathfinder-bestiary-3/elysian-titan.json
@@ -117,7 +117,7 @@
             "type": "spell"
         },
         {
-            "_id": "BNgVJNFEOa0FQgEt",
+            "_id": "nLwQyWdnX8Cvib4n",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.Item.jrBa9deU2ULFWvSl"
@@ -127,7 +127,10 @@
             "name": "Meteor Swarm",
             "sort": 300000,
             "system": {
-                "area": null,
+                "area": {
+                    "type": "burst",
+                    "value": 40
+                },
                 "cost": {
                     "value": ""
                 },
@@ -142,6 +145,16 @@
                         ],
                         "materials": [],
                         "type": "bludgeoning"
+                    },
+                    "6BEyrCCNpDfJh5P8": {
+                        "applyMod": false,
+                        "category": null,
+                        "formula": "14d6",
+                        "kinds": [
+                            "damage"
+                        ],
+                        "materials": [],
+                        "type": "fire"
                     }
                 },
                 "defense": {
@@ -159,7 +172,8 @@
                 },
                 "heightening": {
                     "damage": {
-                        "0": "1d10"
+                        "0": "1d10",
+                        "6BEyrCCNpDfJh5P8": "2d6"
                     },
                     "interval": 1,
                     "type": "interval"

--- a/packs/pathfinder-bestiary-3/elysian-titan.json
+++ b/packs/pathfinder-bestiary-3/elysian-titan.json
@@ -164,7 +164,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the 10-foot burst at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its 40-foot burst. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>"
+                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the @Template[type:burst|distance:10] at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its @Template[type:burst|distance:40]. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,

--- a/packs/pathfinder-bestiary-3/hesperid-queen.json
+++ b/packs/pathfinder-bestiary-3/hesperid-queen.json
@@ -346,7 +346,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the 10-foot burst at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its 40-foot burst. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>"
+                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the @Template[type:burst|distance:10] at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its @Template[type:burst|distance:40]. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,

--- a/packs/pathfinder-bestiary-3/hesperid-queen.json
+++ b/packs/pathfinder-bestiary-3/hesperid-queen.json
@@ -175,7 +175,7 @@
                         "max": 3,
                         "prepared": [
                             {
-                                "id": "4dePH37pWFY6xTOq"
+                                "id": "1P63iPzWwcxYClYs"
                             },
                             {
                                 "id": "Oz4zbBJI5oJA6Jst"
@@ -193,7 +193,8 @@
                 },
                 "tradition": {
                     "value": "primal"
-                }
+                },
+                "traits": {}
             },
             "type": "spellcastingEntry"
         },
@@ -298,7 +299,7 @@
             "type": "spell"
         },
         {
-            "_id": "4dePH37pWFY6xTOq",
+            "_id": "1P63iPzWwcxYClYs",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.Item.jrBa9deU2ULFWvSl"
@@ -308,7 +309,10 @@
             "name": "Meteor Swarm",
             "sort": 400000,
             "system": {
-                "area": null,
+                "area": {
+                    "type": "burst",
+                    "value": 40
+                },
                 "cost": {
                     "value": ""
                 },
@@ -323,6 +327,16 @@
                         ],
                         "materials": [],
                         "type": "bludgeoning"
+                    },
+                    "6BEyrCCNpDfJh5P8": {
+                        "applyMod": false,
+                        "category": null,
+                        "formula": "14d6",
+                        "kinds": [
+                            "damage"
+                        ],
+                        "materials": [],
+                        "type": "fire"
                     }
                 },
                 "defense": {
@@ -340,7 +354,8 @@
                 },
                 "heightening": {
                     "damage": {
-                        "0": "1d10"
+                        "0": "1d10",
+                        "6BEyrCCNpDfJh5P8": "2d6"
                     },
                     "interval": 1,
                     "type": "interval"

--- a/packs/pathfinder-bestiary-3/thanatotic-titan.json
+++ b/packs/pathfinder-bestiary-3/thanatotic-titan.json
@@ -143,7 +143,7 @@
             "type": "spell"
         },
         {
-            "_id": "YfZYdRK6YRVNXa21",
+            "_id": "9zZhaLoCGgr36JLY",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.Item.jrBa9deU2ULFWvSl"
@@ -153,7 +153,10 @@
             "name": "Meteor Swarm",
             "sort": 300000,
             "system": {
-                "area": null,
+                "area": {
+                    "type": "burst",
+                    "value": 40
+                },
                 "cost": {
                     "value": ""
                 },
@@ -168,6 +171,16 @@
                         ],
                         "materials": [],
                         "type": "bludgeoning"
+                    },
+                    "6BEyrCCNpDfJh5P8": {
+                        "applyMod": false,
+                        "category": null,
+                        "formula": "14d6",
+                        "kinds": [
+                            "damage"
+                        ],
+                        "materials": [],
+                        "type": "fire"
                     }
                 },
                 "defense": {
@@ -185,7 +198,8 @@
                 },
                 "heightening": {
                     "damage": {
-                        "0": "1d10"
+                        "0": "1d10",
+                        "6BEyrCCNpDfJh5P8": "2d6"
                     },
                     "interval": 1,
                     "type": "interval"

--- a/packs/pathfinder-bestiary-3/thanatotic-titan.json
+++ b/packs/pathfinder-bestiary-3/thanatotic-titan.json
@@ -190,7 +190,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the 10-foot burst at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its 40-foot burst. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>"
+                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the @Template[type:burst|distance:10] at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its @Template[type:burst|distance:40]. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,

--- a/packs/pathfinder-bestiary/pit-fiend.json
+++ b/packs/pathfinder-bestiary/pit-fiend.json
@@ -217,7 +217,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the 10-foot burst at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its 40-foot burst. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>"
+                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the @Template[type:burst|distance:10] at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its @Template[type:burst|distance:40]. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,

--- a/packs/pathfinder-bestiary/pit-fiend.json
+++ b/packs/pathfinder-bestiary/pit-fiend.json
@@ -170,7 +170,7 @@
             "type": "spell"
         },
         {
-            "_id": "qk6ljACdvlg2llPS",
+            "_id": "w7LDUHe0eMsLHnqq",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.Item.jrBa9deU2ULFWvSl"
@@ -180,7 +180,10 @@
             "name": "Meteor Swarm",
             "sort": 400000,
             "system": {
-                "area": null,
+                "area": {
+                    "type": "burst",
+                    "value": 40
+                },
                 "cost": {
                     "value": ""
                 },
@@ -195,6 +198,16 @@
                         ],
                         "materials": [],
                         "type": "bludgeoning"
+                    },
+                    "6BEyrCCNpDfJh5P8": {
+                        "applyMod": false,
+                        "category": null,
+                        "formula": "14d6",
+                        "kinds": [
+                            "damage"
+                        ],
+                        "materials": [],
+                        "type": "fire"
                     }
                 },
                 "defense": {
@@ -212,7 +225,8 @@
                 },
                 "heightening": {
                     "damage": {
-                        "0": "1d10"
+                        "0": "1d10",
+                        "6BEyrCCNpDfJh5P8": "2d6"
                     },
                     "interval": 1,
                     "type": "interval"

--- a/packs/stolen-fate-bestiary/obcisidaemon.json
+++ b/packs/stolen-fate-bestiary/obcisidaemon.json
@@ -190,7 +190,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the 10-foot burst at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its 40-foot burst. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>"
+                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the @Template[type:burst|distance:10] at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its @Template[type:burst|distance:40]. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,

--- a/packs/stolen-fate-bestiary/obcisidaemon.json
+++ b/packs/stolen-fate-bestiary/obcisidaemon.json
@@ -143,7 +143,7 @@
             "type": "spell"
         },
         {
-            "_id": "v9cyFFrpNP6KybHI",
+            "_id": "q4X1hrKNYdQGPnqr",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.Item.jrBa9deU2ULFWvSl"
@@ -153,7 +153,10 @@
             "name": "Meteor Swarm",
             "sort": 300000,
             "system": {
-                "area": null,
+                "area": {
+                    "type": "burst",
+                    "value": 40
+                },
                 "cost": {
                     "value": ""
                 },
@@ -168,6 +171,16 @@
                         ],
                         "materials": [],
                         "type": "bludgeoning"
+                    },
+                    "6BEyrCCNpDfJh5P8": {
+                        "applyMod": false,
+                        "category": null,
+                        "formula": "14d6",
+                        "kinds": [
+                            "damage"
+                        ],
+                        "materials": [],
+                        "type": "fire"
                     }
                 },
                 "defense": {
@@ -177,7 +190,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the @Template[type:burst|distance:10] at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its @Template[type:burst|distance:40]. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>\n<p>[[/r ((@item.level*2)-4)d6[fire]]]{Leveled Fire Damage}</p>"
+                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the 10-foot burst at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its 40-foot burst. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -185,7 +198,8 @@
                 },
                 "heightening": {
                     "damage": {
-                        "0": "1d10"
+                        "0": "1d10",
+                        "6BEyrCCNpDfJh5P8": "2d6"
                     },
                     "interval": 1,
                     "type": "interval"

--- a/packs/strength-of-thousands-bestiary/unshadowed-haibram.json
+++ b/packs/strength-of-thousands-bestiary/unshadowed-haibram.json
@@ -379,7 +379,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the 10-foot burst at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its 40-foot burst. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>"
+                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the @Template[type:burst|distance:10] at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its @Template[type:burst|distance:40]. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,

--- a/packs/strength-of-thousands-bestiary/unshadowed-haibram.json
+++ b/packs/strength-of-thousands-bestiary/unshadowed-haibram.json
@@ -181,7 +181,7 @@
                                 "id": "54T76Dn1e3MkUSI5"
                             },
                             {
-                                "id": "ue8hOb0y2WzvY7vd"
+                                "id": "301nxoYJEIKchyQv"
                             }
                         ],
                         "value": 3
@@ -196,7 +196,8 @@
                 },
                 "tradition": {
                     "value": "divine"
-                }
+                },
+                "traits": {}
             },
             "type": "spellcastingEntry"
         },
@@ -331,7 +332,7 @@
             "type": "spell"
         },
         {
-            "_id": "ue8hOb0y2WzvY7vd",
+            "_id": "301nxoYJEIKchyQv",
             "flags": {
                 "core": {
                     "sourceId": "Compendium.pf2e.spells-srd.Item.jrBa9deU2ULFWvSl"
@@ -341,13 +342,17 @@
             "name": "Meteor Swarm",
             "sort": 400000,
             "system": {
-                "area": null,
+                "area": {
+                    "type": "burst",
+                    "value": 40
+                },
                 "cost": {
                     "value": ""
                 },
                 "counteraction": false,
                 "damage": {
                     "0": {
+                        "applyMod": false,
                         "category": null,
                         "formula": "6d10",
                         "kinds": [
@@ -355,6 +360,16 @@
                         ],
                         "materials": [],
                         "type": "bludgeoning"
+                    },
+                    "6BEyrCCNpDfJh5P8": {
+                        "applyMod": false,
+                        "category": null,
+                        "formula": "14d6",
+                        "kinds": [
+                            "damage"
+                        ],
+                        "materials": [],
+                        "type": "fire"
                     }
                 },
                 "defense": {
@@ -364,7 +379,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the 10-foot burst at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its 40-foot burst. The meteors' central 10-foot bursts can't overlap, and a creature takes the same amount of fire damage no matter how many overlapping explosions it's caught in. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>"
+                    "value": "<p>You call down four meteors that explode in a fiery blast. Each meteor deals 6d10 bludgeoning damage to any creatures in the 10-foot burst at the center of its area of effect before exploding, dealing 14d6 fire damage to any creatures in its 40-foot burst. The meteors' central 10-foot bursts can't overlap, and a creature attempts only one saving throw against the spell no matter how many overlapping explosions it's caught in, and they can take each type of damage once once. The saving throw applies to both the bludgeoning and the fire damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning damage increases by 1d10, and the fire damage increases by 2d6.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -372,7 +387,8 @@
                 },
                 "heightening": {
                     "damage": {
-                        "0": "1d10"
+                        "0": "1d10",
+                        "6BEyrCCNpDfJh5P8": "2d6"
                     },
                     "interval": 1,
                     "type": "interval"


### PR DESCRIPTION
Edited all instances of Meteor Swarm in the bestiary to include the fire damage and a 40-foot burst.
Closes #14721
