### PR TITLE
Update Rule Elements UI setting to manage access by user role

### DIFF
--- a/build/run-migration.ts
+++ b/build/run-migration.ts
@@ -31,6 +31,7 @@ import { Migration927ClassBackgroundBattleFormSkillLongform } from "@module/migr
 import { Migration928CharacterSkillsLongform } from "@module/migration/migrations/928-character-skills-longform.ts";
 import { Migration929RemoveSkillAbbreviations } from "@module/migration/migrations/929-remove-skill-abbreviations.ts";
 import { Migration930ChoiceSetMedium } from "@module/migration/migrations/930-choice-set-medium.ts";
+import { Migration931ExpandREPermissions } from "@module/migration/migrations/931-expand-re-permissions.ts";
 // ^^^ don't let your IDE use the index in these imports. you need to specify the full path ^^^
 
 const { window } = new JSDOM();
@@ -58,6 +59,7 @@ const migrations: MigrationBase[] = [
     new Migration928CharacterSkillsLongform(),
     new Migration929RemoveSkillAbbreviations(),
     new Migration930ChoiceSetMedium(),
+    new Migration931ExpandREPermissions(),
 ];
 
 const packsDataPath = path.resolve(process.cwd(), "packs");

--- a/src/global.ts
+++ b/src/global.ts
@@ -321,9 +321,9 @@ declare global {
         get(module: "pf2e", setting: "critRule"): "doubledamage" | "doubledice";
         get(module: "pf2e", setting: "deathIcon"): ImageFilePath;
         get(module: "pf2e", setting: "drawCritFumble"): boolean;
-        get(module: "pf2e", setting: "enabledRulesUI"): boolean;
         get(module: "pf2e", setting: "gmVision"): boolean;
         get(module: "pf2e", setting: "identifyMagicNotMatchingTraditionModifier"): 0 | 2 | 5 | 10;
+        get(module: "pf2e", setting: "minimumRulesUI"): 1 | 2 | 3 | 4;
         get(module: "pf2e", setting: "nathMode"): boolean;
         get(module: "pf2e", setting: "seenRemasterJournalEntry"): boolean;
         get(module: "pf2e", setting: "statusEffectType"): StatusEffectIconTheme;

--- a/src/module/item/base/sheet/sheet.ts
+++ b/src/module/item/base/sheet/sheet.ts
@@ -144,7 +144,7 @@ class ItemSheetPF2e<TItem extends ItemPF2e> extends ItemSheet<TItem, ItemSheetOp
             rarities: CONFIG.PF2E.rarityTraits,
             traits,
             traitTagifyData,
-            enabledRulesUI: game.user.isGM || game.settings.get("pf2e", "enabledRulesUI"),
+            enabledRulesUI: game.user.role >= game.settings.get("pf2e", "minimumRulesUI"),
             ruleEditing: !!this.editingRuleElement,
             rules: {
                 selection: {

--- a/src/module/migration/migrations/931-expand-re-permissions.ts
+++ b/src/module/migration/migrations/931-expand-re-permissions.ts
@@ -1,0 +1,12 @@
+import { MigrationBase } from "../base.ts";
+
+/** Migrate from boolean "enabledRulesUI" to "minimumRulesUI" choices. */
+export class Migration931ExpandREPermissions extends MigrationBase {
+    static override version = 0.931;
+
+    override async migrate(): Promise<void> {
+        // If player access is enabled, set minimumRulesUI to Player. Otherwise, set to the old default of Assistant GM.
+        const playerAccess = game.settings.storage.get("world").getItem("pf2e.enabledRulesUI");
+        game.settings.set("pf2e", "minimumRulesUI", playerAccess ? 1 : 3);
+    }
+}

--- a/src/module/migration/migrations/index.ts
+++ b/src/module/migration/migrations/index.ts
@@ -229,3 +229,4 @@ export { Migration927ClassBackgroundBattleFormSkillLongform } from "./927-class-
 export { Migration928CharacterSkillsLongform } from "./928-character-skills-longform.ts";
 export { Migration929RemoveSkillAbbreviations } from "./929-remove-skill-abbreviations.ts";
 export { Migration930ChoiceSetMedium } from "./930-choice-set-medium.ts";
+export { Migration931ExpandREPermissions } from "./931-expand-re-permissions.ts";

--- a/src/module/migration/runner/base.ts
+++ b/src/module/migration/runner/base.ts
@@ -14,7 +14,7 @@ interface CollectionDiff<T extends foundry.documents.ActiveEffectSource | ItemSo
 export class MigrationRunnerBase {
     migrations: MigrationBase[];
 
-    static LATEST_SCHEMA_VERSION = 0.93;
+    static LATEST_SCHEMA_VERSION = 0.931;
 
     static MINIMUM_SAFE_VERSION = 0.7;
 

--- a/src/module/system/settings/index.ts
+++ b/src/module/system/settings/index.ts
@@ -88,13 +88,19 @@ export function registerSettings(): void {
         },
     });
 
-    game.settings.register("pf2e", "enabledRulesUI", {
-        name: "PF2E.SETTINGS.EnabledRulesUI.Name",
-        hint: "PF2E.SETTINGS.EnabledRulesUI.Hint",
+    game.settings.register("pf2e", "minimumRulesUI", {
+        name: "PF2E.SETTINGS.MinimumRulesUI.Name",
+        hint: "PF2E.SETTINGS.MinimumRulesUI.Hint",
         scope: "world",
         config: true,
-        default: false,
-        type: Boolean,
+        default: 4,
+        type: Number,
+        choices: {
+            1: "USER.RolePlayer",
+            2: "USER.RoleTrusted",
+            3: "USER.RoleAssistant",
+            4: "USER.RoleGamemaster",
+        },
         onChange: () => {
             const itemSheets = Object.values(ui.windows).filter(
                 (w): w is ItemSheetPF2e<ItemPF2e> => w instanceof ItemSheetPF2e,

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -3277,10 +3277,6 @@
                 "Default": "World Default ({worldDefault})",
                 "Disabled": "Disabled"
             },
-            "EnabledRulesUI": {
-                "Hint": "When enabled, players are able to see and utilize the rule elements panel on item sheets.",
-                "Name": "Player Rule Elements Access"
-            },
             "Homebrew": {
                 "BaseWeapons": {
                     "Hint": "The bottom level of Pathfinder 2e weapon taxonomy (e.g, Heavy Crossbow, Longsword)",
@@ -3408,6 +3404,10 @@
                     "Hint": "If enabled, then for any NPC token whose nameplate isn't visible to players, its name will also be hidden from them in the encounter tracker and chat messages.",
                     "Name": "Tokens Determine NPC Name Visibility"
                 }
+            },
+            "MinimumRulesUI": {
+                "Hint": "The minimum role required to see and utilize the rule elements panel on item sheets.",
+                "Name": "Minimum Rule Elements Access Role"
             },
             "NathMode": {
                 "Hint": "Use better default token icons",


### PR DESCRIPTION
Closes #14203

Allows setting a minimum role for Rule Elements UI access. Choices are Game Master/Assistant GM, Trusted Player, and Player.

<img width="539" alt="Screenshot 2024-06-02 at 3 05 18 PM" src="https://github.com/foundryvtt/pf2e/assets/43155846/20a7012c-58a4-498f-9a5d-637aa1c53876">