### PR TITLE
Convert melee items to use `TypeDataModel`-based system data

### DIFF
--- a/build/lib/extractor.ts
+++ b/build/lib/extractor.ts
@@ -632,8 +632,11 @@ class PackExtractor {
                     return this.#sortAbilities(docSource.name, itemsByType.action);
                 case "lore":
                     return R.sortBy(itemsByType.lore ?? [], (l) => l.name);
-                case "melee":
-                    return R.sortBy(itemsByType.melee ?? [], (m) => m.system.weaponType.value);
+                case "melee": {
+                    return R.sortBy(itemsByType.melee ?? [], (m) =>
+                        m.system.traits.value.some((t) => t.startsWith("range-")),
+                    );
+                }
                 case "spell":
                     return R.sortBy(itemsByType.spell ?? [], [(s) => s.system.level.value, "desc"], (s) => s.name);
                 case "spellcastingEntry":

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -9,6 +9,7 @@ import type { ActionType, ItemSourcePF2e } from "@item/base/data/index.ts";
 import { createConsumableFromSpell } from "@item/consumable/spell-consumables.ts";
 import { isContainerCycle } from "@item/container/helpers.ts";
 import { itemIsOfType } from "@item/helpers.ts";
+import { NPCAttackTrait } from "@item/melee/types.ts";
 import type { Coins } from "@item/physical/data.ts";
 import { detachSubitem } from "@item/physical/helpers.ts";
 import { DENOMINATIONS, PHYSICAL_ITEM_TYPES } from "@item/physical/values.ts";
@@ -1187,8 +1188,10 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
                 }
                 case "melee": {
                     const name = game.i18n.localize(`PF2E.NewPlaceholders.${itemType.capitalize()}`);
-                    const meleeOrRanged = dataset.actionType === "melee" ? "melee" : "ranged";
-                    return { type: itemType, name, system: { weaponType: { value: meleeOrRanged } } };
+                    const traits: { value: NPCAttackTrait[] } = {
+                        value: dataset.actionType === "melee" ? [] : ["range-increment-10"],
+                    };
+                    return { type: itemType, name, system: { traits } };
                 }
                 case "lore": {
                     const name =

--- a/src/module/item/melee/data.ts
+++ b/src/module/item/melee/data.ts
@@ -1,14 +1,18 @@
+import type { MeleePF2e } from "@item";
+import { ItemSystemModel, ItemSystemSchema } from "@item/base/data/schema.ts";
 import type {
     BaseItemSourcePF2e,
     ItemFlagsPF2e,
-    ItemSystemData,
     ItemSystemSource,
     ItemTraitsNoRarity,
 } from "@item/base/data/system.ts";
 import type { WeaponMaterialData } from "@item/weapon/data.ts";
 import type { WeaponPropertyRuneType } from "@item/weapon/types.ts";
-import type { DamageType } from "@system/damage/types.ts";
+import { damageCategoriesUnique } from "@scripts/config/damage.ts";
+import type { DamageCategoryUnique, DamageType } from "@system/damage/types.ts";
+import { RecordField, SlugField } from "@system/schema-data-fields.ts";
 import type { NPCAttackTrait } from "./types.ts";
+import fields = foundry.data.fields;
 
 type MeleeSource = BaseItemSourcePF2e<"melee", MeleeSystemSource> & {
     flags: DeepPartial<MeleeFlags>;
@@ -20,37 +24,110 @@ type MeleeFlags = ItemFlagsPF2e & {
     };
 };
 
-interface MeleeSystemSource extends ItemSystemSource {
+class MeleeSystemData extends ItemSystemModel<MeleePF2e, NPCAttackSystemSchema> {
+    declare material: WeaponMaterialData;
+
+    /** Weapon property runes (or rather the effects thereof) added via rule element */
+    declare runes: { property: WeaponPropertyRuneType[] };
+
+    static override defineSchema(): NPCAttackSystemSchema {
+        const fields = foundry.data.fields;
+        const traitChoices: Record<NPCAttackTrait, string> = CONFIG.PF2E.npcAttackTraits;
+
+        return {
+            ...super.defineSchema(),
+            traits: new fields.SchemaField({
+                otherTags: new fields.ArrayField(
+                    new SlugField({ required: true, nullable: false, initial: undefined }),
+                ),
+                value: new fields.ArrayField(
+                    new fields.StringField({
+                        required: true,
+                        nullable: false,
+                        choices: traitChoices,
+                        initial: undefined,
+                    }),
+                ),
+            }),
+            damageRolls: new RecordField(
+                new fields.StringField({ required: true, nullable: false, blank: false, initial: undefined }),
+                new fields.SchemaField({
+                    damage: new fields.StringField({
+                        required: true,
+                        nullable: false,
+                        blank: false,
+                        initial: undefined,
+                    }),
+                    damageType: new fields.StringField({
+                        required: true,
+                        nullable: false,
+                        initial: undefined,
+                        choices: CONFIG.PF2E.damageTypes,
+                    }),
+                    category: new fields.StringField({
+                        required: true,
+                        nullable: true,
+                        initial: null,
+                        choices: damageCategoriesUnique,
+                    }),
+                }),
+            ),
+            bonus: new fields.SchemaField({
+                value: new fields.NumberField({ required: true, nullable: false, integer: true, initial: 0 }),
+            }),
+            attackEffects: new fields.SchemaField({
+                value: new fields.ArrayField(
+                    new fields.StringField({ required: true, nullable: false, blank: false, initial: undefined }),
+                ),
+            }),
+        };
+    }
+}
+
+interface MeleeSystemData
+    extends ItemSystemModel<MeleePF2e, NPCAttackSystemSchema>,
+        Omit<ModelPropsFromSchema<NPCAttackSystemSchema>, "description"> {}
+
+type NPCAttackSystemSchema = Omit<ItemSystemSchema, "traits"> & {
+    traits: fields.SchemaField<{
+        otherTags: fields.ArrayField<SlugField<true, false, false>, string[], string[], true, false, true>;
+        value: fields.ArrayField<
+            fields.StringField<NPCAttackTrait, NPCAttackTrait, true, false, false>,
+            NPCAttackTrait[],
+            NPCAttackTrait[],
+            true,
+            false,
+            true
+        >;
+    }>;
+    damageRolls: RecordField<
+        fields.StringField<string, string, true, false, false>,
+        fields.SchemaField<{
+            damage: fields.StringField<string, string, true, false, false>;
+            damageType: fields.StringField<DamageType, DamageType, true, false, false>;
+            category: fields.StringField<DamageCategoryUnique, DamageCategoryUnique, true, true, true>;
+        }>,
+        true,
+        false,
+        true,
+        true
+    >;
+    /** The base attack modifier for this attack  */
+    bonus: fields.SchemaField<{
+        value: fields.NumberField<number, number, true, false, true>;
+    }>;
+    attackEffects: fields.SchemaField<{
+        value: fields.ArrayField<fields.StringField<string, string, true, false, false>>;
+    }>;
+};
+
+type MeleeSystemSource = SourceFromSchema<NPCAttackSystemSchema> & {
     level?: never;
-    traits: NPCAttackTraits;
-    attack: {
-        value: string;
-    };
-    damageRolls: Record<string, NPCAttackDamage>;
-    bonus: {
-        value: number;
-    };
-    attackEffects: {
-        value: string[];
-    };
-    weaponType: {
-        value: "melee" | "ranged";
-    };
-}
+    schema?: ItemSystemSource["schema"];
+};
 
-interface MeleeSystemData extends Omit<MeleeSystemSource, "description">, Omit<ItemSystemData, "level" | "traits"> {
-    material: WeaponMaterialData;
-    runes: { property: WeaponPropertyRuneType[] };
-}
+type NPCAttackDamage = SourceFromSchema<NPCAttackSystemSchema>["damageRolls"]["string"];
+type NPCAttackTraits = ItemTraitsNoRarity<NPCAttackTrait>;
 
-interface NPCAttackDamageSource {
-    damage: string;
-    damageType: DamageType;
-    category?: "persistent" | "precision" | "splash" | null;
-}
-
-type NPCAttackDamage = Required<NPCAttackDamageSource>;
-
-export type NPCAttackTraits = ItemTraitsNoRarity<NPCAttackTrait>;
-
-export type { MeleeFlags, MeleeSource, MeleeSystemData, MeleeSystemSource, NPCAttackDamage, NPCAttackDamageSource };
+export { MeleeSystemData };
+export type { MeleeFlags, MeleeSource, MeleeSystemSource, NPCAttackDamage, NPCAttackTraits };

--- a/src/module/item/melee/document.ts
+++ b/src/module/item/melee/document.ts
@@ -27,11 +27,11 @@ class MeleePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
     }
 
     get isMelee(): boolean {
-        return this.system.weaponType.value === "melee";
+        return !this.isRanged;
     }
 
     get isRanged(): boolean {
-        return this.system.weaponType.value === "ranged";
+        return this.system.traits.value.some((t) => t.startsWith("range-"));
     }
 
     get isThrown(): boolean {

--- a/src/module/item/melee/sheet.ts
+++ b/src/module/item/melee/sheet.ts
@@ -11,7 +11,6 @@ export class MeleeSheetPF2e extends ItemSheetPF2e<MeleePF2e> {
 
         // In case of weak/elite adjustments, display source values for attack modifier and damage formulas
         const itemSource = this.item._source;
-        sheetData.data.attack.value = itemSource.system.attack.value;
         for (const key of Object.keys(sheetData.data.damageRolls)) {
             sheetData.data.damageRolls[key].damage = itemSource.system.damageRolls[key].damage;
         }

--- a/src/module/item/weapon/document.ts
+++ b/src/module/item/weapon/document.ts
@@ -679,7 +679,6 @@ class WeaponPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
             type: "melee",
             system: {
                 slug: this.slug ?? sluggify(this._source.name),
-                weaponType: { value: this.isMelee ? "melee" : "ranged" },
                 bonus: {
                     // Unless there is a fixed attack modifier, give an attack bonus approximating a high-threat NPC
                     value: this.flags.pf2e.fixedAttack || Math.round(1.5 * this.actor.level + 7),

--- a/src/module/migration/migrations/885-convert-alignment-damage.ts
+++ b/src/module/migration/migrations/885-convert-alignment-damage.ts
@@ -1,6 +1,6 @@
 import { ActorSourcePF2e } from "@actor/data/index.ts";
 import { ItemSourcePF2e } from "@item/base/data/index.ts";
-import { NPCAttackDamageSource } from "@item/melee/data.ts";
+import { NPCAttackDamage } from "@item/melee/data.ts";
 import { SpellSystemSource } from "@item/spell/data.ts";
 import { RuleElementSource } from "@module/rules/index.ts";
 import { isObject } from "@util";
@@ -114,7 +114,7 @@ export class Migration885ConvertAlignmentDamage extends MigrationBase {
                 actorTraits.value.push("unholy");
             }
 
-            const partials: Record<string, NPCAttackDamageSource | null> = source.system.damageRolls;
+            const partials: Record<string, NPCAttackDamage | null> = source.system.damageRolls;
             for (const [key, partial] of Object.entries(partials)) {
                 if (!isObject(partial)) continue;
 

--- a/src/scripts/hooks/init.ts
+++ b/src/scripts/hooks/init.ts
@@ -1,5 +1,6 @@
 import { MystifiedTraits } from "@item/base/data/values.ts";
 import { KitSystemData } from "@item/kit/data.ts";
+import { MeleeSystemData } from "@item/melee/data.ts";
 import { HotbarPF2e } from "@module/apps/hotbar.ts";
 import {
     ActorDirectoryPF2e,
@@ -38,6 +39,7 @@ export const Init = {
             CONFIG.debug.ruleElement ??= false;
 
             CONFIG.Item.dataModels.kit = KitSystemData;
+            CONFIG.Item.dataModels.melee = MeleeSystemData;
 
             // Assign canvas layer and placeable classes
             CONFIG.AmbientLight.layerClass = LightingLayerPF2e;


### PR DESCRIPTION
Note to self: remove unused fields in a `DataModel` migration