### PR TITLE
Update Shisagishin to add Grab to its melee attack

### DIFF
--- a/packs/season-of-ghosts-bestiary/shisagishin.json
+++ b/packs/season-of-ghosts-bestiary/shisagishin.json
@@ -699,7 +699,9 @@
                     "value": ""
                 },
                 "attackEffects": {
-                    "value": []
+                    "value": [
+                        "grab"
+                    ]
                 },
                 "bonus": {
                     "value": 25


### PR DESCRIPTION
I added Grab to the melee strike.
Closes #15042