### PR TITLE
Fix several creatures with missing spellcasting DCs

### DIFF
--- a/packs/book-of-the-dead-bestiary/queen-sluagh.json
+++ b/packs/book-of-the-dead-bestiary/queen-sluagh.json
@@ -33,9 +33,8 @@
                 "slots": {},
                 "slug": null,
                 "spelldc": {
-                    "dc": 0,
-                    "mod": 0,
-                    "value": 0
+                    "dc": 41,
+                    "value": 33
                 },
                 "tradition": {
                     "value": "primal"

--- a/packs/pathfinder-bestiary-3/pakalchi.json
+++ b/packs/pathfinder-bestiary-3/pakalchi.json
@@ -32,8 +32,8 @@
                 "slots": {},
                 "slug": null,
                 "spelldc": {
-                    "dc": 0,
-                    "value": 0
+                    "dc": 30,
+                    "value": 22
                 },
                 "tradition": {
                     "value": "divine"

--- a/packs/pathfinder-monster-core/gongorinan.json
+++ b/packs/pathfinder-monster-core/gongorinan.json
@@ -32,8 +32,8 @@
                 "slots": {},
                 "slug": null,
                 "spelldc": {
-                    "dc": 0,
-                    "value": 0
+                    "dc": 30,
+                    "value": 22
                 },
                 "tradition": {
                     "value": "occult"

--- a/packs/tian-xia-world-guide-bestiary/aso-berang.json
+++ b/packs/tian-xia-world-guide-bestiary/aso-berang.json
@@ -29,8 +29,8 @@
                 "slots": {},
                 "slug": null,
                 "spelldc": {
-                    "dc": 0,
-                    "value": 0
+                    "dc": 32,
+                    "value": 24
                 },
                 "tradition": {
                     "value": "divine"


### PR DESCRIPTION
There's two other creatures with 0 but they have whyzo going on for their spells and no specified DC, and it's not worth chasing it down.