### PR TITLE
Add class features for Revolutionary Innovation

### DIFF
--- a/packs/classfeatures/attack-refiner.json
+++ b/packs/classfeatures/attack-refiner.json
@@ -1,0 +1,36 @@
+{
+    "_id": "ZcoOMwEY8FX7UzMo",
+    "img": "systems/pf2e/icons/default-icons/feat.svg",
+    "name": "Attack Refiner",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "classfeature",
+        "description": {
+            "value": "<p>Your weapon makes minute recalibrations after every missed attack to ensure the next lands true. Your innovation gains the backswing and shove traits.</p>"
+        },
+        "level": {
+            "value": 15
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Guns & Gears"
+        },
+        "rules": [],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "inventor"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/packs/classfeatures/automated-impediments.json
+++ b/packs/classfeatures/automated-impediments.json
@@ -1,0 +1,36 @@
+{
+    "_id": "HC99e4WoM36W3lrL",
+    "img": "systems/pf2e/icons/default-icons/feat.svg",
+    "name": "Automated Impediments",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "classfeature",
+        "description": {
+            "value": "<p>Your armor uses electromagnetic fields, subharmonic distortions, or other techniques to make it difficult for those close to you to move unless you allow it. While wearing your armor, all spaces adjacent to you are difficult terrain for your enemies.</p>"
+        },
+        "level": {
+            "value": 15
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Guns & Gears"
+        },
+        "rules": [],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "inventor"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/packs/classfeatures/deadly-strike.json
+++ b/packs/classfeatures/deadly-strike.json
@@ -1,0 +1,36 @@
+{
+    "_id": "KcK3d8zw0bCEoaEG",
+    "img": "systems/pf2e/icons/default-icons/feat.svg",
+    "name": "Deadly Strike",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "classfeature",
+        "description": {
+            "value": "<p>Through precise calculation, you've found the perfect way for your weapon to deal damage on a well-placed strike. Your innovation gains the deadly d8 trait. If your innovation was already deadly, increase the die by up to two die sizes (d6 to d10, d8 to d12), to a maximum of deadly d12.</p>"
+        },
+        "level": {
+            "value": 15
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Guns & Gears"
+        },
+        "rules": [],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "inventor"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/packs/classfeatures/enhanced-damage.json
+++ b/packs/classfeatures/enhanced-damage.json
@@ -1,0 +1,36 @@
+{
+    "_id": "KmFz27FVNXYWwgIc",
+    "img": "systems/pf2e/icons/default-icons/feat.svg",
+    "name": "Enhanced Damage",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "classfeature",
+        "description": {
+            "value": "<p>You've made your innovation more powerful than other weapons of its kind. Increase your innovation's weapon damage die by one step (d4 to d6, d6 to d8, d8 to d10, d10 to d12). As normal, you can't increase your die by more than one size, so this modification isn't cumulative with complex simplicity.</p>"
+        },
+        "level": {
+            "value": 15
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Guns & Gears"
+        },
+        "rules": [],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "inventor"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/packs/classfeatures/extensible-weapon.json
+++ b/packs/classfeatures/extensible-weapon.json
@@ -1,0 +1,36 @@
+{
+    "_id": "YQs4G9YK3VskY2F6",
+    "img": "systems/pf2e/icons/default-icons/feat.svg",
+    "name": "Extensible Weapon",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "classfeature",
+        "description": {
+            "value": "<p><strong>Melee only</strong></p><hr /><p>You've found a way to construct your weapon so that it can extend while leaving its balance unchanged. Your innovation gains the reach trait. If the weapon already had the reach trait, it increases your reach by an additional 10 feet, instead of the usual additional 5 feet.</p>"
+        },
+        "level": {
+            "value": 15
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Guns & Gears"
+        },
+        "rules": [],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "inventor"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/packs/classfeatures/heavy-construction.json
+++ b/packs/classfeatures/heavy-construction.json
@@ -17,7 +17,11 @@
             "value": 7
         },
         "prerequisites": {
-            "value": []
+            "value": [
+                {
+                    "value": "Power Suit Only"
+                }
+            ]
         },
         "publication": {
             "license": "OGL",

--- a/packs/classfeatures/heavy-construction.json
+++ b/packs/classfeatures/heavy-construction.json
@@ -11,17 +11,13 @@
         },
         "category": "classfeature",
         "description": {
-            "value": "<p>You've expanded your innovation into a heavy bulwark, and your groundbreaking design ensures you don't take any of the drawbacks for such heavy defenses. Your innovation becomes heavy armor, and your proficiency in your innovation armor (but no other heavy armor) advances to be equal to your proficiency in medium armor. If your Strength modifier is at least +4, you remove the Speed penalty entirely instead of reducing it to –5 feet.</p>\n<p>The armor's adjusted statistics are: AC Bonus +5; Dex Cap +1; Check Penalty –2; Speed Penalty –10 feet; Strength +3; Bulk 3; Group composite; Armor Traits bulwark.</p>"
+            "value": "<p><strong>Power Suit only</strong></p><hr /><p>You've expanded your innovation into a heavy bulwark, and your groundbreaking design ensures you don't take any of the drawbacks for such heavy defenses. Your innovation becomes heavy armor, and your proficiency in your innovation armor (but no other heavy armor) advances to be equal to your proficiency in medium armor. If your Strength modifier is at least +4, you remove the Speed penalty entirely instead of reducing it to –5 feet.</p>\n<p>The armor's adjusted statistics are: AC Bonus +5; Dex Cap +1; Check Penalty –2; Speed Penalty –10 feet; Strength +3; Bulk 3; Group composite; Armor Traits bulwark.</p>"
         },
         "level": {
             "value": 7
         },
         "prerequisites": {
-            "value": [
-                {
-                    "value": "Power Suit Only"
-                }
-            ]
+            "value": []
         },
         "publication": {
             "license": "OGL",

--- a/packs/classfeatures/impossible-alloy.json
+++ b/packs/classfeatures/impossible-alloy.json
@@ -1,0 +1,36 @@
+{
+    "_id": "2xVLO3JDe4gYlqv4",
+    "img": "systems/pf2e/icons/default-icons/feat.svg",
+    "name": "Impossible Alloy",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "classfeature",
+        "description": {
+            "value": "<p>Other inventors claim it's not even technically possible, but you've managed to create several metal alloys that seem to work for only you. These alloys can damage opponents vulnerable to any one of the seven skymetals. Your innovation is treated as all seven skymetals (abysium, adamantine, djezet, inubrix, noqual, orichalcum, and siccatite). This means you deal more damage to a variety of creatures, though you don't apply any of the other special effects for weapons made of those skymetals.</p>"
+        },
+        "level": {
+            "value": 15
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Guns & Gears"
+        },
+        "rules": [],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "inventor"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/packs/classfeatures/incredible-resistance.json
+++ b/packs/classfeatures/incredible-resistance.json
@@ -1,0 +1,36 @@
+{
+    "_id": "82rxCGBb5qf9fwbp",
+    "img": "systems/pf2e/icons/default-icons/feat.svg",
+    "name": "Incredible Resistance",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "classfeature",
+        "description": {
+            "value": "<p>You've improved upon your breakthrough modification's ability to resist damage. Choose one of the following breakthrough modifications your innovation has: dense plating, layered mesh, or tensile absorption. Increase the resistance you gain from that modification to be equal to your level, instead of half your level.</p>"
+        },
+        "level": {
+            "value": 15
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Guns & Gears"
+        },
+        "rules": [],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "inventor"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/packs/classfeatures/momentum-retainer.json
+++ b/packs/classfeatures/momentum-retainer.json
@@ -1,0 +1,36 @@
+{
+    "_id": "g9UMdKV1TxNdhpDO",
+    "img": "systems/pf2e/icons/default-icons/feat.svg",
+    "name": "Momentum Retainer",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "classfeature",
+        "description": {
+            "value": "<p><strong>Melee only</strong></p><hr /><p>A special weighted device lets your weapon retain more of its momentum when you attack. Your innovation gains the forceful and versatile B traits.</p>"
+        },
+        "level": {
+            "value": 15
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Guns & Gears"
+        },
+        "rules": [],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "inventor"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/packs/classfeatures/multisensory-mask.json
+++ b/packs/classfeatures/multisensory-mask.json
@@ -11,17 +11,13 @@
         },
         "category": "classfeature",
         "description": {
-            "value": "<p>You've built a multisensory mask over your armor that protects you by distorting your figure from all senses, leaving behind only a hazy image, muffled sounds, and so forth. While wearing the armor, you gain concealment against all creatures, even if they are using a nonvisual precise sense, such as a bat's echolocation. As normal for effects that leave your location obvious, you can't use this concealment to Hide or @UUID[Compendium.pf2e.actionspf2e.Item.Sneak]. If you use a hostile action, the concealment ends until you restore the mask as a single action, which has the manipulate trait.</p>"
+            "value": "<p><strong>Subterfuge Suit only</strong></p><hr /><p>You've built a multisensory mask over your armor that protects you by distorting your figure from all senses, leaving behind only a hazy image, muffled sounds, and so forth. While wearing the armor, you gain concealment against all creatures, even if they are using a nonvisual precise sense, such as a bat's echolocation. As normal for effects that leave your location obvious, you can't use this concealment to Hide or @UUID[Compendium.pf2e.actionspf2e.Item.Sneak]. If you use a hostile action, the concealment ends until you restore the mask as a single action, which has the manipulate trait.</p>"
         },
         "level": {
             "value": 15
         },
         "prerequisites": {
-            "value": [
-                {
-                    "value": "Subterfuge Suit Only"
-                }
-            ]
+            "value": []
         },
         "publication": {
             "license": "OGL",

--- a/packs/classfeatures/multisensory-mask.json
+++ b/packs/classfeatures/multisensory-mask.json
@@ -1,0 +1,40 @@
+{
+    "_id": "ZrkyPG41iFicYsdX",
+    "img": "systems/pf2e/icons/default-icons/feat.svg",
+    "name": "Multisensory Mask",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "classfeature",
+        "description": {
+            "value": "<p>You've built a multisensory mask over your armor that protects you by distorting your figure from all senses, leaving behind only a hazy image, muffled sounds, and so forth. While wearing the armor, you gain concealment against all creatures, even if they are using a nonvisual precise sense, such as a bat's echolocation. As normal for effects that leave your location obvious, you can't use this concealment to Hide or @UUID[Compendium.pf2e.actionspf2e.Item.Sneak]. If you use a hostile action, the concealment ends until you restore the mask as a single action, which has the manipulate trait.</p>"
+        },
+        "level": {
+            "value": 15
+        },
+        "prerequisites": {
+            "value": [
+                {
+                    "value": "Subterfuge Suit Only"
+                }
+            ]
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Guns & Gears"
+        },
+        "rules": [],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "inventor"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/packs/classfeatures/omnirange-stabilizers.json
+++ b/packs/classfeatures/omnirange-stabilizers.json
@@ -1,0 +1,36 @@
+{
+    "_id": "GoMoEtTu9uP7nxkg",
+    "img": "systems/pf2e/icons/default-icons/feat.svg",
+    "name": "Omnirange Stabilizers",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "classfeature",
+        "description": {
+            "value": "<p><strong>Ranged only</strong></p><hr /><p>You've modified your innovation to be dangerous and effective at any range. If your innovation had the volley trait, remove the volley trait. Otherwise, increase your innovation's range increment by 50 feet or an amount equal to the weapon's base range increment, whichever is more</p>"
+        },
+        "level": {
+            "value": 15
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Guns & Gears"
+        },
+        "rules": [],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "inventor"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/packs/classfeatures/perfect-fortification.json
+++ b/packs/classfeatures/perfect-fortification.json
@@ -11,17 +11,13 @@
         },
         "category": "classfeature",
         "description": {
-            "value": "<p>You've outfitted your armor with such heavy fortifications that deadly attacks often lose their edge. Each time you're critically hit while wearing the armor, attempt a @Check[type:flat|dc:13]. On a success, it becomes a normal hit. This isn't cumulative with fortification runes or other abilities that reduce critical hits with a flat check. Additionally, you gain resistance 2 + half your level against precision damage.</p>"
+            "value": "<p><strong>Power Suit only</strong></p><hr /><p>You've outfitted your armor with such heavy fortifications that deadly attacks often lose their edge. Each time you're critically hit while wearing the armor, attempt a @Check[type:flat|dc:13]. On a success, it becomes a normal hit. This isn't cumulative with fortification runes or other abilities that reduce critical hits with a flat check. Additionally, you gain resistance 2 + half your level against precision damage.</p>"
         },
         "level": {
             "value": 15
         },
         "prerequisites": {
-            "value": [
-                {
-                    "value": "Power Suit Only"
-                }
-            ]
+            "value": []
         },
         "publication": {
             "license": "OGL",

--- a/packs/classfeatures/perfect-fortification.json
+++ b/packs/classfeatures/perfect-fortification.json
@@ -1,0 +1,40 @@
+{
+    "_id": "Q172fARBaNDR8Gqx",
+    "img": "systems/pf2e/icons/default-icons/feat.svg",
+    "name": "Perfect Fortification",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "classfeature",
+        "description": {
+            "value": "<p>You've outfitted your armor with such heavy fortifications that deadly attacks often lose their edge. Each time you're critically hit while wearing the armor, attempt a @Check[type:flat|dc:13]. On a success, it becomes a normal hit. This isn't cumulative with fortification runes or other abilities that reduce critical hits with a flat check. Additionally, you gain resistance 2 + half your level against precision damage.</p>"
+        },
+        "level": {
+            "value": 15
+        },
+        "prerequisites": {
+            "value": [
+                {
+                    "value": "Power Suit Only"
+                }
+            ]
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Guns & Gears"
+        },
+        "rules": [],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "inventor"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/packs/classfeatures/physical-protections.json
+++ b/packs/classfeatures/physical-protections.json
@@ -1,0 +1,36 @@
+{
+    "_id": "8jELNQUBMAXUj3zR",
+    "img": "systems/pf2e/icons/default-icons/feat.svg",
+    "name": "Physical Protections",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "classfeature",
+        "description": {
+            "value": "<p>Your armor has so many adjustments and precautions that it can guard against all physical damage. While wearing your armor, you gain resistance to all physical damage (bludgeoning, piercing, and slashing damage, as well as persistent bleed damage) equal to half your level. You must have the dense plating, layered mesh, or tensile absorption breakthrough modification to select this modification.</p>"
+        },
+        "level": {
+            "value": 15
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Guns & Gears"
+        },
+        "rules": [],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "inventor"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/packs/classfeatures/rune-capacity.json
+++ b/packs/classfeatures/rune-capacity.json
@@ -1,0 +1,36 @@
+{
+    "_id": "rYfmpMBy7wd1VHeO",
+    "img": "systems/pf2e/icons/default-icons/feat.svg",
+    "name": "Rune Capacity",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "classfeature",
+        "description": {
+            "value": "<p>Whether you've done some dabbling in orichalcum alloys or found another engineering solution, you've built your innovation in such a way that it can hold an additional property rune. Your innovation can have one more property rune than a normal item of its kind (to a maximum of four property runes with a +3 potency armor).</p>"
+        },
+        "level": {
+            "value": 15
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Guns & Gears"
+        },
+        "rules": [],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "inventor"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/packs/classfeatures/tangle-line.json
+++ b/packs/classfeatures/tangle-line.json
@@ -11,7 +11,7 @@
         },
         "category": "classfeature",
         "description": {
-            "value": "<p><strong>Thrown Only</strong></p>\n<hr />\n<p>Your weapon has an extensible line that you can use to knock your enemies over and quickly recall the weapon back to your hand. Your innovation gains the ranged trip trait and the tethered trait.</p>"
+            "value": "<p><strong>Thrown Only</strong></p><hr /><p>Your weapon has an extensible line that you can use to knock your enemies over and quickly recall the weapon back to your hand. Your innovation gains the ranged trip trait and the tethered trait.</p>"
         },
         "level": {
             "value": 7


### PR DESCRIPTION
Class Features granted by Revolutionary Innovation are not in the system. This is a first step to add these and then build towards adding automation.