### PR TITLE
Fix regression with chat message inline saves and fix resolution in party exploration

### DIFF
--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -684,9 +684,7 @@ class TextEditorPF2e extends TextEditor {
             anchor.dataset.invalid = "";
         }
 
-        // In case this is a note on some other action like a Strike, provide the UUID of the item that actually
-        // provokes a saving throw.
-        if (tupleHasValue(SAVE_TYPES, params.type) && item?.uuid) {
+        if (item?.uuid) {
             anchor.dataset.itemUuid = item.uuid;
         }
 


### PR DESCRIPTION
This fixes the "is from document sheet" check returning true even for chat messages, and uses the item uuid field for all item resolution, which means that now it also works in tooltips. There are already checks for saving throws in the inline check listener.