### PR TITLE
Block the existance of item and actor module sub-types

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -1823,7 +1823,10 @@ const ActorProxyPF2e = new Proxy(ActorPF2e, {
         args: [source: PreCreate<ActorSourcePF2e>, context?: DocumentConstructionContext<ActorPF2e["parent"]>],
     ) {
         const type = args[0]?.type;
-        const ActorClass = CONFIG.PF2E.Actor.documentClasses[type] ?? ActorPF2e;
+        const ActorClass = CONFIG.PF2E.Actor.documentClasses[type];
+        if (!ActorClass) {
+            throw ErrorPF2e(`Actor type ${type} does not exist and actor module sub-types are not supported`);
+        }
         return new ActorClass(...args);
     },
 });

--- a/src/module/item/base/document.ts
+++ b/src/module/item/base/document.ts
@@ -892,7 +892,10 @@ const ItemProxyPF2e = new Proxy(ItemPF2e, {
             source?.type === "armor" && (source.system?.category as string | undefined) === "shield"
                 ? "shield"
                 : source?.type;
-        const ItemClass: typeof ItemPF2e = CONFIG.PF2E.Item.documentClasses[type] ?? ItemPF2e;
+        const ItemClass: typeof ItemPF2e = CONFIG.PF2E.Item.documentClasses[type];
+        if (!ItemClass) {
+            throw ErrorPF2e(`Item type ${type} does not exist and item module sub-types are not supported`);
+        }
         return new ItemClass(...args);
     },
 });

--- a/src/scripts/config/index.ts
+++ b/src/scripts/config/index.ts
@@ -1,14 +1,4 @@
-import {
-    ActorPF2e,
-    ArmyPF2e,
-    CharacterPF2e,
-    FamiliarPF2e,
-    HazardPF2e,
-    LootPF2e,
-    NPCPF2e,
-    PartyPF2e,
-    VehiclePF2e,
-} from "@actor";
+import { ArmyPF2e, CharacterPF2e, FamiliarPF2e, HazardPF2e, LootPF2e, NPCPF2e, PartyPF2e, VehiclePF2e } from "@actor";
 import { SenseAcuity } from "@actor/creature/types.ts";
 import { LANGUAGES, SENSE_TYPES } from "@actor/creature/values.ts";
 import { ActorType, AttributeString } from "@actor/types.ts";
@@ -30,7 +20,6 @@ import {
     EquipmentPF2e,
     FeatPF2e,
     HeritagePF2e,
-    ItemPF2e,
     KitPF2e,
     LorePF2e,
     MeleePF2e,
@@ -954,7 +943,6 @@ export const PF2ECONFIG = {
     },
 
     Actor: {
-        base: ActorPF2e,
         documentClasses: {
             army: ArmyPF2e,
             character: CharacterPF2e,
@@ -968,7 +956,6 @@ export const PF2ECONFIG = {
     },
 
     Item: {
-        base: ItemPF2e,
         documentClasses: {
             action: AbilityItemPF2e,
             affliction: AfflictionPF2e,


### PR DESCRIPTION
After evaluation and testing this is not actually something we can support, especially not at this time.

To summarize, ActorPF2e and ItemPF2e have too much behavior baked into them, and we rely on a document hierarchy instead of a system data model hierarchy. We could enable some use cases if we skip all lifetime methods (like prepareBaseData) for sub-types. Early returning if its a module subtype could work but is not the ideal solution. We could make ANOTHER actor base class, this time even more barebones, but this will require extensive system changes for what is effectively a maybe.

I would prefer to re-evaluate once we have system data models and can move some of our lifecycle methods to those system data models.