### PR TITLE
Sheets for non-stowing container show should not show form elements for reducing bulk

### DIFF
--- a/src/module/item/container/document.ts
+++ b/src/module/item/container/document.ts
@@ -94,7 +94,7 @@ class ContainerPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends
 
         for (const property of ["capacity", "ignored"] as const) {
             if (!changed.system.stowing) {
-                changed.system.bulk[property] = 0
+                changed.system.bulk[property] = 0;
             }
 
             if (changed.system.bulk[property] !== undefined) {

--- a/src/module/item/container/document.ts
+++ b/src/module/item/container/document.ts
@@ -93,6 +93,10 @@ class ContainerPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends
         }
 
         for (const property of ["capacity", "ignored"] as const) {
+            if (!changed.system.stowing) {
+                changed.system.bulk[property] = 0
+            }
+
             if (changed.system.bulk[property] !== undefined) {
                 changed.system.bulk[property] =
                     Math.clamp(Math.trunc(Number(changed.system.bulk[property])), 0, 999) || 0;

--- a/static/templates/items/backpack-details.hbs
+++ b/static/templates/items/backpack-details.hbs
@@ -13,15 +13,13 @@
 </div>
 
 {{#if item._source.system.stowing}}
+    <div class="form-group">
+        <label for="{{fieldIdPrefix}}capacity">{{localize "PF2E.Item.Container.Bulk.Capacity"}}</label>
+        <input type="number" name="system.bulk.capacity" id="{{fieldIdPrefix}}capacity" value="{{data.bulk.capacity}}" />
+    </div>
 
-<div class="form-group">
-    <label for="{{fieldIdPrefix}}capacity">{{localize "PF2E.Item.Container.Bulk.Capacity"}}</label>
-    <input type="number" name="system.bulk.capacity" id="{{fieldIdPrefix}}capacity" value="{{data.bulk.capacity}}" />
-</div>
-
-<div class="form-group">
-    <label for="{{fieldIdPrefix}}ignored">{{localize "PF2E.Item.Container.Bulk.Ignored"}}</label>
-    <input type="number" name="system.bulk.ignored" id="{{fieldIdPrefix}}ignored" value="{{data.bulk.ignored}}" />
-</div>
-
+    <div class="form-group">
+        <label for="{{fieldIdPrefix}}ignored">{{localize "PF2E.Item.Container.Bulk.Ignored"}}</label>
+        <input type="number" name="system.bulk.ignored" id="{{fieldIdPrefix}}ignored" value="{{data.bulk.ignored}}" />
+    </div>
 {{/if}}

--- a/static/templates/items/backpack-details.hbs
+++ b/static/templates/items/backpack-details.hbs
@@ -1,6 +1,13 @@
 {{> "systems/pf2e/templates/items/partials/apex.hbs"}}
 
 <div class="form-group">
+    <label for="{{fieldIdPrefix}}stowing">{{localize "PF2E.Item.Container.Stowing"}}</label>
+    <input type="checkbox" name="system.stowing" id="{{fieldIdPrefix}}stowing" {{checked data.stowing}} />
+</div>
+
+{{#if item._source.system.stowing}}
+
+<div class="form-group">
     <label for="{{fieldIdPrefix}}bulk-held-stowed">{{localize "PF2E.Item.Physical.Bulk.HeldOrStowed"}}</label>
     <select name="system.bulk.heldOrStowed" id="{{fieldIdPrefix}}bulk-held-stowed" data-dtype="Number">
         {{selectOptions bulks selected=item._source.system.bulk.heldOrStowed}}
@@ -17,7 +24,4 @@
     <input type="number" name="system.bulk.ignored" id="{{fieldIdPrefix}}ignored" value="{{data.bulk.ignored}}" />
 </div>
 
-<div class="form-group">
-    <label for="{{fieldIdPrefix}}stowing">{{localize "PF2E.Item.Container.Stowing"}}</label>
-    <input type="checkbox" name="system.stowing" id="{{fieldIdPrefix}}stowing" {{checked data.stowing}} />
-</div>
+{{/if}}

--- a/static/templates/items/backpack-details.hbs
+++ b/static/templates/items/backpack-details.hbs
@@ -1,18 +1,18 @@
 {{> "systems/pf2e/templates/items/partials/apex.hbs"}}
 
 <div class="form-group">
-    <label for="{{fieldIdPrefix}}stowing">{{localize "PF2E.Item.Container.Stowing"}}</label>
-    <input type="checkbox" name="system.stowing" id="{{fieldIdPrefix}}stowing" {{checked data.stowing}} />
-</div>
-
-{{#if item._source.system.stowing}}
-
-<div class="form-group">
     <label for="{{fieldIdPrefix}}bulk-held-stowed">{{localize "PF2E.Item.Physical.Bulk.HeldOrStowed"}}</label>
     <select name="system.bulk.heldOrStowed" id="{{fieldIdPrefix}}bulk-held-stowed" data-dtype="Number">
         {{selectOptions bulks selected=item._source.system.bulk.heldOrStowed}}
     </select>
 </div>
+
+<div class="form-group">
+    <label for="{{fieldIdPrefix}}stowing">{{localize "PF2E.Item.Container.Stowing"}}</label>
+    <input type="checkbox" name="system.stowing" id="{{fieldIdPrefix}}stowing" {{checked data.stowing}} />
+</div>
+
+{{#if item._source.system.stowing}}
 
 <div class="form-group">
     <label for="{{fieldIdPrefix}}capacity">{{localize "PF2E.Item.Container.Bulk.Capacity"}}</label>


### PR DESCRIPTION
Addresses: https://github.com/foundryvtt/pf2e/issues/14073

The page for containers shows reduced bulk even if the container is non-stowing.  The definition of a non-stowing container within the system is a "not real" container such as a belt, where the items are functionally "worn" as opposed to "stowed".

The FVTT PF2e system does not allow non-stowing containers to reduce bulk, so the form element is confusing.  This causes them to be hidden, so the user has greater clarity that these numbers will not apply.  The stowing container checkbox is moved upwards as the relevance of the maximum and ignored bulk elements is subordinate to the existence of the stowing field.

https://github.com/foundryvtt/pf2e/assets/22515/6083e8f7-a7c3-40a4-b388-33c183d160da

