### PR TITLE
Add elementTraits to HOMEBREW_TRAIT_KEYS

### DIFF
--- a/src/module/system/settings/homebrew/data.ts
+++ b/src/module/system/settings/homebrew/data.ts
@@ -16,6 +16,7 @@ const HOMEBREW_TRAIT_KEYS = [
     "weaponTraits",
     "equipmentTraits",
     "environmentTypes",
+    "elementTraits"
 ] as const;
 
 /** Homebrew elements from some of the above records are propagated to related records */

--- a/src/module/system/settings/homebrew/data.ts
+++ b/src/module/system/settings/homebrew/data.ts
@@ -16,7 +16,7 @@ const HOMEBREW_TRAIT_KEYS = [
     "weaponTraits",
     "equipmentTraits",
     "environmentTypes",
-    "elementTraits"
+    "elementTraits",
 ] as const;
 
 /** Homebrew elements from some of the above records are propagated to related records */

--- a/src/module/system/settings/homebrew/helpers.ts
+++ b/src/module/system/settings/homebrew/helpers.ts
@@ -68,6 +68,7 @@ function prepareReservedTerms(): ReservedTermsRecord {
         weaponGroups: new Set([...Object.keys(CONFIG.PF2E.weaponGroups), ...universalReservedTerms]),
         weaponTraits: new Set([...Object.keys(CONFIG.PF2E.weaponTraits), ...universalReservedTerms]),
         environmentTypes: new Set([...Object.keys(CONFIG.PF2E.environmentTypes), ...universalReservedTerms]),
+        elementTraits: new Set([...Object.keys(CONFIG.PF2E.elementTraits), ...universalReservedTerms]),
     };
 }
 

--- a/src/scripts/config/index.ts
+++ b/src/scripts/config/index.ts
@@ -901,9 +901,9 @@ export const PF2ECONFIG = {
                 name: "PF2E.SETTINGS.Homebrew.EnvironmentTypes.Name",
                 hint: "PF2E.SETTINGS.Homebrew.EnvironmentTypes.Hint",
             },
-            elementTypes: {
-                name: "PF2E.SETTINGS.Homebrew.ElementTypes.Name",
-                hint: "PF2E.SETTINGS.Homebrew.ElementTypes.Hint",
+            elementTraits: {
+                name: "PF2E.SETTINGS.Homebrew.ElementTraits.Name",
+                hint: "PF2E.SETTINGS.Homebrew.ElementTraits.Hint",
             },
         },
         worldClock: {

--- a/src/scripts/config/index.ts
+++ b/src/scripts/config/index.ts
@@ -901,6 +901,10 @@ export const PF2ECONFIG = {
                 name: "PF2E.SETTINGS.Homebrew.EnvironmentTypes.Name",
                 hint: "PF2E.SETTINGS.Homebrew.EnvironmentTypes.Hint",
             },
+            elementTypes: {
+                name: "PF2E.SETTINGS.Homebrew.ElementTypes.Name",
+                hint: "PF2E.SETTINGS.Homebrew.ElementTypes.Hint",
+            },
         },
         worldClock: {
             name: "PF2E.SETTINGS.WorldClock.Name",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -3346,6 +3346,10 @@
                     "Hint": "Any custom environment type",
                     "Name": "Environment Types"
                 },
+                "ElementTypes": {
+                    "Hint": "Any custom Kineticist elements",
+                    "Name": "Element Types"
+                },
                 "WeaponCategories": {
                     "Hint": "The top level of Pathfinder 2e weapon taxonomy (e.g., Simple, Martial)",
                     "Name": "Weapon Categories"

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -3346,7 +3346,7 @@
                     "Hint": "Any custom environment type",
                     "Name": "Environment Types"
                 },
-                "ElementTypes": {
+                "ElementTraits": {
                     "Hint": "Any custom Kineticist elements",
                     "Name": "Element Types"
                 },


### PR DESCRIPTION
This PR acts both as an Issue and remedy for it.

When one wants to create custom elements for Kineticist, you are forced to use JS to add the new traits to `CONFIG.PF2E.elementTraits` ([said by stwlam](https://discord.com/channels/880968862240239708/880969253765935174/1196555759270506506)). I thought about skipping the user unfriendly JS method and instead use the `pf2e-homebrew` index to add the traits. 

It looks like you can't due to `HOMEBREW_TRAIT_KEYS` not including `elementTraits`

Searching through the repository, `elementTraits` is purely for the purposes of Elemental Blast, which this PR aims to make extendable. I don't foresee any side effects that are going to come from allowing `elementTraits` to be extended in this more conventional way.