### PR TITLE
Fix character biography h3 styling bleeding into content

### DIFF
--- a/src/styles/actor/character/_biography.scss
+++ b/src/styles/actor/character/_biography.scss
@@ -126,7 +126,7 @@
         }
 
         .bio {
-            h3 {
+            > h3 {
                 @include p-reset;
                 background-color: rgba($text-dark-color, 0.1);
                 border: none;


### PR DESCRIPTION
Teeny below notice thing yoinked from the v12 work. The rest of the bio fixes assume prosemirror though, so we can leave that for v12.