### PR TITLE
Fix automation of Awakened Animal and Swimming Animal heritage

### DIFF
--- a/packs/ancestries/awakened-animal.json
+++ b/packs/ancestries/awakened-animal.json
@@ -114,6 +114,16 @@
                 "path": "system.attributes.ancestryhp",
                 "priority": 51,
                 "value": "{item|flags.pf2e.rulesSelections.choice.hitPoints}"
+            },
+            {
+                "key": "BaseSpeed",
+                "predicate": [
+                    {
+                        "not": "heritage:swimming-animal"
+                    }
+                ],
+                "selector": "land",
+                "value": 20
             }
         ],
         "size": "med",

--- a/packs/heritages/awakened-animal/swimming-animal.json
+++ b/packs/heritages/awakened-animal/swimming-animal.json
@@ -19,7 +19,7 @@
         },
         "rules": [
             {
-                "adjustName": "false",
+                "adjustName": false,
                 "choices": [
                     {
                         "label": "PF2E.TraitAquatic",
@@ -39,7 +39,7 @@
                 "predicate": [
                     "swimming-animal:aquatic"
                 ],
-                "selector": "land",
+                "selector": "swim",
                 "value": 30
             },
             {


### PR DESCRIPTION
We've had some people run into the trap of using a versatile heritage with awakened animal. This still leaves a gap in the awakened shark duskwalker niche, but that's a smaller gap than we have now so 🤷