### PR TITLE
Remove workaround of upstream token border coloration

### DIFF
--- a/src/module/canvas/token/object.ts
+++ b/src/module/canvas/token/object.ts
@@ -223,32 +223,6 @@ class TokenPF2e<TDocument extends TokenDocumentPF2e = TokenDocumentPF2e> extends
         this.flankingHighlight.draw();
     }
 
-    /**
-     * Use border color corresponding with disposition even when the token's actor is player-owned.
-     * @see https://github.com/foundryvtt/foundryvtt/issues/9993
-     */
-    protected override _getBorderColor(): number {
-        const isHovered = this.hover || this.layer.highlightObjects;
-        const isControlled = this.controlled || (!game.user.isGM && this.isOwner);
-        const isFriendly = this.document.disposition === CONST.TOKEN_DISPOSITIONS.FRIENDLY;
-        if (!isHovered || isControlled || isFriendly || !this.actor?.hasPlayerOwner) {
-            // Upstream will do the right thing in these cases
-            return super._getBorderColor();
-        }
-
-        const colors = CONFIG.Canvas.dispositionColors;
-        switch (this.document.disposition) {
-            case CONST.TOKEN_DISPOSITIONS.NEUTRAL:
-                return colors.NEUTRAL;
-            case CONST.TOKEN_DISPOSITIONS.HOSTILE:
-                return colors.HOSTILE;
-            case CONST.TOKEN_DISPOSITIONS.SECRET:
-                return this.isOwner ? colors.SECRET : 0;
-            default:
-                return super._getBorderColor();
-        }
-    }
-
     /** Overrides _drawBar(k) to also draw pf2e variants of normal resource bars (such as temp health) */
     protected override _drawBar(number: number, bar: PIXI.Graphics, data: TokenResourceData): void {
         if (!canvas.initialized) return;
@@ -322,7 +296,7 @@ class TokenPF2e<TDocument extends TokenDocumentPF2e = TokenDocumentPF2e> extends
                 if (sceneData.radius === null) return true;
                 const canvasData = R.pick(aura, properties);
 
-                return !R.equals(sceneData, canvasData);
+                return !R.isDeepEqual(sceneData, canvasData);
             })
             .map(([slug]) => slug);
         const newAuraSlugs = Array.from(this.document.auras.keys()).filter((s) => !this.auras.has(s));


### PR DESCRIPTION
V12 is mostly in line with how we preferred it in V11