### PR TITLE
Make retrieving mergeable roll options to toggle more consistent

### DIFF
--- a/src/module/rules/rule-element/roll-option/rule-element.ts
+++ b/src/module/rules/rule-element/roll-option/rule-element.ts
@@ -335,13 +335,13 @@ class RollOptionRuleElement extends RuleElementPF2e<RollOptionSchema> {
 
         if (this.mergeable && selection) {
             // Update the items containing rule elements in the merge family
-            const rules = R.groupBy(R.uniq(this.#resolveSuboptions().map((s) => s.rule)), (r) => r.item.id);
-            for (const itemId of Object.keys(rules)) {
+            const rulesByItem = R.groupBy(R.uniq(this.#resolveSuboptions().map((s) => s.rule)), (r) => r.item.id);
+            for (const [itemId, rules] of Object.entries(rulesByItem)) {
                 const item = actor.items.get(itemId, { strict: true });
                 const ruleSources = item.toObject().system.rules;
-                const rollOptionSources = ruleSources.filter(
-                    (_r, index): _r is RollOptionSource => rules[itemId][index]?.sourceIndex === index,
-                );
+                const rollOptionSources = rules
+                    .map((rule) => (typeof rule.sourceIndex === "number" ? ruleSources[rule.sourceIndex] : null))
+                    .filter((source): source is RollOptionSource => source?.key === "RollOption");
                 for (const ruleSource of rollOptionSources) {
                     ruleSource.value = value;
                     ruleSource.selection = selection;


### PR DESCRIPTION
The previous algorithm attempted to match rules to sources on both index and sourceindex, but the index of the rule was its position in the filtered results. This meant that a bug could occur if there were rule elements above the RollOption.

The new algorithm works by iterating on the rules we're trying to search for instead, and then pulling the source based on the source index. We then check if its a RollOption RE just in case.