### PR TITLE
Unrestrict grid diagonals setting

### DIFF
--- a/src/scripts/hooks/ready.ts
+++ b/src/scripts/hooks/ready.ts
@@ -33,7 +33,6 @@ export const Ready = {
             // Changing a setting to the default still triggers onChange, and in V12.322 can trigger console errors
             // The actual manipulation of the setting is locked down by the renderSettingsConfig hook.
             const defaultGridSettings = {
-                gridDiagonals: 4,
                 gridTemplates: false,
                 coneTemplateType: "round",
             };

--- a/src/scripts/hooks/render-settings-config.ts
+++ b/src/scripts/hooks/render-settings-config.ts
@@ -8,7 +8,7 @@ export const RenderSettingsConfig = {
     listen: (): void => {
         Hooks.on("renderSettingsConfig", (_app, $html) => {
             const html = $html[0];
-            const lockedSettings = ["core.gridDiagonals", "core.gridTemplates", "core.coneTemplateType"];
+            const lockedSettings = ["core.gridTemplates", "core.coneTemplateType"];
             for (const locked of lockedSettings) {
                 const element = htmlQuery(html, `div[data-setting-id="${locked}"]`);
                 if (!element) continue;


### PR DESCRIPTION
Turns out we don't use this setting for calculating anything anyways, only movement.

We can't unrestrict the other two unless we're happy with weird burst shapes. If people are ok with it, I can also flip that switch once I do the refactoring to eventually allow it.