### PR TITLE
Add effectTraits to featTraits propagations

### DIFF
--- a/src/module/system/settings/homebrew/data.ts
+++ b/src/module/system/settings/homebrew/data.ts
@@ -31,12 +31,12 @@ type HomebrewTraitSettingsKey = `homebrew.${HomebrewTraitKey}`;
 
 interface HomebrewTag<T extends HomebrewTraitKey = HomebrewTraitKey> {
     id: T extends "baseWeapons"
-    ? BaseWeaponType
-    : T extends "languages"
-    ? LanguageNotCommon
-    : T extends Exclude<HomebrewTraitKey, "baseWeapons" | "languages">
-    ? keyof (typeof CONFIG.PF2E)[T]
-    : never;
+        ? BaseWeaponType
+        : T extends "languages"
+          ? LanguageNotCommon
+          : T extends Exclude<HomebrewTraitKey, "baseWeapons" | "languages">
+            ? keyof (typeof CONFIG.PF2E)[T]
+            : never;
     value: string;
 }
 
@@ -122,10 +122,10 @@ class LanguageSettings extends foundry.abstract.DataModel<null, LanguageSettings
         return source
             ? obj
             : {
-                ...obj,
-                common: Array.from(this.common),
-                homebrew: Array.from(this.homebrew),
-            };
+                  ...obj,
+                  common: Array.from(this.common),
+                  homebrew: Array.from(this.homebrew),
+              };
     }
 
     /** Schema-restricting choices removes homebrew languages before they're registered: prune in ready hook instead. */
@@ -141,7 +141,7 @@ class LanguageSettings extends foundry.abstract.DataModel<null, LanguageSettings
 
 interface LanguageSettings
     extends foundry.abstract.DataModel<null, LanguageSettingsSchema>,
-    ModelPropsFromSchema<LanguageSettingsSchema> { }
+        ModelPropsFromSchema<LanguageSettingsSchema> {}
 
 type LanguageSettingsSchema = {
     /** The "common" tongue of the region, rather than languages of common rarity */

--- a/src/module/system/settings/homebrew/data.ts
+++ b/src/module/system/settings/homebrew/data.ts
@@ -23,6 +23,7 @@ const TRAIT_PROPAGATIONS = {
     equipmentTraits: ["armorTraits", "consumableTraits"],
     featTraits: ["actionTraits"],
     weaponTraits: ["npcAttackTraits"],
+    effectTraits: ["actionTraits"],
 } as const;
 
 type HomebrewTraitKey = (typeof HOMEBREW_TRAIT_KEYS)[number];
@@ -31,12 +32,12 @@ type HomebrewTraitSettingsKey = `homebrew.${HomebrewTraitKey}`;
 
 interface HomebrewTag<T extends HomebrewTraitKey = HomebrewTraitKey> {
     id: T extends "baseWeapons"
-        ? BaseWeaponType
-        : T extends "languages"
-          ? LanguageNotCommon
-          : T extends Exclude<HomebrewTraitKey, "baseWeapons" | "languages">
-            ? keyof (typeof CONFIG.PF2E)[T]
-            : never;
+    ? BaseWeaponType
+    : T extends "languages"
+    ? LanguageNotCommon
+    : T extends Exclude<HomebrewTraitKey, "baseWeapons" | "languages">
+    ? keyof (typeof CONFIG.PF2E)[T]
+    : never;
     value: string;
 }
 
@@ -122,10 +123,10 @@ class LanguageSettings extends foundry.abstract.DataModel<null, LanguageSettings
         return source
             ? obj
             : {
-                  ...obj,
-                  common: Array.from(this.common),
-                  homebrew: Array.from(this.homebrew),
-              };
+                ...obj,
+                common: Array.from(this.common),
+                homebrew: Array.from(this.homebrew),
+            };
     }
 
     /** Schema-restricting choices removes homebrew languages before they're registered: prune in ready hook instead. */
@@ -141,7 +142,7 @@ class LanguageSettings extends foundry.abstract.DataModel<null, LanguageSettings
 
 interface LanguageSettings
     extends foundry.abstract.DataModel<null, LanguageSettingsSchema>,
-        ModelPropsFromSchema<LanguageSettingsSchema> {}
+    ModelPropsFromSchema<LanguageSettingsSchema> { }
 
 type LanguageSettingsSchema = {
     /** The "common" tongue of the region, rather than languages of common rarity */

--- a/src/module/system/settings/homebrew/data.ts
+++ b/src/module/system/settings/homebrew/data.ts
@@ -21,9 +21,8 @@ const HOMEBREW_TRAIT_KEYS = [
 const TRAIT_PROPAGATIONS = {
     creatureTraits: ["ancestryTraits"],
     equipmentTraits: ["armorTraits", "consumableTraits"],
-    featTraits: ["actionTraits"],
+    featTraits: ["actionTraits", "effectTraits"],
     weaponTraits: ["npcAttackTraits"],
-    effectTraits: ["actionTraits"],
 } as const;
 
 type HomebrewTraitKey = (typeof HOMEBREW_TRAIT_KEYS)[number];


### PR DESCRIPTION
i.e. any traits you add to feats now propagate to effect traits. 

**Without this PR, #15099 has little to no purpose in regards to homebrew Kineticist Gates.**

Replaces #15083