### PR TITLE
Remove Dragonhide table from Dragonslayer's Shield description

### DIFF
--- a/packs/equipment/dragonslayers-shield.json
+++ b/packs/equipment/dragonslayers-shield.json
@@ -10,7 +10,7 @@
         },
         "containerId": null,
         "description": {
-            "value": "<p>A <em>dragonslayer's shield</em> is a steel shield covered with dragonhide from a specific dragon, which visually distinguishes each shield from the others. While raised, this steel shield (Hardness 8, HP 32, BT 16) grants its circumstance bonus to Reflex saves against area effects (as well as to AC, as normal).</p>\n<p>While you hold the shield, it also grants you a +2 circumstance bonus to Will saves against a dragon's frightful presence ability. The shield has resistance 10 against the damage type corresponding to the dragon breath of the dragon whose hide was used in its creation (for example, a <em>dragonslayer's shield</em> made with the hide of a diabolic dragon would grant resistance to fire); this applies after reducing the damage for Hardness, so when you use Shield Block, the <em>dragonslayer's shield</em> takes 18 less damage from attacks of that damage type. You can use Shield Block against effects that deal damage of that type.</p>\n<hr />\n<p><strong>Craft Requirements</strong> The initial raw materials must include at least 30 gp of dragonhide.</p>\n<hr />\n<h2>Dragonhide</h2>\n<table class=\"pf2e\">\n<thead>\n<tr>\n<th>Dragon Type</th>\n<th>Resistance</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>Black or copper</td>\n<td>Acid</td>\n</tr>\n<tr>\n<td>Blue or bronze</td>\n<td>Electricity</td>\n</tr>\n<tr>\n<td>Brass, gold or red</td>\n<td>Fire</td>\n</tr>\n<tr>\n<td>Green</td>\n<td>Poison</td>\n</tr>\n<tr>\n<td>Silver or white</td>\n<td>Cold</td>\n</tr>\n</tbody>\n</table>"
+            "value": "<p>A <em>dragonslayer's shield</em> is a steel shield covered with dragonhide from a specific dragon, which visually distinguishes each shield from the others. While raised, this steel shield (Hardness 8, HP 32, BT 16) grants its circumstance bonus to Reflex saves against area effects (as well as to AC, as normal).</p>\n<p>While you hold the shield, it also grants you a +2 circumstance bonus to Will saves against a dragon's frightful presence ability. The shield has resistance 10 against the damage type corresponding to the dragon breath of the dragon whose hide was used in its creation (for example, a <em>dragonslayer's shield</em> made with the hide of a diabolic dragon would grant resistance to fire); this applies after reducing the damage for Hardness, so when you use Shield Block, the <em>dragonslayer's shield</em> takes 18 less damage from attacks of that damage type. You can use Shield Block against effects that deal damage of that type.</p><hr /><p><strong>Craft Requirements</strong> The initial raw materials must include at least 30 gp of dragonhide.</p>"
         },
         "hardness": 8,
         "hp": {
@@ -48,7 +48,7 @@
             }
         ],
         "runes": {
-            "reinforcing": 0
+            "reinforcing": null
         },
         "size": "med",
         "specific": {


### PR DESCRIPTION
Removed Dragonhide table reference to OGL - it was never part of the item description.

See #15170 for reference.