### PR TITLE
Add basic diffcult terrain region support

### DIFF
--- a/src/module/actor/character/data.ts
+++ b/src/module/actor/character/data.ts
@@ -6,6 +6,7 @@ import {
     CreatureAttributes,
     CreatureDetails,
     CreatureDetailsSource,
+    CreatureFlags,
     CreatureLanguagesData,
     CreaturePerceptionData,
     CreatureResources,
@@ -18,7 +19,6 @@ import {
 import { CreatureInitiativeSource, CreatureSpeeds, Language } from "@actor/creature/index.ts";
 import {
     ActorAttributesSource,
-    ActorFlagsPF2e,
     AttributeBasedTraceData,
     HitPointsStatistic,
     InitiativeData,
@@ -43,7 +43,7 @@ type CharacterSource = BaseCreatureSource<"character", CharacterSystemSource> & 
     flags: DeepPartial<CharacterFlags>;
 };
 
-type CharacterFlags = ActorFlagsPF2e & {
+type CharacterFlags = CreatureFlags & {
     pf2e: {
         /** If applicable, the character's proficiency rank in their deity's favored weapon */
         favoredWeaponRank: number;

--- a/src/module/actor/creature/data.ts
+++ b/src/module/actor/creature/data.ts
@@ -2,6 +2,7 @@ import type {
     ActorAttributes,
     ActorAttributesSource,
     ActorDetailsSource,
+    ActorFlagsPF2e,
     ActorHitPoints,
     ActorHitPointsSource,
     ActorSystemData,
@@ -15,6 +16,7 @@ import type { ActorSizePF2e } from "@actor/data/size.ts";
 import type { DamageDicePF2e, ModifierPF2e, RawModifier, StatisticModifier } from "@actor/modifiers.ts";
 import type { AttributeString, MovementType, SaveType, SkillSlug } from "@actor/types.ts";
 import type { LabeledNumber, Size, ValueAndMax, ZeroToThree } from "@module/data.ts";
+import type { PredicateStatement } from "@system/predication.ts";
 import type { ArmorClassTraceData } from "@system/statistic/index.ts";
 import type { PerceptionTraceData } from "@system/statistic/perception.ts";
 import type { CreatureActorType, CreatureTrait, Language, SenseAcuity, SenseType, SpecialVisionType } from "./types.ts";
@@ -22,9 +24,20 @@ import type { CreatureActorType, CreatureTrait, Language, SenseAcuity, SenseType
 type BaseCreatureSource<
     TType extends CreatureActorType,
     TSystemSource extends CreatureSystemSource,
-> = BaseActorSourcePF2e<TType, TSystemSource>;
+> = BaseActorSourcePF2e<TType, TSystemSource> & {
+    flags: DeepPartial<CreatureFlags>;
+};
 
-/** Skill and Lore statistics for rolling. */
+type CreatureFlags = ActorFlagsPF2e & {
+    pf2e: {
+        difficultTerrain: {
+            /** Predicate statements used to test whether this actor ignores difficult terrain  */
+            ignore: PredicateStatement[];
+            /** Predicate statements used to test whether this actor ignores greater difficult terrain */
+            ignoreGreater: PredicateStatement[];
+        };
+    };
+};
 
 interface CreatureSystemSource extends ActorSystemSource {
     attributes: CreatureAttributesSource;
@@ -238,6 +251,7 @@ export type {
     CreatureAttributes,
     CreatureDetails,
     CreatureDetailsSource,
+    CreatureFlags,
     CreatureHitPointsSource,
     CreatureInitiativeSource,
     CreatureLanguagesData,

--- a/src/module/actor/creature/document.ts
+++ b/src/module/actor/creature/document.ts
@@ -30,7 +30,7 @@ import { Statistic, StatisticDifficultyClass, type ArmorStatistic } from "@syste
 import { PerceptionStatistic } from "@system/statistic/perception.ts";
 import { ErrorPF2e, localizer, setHasElement } from "@util";
 import * as R from "remeda";
-import { CreatureSpeeds, CreatureSystemData, LabeledSpeed, VisionLevel, VisionLevels } from "./data.ts";
+import { CreatureFlags, CreatureSpeeds, CreatureSystemData, LabeledSpeed, VisionLevel, VisionLevels } from "./data.ts";
 import { imposeEncumberedCondition, setImmunitiesFromTraits } from "./helpers.ts";
 import { CreatureTrait, CreatureType, CreatureUpdateOperation, GetReachParameters } from "./types.ts";
 
@@ -275,6 +275,14 @@ abstract class CreaturePF2e<
         super.prepareBaseData();
 
         this.flags.pf2e.rollOptions.all["self:creature"] = true;
+
+        // Setup initial diffcult terrain flag and work around mergeObject not merging arrays
+        const ignore = this._source.flags.pf2e?.difficultTerrain?.ignore ?? [];
+        const ignoreGreater = this._source.flags.pf2e?.difficultTerrain?.ignoreGreater ?? [];
+        this.flags.pf2e.difficultTerrain = {
+            ignore: [...R.filter(ignore, R.isTruthy)],
+            ignoreGreater: [...R.filter(ignoreGreater, R.isTruthy)],
+        };
 
         this.system.perception = fu.mergeObject({ attribute: "wis", senses: [] }, this.system.perception);
 
@@ -793,6 +801,7 @@ abstract class CreaturePF2e<
 
 interface CreaturePF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | null> extends ActorPF2e<TParent> {
     readonly _source: CreatureSource;
+    flags: CreatureFlags;
     system: CreatureSystemData;
 
     get traits(): Set<CreatureTrait>;

--- a/src/module/actor/helpers.ts
+++ b/src/module/actor/helpers.ts
@@ -256,6 +256,7 @@ function createEncounterRollOptions(actor: ActorPF2e): Record<string, boolean> {
 /** Create roll options pertaining to the terrain the actor is currently in */
 function createEnvironmentRollOptions(actor: ActorPF2e): Record<string, boolean> {
     const toAdd = new Set<string>();
+    const difficultTerrains = new Set<string>();
     // Always add the scene terrain types
     for (const terrain of canvas.scene?.flags.pf2e.environmentTypes ?? []) {
         toAdd.add(terrain);
@@ -275,6 +276,18 @@ function createEnvironmentRollOptions(actor: ActorPF2e): Record<string, boolean>
                 (b): b is EnvironmentRegionBehaviorPF2e => b.type === "environment",
             )) {
                 const system = behavior.system;
+                if (system.groundOnly && token.elevation > 0) continue;
+
+                if (system.difficultTerrain) {
+                    difficultTerrains.add(`difficult`);
+                    if (system.difficultTerrain === "greater") {
+                        difficultTerrains.add(`difficult:greater`);
+                    }
+                    if (system.isMagical) {
+                        difficultTerrains.add(`difficult:magical`);
+                    }
+                }
+
                 switch (system.mode) {
                     case "add": {
                         for (const terrain of system.environmentTypes) {
@@ -307,7 +320,7 @@ function createEnvironmentRollOptions(actor: ActorPF2e): Record<string, boolean>
         return toAdd;
     })();
 
-    return Object.fromEntries(terrains.map((t) => [`terrain:${t}`, true]));
+    return Object.fromEntries([...terrains, ...difficultTerrains].map((t) => [`terrain:${t}`, true]));
 }
 
 /** Whether flanking puts this actor off-guard */

--- a/src/module/actor/npc/data.ts
+++ b/src/module/actor/npc/data.ts
@@ -5,6 +5,7 @@ import type {
     CreatureAttributes,
     CreatureDetails,
     CreatureDetailsSource,
+    CreatureFlags,
     CreatureHitPointsSource,
     CreatureInitiativeSource,
     CreatureLanguagesData,
@@ -22,7 +23,6 @@ import type {
 } from "@actor/creature/data.ts";
 import type {
     ActorAttributesSource,
-    ActorFlagsPF2e,
     AttributeBasedTraceData,
     HitPointsStatistic,
     StrikeData,
@@ -37,7 +37,7 @@ type NPCSource = BaseCreatureSource<"npc", NPCSystemSource> & {
     flags: DeepPartial<NPCFlags>;
 };
 
-type NPCFlags = ActorFlagsPF2e & {
+type NPCFlags = CreatureFlags & {
     pf2e: { lootable: boolean };
 };
 

--- a/src/module/canvas/ruler.ts
+++ b/src/module/canvas/ruler.ts
@@ -1,0 +1,147 @@
+import type { ActorPF2e } from "@actor";
+import { ModifierPF2e, StatisticModifier } from "@actor/modifiers.ts";
+import { extractModifierAdjustments } from "@module/rules/helpers.ts";
+import type { UserPF2e } from "@module/user/document.ts";
+import type { ScenePF2e } from "@scene";
+import type { EnvironmentRegionBehaviorPF2e } from "@scene/region-behavior/types.ts";
+import type { TokenPF2e } from "./token/object.ts";
+
+class RulerPF2e<TToken extends TokenPF2e = TokenPF2e, TUser extends UserPF2e = UserPF2e> extends Ruler<TToken, TUser> {
+    /** A filtered list of scene region behaviors */
+    #behaviors: EnvironmentRegionBehaviorPF2e[] = [];
+    /** A cache for cost by behavior id */
+    #behaviorCosts = new Map<string, number>();
+    /** A cache for cost and difficulty label by grid coordinates */
+    #coordinatesCache = new Map<string, { cost: number; label: string | null }>();
+    /** The difficulty label for the current segment */
+    #difficultyLabel: string | null = null;
+    /** Difficult terrain labels */
+    #difficultTerrainLabels: { standard: string; greater: string };
+
+    constructor() {
+        super();
+
+        this.#difficultTerrainLabels = {
+            standard: game.i18n.localize("PF2E.Region.Environment.DifficultTerrain.Standard"),
+            greater: game.i18n.localize("PF2E.Region.Environment.DifficultTerrain.Greater"),
+        };
+    }
+
+    protected override _startMeasurement(origin: Point, options?: { snap?: boolean; token?: TToken | null }): void {
+        this.#behaviors =
+            canvas.scene?.regions.contents.flatMap((r) =>
+                r.behaviors.filter((b): b is EnvironmentRegionBehaviorPF2e<RegionDocument<ScenePF2e>> =>
+                    b.isOfType("environment"),
+                ),
+            ) ?? [];
+        super._startMeasurement(origin, options);
+    }
+
+    protected override _endMeasurement(): void {
+        this.#behaviors = [];
+        this.#behaviorCosts.clear();
+        this.#coordinatesCache.clear();
+        this.#difficultyLabel = null;
+
+        super._endMeasurement();
+    }
+
+    protected override _getCostFunction(): GridMeasurePathCostFunction | void {
+        // This function will be called for every ruler segment every time the length changes
+        return (_from, to, distance) => {
+            const point = canvas.grid.getCenterPoint(to);
+            const coords = `${point.x}.${point.y}`;
+            // Return cached cost and difficulty label for this grid coordinate to avoid testing all regions again
+            if (this.#coordinatesCache.has(coords)) {
+                const data = this.#coordinatesCache.get(coords);
+                this.#difficultyLabel = data?.label ?? null;
+                return data?.cost ?? distance;
+            }
+            const elevation = this.token?.document.elevation ?? 0;
+            const behaviors = this.#behaviors.filter((b) => {
+                const inside = b.region.object.testPoint(point, elevation);
+                if (!inside) return false;
+                return b.system.groundOnly ? elevation === 0 : true;
+            });
+            if (behaviors.length > 0) {
+                const isGreater = behaviors.some((b) => b.system.difficultTerrain === "greater");
+                this.#difficultyLabel = isGreater
+                    ? this.#difficultTerrainLabels.greater
+                    : this.#difficultTerrainLabels.standard;
+                const cost = this.#calculateCost(behaviors, distance, isGreater);
+                this.#coordinatesCache.set(coords, { cost, label: this.#difficultyLabel });
+                return cost;
+            }
+            this.#difficultyLabel = null;
+            this.#coordinatesCache.set(coords, { cost: distance, label: null });
+            return distance;
+        };
+    }
+
+    protected override _getSegmentLabel(segment: RulerMeasurementSegment): string {
+        if (segment.teleport) return "";
+        const isWaypoint = this.waypoints.some((p) => p.x === segment.ray.B.x && p.y === segment.ray.B.y);
+        const units = canvas.grid.units;
+        let label = `${Math.round(segment.cumulativeDistance * 100) / 100}${units ? ` ${units}` : ""}`;
+        if (segment.last || isWaypoint) {
+            const cumulativeCost = `${Math.round(segment.cumulativeCost * 100) / 100}${units ? ` ${units}` : ""}`;
+            label += ` [${cumulativeCost}]`;
+        }
+        const lines = [label];
+        if (this.#difficultyLabel && !isWaypoint) {
+            lines.push(this.#difficultyLabel);
+        }
+        return lines.join("\n");
+    }
+
+    #calculateCost(behaviors: EnvironmentRegionBehaviorPF2e[], distance: number, isGreater: boolean): number {
+        for (const behavior of behaviors) {
+            // Return a cached value as it is very unlikely that the behavior changes while measuring
+            if (this.#behaviorCosts.has(behavior.id)) {
+                return this.#behaviorCosts.get(behavior.id) ?? distance;
+            }
+        }
+        const actor = this.token?.actor;
+        if (!actor) return distance;
+
+        const difficulTerrainModifier = new ModifierPF2e({
+            label: "",
+            modifier: 1,
+            adjustments: extractModifierAdjustments(
+                actor.synthetics.modifierAdjustments,
+                ["difficult-terrain-multiplier"],
+                "difficult-terrain-multiplier",
+            ),
+        });
+        const rollOptions = this.#getRollOptionsForBehaviors(actor, behaviors);
+        const statistic = new StatisticModifier("difficult-terrain-multiplier", [difficulTerrainModifier], rollOptions);
+        const multiplier = Math.clamp(isGreater ? statistic.totalModifier + 1 : statistic.totalModifier, 0, 2);
+        const cost = distance + multiplier * 5;
+
+        for (const behavior of behaviors) {
+            this.#behaviorCosts.set(behavior.id, cost);
+        }
+        return cost;
+    }
+
+    /** Get roll options for regions the ruler passes through as if the actor was in those regions */
+    #getRollOptionsForBehaviors(actor: ActorPF2e, behaviors: EnvironmentRegionBehaviorPF2e[]): string[] {
+        const tokenDoc = this.token?.document;
+        const tokenRegions = tokenDoc?.regions;
+        if (!tokenDoc || !tokenRegions) return [];
+        const regions = behaviors.map((b) => b.region);
+        const newRegions = regions.filter((r) => !tokenRegions.has(r));
+        for (const region of newRegions) {
+            tokenRegions.add(region);
+        }
+        actor.reset();
+        const options = actor.getRollOptions();
+        for (const region of newRegions) {
+            tokenRegions.delete(region);
+        }
+        actor.reset();
+        return options;
+    }
+}
+
+export { RulerPF2e };

--- a/src/module/scene/region-behavior/environment.ts
+++ b/src/module/scene/region-behavior/environment.ts
@@ -1,6 +1,6 @@
 import { resetActors } from "@actor/helpers.ts";
 import type { RegionEventType } from "types/foundry/client-esm/data/region-behaviors/base.d.ts";
-import type { SetField, StringField } from "types/foundry/common/data/fields.d.ts";
+import type { BooleanField, SetField, StringField } from "types/foundry/common/data/fields.d.ts";
 import type { RegionEventPF2e } from "./types.ts";
 
 class EnvironmentBehaviorTypePF2e extends foundry.data.regionBehaviors.RegionBehaviorType<EnvironmentTypeSchema> {
@@ -27,6 +27,25 @@ class EnvironmentBehaviorTypePF2e extends foundry.data.regionBehaviors.RegionBeh
                 label: "PF2E.Region.Environment.Mode.Label",
                 hint: "PF2E.Region.Environment.Mode.Hint",
             }),
+            difficultTerrain: new fields.StringField({
+                blank: true,
+                choices: () => ({
+                    standard: "PF2E.Region.Environment.DifficultTerrain.Option.Standard",
+                    greater: "PF2E.Region.Environment.DifficultTerrain.Option.Greater",
+                }),
+                label: "PF2E.Region.Environment.DifficultTerrain.Standard",
+                hint: "PF2E.Region.Environment.DifficultTerrain.Option.Hint",
+            }),
+            isMagical: new fields.BooleanField({
+                initial: false,
+                label: "PF2E.Region.Environment.DifficultTerrain.Magical.Label",
+                hint: "PF2E.Region.Environment.DifficultTerrain.Magical.Hint",
+            }),
+            groundOnly: new fields.BooleanField({
+                initial: true,
+                label: "PF2E.Region.Environment.DifficultTerrain.GroundOnly.Label",
+                hint: "PF2E.Region.Environment.DifficultTerrain.GroundOnly.Hint",
+            }),
         };
     }
 
@@ -44,6 +63,9 @@ interface EnvironmentBehaviorTypePF2e
 type EnvironmentTypeSchema = {
     environmentTypes: SetField<StringField>;
     mode: StringField<"add" | "remove" | "override">;
+    difficultTerrain: StringField<"standard" | "greater">;
+    isMagical: BooleanField;
+    groundOnly: BooleanField;
 };
 
 type EnvironmentTypeData = ModelPropsFromSchema<EnvironmentTypeSchema>;

--- a/src/scripts/hooks/init.ts
+++ b/src/scripts/hooks/init.ts
@@ -20,6 +20,7 @@ import {
 import { setPerceptionModes } from "@module/canvas/perception/modes.ts";
 import { PointVisionSourcePF2e } from "@module/canvas/perception/point-vision-source.ts";
 import { RegionPF2e } from "@module/canvas/region.ts";
+import { RulerPF2e } from "@module/canvas/ruler.ts";
 import { RegionBehaviorPF2e } from "@scene/region-behavior/document.ts";
 import { EnvironmentBehaviorTypePF2e } from "@scene/region-behavior/environment.ts";
 import { RegionDocumentPF2e } from "@scene/region-document/document.ts";
@@ -57,6 +58,7 @@ export const Init = {
             CONFIG.Canvas.groups.effects.groupClass = EffectsCanvasGroupPF2e;
             CONFIG.Canvas.layers.lighting.layerClass = LightingLayerPF2e;
             CONFIG.Canvas.layers.templates.layerClass = TemplateLayerPF2e;
+            CONFIG.Canvas.rulerClass = RulerPF2e;
             CONFIG.Canvas.visionSourceClass = PointVisionSourcePF2e;
 
             CONFIG.Region.documentClass = RegionDocumentPF2e;

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -3085,6 +3085,23 @@
         },
         "Region": {
             "Environment": {
+                "DifficultTerrain": {
+                    "Greater": "Greater Difficult Terrain",
+                    "GroundOnly": {
+                        "Hint": "Toggle whether this Difficult Terrain only affects tokens at elevation 0.",
+                        "Label": "Ground Only"
+                    },
+                    "Magical": {
+                        "Hint": "Toggle whether this is magical Difficult Terrain.",
+                        "Label": "Magical"
+                    },
+                    "Option": {
+                        "Greater": "Greater",
+                        "Hint": "Set this environment to be Difficult Terrain.",
+                        "Standard": "Standard"
+                    },
+                    "Standard": "Difficult Terrain"
+                },
                 "Mode": {
                     "Add": {
                         "Label": "Add"

--- a/types/foundry/client/pixi/layers/controls/ruler.d.ts
+++ b/types/foundry/client/pixi/layers/controls/ruler.d.ts
@@ -138,7 +138,7 @@ declare global {
         protected _removeWaypoint(): void;
 
         /** Get the cost function to be used for Ruler measurements. */
-        protected _getCostFunction(): GridMeasurePathCostFunction | undefined;
+        protected _getCostFunction(): GridMeasurePathCostFunction | void;
 
         /** Compute the distance of each segment and the total distance of the measured path. */
         protected _computeDistance(): void;


### PR DESCRIPTION
This adds a few new roll options for difficult terrain: `terrain:difficult`, `terrain:difficult:greater`, and `terrain:difficult:magical`. These are not mutually exclusive.

The ruler has two layers of caching to make the impact as low as possible. First the cost per region is cached because the behavior is probably not chaning and we don't have to recalculate everything for the same region. The second caching happens by grid coordinates to avoid calling `Region#testPoint` over and over again for alle regions in the scene.
The cost can be changed by using an `ActiveEffectLike` rule element that adds a new predicate statement to `flags.pf2e.difficultTerrain.ignore` or `ignoreGreater` on the actor. 

```json
{
  "key": "ActiveEffectLike",
  "mode": "add",
  "path": "flags.pf2e.difficultTerrain.ignore",
  "value": {
    "and": [
      "terrain:forest",
      {
        "not": "terrain:difficult:magical"
      }
    ]
  }
}
```

<img width="371" alt="Screenshot 2024-06-04 224819" src="https://github.com/foundryvtt/pf2e/assets/41452412/cb5fdb4c-f9fd-42db-b320-bd9503c86b72">

<img width="218" alt="Screenshot 2024-06-04 225440" src="https://github.com/foundryvtt/pf2e/assets/41452412/0bb71cf0-8fc1-43f6-8280-b8b5846b3e90">


