### PR TITLE
Automate Phase Bolt's circumstance bonus reduction

### DIFF
--- a/packs/spell-effects/spell-effect-phase-bolt.json
+++ b/packs/spell-effects/spell-effect-phase-bolt.json
@@ -1,0 +1,55 @@
+{
+    "_id": "ZVPlFsk5Zimd8Mc9",
+    "img": "systems/pf2e/icons/spells/phase-bolt.webp",
+    "name": "Spell Effect: Phase Bolt",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Phase Bolt]</p>\n<p>If the target has any circumstance bonuses to AC, reduce that bonus by 2 for this attack.</p>"
+        },
+        "duration": {
+            "expiry": null,
+            "sustained": false,
+            "unit": "unlimited",
+            "value": -1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Dark Archive"
+        },
+        "rules": [
+            {
+                "key": "AdjustModifier",
+                "mode": "subtract",
+                "predicate": [
+                    "bonus:type:circumstance"
+                ],
+                "selector": "ac",
+                "value": 2
+            },
+            {
+                "key": "AdjustModifier",
+                "mode": "upgrade",
+                "predicate": [
+                    "bonus:type:circumstance"
+                ],
+                "selector": "ac",
+                "value": 0
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/spells/phase-bolt.json
+++ b/packs/spells/phase-bolt.json
@@ -47,7 +47,18 @@
             "value": "30 feet"
         },
         "requirements": "",
-        "rules": [],
+        "rules": [
+            {
+                "key": "EphemeralEffect",
+                "predicate": [
+                    "item:slug:phase-bolt"
+                ],
+                "selectors": [
+                    "spell-attack-roll"
+                ],
+                "uuid": "Compendium.pf2e.spell-effects.Item.Spell Effect: Phase Bolt"
+            }
+        ],
         "target": {
             "value": "1 creature"
         },


### PR DESCRIPTION
Closes #14734

I'm not sure if adding rule elements to spells is allowed, but after searching the repo I saw some cases where it's been used, so I feel confident enough to at least try. If not, this could simply be made a draggable spell effect as usual.