### PR TITLE
add actions and effects to Ostilli Host Archetypes

### DIFF
--- a/packs/actions/administer-ambient-magic.json
+++ b/packs/actions/administer-ambient-magic.json
@@ -1,0 +1,33 @@
+{
+    "_id": "PWNi3h0F9EsttE2p",
+    "img": "systems/pf2e/icons/actions/OneAction.webp",
+    "name": "Administer Ambient Magic",
+    "system": {
+        "actionType": {
+            "value": "action"
+        },
+        "actions": {
+            "value": 1
+        },
+        "category": "defensive",
+        "description": {
+            "value": "<p><strong>Frequency</strong> once per hour</p><hr /><p><strong>Effect</strong> Your ostilli pulses a calm lavender color as it converts stored magic into a curative balm. You regain 2d4 Hit Points, and you can immediately attempt a flat check to recover from persistent bleed damage with the DC reduced to 10. This healing increases by 2d4 at 8th level and every 4 levels thereafter.</p>"
+        },
+        "frequency": {
+            "max": 1,
+            "per": "PT1H"
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Howl of the Wild"
+        },
+        "rules": [],
+        "traits": {
+            "value": [
+                "healing"
+            ]
+        }
+    },
+    "type": "action"
+}

--- a/packs/actions/devour-ambient-magic.json
+++ b/packs/actions/devour-ambient-magic.json
@@ -1,0 +1,33 @@
+{
+    "_id": "3sgY9afTTBhZXE8V",
+    "img": "systems/pf2e/icons/actions/Reaction.webp",
+    "name": "Devour Ambient Magic",
+    "system": {
+        "actionType": {
+            "value": "reaction"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "defensive",
+        "description": {
+            "value": "<p><strong>Frequency</strong> once per day</p>\n<p><strong>Trigger</strong> A creature Casts a Spell with you as the only target</p><hr /><p><strong>Effect</strong> Your ostilli radiates cyan light as its tentacle-like filters attempt to consume the magical effect. You can attempt to counteract the triggering spell with an Arcana or Nature check and a counteract rank equal to half your level.</p>"
+        },
+        "frequency": {
+            "max": 1,
+            "per": "day"
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": false,
+            "title": "Pathfinder Howl of the Wild"
+        },
+        "rules": [],
+        "traits": {
+            "value": [
+                "concentrate"
+            ]
+        }
+    },
+    "type": "action"
+}

--- a/packs/actions/drape-ambient-magic.json
+++ b/packs/actions/drape-ambient-magic.json
@@ -1,0 +1,33 @@
+{
+    "_id": "GKIKJNInDev72qai",
+    "img": "systems/pf2e/icons/actions/OneAction.webp",
+    "name": "Drape Ambient Magic",
+    "system": {
+        "actionType": {
+            "value": "action"
+        },
+        "actions": {
+            "value": 1
+        },
+        "category": "defensive",
+        "description": {
+            "value": "<p><strong>Frequency</strong> once per round</p><hr /><p><strong>Effect</strong> Your ostilli turns clear as it converts its stored magic into a bubble of refracting light around you. You become @UUID[Compendium.pf2e.conditionitems.Item.Hidden] to all creatures until the end of your turn. If you Strike a creature, that creature is @UUID[Compendium.pf2e.conditionitems.Item.Off-Guard] against that attack, and you then become observed.</p>"
+        },
+        "frequency": {
+            "max": 1,
+            "per": "round"
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Howl of the Wild"
+        },
+        "rules": [],
+        "traits": {
+            "value": [
+                "illusion"
+            ]
+        }
+    },
+    "type": "action"
+}

--- a/packs/actions/repel-ambient-magic.json
+++ b/packs/actions/repel-ambient-magic.json
@@ -1,0 +1,33 @@
+{
+    "_id": "SN3sVsU7rD2eBfkf",
+    "img": "systems/pf2e/icons/actions/OneAction.webp",
+    "name": "Repel Ambient Magic",
+    "system": {
+        "actionType": {
+            "value": "action"
+        },
+        "actions": {
+            "value": 1
+        },
+        "category": "defensive",
+        "description": {
+            "value": "<p>Your ostilli glows green as it absorbs magic. Until the start of your next turn, you gain a +1 circumstance bonus to AC and saving throws against the next magical attack, cantrip, or spell that targets you. This bonus increases to +2 at 12th level.</p>"
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Howl of the Wild"
+        },
+        "rules": [],
+        "selfEffect": {
+            "name": "Effect: Repel Ambient Magic",
+            "uuid": "Compendium.pf2e.feat-effects.Item.wnCKvlOecXAmtWII"
+        },
+        "traits": {
+            "value": [
+                "concentrate"
+            ]
+        }
+    },
+    "type": "action"
+}

--- a/packs/actions/spit-ambient-magic.json
+++ b/packs/actions/spit-ambient-magic.json
@@ -1,0 +1,34 @@
+{
+    "_id": "dwA0wfUaRf4aT0eB",
+    "img": "systems/pf2e/icons/actions/OneAction.webp",
+    "name": "Spit Ambient Magic",
+    "system": {
+        "actionType": {
+            "value": "action"
+        },
+        "actions": {
+            "value": 1
+        },
+        "category": "offensive",
+        "description": {
+            "value": "<p><strong>Frequency</strong> once per round</p><hr /><p><strong>Effect</strong> Your ostilli flashes red as it regurgitates a dart of magic at a target within 30 feet. This magical dart deals @Damage[1d6[piercing]] damage (basic Reflex save against the higher of your class DC or spell DC). This damage increases by 1d6 at 6th level and every 4 levels thereafter.</p>"
+        },
+        "frequency": {
+            "max": 1,
+            "per": "turn"
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Howl of the Wild"
+        },
+        "rules": [],
+        "traits": {
+            "value": [
+                "concentrate",
+                "magical"
+            ]
+        }
+    },
+    "type": "action"
+}

--- a/packs/actions/turn-aside-ambient-magic.json
+++ b/packs/actions/turn-aside-ambient-magic.json
@@ -1,0 +1,33 @@
+{
+    "_id": "5g0gCXJnUVipYtW0",
+    "img": "systems/pf2e/icons/actions/OneAction.webp",
+    "name": "Turn Aside Ambient Magic",
+    "system": {
+        "actionType": {
+            "value": "action"
+        },
+        "actions": {
+            "value": 1
+        },
+        "category": "defensive",
+        "description": {
+            "value": "<p>Your ostilli glows a faint yellow as it establishes a barrier. Choose acid, cold, electricity, fire, or sonic damage. Until the beginning of your next turn, you gain resistance against the chosen damage type equal to half your level.</p>"
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Howl of the Wild"
+        },
+        "rules": [],
+        "selfEffect": {
+            "name": "Effect: Turn Aside Ambient Magic",
+            "uuid": "Compendium.pf2e.feat-effects.Item.uRwnbZ0xWrB5ZzZ9"
+        },
+        "traits": {
+            "value": [
+                "concentrate"
+            ]
+        }
+    },
+    "type": "action"
+}

--- a/packs/feat-effects/effect-repel-ambient-magic.json
+++ b/packs/feat-effects/effect-repel-ambient-magic.json
@@ -1,0 +1,46 @@
+{
+    "_id": "wnCKvlOecXAmtWII",
+    "img": "systems/pf2e/icons/default-icons/effect.svg",
+    "name": "Effect: Repel Ambient Magic",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.actionspf2e.Item.Repel Ambient Magic]<br /></p>\n<p>Your ostilli glows green as it absorbs magic. Until the start of your next turn, you gain a +1 circumstance bonus to AC and saving throws against the next magical attack, cantrip, or spell that targets you. This bonus increases to +2 at 12th level.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Howl of the Wild"
+        },
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "selector": [
+                    "ac",
+                    "saving-throw"
+                ],
+                "type": "circumstance",
+                "value": "ternary(gte(@actor.level,12),2,1)"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feat-effects/effect-turn-aside-ambient-magic.json
+++ b/packs/feat-effects/effect-turn-aside-ambient-magic.json
@@ -1,0 +1,69 @@
+{
+    "_id": "uRwnbZ0xWrB5ZzZ9",
+    "img": "systems/pf2e/icons/default-icons/effect.svg",
+    "name": "Effect: Turn Aside Ambient Magic",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.actionspf2e.Item.Turn Aside Ambient Magic]</p>\n<p><span style=\"font-family:Roboto, sans-serif\">Your ostilli glows a faint yellow as it establishes a barrier. Choose acid, cold, electricity, fire, or sonic damage. Until the beginning of your next turn, you gain resistance against the chosen damage type equal to half your level.</span></p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Howl of the Wild"
+        },
+        "rules": [
+            {
+                "choices": [
+                    {
+                        "label": "Acid",
+                        "value": "acid"
+                    },
+                    {
+                        "label": "Cold",
+                        "value": "cold"
+                    },
+                    {
+                        "label": "Electricity",
+                        "value": "electricity"
+                    },
+                    {
+                        "label": "Fire",
+                        "value": "fire"
+                    },
+                    {
+                        "label": "Sonic",
+                        "value": "sonic"
+                    }
+                ],
+                "flag": "damage",
+                "key": "ChoiceSet",
+                "prompt": "Choose a damage type"
+            },
+            {
+                "key": "Resistance",
+                "type": "{item|flags.pf2e.rulesSelections.damage}",
+                "value": "floor(@actor.level/2)"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feats/cloaking-pulse.json
+++ b/packs/feats/cloaking-pulse.json
@@ -28,7 +28,16 @@
             "remaster": true,
             "title": "Pathfinder Howl of the Wild"
         },
-        "rules": [],
+        "rules": [
+            {
+                "allowDuplicate": false,
+                "key": "GrantItem",
+                "predicate": [
+                    "feat:ostilli-host-dedication"
+                ],
+                "uuid": "Compendium.pf2e.actionspf2e.Item.Drape Ambient Magic"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/deflecting-pulse.json
+++ b/packs/feats/deflecting-pulse.json
@@ -28,7 +28,16 @@
             "remaster": true,
             "title": "Pathfinder Howl of the Wild"
         },
-        "rules": [],
+        "rules": [
+            {
+                "allowDuplicate": false,
+                "key": "GrantItem",
+                "predicate": [
+                    "feat:ostilli-host-dedication"
+                ],
+                "uuid": "Compendium.pf2e.actionspf2e.Item.Turn Aside Ambient Magic"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/ostilli-host-dedication.json
+++ b/packs/feats/ostilli-host-dedication.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p><strong>Access</strong> surki ancestry</p>\n<hr />\n<p>You've bonded with an attached symbiote known as an ostilli. You can bond with only one ostilli at a time since the symbiote emits low-frequency magical pulses that repel other ostillis. You become trained in Ostilli Lore; if you were already trained, you become an expert.</p>\n<p>The ostilli is a Tiny creature grafted to your body. Like other grafts, it has no Hit Points or Speeds of its own and can't be targeted separately. It can't be removed and dies when you do; in the event of your demise and resurrection, you can bond to a new ostilli during a week of downtime, though you lose any abilities granted by your ostilli bond during that time. Your ostilli is obvious, unless you attempt to cover it with clothing or armor. In such a case, an onlooker can determine you're bonded to an ostilli with a successful Nature, Perception, or Surki Lore check against your Deception DC. Your ostilli must be visible for you to use any of the actions it grants.</p>\n<p>Your ostilli is constantly siphoning ambient magic from the surroundings, granting you the Repel Ambient Magic and Spit Ambient Magic actions.</p>\n<p><strong>Repel Ambient Magic</strong> <span class=\"action-glyph\">1</span> (concentrate) Your ostilli glows green as it absorbs magic. Until the start of your next turn, you gain a +1 circumstance bonus to AC and saving throws against the next magical attack, cantrip, or spell that targets you. This bonus increases to +2 at 12th level.</p>\n<p><strong>Spit Ambient Magic</strong> <span class=\"action-glyph\">1</span> (concentrate, magical); <strong>Frequency</strong> once per round</p>\n<hr />\n<p><strong>Effect</strong> Your ostilli flashes red as it regurgitates a dart of magic at a target within 30 feet. This magical dart deals @Damage[1d6[piercing]] damage (basic Reflex save against the higher of your class DC or spell DC). This damage increases by 1d6 at 6th level and every 4 levels thereafter.</p>"
+            "value": "<p><strong>Access</strong> surki ancestry</p><hr /><p>You've bonded with an attached symbiote known as an ostilli. You can bond with only one ostilli at a time since the symbiote emits low-frequency magical pulses that repel other ostillis. You become trained in Ostilli Lore; if you were already trained, you become an expert.</p>\n<p>The ostilli is a Tiny creature grafted to your body. Like other grafts, it has no Hit Points or Speeds of its own and can't be targeted separately. It can't be removed and dies when you do; in the event of your demise and resurrection, you can bond to a new ostilli during a week of downtime, though you lose any abilities granted by your ostilli bond during that time. Your ostilli is obvious, unless you attempt to cover it with clothing or armor. In such a case, an onlooker can determine you're bonded to an ostilli with a successful Nature, Perception, or Surki Lore check against your Deception DC. Your ostilli must be visible for you to use any of the actions it grants.</p>\n<p>Your ostilli is constantly siphoning ambient magic from the surroundings, granting you the Repel Ambient Magic and Spit Ambient Magic actions.</p>\n<p><strong>Repel Ambient Magic</strong> <span class=\"action-glyph\">1</span> (concentrate) Your ostilli glows green as it absorbs magic. Until the start of your next turn, you gain a +1 circumstance bonus to AC and saving throws against the next magical attack, cantrip, or spell that targets you. This bonus increases to +2 at 12th level.</p>\n<p><strong>Spit Ambient Magic</strong> <span class=\"action-glyph\">1</span> (concentrate, magical)</p>\n<p><strong>Frequency</strong> once per round</p><hr /><p><strong>Effect</strong> Your ostilli flashes red as it regurgitates a dart of magic at a target within 30 feet. This magical dart deals @Damage[1d6[piercing]] damage (basic Reflex save against the higher of your class DC or spell DC). This damage increases by 1d6 at 6th level and every 4 levels thereafter.</p>"
         },
         "level": {
             "value": 2
@@ -28,7 +28,24 @@
             "remaster": true,
             "title": "Pathfinder Howl of the Wild"
         },
-        "rules": [],
+        "rules": [
+            {
+                "allowDuplicate": false,
+                "key": "GrantItem",
+                "predicate": [
+                    "feat:ostilli-host-dedication"
+                ],
+                "uuid": "Compendium.pf2e.actionspf2e.Item.Repel Ambient Magic"
+            },
+            {
+                "allowDuplicate": false,
+                "key": "GrantItem",
+                "predicate": [
+                    "feat:ostilli-host-dedication"
+                ],
+                "uuid": "Compendium.pf2e.actionspf2e.Item.Spit Ambient Magic"
+            }
+        ],
         "traits": {
             "rarity": "uncommon",
             "value": [

--- a/packs/feats/soothing-pulse.json
+++ b/packs/feats/soothing-pulse.json
@@ -28,7 +28,15 @@
             "remaster": true,
             "title": "Pathfinder Howl of the Wild"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "GrantItem",
+                "predicate": [
+                    "feat:ostilli-host-dedication"
+                ],
+                "uuid": "Compendium.pf2e.actionspf2e.Item.Administer Ambient Magic"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/spell-swallow.json
+++ b/packs/feats/spell-swallow.json
@@ -28,7 +28,15 @@
             "remaster": true,
             "title": "Pathfinder Howl of the Wild"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "GrantItem",
+                "predicate": [
+                    "feat:ostilli-host-dedication"
+                ],
+                "uuid": "Compendium.pf2e.actionspf2e.Item.Devour Ambient Magic"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [


### PR DESCRIPTION
created Repel Ambient Magic and Spit Ambient Magic (requires automation) actions.

created effect for Repel Ambient Magic

added Repel Ambient Magic and Spit Ambient Magic to Ostilli Host Dedication.

created Administer Ambient Magic action (requires automation).

added Administer Ambient Magic to Soothing Pulse feat.

created Drape Ambient Magic action.

added Drape Ambient Magic to Cloaking Pulse feat.

created Turn Aside Ambient Magic action.

created Turn Aside Ambient Magic effect.

added Turn Aside Ambient Magic to Deflecting Pulse feat.

created Devour Ambient Magic action (requires automation).

added Devour Ambient Magic to Spell Swallow feat.