### PR TITLE
Fix invalid secondary casters in Awaken Portal ritual

### DIFF
--- a/packs/spells/awaken-portal.json
+++ b/packs/spells/awaken-portal.json
@@ -35,7 +35,7 @@
                 "check": "Arcana or Occultism (trained)"
             },
             "secondary": {
-                "casters": "up to 5",
+                "casters": 0,
                 "checks": "Whichever is used for the primary check"
             }
         },


### PR DESCRIPTION
Since https://github.com/foundryvtt/pf2e/pull/14050 might not make it before V12, I at least want to fix the error I made back in https://github.com/foundryvtt/pf2e/pull/14043 so that V11 users are not stuck with an invalid Awaken Portal spell state.