### PR TITLE
Remove class predicate from Parallel Breakthrough

### DIFF
--- a/packs/feats/parallel-breakthrough.json
+++ b/packs/feats/parallel-breakthrough.json
@@ -59,6 +59,12 @@
                 "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
+                    {
+                        "or": [
+                            "class:psychic",
+                            "feat:psychic-dedication"
+                        ]
+                    },
                     "spellcasting:tradition:occult",
                     "item:slug:{item|flags.pf2e.rulesSelections.spell}"
                 ],

--- a/packs/feats/parallel-breakthrough.json
+++ b/packs/feats/parallel-breakthrough.json
@@ -59,7 +59,6 @@
                 "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
-                    "class:psychic",
                     "spellcasting:tradition:occult",
                     "item:slug:{item|flags.pf2e.rulesSelections.spell}"
                 ],


### PR DESCRIPTION
Closes #15028
Allows psychic archetypes to amp their chosen cantrip