### PR TITLE
Add engines: node to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "foundry-pf2e",
-            "version": "6.0.3",
+            "version": "6.0.4",
             "license": "Apache-2.0",
             "dependencies": {
                 "@codemirror/autocomplete": "^6.16.0",
@@ -52,6 +52,7 @@
                 "jest-each": "^29.7.0",
                 "js-angusj-clipper": "^1.3.1",
                 "jsdom": "^24.1.0",
+                "node": "^20.15.0",
                 "peggy": "^4.0.3",
                 "pixi.js": "^7.4.2",
                 "prettier": "3.2.5",
@@ -6051,6 +6052,28 @@
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+            "dev": true
+        },
+        "node_modules/node": {
+            "version": "20.15.0",
+            "resolved": "https://registry.npmjs.org/node/-/node-20.15.0.tgz",
+            "integrity": "sha512-zsJ9aOJAKhnR9rJ4BBfGmgiBmG3ZlLXLZ4jBjshPib+S8qKSY+ggBvphceT5gHF1X7KB4UP1ImU/A4EYr31Y2g==",
+            "dev": true,
+            "hasInstallScript": true,
+            "dependencies": {
+                "node-bin-setup": "^1.0.0"
+            },
+            "bin": {
+                "node": "bin/node"
+            },
+            "engines": {
+                "npm": ">=5.0.0"
+            }
+        },
+        "node_modules/node-bin-setup": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.1.3.tgz",
+            "integrity": "sha512-opgw9iSCAzT2+6wJOETCpeRYAQxSopqQ2z+N6BXwIMsQQ7Zj5M8MaafQY8JMlolRR6R1UXg2WmhKp0p9lSOivg==",
             "dev": true
         },
         "node_modules/node-gyp-build": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,6 @@
                 "jest-each": "^29.7.0",
                 "js-angusj-clipper": "^1.3.1",
                 "jsdom": "^24.1.0",
-                "node": "^20.15.0",
                 "peggy": "^4.0.3",
                 "pixi.js": "^7.4.2",
                 "prettier": "3.2.5",
@@ -6052,28 +6051,6 @@
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-            "dev": true
-        },
-        "node_modules/node": {
-            "version": "20.15.0",
-            "resolved": "https://registry.npmjs.org/node/-/node-20.15.0.tgz",
-            "integrity": "sha512-zsJ9aOJAKhnR9rJ4BBfGmgiBmG3ZlLXLZ4jBjshPib+S8qKSY+ggBvphceT5gHF1X7KB4UP1ImU/A4EYr31Y2g==",
-            "dev": true,
-            "hasInstallScript": true,
-            "dependencies": {
-                "node-bin-setup": "^1.0.0"
-            },
-            "bin": {
-                "node": "bin/node"
-            },
-            "engines": {
-                "npm": ">=5.0.0"
-            }
-        },
-        "node_modules/node-bin-setup": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.1.3.tgz",
-            "integrity": "sha512-opgw9iSCAzT2+6wJOETCpeRYAQxSopqQ2z+N6BXwIMsQQ7Zj5M8MaafQY8JMlolRR6R1UXg2WmhKp0p9lSOivg==",
             "dev": true
         },
         "node_modules/node-gyp-build": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
         "jest-each": "^29.7.0",
         "js-angusj-clipper": "^1.3.1",
         "jsdom": "^24.1.0",
+        "node": "^20.15.0",
         "peggy": "^4.0.3",
         "pixi.js": "^7.4.2",
         "prettier": "3.2.5",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     },
     "author": "The PF2e System Developers",
     "license": "Apache-2.0",
+    "engines": {
+        "node": ">=20.15.0"
+    },
     "devDependencies": {
         "@pixi/graphics-smooth": "^1.1.0",
         "@pixi/particle-emitter": "5.0.8",
@@ -57,7 +60,6 @@
         "jest-each": "^29.7.0",
         "js-angusj-clipper": "^1.3.1",
         "jsdom": "^24.1.0",
-        "node": "^20.15.0",
         "peggy": "^4.0.3",
         "pixi.js": "^7.4.2",
         "prettier": "3.2.5",


### PR DESCRIPTION
Add a node 20 dependency to the package.json to avoid issues in regards to parsing dice ([18-19 said to be broken by Tikael](https://discord.com/channels/880968862240239708/880969304365994034/1253736595056496680), and node 21 also broke my local build process.)