### PR TITLE
Replace level with rank in Unimpeded Stride description

### DIFF
--- a/packs/spells/unimpeded-stride.json
+++ b/packs/spells/unimpeded-stride.json
@@ -11,7 +11,7 @@
         "damage": {},
         "defense": null,
         "description": {
-            "value": "<p>Divine grace ensure that nothing can keep you prisoner or hold you back. You immediately escape from every magical effect that has you @UUID[Compendium.pf2e.conditionitems.Item.Immobilized] or @UUID[Compendium.pf2e.conditionitems.Item.Grabbed] unless the effect is of a higher level than your unimpeded stride spell. You then Stride. During this movement, you ignore difficult terrain and any circumstance or status penalties to your Speed.</p>"
+            "value": "<p>Divine grace ensure that nothing can keep you prisoner or hold you back. You immediately escape from every magical effect that has you @UUID[Compendium.pf2e.conditionitems.Item.Immobilized] or @UUID[Compendium.pf2e.conditionitems.Item.Grabbed] unless the effect is of a higher rank than your unimpeded stride spell. You then Stride. During this movement, you ignore difficult terrain and any circumstance or status penalties to your Speed.</p>"
         },
         "duration": {
             "sustained": false,


### PR DESCRIPTION
I'm splitting https://github.com/foundryvtt/pf2e/pull/14976 PR into several smaller-sized and logically contained PRs for easier review.

There are bestiary creatures that use legacy version of this spell that still use spell level instead of rank. Namely, those are
- Fallen Champion from Book of the dead
- Ordwi from Rusthenge

I did not change them here but tell me if you want me to.