### PR TITLE
Fix grant item RE form error with resolvable UUIDs

### DIFF
--- a/src/module/item/base/sheet/rule-element-form/grant-item.ts
+++ b/src/module/item/base/sheet/rule-element-form/grant-item.ts
@@ -1,4 +1,5 @@
 import type { GrantItemRuleElement, GrantItemSource } from "@module/rules/rule-element/grant-item/rule-element.ts";
+import { UUIDUtils } from "@util/uuid.ts";
 import { RuleElementForm, RuleElementFormSheetData } from "./base.ts";
 
 /** Form handler for the GrantItem rule element */
@@ -7,7 +8,7 @@ class GrantItemForm extends RuleElementForm<GrantItemSource, GrantItemRuleElemen
     override async getData(): Promise<GrantItemFormSheetData> {
         const data = await super.getData();
         const uuid = this.rule.uuid ? String(this.rule.uuid) : null;
-        const granted = uuid ? await fromUuid(uuid) : null;
+        const granted = UUIDUtils.isItemUUID(uuid) ? await fromUuid(uuid) : null;
         return { ...data, granted };
     }
 


### PR DESCRIPTION
`fromUuid` now throws an error instead of returning `null` when it encounters an invalid UUID.