### PR TITLE
Fix vision mode initialization before the canvas is ready

### DIFF
--- a/src/module/canvas/token/object.ts
+++ b/src/module/canvas/token/object.ts
@@ -87,13 +87,6 @@ class TokenPF2e<TDocument extends TokenDocumentPF2e = TokenDocumentPF2e> extends
         return bounds;
     }
 
-    /** Short-circuit calculation for long sight ranges */
-    override get sightRange(): number {
-        if (!canvas.ready) return 0;
-        const dimensions = canvas.dimensions;
-        return (this.document.sight.range ?? 0) >= dimensions.maxR ? dimensions.maxR : super.sightRange;
-    }
-
     isAdjacentTo(token: TokenPF2e): boolean {
         return this.distanceTo(token) === 5;
     }


### PR DESCRIPTION
`Token#_getVisionSourceData()` uses the value from `Token#sightRange` as radius. This is first called before the canvas is ready so the override returned a radius of 0 which led to the vision mode not doing anything.
Upstream `sightRange` was changed to this:
```js
  get sightRange() {
    return this.getLightRadius(this.document.sight.range ?? Infinity);
  }
```
so I don't think the override is necessary anymore.

Closes #14963 