### PR TITLE
Add custom resistance exception for Iron Warden

### DIFF
--- a/packs/pathfinder-monster-core/iron-warden.json
+++ b/packs/pathfinder-monster-core/iron-warden.json
@@ -194,7 +194,26 @@
                     "remaster": true,
                     "title": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "exceptions": [
+                            {
+                                "definition": [
+                                    {
+                                        "or": [
+                                            "damage:type:acid",
+                                            "spell:cause-rust"
+                                        ]
+                                    }
+                                ],
+                                "label": "PF2E.IWR.Custom.AcidAndSpellsThatCauseRust"
+                            }
+                        ],
+                        "key": "Resistance",
+                        "type": "spells",
+                        "value": 15
+                    }
+                ],
                 "slug": null,
                 "traits": {
                     "value": [
@@ -340,14 +359,6 @@
                         "adamantine"
                     ],
                     "type": "physical",
-                    "value": 15
-                },
-                {
-                    "doubleVs": [],
-                    "exceptions": [
-                        "acid"
-                    ],
-                    "type": "spells",
                     "value": 15
                 }
             ],

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -593,6 +593,7 @@
         },
         "IWR": {
             "Custom": {
+                "AcidAndSpellsThatCauseRust": "acid and spells that cause rust",
                 "AdamantineBludgeoning": "adamantine bludgeoning",
                 "AllDamageFromArcaneSpells": "all damage from arcane spells",
                 "AllDamageFromFungus": "all damage from fungus",


### PR DESCRIPTION
The "spells that cause rust" portion isn't functional, but at least it will show in the sheet.

Closes https://github.com/foundryvtt/pf2e/issues/15035