### PR TITLE
Reset contained actors when an environment region behavior is updated

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -40,7 +40,8 @@ import type {
     TileDocumentPF2e,
     TokenDocumentPF2e,
 } from "@scene";
-import type { RegionBehaviorInstance } from "@scene/region-behaviors/types.ts";
+import type { RegionBehaviorPF2e } from "@scene/region-behavior/document.ts";
+import type { RegionBehaviorInstance } from "@scene/region-behavior/types.ts";
 import type { ActorDeltaPF2e } from "@scene/token-document/actor-delta.ts";
 import type { PF2ECONFIG, StatusEffectIconTheme } from "@scripts/config/index.ts";
 import type { DicePF2e } from "@scripts/dice.ts";
@@ -204,7 +205,7 @@ type ConfiguredConfig = Config<
     MacroPF2e,
     MeasuredTemplateDocumentPF2e,
     RegionDocument<ScenePF2e | null>,
-    RegionBehavior<RegionDocument<ScenePF2e | null>>,
+    RegionBehaviorPF2e<RegionDocument<ScenePF2e | null>>,
     TileDocumentPF2e,
     TokenDocumentPF2e,
     WallDocument<ScenePF2e | null>,

--- a/src/module/actor/helpers.ts
+++ b/src/module/actor/helpers.ts
@@ -13,7 +13,7 @@ import {
     extractRollSubstitutions,
     extractRollTwice,
 } from "@module/rules/helpers.ts";
-import { EnvironmentRegionBehaviorPF2e } from "@scene/region-behaviors/types.ts";
+import { EnvironmentRegionBehaviorPF2e } from "@scene/region-behavior/types.ts";
 import { eventToRollParams } from "@scripts/sheet-util.ts";
 import { CheckCheckContext, CheckPF2e, CheckRoll } from "@system/check/index.ts";
 import { DamageDamageContext, DamagePF2e } from "@system/damage/index.ts";

--- a/src/module/scene/region-behavior/document.ts
+++ b/src/module/scene/region-behavior/document.ts
@@ -1,0 +1,30 @@
+import { resetActors } from "@actor/helpers.ts";
+import type { RegionBehaviorInstanceType, RegionBehaviorInstances } from "./types.ts";
+
+class RegionBehaviorPF2e<TParent extends RegionDocument = RegionDocument> extends RegionBehavior<TParent> {
+    isOfType<T extends RegionBehaviorInstanceType>(...types: T[]): this is RegionBehaviorInstances<TParent>[T];
+    isOfType(...types: string[]): boolean {
+        return types.some((t) => t === this.type);
+    }
+
+    protected override _onUpdate(
+        data: DeepPartial<this["_source"]>,
+        operation: DatabaseUpdateOperation<TParent>,
+        userId: string,
+    ): void {
+        // Reset actors inside the region of this behavior
+        if (this.viewed && this.isOfType("environment")) {
+            const system = data.system ?? {};
+            if ("environmentTypes" in system || "mode" in system) {
+                resetActors(
+                    [...this.region.tokens].flatMap((t) => t.actor ?? []),
+                    { tokens: true },
+                );
+            }
+        }
+
+        return super._onUpdate(data, operation, userId);
+    }
+}
+
+export { RegionBehaviorPF2e };

--- a/src/module/scene/region-behavior/environment.ts
+++ b/src/module/scene/region-behavior/environment.ts
@@ -47,6 +47,7 @@ type EnvironmentTypeSchema = {
 };
 
 type EnvironmentTypeData = ModelPropsFromSchema<EnvironmentTypeSchema>;
+type EnvironmentTypeSource = SourceFromSchema<EnvironmentTypeSchema>;
 
 export { EnvironmentBehaviorTypePF2e };
-export type { EnvironmentTypeData };
+export type { EnvironmentTypeData, EnvironmentTypeSource };

--- a/src/module/scene/region-behavior/types.ts
+++ b/src/module/scene/region-behavior/types.ts
@@ -8,11 +8,12 @@ import type { PauseGameRegionBehaviorTypeSchema } from "types/foundry/client-esm
 import type { SuppressWeatherRegionBehaviorTypeSchema } from "types/foundry/client-esm/data/region-behaviors/suppress-weather.d.ts";
 import type { TeleportTokenRegionBehaviorTypeSchema } from "types/foundry/client-esm/data/region-behaviors/teleport-token.d.ts";
 import type { ToggleBehaviorRegionBehaviorTypeSchema } from "types/foundry/client-esm/data/region-behaviors/toggle-behavior.d.ts";
+import type { RegionBehaviorPF2e } from "./document.ts";
 import type { EnvironmentTypeData } from "./environment.ts";
 
 type RegionEventPF2e = RegionEvent<TokenDocumentPF2e, UserPF2e, CombatantPF2e, RegionDocument<ScenePF2e | null>>;
 
-interface BaseRegionBehavior<TParent extends RegionDocument = RegionDocument> extends RegionBehavior<TParent> {
+interface BaseRegionBehavior<TParent extends RegionDocument = RegionDocument> extends RegionBehaviorPF2e<TParent> {
     get scene(): ScenePF2e | null;
 
     _handleRegionEvent(event: RegionEventPF2e): Promise<void>;
@@ -73,14 +74,26 @@ interface EnvironmentRegionBehaviorPF2e<TParent extends RegionDocument = RegionD
     system: EnvironmentTypeData;
 }
 
-type RegionBehaviorInstance<TParent extends RegionDocument = RegionDocument> =
-    | AdjustDarknessLevelRegionBehavior<TParent>
-    | ExecuteMacroRegionBehavior<TParent>
-    | ExecuteScriptRegionBehavior<TParent>
-    | PauseGameRegionBehavior<TParent>
-    | SuppressWeatherRegionBehavior<TParent>
-    | TeleportTokenRegionBehavior<TParent>
-    | ToggleBehaviorRegionBehavior<TParent>
-    | EnvironmentRegionBehaviorPF2e<TParent>;
+interface RegionBehaviorInstances<TParent extends RegionDocument = RegionDocument> {
+    adjustDarknessLevel: AdjustDarknessLevelRegionBehavior<TParent>;
+    executeMacro: ExecuteMacroRegionBehavior<TParent>;
+    executeScript: ExecuteScriptRegionBehavior<TParent>;
+    pauseGame: PauseGameRegionBehavior<TParent>;
+    suppressWeather: SuppressWeatherRegionBehavior<TParent>;
+    teleportToken: TeleportTokenRegionBehavior<TParent>;
+    toggleBehavior: ToggleBehaviorRegionBehavior<TParent>;
+    environment: EnvironmentRegionBehaviorPF2e<TParent>;
+}
 
-export type { EnvironmentRegionBehaviorPF2e, RegionBehaviorInstance, RegionEventPF2e };
+type RegionBehaviorInstance<TParent extends RegionDocument = RegionDocument> =
+    RegionBehaviorInstances<TParent>[keyof RegionBehaviorInstances];
+
+type RegionBehaviorInstanceType = RegionBehaviorInstance["type"];
+
+export type {
+    EnvironmentRegionBehaviorPF2e,
+    RegionBehaviorInstance,
+    RegionBehaviorInstances,
+    RegionBehaviorInstanceType,
+    RegionEventPF2e,
+};

--- a/src/scripts/hooks/init.ts
+++ b/src/scripts/hooks/init.ts
@@ -17,7 +17,8 @@ import {
 } from "@module/canvas/index.ts";
 import { setPerceptionModes } from "@module/canvas/perception/modes.ts";
 import { PointVisionSourcePF2e } from "@module/canvas/perception/point-vision-source.ts";
-import { EnvironmentBehaviorTypePF2e } from "@scene/region-behaviors/environment.ts";
+import { RegionBehaviorPF2e } from "@scene/region-behavior/document.ts";
+import { EnvironmentBehaviorTypePF2e } from "@scene/region-behavior/environment.ts";
 import { PF2ECONFIG } from "@scripts/config/index.ts";
 import { registerHandlebarsHelpers } from "@scripts/handlebars.ts";
 import { registerFonts } from "@scripts/register-fonts.ts";
@@ -51,6 +52,7 @@ export const Init = {
             CONFIG.Canvas.layers.templates.layerClass = TemplateLayerPF2e;
             CONFIG.Canvas.visionSourceClass = PointVisionSourcePF2e;
 
+            CONFIG.RegionBehavior.documentClass = RegionBehaviorPF2e;
             CONFIG.RegionBehavior.dataModels.environment = EnvironmentBehaviorTypePF2e;
             CONFIG.RegionBehavior.typeLabels.environment = "PF2E.Region.Environment.Label";
             CONFIG.RegionBehavior.typeIcons.environment = "fa-solid fa-mountain-sun";


### PR DESCRIPTION
Also adds `RegionBehaviorPF2e#isOfType` although I didn't end up really needing it for this PR