### PR TITLE
Include sub items in choice sets

### DIFF
--- a/src/module/actor/helpers.ts
+++ b/src/module/actor/helpers.ts
@@ -1,5 +1,5 @@
 import { ActorProxyPF2e, type ActorPF2e } from "@actor";
-import type { ItemPF2e, MeleePF2e, WeaponPF2e } from "@item";
+import type { ItemPF2e, MeleePF2e, PhysicalItemPF2e, WeaponPF2e } from "@item";
 import { ActionTrait } from "@item/ability/types.ts";
 import { getPropertyRuneStrikeAdjustments } from "@item/physical/runes.ts";
 import { ZeroToFour, ZeroToTwo } from "@module/data.ts";
@@ -742,6 +742,19 @@ function isReallyPC(actor: ActorPF2e): boolean {
     return actor.isOfType("character") && !(traits.has("minion") || traits.has("eidolon"));
 }
 
+/** Recursive generator function to iterate over all items and their sub items */
+function* iterateAllItems<T extends ActorPF2e>(document: T | PhysicalItemPF2e<T>): Generator<ItemPF2e<T>> {
+    const collection = document instanceof Actor ? document.items : document.subitems;
+    for (const item of collection ?? []) {
+        yield item;
+        if (item.isOfType("physical")) {
+            for (const subitem of iterateAllItems(item)) {
+                yield subitem;
+            }
+        }
+    }
+}
+
 export {
     auraAffectsActor,
     calculateMAPs,
@@ -754,6 +767,7 @@ export {
     getStrikeDamageDomains,
     isOffGuardFromFlanking,
     isReallyPC,
+    iterateAllItems,
     migrateActorSource,
     resetActors,
     setHitPointsRollOptions,

--- a/src/module/rules/rule-element/choice-set/rule-element.ts
+++ b/src/module/rules/rule-element/choice-set/rule-element.ts
@@ -1,5 +1,6 @@
 import type { ActorPF2e } from "@actor";
 import { StrikeData } from "@actor/data/base.ts";
+import { iterateAllItems } from "@actor/helpers.ts";
 import { ItemPF2e, ItemProxyPF2e } from "@item";
 import { ItemSourcePF2e } from "@item/base/data/index.ts";
 import { PickableThing } from "@module/apps/pick-a-thing-prompt.ts";
@@ -325,7 +326,7 @@ class ChoiceSetRuleElement extends RuleElementPF2e<ChoiceSetSchema> {
         const { includeHandwraps, types } = options;
         const predicate = new Predicate(this.resolveInjectedProperties(options.predicate));
 
-        const choices = this.actor.items
+        const choices = [...iterateAllItems(this.actor)]
             .filter((i) => i.isOfType(...types) && predicate.test([...actorRollOptions, ...i.getRollOptions("item")]))
             .filter((i) => !i.isOfType("weapon") || i.category !== "unarmed")
             .map(


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/14789

While a getter that does this would be fine to have on the actor, I'm not sure on its signature yet. Better to keep it a method for now. An alternative is to rely on https://github.com/foundryvtt/pf2e/pull/15175 but `[...actor.items, ...actor.inventory.subitems]` might not be as intuitive.