### PR TITLE
Hide ordered list number in attack-popout

### DIFF
--- a/src/styles/actor/character/_attack-popout.scss
+++ b/src/styles/actor/character/_attack-popout.scss
@@ -12,6 +12,7 @@
 
     ol.actions-list {
         list-style: none;
+
         li.strike {
             border: unset;
             .ammo {

--- a/src/styles/actor/character/_attack-popout.scss
+++ b/src/styles/actor/character/_attack-popout.scss
@@ -11,6 +11,7 @@
     }
 
     ol.actions-list {
+        list-style: none;
         li.strike {
             border: unset;
             .ammo {


### PR DESCRIPTION
The attack list shouldn't show the "1.", "2.", etc. in the `<OL>` of strikes.  The character sheet has list-style set to none for ol in general, but the attack-popout doesn't match the same css selector.

While the margin settings mostly cut it off, you can see a bit of the digit poking out on the edge of the window.