### PR TITLE
Add Psychic to feats and add trait RE to Irezoko Tattoo feat

### DIFF
--- a/packs/feats/irezoko-tattoo.json
+++ b/packs/feats/irezoko-tattoo.json
@@ -28,7 +28,19 @@
             "remaster": false,
             "title": "Pathfinder Lost Omens: Absalom, City of Lost Omens"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:id:{item|id}"
+                ],
+                "property": "traits",
+                "selector": "{item|_id}",
+                "value": "{actor|system.details.class.trait}"
+            }
+        ],
         "traits": {
             "rarity": "uncommon",
             "value": []

--- a/packs/feats/steady-spellcasting.json
+++ b/packs/feats/steady-spellcasting.json
@@ -32,6 +32,7 @@
                 "cleric",
                 "druid",
                 "oracle",
+                "psychic",
                 "sorcerer",
                 "witch",
                 "wizard"

--- a/packs/feats/twin-psyche.json
+++ b/packs/feats/twin-psyche.json
@@ -27,7 +27,9 @@
         "rules": [],
         "traits": {
             "rarity": "common",
-            "value": []
+            "value": [
+                "psychic"
+            ]
         }
     },
     "type": "feat"


### PR DESCRIPTION
Closes #14863

Irezoko Tattoo is strangely written - it's listed with all the spellcasting class traits but it only actually gains a class trait when taken. I left the trait list off the feat, but added an alteration for it to gain the trait of the class that takes it.

Steady Spellcasting was reprinted in Player Core 1 under each spellcasting class in there, but because it was printed identical, it should still have the class traits from its previous Legacy printings, so I added Psychic.