### PR TITLE
Move impulse junction notes to feat description alterations

### DIFF
--- a/packs/classfeatures/air-gate.json
+++ b/packs/classfeatures/air-gate.json
@@ -260,27 +260,27 @@
                 "title": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Title"
             },
             {
-                "key": "Note",
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
                 "predicate": [
                     {
-                        "not": "self:action:slug:elemental-blast"
-                    },
-                    {
                         "gte": [
-                            "action:cost",
+                            "item:action:cost",
                             2
                         ]
                     },
                     "junction:air:impulse",
-                    "self:action:trait:impulse",
-                    "self:action:trait:air"
+                    "item:trait:impulse",
+                    "item:trait:air"
                 ],
-                "selector": [
-                    "impulse-damage",
-                    "inline-damage"
-                ],
-                "text": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Air",
-                "title": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Title"
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Air",
+                        "title": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Title"
+                    }
+                ]
             },
             {
                 "key": "ActiveEffectLike",

--- a/packs/classfeatures/earth-gate.json
+++ b/packs/classfeatures/earth-gate.json
@@ -250,27 +250,27 @@
                 "title": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Title"
             },
             {
-                "key": "Note",
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
                 "predicate": [
                     {
-                        "not": "self:action:slug:elemental-blast"
-                    },
-                    {
                         "gte": [
-                            "action:cost",
+                            "item:action:cost",
                             2
                         ]
                     },
                     "junction:earth:impulse",
-                    "self:action:trait:impulse",
-                    "self:action:trait:earth"
+                    "item:trait:impulse",
+                    "item:trait:earth"
                 ],
-                "selector": [
-                    "impulse-damage",
-                    "inline-damage"
-                ],
-                "text": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Earth",
-                "title": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Title"
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Earth",
+                        "title": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Title"
+                    }
+                ]
             },
             {
                 "key": "ActiveEffectLike",

--- a/packs/classfeatures/metal-gate.json
+++ b/packs/classfeatures/metal-gate.json
@@ -276,27 +276,27 @@
                 "title": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Title"
             },
             {
-                "key": "Note",
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
                 "predicate": [
                     {
-                        "not": "self:action:slug:elemental-blast"
-                    },
-                    {
                         "gte": [
-                            "action:cost",
+                            "item:action:cost",
                             2
                         ]
                     },
                     "junction:metal:impulse",
-                    "self:action:trait:impulse",
-                    "self:action:trait:metal"
+                    "item:trait:impulse",
+                    "item:trait:metal"
                 ],
-                "selector": [
-                    "impulse-damage",
-                    "inline-damage"
-                ],
-                "text": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Metal",
-                "title": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Title"
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Metal",
+                        "title": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Title"
+                    }
+                ]
             },
             {
                 "key": "ActiveEffectLike",

--- a/packs/classfeatures/water-gate.json
+++ b/packs/classfeatures/water-gate.json
@@ -249,27 +249,27 @@
                 "title": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Title"
             },
             {
-                "key": "Note",
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
                 "predicate": [
                     {
-                        "not": "self:action:slug:elemental-blast"
-                    },
-                    {
                         "gte": [
-                            "action:cost",
+                            "item:action:cost",
                             2
                         ]
                     },
                     "junction:water:impulse",
-                    "self:action:trait:impulse",
-                    "self:action:trait:water"
+                    "item:trait:impulse",
+                    "item:trait:water"
                 ],
-                "selector": [
-                    "impulse-damage",
-                    "inline-damage"
-                ],
-                "text": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Water",
-                "title": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Title"
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Water",
+                        "title": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Title"
+                    }
+                ]
             },
             {
                 "key": "ActiveEffectLike",

--- a/packs/classfeatures/wood-gate.json
+++ b/packs/classfeatures/wood-gate.json
@@ -253,27 +253,27 @@
                 "title": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Title"
             },
             {
-                "key": "Note",
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
                 "predicate": [
                     {
-                        "not": "self:action:slug:elemental-blast"
-                    },
-                    {
                         "gte": [
-                            "action:cost",
+                            "item:action:cost",
                             2
                         ]
                     },
                     "junction:wood:impulse",
-                    "self:action:trait:impulse",
-                    "self:action:trait:wood"
+                    "item:trait:impulse",
+                    "item:trait:wood"
                 ],
-                "selector": [
-                    "impulse-damage",
-                    "inline-damage"
-                ],
-                "text": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Wood",
-                "title": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Title"
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Wood",
+                        "title": "PF2E.SpecificRule.Kineticist.Impulse.ImpulseJunction.Title"
+                    }
+                ]
             },
             {
                 "key": "ActiveEffectLike",


### PR DESCRIPTION
Now that we have action cost roll options in feats, it seems like this is a better place for these to be in.