### PR TITLE
Show invested icon within non-stowing containers

### DIFF
--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -544,7 +544,7 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
 
     protected override prepareInventoryItem(item: PhysicalItemPF2e): InventoryItem {
         const data = super.prepareInventoryItem(item);
-        data.isInvestable = !item.isInContainer && item.isIdentified && item.isInvested !== null;
+        data.isInvestable = !item.isStowed && item.isIdentified && item.isInvested !== null;
 
         // If armor is equipped, and can be invested, hint at the user that it should be invested
         const invested = this.actor.inventory.invested;

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -230,7 +230,7 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
 
         return {
             item,
-            canBeEquipped: !item.isInContainer,
+            canBeEquipped: !item.isStowed,
             hasCharges: item.isOfType("consumable") && item.system.uses.max > 0,
             heldItems,
             isContainer: item.isOfType("backpack"),


### PR DESCRIPTION
Whether an item is actually equipped/invested depends on whether its stowed or not, but the *display* of said elements were based on whether it was in a container or not. This makes the latter match the former.