### PR TITLE
Type for Macro.execute() can accept additional properties for scope

### DIFF
--- a/types/foundry/client/data/documents/macro.d.ts
+++ b/types/foundry/client/data/documents/macro.d.ts
@@ -32,6 +32,6 @@ declare global {
          * @param [scope.token] A Token which is the protagonist of the executed action
          * @returns A created ChatMessage from chat macros or returned value from script macros
          */
-        execute(scope?: { actor?: Actor; token?: Token }): unknown;
+        execute(scope?: { actor?: Actor; token?: Token; [k: string]: unknown }): unknown;
     }
 }


### PR DESCRIPTION
While actor and token are the only ones listed explicitly in the Macro.execute() docs, the code can accept any additional properties and they will be placed into the scope the macro executes in.  There's code in executeScript() that serves no purpose other than allow this to be possible, so it's clearly intended.

This can be used to pass an event to the macro other than the global one or to pass arbitrary parameters.