### PR TITLE
Show damage type override label in dialog

### DIFF
--- a/src/module/system/damage/dialog.ts
+++ b/src/module/system/damage/dialog.ts
@@ -12,10 +12,10 @@ import {
 } from "@util";
 import * as R from "remeda";
 import { createDamageFormula } from "./formula.ts";
+import { getDamageDiceOverrideLabel, getDamageDiceValueLabel } from "./helpers.ts";
 import { DamageRoll } from "./roll.ts";
 import { DamageCategoryUnique, DamageDamageContext, DamageDieSize, DamageFormulaData, DamageType } from "./types.ts";
 import { DAMAGE_CATEGORIES_UNIQUE, DAMAGE_TYPE_ICONS } from "./values.ts";
-import { getDamageDiceOverrideLabel, getDamageDiceValueLabel } from "./helpers.ts";
 
 /**
  * Dialog for excluding certain modifiers before rolling damage.
@@ -188,7 +188,10 @@ class DamageModifierDialog extends Application {
                     enabled: d.enabled,
                     ignored: d.ignored,
                     critical: d.critical,
-                    icon: this.#getModifierIcon(d),
+                    icon: this.#getModifierIcon({
+                        damageType: d.override.damageType ?? d.damageType,
+                        category: d.category,
+                    }),
                 })),
             ),
             isCritical: this.isCritical,

--- a/src/module/system/damage/helpers.ts
+++ b/src/module/system/damage/helpers.ts
@@ -402,13 +402,16 @@ function getDamageDiceOverrideLabel(d: DamageDicePF2e | RawDamageDice): string {
             : null,
     ].filter(R.isTruthy);
 
-    return parts.join(" + ");
+    // If this is only a damage type override, show "Override" and let the icon sort out the meaning
+    return parts.length === 0 && d.override?.damageType
+        ? game.i18n.format("PF2E.Roll.Dialog.Damage.OverrideLabel")
+        : parts.join(" + ");
 }
 
 export {
+    DamageCategorization,
     applyBaseDamageAlterations,
     applyDamageDiceOverrides,
-    DamageCategorization,
     damageDiceIcon,
     damageDieSizeToFaces,
     deepFindTerms,

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -3162,6 +3162,7 @@
                     "Label": "Label",
                     "None": "None",
                     "Override": "Override {value}",
+                    "OverrideLabel": "Override",
                     "Splash": "{damageType} Splash",
                     "TitleCritical": "Critical Damage Roll",
                     "Title": "Damage Roll"


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/13701

![image](https://github.com/foundryvtt/pf2e/assets/1286721/90339815-9e8f-401b-9d70-b8e170a10f54)
