### PR TITLE
Fix inconsistent line heights with inline links and content links

### DIFF
--- a/src/styles/_globals.scss
+++ b/src/styles/_globals.scss
@@ -143,8 +143,7 @@ table.pf2-table {
     border: 1px solid var(--color-border-dark-tertiary);
     box-sizing: border-box;
     color: var(--color-text-dark-primary);
-    line-height: 1.6em;
-    padding: var(--space-1) var(--space-4);
+    padding: 0 var(--space-4);
     white-space: nowrap;
     word-break: break-all;
 
@@ -154,9 +153,12 @@ table.pf2-table {
     }
 }
 
-a.content-link {
-    line-height: 1.6em;
+a.content-link,
+a.inline-roll {
+    padding: 0 var(--space-4);
+}
 
+a.content-link {
     // Automatically italicize spell content links
     &:has(i.fa-sparkles) {
         font-style: italic;


### PR DESCRIPTION
The line height property was actually something we added and removing it gets us closer to core's styling. The reduced padding is unnecessary and I can roll that back but it makes the text more readable I hope with that in play as well. The way premium modules actually fix this is by applying font-size: 0.9em instead, which we can try instead of adjusting padding if you want.

Before:
![image](https://github.com/foundryvtt/pf2e/assets/1286721/adeab5c7-7909-4c88-aac3-bf893f95cd0f)

After: 
![image](https://github.com/foundryvtt/pf2e/assets/1286721/8d0d6580-d995-4c44-b291-34908fc2db45)

Its more obvious what's going on if you check the second line on the before. The 4th line wasn't impacted because we never applied the line height to inline roll links.
