### PR TITLE
Allow sheets to still open despite invalid data

### DIFF
--- a/src/module/actor/creature/sheet.ts
+++ b/src/module/actor/creature/sheet.ts
@@ -38,7 +38,7 @@ abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends ActorSheet
 
         sheetData.data.perception.senses = R.sortBy(sheetData.data.perception.senses, (a) => a.label ?? "");
         const initiativeOptions = [{ value: "perception", label: "PF2E.PerceptionLabel" }];
-        initiativeOptions.push(...Object.values(sheetData.data.skills).map((s) => ({ value: s.slug, label: s.label })));
+        initiativeOptions.push(...Object.values(this.actor.skills).map((s) => ({ value: s.slug, label: s.label })));
 
         return {
             ...sheetData,

--- a/src/scripts/handlebars.ts
+++ b/src/scripts/handlebars.ts
@@ -150,6 +150,22 @@ export function registerHandlebarsHelpers(): void {
     Handlebars.registerHelper("raw", function (this: unknown, options: Handlebars.HelperOptions): string {
         return options.fn(this);
     });
+
+    /**
+     * Work around core issue with numberFormat where null/undefined values crash the sheet
+     * https://github.com/foundryvtt/foundryvtt/issues/11165
+     */
+    Handlebars.registerHelper(
+        "numberFormat",
+        (value: unknown, options: { hash: { decimals: number; sign: boolean } }) => {
+            const numValue = Number(value);
+            const dec = options.hash.decimals ?? 0;
+            const sign = options.hash.sign || false;
+            return new Handlebars.SafeString(
+                sign && numValue >= 0 ? `+${numValue.toFixed(dec)}` : numValue.toFixed(dec),
+            );
+        },
+    );
 }
 
 /** Used by the "pick" and "omit" helpers */


### PR DESCRIPTION
The skills themselves are still broken, and we need to do a bit more filtering, but the sheet should be openable now.