### PR TITLE
Fix Thaumaturges Investment for partial boosts

### DIFF
--- a/packs/feats/thaumaturges-investiture.json
+++ b/packs/feats/thaumaturges-investiture.json
@@ -40,17 +40,17 @@
                 "value": {
                     "brackets": [
                         {
-                            "end": 4,
+                            "end": 4.5,
                             "start": 4,
                             "value": 14
                         },
                         {
-                            "end": 5,
+                            "end": 5.5,
                             "start": 5,
                             "value": 16
                         },
                         {
-                            "end": 6,
+                            "end": 6.5,
                             "start": 6,
                             "value": 18
                         },


### PR DESCRIPTION
Closes #14687

Checks for the partial boost that decimalizes the attribute.