### PR TITLE
Fix button wrapping in prepared spellcasting entry with long statistic names

### DIFF
--- a/src/styles/actor/character/_spellcasting.scss
+++ b/src/styles/actor/character/_spellcasting.scss
@@ -83,6 +83,7 @@
             button.prepare-spells {
                 font-family: var(--serif);
                 font-size: var(--font-size-14);
+                white-space: nowrap;
             }
 
             .statistic-values {


### PR DESCRIPTION
Also an issue in v11