### PR TITLE
Show error instead of silently failing when rolling inline checks for invalid actors

### DIFF
--- a/src/module/actor/creature/document.ts
+++ b/src/module/actor/creature/document.ts
@@ -218,6 +218,16 @@ abstract class CreaturePF2e<
                 );
         }
 
+        if (slug in CONFIG.PF2E.magicTraditions) {
+            const bestSpellcasting =
+                this.spellcasting
+                    .filter((c) => c.tradition === slug)
+                    .flatMap((s) => s.statistic ?? [])
+                    .sort((a, b) => b.check.mod - a.check.mod)
+                    .shift() ?? null;
+            return bestSpellcasting ?? null;
+        }
+
         return (
             this.spellcasting.contents.flatMap((sc) => sc.statistic ?? []).find((s) => s.slug === slug) ??
             super.getStatistic(slug)

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1526,6 +1526,7 @@
             "NoUpdatePermission": "You lack permission to update this actor.",
             "NotEnoughAmmo": "You don't have enough ammo to make this strike.",
             "NotEnoughCoins": "Insufficient Coins",
+            "MissingStatisticSelected": "Missing statistic {statistic} on selected actors.",
             "RuleElementSyntax": "Syntax error in rule element definition: {message}",
             "SubV9Module": "{module} is unmaintained and may introduce stability issues to your game.",
             "WeaponNoDamage": "This weapon deals no damage.",


### PR DESCRIPTION
This bug is actually quite old. A below mention new feature is that actor.getStatistic() now resolves "best casting entry for tradition" rather than handling it in the inline check code.

Enable hide whitespace to reduce the diff.