### PR TITLE
Remove CONFIG.PF2E.skills

### DIFF
--- a/packs/backgrounds/mortuarium-survivor.json
+++ b/packs/backgrounds/mortuarium-survivor.json
@@ -36,10 +36,12 @@
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Inured to Death"
             }
         ],
-        "trainedLore": "Necromancy Lore",
         "trainedSkills": {
+            "lore": [
+                "Necromancy Lore"
+            ],
             "value": [
-                "arc"
+                "arcana"
             ]
         },
         "traits": {

--- a/packs/spells/carrion-mire.json
+++ b/packs/spells/carrion-mire.json
@@ -23,7 +23,7 @@
         },
         "duration": {
             "sustained": true,
-            "value": "sustained up to 1 minute"
+            "value": "1 minute"
         },
         "level": {
             "value": 2

--- a/packs/spells/osseous-cage.json
+++ b/packs/spells/osseous-cage.json
@@ -23,7 +23,7 @@
         },
         "duration": {
             "sustained": true,
-            "value": " sustained up to 1 minute"
+            "value": "1 minute"
         },
         "level": {
             "value": 2

--- a/src/module/actor/familiar/document.ts
+++ b/src/module/actor/familiar/document.ts
@@ -232,7 +232,7 @@ class FamiliarPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e 
             const attribute = SKILL_EXPANDED[longForm].attribute;
             const domains = [longForm, `${attribute}-based`, "skill-check", "all"];
 
-            const label = CONFIG.PF2E.skills[shortForm] ?? longForm;
+            const label = CONFIG.PF2E.skillList[longForm] ?? longForm;
             const statistic = new Statistic(this, {
                 slug: longForm,
                 label,

--- a/src/module/apps/hotbar.ts
+++ b/src/module/apps/hotbar.ts
@@ -1,8 +1,7 @@
-import { SKILL_ABBREVIATIONS } from "@actor/values.ts";
 import { ItemPF2e } from "@item";
 import { MacroPF2e } from "@module/macro.ts";
-import { createActionMacro, createSkillMacro, createToggleEffectMacro } from "@scripts/macros/hotbar.ts";
-import { ErrorPF2e, htmlClosest, isObject, tupleHasValue } from "@util";
+import { createActionMacro, createToggleEffectMacro } from "@scripts/macros/hotbar.ts";
+import { ErrorPF2e, htmlClosest, isObject } from "@util";
 
 class HotbarPF2e extends Hotbar<MacroPF2e> {
     /** Handle macro creation from non-macros */
@@ -12,7 +11,7 @@ class HotbarPF2e extends Hotbar<MacroPF2e> {
         if (!slot) return;
 
         const data: HotbarDropData = TextEditor.getDragEventData(event);
-        if (!["Item", "RollOption", "Skill", "Action"].includes(data.type ?? "")) {
+        if (!["Item", "RollOption", "Action"].includes(data.type ?? "")) {
             return super._onDrop(event);
         }
         if (Hooks.call("hotbarDrop", this, data, slot) === false) return;
@@ -52,11 +51,6 @@ class HotbarPF2e extends Hotbar<MacroPF2e> {
                 }
                 if (!this.#hasRollOptionData(data)) return;
                 return HotbarPF2e.#createRollOptionToggleMacro({ ...data, item }, slot);
-            }
-            case "Skill": {
-                if (!(data.actorId && tupleHasValue(SKILL_ABBREVIATIONS, data.skill))) return;
-                const skillName = data.skillName ?? game.i18n.localize(CONFIG.PF2E.skills[data.skill]);
-                return createSkillMacro(data.skill, skillName, data.actorId, slot);
             }
             case "Action": {
                 if (typeof data.index !== "number" && !data.elementTrait) return;

--- a/src/module/item/class/sheet.ts
+++ b/src/module/item/class/sheet.ts
@@ -10,7 +10,6 @@ export class ClassSheetPF2e extends ABCSheetPF2e<ClassPF2e> {
 
         return {
             ...sheetData,
-            skills: CONFIG.PF2E.skills,
             proficiencyChoices: CONFIG.PF2E.proficiencyLevels,
             selectedKeyAbility: this.getLocalizedAbilities(itemData.system.keyAbility),
             trainedSkills: createSheetTags(CONFIG.PF2E.skillList, itemData.system.trainedSkills),
@@ -24,7 +23,6 @@ export class ClassSheetPF2e extends ABCSheetPF2e<ClassPF2e> {
 }
 
 interface ClassSheetData extends ABCSheetData<ClassPF2e> {
-    skills: typeof CONFIG.PF2E.skills;
     proficiencyChoices: typeof CONFIG.PF2E.proficiencyLevels;
     selectedKeyAbility: Record<string, string>;
     trainedSkills: SheetOptions;

--- a/src/module/system/settings/homebrew/helpers.ts
+++ b/src/module/system/settings/homebrew/helpers.ts
@@ -7,6 +7,7 @@ import { isObject } from "@util";
 import * as R from "remeda";
 import { CustomDamageData, HomebrewTraitKey } from "./data.ts";
 import { HomebrewElements } from "./menu.ts";
+import { SKILL_ABBREVIATIONS } from "@actor/values.ts";
 
 /** User-defined type guard for checking that an object is a well-formed flag category of module-provided homebrew elements */
 function isHomebrewFlagCategory(value: unknown): value is Record<string, string | LabelAndDescription> {
@@ -45,7 +46,7 @@ function prepareReservedTerms(): ReservedTermsRecord {
         ...Object.keys(CONFIG.PF2E.resistanceTypes),
         ...Object.keys(CONFIG.PF2E.saves),
         ...Object.keys(CONFIG.PF2E.skillList),
-        ...Object.keys(CONFIG.PF2E.skills),
+        ...SKILL_ABBREVIATIONS, // will be removed once skill abbreviations are removed fully
         ...Object.keys(CONFIG.PF2E.weaknessTypes),
         ...Object.keys(CONFIG.PF2E.environmentTypes),
         "damage",

--- a/src/module/system/tag-selector/index.ts
+++ b/src/module/system/tag-selector/index.ts
@@ -14,7 +14,6 @@ const SELECTABLE_TAG_FIELDS = [
     "otherConsumableTags",
     "otherWeaponTags",
     "senses",
-    "skills",
     "skillList",
     "speedTypes",
     "vehicleTraits",

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -1,7 +1,7 @@
 import type { ActorPF2e } from "@actor";
 import { ModifierPF2e } from "@actor/modifiers.ts";
 import { ActorSheetPF2e } from "@actor/sheet/base.ts";
-import { SAVE_TYPES, SKILL_DICTIONARY, SKILL_EXPANDED } from "@actor/values.ts";
+import { SAVE_TYPES } from "@actor/values.ts";
 import { ItemPF2e, ItemSheetPF2e } from "@item";
 import { ActionTrait } from "@item/ability/types.ts";
 import { ItemSystemData } from "@item/base/data/system.ts";
@@ -643,22 +643,19 @@ class TextEditorPF2e extends TextEditor {
                     return game.i18n.localize("PF2E.PerceptionLabel");
                 default: {
                     // Skill or Lore
-                    const shortForm = (() => {
-                        if (objectHasKey(SKILL_EXPANDED, params.type)) {
-                            return SKILL_EXPANDED[params.type].shortForm;
-                        } else if (objectHasKey(SKILL_DICTIONARY, params.type)) {
-                            return params.type;
-                        }
-                        return;
-                    })();
-                    return shortForm
-                        ? game.i18n.localize(CONFIG.PF2E.skills[shortForm])
-                        : params.type
-                              .split("-")
-                              .map((word) => {
-                                  return word.slice(0, 1).toUpperCase() + word.slice(1);
-                              })
-                              .join(" ");
+                    const skillLabel = objectHasKey(CONFIG.PF2E.skillList, params.type)
+                        ? game.i18n.localize(CONFIG.PF2E.skillList[params.type])
+                        : null;
+
+                    return (
+                        skillLabel ??
+                        params.type
+                            .split("-")
+                            .map((word) => {
+                                return word.slice(0, 1).toUpperCase() + word.slice(1);
+                            })
+                            .join(" ")
+                    );
                 }
             }
         })();

--- a/src/scripts/config/index.ts
+++ b/src/scripts/config/index.ts
@@ -345,25 +345,6 @@ export const PF2ECONFIG = {
 
     checkDCs: configFromLocalization(EN_JSON.PF2E.Check.DC, "PF2E.Check.DC"),
 
-    skills: {
-        acr: "PF2E.SkillAcr",
-        arc: "PF2E.SkillArc",
-        ath: "PF2E.SkillAth",
-        cra: "PF2E.SkillCra",
-        dec: "PF2E.SkillDec",
-        dip: "PF2E.SkillDip",
-        itm: "PF2E.SkillItm",
-        med: "PF2E.SkillMed",
-        nat: "PF2E.SkillNat",
-        occ: "PF2E.SkillOcc",
-        prf: "PF2E.SkillPrf",
-        rel: "PF2E.SkillRel",
-        soc: "PF2E.SkillSoc",
-        ste: "PF2E.SkillSte",
-        sur: "PF2E.SkillSur",
-        thi: "PF2E.SkillThi",
-    },
-
     saves: {
         fortitude: "PF2E.SavesFortitude",
         reflex: "PF2E.SavesReflex",

--- a/src/scripts/macros/hotbar.ts
+++ b/src/scripts/macros/hotbar.ts
@@ -1,8 +1,6 @@
 import { ActorPF2e } from "@actor";
 import { AttackPopout } from "@actor/character/attack-popouts.ts";
 import { ElementalBlast } from "@actor/character/elemental-blast.ts";
-import type { SkillAbbreviation } from "@actor/creature/data.ts";
-import { SKILL_DICTIONARY } from "@actor/values.ts";
 import type { ConditionPF2e, EffectPF2e } from "@item";
 import { ChatMessagePF2e } from "@module/chat-message/document.ts";
 import { createSelfEffectMessage } from "@module/chat-message/helpers.ts";
@@ -164,37 +162,6 @@ export async function rollActionMacro({
     if (rollMode === "blindroll") chatData.blind = true;
 
     return ChatMessagePF2e.create(chatData);
-}
-
-export async function createSkillMacro(
-    skill: SkillAbbreviation,
-    skillName: string,
-    actorId: string,
-    slot: number,
-): Promise<void> {
-    const dictName = SKILL_DICTIONARY[skill] ?? skill;
-    const command = `
-const a = game.actors.get("${actorId}");
-if (a) {
-    const opts = a.getRollOptions(["all", "skill-check", "${dictName}"]);
-    a.system.skills["${skill}"]?.roll(event, opts);
-} else {
-    ui.notifications.error(game.i18n.localize("PF2E.MacroActionNoActorError"));
-}`;
-    const macroName = game.i18n.format("PF2E.SkillCheckWithName", { skillName });
-    const skillMacro =
-        game.macros.find((macro) => macro.name === macroName && macro.command === command) ??
-        (await MacroPF2e.create(
-            {
-                command,
-                name: macroName,
-                type: "script",
-                img: "icons/svg/d20-grey.svg",
-                flags: { pf2e: { skillMacro: true } },
-            },
-            { renderSheet: false },
-        ));
-    game.user.assignHotbarMacro(skillMacro ?? null, slot);
 }
 
 export async function createToggleEffectMacro(effect: ConditionPF2e | EffectPF2e, slot: number): Promise<void> {


### PR DESCRIPTION
Also removes unused macro code, and runs the migration again to catch new data entries. The skill list in class sheet data wasn't actually in use..