### PR TITLE
Work around `TokenDocument##identifyRegions` using the token center to test region inclusion

### DIFF
--- a/src/module/canvas/region/object.ts
+++ b/src/module/canvas/region/object.ts
@@ -1,0 +1,28 @@
+class RegionPF2e<TParent extends RegionDocument = RegionDocument> extends Region<TParent> {
+    override testPoint(point: Point, elevation?: number): boolean {
+        if (
+            canvas.grid.type !== CONST.GRID_TYPES.SQUARE ||
+            this.document.behaviors.some((b) => b.isOfType("teleportToken"))
+        ) {
+            return super.testPoint(point, elevation);
+        }
+
+        // The tested point might be the post-update token position so we need to find the token that will be moving
+        const token = canvas.tokens.documentCollection?.find((t) => {
+            if (!t.newPosition || !t.object) return false;
+            const center = t.object.getCenterPoint({ x: t.newPosition.x, y: t.newPosition.y });
+            if (center.x === point.x && center.y === point.y) return true;
+            return false;
+        });
+        if (token) {
+            return (
+                (elevation === undefined || (this.bottom <= elevation && elevation <= this.top)) &&
+                !!token.object?.getGridSquaresFromCenterPoint(point).some((p) => this.polygonTree.testPoint(p))
+            );
+        }
+
+        return super.testPoint(point, elevation);
+    }
+}
+
+export { RegionPF2e };

--- a/src/module/canvas/token/object.ts
+++ b/src/module/canvas/token/object.ts
@@ -94,6 +94,33 @@ class TokenPF2e<TDocument extends TokenDocumentPF2e = TokenDocumentPF2e> extends
         return (this.document.sight.range ?? 0) >= dimensions.maxR ? dimensions.maxR : super.sightRange;
     }
 
+    /** Returns every grid square this token occupies as an array of grid square center points. Empty for non-square grids
+     *  @param [center] The center point of the token. Defaults to the current center point
+     */
+    getGridSquaresFromCenterPoint(center: Point = this.getCenterPoint()): Point[] {
+        if (canvas.grid.type !== CONST.GRID_TYPES.SQUARE) return [];
+        const { width, height } = this.document.bounds;
+        const size = canvas.dimensions.size;
+        if (width === size && height === size) {
+            return [center];
+        }
+        const rows = height / size;
+        const columns = width / size;
+        // Calculate the coordinates for the center point of the top left square of this token from the given token center point
+        const x = center.x - columns * size * 0.5 + size * 0.5;
+        const y = center.y - rows * size * 0.5 + size * 0.5;
+        // Generate center Points row by row from the top left to the bottom right
+        const points: Point[] = [];
+        for (let i = 0; i < rows; i++) {
+            const gy = y + i * size;
+            for (let j = 0; j < columns; j++) {
+                const gx = x + j * size;
+                points.push({ x: gx, y: gy });
+            }
+        }
+        return points;
+    }
+
     isAdjacentTo(token: TokenPF2e): boolean {
         return this.distanceTo(token) === 5;
     }

--- a/src/scripts/hooks/init.ts
+++ b/src/scripts/hooks/init.ts
@@ -17,6 +17,7 @@ import {
 } from "@module/canvas/index.ts";
 import { setPerceptionModes } from "@module/canvas/perception/modes.ts";
 import { PointVisionSourcePF2e } from "@module/canvas/perception/point-vision-source.ts";
+import { RegionPF2e } from "@module/canvas/region/object.ts";
 import { RegionBehaviorPF2e } from "@scene/region-behavior/document.ts";
 import { EnvironmentBehaviorTypePF2e } from "@scene/region-behavior/environment.ts";
 import { PF2ECONFIG } from "@scripts/config/index.ts";
@@ -51,6 +52,8 @@ export const Init = {
             CONFIG.Canvas.layers.lighting.layerClass = LightingLayerPF2e;
             CONFIG.Canvas.layers.templates.layerClass = TemplateLayerPF2e;
             CONFIG.Canvas.visionSourceClass = PointVisionSourcePF2e;
+
+            CONFIG.Region.objectClass = RegionPF2e;
 
             CONFIG.RegionBehavior.documentClass = RegionBehaviorPF2e;
             CONFIG.RegionBehavior.dataModels.environment = EnvironmentBehaviorTypePF2e;

--- a/types/foundry/client/pixi/placeables/region.d.ts
+++ b/types/foundry/client/pixi/placeables/region.d.ts
@@ -1,114 +1,114 @@
 import * as ClipperLib from "js-angusj-clipper";
 
-/**
- * A Region is an implementation of PlaceableObject which represents a Region document
- * within a viewed Scene on the game canvas.
- * @category - Canvas
- * @see {RegionDocument}
- * @see {RegionLayer}
- */
-declare class Region<
-    TDocument extends RegionDocument<Scene | null> = RegionDocument<Scene | null>,
-> extends PlaceableObject<TDocument> {
-    static override embeddedName: "Region";
-
-    static override RENDER_FLAGS: {
-        redraw: { propagate: ["refresh"] };
-        refresh: { propagate: ["refreshState", "refreshBorder"]; alias: true };
-        refreshState: {};
-        refreshBorder: {};
-    };
-
-    /** The scaling factor used for Clipper paths. */
-    static CLIPPER_SCALING_FACTOR: {
-        value: number;
-    };
-
-    /** The three movement segment types: ENTER, MOVE, and EXIT. */
-    static readonly MOVEMENT_SEGMENT_TYPES: {
-        /** The segment crosses the boundary of the region and exits it. */
-        EXIT: -1;
-        /** The segment does not cross the boundary of the region and is contained within it. */
-        MOVE: 0;
-        /** The segment crosses the boundary of the region and enters it. */
-        ENTER: 1;
-    };
-
-    /** The shapes of this Region in draw order. */
-    get shapes(): readonly foundry.canvas.regions.RegionShape[];
-
-    /** The bottom elevation of this Region. */
-    get bottom(): number;
-
-    /** The top elevation of this Region. */
-    get top(): number;
-
-    /** The polygons of this Region. */
-    get polygons(): readonly PIXI.Polygon[];
-
-    /** The polygon tree of this Region. */
-    get polygonTree(): foundry.canvas.regions.RegionPolygonTree;
-
-    /** The Clipper paths of this Region. */
-    get clipperPaths(): readonly (readonly ClipperLib.IntPoint[])[];
-
-    /** The triangulation of this Region. */
-    get triangulation(): { vertices: Float32Array; indices: Uint16Array | Uint32Array };
-
-    /** The geometry of this Region. */
-    get geometry(): foundry.canvas.regions.RegionGeometry;
-
-    /** Is this Region currently visible on the Canvas? */
-    get isVisible(): boolean;
-
-    /* -------------------------------------------- */
-    /*  Rendering                                   */
-    /* -------------------------------------------- */
-
-    override _draw(options?: object): Promise<void>;
-
-    /* -------------------------------------------- */
-    /*  Incremental Refresh                         */
-    /* -------------------------------------------- */
-
-    override _applyRenderFlags(flags: Record<string, boolean>): void;
-
-    /** Refresh the state of the Region. */
-    protected _refreshState(): void;
-
-    /** Refresh the border of the Region. */
-    protected _refreshBorder(): void;
-
-    /* -------------------------------------------- */
-    /*  Shape Methods                               */
-    /* -------------------------------------------- */
-
-    /**
-     * Test whether the given point (at the given elevation) is inside this Region.
-     * @param   point         The point.
-     * @param   [elevation]   The elevation of the point.
-     * @returns               Is the point (at the given elevation) inside this Region?
-     */
-    testPoint(point: Point, elevation?: number): boolean;
-
-    /**
-     * Split the movement into its segments.
-     * @param   waypoints                  The waypoints of movement.
-     * @param   samples                    The points relative to the waypoints that are tested.
-     *                                     Whenever one of them is inside the region, the moved object
-     *                                     is considered to be inside the region.
-     * @param   [options]                  Additional options
-     * @param   [options.teleport=false]   Is it teleportation?
-     * @returns                            The movement split into its segments.
-     */
-    segmentizeMovement(
-        waypoints: RegionMovementWaypoint[],
-        samples: Point[],
-        options?: { teleport?: boolean },
-    ): RegionMovementSegment[];
-}
-
 declare global {
+    /**
+     * A Region is an implementation of PlaceableObject which represents a Region document
+     * within a viewed Scene on the game canvas.
+     * @category - Canvas
+     * @see {RegionDocument}
+     * @see {RegionLayer}
+     */
+    class Region<
+        TDocument extends RegionDocument<Scene | null> = RegionDocument<Scene | null>,
+    > extends PlaceableObject<TDocument> {
+        static override embeddedName: "Region";
+
+        static override RENDER_FLAGS: {
+            redraw: { propagate: ["refresh"] };
+            refresh: { propagate: ["refreshState", "refreshBorder"]; alias: true };
+            refreshState: {};
+            refreshBorder: {};
+        };
+
+        /** The scaling factor used for Clipper paths. */
+        static CLIPPER_SCALING_FACTOR: {
+            value: number;
+        };
+
+        /** The three movement segment types: ENTER, MOVE, and EXIT. */
+        static readonly MOVEMENT_SEGMENT_TYPES: {
+            /** The segment crosses the boundary of the region and exits it. */
+            EXIT: -1;
+            /** The segment does not cross the boundary of the region and is contained within it. */
+            MOVE: 0;
+            /** The segment crosses the boundary of the region and enters it. */
+            ENTER: 1;
+        };
+
+        /** The shapes of this Region in draw order. */
+        get shapes(): readonly foundry.canvas.regions.RegionShape[];
+
+        /** The bottom elevation of this Region. */
+        get bottom(): number;
+
+        /** The top elevation of this Region. */
+        get top(): number;
+
+        /** The polygons of this Region. */
+        get polygons(): readonly PIXI.Polygon[];
+
+        /** The polygon tree of this Region. */
+        get polygonTree(): foundry.canvas.regions.RegionPolygonTree;
+
+        /** The Clipper paths of this Region. */
+        get clipperPaths(): readonly (readonly ClipperLib.IntPoint[])[];
+
+        /** The triangulation of this Region. */
+        get triangulation(): { vertices: Float32Array; indices: Uint16Array | Uint32Array };
+
+        /** The geometry of this Region. */
+        get geometry(): foundry.canvas.regions.RegionGeometry;
+
+        /** Is this Region currently visible on the Canvas? */
+        get isVisible(): boolean;
+
+        /* -------------------------------------------- */
+        /*  Rendering                                   */
+        /* -------------------------------------------- */
+
+        override _draw(options?: object): Promise<void>;
+
+        /* -------------------------------------------- */
+        /*  Incremental Refresh                         */
+        /* -------------------------------------------- */
+
+        override _applyRenderFlags(flags: Record<string, boolean>): void;
+
+        /** Refresh the state of the Region. */
+        protected _refreshState(): void;
+
+        /** Refresh the border of the Region. */
+        protected _refreshBorder(): void;
+
+        /* -------------------------------------------- */
+        /*  Shape Methods                               */
+        /* -------------------------------------------- */
+
+        /**
+         * Test whether the given point (at the given elevation) is inside this Region.
+         * @param   point         The point.
+         * @param   [elevation]   The elevation of the point.
+         * @returns               Is the point (at the given elevation) inside this Region?
+         */
+        testPoint(point: Point, elevation?: number): boolean;
+
+        /**
+         * Split the movement into its segments.
+         * @param   waypoints                  The waypoints of movement.
+         * @param   samples                    The points relative to the waypoints that are tested.
+         *                                     Whenever one of them is inside the region, the moved object
+         *                                     is considered to be inside the region.
+         * @param   [options]                  Additional options
+         * @param   [options.teleport=false]   Is it teleportation?
+         * @returns                            The movement split into its segments.
+         */
+        segmentizeMovement(
+            waypoints: RegionMovementWaypoint[],
+            samples: Point[],
+            options?: { teleport?: boolean },
+        ): RegionMovementSegment[];
+    }
+
     interface RegionMovementWaypoint {
         /** The x-coordinates in pixels (integer). */
         x: number;

--- a/types/foundry/client/pixi/placeables/token.d.ts
+++ b/types/foundry/client/pixi/placeables/token.d.ts
@@ -439,6 +439,13 @@ declare global {
         getCenter(x: number, y: number): Point;
 
         /**
+         * Get the center point for a given position or the current position.
+         * @param [position]    The position to be used instead of the current position
+         * @returns             The center point
+         */
+        getCenterPoint(position?: Point): Point;
+
+        /**
          * Set the token's position by comparing its center position vs the nearest grid vertex
          * Return a Promise that resolves to the Token once the animation for the movement has been completed
          * @param x The x-coordinate of the token center


### PR DESCRIPTION
This tries to solve the problem by overriding `Region#testPoint` to check all grid squares a token occupies if possible. Sadly this only works when a single token is moving.

[large-token.webm](https://github.com/foundryvtt/pf2e/assets/41452412/b1b447a7-9256-48b6-a8d7-53646041d4d9)
