### PR TITLE
Automate Persistent Boost

### DIFF
--- a/packs/classfeatures/offensive-boost.json
+++ b/packs/classfeatures/offensive-boost.json
@@ -65,6 +65,7 @@
                 "damageType": "{actor|flags.pf2e.inventor.offensiveBoost}",
                 "diceNumber": 1,
                 "dieSize": "d6",
+                "hideIfDisabled": true,
                 "key": "DamageDice",
                 "label": "PF2E.SpecificRule.Inventor.OffensiveBoost.Label",
                 "predicate": [

--- a/packs/feat-effects/effect-offensive-boost.json
+++ b/packs/feat-effects/effect-offensive-boost.json
@@ -7,7 +7,7 @@
             "value": "<p>Granted by @UUID[Compendium.pf2e.classfeatures.Item.Offensive Boost]</p>\n<p>Your improvements make any Strikes that rely on your innovation deal an additional 1d6 damage, with a type determined by the boost you choose. If your innovation is armor, the boost applies to your melee Strikes with one weapon you choose during daily preparations; if your innovation is a construct, the boost applies to your construct companion's Strikes.</p>"
         },
         "duration": {
-            "expiry": "turn-start",
+            "expiry": null,
             "sustained": false,
             "unit": "unlimited",
             "value": -1
@@ -34,22 +34,6 @@
                     "feature:armor-innovation"
                 ],
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
-            },
-            {
-                "key": "RollOption",
-                "label": "PF2E.SpecificRule.Inventor.PersistentBoost.ConstructLabel",
-                "option": "persistent-boost",
-                "predicate": [
-                    "self:trait:minion",
-                    {
-                        "gte": [
-                            "self:level",
-                            16
-                        ]
-                    }
-                ],
-                "priority": 51,
-                "toggleable": true
             },
             {
                 "damageType": "{item|origin.flags.pf2e.inventor.offensiveBoost}",
@@ -82,8 +66,8 @@
                 "key": "DamageDice",
                 "label": "PF2E.SpecificRule.Inventor.PersistentBoost.Label",
                 "predicate": [
-                    "self:trait:minion",
-                    "persistent-boost"
+                    "parent:persistent-boost",
+                    "self:trait:minion"
                 ],
                 "selector": "strike-damage"
             },

--- a/packs/feat-effects/effect-offensive-boost.json
+++ b/packs/feat-effects/effect-offensive-boost.json
@@ -40,7 +40,13 @@
                 "label": "PF2E.SpecificRule.Inventor.PersistentBoost.ConstructLabel",
                 "option": "persistent-boost",
                 "predicate": [
-                    "self:trait:minion"
+                    "self:trait:minion",
+                    {
+                        "gte": [
+                            "self:level",
+                            16
+                        ]
+                    }
                 ],
                 "priority": 51,
                 "toggleable": true
@@ -74,6 +80,7 @@
                 "dieSize": "d8",
                 "hideIfDisabled": true,
                 "key": "DamageDice",
+                "label": "PF2E.SpecificRule.Inventor.PersistentBoost.Label",
                 "predicate": [
                     "self:trait:minion",
                     "persistent-boost"

--- a/packs/feat-effects/effect-offensive-boost.json
+++ b/packs/feat-effects/effect-offensive-boost.json
@@ -66,7 +66,7 @@
                 "key": "DamageDice",
                 "label": "PF2E.SpecificRule.Inventor.PersistentBoost.Label",
                 "predicate": [
-                    "parent:persistent-boost",
+                    "parent:origin:item:tag:persistent-boost",
                     "self:trait:minion"
                 ],
                 "selector": "strike-damage"

--- a/packs/feat-effects/effect-offensive-boost.json
+++ b/packs/feat-effects/effect-offensive-boost.json
@@ -36,9 +36,20 @@
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
             {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Inventor.PersistentBoost.ConstructLabel",
+                "option": "persistent-boost",
+                "predicate": [
+                    "self:trait:minion"
+                ],
+                "priority": 51,
+                "toggleable": true
+            },
+            {
                 "damageType": "{item|origin.flags.pf2e.inventor.offensiveBoost}",
                 "diceNumber": 1,
                 "dieSize": "d6",
+                "hideIfDisabled": true,
                 "key": "DamageDice",
                 "predicate": [
                     "self:trait:minion"
@@ -49,9 +60,37 @@
                 "damageType": "{item|origin.flags.pf2e.inventor.offensiveBoost}",
                 "diceNumber": 1,
                 "dieSize": "d6",
+                "hideIfDisabled": true,
                 "key": "DamageDice",
                 "predicate": [
                     "feature:armor-innovation"
+                ],
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-damage"
+            },
+            {
+                "category": "persistent",
+                "damageType": "{item|origin.flags.pf2e.inventor.offensiveBoost}",
+                "diceNumber": 1,
+                "dieSize": "d8",
+                "hideIfDisabled": true,
+                "key": "DamageDice",
+                "predicate": [
+                    "self:trait:minion",
+                    "persistent-boost"
+                ],
+                "selector": "strike-damage"
+            },
+            {
+                "category": "persistent",
+                "damageType": "{item|origin.flags.pf2e.inventor.offensiveBoost}",
+                "diceNumber": 1,
+                "dieSize": "d8",
+                "hideIfDisabled": true,
+                "key": "DamageDice",
+                "label": "PF2E.SpecificRule.Inventor.PersistentBoost.Label",
+                "predicate": [
+                    "feature:armor-innovation",
+                    "feat:persistent-boost"
                 ],
                 "selector": "{item|flags.pf2e.rulesSelections.weapon}-damage"
             }

--- a/packs/feats/persistent-boost.json
+++ b/packs/feats/persistent-boost.json
@@ -30,8 +30,14 @@
         },
         "rules": [
             {
-                "key": "RollOption",
-                "option": "self:persistent-boost"
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:offensive-boost"
+                ],
+                "property": "other-tags",
+                "value": "persistent-boost"
             },
             {
                 "category": "persistent",

--- a/packs/feats/persistent-boost.json
+++ b/packs/feats/persistent-boost.json
@@ -30,6 +30,10 @@
         },
         "rules": [
             {
+                "key": "RollOption",
+                "option": "self:persistent-boost"
+            },
+            {
                 "category": "persistent",
                 "damageType": "{actor|flags.pf2e.inventor.offensiveBoost}",
                 "diceNumber": 1,

--- a/packs/feats/persistent-boost.json
+++ b/packs/feats/persistent-boost.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>Your innovation sets foes on fire, covers them in acid, leaves barbed thorns behind, or otherwise deals persistent damage to your foes that sticks around long after you deliver your boosted attack. When you or your construct innovation damage a foe with offensive boost, that foe also takes @Damage[1d8[persistent,@actor.flags.pf2e.inventor.offensiveBoost]]{persistent damage} of the same damage type as the offensive boost damage.</p>"
+            "value": "<p>Your innovation sets foes on fire, covers them in acid, leaves barbed thorns behind, or otherwise deals persistent damage to your foes that sticks around long after you deliver your boosted attack. When you or your construct innovation damage a foe with offensive boost, that foe also takes 1d8 persistent damage of the same damage type as the offensive boost damage.</p>"
         },
         "level": {
             "value": 16
@@ -28,7 +28,35 @@
             "remaster": false,
             "title": "Pathfinder Guns & Gears"
         },
-        "rules": [],
+        "rules": [
+            {
+                "category": "persistent",
+                "damageType": "{actor|flags.pf2e.inventor.offensiveBoost}",
+                "diceNumber": 1,
+                "dieSize": "d8",
+                "hideIfDisabled": true,
+                "key": "DamageDice",
+                "predicate": [
+                    {
+                        "or": [
+                            {
+                                "and": [
+                                    "feature:weapon-innovation",
+                                    "item:id:{actor|flags.pf2e.innovationId}"
+                                ]
+                            },
+                            {
+                                "and": [
+                                    "feature:armor-innovation",
+                                    "unarmed"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "selector": "strike-damage"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -3143,8 +3143,7 @@
                     "Success": "Your gizmos go into @UUID[Compendium.pf2e.feat-effects.Item.1XlJ9xLzL19GHoOL]{Overdrive}, adding power to your attacks."
                 },
                 "PersistentBoost": {
-                    "Label": "Persistent Boost",
-                    "ConstructLabel": "Inventor has Persistent Boost"
+                    "Label": "Persistent Boost"
                 },
                 "Unstable": {
                     "FlatCheck": {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -3142,6 +3142,10 @@
                     "FireDamage": "Overdrive: Fire Damage",
                     "Success": "Your gizmos go into @UUID[Compendium.pf2e.feat-effects.Item.1XlJ9xLzL19GHoOL]{Overdrive}, adding power to your attacks."
                 },
+                "PersistentBoost": {
+                    "Label": "Persistent Boost",
+                    "ConstructLabel": "Inventor has Persistent Boost"
+                },
                 "Unstable": {
                     "FlatCheck": {
                         "CriticalFailure": "The innovation becomes incapable of being used for further unstable actions, and you also take @Damage[@actor.level[@actor.flags.pf2e.inventor.explode]|immutable|name:PF2E.SpecificRule.Inventor.Innovation.MalfunctionDamage] damage.",


### PR DESCRIPTION
Closes #14704
Since construct and inventor use an effect for their particular cases, I used that for their persistent boost automation.