### PR TITLE
Use specific skill check localizations for check dialogs and messages

### DIFF
--- a/src/module/system/statistic/statistic.ts
+++ b/src/module/system/statistic/statistic.ts
@@ -348,6 +348,13 @@ class StatisticCheck<TParent extends Statistic = Statistic> {
         const parentLabel = this.parent.label;
         if (data.check?.label) return game.i18n.localize(data.check?.label);
 
+        // Check for specific check localization, and use if it exists
+        const checkKey = `PF2E.ActionsCheck.${this.parent.slug}`;
+        const checkLabel = game.i18n.localize(checkKey);
+        if (!["x", "x-attack-roll"].includes(this.parent.slug) && checkLabel !== checkKey) {
+            return checkLabel;
+        }
+
         if (this.domains.includes("spell-attack-roll")) {
             return game.i18n.format("PF2E.SpellAttackWithTradition", { tradition: parentLabel });
         }


### PR DESCRIPTION
It seems we're going with the "add stuff in ActionsCheck to show alternative labels" without putting it in config so that's what we're doing.

Eventually we need to remove the generic messages from the slug key'd super collection.