### PR TITLE
Token Attribute: Allow editing Shield HP

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -918,6 +918,17 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
             const damage = isDelta ? -1 * value : hitPoints.value - value;
             return this.applyDamage({ damage, token, final: true });
         }
+        const isShield = !!(attribute === "attributes.shield.hp" && this.isOfType("character", "npc"));
+        if (isShield && token) {
+            const { hp, itemId } = this.attributes.shield;
+            if (itemId) {
+                const damage = isDelta ? hp.value + value : value;
+                const item = this.items.get(itemId);
+                await item?.update({ "system.hp.value": damage });
+            }
+            return this;
+        }
+
         return super.modifyTokenAttribute(attribute, value, isDelta, isBar);
     }
 

--- a/src/module/actor/data/base.ts
+++ b/src/module/actor/data/base.ts
@@ -85,6 +85,7 @@ interface ActorAttributes extends ActorAttributesSource {
     shield?: {
         raised: boolean;
         broken: boolean;
+        itemId: string | null;
     };
     flanking: {
         /** Whether the actor can flank at all */
@@ -309,9 +310,9 @@ export type {
     HitPointsStatistic,
     InitiativeData,
     PrototypeTokenPF2e,
-    Rollable,
     RollFunction,
     RollOptionFlags,
+    Rollable,
     StrikeData,
     TraitViewData,
 };

--- a/src/module/scene/token-document/document.ts
+++ b/src/module/scene/token-document/document.ts
@@ -94,7 +94,13 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
     /** Make stamina and resolve editable despite not being present in template.json */
     override getBarAttribute(barName: string, options?: { alternative?: string }): TokenResourceData | null {
         const attribute = super.getBarAttribute(barName, options);
-        if (attribute && ["attributes.hp.sp", "resources.resolve"].includes(attribute.attribute)) {
+        if (
+            attribute &&
+            (["attributes.hp.sp", "resources.resolve"].includes(attribute.attribute) ||
+                (this.actor?.isOfType("character", "npc") &&
+                    attribute.attribute === "attributes.shield.hp" &&
+                    this.actor.attributes.shield.itemId))
+        ) {
             attribute.editable = true;
         }
 

--- a/src/module/scene/token-document/document.ts
+++ b/src/module/scene/token-document/document.ts
@@ -91,16 +91,15 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
         return super.getTrackedAttributeChoices(attributes);
     }
 
-    /** Make stamina and resolve editable despite not being present in template.json */
+    /** Make stamina, resolve, and shield HP editable despite not being present in template.json */
     override getBarAttribute(barName: string, options?: { alternative?: string }): TokenResourceData | null {
         const attribute = super.getBarAttribute(barName, options);
-        if (
-            attribute &&
-            (["attributes.hp.sp", "resources.resolve"].includes(attribute.attribute) ||
-                (this.actor?.isOfType("character", "npc") &&
-                    attribute.attribute === "attributes.shield.hp" &&
-                    this.actor.attributes.shield.itemId))
-        ) {
+        if (!attribute) return null;
+        const isStaminaOrResolve =
+            ["attributes.hp.sp", "resources.resolve"].includes(attribute.attribute) &&
+            game.pf2e.settings.variants.stamina;
+        const isShieldHP = attribute.attribute === "attributes.shield.hp" && !!this.actor?.attributes.shield?.itemId;
+        if (isStaminaOrResolve || isShieldHP) {
             attribute.editable = true;
         }
 


### PR DESCRIPTION
This enables a Shield's HP to be edited on the Token Attribute bar, just like HP.