### PR TITLE
Add custom `tagify-tags` HTML element that handles `Tagify` form data

### DIFF
--- a/src/module/actor/hazard/sheet.ts
+++ b/src/module/actor/hazard/sheet.ts
@@ -1,6 +1,7 @@
 import { StrikeData } from "@actor/data/base.ts";
 import { ActorSheetPF2e, SheetClickActionHandlers } from "@actor/sheet/base.ts";
 import { SAVE_TYPES } from "@actor/values.ts";
+import { HTMLTagifyTraitsElement } from "@system/html-elements/tagify-traits.ts";
 import { htmlClosest, htmlQuery, tagify, traitSlugToObject } from "@util";
 import type { HazardPF2e } from "./document.ts";
 import { HazardActionSheetData, HazardSaveSheetData, HazardSheetData } from "./types.ts";
@@ -136,7 +137,7 @@ export class HazardSheetPF2e extends ActorSheetPF2e<HazardPF2e> {
         const html = $html[0];
 
         // Tagify the traits selection
-        const traitsEl = html.querySelector<HTMLInputElement>('input[name="system.traits.value"]');
+        const traitsEl = htmlQuery<HTMLTagifyTraitsElement>(html, 'tagify-traits[name="system.traits.value"]');
         if (traitsEl) {
             const tags = tagify(traitsEl, { whitelist: CONFIG.PF2E.hazardTraits });
             const traitsPrepend = html.querySelector<HTMLTemplateElement>(".traits-extra");

--- a/src/module/actor/hazard/sheet.ts
+++ b/src/module/actor/hazard/sheet.ts
@@ -1,7 +1,7 @@
 import { StrikeData } from "@actor/data/base.ts";
 import { ActorSheetPF2e, SheetClickActionHandlers } from "@actor/sheet/base.ts";
 import { SAVE_TYPES } from "@actor/values.ts";
-import { HTMLTagifyTraitsElement } from "@system/html-elements/tagify-traits.ts";
+import { HTMLTagifyTagsElement } from "@system/html-elements/tagify-tags.ts";
 import { htmlClosest, htmlQuery, tagify, traitSlugToObject } from "@util";
 import type { HazardPF2e } from "./document.ts";
 import { HazardActionSheetData, HazardSaveSheetData, HazardSheetData } from "./types.ts";
@@ -137,7 +137,7 @@ export class HazardSheetPF2e extends ActorSheetPF2e<HazardPF2e> {
         const html = $html[0];
 
         // Tagify the traits selection
-        const traitsEl = htmlQuery<HTMLTagifyTraitsElement>(html, 'tagify-traits[name="system.traits.value"]');
+        const traitsEl = htmlQuery<HTMLTagifyTagsElement>(html, 'tagify-tags[name="system.traits.value"]');
         if (traitsEl) {
             const tags = tagify(traitsEl, { whitelist: CONFIG.PF2E.hazardTraits });
             const traitsPrepend = html.querySelector<HTMLTemplateElement>(".traits-extra");

--- a/src/module/actor/npc/sheet.ts
+++ b/src/module/actor/npc/sheet.ts
@@ -8,6 +8,7 @@ import { ATTRIBUTE_ABBREVIATIONS, MOVEMENT_TYPES, SAVE_TYPES } from "@actor/valu
 import { createTagifyTraits } from "@module/sheet/helpers.ts";
 import type { UserPF2e } from "@module/user/document.ts";
 import { DicePF2e } from "@scripts/dice.ts";
+import type { HTMLTagifyTraitsElement } from "@system/html-elements/tagify-traits.ts";
 import {
     getActionGlyph,
     htmlClosest,
@@ -100,7 +101,7 @@ abstract class AbstractNPCSheet extends CreatureSheetPF2e<NPCPF2e> {
         const html = $html[0];
 
         // Tagify the traits selection
-        const traitsEl = htmlQuery<HTMLInputElement>(html, 'input[name="system.traits.value"]');
+        const traitsEl = htmlQuery<HTMLTagifyTraitsElement>(html, 'tagify-traits[name="system.traits.value"]');
         tagify(traitsEl, { whitelist: CONFIG.PF2E.creatureTraits });
     }
 

--- a/src/module/actor/npc/sheet.ts
+++ b/src/module/actor/npc/sheet.ts
@@ -8,7 +8,7 @@ import { ATTRIBUTE_ABBREVIATIONS, MOVEMENT_TYPES, SAVE_TYPES } from "@actor/valu
 import { createTagifyTraits } from "@module/sheet/helpers.ts";
 import type { UserPF2e } from "@module/user/document.ts";
 import { DicePF2e } from "@scripts/dice.ts";
-import type { HTMLTagifyTraitsElement } from "@system/html-elements/tagify-traits.ts";
+import type { HTMLTagifyTagsElement } from "@system/html-elements/tagify-tags.ts";
 import {
     getActionGlyph,
     htmlClosest,
@@ -101,7 +101,7 @@ abstract class AbstractNPCSheet extends CreatureSheetPF2e<NPCPF2e> {
         const html = $html[0];
 
         // Tagify the traits selection
-        const traitsEl = htmlQuery<HTMLTagifyTraitsElement>(html, 'tagify-traits[name="system.traits.value"]');
+        const traitsEl = htmlQuery<HTMLTagifyTagsElement>(html, 'tagify-tags[name="system.traits.value"]');
         tagify(traitsEl, { whitelist: CONFIG.PF2E.creatureTraits });
     }
 

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -15,7 +15,7 @@ import { detachSubitem } from "@item/physical/helpers.ts";
 import { DENOMINATIONS, PHYSICAL_ITEM_TYPES } from "@item/physical/values.ts";
 import { DropCanvasItemDataPF2e } from "@module/canvas/drop-canvas-data.ts";
 import { createSelfEffectMessage } from "@module/chat-message/helpers.ts";
-import { createSheetTags, maintainFocusInRender, processTagifyInSubmitData } from "@module/sheet/helpers.ts";
+import { createSheetTags, maintainFocusInRender } from "@module/sheet/helpers.ts";
 import { eventToRollMode, eventToRollParams } from "@scripts/sheet-util.ts";
 import { DamageRoll } from "@system/damage/roll.ts";
 import type { StatisticRollParameters } from "@system/statistic/statistic.ts";
@@ -1281,21 +1281,8 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
         }
     }
 
-    /** Tagify sets an empty input field to "" instead of "[]", which later causes the JSON parse to throw an error */
-    protected override async _onSubmit(
-        event: Event,
-        { updateData = null, preventClose = false, preventRender = false }: OnSubmitFormOptions = {},
-    ): Promise<Record<string, unknown> | false> {
-        for (const input of htmlQueryAll<HTMLInputElement>(this.form, "tags ~ input")) {
-            if (input.value === "") input.value = "[]";
-        }
-
-        return super._onSubmit(event, { updateData, preventClose, preventRender });
-    }
-
     protected override _getSubmitData(updateData?: Record<string, unknown>): Record<string, unknown> {
         const data = super._getSubmitData(updateData);
-        processTagifyInSubmitData(this.form, data);
 
         // Use delta values for inputs that have `data-allow-delta` if input value starts with + or -
         for (const el of this.form.elements) {

--- a/src/module/item/base/sheet/rule-element-form/aura.ts
+++ b/src/module/item/base/sheet/rule-element-form/aura.ts
@@ -1,7 +1,7 @@
 import { userColorForActor } from "@actor/helpers.ts";
 import type { ItemPF2e } from "@item";
 import type { AuraRuleElement, AuraRuleElementSchema } from "@module/rules/rule-element/aura.ts";
-import type { HTMLTagifyTraitsElement } from "@system/html-elements/tagify-traits.ts";
+import type { HTMLTagifyTagsElement } from "@system/html-elements/tagify-tags.ts";
 import { htmlClosest, htmlQuery, htmlQueryAll, isImageFilePath, tagify } from "@util";
 import * as R from "remeda";
 import { RuleElementForm, RuleElementFormSheetData, RuleElementFormTabData } from "./base.ts";
@@ -31,13 +31,13 @@ class AuraForm extends RuleElementForm<AuraRuleElementSource, AuraRuleElement> {
     override activateListeners(html: HTMLElement): void {
         super.activateListeners(html);
 
-        const traitsElement = htmlQuery<HTMLTagifyTraitsElement>(html, "tagify-traits.tagify-traits");
+        const traitsElement = htmlQuery<HTMLTagifyTagsElement>(html, "tagify-tags.tagify-traits");
         if (traitsElement) {
             const whitelist = { ...CONFIG.PF2E.spellTraits, ...CONFIG.PF2E.actionTraits };
             tagify(traitsElement, { whitelist, enforceWhitelist: false });
         }
 
-        for (const eventsElement of htmlQueryAll<HTMLTagifyTraitsElement>(html, "tagify-traits.tagify-events")) {
+        for (const eventsElement of htmlQueryAll<HTMLTagifyTagsElement>(html, "tagify-tags.tagify-events")) {
             const whitelist = [
                 ["enter", game.i18n.localize("PF2E.RuleEditor.Aura.Effects.EventsOptions.Enter")],
                 ["turn-start", game.i18n.localize("PF2E.RuleEditor.Aura.Effects.EventsOptions.TurnStart")],

--- a/src/module/item/base/sheet/rule-element-form/aura.ts
+++ b/src/module/item/base/sheet/rule-element-form/aura.ts
@@ -1,6 +1,7 @@
 import { userColorForActor } from "@actor/helpers.ts";
 import type { ItemPF2e } from "@item";
 import type { AuraRuleElement, AuraRuleElementSchema } from "@module/rules/rule-element/aura.ts";
+import type { HTMLTagifyTraitsElement } from "@system/html-elements/tagify-traits.ts";
 import { htmlClosest, htmlQuery, htmlQueryAll, isImageFilePath, tagify } from "@util";
 import * as R from "remeda";
 import { RuleElementForm, RuleElementFormSheetData, RuleElementFormTabData } from "./base.ts";
@@ -30,13 +31,13 @@ class AuraForm extends RuleElementForm<AuraRuleElementSource, AuraRuleElement> {
     override activateListeners(html: HTMLElement): void {
         super.activateListeners(html);
 
-        const traitsElement = htmlQuery<HTMLInputElement>(html, ".tagify-traits");
+        const traitsElement = htmlQuery<HTMLTagifyTraitsElement>(html, "tagify-traits.tagify-traits");
         if (traitsElement) {
             const whitelist = { ...CONFIG.PF2E.spellTraits, ...CONFIG.PF2E.actionTraits };
             tagify(traitsElement, { whitelist, enforceWhitelist: false });
         }
 
-        for (const eventsElement of htmlQueryAll<HTMLInputElement>(html, ".tagify-events")) {
+        for (const eventsElement of htmlQueryAll<HTMLTagifyTraitsElement>(html, "tagify-traits.tagify-events")) {
             const whitelist = [
                 ["enter", game.i18n.localize("PF2E.RuleEditor.Aura.Effects.EventsOptions.Enter")],
                 ["turn-start", game.i18n.localize("PF2E.RuleEditor.Aura.Effects.EventsOptions.TurnStart")],

--- a/src/module/item/base/sheet/rule-element-form/base.ts
+++ b/src/module/item/base/sheet/rule-element-form/base.ts
@@ -3,6 +3,7 @@ import { ItemPF2e, ItemProxyPF2e } from "@item";
 import { isBracketedValue } from "@module/rules/helpers.ts";
 import { RuleElements, type RuleElementPF2e, type RuleElementSource } from "@module/rules/index.ts";
 import { ResolvableValueField, RuleElementSchema } from "@module/rules/rule-element/data.ts";
+import type { HTMLTagifyTraitsElement } from "@system/html-elements/tagify-traits.ts";
 import type { LaxSchemaField } from "@system/schema-data-fields.ts";
 import { createHTMLElement, fontAwesomeIcon, htmlClosest, htmlQuery, htmlQueryAll, isObject, tagify } from "@util";
 import * as R from "remeda";
@@ -199,7 +200,7 @@ class RuleElementForm<
         this.element = html;
 
         // Tagify selectors lists
-        const selectorElement = htmlQuery<HTMLInputElement>(html, ".selector-list");
+        const selectorElement = htmlQuery<HTMLTagifyTraitsElement>(html, "tagify-traits.selector-list");
         tagify(selectorElement);
 
         // Add event listener for priority. This exists because normal form submission won't work for text-area forms

--- a/src/module/item/base/sheet/rule-element-form/base.ts
+++ b/src/module/item/base/sheet/rule-element-form/base.ts
@@ -3,7 +3,7 @@ import { ItemPF2e, ItemProxyPF2e } from "@item";
 import { isBracketedValue } from "@module/rules/helpers.ts";
 import { RuleElements, type RuleElementPF2e, type RuleElementSource } from "@module/rules/index.ts";
 import { ResolvableValueField, RuleElementSchema } from "@module/rules/rule-element/data.ts";
-import type { HTMLTagifyTraitsElement } from "@system/html-elements/tagify-traits.ts";
+import type { HTMLTagifyTagsElement } from "@system/html-elements/tagify-tags.ts";
 import type { LaxSchemaField } from "@system/schema-data-fields.ts";
 import { createHTMLElement, fontAwesomeIcon, htmlClosest, htmlQuery, htmlQueryAll, isObject, tagify } from "@util";
 import * as R from "remeda";
@@ -200,7 +200,7 @@ class RuleElementForm<
         this.element = html;
 
         // Tagify selectors lists
-        const selectorElement = htmlQuery<HTMLTagifyTraitsElement>(html, "tagify-traits.selector-list");
+        const selectorElement = htmlQuery<HTMLTagifyTagsElement>(html, "tagify-tags.selector-list");
         tagify(selectorElement);
 
         // Add event listener for priority. This exists because normal form submission won't work for text-area forms

--- a/src/module/item/base/sheet/rule-element-form/fast-healing.ts
+++ b/src/module/item/base/sheet/rule-element-form/fast-healing.ts
@@ -3,7 +3,7 @@ import type {
     FastHealingSource,
     FastHealingType,
 } from "@module/rules/rule-element/fast-healing.ts";
-import type { HTMLTagifyTraitsElement } from "@system/html-elements/tagify-traits.ts";
+import type { HTMLTagifyTagsElement } from "@system/html-elements/tagify-tags.ts";
 import { htmlQuery, tagify } from "@util";
 import { RuleElementForm, RuleElementFormSheetData } from "./base.ts";
 
@@ -13,7 +13,7 @@ class FastHealingForm extends RuleElementForm<FastHealingSource, FastHealingRule
         super.activateListeners(html);
 
         // Tagify the selector list. Valid defaults should be the IWR weakness types
-        const selectorElement = htmlQuery<HTMLTagifyTraitsElement>(html, "tagify-traits.deactivated-by");
+        const selectorElement = htmlQuery<HTMLTagifyTagsElement>(html, "tagify-tags.deactivated-by");
         if (selectorElement) {
             const whitelist = CONFIG.PF2E.weaknessTypes;
             tagify(selectorElement, { whitelist, enforceWhitelist: false });

--- a/src/module/item/base/sheet/rule-element-form/fast-healing.ts
+++ b/src/module/item/base/sheet/rule-element-form/fast-healing.ts
@@ -3,6 +3,7 @@ import type {
     FastHealingSource,
     FastHealingType,
 } from "@module/rules/rule-element/fast-healing.ts";
+import type { HTMLTagifyTraitsElement } from "@system/html-elements/tagify-traits.ts";
 import { htmlQuery, tagify } from "@util";
 import { RuleElementForm, RuleElementFormSheetData } from "./base.ts";
 
@@ -12,7 +13,7 @@ class FastHealingForm extends RuleElementForm<FastHealingSource, FastHealingRule
         super.activateListeners(html);
 
         // Tagify the selector list. Valid defaults should be the IWR weakness types
-        const selectorElement = htmlQuery<HTMLInputElement>(html, ".deactivated-by");
+        const selectorElement = htmlQuery<HTMLTagifyTraitsElement>(html, "tagify-traits.deactivated-by");
         if (selectorElement) {
             const whitelist = CONFIG.PF2E.weaknessTypes;
             tagify(selectorElement, { whitelist, enforceWhitelist: false });

--- a/src/module/item/base/sheet/rule-element-form/roll-note.ts
+++ b/src/module/item/base/sheet/rule-element-form/roll-note.ts
@@ -1,5 +1,6 @@
 import type { NoteRESource, RollNoteRuleElement } from "@module/rules/rule-element/roll-note.ts";
 import { DEGREE_OF_SUCCESS_STRINGS } from "@system/degree-of-success.ts";
+import type { HTMLTagifyTraitsElement } from "@system/html-elements/tagify-traits.ts";
 import { htmlQuery, tagify } from "@util";
 import { RuleElementForm, RuleElementFormSheetData } from "./base.ts";
 
@@ -23,7 +24,7 @@ class RollNoteForm extends RuleElementForm<NoteRESource, RollNoteRuleElement> {
             const newValue = Array.isArray(selector) ? selector.at(0) ?? "" : [selector ?? ""].filter((s) => !!s);
             this.updateItem({ selector: newValue });
         });
-        const optionsEl = htmlQuery<HTMLInputElement>(html, ".outcomes");
+        const optionsEl = htmlQuery<HTMLTagifyTraitsElement>(html, "tagify-traits.outcomes");
         tagify(optionsEl, { whitelist: [...DEGREE_OF_SUCCESS_STRINGS], maxTags: 3 });
     }
 

--- a/src/module/item/base/sheet/rule-element-form/roll-note.ts
+++ b/src/module/item/base/sheet/rule-element-form/roll-note.ts
@@ -1,6 +1,6 @@
 import type { NoteRESource, RollNoteRuleElement } from "@module/rules/rule-element/roll-note.ts";
 import { DEGREE_OF_SUCCESS_STRINGS } from "@system/degree-of-success.ts";
-import type { HTMLTagifyTraitsElement } from "@system/html-elements/tagify-traits.ts";
+import type { HTMLTagifyTagsElement } from "@system/html-elements/tagify-tags.ts";
 import { htmlQuery, tagify } from "@util";
 import { RuleElementForm, RuleElementFormSheetData } from "./base.ts";
 
@@ -24,7 +24,7 @@ class RollNoteForm extends RuleElementForm<NoteRESource, RollNoteRuleElement> {
             const newValue = Array.isArray(selector) ? selector.at(0) ?? "" : [selector ?? ""].filter((s) => !!s);
             this.updateItem({ selector: newValue });
         });
-        const optionsEl = htmlQuery<HTMLTagifyTraitsElement>(html, "tagify-traits.outcomes");
+        const optionsEl = htmlQuery<HTMLTagifyTagsElement>(html, "tagify-tags.outcomes");
         tagify(optionsEl, { whitelist: [...DEGREE_OF_SUCCESS_STRINGS], maxTags: 3 });
     }
 

--- a/src/module/item/base/sheet/sheet.ts
+++ b/src/module/item/base/sheet/sheet.ts
@@ -6,10 +6,10 @@ import {
     createSheetTags,
     createTagifyTraits,
     maintainFocusInRender,
-    processTagifyInSubmitData,
     SheetOptions,
     TraitTagifyEntry,
 } from "@module/sheet/helpers.ts";
+import type { HTMLTagifyTraitsElement } from "@system/html-elements/tagify-traits.ts";
 import {
     BasicConstructorOptions,
     LanguageSelector,
@@ -459,9 +459,9 @@ class ItemSheetPF2e<TItem extends ItemPF2e> extends ItemSheet<TItem, ItemSheetOp
 
         // Set up traits selection in the header
         const { validTraits } = this;
-        const tagElement = htmlQuery(this.form, ":scope > header .tags");
+        const tagElement = htmlQuery<HTMLTagifyTraitsElement>(this.form, ":scope > header tagify-traits");
         const traitsPrepend = html.querySelector<HTMLTemplateElement>(".traits-extra");
-        if (validTraits !== null && tagElement instanceof HTMLInputElement) {
+        if (validTraits !== null && tagElement) {
             const tags = tagify(tagElement, { whitelist: validTraits });
             if (traitsPrepend) {
                 tags.DOM.scope.prepend(traitsPrepend.content);
@@ -472,7 +472,9 @@ class ItemSheetPF2e<TItem extends ItemPF2e> extends ItemSheet<TItem, ItemSheetOp
         }
 
         // Tagify other-tags input if present
-        tagify(htmlQuery<HTMLInputElement>(html, 'input[type=text][name="system.traits.otherTags"]'), { maxTags: 6 });
+        tagify(htmlQuery<HTMLTagifyTraitsElement>(html, 'tagify-traits[name="system.traits.otherTags"]'), {
+            maxTags: 6,
+        });
 
         // Handle select and input elements that show modified prepared values until focused
         const modifiedPropertyFields = htmlQueryAll<HTMLSelectElement | HTMLInputElement>(html, "[data-property]");
@@ -579,18 +581,6 @@ class ItemSheetPF2e<TItem extends ItemPF2e> extends ItemSheet<TItem, ItemSheetOp
         }
     }
 
-    protected override _getSubmitData(updateData: Record<string, unknown> | null = null): Record<string, unknown> {
-        // create the expanded update data object
-        const fd = new FormDataExtended(this.form, { editors: this.editors });
-        const data: Record<string, unknown> & { system?: { rules?: string[] } } = updateData
-            ? fu.mergeObject(fd.object, updateData)
-            : fu.expandObject(fd.object);
-
-        const flattenedData = fu.flattenObject(data);
-        processTagifyInSubmitData(this.form, flattenedData);
-        return flattenedData;
-    }
-
     /** Add button to refresh from compendium if setting is enabled. */
     protected override _getHeaderButtons(): ApplicationHeaderButton[] {
         const buttons = super._getHeaderButtons();
@@ -618,18 +608,6 @@ class ItemSheetPF2e<TItem extends ItemPF2e> extends ItemSheet<TItem, ItemSheetOp
 
     protected override _canDragDrop(_selector: string): boolean {
         return this.item.isOwner;
-    }
-
-    /** Tagify sets an empty input field to "" instead of "[]", which later causes the JSON parse to throw an error */
-    protected override async _onSubmit(
-        event: Event,
-        { updateData = null, preventClose = false, preventRender = false }: OnSubmitFormOptions = {},
-    ): Promise<Record<string, unknown> | false> {
-        for (const input of htmlQueryAll<HTMLInputElement>(this.form, "tags ~ input")) {
-            if (input.value === "") input.value = "[]";
-        }
-
-        return super._onSubmit(event, { updateData, preventClose, preventRender });
     }
 
     protected override async _updateObject(event: Event, formData: Record<string, unknown>): Promise<void> {

--- a/src/module/item/base/sheet/sheet.ts
+++ b/src/module/item/base/sheet/sheet.ts
@@ -9,7 +9,7 @@ import {
     SheetOptions,
     TraitTagifyEntry,
 } from "@module/sheet/helpers.ts";
-import type { HTMLTagifyTraitsElement } from "@system/html-elements/tagify-traits.ts";
+import type { HTMLTagifyTagsElement } from "@system/html-elements/tagify-tags.ts";
 import {
     BasicConstructorOptions,
     LanguageSelector,
@@ -459,7 +459,7 @@ class ItemSheetPF2e<TItem extends ItemPF2e> extends ItemSheet<TItem, ItemSheetOp
 
         // Set up traits selection in the header
         const { validTraits } = this;
-        const tagElement = htmlQuery<HTMLTagifyTraitsElement>(this.form, ":scope > header tagify-traits");
+        const tagElement = htmlQuery<HTMLTagifyTagsElement>(this.form, ":scope > header tagify-tags");
         const traitsPrepend = html.querySelector<HTMLTemplateElement>(".traits-extra");
         if (validTraits !== null && tagElement) {
             const tags = tagify(tagElement, { whitelist: validTraits });
@@ -472,7 +472,7 @@ class ItemSheetPF2e<TItem extends ItemPF2e> extends ItemSheet<TItem, ItemSheetOp
         }
 
         // Tagify other-tags input if present
-        tagify(htmlQuery<HTMLTagifyTraitsElement>(html, 'tagify-traits[name="system.traits.otherTags"]'), {
+        tagify(htmlQuery<HTMLTagifyTagsElement>(html, 'tagify-tags[name="system.traits.otherTags"]'), {
             maxTags: 6,
         });
 

--- a/src/module/item/campaign-feature/sheet.ts
+++ b/src/module/item/campaign-feature/sheet.ts
@@ -1,6 +1,6 @@
 import { activateActionSheetListeners } from "@item/ability/helpers.ts";
 import { ItemSheetDataPF2e, ItemSheetOptions, ItemSheetPF2e } from "@item/base/sheet/sheet.ts";
-import type { HTMLTagifyTraitsElement } from "@system/html-elements/tagify-traits.ts";
+import type { HTMLTagifyTagsElement } from "@system/html-elements/tagify-tags.ts";
 import { htmlQuery, tagify } from "@util";
 import type { CampaignFeaturePF2e } from "./document.ts";
 import { KINGMAKER_CATEGORIES } from "./values.ts";
@@ -35,10 +35,7 @@ class CampaignFeatureSheetPF2e extends ItemSheetPF2e<CampaignFeaturePF2e> {
         const html = $html[0];
         activateActionSheetListeners(this.item, html);
 
-        const prerequisites = htmlQuery<HTMLTagifyTraitsElement>(
-            html,
-            'tagify-traits[name="system.prerequisites.value"]',
-        );
+        const prerequisites = htmlQuery<HTMLTagifyTagsElement>(html, 'tagify-tags[name="system.prerequisites.value"]');
         if (prerequisites) {
             tagify(prerequisites, {
                 editTags: 1,

--- a/src/module/item/campaign-feature/sheet.ts
+++ b/src/module/item/campaign-feature/sheet.ts
@@ -1,7 +1,7 @@
 import { activateActionSheetListeners } from "@item/ability/helpers.ts";
 import { ItemSheetDataPF2e, ItemSheetOptions, ItemSheetPF2e } from "@item/base/sheet/sheet.ts";
-import { htmlQuery } from "@util";
-import Tagify from "@yaireo/tagify";
+import type { HTMLTagifyTraitsElement } from "@system/html-elements/tagify-traits.ts";
+import { htmlQuery, tagify } from "@util";
 import type { CampaignFeaturePF2e } from "./document.ts";
 import { KINGMAKER_CATEGORIES } from "./values.ts";
 
@@ -35,9 +35,12 @@ class CampaignFeatureSheetPF2e extends ItemSheetPF2e<CampaignFeaturePF2e> {
         const html = $html[0];
         activateActionSheetListeners(this.item, html);
 
-        const prerequisites = htmlQuery<HTMLInputElement>(html, 'input[name="system.prerequisites.value"]');
+        const prerequisites = htmlQuery<HTMLTagifyTraitsElement>(
+            html,
+            'tagify-traits[name="system.prerequisites.value"]',
+        );
         if (prerequisites) {
-            new Tagify(prerequisites, {
+            tagify(prerequisites, {
                 editTags: 1,
             });
         }

--- a/src/module/item/deity/sheet.ts
+++ b/src/module/item/deity/sheet.ts
@@ -2,6 +2,7 @@ import type { SkillSlug } from "@actor/types.ts";
 import { ItemPF2e, SpellPF2e, type DeityPF2e } from "@item";
 import { ItemSheetDataPF2e, ItemSheetOptions, ItemSheetPF2e } from "@item/base/sheet/sheet.ts";
 import { SheetOptions, createSheetOptions } from "@module/sheet/helpers.ts";
+import type { HTMLTagifyTraitsElement } from "@system/html-elements/tagify-traits.ts";
 import { ErrorPF2e, htmlClosest, htmlQuery, htmlQueryAll, tagify } from "@util";
 import { UUIDUtils } from "@util/uuid.ts";
 import * as R from "remeda";
@@ -65,7 +66,8 @@ export class DeitySheetPF2e extends ItemSheetPF2e<DeityPF2e> {
         const html = $html[0];
 
         // Create tagify selection inputs
-        const getInput = (name: string): HTMLInputElement | null => html.querySelector(`input[name="${name}"]`);
+        const getInput = (name: string): HTMLTagifyTraitsElement | null =>
+            htmlQuery<HTMLTagifyTraitsElement>(html, `tagify-traits[name="${name}"]`);
 
         tagify(getInput("system.attribute"), { whitelist: CONFIG.PF2E.abilities, maxTags: 2 });
 

--- a/src/module/item/deity/sheet.ts
+++ b/src/module/item/deity/sheet.ts
@@ -2,7 +2,7 @@ import type { SkillSlug } from "@actor/types.ts";
 import { ItemPF2e, SpellPF2e, type DeityPF2e } from "@item";
 import { ItemSheetDataPF2e, ItemSheetOptions, ItemSheetPF2e } from "@item/base/sheet/sheet.ts";
 import { SheetOptions, createSheetOptions } from "@module/sheet/helpers.ts";
-import type { HTMLTagifyTraitsElement } from "@system/html-elements/tagify-traits.ts";
+import type { HTMLTagifyTagsElement } from "@system/html-elements/tagify-tags.ts";
 import { ErrorPF2e, htmlClosest, htmlQuery, htmlQueryAll, tagify } from "@util";
 import { UUIDUtils } from "@util/uuid.ts";
 import * as R from "remeda";
@@ -66,8 +66,8 @@ export class DeitySheetPF2e extends ItemSheetPF2e<DeityPF2e> {
         const html = $html[0];
 
         // Create tagify selection inputs
-        const getInput = (name: string): HTMLTagifyTraitsElement | null =>
-            htmlQuery<HTMLTagifyTraitsElement>(html, `tagify-traits[name="${name}"]`);
+        const getInput = (name: string): HTMLTagifyTagsElement | null =>
+            htmlQuery<HTMLTagifyTagsElement>(html, `tagify-tags[name="${name}"]`);
 
         tagify(getInput("system.attribute"), { whitelist: CONFIG.PF2E.abilities, maxTags: 2 });
 

--- a/src/module/item/feat/sheet.ts
+++ b/src/module/item/feat/sheet.ts
@@ -11,6 +11,7 @@ import { ItemSheetDataPF2e, ItemSheetOptions, ItemSheetPF2e } from "@item/base/s
 import type { FeatPF2e } from "@item/feat/document.ts";
 import { WEAPON_CATEGORIES } from "@item/weapon/values.ts";
 import { OneToFour } from "@module/data.ts";
+import type { HTMLTagifyTraitsElement } from "@system/html-elements/tagify-traits.ts";
 import {
     ErrorPF2e,
     htmlClosest,
@@ -208,7 +209,9 @@ class FeatSheetPF2e extends ItemSheetPF2e<FeatPF2e> {
         const feat = this.item;
         activateActionSheetListeners(feat, html);
 
-        const getInput = (name: string): HTMLInputElement | null => html.querySelector(`input[name="${name}"]`);
+        const getInput = (name: string): HTMLTagifyTraitsElement | null =>
+            htmlQuery<HTMLTagifyTraitsElement>(html, `tagify-traits[name="${name}"]`);
+
         tagify(getInput("system.prerequisites.value"), { maxTags: 6 });
         tagify(getInput("system.subfeatures.keyOptions"), { whitelist: CONFIG.PF2E.abilities, maxTags: 3 });
 

--- a/src/module/item/feat/sheet.ts
+++ b/src/module/item/feat/sheet.ts
@@ -11,7 +11,7 @@ import { ItemSheetDataPF2e, ItemSheetOptions, ItemSheetPF2e } from "@item/base/s
 import type { FeatPF2e } from "@item/feat/document.ts";
 import { WEAPON_CATEGORIES } from "@item/weapon/values.ts";
 import { OneToFour } from "@module/data.ts";
-import type { HTMLTagifyTraitsElement } from "@system/html-elements/tagify-traits.ts";
+import type { HTMLTagifyTagsElement } from "@system/html-elements/tagify-tags.ts";
 import {
     ErrorPF2e,
     htmlClosest,
@@ -209,8 +209,8 @@ class FeatSheetPF2e extends ItemSheetPF2e<FeatPF2e> {
         const feat = this.item;
         activateActionSheetListeners(feat, html);
 
-        const getInput = (name: string): HTMLTagifyTraitsElement | null =>
-            htmlQuery<HTMLTagifyTraitsElement>(html, `tagify-traits[name="${name}"]`);
+        const getInput = (name: string): HTMLTagifyTagsElement | null =>
+            htmlQuery<HTMLTagifyTagsElement>(html, `tagify-tags[name="${name}"]`);
 
         tagify(getInput("system.prerequisites.value"), { maxTags: 6 });
         tagify(getInput("system.subfeatures.keyOptions"), { whitelist: CONFIG.PF2E.abilities, maxTags: 3 });

--- a/src/module/item/spell/sheet.ts
+++ b/src/module/item/spell/sheet.ts
@@ -4,7 +4,7 @@ import { OneToTen } from "@module/data.ts";
 import { TraitTagifyEntry, createTagifyTraits } from "@module/sheet/helpers.ts";
 import { DamageCategoryUnique, DamageType } from "@system/damage/types.ts";
 import { DAMAGE_CATEGORIES_UNIQUE } from "@system/damage/values.ts";
-import { HTMLTagifyTraitsElement } from "@system/html-elements/tagify-traits.ts";
+import { HTMLTagifyTagsElement } from "@system/html-elements/tagify-tags.ts";
 import {
     ErrorPF2e,
     fontAwesomeIcon,
@@ -148,7 +148,7 @@ export class SpellSheetPF2e extends ItemSheetPF2e<SpellPF2e> {
             if (levelInput) levelInput.readOnly = true;
         }
 
-        tagify(htmlQuery<HTMLTagifyTraitsElement>(html, 'tagify-traits[name="system.traits.traditions"]'), {
+        tagify(htmlQuery<HTMLTagifyTagsElement>(html, 'tagify-tags[name="system.traits.traditions"]'), {
             whitelist: CONFIG.PF2E.magicTraditions,
         });
 

--- a/src/module/item/spell/sheet.ts
+++ b/src/module/item/spell/sheet.ts
@@ -4,6 +4,7 @@ import { OneToTen } from "@module/data.ts";
 import { TraitTagifyEntry, createTagifyTraits } from "@module/sheet/helpers.ts";
 import { DamageCategoryUnique, DamageType } from "@system/damage/types.ts";
 import { DAMAGE_CATEGORIES_UNIQUE } from "@system/damage/values.ts";
+import { HTMLTagifyTraitsElement } from "@system/html-elements/tagify-traits.ts";
 import {
     ErrorPF2e,
     fontAwesomeIcon,
@@ -147,7 +148,7 @@ export class SpellSheetPF2e extends ItemSheetPF2e<SpellPF2e> {
             if (levelInput) levelInput.readOnly = true;
         }
 
-        tagify(html.querySelector('input[name="system.traits.traditions"]'), {
+        tagify(htmlQuery<HTMLTagifyTraitsElement>(html, 'tagify-traits[name="system.traits.traditions"]'), {
             whitelist: CONFIG.PF2E.magicTraditions,
         });
 

--- a/src/module/scene/sheet.ts
+++ b/src/module/scene/sheet.ts
@@ -1,6 +1,6 @@
 import { resetActors } from "@actor/helpers.ts";
 import { WorldClock } from "@module/apps/world-clock/app.ts";
-import type { HTMLTagifyTraitsElement } from "@system/html-elements/tagify-traits.ts";
+import type { HTMLTagifyTagsElement } from "@system/html-elements/tagify-tags.ts";
 import { SettingsMenuOptions } from "@system/settings/menu.ts";
 import { ErrorPF2e, createHTMLElement, htmlQuery, htmlQueryAll, tagify } from "@util";
 import * as R from "remeda";
@@ -74,7 +74,7 @@ export class SceneConfigPF2e<TDocument extends ScenePF2e> extends SceneConfig<TD
             }
         });
 
-        tagify(htmlQuery<HTMLTagifyTraitsElement>(html, 'tagify-traits[name="flags.pf2e.environmentTypes"]'), {
+        tagify(htmlQuery<HTMLTagifyTagsElement>(html, 'tagify-tags[name="flags.pf2e.environmentTypes"]'), {
             whitelist: CONFIG.PF2E.environmentTypes,
             enforceWhitelist: true,
         });

--- a/src/module/scene/sheet.ts
+++ b/src/module/scene/sheet.ts
@@ -1,6 +1,6 @@
 import { resetActors } from "@actor/helpers.ts";
 import { WorldClock } from "@module/apps/world-clock/app.ts";
-import { processTagifyInSubmitData } from "@module/sheet/helpers.ts";
+import type { HTMLTagifyTraitsElement } from "@system/html-elements/tagify-traits.ts";
 import { SettingsMenuOptions } from "@system/settings/menu.ts";
 import { ErrorPF2e, createHTMLElement, htmlQuery, htmlQueryAll, tagify } from "@util";
 import * as R from "remeda";
@@ -74,7 +74,7 @@ export class SceneConfigPF2e<TDocument extends ScenePF2e> extends SceneConfig<TD
             }
         });
 
-        tagify(htmlQuery<HTMLInputElement>(html, 'input[name="flags.pf2e.environmentTypes"]'), {
+        tagify(htmlQuery<HTMLTagifyTraitsElement>(html, 'tagify-traits[name="flags.pf2e.environmentTypes"]'), {
             whitelist: CONFIG.PF2E.environmentTypes,
             enforceWhitelist: true,
         });
@@ -132,41 +132,6 @@ export class SceneConfigPF2e<TDocument extends ScenePF2e> extends SceneConfig<TD
                 darknessInput.closest(".form-group")?.querySelector("p.notes")?.append(managedBy);
             }
         }
-    }
-
-    protected override async _onSubmit(
-        event: Event,
-        options?: OnSubmitFormOptions,
-    ): Promise<false | Record<string, unknown>> {
-        // Prevent tagify input JSON parsing from blowing up
-        const environmentTypes = htmlQuery<HTMLInputElement>(
-            this.element[0],
-            'input[name="flags.pf2e.environmentTypes"]',
-        );
-        if (environmentTypes?.value === "") environmentTypes.value = "[]";
-        return super._onSubmit(event, options);
-    }
-
-    protected override async _onChangeInput(event: Event): Promise<void> {
-        // Prevent tagify input JSON parsing from blowing up
-        const environmentTypes = htmlQuery<HTMLInputElement>(
-            this.element[0],
-            'input[name="flags.pf2e.environmentTypes"]',
-        );
-        if (environmentTypes?.value === "") environmentTypes.value = "[]";
-        super._onChangeInput(event);
-    }
-
-    protected override _getSubmitData(updateData?: Record<string, unknown>): Record<string, unknown> {
-        // create the expanded update data object
-        const fd = new FormDataExtended(this.form, { editors: this.editors });
-        const data: Record<string, unknown> = updateData
-            ? fu.mergeObject(fd.object, updateData)
-            : fu.expandObject(fd.object);
-
-        const flattenedData = fu.flattenObject(data);
-        processTagifyInSubmitData(this.form, flattenedData);
-        return flattenedData;
     }
 
     /** Intercept flag update and change to boolean/null. */

--- a/src/module/system/html-elements/tagify-tags.ts
+++ b/src/module/system/html-elements/tagify-tags.ts
@@ -4,8 +4,8 @@ import * as R from "remeda";
  * A HTML Element that handles `Tagify` data and always has a `value` of `string[]`.
  * `Tagify` must be bound to the child input element that can be accessed at `HTMLTagifyTraitsElement#input`
  */
-class HTMLTagifyTraitsElement extends foundry.applications.elements.AbstractFormInputElement<string[], string> {
-    static override tagName = "tagify-traits";
+class HTMLTagifyTagsElement extends foundry.applications.elements.AbstractFormInputElement<string[], string> {
+    static override tagName = "tagify-tags";
 
     /** The input elmement that the `Tagify` instance is bound to */
     declare input: HTMLInputElement;
@@ -79,4 +79,4 @@ class HTMLTagifyTraitsElement extends foundry.applications.elements.AbstractForm
 
 type TagifySelection = { id?: string; value?: string; readonly?: boolean };
 
-export { HTMLTagifyTraitsElement };
+export { HTMLTagifyTagsElement };

--- a/src/module/system/html-elements/tagify-traits.ts
+++ b/src/module/system/html-elements/tagify-traits.ts
@@ -1,0 +1,82 @@
+import * as R from "remeda";
+
+/**
+ * A HTML Element that handles `Tagify` data and always has a `value` of `string[]`.
+ * `Tagify` must be bound to the child input element that can be accessed at `HTMLTagifyTraitsElement#input`
+ */
+class HTMLTagifyTraitsElement extends foundry.applications.elements.AbstractFormInputElement<string[], string> {
+    static override tagName = "tagify-traits";
+
+    /** The input elmement that the `Tagify` instance is bound to */
+    declare input: HTMLInputElement;
+
+    constructor() {
+        super();
+        // Set the initial value
+        this._setValue(this.getAttribute("value") || "[]");
+    }
+
+    protected override _buildElements(): HTMLElement[] {
+        this.input = document.createElement("input") as HTMLInputElement;
+        this.input.type = "text";
+        this._applyInputAttributes(this.input);
+
+        return [this.input];
+    }
+
+    protected override _setValue(value: string): void {
+        try {
+            const parsed = JSON.parse(value) as TagifySelection[] | string[];
+            // The initial value might already be a string array
+            if (parsed.every((s): s is string => typeof s === "string")) {
+                this._value = parsed;
+                return;
+            }
+            // Otherwise extract tagify values
+            this._value = R.filter(
+                parsed.filter((s) => !s.readonly).map((s) => s.id ?? s.value),
+                R.isTruthy,
+            );
+        } catch (error) {
+            if (error instanceof Error) {
+                console.error(
+                    new Error(`PF2e System | Invalid value for HTMLTagifyTraitsElement: ${value}`, {
+                        cause: error,
+                    }),
+                );
+            }
+        }
+    }
+
+    override _applyInputAttributes(input: HTMLInputElement): void {
+        super._applyInputAttributes(input);
+
+        // Transfer all attributes, except name and value, to the input element
+        for (const attribute of this.attributes) {
+            if (attribute.name === "name" || attribute.name === "value") continue;
+            this.input.setAttribute(attribute.name, attribute.value);
+            // Remove transfered attributes, expect class, from this element
+            if (attribute.name !== "class") {
+                this.removeAttribute(attribute.name);
+            }
+        }
+        this.input.setAttribute("data-tagify-traits-name", this.name);
+        this.input.value = JSON.stringify(this._value);
+    }
+
+    protected override _toggleDisabled(disabled: boolean): void {
+        this.input.disabled = disabled;
+    }
+
+    override _activateListeners(): void {
+        this.input.addEventListener("change", (event) => {
+            const target = event.target;
+            if (!(target instanceof HTMLInputElement)) return;
+            this.value = target.value || "[]";
+        });
+    }
+}
+
+type TagifySelection = { id?: string; value?: string; readonly?: boolean };
+
+export { HTMLTagifyTraitsElement };

--- a/src/scripts/hooks/load.ts
+++ b/src/scripts/hooks/load.ts
@@ -30,7 +30,7 @@ import { CheckRoll, StrikeAttackRoll } from "@system/check/roll.ts";
 import { ClientDatabaseBackendPF2e } from "@system/client-backend.ts";
 import { DamageInstance, DamageRoll } from "@system/damage/roll.ts";
 import { ArithmeticExpression, Grouping, InstancePool, IntermediateDie } from "@system/damage/terms.ts";
-import { HTMLTagifyTraitsElement } from "@system/html-elements/tagify-traits.ts";
+import { HTMLTagifyTagsElement } from "@system/html-elements/tagify-tags.ts";
 import * as R from "remeda";
 
 /** Not an actual hook listener but rather things to run on initial load */
@@ -120,7 +120,7 @@ export const Load = {
         window.AutomaticBonusProgression = AutomaticBonusProgression;
 
         // Add custom HTML elements
-        window.customElements.define(HTMLTagifyTraitsElement.tagName, HTMLTagifyTraitsElement);
+        window.customElements.define(HTMLTagifyTagsElement.tagName, HTMLTagifyTagsElement);
 
         // Monkey-patch `TextEditor.enrichHTML`
         monkeyPatchFoundry();

--- a/src/scripts/hooks/load.ts
+++ b/src/scripts/hooks/load.ts
@@ -30,6 +30,7 @@ import { CheckRoll, StrikeAttackRoll } from "@system/check/roll.ts";
 import { ClientDatabaseBackendPF2e } from "@system/client-backend.ts";
 import { DamageInstance, DamageRoll } from "@system/damage/roll.ts";
 import { ArithmeticExpression, Grouping, InstancePool, IntermediateDie } from "@system/damage/terms.ts";
+import { HTMLTagifyTraitsElement } from "@system/html-elements/tagify-traits.ts";
 import * as R from "remeda";
 
 /** Not an actual hook listener but rather things to run on initial load */
@@ -117,6 +118,9 @@ export const Load = {
 
         // Make available immediately on load for module subclassing
         window.AutomaticBonusProgression = AutomaticBonusProgression;
+
+        // Add custom HTML elements
+        window.customElements.define(HTMLTagifyTraitsElement.tagName, HTMLTagifyTraitsElement);
 
         // Monkey-patch `TextEditor.enrichHTML`
         monkeyPatchFoundry();

--- a/src/styles/_tags.scss
+++ b/src/styles/_tags.scss
@@ -8,6 +8,7 @@
     list-style-type: none;
     margin-bottom: var(--space-2);
     padding-left: 0;
+    width: calc(100% - 2px);
 
     .tag,
     .tag option {
@@ -284,6 +285,7 @@ tags.tagify.pf2e-tagify {
     border-radius: 3px;
     gap: var(--space-3);
     padding: var(--space-2);
+    width: calc(100% - 2px);
 
     &[disabled] {
         --tag-text-color: var(--color-disabled);

--- a/src/styles/item/_header.scss
+++ b/src/styles/item/_header.scss
@@ -11,7 +11,7 @@
         flex-wrap: wrap;
 
         input,
-        tagify-traits,
+        tagify-tags,
         .level {
             font: 700 var(--font-size-36) var(--serif-condensed);
         }
@@ -19,7 +19,7 @@
 
     input[type="text"],
     input[type="number"],
-    tagify-traits {
+    tagify-tags {
         color: var(--color-text-dark-input);
         border: none;
         height: var(--font-size-34);

--- a/src/styles/item/_header.scss
+++ b/src/styles/item/_header.scss
@@ -11,13 +11,15 @@
         flex-wrap: wrap;
 
         input,
+        tagify-traits,
         .level {
             font: 700 var(--font-size-36) var(--serif-condensed);
         }
     }
 
     input[type="text"],
-    input[type="number"] {
+    input[type="number"],
+    tagify-traits {
         color: var(--color-text-dark-input);
         border: none;
         height: var(--font-size-34);

--- a/src/styles/item/_rules.scss
+++ b/src/styles/item/_rules.scss
@@ -242,6 +242,7 @@
 
             .attachment,
             input,
+            tagify-traits,
             .tags {
                 z-index: 0;
 
@@ -274,6 +275,7 @@
             }
 
             input,
+            tagify-traits,
             tags {
                 border-top-left-radius: 0;
                 border-bottom-left-radius: 0;

--- a/src/styles/item/_rules.scss
+++ b/src/styles/item/_rules.scss
@@ -242,7 +242,7 @@
 
             .attachment,
             input,
-            tagify-traits,
+            tagify-tags,
             .tags {
                 z-index: 0;
 
@@ -275,7 +275,7 @@
             }
 
             input,
-            tagify-traits,
+            tagify-tags,
             tags {
                 border-top-left-radius: 0;
                 border-bottom-left-radius: 0;

--- a/src/util/tags.ts
+++ b/src/util/tags.ts
@@ -1,6 +1,7 @@
 import { TraitViewData } from "@actor/data/base.ts";
-import Tagify from "@yaireo/tagify";
-import { ErrorPF2e, objectHasKey } from "./misc.ts";
+import type { HTMLTagifyTraitsElement } from "@system/html-elements/tagify-traits.ts";
+import Tagify, { TagifySettings } from "@yaireo/tagify";
+import { objectHasKey } from "./misc.ts";
 
 type WhitelistData = string[] | Record<string, string | { label: string }>;
 
@@ -31,15 +32,23 @@ function transformWhitelist(whitelist: WhitelistData) {
 }
 
 /** Create a tagify select menu out of a JSON input element */
-function tagify(input: HTMLInputElement, options?: TagifyOptions): Tagify<TagRecord>;
-function tagify(input: HTMLInputElement | null, options?: TagifyOptions): Tagify<TagRecord> | null;
+function tagify(element: HTMLInputElement, options?: TagifyOptions): Tagify<TagRecord>;
+function tagify(element: HTMLTagifyTraitsElement, options?: TagifyOptions): Tagify<TagRecord>;
 function tagify(
-    input: HTMLInputElement | null,
-    { whitelist, maxTags, enforceWhitelist = true }: TagifyOptions = {},
+    element: HTMLInputElement | HTMLTagifyTraitsElement | null,
+    options?: TagifyOptions,
+): Tagify<TagRecord> | null;
+function tagify(
+    element: HTMLInputElement | HTMLTagifyTraitsElement | null,
+    { whitelist, maxTags, enforceWhitelist = true, editTags }: TagifyOptions = {},
 ): Tagify<TagRecord> | null {
-    if (input?.hasAttribute("name") && input.dataset.dtype !== "JSON") {
-        throw ErrorPF2e("Usable only on input elements with JSON data-dtype");
-    } else if (!input) {
+    // Avoid importing the HTMLTagifyTraitsElement class that references the foundry API
+    const isTagifyTraitsElement = (element: HTMLElement | null): element is HTMLTagifyTraitsElement => {
+        return element?.tagName.toLowerCase() === "tagify-traits";
+    };
+
+    const input = isTagifyTraitsElement(element) ? element.input : element;
+    if (!input) {
         return null;
     }
 
@@ -56,6 +65,7 @@ function tagify(
             maxItems,
             searchKeys: ["id", "value"],
         },
+        editTags,
         whitelist: whitelistTransformed,
     });
 
@@ -84,6 +94,12 @@ interface TagifyOptions {
     whitelist?: WhitelistData;
     /** Whether this whitelist is exhaustive */
     enforceWhitelist?: boolean;
+    /**
+     *  Number of clicks to enter edit mode: `1` for single click, `2` for a double-click.
+     * `false` or `null` will disallow editing.
+     * @default {clicks: 2, keepInvalid: true}
+     */
+    editTags?: TagifySettings["editTags"];
 }
 
 export { tagify, traitSlugToObject };

--- a/src/util/tags.ts
+++ b/src/util/tags.ts
@@ -1,5 +1,5 @@
 import { TraitViewData } from "@actor/data/base.ts";
-import type { HTMLTagifyTraitsElement } from "@system/html-elements/tagify-traits.ts";
+import type { HTMLTagifyTagsElement } from "@system/html-elements/tagify-tags.ts";
 import Tagify, { TagifySettings } from "@yaireo/tagify";
 import { objectHasKey } from "./misc.ts";
 
@@ -33,18 +33,18 @@ function transformWhitelist(whitelist: WhitelistData) {
 
 /** Create a tagify select menu out of a JSON input element */
 function tagify(element: HTMLInputElement, options?: TagifyOptions): Tagify<TagRecord>;
-function tagify(element: HTMLTagifyTraitsElement, options?: TagifyOptions): Tagify<TagRecord>;
+function tagify(element: HTMLTagifyTagsElement, options?: TagifyOptions): Tagify<TagRecord>;
 function tagify(
-    element: HTMLInputElement | HTMLTagifyTraitsElement | null,
+    element: HTMLInputElement | HTMLTagifyTagsElement | null,
     options?: TagifyOptions,
 ): Tagify<TagRecord> | null;
 function tagify(
-    element: HTMLInputElement | HTMLTagifyTraitsElement | null,
+    element: HTMLInputElement | HTMLTagifyTagsElement | null,
     { whitelist, maxTags, enforceWhitelist = true, editTags }: TagifyOptions = {},
 ): Tagify<TagRecord> | null {
     // Avoid importing the HTMLTagifyTraitsElement class that references the foundry API
-    const isTagifyTraitsElement = (element: HTMLElement | null): element is HTMLTagifyTraitsElement => {
-        return element?.tagName.toLowerCase() === "tagify-traits";
+    const isTagifyTraitsElement = (element: HTMLElement | null): element is HTMLTagifyTagsElement => {
+        return element?.tagName.toLowerCase() === "tagify-tags";
     };
 
     const input = isTagifyTraitsElement(element) ? element.input : element;

--- a/static/templates/actors/hazard/partials/header.hbs
+++ b/static/templates/actors/hazard/partials/header.hbs
@@ -30,7 +30,7 @@
                     {{selectOptions complexityOptions selected=data.details.isComplex localize=true}}
                 </select>
             </template>
-            <tagify-traits class="tags paizo-style" name="system.traits.value" value="{{json data.traits.value}}"
+            <tagify-tags class="tags paizo-style" name="system.traits.value" value="{{json data.traits.value}}"
                 {{#if (eq data.traits.value.length 0)}}placeholder="{{localize "PF2E.Traits"}}"{{/if}} />
         {{else}}
             <div class="tags paizo-style">

--- a/static/templates/actors/hazard/partials/header.hbs
+++ b/static/templates/actors/hazard/partials/header.hbs
@@ -30,7 +30,7 @@
                     {{selectOptions complexityOptions selected=data.details.isComplex localize=true}}
                 </select>
             </template>
-            <input class="tags paizo-style" name="system.traits.value" value="{{json data.traits.value}}" data-dtype="JSON"
+            <tagify-traits class="tags paizo-style" name="system.traits.value" value="{{json data.traits.value}}"
                 {{#if (eq data.traits.value.length 0)}}placeholder="{{localize "PF2E.Traits"}}"{{/if}} />
         {{else}}
             <div class="tags paizo-style">

--- a/static/templates/actors/npc/partials/header.hbs
+++ b/static/templates/actors/npc/partials/header.hbs
@@ -45,7 +45,7 @@
         {{/if}}
     </div>
     <div class="flexrow">
-        <input class="tags paizo-style" name="system.traits.value" value="{{json traitTagifyData}}" data-dtype="JSON"
+        <tagify-traits class="tags paizo-style" name="system.traits.value" value="{{json traitTagifyData}}"
             {{#if (eq data.traits.value.length 0)}}placeholder="{{localize "PF2E.Traits"}}"{{/if}} />
     </div>
     <div class="flexrow">

--- a/static/templates/actors/npc/partials/header.hbs
+++ b/static/templates/actors/npc/partials/header.hbs
@@ -45,7 +45,7 @@
         {{/if}}
     </div>
     <div class="flexrow">
-        <tagify-traits class="tags paizo-style" name="system.traits.value" value="{{json traitTagifyData}}"
+        <tagify-tags class="tags paizo-style" name="system.traits.value" value="{{json traitTagifyData}}"
             {{#if (eq data.traits.value.length 0)}}placeholder="{{localize "PF2E.Traits"}}"{{/if}} />
     </div>
     <div class="flexrow">

--- a/static/templates/items/campaign-feature-details.hbs
+++ b/static/templates/items/campaign-feature-details.hbs
@@ -2,5 +2,5 @@
 
 <div class="form-group stacked">
     <label>{{localize "PF2E.FeatPrereqLabel"}}</label>
-    <input class="pf2e-tagify" type="text" name="system.prerequisites.value" value="{{prerequisites}}" data-dtype="JSON" />
+    <tagify-traits class="pf2e-tagify" name="system.prerequisites.value" value="{{prerequisites}}" />
 </div>

--- a/static/templates/items/campaign-feature-details.hbs
+++ b/static/templates/items/campaign-feature-details.hbs
@@ -2,5 +2,5 @@
 
 <div class="form-group stacked">
     <label>{{localize "PF2E.FeatPrereqLabel"}}</label>
-    <tagify-traits class="pf2e-tagify" name="system.prerequisites.value" value="{{prerequisites}}" />
+    <tagify-tags class="pf2e-tagify" name="system.prerequisites.value" value="{{prerequisites}}" />
 </div>

--- a/static/templates/items/deity-details.hbs
+++ b/static/templates/items/deity-details.hbs
@@ -20,21 +20,21 @@
         {{!-- Divine Attribute --}}
         <div class="form-group form-group-trait">
             <label>{{localize "PF2E.Item.Deity.DivineAttribute.Label"}}</label>
-            <input type="text" name="system.attribute" value="{{json data.attribute}}" class="pf2e-tagify" data-dtype="JSON" />
+            <tagify-traits name="system.attribute" value="{{json data.attribute}}" class="pf2e-tagify" />
             <p class="hint">{{localize "PF2E.Item.Deity.DivineAttribute.Hint"}}</p>
         </div>
 
         {{!-- Divine Skill --}}
         <div class="form-group form-group-trait">
             <label>{{localize "PF2E.Item.Deity.DivineSkill.Label"}}</label>
-            <input type="text" name="system.skill" value="{{json data.skill}}" class="pf2e-tagify" data-dtype="JSON" />
+            <tagify-traits name="system.skill" value="{{json data.skill}}" class="pf2e-tagify" />
             <p class="hint">{{localize "PF2E.Item.Deity.DivineSkill.Hint"}}</p>
         </div>
 
         {{!-- Favored Weapon --}}
         <div class="form-group">
             <label>{{localize "PF2E.Item.Deity.FavoredWeapons.Label"}}</label>
-            <input name="system.weapons" value="{{json data.weapons}}" class="pf2e-tagify" data-dtype="JSON" />
+            <tagify-traits name="system.weapons" value="{{json data.weapons}}" class="pf2e-tagify" />
             <p class="hint">{{localize "PF2E.Item.Deity.FavoredWeapons.Hint"}}</p>
         </div>
     {{/unless}}
@@ -50,7 +50,7 @@
         <div class="form-group">
             <label>{{localize "PF2E.Item.Deity.Domains.Primary"}}</label>
             <div class="form-fields">
-                <input name="system.domains.primary" class="pf2e-tagify" value="{{json data.domains.primary}}" data-dtype="JSON" />
+                <tagify-traits name="system.domains.primary" class="pf2e-tagify" value="{{json data.domains.primary}}" />
             </div>
         </div>
 
@@ -58,7 +58,7 @@
         <div class="form-group">
             <label>{{localize "PF2E.Item.Deity.Domains.Alternate.Label"}}</label>
             <div class="form-fields">
-                <input name="system.domains.alternate" class="pf2e-tagify" value="{{json data.domains.alternate}}" data-dtype="JSON" />
+                <tagify-traits name="system.domains.alternate" class="pf2e-tagify" value="{{json data.domains.alternate}}" />
             </div>
             <p class="hint">{{localize "PF2E.Item.Deity.Domains.Alternate.Hint"}}</p>
         </div>

--- a/static/templates/items/deity-details.hbs
+++ b/static/templates/items/deity-details.hbs
@@ -20,21 +20,21 @@
         {{!-- Divine Attribute --}}
         <div class="form-group form-group-trait">
             <label>{{localize "PF2E.Item.Deity.DivineAttribute.Label"}}</label>
-            <tagify-traits name="system.attribute" value="{{json data.attribute}}" class="pf2e-tagify" />
+            <tagify-tags name="system.attribute" value="{{json data.attribute}}" class="pf2e-tagify" />
             <p class="hint">{{localize "PF2E.Item.Deity.DivineAttribute.Hint"}}</p>
         </div>
 
         {{!-- Divine Skill --}}
         <div class="form-group form-group-trait">
             <label>{{localize "PF2E.Item.Deity.DivineSkill.Label"}}</label>
-            <tagify-traits name="system.skill" value="{{json data.skill}}" class="pf2e-tagify" />
+            <tagify-tags name="system.skill" value="{{json data.skill}}" class="pf2e-tagify" />
             <p class="hint">{{localize "PF2E.Item.Deity.DivineSkill.Hint"}}</p>
         </div>
 
         {{!-- Favored Weapon --}}
         <div class="form-group">
             <label>{{localize "PF2E.Item.Deity.FavoredWeapons.Label"}}</label>
-            <tagify-traits name="system.weapons" value="{{json data.weapons}}" class="pf2e-tagify" />
+            <tagify-tags name="system.weapons" value="{{json data.weapons}}" class="pf2e-tagify" />
             <p class="hint">{{localize "PF2E.Item.Deity.FavoredWeapons.Hint"}}</p>
         </div>
     {{/unless}}
@@ -50,7 +50,7 @@
         <div class="form-group">
             <label>{{localize "PF2E.Item.Deity.Domains.Primary"}}</label>
             <div class="form-fields">
-                <tagify-traits name="system.domains.primary" class="pf2e-tagify" value="{{json data.domains.primary}}" />
+                <tagify-tags name="system.domains.primary" class="pf2e-tagify" value="{{json data.domains.primary}}" />
             </div>
         </div>
 
@@ -58,7 +58,7 @@
         <div class="form-group">
             <label>{{localize "PF2E.Item.Deity.Domains.Alternate.Label"}}</label>
             <div class="form-fields">
-                <tagify-traits name="system.domains.alternate" class="pf2e-tagify" value="{{json data.domains.alternate}}" />
+                <tagify-tags name="system.domains.alternate" class="pf2e-tagify" value="{{json data.domains.alternate}}" />
             </div>
             <p class="hint">{{localize "PF2E.Item.Deity.Domains.Alternate.Hint"}}</p>
         </div>

--- a/static/templates/items/feat-details.hbs
+++ b/static/templates/items/feat-details.hbs
@@ -35,7 +35,7 @@
     <div class="form-group stacked">
         <label for="{{fieldIdPrefix}}prerequisites">{{localize "PF2E.FeatPrereqLabel"}}</label>
         <div class="form-fields">
-            <tagify-traits
+            <tagify-tags
                 class="pf2e-tagify"
                 type="text"
                 name="system.prerequisites.value"
@@ -53,7 +53,7 @@
         <div class="form-group stacked">
             <label for="{{fieldIdPrefix}}key-options">{{localize "PF2E.Item.Feat.Subfeatures.KeyAbilityOptions.Label"}}</label>
             <div class="form-fields">
-                <tagify-traits class="pf2e-tagify"
+                <tagify-tags class="pf2e-tagify"
                     type="text"
                     name="system.subfeatures.keyOptions"
                     id="{{fieldIdPrefix}}key-options"

--- a/static/templates/items/feat-details.hbs
+++ b/static/templates/items/feat-details.hbs
@@ -35,13 +35,12 @@
     <div class="form-group stacked">
         <label for="{{fieldIdPrefix}}prerequisites">{{localize "PF2E.FeatPrereqLabel"}}</label>
         <div class="form-fields">
-            <input
+            <tagify-traits
                 class="pf2e-tagify"
                 type="text"
                 name="system.prerequisites.value"
                 id="{{fieldIdPrefix}}prerequisites"
                 value="{{json item.system.prerequisites.value}}"
-                data-dtype="JSON"
             />
         </div>
     </div>
@@ -54,12 +53,11 @@
         <div class="form-group stacked">
             <label for="{{fieldIdPrefix}}key-options">{{localize "PF2E.Item.Feat.Subfeatures.KeyAbilityOptions.Label"}}</label>
             <div class="form-fields">
-                <input class="pf2e-tagify"
+                <tagify-traits class="pf2e-tagify"
                     type="text"
                     name="system.subfeatures.keyOptions"
                     id="{{fieldIdPrefix}}key-options"
                     value="{{json item.system.subfeatures.keyOptions}}"
-                    data-dtype="JSON"
                 />
             </div>
             <p class="hint">{{localize "PF2E.Item.Feat.Subfeatures.KeyAbilityOptions.Hint"}}</p>

--- a/static/templates/items/partials/other-tags.hbs
+++ b/static/templates/items/partials/other-tags.hbs
@@ -1,12 +1,10 @@
 <div class="form-group{{#if hasSidebar}} stacked{{/if}}">
     <label for="{{fieldIdPrefix}}other-tags">{{localize "PF2E.Item.OtherTags.Label"}}</label>
-    <input
+    <tagify-traits
         class="pf2e-tagify"
-        type="text"
         name="system.traits.otherTags"
         id="{{fieldIdPrefix}}other-tags"
         value="{{json item.system.traits.otherTags}}"
-        data-dtype="JSON"
     />
     <p class="hint">{{localize "PF2E.Item.OtherTags.Hint"}}</p>
 </div>

--- a/static/templates/items/partials/other-tags.hbs
+++ b/static/templates/items/partials/other-tags.hbs
@@ -1,6 +1,6 @@
 <div class="form-group{{#if hasSidebar}} stacked{{/if}}">
     <label for="{{fieldIdPrefix}}other-tags">{{localize "PF2E.Item.OtherTags.Label"}}</label>
-    <tagify-traits
+    <tagify-tags
         class="pf2e-tagify"
         name="system.traits.otherTags"
         id="{{fieldIdPrefix}}other-tags"

--- a/static/templates/items/rules/actor-traits.hbs
+++ b/static/templates/items/rules/actor-traits.hbs
@@ -1,10 +1,10 @@
 <div class="form-group">
     <label class="short">{{localize "PF2E.RuleEditor.General.Add"}}</label>
-    <input class="pf2e-tagify" name="{{basePath}}.add" value="{{json rule.add}}" data-dtype="JSON" />
+    <tagify-traits class="pf2e-tagify" name="{{basePath}}.add" value="{{json rule.add}}" />
 </div>
 <div class="form-group">
     <label class="short">{{localize "PF2E.RuleEditor.General.Remove"}}</label>
-    <input class="pf2e-tagify" name="{{basePath}}.remove" value="{{json rule.remove}}" data-dtype="JSON" />
+    <tagify-traits class="pf2e-tagify" name="{{basePath}}.remove" value="{{json rule.remove}}" />
 </div>
 <div class="form-group">
     <label class="short">{{localize "PF2E.RuleEditor.General.Predicate"}}</label>

--- a/static/templates/items/rules/actor-traits.hbs
+++ b/static/templates/items/rules/actor-traits.hbs
@@ -1,10 +1,10 @@
 <div class="form-group">
     <label class="short">{{localize "PF2E.RuleEditor.General.Add"}}</label>
-    <tagify-traits class="pf2e-tagify" name="{{basePath}}.add" value="{{json rule.add}}" />
+    <tagify-tags class="pf2e-tagify" name="{{basePath}}.add" value="{{json rule.add}}" />
 </div>
 <div class="form-group">
     <label class="short">{{localize "PF2E.RuleEditor.General.Remove"}}</label>
-    <tagify-traits class="pf2e-tagify" name="{{basePath}}.remove" value="{{json rule.remove}}" />
+    <tagify-tags class="pf2e-tagify" name="{{basePath}}.remove" value="{{json rule.remove}}" />
 </div>
 <div class="form-group">
     <label class="short">{{localize "PF2E.RuleEditor.General.Predicate"}}</label>

--- a/static/templates/items/rules/aura.hbs
+++ b/static/templates/items/rules/aura.hbs
@@ -35,7 +35,7 @@
     <div class="stacked">
         <div class="grid-item">
             <label>{{localize fields.traits.label}}</label>
-            <tagify-traits class="pf2e-tagify tagify-traits" name="system.rules.{{index}}.traits" value="{{json object.traits}}" />
+            <tagify-tags class="pf2e-tagify tagify-traits" name="system.rules.{{index}}.traits" value="{{json object.traits}}" />
         </div>
 
         <div class="grid-item long-label">

--- a/static/templates/items/rules/aura.hbs
+++ b/static/templates/items/rules/aura.hbs
@@ -35,7 +35,7 @@
     <div class="stacked">
         <div class="grid-item">
             <label>{{localize fields.traits.label}}</label>
-            <input type="text" class="pf2e-tagify tagify-traits" name="system.rules.{{index}}.traits" value="{{json object.traits}}" data-dtype="JSON" />
+            <tagify-traits class="pf2e-tagify tagify-traits" name="system.rules.{{index}}.traits" value="{{json object.traits}}" />
         </div>
 
         <div class="grid-item long-label">

--- a/static/templates/items/rules/fast-healing.hbs
+++ b/static/templates/items/rules/fast-healing.hbs
@@ -13,7 +13,7 @@
 {{#if (eq rule.type "regeneration")}}
     <div class="form-group">
         <label class="short">{{localize "PF2E.RuleEditor.FastHealing.DeactivatedBy"}}</label>
-        <input type="text" class="pf2e-tagify deactivated-by" name="system.rules.{{index}}.deactivatedBy" value="{{json rule.deactivatedBy}}" data-dtype="JSON"/>
+        <tagify-traits class="pf2e-tagify deactivated-by" name="system.rules.{{index}}.deactivatedBy" value="{{json rule.deactivatedBy}}" />
     </div>
 {{else}}
     <div class="form-group">

--- a/static/templates/items/rules/fast-healing.hbs
+++ b/static/templates/items/rules/fast-healing.hbs
@@ -13,7 +13,7 @@
 {{#if (eq rule.type "regeneration")}}
     <div class="form-group">
         <label class="short">{{localize "PF2E.RuleEditor.FastHealing.DeactivatedBy"}}</label>
-        <tagify-traits class="pf2e-tagify deactivated-by" name="system.rules.{{index}}.deactivatedBy" value="{{json rule.deactivatedBy}}" />
+        <tagify-tags class="pf2e-tagify deactivated-by" name="system.rules.{{index}}.deactivatedBy" value="{{json rule.deactivatedBy}}" />
     </div>
 {{else}}
     <div class="form-group">

--- a/static/templates/items/rules/flat-modifier.hbs
+++ b/static/templates/items/rules/flat-modifier.hbs
@@ -16,7 +16,7 @@
             {{#if selectorIsArray}}Multiple{{else}}Single{{/if}}
         </button>
         {{#if selectorIsArray}}
-            <input type="text" class="pf2e-tagify selector-list" name="{{basePath}}.selector" value="{{json rule.selector}}" data-dtype="JSON" />
+            <tagify-traits class="pf2e-tagify selector-list" name="{{basePath}}.selector" value="{{json rule.selector}}" />
         {{else}}
             <input type="text" name="{{basePath}}.selector" value="{{rule.selector}}" />
         {{/if}}

--- a/static/templates/items/rules/flat-modifier.hbs
+++ b/static/templates/items/rules/flat-modifier.hbs
@@ -16,7 +16,7 @@
             {{#if selectorIsArray}}Multiple{{else}}Single{{/if}}
         </button>
         {{#if selectorIsArray}}
-            <tagify-traits class="pf2e-tagify selector-list" name="{{basePath}}.selector" value="{{json rule.selector}}" />
+            <tagify-tags class="pf2e-tagify selector-list" name="{{basePath}}.selector" value="{{json rule.selector}}" />
         {{else}}
             <input type="text" name="{{basePath}}.selector" value="{{rule.selector}}" />
         {{/if}}

--- a/static/templates/items/rules/note.hbs
+++ b/static/templates/items/rules/note.hbs
@@ -16,7 +16,7 @@
             {{#if selectorIsArray}}Multiple{{else}}Single{{/if}}
         </button>
         {{#if selectorIsArray}}
-            <input type="text" class="pf2e-tagify selector-list" name="system.rules.{{index}}.selector" value="{{json rule.selector}}" data-dtype="JSON" />
+            <tagify-traits class="pf2e-tagify selector-list" name="system.rules.{{index}}.selector" value="{{json rule.selector}}" />
         {{else}}
             <input type="text" name="system.rules.{{index}}.selector" value="{{rule.selector}}" />
         {{/if}}
@@ -27,7 +27,7 @@
 
 <div class="form-group">
     <label class="short">{{localize "PF2E.RuleEditor.Note.Outcome"}}</label>
-    <input class="pf2e-tagify outcomes" name="system.rules.{{index}}.outcome" value="{{json rule.outcome}}" data-dtype="JSON" />
+    <tagify-traits class="pf2e-tagify outcomes" name="system.rules.{{index}}.outcome" value="{{json rule.outcome}}" />
 </div>
 
 <div class="form-group">

--- a/static/templates/items/rules/note.hbs
+++ b/static/templates/items/rules/note.hbs
@@ -16,7 +16,7 @@
             {{#if selectorIsArray}}Multiple{{else}}Single{{/if}}
         </button>
         {{#if selectorIsArray}}
-            <tagify-traits class="pf2e-tagify selector-list" name="system.rules.{{index}}.selector" value="{{json rule.selector}}" />
+            <tagify-tags class="pf2e-tagify selector-list" name="system.rules.{{index}}.selector" value="{{json rule.selector}}" />
         {{else}}
             <input type="text" name="system.rules.{{index}}.selector" value="{{rule.selector}}" />
         {{/if}}
@@ -27,7 +27,7 @@
 
 <div class="form-group">
     <label class="short">{{localize "PF2E.RuleEditor.Note.Outcome"}}</label>
-    <tagify-traits class="pf2e-tagify outcomes" name="system.rules.{{index}}.outcome" value="{{json rule.outcome}}" />
+    <tagify-tags class="pf2e-tagify outcomes" name="system.rules.{{index}}.outcome" value="{{json rule.outcome}}" />
 </div>
 
 <div class="form-group">

--- a/static/templates/items/sheet.hbs
+++ b/static/templates/items/sheet.hbs
@@ -43,7 +43,7 @@
                 {{/if}}
             </template>
             {{#if showTraits}}
-                <tagify-traits class="paizo-style tags" name="system.traits.value" value="{{json traitTagifyData}}"
+                <tagify-tags class="paizo-style tags" name="system.traits.value" value="{{json traitTagifyData}}"
                     {{#if (eq data.traits.value.length 0)}}placeholder="{{localize "PF2E.Traits"}}"{{/if}} />
             {{else if rarity}}
                 <div class="paizo-style tags"></div>

--- a/static/templates/items/sheet.hbs
+++ b/static/templates/items/sheet.hbs
@@ -43,7 +43,7 @@
                 {{/if}}
             </template>
             {{#if showTraits}}
-                <input class="paizo-style tags" name="system.traits.value" value="{{json traitTagifyData}}" data-dtype="JSON"
+                <tagify-traits class="paizo-style tags" name="system.traits.value" value="{{json traitTagifyData}}"
                     {{#if (eq data.traits.value.length 0)}}placeholder="{{localize "PF2E.Traits"}}"{{/if}} />
             {{else if rarity}}
                 <div class="paizo-style tags"></div>

--- a/static/templates/items/spell-details.hbs
+++ b/static/templates/items/spell-details.hbs
@@ -2,7 +2,7 @@
     {{#unless (or item.isRitual (and item.isFocusSpell (not item.isCantrip)))}}
         <div class="form-group">
             <label>{{localize "PF2E.SpellTraditionsLabel"}}</label>
-            <input class="tags paizo-style" name="system.traits.traditions" value="{{json data.traits.traditions}}" data-dtype="JSON" />
+            <tagify-traits class="tags paizo-style" name="system.traits.traditions" value="{{json data.traits.traditions}}" />
         </div>
     {{/unless}}
 

--- a/static/templates/items/spell-details.hbs
+++ b/static/templates/items/spell-details.hbs
@@ -2,7 +2,7 @@
     {{#unless (or item.isRitual (and item.isFocusSpell (not item.isCantrip)))}}
         <div class="form-group">
             <label>{{localize "PF2E.SpellTraditionsLabel"}}</label>
-            <tagify-traits class="tags paizo-style" name="system.traits.traditions" value="{{json data.traits.traditions}}" />
+            <tagify-tags class="tags paizo-style" name="system.traits.traditions" value="{{json data.traits.traditions}}" />
         </div>
     {{/unless}}
 

--- a/static/templates/items/spell-overlay.hbs
+++ b/static/templates/items/spell-overlay.hbs
@@ -35,7 +35,7 @@
     {{#if (includes system "traits")}}
         <div class="traits">
             <a data-action="delete-overlay-property" data-property="traits"><i class="fa-solid fa-times"></i></a>
-            <tagify-traits
+            <tagify-tags
                 class="paizo-style tags spell-traits"
                 name="{{dataPath}}.traits.value"
                 value="{{json traits}}"

--- a/static/templates/items/spell-overlay.hbs
+++ b/static/templates/items/spell-overlay.hbs
@@ -35,11 +35,10 @@
     {{#if (includes system "traits")}}
         <div class="traits">
             <a data-action="delete-overlay-property" data-property="traits"><i class="fa-solid fa-times"></i></a>
-            <input
+            <tagify-traits
                 class="paizo-style tags spell-traits"
                 name="{{dataPath}}.traits.value"
                 value="{{json traits}}"
-                data-dtype="JSON"
                 {{#if (eq system.traits.value.length 0)}}placeholder="{{localize "PF2E.Traits"}}"{{/if}} />
         </div>
     {{/if}}

--- a/static/templates/scene/sheet-partials.hbs
+++ b/static/templates/scene/sheet-partials.hbs
@@ -35,7 +35,7 @@
         <div class="form-group">
             <label for="{{scene.uuid}}-environment-types">{{localize "PF2E.Region.Environment.Type.Label"}}</label>
             <div class="form-fields">
-                <tagify-traits class="pf2e-tagify tags" id="{{scene.uuid}}-environment-types" name="flags.pf2e.environmentTypes" value="{{json environmentTypes}}">
+                <tagify-tags class="pf2e-tagify tags" id="{{scene.uuid}}-environment-types" name="flags.pf2e.environmentTypes" value="{{json environmentTypes}}">
             </div>
             <p class="hint">{{localize "PF2E.Region.Environment.Type.SceneHint"}}</p>
         </div>

--- a/static/templates/scene/sheet-partials.hbs
+++ b/static/templates/scene/sheet-partials.hbs
@@ -35,7 +35,7 @@
         <div class="form-group">
             <label for="{{scene.uuid}}-environment-types">{{localize "PF2E.Region.Environment.Type.Label"}}</label>
             <div class="form-fields">
-                <input class="pf2e-tagify tags" id="{{scene.uuid}}-environment-types" name="flags.pf2e.environmentTypes" value="{{json environmentTypes}}" data-dtype="JSON">
+                <tagify-traits class="pf2e-tagify tags" id="{{scene.uuid}}-environment-types" name="flags.pf2e.environmentTypes" value="{{json environmentTypes}}">
             </div>
             <p class="hint">{{localize "PF2E.Region.Environment.Type.SceneHint"}}</p>
         </div>

--- a/types/foundry/client-esm/applications/elements/form-element.d.ts
+++ b/types/foundry/client-esm/applications/elements/form-element.d.ts
@@ -33,7 +33,7 @@ export abstract class AbstractFormInputElement<TInternalValue, TInputValue = TIn
     protected _value: TInternalValue;
 
     /** Return the value of the input element which should be submitted to the form. */
-    protected _getValue(): TInputValue;
+    protected _getValue(): TInternalValue;
 
     /**
      * Translate user-provided input value into the format that should be stored.
@@ -70,6 +70,12 @@ export abstract class AbstractFormInputElement<TInternalValue, TInputValue = TIn
 
     /** Refresh the active state of the custom element. */
     protected _refresh(): void;
+
+    /**
+     * Apply key attributes on the containing custom HTML element to input elements contained within it.
+     * @internal
+     */
+    _applyInputAttributes(input: HTMLInputElement): void;
 
     /** Activate event listeners which add dynamic behavior to the custom element. */
     _activateListeners(): void;


### PR DESCRIPTION
The `HTMLTagifyTraitsElement` has an `HTMLInputElement` child that must be used to attach a `Tagify` instance. The `value` of the `HTMLTagifyTraitsElement` will always be an array so `FormDataExtended` won't have any problems with JSON data anymore.
The input child inherits the `HTMLTagifyTraitsElement`'s name as `data-tagify-name` for selector purposes. It can also be targeted with `tagify-traits > input` of course.
I've tested every input after converting it and it looks like everything is still working as expected.