### PR TITLE
Add ItemAlteration rule element to Explosive Arrival

### DIFF
--- a/packs/feats/explosive-arrival.json
+++ b/packs/feats/explosive-arrival.json
@@ -24,7 +24,25 @@
             "remaster": true,
             "title": "Pathfinder Player Core"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:trait:summon"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "predicate": [
+                            "item:trait:summon"
+                        ],
+                        "text": "PF2E.SpecificRule.Wizard.ExplosiveArrival"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/explosive-arrival.json
+++ b/packs/feats/explosive-arrival.json
@@ -42,7 +42,7 @@
             },
             {
                 "key": "RollOption",
-                "label": "PF2E.SpecificRule.Spellshape.Label",
+                "label": "PF2E.TraitSpellshape",
                 "mergeable": true,
                 "option": "spellshape",
                 "placement": "spellcasting",

--- a/packs/feats/explosive-arrival.json
+++ b/packs/feats/explosive-arrival.json
@@ -30,17 +30,30 @@
                 "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
-                    "item:trait:summon"
+                    "item:trait:summon",
+                    "spellshape:explosive-arrival"
                 ],
                 "property": "description",
                 "value": [
                     {
-                        "predicate": [
-                            "item:trait:summon"
-                        ],
-                        "text": "PF2E.SpecificRule.Wizard.ExplosiveArrival"
+                        "text": "PF2E.SpecificRule.Spellshape.ExplosiveArrival"
                     }
                 ]
+            },
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Spellshape.Label",
+                "mergeable": true,
+                "option": "spellshape",
+                "placement": "spellcasting",
+                "suboptions": [
+                    {
+                        "label": "{item|name}",
+                        "value": "explosive-arrival"
+                    }
+                ],
+                "toggleable": true,
+                "value": true
             }
         ],
         "traits": {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -3871,6 +3871,10 @@
                 "Tenth": "10th-Rank",
                 "Third": "3rd-Rank"
             },
+            "Spellshape": {
+                "ExplosiveArrival": "Your summoned creature appears in a detonation of arcane runes. If your next action is to Cast a Spell with the summon trait, all creatures in a @Template[type:emanation|distance:10] around the creature you summoned take @Damage[(@item.level)d4[fire]] damage. If the creature summoned has the @Damage[(@item.level)d4[acid]]{acid}, @Damage[(@item.level)d4[cold]]{cold}, @Damage[(@item.level)d4[electricity]]{electricity}, @Damage[(@item.level)d4[sonic]]{sonic}, or @Damage[(@item.level)d4[spirit]]{spirit} trait, you can deal damage of that type instead.",
+                "Label": "Spellshape"
+            },
             "SpellTrickster": {
                 "AgileHand": {
                     "CriticalFailureNote": "If you critically fail, the spell ends and you can't use this modification again for 24 hours.",
@@ -4368,8 +4372,6 @@
                 "UnifiedMagicalTheory": {
                     "Prompt": "Select a 1st-level wizard feat."
                 },
-                "ExplosiveArrival": "Your summoned creature appears in a detonation of arcane runes. If your next action is to Cast a Spell with the summon trait, all creatures in a @Template[type:emanation|distance:10] around the creature you summoned take @Damage[1d4[fire]] damage per spell rank. If the creature summoned has the acid, cold, electricity, sonic, or spirit trait, you can deal damage of that type instead."
-            },
             "Zombie": {
                 "Deteriorated": "Deteriorated"
             }

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -4371,7 +4371,8 @@
                 },
                 "UnifiedMagicalTheory": {
                     "Prompt": "Select a 1st-level wizard feat."
-                },
+                }
+            },
             "Zombie": {
                 "Deteriorated": "Deteriorated"
             }

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -4367,7 +4367,8 @@
                 },
                 "UnifiedMagicalTheory": {
                     "Prompt": "Select a 1st-level wizard feat."
-                }
+                },
+                "ExplosiveArrival": "Your summoned creature appears in a detonation of arcane runes. If your next action is to Cast a Spell with the summon trait, all creatures in a @Template[type:emanation|distance:10] around the creature you summoned take @Damage[1d4[fire]] damage per spell rank. If the creature summoned has the acid, cold, electricity, sonic, or spirit trait, you can deal damage of that type instead."
             },
             "Zombie": {
                 "Deteriorated": "Deteriorated"

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -3872,8 +3872,7 @@
                 "Third": "3rd-Rank"
             },
             "Spellshape": {
-                "ExplosiveArrival": "Your summoned creature appears in a detonation of arcane runes. If your next action is to Cast a Spell with the summon trait, all creatures in a @Template[type:emanation|distance:10] around the creature you summoned take @Damage[(@item.level)d4[fire]] damage. If the creature summoned has the @Damage[(@item.level)d4[acid]]{acid}, @Damage[(@item.level)d4[cold]]{cold}, @Damage[(@item.level)d4[electricity]]{electricity}, @Damage[(@item.level)d4[sonic]]{sonic}, or @Damage[(@item.level)d4[spirit]]{spirit} trait, you can deal damage of that type instead.",
-                "Label": "Spellshape"
+                "ExplosiveArrival": "Your summoned creature appears in a detonation of arcane runes. If your next action is to Cast a Spell with the summon trait, all creatures in a @Template[type:emanation|distance:10] around the creature you summoned take @Damage[(@item.level)d4[fire]] damage. If the creature summoned has the @Damage[(@item.level)d4[acid]]{acid}, @Damage[(@item.level)d4[cold]]{cold}, @Damage[(@item.level)d4[electricity]]{electricity}, @Damage[(@item.level)d4[sonic]]{sonic}, or @Damage[(@item.level)d4[spirit]]{spirit} trait, you can deal damage of that type instead."
             },
             "SpellTrickster": {
                 "AgileHand": {


### PR DESCRIPTION
This would proc a note on Summon spells if a Wizard PC has the Explosive Arrival Feat.

Note - damage does not scale from the note.