### PR TITLE
Fix sending description to chat for actions with variants when no variant is specified

### DIFF
--- a/src/module/actor/actions/base.ts
+++ b/src/module/actor/actions/base.ts
@@ -187,7 +187,9 @@ abstract class BaseAction<TData extends BaseActionVariantData, TAction extends B
     }
 
     async toMessage(options?: Partial<ActionMessageOptions>): Promise<ChatMessagePF2e | undefined> {
-        return this.getDefaultVariant(options).toMessage(options);
+        return options?.variant
+            ? this.getDefaultVariant(options).toMessage(options)
+            : this.toActionVariant().toMessage(options);
     }
 
     async use(options?: Partial<ActionUseOptions>): Promise<unknown> {


### PR DESCRIPTION
Fixes an edge case introduced by https://github.com/foundryvtt/pf2e/pull/13198