### PR TITLE
Pass mapIncreases when rollDamage heightens the spell

### DIFF
--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -1023,7 +1023,7 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
         // If this isn't a variant, it probably needs to be heightened via overlays
         if (!this.isVariant) {
             const variant = this.loadVariant({ castRank });
-            if (variant) return variant.rollDamage(event);
+            if (variant) return variant.rollDamage(event, mapIncreases);
         }
 
         const targetToken =


### PR DESCRIPTION
rollDamage will automatically try to heighten the spell if it's not a variant, but doesn't pass on the mapIncreases option when it does that.