### PR TITLE
Update table result type to v12 definition

### DIFF
--- a/types/foundry/common/constants.d.ts
+++ b/types/foundry/common/constants.d.ts
@@ -445,9 +445,9 @@ export const SORT_INTEGER_DENSITY: 100000;
 
 /** The allowed types of a TableResult document */
 export const TABLE_RESULT_TYPES: {
-    TEXT: 0;
-    DOCUMENT: 1;
-    COMPENDIUM: 2;
+    TEXT: "text";
+    DOCUMENT: "document";
+    COMPENDIUM: "pack";
 };
 
 /** The allowed formats of a Journal Entry Page. */

--- a/types/foundry/common/documents/table-result.d.ts
+++ b/types/foundry/common/documents/table-result.d.ts
@@ -1,6 +1,6 @@
 import type { Document, DocumentMetadata } from "../abstract/module.d.ts";
-import type * as documents from "./module.d.ts";
 import type * as fields from "../data/fields.d.ts";
+import type * as documents from "./module.d.ts";
 
 /** The TableResult document model. */
 export default class BaseTableResult<TParent extends documents.BaseRollTable | null> extends Document<
@@ -39,7 +39,7 @@ type TableResultSchema = {
     /** The _id which uniquely identifies this TableResult embedded document */
     _id: fields.DocumentIdField;
     /** A result subtype from CONST.TABLE_RESULT_TYPES */
-    type: fields.NumberField<TableResultType, TableResultType, true, true, true>;
+    type: fields.DocumentTypeField<TableResultType>;
     /** The text which describes the table result */
     text: fields.HTMLField;
     /** An image file url that represents the table result */


### PR DESCRIPTION
The compendium browser was already using CONST.TABLE_RESULT_TYPES.COMPENDIUM so only the types needed to change.