### PR TITLE
Update Thlipit Contestant Dedication Feat to add Lash strike

### DIFF
--- a/packs/feats/thlipit-contestant-dedication.json
+++ b/packs/feats/thlipit-contestant-dedication.json
@@ -42,6 +42,8 @@
                 "img": "systems/pf2e/icons/unarmed-attacks/tongue.webp",
                 "key": "Strike",
                 "label": "PF2E.SpecificRule.Feat.ThlipitContestantDedication.Lash",
+                "range": null,
+                "replaceAll": false,
                 "slug": "lash",
                 "traits": [
                     "grapple",


### PR DESCRIPTION
The Lash strike was not displaying/getting added when the dedication feat was added to the Character sheet. This push change should correct for this