### PR TITLE
Show roll mode indicator in damage rolls

### DIFF
--- a/static/templates/dice/damage-tooltip.hbs
+++ b/static/templates/dice/damage-tooltip.hbs
@@ -7,6 +7,9 @@
             {{#each instance.dice as |dice|}}
                 <div class="dice">
                     <header class="part-header flexrow">
+                        {{#if dice.icon}}
+                            <span class="part-method" data-tooltip="{{dice.method}}" aria-label="{{localize dice.method}}">{{{dice.icon}}}</span>
+                        {{/if}}
                         <span class="part-formula">{{dice.formula}}</span>
                         <span class="part-total">{{dice.total}}</span>
                     </header>


### PR DESCRIPTION
<img width="227" alt="Screenshot 2024-06-08 195237" src="https://github.com/foundryvtt/pf2e/assets/41452412/b7cc2376-00cb-44e3-9197-141e863e9016">
