### PR TITLE
correct Fire Giant's (Monster Core) Flame Attack

### DIFF
--- a/packs/pathfinder-monster-core/fire-giant.json
+++ b/packs/pathfinder-monster-core/fire-giant.json
@@ -383,15 +383,16 @@
                     ]
                 },
                 "bonus": {
-                    "value": 23
+                    "value": 21
                 },
                 "damageRolls": {
                     "i4ggn8pkplgq6191icks": {
-                        "damage": "2d8+13",
-                        "damageType": "bludgeoning"
+                        "damage": "4d6",
+                        "damageType": "fire"
                     },
                     "g7vi65l83agsomxlgjhc": {
-                        "damage": "1d6",
+                        "category": "persistent",
+                        "damage": "2d6",
                         "damageType": "fire"
                     }
                 },


### PR DESCRIPTION
Fix the Flame attack to reflect the Monster Core attack parameters.
Closes #15040