### PR TITLE
Fix AC value in Construct Armor description for Statue of Alaznist

### DIFF
--- a/packs/seven-dooms-for-sandpoint-bestiary/statue-of-alaznist.json
+++ b/packs/seven-dooms-for-sandpoint-bestiary/statue-of-alaznist.json
@@ -153,7 +153,7 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p>Like normal objects, an animated statue has Hardness. This Hardness reduces any damage it takes by an amount equal to the Hardness.</p>\n<p>Once an animated statue is reduced to less than half its Hit Points, or immediately upon being damaged by a critical hit, its construct armor breaks and its Armor Class is reduced to 15.</p>"
+                    "value": "<p>Like normal objects, an animated statue has Hardness. This Hardness reduces any damage it takes by an amount equal to the Hardness.</p>\n<p>Once an animated statue is reduced to less than half its Hit Points, or immediately upon being damaged by a critical hit, its construct armor breaks and its Armor Class is reduced to 19.</p>"
                 },
                 "publication": {
                     "license": "OGL",


### PR DESCRIPTION
checked with the PDF, and the rule Elements are set up for the correct value.