### PR TITLE
Add option to disable experience tracking.

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -143,6 +143,7 @@ interface GamePF2e
                 buttons: boolean;
                 cards: boolean;
             };
+            disableExperienceTracking: boolean;
             /** Encumbrance automation */
             encumbrance: boolean;
             gmVision: boolean;
@@ -320,6 +321,7 @@ declare global {
         get(module: "pf2e", setting: "critFumbleButtons"): boolean;
         get(module: "pf2e", setting: "critRule"): "doubledamage" | "doubledice";
         get(module: "pf2e", setting: "deathIcon"): ImageFilePath;
+        get(module: "pf2e", setting: "disableExperienceTracking"): boolean;
         get(module: "pf2e", setting: "drawCritFumble"): boolean;
         get(module: "pf2e", setting: "enabledRulesUI"): boolean;
         get(module: "pf2e", setting: "gmVision"): boolean;

--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -290,6 +290,9 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
         sheetData.actions = this.#prepareAbilities();
         sheetData.feats = [...actor.feats, actor.feats.bonus];
 
+        // Is experience tracking disabled?
+        sheetData.experienceTrackingDisabled = game.pf2e.settings.disableExperienceTracking;
+
         const craftingFormulas = await actor.getCraftingFormulas();
         const formulasByLevel = R.groupBy(craftingFormulas, (f) => f.level);
         const flags = actor.flags.pf2e;
@@ -1642,6 +1645,7 @@ interface CharacterSheetData<TActor extends CharacterPF2e = CharacterPF2e> exten
     data: CharacterSystemSheetData;
     deity: DeityPF2e<CharacterPF2e> | null;
     hasStamina: boolean;
+    experienceTrackingDisabled: boolean;
     /** This actor has actual containers for stowing, rather than just containers serving as a UI convenience */
     hasRealContainers: boolean;
     languages: LanguageSheetData[];

--- a/src/module/system/settings/index.ts
+++ b/src/module/system/settings/index.ts
@@ -1,5 +1,6 @@
 import { resetActors } from "@actor/helpers.ts";
 import { ActorSheetPF2e } from "@actor/sheet/base.ts";
+import { CharacterSheetPF2e } from "@actor/character/sheet.ts";
 import { ItemSheetPF2e, type ItemPF2e } from "@item";
 import { StatusEffects } from "@module/canvas/status-effects.ts";
 import { MigrationRunner } from "@module/migration/runner/index.ts";
@@ -85,6 +86,21 @@ export function registerSettings(): void {
         onChange: () => {
             game.pf2e.compendiumBrowser.packLoader.reset();
             game.pf2e.compendiumBrowser.initCompendiumList();
+        },
+    });
+
+    game.settings.register("pf2e", "disableExperienceTracking", {
+        name: "PF2E.SETTINGS.DisableExperienceTracking.Name",
+        hint: "PF2E.SETTINGS.DisableExperienceTracking.Hint",
+        scope: "world",
+        config: true,
+        default: false,
+        type: Boolean,
+        onChange: (value) => {
+            game.pf2e.settings.disableExperienceTracking = !!value;
+            for (const sheet of Object.values(ui.windows).filter((w) => w instanceof CharacterSheetPF2e)) {
+                sheet.render();
+            }
         },
     });
 

--- a/src/scripts/set-game-pf2e.ts
+++ b/src/scripts/set-game-pf2e.ts
@@ -118,6 +118,7 @@ export const SetGamePF2e = {
                 buttons: game.settings.get("pf2e", "critFumbleButtons"),
                 cards: game.settings.get("pf2e", "drawCritFumble"),
             },
+            disableExperienceTracking: game.settings.get("pf2e", "disableExperienceTracking"),
             encumbrance: game.settings.get("pf2e", "automation.encumbrance"),
             gmVision: game.settings.get("pf2e", "gmVision"),
             iwr: game.settings.get("pf2e", "automation.iwr"),

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -3268,6 +3268,10 @@
                 "Hint": "Set the overlay icon used to mark dead actors.",
                 "Name": "Death Icon"
             },
+            "DisableExperienceTracking": {
+                "Hint": "Remove experience bars from character sheets.",
+                "Name": "Disable Experience Tracking"
+            },
             "EnabledDisabled": {
                 "Enabled": "Enabled",
                 "Default": "World Default ({worldDefault})",

--- a/static/templates/actors/character/partials/header.hbs
+++ b/static/templates/actors/character/partials/header.hbs
@@ -21,13 +21,15 @@
             <label>{{localize "PF2E.LevelLabel"}}</label>
             <input name="system.details.level.value" type="number" value="{{data.details.level.value}}" placeholder="1" size="2" />
         </div>
-        <div class="exp-data">
-            <div class="exp-input">
-                <input name="system.details.xp.value" type="text" value="{{data.details.xp.value}}" data-dtype="Number" data-allow-delta placeholder="0" size="4" />
-                <span class="max"> / </span>
-                <input name="system.details.xp.max" type="text" value="{{data.details.xp.max}}" data-dtype="Number" placeholder="1000" size="4" />
+        {{#if (not experienceTrackingDisabled)}}
+            <div class="exp-data">
+                <div class="exp-input">
+                    <input name="system.details.xp.value" type="text" value="{{data.details.xp.value}}" data-dtype="Number" data-allow-delta placeholder="0" size="4" />
+                    <span class="max"> / </span>
+                    <input name="system.details.xp.max" type="text" value="{{data.details.xp.max}}" data-dtype="Number" placeholder="1000" size="4" />
+                </div>
+                <progress value="{{data.details.xp.pct}}" max="100"></progress>
             </div>
-            <progress value="{{data.details.xp.pct}}" max="100"></progress>
-        </div>
+        {{/if}}
     </section>
 </header>


### PR DESCRIPTION
I have added an option to remove experience bars from character sheets. Although this can already be achieved by modules such as Custom CSS I think this is more convienient and also less likely to break when the html of the character sheet changes. The setting can currently be found between the "Critical Damage Rule" setting and the "Player Rule Elements Access" setting.