### PR TITLE
Fix Leukodaemon's Breath Weapon description

### DIFF
--- a/packs/pathfinder-bestiary/leukodaemon.json
+++ b/packs/pathfinder-bestiary/leukodaemon.json
@@ -777,7 +777,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The leukodaemon exhales a cloud of corpse-bloated, biting black flies in a @Template[type:cone|distance:20]. Creatures within the cone take @Damage[4d8[piercing]] damage (@Check[type:reflex|dc:28|basic:true] save).</p>\n<hr />\n<p><strong>Critical Success</strong> uneffected</p>\n<p><strong>Success</strong> half damage</p>\n<p><strong>Failure</strong> full damage and @UUID[Compendium.pf2e.conditionitems.Item.Sickened]{Sickened 1}</p>\n<p><strong>Critical Failure</strong> double damage and @UUID[Compendium.pf2e.conditionitems.Item.Sickened]{Sickened 2}</p>"
+                    "value": "<p>The leukodaemon exhales a cloud of corpse-bloated, biting black flies in a @Template[type:cone|distance:20]. Creatures within the cone take @Damage[4d8[piercing]] damage (@Check[type:reflex|dc:28|basic:true] save). A creature that fails the save becomes @UUID[Compendium.pf2e.conditionitems.Item.Sickened]{Sickened 1} (or @UUID[Compendium.pf2e.conditionitems.Item.Sickened]{Sickened 2} on a critical failure).</p>"
                 },
                 "publication": {
                     "license": "OGL",


### PR DESCRIPTION
The ability's description in Bestiary 1 is the same as in Monster Core.