### PR TITLE
Remove rule for success note from Greater Rooting rune

### DIFF
--- a/src/module/item/physical/runes.ts
+++ b/src/module/item/physical/runes.ts
@@ -1677,11 +1677,6 @@ const WEAPON_PROPERTY_RUNES: { [T in WeaponPropertyRuneType]: WeaponPropertyRune
                     title: "PF2E.WeaponPropertyRune.greaterRooting.Name",
                     text: "PF2E.WeaponPropertyRune.greaterRooting.Note.criticalSuccess",
                 },
-                {
-                    outcome: ["success"],
-                    title: "PF2E.WeaponPropertyRune.greaterRooting.Name",
-                    text: "PF2E.WeaponPropertyRune.greaterRooting.Note.success",
-                },
             ],
         },
     },


### PR DESCRIPTION
Greater Rooting rune had a Note for success, but the rune only has an effect on Critical Success, and the localization string for the Note text doesn't actually exist.