### PR TITLE
Rename SkillLongForm to SkillSlug and remove more abbreviation data

### DIFF
--- a/src/module/actor/character/data.ts
+++ b/src/module/actor/character/data.ts
@@ -25,7 +25,7 @@ import {
     StrikeData,
     TraitViewData,
 } from "@actor/data/base.ts";
-import { AttributeString, MovementType, SaveType, SkillLongForm } from "@actor/types.ts";
+import { AttributeString, MovementType, SaveType, SkillSlug } from "@actor/types.ts";
 import type { WeaponPF2e } from "@item";
 import { ArmorCategory } from "@item/armor/types.ts";
 import { ProficiencyRank } from "@item/base/data/index.ts";
@@ -70,7 +70,7 @@ interface CharacterSystemSource extends CreatureSystemSource {
     proficiencies?: {
         attacks?: Record<string, MartialProficiencySource | undefined>;
     };
-    skills: Partial<Record<SkillLongForm, { rank: ZeroToFour }>>;
+    skills: Partial<Record<SkillSlug, { rank: ZeroToFour }>>;
     resources: CharacterResourcesSource;
     initiative: CreatureInitiativeSource;
     crafting?: { formulas: CraftingFormulaData[] };

--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -24,13 +24,13 @@ import {
 } from "@actor/modifiers.ts";
 import { CheckContext } from "@actor/roll-context/check.ts";
 import { DamageContext } from "@actor/roll-context/damage.ts";
-import { AttributeString, MovementType, SkillLongForm } from "@actor/types.ts";
+import { AttributeString, MovementType, SkillSlug } from "@actor/types.ts";
 import {
     ATTRIBUTE_ABBREVIATIONS,
     SAVE_TYPES,
     SKILL_DICTIONARY_REVERSE,
     SKILL_EXPANDED,
-    SKILL_LONG_FORMS,
+    SKILL_SLUGS,
 } from "@actor/values.ts";
 import type {
     AncestryPF2e,
@@ -410,7 +410,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
         attributes.classhp = 0;
 
         // Skills
-        system.skills = R.mapToObj([...SKILL_LONG_FORMS], (key) => {
+        system.skills = R.mapToObj([...SKILL_SLUGS], (key) => {
             const rank = Math.clamp(this._source.system.skills[key]?.rank || 0, 0, 4) as ZeroToFour;
             const attribute = SKILL_EXPANDED[key].attribute;
             return [key, { rank, attribute, armor: ["dex", "str"].includes(attribute) }];
@@ -742,7 +742,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
             rollOptionsAll[`attribute:${key}:mod:${mod}`] = true;
         }
 
-        for (const key of SKILL_LONG_FORMS) {
+        for (const key of SKILL_SLUGS) {
             const rank = this.system.skills[key].rank;
             rollOptionsAll[`skill:${key}:rank:${rank}`] = true;
             // Add a backwards compatibility roll option as well, which will be removed soon
@@ -889,7 +889,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
         // rebuild the skills object to clear out any deleted or renamed skills from previous iterations
         const { synthetics, system, wornArmor } = this;
 
-        const skills = R.mapToObj([...SKILL_LONG_FORMS], (longForm) => {
+        const skills = R.mapToObj([...SKILL_SLUGS], (longForm) => {
             const skill = system.skills[longForm];
             const label = CONFIG.PF2E.skillList[longForm] ?? longForm;
 
@@ -951,7 +951,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
         // Make temporary backwards compatible short form shims
         // This will be removed very very soon
         Object.defineProperties(this.system.skills, {
-            ...R.mapToObj([...SKILL_LONG_FORMS], (longform) => {
+            ...R.mapToObj([...SKILL_SLUGS], (longform) => {
                 const shortForm = SKILL_DICTIONARY_REVERSE[longform];
                 return [shortForm, { get: () => this.skills[longform] }];
             }),
@@ -973,7 +973,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
                 check: { type: "skill-check" },
             }) as CharacterSkill<this>;
 
-            skills[longForm as SkillLongForm] = statistic;
+            skills[longForm as SkillSlug] = statistic;
             system.skills[longForm] = {
                 ...statistic.getTraceData(),
                 armor: false,

--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -5,7 +5,7 @@ import { MODIFIER_TYPES, createProficiencyModifier } from "@actor/modifiers.ts";
 import { SheetClickActionHandlers } from "@actor/sheet/base.ts";
 import { ActorSheetDataPF2e, InventoryItem } from "@actor/sheet/data-types.ts";
 import { condenseSenses } from "@actor/sheet/helpers.ts";
-import { AttributeString, SaveType, SkillLongForm } from "@actor/types.ts";
+import { AttributeString, SaveType, SkillSlug } from "@actor/types.ts";
 import { ATTRIBUTE_ABBREVIATIONS } from "@actor/values.ts";
 import type {
     AncestryPF2e,
@@ -363,7 +363,7 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
                     .localize(skillA.label ?? "")
                     .localeCompare(game.i18n.localize(skillB.label ?? ""), game.i18n.lang),
             ),
-        ) as Record<SkillLongForm, CharacterSkillData>;
+        ) as Record<SkillSlug, CharacterSkillData>;
 
         sheetData.tabVisibility = fu.deepClone(actor.flags.pf2e.sheetTabs);
 

--- a/src/module/actor/character/types.ts
+++ b/src/module/actor/character/types.ts
@@ -1,5 +1,5 @@
 import type { HitPointsSummary } from "@actor/base.ts";
-import type { SaveType, SkillLongForm } from "@actor/types.ts";
+import type { SaveType, SkillSlug } from "@actor/types.ts";
 import type { MagicTradition } from "@item/spell/types.ts";
 import type { ZeroToFour } from "@module/data.ts";
 import type { Statistic } from "@system/statistic/index.ts";
@@ -25,7 +25,7 @@ interface DexterityModifierCapData {
 /** Slugs guaranteed to return a `Statistic` when passed to `CharacterPF2e#getStatistic` */
 type GuaranteedGetStatisticSlug =
     | SaveType
-    | SkillLongForm
+    | SkillSlug
     | "perception"
     | "class-spell"
     | "class"

--- a/src/module/actor/creature/data.ts
+++ b/src/module/actor/creature/data.ts
@@ -13,7 +13,7 @@ import type {
 } from "@actor/data/base.ts";
 import type { ActorSizePF2e } from "@actor/data/size.ts";
 import type { DamageDicePF2e, ModifierPF2e, RawModifier, StatisticModifier } from "@actor/modifiers.ts";
-import type { AttributeString, MovementType, SaveType, SkillAbbreviation, SkillLongForm } from "@actor/types.ts";
+import type { AttributeString, MovementType, SaveType, SkillAbbreviation, SkillSlug } from "@actor/types.ts";
 import type { LabeledNumber, Size, ValueAndMax, ZeroToThree } from "@module/data.ts";
 import type { ArmorClassTraceData } from "@system/statistic/index.ts";
 import type { PerceptionTraceData } from "@system/statistic/perception.ts";
@@ -184,7 +184,7 @@ interface LabeledSpeed extends Omit<LabeledNumber, "exceptions"> {
 /** Creature initiative statistic */
 interface CreatureInitiativeSource {
     /** What skill or ability is currently being used to compute initiative. */
-    statistic: SkillLongForm | "perception";
+    statistic: SkillSlug | "perception";
 }
 
 interface CreatureResources extends CreatureResourcesSource {

--- a/src/module/actor/creature/document.ts
+++ b/src/module/actor/creature/document.ts
@@ -3,7 +3,7 @@ import { HitPointsSummary } from "@actor/base.ts";
 import { CreatureSource } from "@actor/data/index.ts";
 import { MODIFIER_TYPES, ModifierPF2e, RawModifier, StatisticModifier } from "@actor/modifiers.ts";
 import { ActorSpellcasting } from "@actor/spellcasting.ts";
-import { MovementType, SaveType, SkillLongForm } from "@actor/types.ts";
+import { MovementType, SaveType, SkillSlug } from "@actor/types.ts";
 import { ArmorPF2e, ItemPF2e, type PhysicalItemPF2e, type ShieldPF2e } from "@item";
 import { ArmorSource, ItemType } from "@item/base/data/index.ts";
 import { isContainerCycle } from "@item/container/helpers.ts";
@@ -195,7 +195,7 @@ abstract class CreaturePF2e<
     }
 
     /** Retrieve percpetion and spellcasting statistics */
-    override getStatistic(slug: SaveType | SkillLongForm | "perception"): Statistic<this>;
+    override getStatistic(slug: SaveType | SkillSlug | "perception"): Statistic<this>;
     override getStatistic(slug: string): Statistic<this> | null;
     override getStatistic(slug: string): Statistic | null {
         switch (slug) {

--- a/src/module/actor/data/base.ts
+++ b/src/module/actor/data/base.ts
@@ -3,7 +3,7 @@ import type { DexterityModifierCapData } from "@actor/character/types.ts";
 import type { Abilities } from "@actor/creature/data.ts";
 import type { InitiativeTraceData } from "@actor/initiative.ts";
 import type { StatisticModifier } from "@actor/modifiers.ts";
-import type { ActorAlliance, AttributeString, SkillLongForm } from "@actor/types.ts";
+import type { ActorAlliance, AttributeString, SkillSlug } from "@actor/types.ts";
 import type { MeleePF2e, WeaponPF2e } from "@item";
 import type { ItemSourcePF2e } from "@item/base/data/index.ts";
 import type { MigrationRecord, Rarity, Size, ValueAndMaybeMax, ZeroToTwo } from "@module/data.ts";
@@ -177,7 +177,7 @@ type RollFunction<T extends RollParameters = RollParameters> = (
 type DamageRollFunction = (params?: DamageRollParams) => Promise<string | Rolled<DamageRoll> | null>;
 
 interface InitiativeData extends StatisticTraceData {
-    statistic: SkillLongForm | "perception";
+    statistic: SkillSlug | "perception";
     /**
      * If a pair of initiative rolls are tied, the next resolution step is the tiebreak priority. A lower value
      * constitutes a higher priority.

--- a/src/module/actor/familiar/document.ts
+++ b/src/module/actor/familiar/document.ts
@@ -5,7 +5,7 @@ import { ActorSizePF2e } from "@actor/data/size.ts";
 import { createEncounterRollOptions, setHitPointsRollOptions } from "@actor/helpers.ts";
 import { ModifierPF2e, applyStackingRules } from "@actor/modifiers.ts";
 import { SaveType } from "@actor/types.ts";
-import { SAVE_TYPES, SKILL_DICTIONARY_REVERSE, SKILL_EXPANDED, SKILL_LONG_FORMS } from "@actor/values.ts";
+import { SAVE_TYPES, SKILL_DICTIONARY_REVERSE, SKILL_EXPANDED, SKILL_SLUGS } from "@actor/values.ts";
 import type { ItemType } from "@item/base/data/index.ts";
 import type { CombatantPF2e, EncounterPF2e } from "@module/encounter/index.ts";
 import type { RuleElementPF2e } from "@module/rules/index.ts";
@@ -221,7 +221,7 @@ class FamiliarPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e 
         system.perception = fu.mergeObject(this.perception.getTraceData(), { attribute: "wis" as const });
 
         // Skills
-        this.skills = [...SKILL_LONG_FORMS].reduce((builtSkills: Record<string, Statistic<this>>, skill) => {
+        this.skills = [...SKILL_SLUGS].reduce((builtSkills: Record<string, Statistic<this>>, skill) => {
             const modifiers = [new ModifierPF2e("PF2E.MasterLevel", masterLevel, "untyped")];
             if (["acrobatics", "stealth"].includes(skill)) {
                 const label = `PF2E.MasterAbility.${system.master.ability}`;
@@ -251,7 +251,7 @@ class FamiliarPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e 
         // Make temporary backwards compatible short form shims
         // This will be removed very very soon
         Object.defineProperties(this.system.skills, {
-            ...R.mapToObj([...SKILL_LONG_FORMS], (longform) => {
+            ...R.mapToObj([...SKILL_SLUGS], (longform) => {
                 const shortForm = SKILL_DICTIONARY_REVERSE[longform];
                 return [shortForm, { get: () => this.skills[longform] }];
             }),

--- a/src/module/actor/npc/document.ts
+++ b/src/module/actor/npc/document.ts
@@ -4,7 +4,7 @@ import { setHitPointsRollOptions, strikeFromMeleeItem } from "@actor/helpers.ts"
 import { ActorInitiative } from "@actor/initiative.ts";
 import { ModifierPF2e, StatisticModifier } from "@actor/modifiers.ts";
 import type { AttributeString, SaveType } from "@actor/types.ts";
-import { SAVE_TYPES, SKILL_EXPANDED, SKILL_LONG_FORMS } from "@actor/values.ts";
+import { SAVE_TYPES, SKILL_EXPANDED, SKILL_SLUGS } from "@actor/values.ts";
 import type { ItemPF2e, LorePF2e, MeleePF2e } from "@item";
 import type { ItemType } from "@item/base/data/index.ts";
 import { calculateDC } from "@module/dc.ts";
@@ -320,7 +320,7 @@ class NPCPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | nul
         const modifierAdjustments = this.synthetics.modifierAdjustments;
 
         const trainedSkills = R.mapToObj(this.itemTypes.lore, (s) => [sluggify(s.name), s]);
-        const coreSkillSlugs = Array.from(SKILL_LONG_FORMS);
+        const coreSkillSlugs = Array.from(SKILL_SLUGS);
         const skillOrNull = {
             ...R.mapToObj(coreSkillSlugs, (s) => [s, trainedSkills[s] ?? null]),
             ...R.omit(trainedSkills, coreSkillSlugs),

--- a/src/module/actor/npc/skills-editor.ts
+++ b/src/module/actor/npc/skills-editor.ts
@@ -1,6 +1,6 @@
 import type { NPCPF2e } from "@actor";
 import { NPCSkillData } from "@actor/npc/data.ts";
-import { SKILL_LONG_FORMS } from "@actor/values.ts";
+import { SKILL_SLUGS } from "@actor/values.ts";
 import { LoreSource } from "@item/base/data/index.ts";
 import { htmlClosest, htmlQuery, htmlQueryAll, setHasElement } from "@util";
 
@@ -46,7 +46,7 @@ export class NPCSkillsEditor extends DocumentSheet<NPCPF2e> {
 
         htmlQuery(html, "button[data-action=add-skill]")?.addEventListener("click", async (event) => {
             const slug = htmlQuery(htmlClosest(event.currentTarget, ".skill-selector"), "select")?.value;
-            if (setHasElement(SKILL_LONG_FORMS, slug)) {
+            if (setHasElement(SKILL_SLUGS, slug)) {
                 await this.actor.createEmbeddedDocuments("Item", [{ name: slug.titleCase(), type: "lore" }]);
             }
         });

--- a/src/module/actor/party/sheet.ts
+++ b/src/module/actor/party/sheet.ts
@@ -6,7 +6,7 @@ import { ActorSheetPF2e } from "@actor/sheet/base.ts";
 import { ActorSheetDataPF2e, ActorSheetRenderOptionsPF2e } from "@actor/sheet/data-types.ts";
 import { condenseSenses } from "@actor/sheet/helpers.ts";
 import { DistributeCoinsPopup } from "@actor/sheet/popups/distribute-coins-popup.ts";
-import { SKILL_LONG_FORMS } from "@actor/values.ts";
+import { SKILL_SLUGS } from "@actor/values.ts";
 import { ItemPF2e } from "@item";
 import { ItemSourcePF2e } from "@item/base/data/index.ts";
 import { Bulk } from "@item/physical/index.ts";
@@ -235,7 +235,7 @@ class PartySheetPF2e extends ActorSheetPF2e<PartyPF2e> {
                 (l) => l.label,
             ),
             skills: R.sortBy(
-                Array.from(SKILL_LONG_FORMS).map((slug): SkillData => {
+                Array.from(SKILL_SLUGS).map((slug): SkillData => {
                     const best = getBestSkill(slug);
                     const label = game.i18n.localize(CONFIG.PF2E.skillList[slug]);
                     return best ?? { mod: 0, label, slug, rank: 0 };

--- a/src/module/actor/types.ts
+++ b/src/module/actor/types.ts
@@ -16,8 +16,8 @@ import type {
     DC_SLUGS,
     MOVEMENT_TYPES,
     SAVE_TYPES,
-    SKILL_ABBREVIATIONS,
-    SKILL_LONG_FORMS,
+    SKILL_DICTIONARY,
+    SKILL_SLUGS,
     UNAFFECTED_TYPES,
 } from "./values.ts";
 
@@ -47,8 +47,8 @@ interface ActorDimensions {
     height: number;
 }
 
-type SkillAbbreviation = (typeof SKILL_ABBREVIATIONS)[number];
-type SkillLongForm = SetElement<typeof SKILL_LONG_FORMS>;
+type SkillAbbreviation = keyof typeof SKILL_DICTIONARY;
+type SkillSlug = SetElement<typeof SKILL_SLUGS>;
 
 type ActorAlliance = "party" | "opposition" | null;
 
@@ -139,7 +139,7 @@ export type {
     ResistanceType,
     SaveType,
     SkillAbbreviation,
-    SkillLongForm,
+    SkillSlug,
     UnaffectedType,
     WeaknessType,
 };

--- a/src/module/actor/values.ts
+++ b/src/module/actor/values.ts
@@ -1,5 +1,5 @@
 import { SkillAbbreviation } from "@actor/creature/data.ts";
-import { AttributeString, ImmunityType, ResistanceType, SkillLongForm, WeaknessType } from "@actor/types.ts";
+import { AttributeString, ImmunityType, ResistanceType, SkillSlug, WeaknessType } from "@actor/types.ts";
 import { immunityTypes, resistanceTypes, weaknessTypes } from "@scripts/config/iwr.ts";
 
 const ATTRIBUTE_ABBREVIATIONS = new Set(["str", "dex", "con", "int", "wis", "cha"] as const);
@@ -17,25 +17,6 @@ const WEAKNESS_TYPES = new Set(Object.keys(weaknessTypes)) as Set<WeaknessType>;
 const RESISTANCE_TYPES = new Set(Object.keys(resistanceTypes)) as Set<ResistanceType>;
 
 const UNAFFECTED_TYPES = new Set(["bleed", "good", "evil", "lawful", "chaotic", "spirit", "vitality", "void"] as const);
-
-const SKILL_ABBREVIATIONS = [
-    "acr",
-    "arc",
-    "ath",
-    "cra",
-    "dec",
-    "dip",
-    "itm",
-    "med",
-    "nat",
-    "occ",
-    "prf",
-    "rel",
-    "soc",
-    "ste",
-    "sur",
-    "thi",
-] as const;
 
 const SKILL_DICTIONARY = {
     acr: "acrobatics",
@@ -56,36 +37,35 @@ const SKILL_DICTIONARY = {
     thi: "thievery",
 } as const;
 
-const SKILL_LONG_FORMS = new Set(Object.values(SKILL_DICTIONARY));
+const SKILL_SLUGS = new Set(Object.values(SKILL_DICTIONARY));
 
 const SKILL_DICTIONARY_REVERSE = Object.fromEntries(
-    Object.entries(SKILL_DICTIONARY).map(([abbrev, value]) => [value, abbrev] as [SkillLongForm, SkillAbbreviation]),
+    Object.entries(SKILL_DICTIONARY).map(([abbrev, value]) => [value, abbrev] as [SkillSlug, SkillAbbreviation]),
 );
 
-const DC_SLUGS = new Set(["ac", "armor", "perception", ...SAVE_TYPES, ...SKILL_LONG_FORMS] as const);
+const DC_SLUGS = new Set(["ac", "armor", "perception", ...SAVE_TYPES, ...SKILL_SLUGS] as const);
 
 interface SkillExpanded {
     attribute: AttributeString;
-    shortForm: SkillAbbreviation;
 }
 
-const SKILL_EXPANDED: Record<SkillLongForm, SkillExpanded> = {
-    acrobatics: { attribute: "dex", shortForm: "acr" },
-    arcana: { attribute: "int", shortForm: "arc" },
-    athletics: { attribute: "str", shortForm: "ath" },
-    crafting: { attribute: "int", shortForm: "cra" },
-    deception: { attribute: "cha", shortForm: "dec" },
-    diplomacy: { attribute: "cha", shortForm: "dip" },
-    intimidation: { attribute: "cha", shortForm: "itm" },
-    medicine: { attribute: "wis", shortForm: "med" },
-    nature: { attribute: "wis", shortForm: "nat" },
-    occultism: { attribute: "int", shortForm: "occ" },
-    performance: { attribute: "cha", shortForm: "prf" },
-    religion: { attribute: "wis", shortForm: "rel" },
-    society: { attribute: "int", shortForm: "soc" },
-    stealth: { attribute: "dex", shortForm: "ste" },
-    survival: { attribute: "wis", shortForm: "sur" },
-    thievery: { attribute: "dex", shortForm: "thi" },
+const SKILL_EXPANDED: Record<SkillSlug, SkillExpanded> = {
+    acrobatics: { attribute: "dex" },
+    arcana: { attribute: "int" },
+    athletics: { attribute: "str" },
+    crafting: { attribute: "int" },
+    deception: { attribute: "cha" },
+    diplomacy: { attribute: "cha" },
+    intimidation: { attribute: "cha" },
+    medicine: { attribute: "wis" },
+    nature: { attribute: "wis" },
+    occultism: { attribute: "int" },
+    performance: { attribute: "cha" },
+    religion: { attribute: "wis" },
+    society: { attribute: "int" },
+    stealth: { attribute: "dex" },
+    survival: { attribute: "wis" },
+    thievery: { attribute: "dex" },
 };
 
 const MOVEMENT_TYPES = ["land", "burrow", "climb", "fly", "swim"] as const;
@@ -103,11 +83,10 @@ export {
     RESISTANCE_TYPES,
     SAVE_TYPES,
     SIZE_LINKABLE_ACTOR_TYPES,
-    SKILL_ABBREVIATIONS,
     SKILL_DICTIONARY,
     SKILL_DICTIONARY_REVERSE,
     SKILL_EXPANDED,
-    SKILL_LONG_FORMS,
+    SKILL_SLUGS,
     UNAFFECTED_TYPES,
     WEAKNESS_TYPES,
 };

--- a/src/module/encounter/combatant.ts
+++ b/src/module/encounter/combatant.ts
@@ -1,5 +1,5 @@
 import type { ActorPF2e } from "@actor";
-import type { SkillLongForm } from "@actor/types.ts";
+import type { SkillSlug } from "@actor/types.ts";
 import type { TokenDocumentPF2e } from "@scene/index.ts";
 import { ErrorPF2e } from "@util";
 import type { EncounterPF2e } from "./index.ts";
@@ -288,7 +288,7 @@ interface CombatantPF2e<
 
 interface CombatantFlags extends DocumentFlags {
     pf2e: {
-        initiativeStatistic: SkillLongForm | "perception" | null;
+        initiativeStatistic: SkillSlug | "perception" | null;
         roundOfLastTurn: number | null;
         roundOfLastTurnEnd: number | null;
         overridePriority: Record<number, number | null | undefined>;

--- a/src/module/encounter/document.ts
+++ b/src/module/encounter/document.ts
@@ -3,8 +3,8 @@ import type { CharacterSheetPF2e } from "@actor/character/sheet.ts";
 import { RollInitiativeOptionsPF2e } from "@actor/data/index.ts";
 import { isReallyPC, resetActors } from "@actor/helpers.ts";
 import { InitiativeRollResult } from "@actor/initiative.ts";
-import { SkillLongForm } from "@actor/types.ts";
-import { SKILL_LONG_FORMS } from "@actor/values.ts";
+import { SkillSlug } from "@actor/types.ts";
+import { SKILL_SLUGS } from "@actor/values.ts";
 import type { ScenePF2e, TokenDocumentPF2e } from "@scene/index.ts";
 import { calculateXP } from "@scripts/macros/index.ts";
 import { ThreatRating } from "@scripts/macros/xp/index.ts";
@@ -179,8 +179,7 @@ class EncounterPF2e extends Combat {
                       value: result.roll.total,
                       statistic:
                           result.roll.options.domains?.find(
-                              (s): s is SkillLongForm | "perception" =>
-                                  setHasElement(SKILL_LONG_FORMS, s) || s === "perception",
+                              (s): s is SkillSlug | "perception" => setHasElement(SKILL_SLUGS, s) || s === "perception",
                           ) ?? null,
                   }
                 : [],
@@ -375,7 +374,7 @@ interface EncounterMetrics {
 interface SetInitiativeData {
     id: string;
     value: number;
-    statistic?: SkillLongForm | "perception" | null;
+    statistic?: SkillSlug | "perception" | null;
     overridePriority?: number | null;
 }
 

--- a/src/module/item/background/data.ts
+++ b/src/module/item/background/data.ts
@@ -1,4 +1,4 @@
-import { AttributeString, SkillLongForm } from "@actor/types.ts";
+import { AttributeString, SkillSlug } from "@actor/types.ts";
 import { ABCSystemData, ABCSystemSource } from "@item/abc/data.ts";
 import { BaseItemSourcePF2e, ItemTraits } from "@item/base/data/system.ts";
 import { BackgroundTrait } from "./types.ts";
@@ -9,7 +9,7 @@ interface BackgroundSystemSource extends ABCSystemSource {
     traits: BackgroundTraits;
     boosts: Record<number, { value: AttributeString[]; selected: AttributeString | null }>;
     trainedSkills: {
-        value: SkillLongForm[];
+        value: SkillSlug[];
         lore: string[];
     };
     level?: never;

--- a/src/module/item/class/data.ts
+++ b/src/module/item/class/data.ts
@@ -1,4 +1,4 @@
-import { AttributeString, SaveType, SkillLongForm } from "@actor/types.ts";
+import { AttributeString, SaveType, SkillSlug } from "@actor/types.ts";
 import { ABCSystemData, ABCSystemSource } from "@item/abc/data.ts";
 import { BaseItemSourcePF2e, RarityTraitAndOtherTags } from "@item/base/data/system.ts";
 import { ZeroToFour } from "@module/data.ts";
@@ -16,7 +16,7 @@ interface ClassSystemSource extends ABCSystemSource {
     /** Starting proficiency in "spell attack rolls and DCs" */
     spellcasting: ZeroToFour;
     trainedSkills: {
-        value: SkillLongForm[];
+        value: SkillSlug[];
         additional: number;
     };
     ancestryFeatLevels: { value: number[] };

--- a/src/module/item/class/document.ts
+++ b/src/module/item/class/document.ts
@@ -2,7 +2,7 @@ import type { ActorPF2e, CharacterPF2e } from "@actor";
 import { ClassDCData } from "@actor/character/data.ts";
 import { FeatSlotCreationData } from "@actor/character/feats.ts";
 import { SaveType } from "@actor/types.ts";
-import { SAVE_TYPES, SKILL_LONG_FORMS } from "@actor/values.ts";
+import { SAVE_TYPES, SKILL_SLUGS } from "@actor/values.ts";
 import { ABCItemPF2e, FeatPF2e } from "@item";
 import { ArmorCategory } from "@item/armor/index.ts";
 import { ARMOR_CATEGORIES } from "@item/armor/values.ts";
@@ -134,7 +134,7 @@ class ClassPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends ABC
         }
 
         for (const trainedSkill of this.system.trainedSkills.value) {
-            if (SKILL_LONG_FORMS.has(trainedSkill)) {
+            if (SKILL_SLUGS.has(trainedSkill)) {
                 skills[trainedSkill].rank = Math.max(skills[trainedSkill].rank, 1) as ZeroToFour;
             }
         }

--- a/src/module/item/deity/data.ts
+++ b/src/module/item/deity/data.ts
@@ -1,4 +1,4 @@
-import { SkillLongForm } from "@actor/types.ts";
+import { SkillSlug } from "@actor/types.ts";
 import { AttributeString } from "@actor/types.ts";
 import { BaseItemSourcePF2e, ItemSystemData, ItemSystemSource, OtherTagsOnly } from "@item/base/data/system.ts";
 import { BaseWeaponType } from "@item/weapon/types.ts";
@@ -15,7 +15,7 @@ type DeitySystemSource = ItemSystemSource & {
     };
     font: DivineFonts;
     attribute: AttributeString[];
-    skill: SkillLongForm[] | null;
+    skill: SkillSlug[] | null;
     weapons: BaseWeaponType[];
     spells: Record<number, ItemUUID>;
     level?: never;

--- a/src/module/item/deity/sheet.ts
+++ b/src/module/item/deity/sheet.ts
@@ -1,4 +1,4 @@
-import type { SkillLongForm } from "@actor/types.ts";
+import type { SkillSlug } from "@actor/types.ts";
 import { ItemPF2e, SpellPF2e, type DeityPF2e } from "@item";
 import { ItemSheetDataPF2e, ItemSheetOptions, ItemSheetPF2e } from "@item/base/sheet/sheet.ts";
 import { SheetOptions, createSheetOptions } from "@module/sheet/helpers.ts";
@@ -174,7 +174,7 @@ export class DeitySheetPF2e extends ItemSheetPF2e<DeityPF2e> {
 interface DeitySheetData extends ItemSheetDataPF2e<DeityPF2e> {
     categories: FormSelectOption[];
     sanctifications: FormSelectOption[];
-    skills: Record<SkillLongForm, string>;
+    skills: Record<SkillSlug, string>;
     divineFonts: SheetOptions;
     spells: SpellBrief[];
 }

--- a/src/module/item/identification.ts
+++ b/src/module/item/identification.ts
@@ -1,4 +1,4 @@
-import { SkillLongForm } from "@actor/types.ts";
+import { SkillSlug } from "@actor/types.ts";
 import { Rarity } from "@module/data.ts";
 import { setHasElement } from "@util";
 import { adjustDCByRarity, calculateDC, DCOptions } from "../dc.ts";
@@ -23,7 +23,7 @@ function getMagicTraditions(item: PhysicalItemPF2e): Set<MagicTradition> {
     return new Set(traits.filter((t): t is MagicTradition => setHasElement(MAGIC_TRADITIONS, t)));
 }
 
-type MagicSkill = Extract<SkillLongForm, "arcana" | "nature" | "religion" | "occultism">;
+type MagicSkill = Extract<SkillSlug, "arcana" | "nature" | "religion" | "occultism">;
 
 /** All cursed items are incredibly hard to identify */
 function getDcRarity(item: PhysicalItemPF2e): Rarity {

--- a/src/module/item/spellcasting-entry/trick.ts
+++ b/src/module/item/spellcasting-entry/trick.ts
@@ -1,6 +1,6 @@
 import { ActorPF2e } from "@actor";
 import { createProficiencyModifier } from "@actor/modifiers.ts";
-import { AttributeString, SkillLongForm } from "@actor/types.ts";
+import { AttributeString, SkillSlug } from "@actor/types.ts";
 import { SpellPF2e } from "@item";
 import { MagicTradition } from "@item/spell/types.ts";
 import { extractModifiers } from "@module/rules/helpers.ts";
@@ -33,7 +33,7 @@ class TrickMagicItemEntry<TActor extends ActorPF2e = ActorPF2e> implements Spell
 
     actor: TActor;
 
-    skill: SkillLongForm;
+    skill: SkillSlug;
 
     statistic: Statistic;
 

--- a/src/module/migration/migrations/749-assurance-res.ts
+++ b/src/module/migration/migrations/749-assurance-res.ts
@@ -1,5 +1,5 @@
-import { SkillLongForm } from "@actor/types.ts";
-import { SKILL_LONG_FORMS } from "@actor/values.ts";
+import { SkillSlug } from "@actor/types.ts";
+import { SKILL_SLUGS } from "@actor/values.ts";
 import { ItemSourcePF2e } from "@item/base/data/index.ts";
 import { RuleElementSource } from "@module/rules/index.ts";
 import { ChoiceSetSource } from "@module/rules/rule-element/choice-set/data.ts";
@@ -13,7 +13,7 @@ export class Migration749AssuranceREs extends MigrationBase {
         return rule.key === "ChoiceSet";
     }
 
-    #newRules(skill: SkillLongForm | "choice"): RuleElementSource[] {
+    #newRules(skill: SkillSlug | "choice"): RuleElementSource[] {
         const selector = skill === "choice" ? "{item|flags.pf2e.rulesSelections.assurance}" : skill;
         const rules = [
             {
@@ -49,7 +49,7 @@ export class Migration749AssuranceREs extends MigrationBase {
             rules.push(...this.#newRules("choice"));
         } else if (rules.length === 0) {
             const skill = /^assurance-([a-z]+)$/.exec(slug)?.at(1);
-            if (setHasElement(SKILL_LONG_FORMS, skill)) {
+            if (setHasElement(SKILL_SLUGS, skill)) {
                 rules.push(...this.#newRules(skill));
             }
         }

--- a/src/module/migration/migrations/914-move-perception-senses.ts
+++ b/src/module/migration/migrations/914-move-perception-senses.ts
@@ -4,7 +4,7 @@ import { SENSES_WITH_MANDATORY_ACUITIES, SENSES_WITH_UNLIMITED_RANGE, SENSE_TYPE
 import { ActorSourcePF2e, CharacterSource } from "@actor/data/index.ts";
 import { NPCPerceptionSource } from "@actor/npc/data.ts";
 import { SaveType } from "@actor/types.ts";
-import { SAVE_TYPES, SKILL_LONG_FORMS } from "@actor/values.ts";
+import { SAVE_TYPES, SKILL_SLUGS } from "@actor/values.ts";
 import { ARMOR_CATEGORIES } from "@item/armor/values.ts";
 import { AncestrySource, FeatSource, ItemSourcePF2e } from "@item/base/data/index.ts";
 import { HeritageSource } from "@item/heritage/data.ts";
@@ -25,7 +25,7 @@ export class Migration914MovePerceptionSenses extends MigrationBase {
                 if (
                     R.isObject(attributes.initiative) &&
                     "statistic" in attributes.initiative &&
-                    setHasElement(SKILL_LONG_FORMS, attributes.initiative.statistic)
+                    setHasElement(SKILL_SLUGS, attributes.initiative.statistic)
                 ) {
                     source.system.initiative.statistic = attributes.initiative.statistic;
                 }

--- a/src/module/migration/migrations/927-class-background-skill-longform.ts
+++ b/src/module/migration/migrations/927-class-background-skill-longform.ts
@@ -1,7 +1,7 @@
 import { BackgroundSource, ClassSource, ItemSourcePF2e } from "@item/base/data/index.ts";
 import { MigrationBase } from "../base.ts";
 import { ClassSystemSource } from "@item/class/data.ts";
-import { SkillLongForm } from "@actor/types.ts";
+import { SkillSlug } from "@actor/types.ts";
 import { BackgroundSystemSource } from "@item/background/data.ts";
 import { BattleFormSource } from "@module/rules/rule-element/battle-form/types.ts";
 import { objectHasKey } from "@util";
@@ -29,7 +29,7 @@ export class Migration927ClassBackgroundBattleFormSkillLongform extends Migratio
     #updateBattleForm(rule: BattleFormSource) {
         if (!rule.overrides?.skills) return;
 
-        const skills: Partial<Record<SkillLongForm | SkillAbbreviation, unknown>> = rule.overrides.skills;
+        const skills: Partial<Record<SkillSlug | SkillAbbreviation, unknown>> = rule.overrides.skills;
         for (const [key, value] of Object.entries(skills)) {
             if (objectHasKey(SKILL_DICTIONARY, key)) {
                 skills[SKILL_DICTIONARY[key]] = value;
@@ -40,13 +40,13 @@ export class Migration927ClassBackgroundBattleFormSkillLongform extends Migratio
 
     #updateClass(source: ClassSource) {
         const system: ClassSystemSourceMaybeOld = source.system;
-        const mapping: Record<string, SkillLongForm | undefined> = SKILL_DICTIONARY;
+        const mapping: Record<string, SkillSlug | undefined> = SKILL_DICTIONARY;
         system.trainedSkills.value = system.trainedSkills.value.map((s) => mapping[s] ?? s);
     }
 
     #updateBackground(source: BackgroundSource) {
         const system: BackgroundSystemSourceMaybeOld = source.system;
-        const mapping: Record<string, SkillLongForm | undefined> = SKILL_DICTIONARY;
+        const mapping: Record<string, SkillSlug | undefined> = SKILL_DICTIONARY;
         system.trainedSkills.value = system.trainedSkills.value.map((s) => mapping[s] ?? s);
         if ("trainedLore" in system) {
             // Move lores and convert to array. Lore entry may not exist in source data
@@ -82,7 +82,7 @@ export const SKILL_ABBREVIATIONS = R.keys.strict(SKILL_DICTIONARY);
 
 interface ClassSystemSourceMaybeOld extends Omit<ClassSystemSource, "trainedSkills"> {
     trainedSkills: {
-        value: (SkillAbbreviation | SkillLongForm)[];
+        value: (SkillAbbreviation | SkillSlug)[];
     };
 }
 
@@ -90,7 +90,7 @@ interface BackgroundSystemSourceMaybeOld extends Omit<BackgroundSystemSource, "t
     trainedLore?: string;
     "-=trainedLore"?: null;
     trainedSkills: {
-        value: (SkillAbbreviation | SkillLongForm)[];
+        value: (SkillAbbreviation | SkillSlug)[];
         lore: string[];
     };
 }

--- a/src/module/migration/migrations/928-character-skills-longform.ts
+++ b/src/module/migration/migrations/928-character-skills-longform.ts
@@ -1,5 +1,5 @@
 import { MigrationBase } from "../base.ts";
-import { SkillLongForm } from "@actor/types.ts";
+import { SkillSlug } from "@actor/types.ts";
 import { objectHasKey, recursiveReplaceString } from "@util";
 import { CharacterSystemSource } from "@actor/character/data.ts";
 import { ActorSourcePF2e } from "@actor/data/index.ts";
@@ -54,6 +54,6 @@ export class Migration928CharacterSkillsLongform extends MigrationBase {
 }
 
 interface CharacterSystemSourceMaybeOld extends CharacterSystemSource {
-    skills: Partial<Record<SkillLongForm | SkillAbbreviation, { rank: ZeroToFour }>> &
+    skills: Partial<Record<SkillSlug | SkillAbbreviation, { rank: ZeroToFour }>> &
         Partial<Record<`-=${SkillAbbreviation}`, null>>;
 }

--- a/src/module/recall-knowledge.ts
+++ b/src/module/recall-knowledge.ts
@@ -1,6 +1,6 @@
 import { NPCPF2e } from "@actor";
 import { CreatureTrait } from "@actor/creature/types.ts";
-import { SkillLongForm } from "@actor/types.ts";
+import { SkillSlug } from "@actor/types.ts";
 import { Rarity } from "@module/data.ts";
 import {
     adjustDC,
@@ -21,7 +21,7 @@ import {
  * See https://www.youtube.com/watch?v=UtNS1vM7czM for interpretations
  */
 
-const identifySkills = new Map<CreatureTrait, SkillLongForm[]>([
+const identifySkills = new Map<CreatureTrait, SkillSlug[]>([
     ["aberration", ["occultism"]],
     ["animal", ["nature"]],
     ["astral", ["occultism"]],
@@ -74,7 +74,7 @@ interface RecallKnowledgeDC {
 }
 
 interface CreatureIdentificationData {
-    skills: SkillLongForm[];
+    skills: SkillSlug[];
     standard: RecallKnowledgeDC;
     lore: [RecallKnowledgeDC, RecallKnowledgeDC];
 }

--- a/src/module/rules/rule-element/ae-like.ts
+++ b/src/module/rules/rule-element/ae-like.ts
@@ -1,4 +1,4 @@
-import { SKILL_ABBREVIATIONS, SKILL_DICTIONARY } from "@actor/values.ts";
+import { SKILL_DICTIONARY } from "@actor/values.ts";
 import { isObject, objectHasKey } from "@util";
 import * as R from "remeda";
 import type { BooleanField, StringField } from "types/foundry/common/data/fields.d.ts";
@@ -54,7 +54,7 @@ class AELikeRuleElement<TSchema extends AELikeSchema> extends RuleElementPF2e<TS
      * Temporary solution until skill data has fully migrated to long form
      */
     static #SKILL_SHORT_FORM_PATH = ((): RegExp => {
-        const skillShortForms = Array.from(SKILL_ABBREVIATIONS).join("|");
+        const skillShortForms = R.keys.strict(SKILL_DICTIONARY).join("|");
         return new RegExp(String.raw`^system\.skills\.(${skillShortForms})\b`);
     })();
 

--- a/src/module/rules/rule-element/battle-form/rule-element.ts
+++ b/src/module/rules/rule-element/battle-form/rule-element.ts
@@ -3,7 +3,7 @@ import { CharacterStrike } from "@actor/character/data.ts";
 import { SENSE_TYPES } from "@actor/creature/values.ts";
 import { ActorInitiative } from "@actor/initiative.ts";
 import { DamageDicePF2e, ModifierPF2e, StatisticModifier } from "@actor/modifiers.ts";
-import { MOVEMENT_TYPES, SKILL_LONG_FORMS } from "@actor/values.ts";
+import { MOVEMENT_TYPES, SKILL_SLUGS } from "@actor/values.ts";
 import { WeaponPF2e } from "@item";
 import { RollNotePF2e } from "@module/notes.ts";
 import { Predicate } from "@system/predication.ts";
@@ -255,7 +255,7 @@ class BattleFormRuleElement extends RuleElementPF2e<BattleFormRuleSchema> {
 
         // Inform predicates that this battle form grants a skill modifier
         for (const key of Object.keys(this.overrides.skills)) {
-            if (!setHasElement(SKILL_LONG_FORMS, key)) continue;
+            if (!setHasElement(SKILL_SLUGS, key)) continue;
             rollOptions.all[`battle-form:${key}`] = true;
         }
 
@@ -341,7 +341,7 @@ class BattleFormRuleElement extends RuleElementPF2e<BattleFormRuleSchema> {
     #prepareSkills(): void {
         const actor = this.actor;
         for (const [key, newSkill] of Object.entries(this.overrides.skills)) {
-            if (!setHasElement(SKILL_LONG_FORMS, key)) {
+            if (!setHasElement(SKILL_SLUGS, key)) {
                 return this.failValidation(`Unrecognized skill: ${key}`);
             }
             newSkill.ownIfHigher ??= true;

--- a/src/module/rules/rule-element/battle-form/types.ts
+++ b/src/module/rules/rule-element/battle-form/types.ts
@@ -1,5 +1,5 @@
 import type { CreatureTrait, SenseAcuity, SenseType } from "@actor/creature/index.ts";
-import type { AttributeString, MovementType, SkillLongForm } from "@actor/types.ts";
+import type { AttributeString, MovementType, SkillSlug } from "@actor/types.ts";
 import type { WeaponDamage } from "@item/weapon/data.ts";
 import type { BaseWeaponType, WeaponCategory, WeaponGroup, WeaponTrait } from "@item/weapon/types.ts";
 import type { Size } from "@module/data.ts";
@@ -48,7 +48,7 @@ interface BattleFormSkill {
 }
 
 type BattleFormSenses = { [K in SenseType]?: BattleFormSense };
-type BattleFormSkills = { [K in SkillLongForm]?: BattleFormSkill };
+type BattleFormSkills = { [K in SkillSlug]?: BattleFormSkill };
 type BattleFormSpeeds = { [K in MovementType]?: number };
 
 interface BattleFormStrike {

--- a/src/module/rules/rule-element/fixed-proficiency.ts
+++ b/src/module/rules/rule-element/fixed-proficiency.ts
@@ -1,9 +1,9 @@
 import type { ActorType, CharacterPF2e } from "@actor";
 import { ModifierPF2e } from "@actor/modifiers.ts";
 import { AttributeString } from "@actor/types.ts";
-import { ATTRIBUTE_ABBREVIATIONS, SKILL_ABBREVIATIONS, SKILL_EXPANDED } from "@actor/values.ts";
+import { ATTRIBUTE_ABBREVIATIONS } from "@actor/values.ts";
 import { Predicate } from "@system/predication.ts";
-import { sluggify, tupleHasValue } from "@util";
+import { objectHasKey, sluggify } from "@util";
 import type { StringField } from "types/foundry/common/data/fields.d.ts";
 import { RuleElementPF2e } from "./base.ts";
 import { ModelPropsFromRESchema, ResolvableValueField, RuleElementSchema } from "./data.ts";
@@ -48,14 +48,12 @@ class FixedProficiencyRuleElement extends RuleElementPF2e<FixedProficiencyRuleSc
 
     override afterPrepareData(): void {
         const selector = this.resolveInjectedProperties(this.selector);
-        const systemData = this.actor.system;
-        const skillLongForms: Record<string, { shortForm?: string } | undefined> = SKILL_EXPANDED;
-        const proficiency = skillLongForms[selector]?.shortForm ?? selector;
-        const statistic = tupleHasValue(SKILL_ABBREVIATIONS, proficiency)
-            ? this.actor.skills[proficiency]
-            : proficiency === "ac"
-              ? systemData.attributes.ac
-              : null;
+        const statistic =
+            selector === "ac"
+                ? this.actor.system.attributes.ac
+                : objectHasKey(this.actor.skills, selector)
+                  ? this.actor.skills[selector]
+                  : null;
 
         if (statistic) {
             const toIgnore = statistic.modifiers.filter((m) => m.type === "proficiency" && m.slug !== this.slug);

--- a/src/module/rules/rule-element/special-statistic.ts
+++ b/src/module/rules/rule-element/special-statistic.ts
@@ -1,7 +1,7 @@
 import type { CreaturePF2e } from "@actor";
 import { ModifierPF2e } from "@actor/modifiers.ts";
 import { AttributeString } from "@actor/types.ts";
-import { ATTRIBUTE_ABBREVIATIONS, SAVE_TYPES, SKILL_LONG_FORMS } from "@actor/values.ts";
+import { ATTRIBUTE_ABBREVIATIONS, SAVE_TYPES, SKILL_SLUGS } from "@actor/values.ts";
 import { MagicTradition } from "@item/spell/types.ts";
 import { ItemSpellcasting } from "@item/spellcasting-entry/item-spellcasting.ts";
 import { Predicate, RawPredicate } from "@system/predication.ts";
@@ -31,7 +31,7 @@ class SpecialStatisticRuleElement extends RuleElementPF2e<SpecialStatisticSchema
                     !(
                         v in CONFIG.PF2E.magicTraditions ||
                         v in CONFIG.PF2E.classTraits ||
-                        setHasElement(SKILL_LONG_FORMS, v) ||
+                        setHasElement(SKILL_SLUGS, v) ||
                         tupleHasValue(SAVE_TYPES, v) ||
                         ["perception", "initiative"].includes(v)
                     ),

--- a/src/module/system/action-macros/general/recall-knowledge.ts
+++ b/src/module/system/action-macros/general/recall-knowledge.ts
@@ -5,20 +5,16 @@ import {
     SingleCheckActionVariant,
     SingleCheckActionVariantData,
 } from "@actor/actions/index.ts";
-import { SkillLongForm } from "@actor/types.ts";
-import { SKILL_LONG_FORMS } from "@actor/values.ts";
+import { SKILL_SLUGS } from "@actor/values.ts";
 import { TokenPF2e } from "@module/canvas/index.ts";
 import { ActionMacroHelpers } from "@system/action-macros/index.ts";
 import { CheckResultCallback } from "@system/action-macros/types.ts";
+import { setHasElement } from "@util/misc.ts";
 
 const PREFIX = "PF2E.Actions.RecallKnowledge";
 
 interface RecallKnowledgeActionUseOptions extends Partial<SingleCheckActionUseOptions> {
     statistic: string;
-}
-
-function isSkillLongForm(statistic: string): statistic is SkillLongForm {
-    return (SKILL_LONG_FORMS as Set<string>).has(statistic);
 }
 
 class RecallKnowledgeActionVariant extends SingleCheckActionVariant {
@@ -41,7 +37,7 @@ class RecallKnowledgeActionVariant extends SingleCheckActionVariant {
                     : options.target instanceof TokenPF2e
                       ? options.target.actor
                       : ActionMacroHelpers.target()?.actor;
-            if (target instanceof NPCPF2e && isSkillLongForm(options.statistic)) {
+            if (target instanceof NPCPF2e && setHasElement(SKILL_SLUGS, options.statistic)) {
                 const identification = target.identificationDCs;
                 if (identification.skills.includes(options.statistic)) {
                     options.difficultyClass = {

--- a/src/module/system/settings/homebrew/helpers.ts
+++ b/src/module/system/settings/homebrew/helpers.ts
@@ -7,7 +7,7 @@ import { isObject } from "@util";
 import * as R from "remeda";
 import { CustomDamageData, HomebrewTraitKey } from "./data.ts";
 import { HomebrewElements } from "./menu.ts";
-import { SKILL_ABBREVIATIONS } from "@actor/values.ts";
+import { SKILL_DICTIONARY } from "@actor/values.ts";
 
 /** User-defined type guard for checking that an object is a well-formed flag category of module-provided homebrew elements */
 function isHomebrewFlagCategory(value: unknown): value is Record<string, string | LabelAndDescription> {
@@ -46,7 +46,7 @@ function prepareReservedTerms(): ReservedTermsRecord {
         ...Object.keys(CONFIG.PF2E.resistanceTypes),
         ...Object.keys(CONFIG.PF2E.saves),
         ...Object.keys(CONFIG.PF2E.skillList),
-        ...SKILL_ABBREVIATIONS, // will be removed once skill abbreviations are removed fully
+        ...R.keys.strict(SKILL_DICTIONARY), // will be removed once skill abbreviations are removed fully
         ...Object.keys(CONFIG.PF2E.weaknessTypes),
         ...Object.keys(CONFIG.PF2E.environmentTypes),
         "damage",


### PR DESCRIPTION
ok fine we can do it earlier. Turns out also I missed a spot with FixedProficiency.