### PR TITLE
Add distances to Telepathy and Sense items

### DIFF
--- a/packs/age-of-ashes-bestiary/xotanispawn.json
+++ b/packs/age-of-ashes-bestiary/xotanispawn.json
@@ -110,7 +110,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 60 feet",
             "sort": 300000,
             "system": {
                 "actionType": {

--- a/packs/blood-lords-bestiary/kemnebi.json
+++ b/packs/blood-lords-bestiary/kemnebi.json
@@ -6693,7 +6693,7 @@
                     "type": "darkvision"
                 },
                 {
-                    "acuity": "imprecise",
+                    "acuity": "precise",
                     "range": 100,
                     "type": "thoughtsense"
                 }

--- a/packs/blood-lords-bestiary/nydazuul.json
+++ b/packs/blood-lords-bestiary/nydazuul.json
@@ -331,7 +331,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 700000,
             "system": {
                 "actionType": {

--- a/packs/blood-lords-bestiary/soul-slime.json
+++ b/packs/blood-lords-bestiary/soul-slime.json
@@ -102,7 +102,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Lifesense",
+            "name": "Lifesense 60 feet",
             "sort": 300000,
             "system": {
                 "actionType": {

--- a/packs/blood-lords-bestiary/vampire-taviah.json
+++ b/packs/blood-lords-bestiary/vampire-taviah.json
@@ -1275,6 +1275,8 @@
             "mod": 23,
             "senses": [
                 {
+                    "acuity": "precise",
+                    "range": 100,
                     "type": "thoughtsense"
                 },
                 {

--- a/packs/fists-of-the-ruby-phoenix-bestiary/canopy-elder.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/canopy-elder.json
@@ -379,7 +379,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 120 feet",
             "sort": 800000,
             "system": {
                 "actionType": {

--- a/packs/fists-of-the-ruby-phoenix-bestiary/desecrated-guardian.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/desecrated-guardian.json
@@ -105,7 +105,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Lifesense",
+            "name": "Lifesense 60 feet",
             "sort": 300000,
             "system": {
                 "actionType": {

--- a/packs/fists-of-the-ruby-phoenix-bestiary/inmyeonjo.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/inmyeonjo.json
@@ -1253,7 +1253,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 1900000,
             "system": {
                 "actionType": {

--- a/packs/fists-of-the-ruby-phoenix-bestiary/lophiithu.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/lophiithu.json
@@ -811,7 +811,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 1300000,
             "system": {
                 "actionType": {

--- a/packs/gatewalkers-bestiary/abyssal-muckrager.json
+++ b/packs/gatewalkers-bestiary/abyssal-muckrager.json
@@ -98,7 +98,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 60 feet",
             "sort": 300000,
             "system": {
                 "actionType": {

--- a/packs/gatewalkers-bestiary/ogmunzorius.json
+++ b/packs/gatewalkers-bestiary/ogmunzorius.json
@@ -668,7 +668,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 1100000,
             "system": {
                 "actionType": {

--- a/packs/kingmaker-bestiary/ankou-assassin.json
+++ b/packs/kingmaker-bestiary/ankou-assassin.json
@@ -812,7 +812,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Lifesense",
+            "name": "Lifesense 120 feet",
             "sort": 1400000,
             "system": {
                 "actionType": {

--- a/packs/kingmaker-bestiary/ankou-assassin.json
+++ b/packs/kingmaker-bestiary/ankou-assassin.json
@@ -774,7 +774,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 1300000,
             "system": {
                 "actionType": {

--- a/packs/kingmaker-bestiary/niodrhast.json
+++ b/packs/kingmaker-bestiary/niodrhast.json
@@ -1340,7 +1340,7 @@
         {
             "_id": "zKvBvpelIhRXPoSW",
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Thoughtsense",
+            "name": "Thoughtsense (Precise) 100 feet",
             "sort": 2000000,
             "system": {
                 "actionType": {
@@ -1862,7 +1862,7 @@
                     "type": "greater-darkvision"
                 },
                 {
-                    "acuity": "imprecise",
+                    "acuity": "precise",
                     "range": 100,
                     "type": "thoughtsense"
                 }

--- a/packs/kingmaker-bestiary/the-wriggling-man.json
+++ b/packs/kingmaker-bestiary/the-wriggling-man.json
@@ -3776,7 +3776,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 30 feet",
             "sort": 5200000,
             "system": {
                 "actionType": {

--- a/packs/malevolence-bestiary/yianyin.json
+++ b/packs/malevolence-bestiary/yianyin.json
@@ -515,7 +515,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 120 feet",
             "sort": 900000,
             "system": {
                 "actionType": {

--- a/packs/outlaws-of-alkenstar-bestiary/glass-sentry.json
+++ b/packs/outlaws-of-alkenstar-bestiary/glass-sentry.json
@@ -54,7 +54,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 60 feet",
             "sort": 200000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/animate-dream.json
+++ b/packs/pathfinder-bestiary-2/animate-dream.json
@@ -531,7 +531,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 900000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/ankou.json
+++ b/packs/pathfinder-bestiary-2/ankou.json
@@ -666,7 +666,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 1200000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/ankou.json
+++ b/packs/pathfinder-bestiary-2/ankou.json
@@ -704,7 +704,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Lifesense",
+            "name": "Lifesense 120 feet",
             "sort": 1300000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/assassin-vine.json
+++ b/packs/pathfinder-bestiary-2/assassin-vine.json
@@ -55,7 +55,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 30 feet",
             "sort": 200000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/augnagar.json
+++ b/packs/pathfinder-bestiary-2/augnagar.json
@@ -328,7 +328,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 700000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/black-dracolisk.json
+++ b/packs/pathfinder-bestiary-2/black-dracolisk.json
@@ -94,7 +94,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 30 feet",
             "sort": 300000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/black-scorpion.json
+++ b/packs/pathfinder-bestiary-2/black-scorpion.json
@@ -102,7 +102,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 90 feet",
             "sort": 300000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/blue-dracolisk.json
+++ b/packs/pathfinder-bestiary-2/blue-dracolisk.json
@@ -94,7 +94,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 30 feet",
             "sort": 300000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/bog-strider.json
+++ b/packs/pathfinder-bestiary-2/bog-strider.json
@@ -324,7 +324,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Wavesense",
+            "name": "Wavesense 120 feet",
             "sort": 700000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/bone-prophet.json
+++ b/packs/pathfinder-bestiary-2/bone-prophet.json
@@ -2466,7 +2466,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 3600000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/catrina.json
+++ b/packs/pathfinder-bestiary-2/catrina.json
@@ -512,7 +512,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Lifesense",
+            "name": "Lifesense 60 feet",
             "sort": 1000000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/catrina.json
+++ b/packs/pathfinder-bestiary-2/catrina.json
@@ -474,7 +474,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 120 feet",
             "sort": 900000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/chernobue.json
+++ b/packs/pathfinder-bestiary-2/chernobue.json
@@ -796,7 +796,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 1300000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/derghodaemon.json
+++ b/packs/pathfinder-bestiary-2/derghodaemon.json
@@ -499,7 +499,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 900000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/dig-widget.json
+++ b/packs/pathfinder-bestiary-2/dig-widget.json
@@ -101,7 +101,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 30 feet",
             "sort": 300000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/duneshaker-solifugid.json
+++ b/packs/pathfinder-bestiary-2/duneshaker-solifugid.json
@@ -97,7 +97,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 30 feet",
             "sort": 300000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/dziriak.json
+++ b/packs/pathfinder-bestiary-2/dziriak.json
@@ -163,7 +163,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 400000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/earthen-destrier.json
+++ b/packs/pathfinder-bestiary-2/earthen-destrier.json
@@ -98,7 +98,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 60 feet",
             "sort": 300000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/eremite.json
+++ b/packs/pathfinder-bestiary-2/eremite.json
@@ -1419,7 +1419,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 1900000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/esobok.json
+++ b/packs/pathfinder-bestiary-2/esobok.json
@@ -206,7 +206,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Lifesense",
+            "name": "Lifesense 60 feet",
             "sort": 500000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/gosreg.json
+++ b/packs/pathfinder-bestiary-2/gosreg.json
@@ -1026,7 +1026,7 @@
         {
             "_id": "WKWzTrWyiPJNihmZ",
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Thoughtsense",
+            "name": "Thoughtsense 60 feet",
             "sort": 1600000,
             "system": {
                 "actionType": {
@@ -1447,7 +1447,7 @@
                     "type": "darkvision"
                 },
                 {
-                    "acuity": "imprecise",
+                    "acuity": "precise",
                     "range": 60,
                     "type": "thoughtsense"
                 }

--- a/packs/pathfinder-bestiary-2/gosreg.json
+++ b/packs/pathfinder-bestiary-2/gosreg.json
@@ -993,7 +993,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 1500000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/granite-glyptodont.json
+++ b/packs/pathfinder-bestiary-2/granite-glyptodont.json
@@ -58,7 +58,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 90 feet",
             "sort": 200000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/green-dracolisk.json
+++ b/packs/pathfinder-bestiary-2/green-dracolisk.json
@@ -94,7 +94,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 30 feet",
             "sort": 300000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/gylou.json
+++ b/packs/pathfinder-bestiary-2/gylou.json
@@ -854,7 +854,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 1500000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/hamatula.json
+++ b/packs/pathfinder-bestiary-2/hamatula.json
@@ -796,7 +796,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 1200000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/hellcat.json
+++ b/packs/pathfinder-bestiary-2/hellcat.json
@@ -97,7 +97,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 300000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/hezrou.json
+++ b/packs/pathfinder-bestiary-2/hezrou.json
@@ -793,7 +793,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 1300000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/invidiak.json
+++ b/packs/pathfinder-bestiary-2/invidiak.json
@@ -706,7 +706,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 1100000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/living-boulder.json
+++ b/packs/pathfinder-bestiary-2/living-boulder.json
@@ -51,7 +51,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 30 feet",
             "sort": 200000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/meladaemon.json
+++ b/packs/pathfinder-bestiary-2/meladaemon.json
@@ -685,7 +685,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Lifesense",
+            "name": "Lifesense (Imprecise) 30 feet",
             "sort": 1200000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/meladaemon.json
+++ b/packs/pathfinder-bestiary-2/meladaemon.json
@@ -647,7 +647,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 1100000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/nabasu.json
+++ b/packs/pathfinder-bestiary-2/nabasu.json
@@ -517,7 +517,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 900000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/nalfeshnee.json
+++ b/packs/pathfinder-bestiary-2/nalfeshnee.json
@@ -616,7 +616,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 1100000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/neothelid.json
+++ b/packs/pathfinder-bestiary-2/neothelid.json
@@ -1277,7 +1277,7 @@
         {
             "_id": "zKvBvpelIhRXPoSW",
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Thoughtsense",
+            "name": "Thoughtsense (Precise) 100 feet",
             "sort": 2000000,
             "system": {
                 "actionType": {
@@ -1799,7 +1799,7 @@
                     "type": "greater-darkvision"
                 },
                 {
-                    "acuity": "imprecise",
+                    "acuity": "precise",
                     "range": 100,
                     "type": "thoughtsense"
                 }

--- a/packs/pathfinder-bestiary-2/norn.json
+++ b/packs/pathfinder-bestiary-2/norn.json
@@ -1177,7 +1177,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Lifesense",
+            "name": "Lifesense 120 feet",
             "sort": 2000000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/nyogoth.json
+++ b/packs/pathfinder-bestiary-2/nyogoth.json
@@ -467,7 +467,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 800000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/olethrodaemon.json
+++ b/packs/pathfinder-bestiary-2/olethrodaemon.json
@@ -1024,7 +1024,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 1600000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/olethrodaemon.json
+++ b/packs/pathfinder-bestiary-2/olethrodaemon.json
@@ -989,7 +989,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 120 feet",
             "sort": 1500000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/ostiarius.json
+++ b/packs/pathfinder-bestiary-2/ostiarius.json
@@ -599,7 +599,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 1100000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/piscodaemon.json
+++ b/packs/pathfinder-bestiary-2/piscodaemon.json
@@ -546,7 +546,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 1000000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/purrodaemon.json
+++ b/packs/pathfinder-bestiary-2/purrodaemon.json
@@ -1009,7 +1009,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 1600000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/quetz-couatl.json
+++ b/packs/pathfinder-bestiary-2/quetz-couatl.json
@@ -933,7 +933,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 1500000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/red-dracolisk.json
+++ b/packs/pathfinder-bestiary-2/red-dracolisk.json
@@ -94,7 +94,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 30 feet",
             "sort": 300000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/sand-sentry.json
+++ b/packs/pathfinder-bestiary-2/sand-sentry.json
@@ -54,7 +54,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 60 feet",
             "sort": 200000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/sard.json
+++ b/packs/pathfinder-bestiary-2/sard.json
@@ -585,7 +585,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 120 feet",
             "sort": 1100000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/sceaduinar.json
+++ b/packs/pathfinder-bestiary-2/sceaduinar.json
@@ -819,7 +819,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Lifesense",
+            "name": "Lifesense 120 feet",
             "sort": 1200000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/shoggti.json
+++ b/packs/pathfinder-bestiary-2/shoggti.json
@@ -516,7 +516,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 900000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/thanadaemon.json
+++ b/packs/pathfinder-bestiary-2/thanadaemon.json
@@ -1092,7 +1092,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 1700000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/thulgant.json
+++ b/packs/pathfinder-bestiary-2/thulgant.json
@@ -1077,7 +1077,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 1700000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/umbral-dragon-ancient-spellcaster.json
+++ b/packs/pathfinder-bestiary-2/umbral-dragon-ancient-spellcaster.json
@@ -3209,7 +3209,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 60 feet",
             "sort": 4600000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/umbral-dragon-ancient.json
+++ b/packs/pathfinder-bestiary-2/umbral-dragon-ancient.json
@@ -736,7 +736,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 60 feet",
             "sort": 1300000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/umonlee.json
+++ b/packs/pathfinder-bestiary-2/umonlee.json
@@ -103,7 +103,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 80 feet",
             "sort": 300000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/vanth.json
+++ b/packs/pathfinder-bestiary-2/vanth.json
@@ -595,7 +595,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Lifesense",
+            "name": "Lifesense 60 feet",
             "sort": 1000000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/veranallia.json
+++ b/packs/pathfinder-bestiary-2/veranallia.json
@@ -1800,7 +1800,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 120 feet",
             "sort": 2700000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/viper-vine.json
+++ b/packs/pathfinder-bestiary-2/viper-vine.json
@@ -103,7 +103,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 60 feet",
             "sort": 300000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/vrolikai.json
+++ b/packs/pathfinder-bestiary-2/vrolikai.json
@@ -779,7 +779,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 1300000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/white-dracolisk.json
+++ b/packs/pathfinder-bestiary-2/white-dracolisk.json
@@ -94,7 +94,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 30 feet",
             "sort": 300000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/worm-that-walks-cultist.json
+++ b/packs/pathfinder-bestiary-2/worm-that-walks-cultist.json
@@ -2329,7 +2329,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 30 feet",
             "sort": 3500000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/yamaraj.json
+++ b/packs/pathfinder-bestiary-2/yamaraj.json
@@ -1560,7 +1560,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Lifesense",
+            "name": "Lifesense 240 feet",
             "sort": 2100000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/yamaraj.json
+++ b/packs/pathfinder-bestiary-2/yamaraj.json
@@ -1522,7 +1522,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 120 feet",
             "sort": 2000000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/zomok.json
+++ b/packs/pathfinder-bestiary-2/zomok.json
@@ -722,7 +722,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 60 feet",
             "sort": 1300000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-2/zyss-serpentfolk.json
+++ b/packs/pathfinder-bestiary-2/zyss-serpentfolk.json
@@ -708,7 +708,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 1200000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary-3/shaukeen.json
+++ b/packs/pathfinder-bestiary-3/shaukeen.json
@@ -577,7 +577,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy (touch)",
             "sort": 1000000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary/gold-dragon-adult.json
+++ b/packs/pathfinder-bestiary/gold-dragon-adult.json
@@ -524,7 +524,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Reaction.webp",
-            "name": "Attack of Opportunity",
+            "name": "Attack of Opportunity (Jaws Only)",
             "sort": 1000000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-bestiary/gold-dragon-ancient-spellcaster.json
+++ b/packs/pathfinder-bestiary/gold-dragon-ancient-spellcaster.json
@@ -2868,7 +2868,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Reaction.webp",
-            "name": "Attack of Opportunity",
+            "name": "Attack of Opportunity (Jaws only)",
             "sort": 4000000,
             "system": {
                 "actionType": {

--- a/packs/pathfinder-monster-core/thulgant.json
+++ b/packs/pathfinder-monster-core/thulgant.json
@@ -1051,7 +1051,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 1600000,
             "system": {
                 "actionType": {

--- a/packs/pfs-season-4-bestiary/dig-widget-pfs-4-07.json
+++ b/packs/pfs-season-4-bestiary/dig-widget-pfs-4-07.json
@@ -101,7 +101,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 30 feet",
             "sort": 300000,
             "system": {
                 "actionType": {

--- a/packs/pfs-season-4-bestiary/dream-of-doom.json
+++ b/packs/pfs-season-4-bestiary/dream-of-doom.json
@@ -469,7 +469,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 800000,
             "system": {
                 "actionType": {

--- a/packs/pfs-season-4-bestiary/elite-animate-dream-pfs-4-11.json
+++ b/packs/pfs-season-4-bestiary/elite-animate-dream-pfs-4-11.json
@@ -531,7 +531,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 900000,
             "system": {
                 "actionType": {

--- a/packs/pfs-season-4-bestiary/faded-animate-dream.json
+++ b/packs/pfs-season-4-bestiary/faded-animate-dream.json
@@ -531,7 +531,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 900000,
             "system": {
                 "actionType": {

--- a/packs/pfs-season-4-bestiary/living-boulder-pfs-4-04.json
+++ b/packs/pfs-season-4-bestiary/living-boulder-pfs-4-04.json
@@ -51,7 +51,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 30 feet",
             "sort": 200000,
             "system": {
                 "actionType": {

--- a/packs/pfs-season-5-bestiary/omertius-the-engorged.json
+++ b/packs/pfs-season-5-bestiary/omertius-the-engorged.json
@@ -580,7 +580,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 900000,
             "system": {
                 "actionType": {

--- a/packs/pfs-season-5-bestiary/omertius-the-gorger.json
+++ b/packs/pfs-season-5-bestiary/omertius-the-gorger.json
@@ -580,7 +580,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 900000,
             "system": {
                 "actionType": {

--- a/packs/seven-dooms-for-sandpoint-bestiary/pthuminin.json
+++ b/packs/seven-dooms-for-sandpoint-bestiary/pthuminin.json
@@ -1027,7 +1027,7 @@
         {
             "_id": "WKWzTrWyiPJNihmZ",
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Thoughtsense",
+            "name": "Thoughtsense 60 feet",
             "sort": 1600000,
             "system": {
                 "actionType": {
@@ -1453,7 +1453,7 @@
                     "type": "darkvision"
                 },
                 {
-                    "acuity": "imprecise",
+                    "acuity": "precise",
                     "range": 60,
                     "type": "thoughtsense"
                 }

--- a/packs/seven-dooms-for-sandpoint-bestiary/pthuminin.json
+++ b/packs/seven-dooms-for-sandpoint-bestiary/pthuminin.json
@@ -994,7 +994,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 1500000,
             "system": {
                 "actionType": {

--- a/packs/seven-dooms-for-sandpoint-bestiary/serpentfolk-cultist.json
+++ b/packs/seven-dooms-for-sandpoint-bestiary/serpentfolk-cultist.json
@@ -2187,7 +2187,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 2800000,
             "system": {
                 "actionType": {

--- a/packs/seven-dooms-for-sandpoint-bestiary/vizmivool.json
+++ b/packs/seven-dooms-for-sandpoint-bestiary/vizmivool.json
@@ -2989,7 +2989,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 3700000,
             "system": {
                 "actionType": {

--- a/packs/seven-dooms-for-sandpoint-bestiary/zalavexus.json
+++ b/packs/seven-dooms-for-sandpoint-bestiary/zalavexus.json
@@ -1810,7 +1810,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 30 feet",
             "sort": 2600000,
             "system": {
                 "actionType": {

--- a/packs/sky-kings-tomb-bestiary/alchemist-ivy.json
+++ b/packs/sky-kings-tomb-bestiary/alchemist-ivy.json
@@ -97,7 +97,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 30 feet",
             "sort": 300000,
             "system": {
                 "actionType": {

--- a/packs/sky-kings-tomb-bestiary/enraged-dream.json
+++ b/packs/sky-kings-tomb-bestiary/enraged-dream.json
@@ -569,7 +569,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 900000,
             "system": {
                 "actionType": {

--- a/packs/sky-kings-tomb-bestiary/heartbroken-dream.json
+++ b/packs/sky-kings-tomb-bestiary/heartbroken-dream.json
@@ -549,7 +549,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 900000,
             "system": {
                 "actionType": {

--- a/packs/stolen-fate-bestiary/aquatic-viper-vine.json
+++ b/packs/stolen-fate-bestiary/aquatic-viper-vine.json
@@ -103,7 +103,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 60 feet",
             "sort": 300000,
             "system": {
                 "actionType": {

--- a/packs/stolen-fate-bestiary/demonic-rabble.json
+++ b/packs/stolen-fate-bestiary/demonic-rabble.json
@@ -10,7 +10,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 100000,
             "system": {
                 "actionType": {

--- a/packs/stolen-fate-bestiary/diskrasia-the-sharp.json
+++ b/packs/stolen-fate-bestiary/diskrasia-the-sharp.json
@@ -1177,7 +1177,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Lifesense",
+            "name": "Lifesense 120 feet",
             "sort": 2000000,
             "system": {
                 "actionType": {

--- a/packs/stolen-fate-bestiary/fabrina-the-spinster.json
+++ b/packs/stolen-fate-bestiary/fabrina-the-spinster.json
@@ -1177,7 +1177,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Lifesense",
+            "name": "Lifesense 120 feet",
             "sort": 2000000,
             "system": {
                 "actionType": {

--- a/packs/stolen-fate-bestiary/ghalzarokh.json
+++ b/packs/stolen-fate-bestiary/ghalzarokh.json
@@ -683,7 +683,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 1100000,
             "system": {
                 "actionType": {

--- a/packs/stolen-fate-bestiary/hala-the-rod.json
+++ b/packs/stolen-fate-bestiary/hala-the-rod.json
@@ -1177,7 +1177,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Lifesense",
+            "name": "Lifesense 120 feet",
             "sort": 2000000,
             "system": {
                 "actionType": {

--- a/packs/stolen-fate-bestiary/katpaskir.json
+++ b/packs/stolen-fate-bestiary/katpaskir.json
@@ -975,7 +975,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 1600000,
             "system": {
                 "actionType": {

--- a/packs/stolen-fate-bestiary/torgral.json
+++ b/packs/stolen-fate-bestiary/torgral.json
@@ -763,7 +763,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 1200000,
             "system": {
                 "actionType": {

--- a/packs/stolen-fate-bestiary/vincuvicar.json
+++ b/packs/stolen-fate-bestiary/vincuvicar.json
@@ -1264,7 +1264,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 2000000,
             "system": {
                 "actionType": {

--- a/packs/stolen-fate-bestiary/wrath-riot.json
+++ b/packs/stolen-fate-bestiary/wrath-riot.json
@@ -10,7 +10,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Telepathy",
+            "name": "Telepathy 100 feet",
             "sort": 100000,
             "system": {
                 "actionType": {

--- a/packs/strength-of-thousands-bestiary/gluttonworm.json
+++ b/packs/strength-of-thousands-bestiary/gluttonworm.json
@@ -99,7 +99,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 100 feet",
             "sort": 300000,
             "system": {
                 "actionType": {

--- a/packs/strength-of-thousands-bestiary/hivebound-arboreal.json
+++ b/packs/strength-of-thousands-bestiary/hivebound-arboreal.json
@@ -687,7 +687,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 120 feet",
             "sort": 1200000,
             "system": {
                 "actionType": {

--- a/packs/the-enmity-cycle-bestiary/sand-wolf.json
+++ b/packs/the-enmity-cycle-bestiary/sand-wolf.json
@@ -95,7 +95,7 @@
                 }
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Tremorsense",
+            "name": "Tremorsense 30 feet",
             "sort": 300000,
             "system": {
                 "actionType": {


### PR DESCRIPTION
They are mostly absent in Bestiary 2. Would make them consistent with other Bestiaries and Monster Core

Fix Gosreg/Pthuminin thoughtsense acuity.
Add acuity and distance to Vampire Taviah's thoughtsense

Specify Gold Dragon AoO as jaws only in the item name