### PR TITLE
Brush up automation for Chronoskimmer archetype

### DIFF
--- a/packs/feat-effects/effect-combat-premonition.json
+++ b/packs/feat-effects/effect-combat-premonition.json
@@ -1,0 +1,57 @@
+{
+    "_id": "CdWAXaePkMP4hts9",
+    "img": "icons/magic/control/hypnosis-mesmerism-eye-tan.webp",
+    "name": "Effect: Combat Premonition",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Combat Premonition]</p>\n<p>Choose two allies. Those allies roll their initiative roll twice and take the better result; You roll your initiative roll twice and take the worse result.</p>"
+        },
+        "duration": {
+            "expiry": null,
+            "sustained": false,
+            "unit": "unlimited",
+            "value": -1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Dark Archive"
+        },
+        "rules": [
+            {
+                "keep": "lower",
+                "key": "RollTwice",
+                "predicate": [
+                    "self:signature:{item|origin.signature}"
+                ],
+                "removeAfterRoll": true,
+                "selector": "initiative"
+            },
+            {
+                "keep": "higher",
+                "key": "RollTwice",
+                "predicate": [
+                    {
+                        "not": "self:signature:{item|origin.signature}"
+                    }
+                ],
+                "removeAfterRoll": true,
+                "selector": "initiative"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feat-effects/effect-guide-the-timeline.json
+++ b/packs/feat-effects/effect-guide-the-timeline.json
@@ -1,0 +1,87 @@
+{
+    "_id": "bxxek5BP4zqP5GzM",
+    "img": "icons/magic/time/clock-spinning-gold-pink.webp",
+    "name": "Effect: Guide the Timeline",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Guide the Timeline]</p>\n<p>Choose an ally or a foe. If you choose an ally, the next time within the next round that ally makes an attack roll or skill check, they roll it twice and take the higher result. If you choose a foe, the next time within the next round that foe makes an attack roll or skill check, they must roll twice and take the lower result.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Dark Archive"
+        },
+        "rules": [
+            {
+                "choices": [
+                    {
+                        "label": "PF2E.TraitFortune",
+                        "value": "fortune"
+                    },
+                    {
+                        "label": "PF2E.TraitMisfortune",
+                        "value": "misfortune"
+                    }
+                ],
+                "key": "ChoiceSet",
+                "rollOption": "guide-the-timeline"
+            },
+            {
+                "keep": "higher",
+                "key": "RollTwice",
+                "predicate": [
+                    "guide-the-timeline:fortune"
+                ],
+                "removeAfterRoll": true,
+                "selector": "attack-roll"
+            },
+            {
+                "keep": "higher",
+                "key": "RollTwice",
+                "predicate": [
+                    "guide-the-timeline:fortune"
+                ],
+                "removeAfterRoll": true,
+                "selector": "skill-check"
+            },
+            {
+                "keep": "lower",
+                "key": "RollTwice",
+                "predicate": [
+                    "guide-the-timeline:misfortune"
+                ],
+                "removeAfterRoll": true,
+                "selector": "attack-roll"
+            },
+            {
+                "keep": "lower",
+                "key": "RollTwice",
+                "predicate": [
+                    "guide-the-timeline:misfortune"
+                ],
+                "removeAfterRoll": true,
+                "selector": "skill-check"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feat-effects/effect-turn-back-the-clock.json
+++ b/packs/feat-effects/effect-turn-back-the-clock.json
@@ -1,0 +1,47 @@
+{
+    "_id": "LbICHKe5jLMxhaOw",
+    "img": "icons/magic/time/clock-analog-gray.webp",
+    "name": "Effect: Turn Back The Clock",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Turn Back the Clock]</p>\n<p>You reroll the triggering check with a +1 circumstance bonus.</p>"
+        },
+        "duration": {
+            "expiry": null,
+            "sustained": false,
+            "unit": "unlimited",
+            "value": -1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Dark Archive"
+        },
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "removeAfterRoll": true,
+                "selector": [
+                    "skill-check",
+                    "saving-throw"
+                ],
+                "type": "circumstance",
+                "value": 1
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feats/chronoskimmer-dedication.json
+++ b/packs/feats/chronoskimmer-dedication.json
@@ -30,32 +30,16 @@
                 "option": "chronoskimmer-dedication",
                 "suboptions": [
                     {
-                        "label": "PF2E.SpecificRule.Chronoskimmer.DestabilizeLabel",
-                        "value": "destabilize"
+                        "label": "PF2E.SpecificRule.Chronoskimmer.DestabilizeFailureLabel",
+                        "value": "destabilize-failure"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Chronoskimmer.DestabilizeSuccessLabel",
+                        "value": "destabilize-success"
                     },
                     {
                         "label": "PF2E.SpecificRule.Chronoskimmer.StabilizeLabel",
                         "value": "stabilize"
-                    }
-                ],
-                "toggleable": true
-            },
-            {
-                "alwaysActive": true,
-                "key": "RollOption",
-                "label": "PF2E.SpecificRule.Chronoskimmer.DestabilizeResult",
-                "option": "destabilize-timestream",
-                "predicate": [
-                    "chronoskimmer-dedication:destabilize"
-                ],
-                "suboptions": [
-                    {
-                        "label": "PF2E.Check.Result.Degree.Check.failure",
-                        "value": "failure"
-                    },
-                    {
-                        "label": "PF2E.Check.Result.Degree.Check.success",
-                        "value": "success"
                     }
                 ],
                 "toggleable": true
@@ -76,8 +60,7 @@
                 "key": "SubstituteRoll",
                 "label": "PF2E.SpecificRule.Chronoskimmer.DestabilizeSuccessLabel",
                 "predicate": [
-                    "chronoskimmer-dedication:destabilize",
-                    "destabilize-timestream:success"
+                    "chronoskimmer-dedication:destabilize-success"
                 ],
                 "required": true,
                 "selector": "initiative",
@@ -88,8 +71,7 @@
                 "key": "SubstituteRoll",
                 "label": "PF2E.SpecificRule.Chronoskimmer.DestabilizeFailureLabel",
                 "predicate": [
-                    "chronoskimmer-dedication:destabilize",
-                    "destabilize-timestream:failure"
+                    "chronoskimmer-dedication:destabilize-failure"
                 ],
                 "required": true,
                 "selector": "initiative",

--- a/packs/feats/chronoskimmer-dedication.json
+++ b/packs/feats/chronoskimmer-dedication.json
@@ -26,10 +26,48 @@
         },
         "rules": [
             {
+                "key": "RollOption",
+                "option": "chronoskimmer-dedication",
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Chronoskimmer.DestabilizeLabel",
+                        "value": "destabilize"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Chronoskimmer.StabilizeLabel",
+                        "value": "stabilize"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "alwaysActive": true,
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Chronoskimmer.DestabilizeResult",
+                "option": "destabilize-timestream",
+                "predicate": [
+                    "chronoskimmer-dedication:destabilize"
+                ],
+                "suboptions": [
+                    {
+                        "label": "PF2E.Check.Result.Degree.Check.failure",
+                        "value": "failure"
+                    },
+                    {
+                        "label": "PF2E.Check.Result.Degree.Check.success",
+                        "value": "success"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
                 "effectType": "fortune",
                 "key": "SubstituteRoll",
                 "label": "PF2E.SpecificRule.Chronoskimmer.StabilizeLabel",
-                "required": false,
+                "predicate": [
+                    "chronoskimmer-dedication:stabilize"
+                ],
+                "required": true,
                 "selector": "initiative",
                 "value": 10
             },
@@ -37,7 +75,11 @@
                 "effectType": "fortune",
                 "key": "SubstituteRoll",
                 "label": "PF2E.SpecificRule.Chronoskimmer.DestabilizeSuccessLabel",
-                "required": false,
+                "predicate": [
+                    "chronoskimmer-dedication:destabilize",
+                    "destabilize-timestream:success"
+                ],
+                "required": true,
                 "selector": "initiative",
                 "value": 19
             },
@@ -45,7 +87,11 @@
                 "effectType": "fortune",
                 "key": "SubstituteRoll",
                 "label": "PF2E.SpecificRule.Chronoskimmer.DestabilizeFailureLabel",
-                "required": false,
+                "predicate": [
+                    "chronoskimmer-dedication:destabilize",
+                    "destabilize-timestream:failure"
+                ],
+                "required": true,
                 "selector": "initiative",
                 "value": 1
             }

--- a/packs/feats/combat-premonition.json
+++ b/packs/feats/combat-premonition.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>By narrowing your sense of the future, you can improve that of your allies. When you roll initiative, instead of stabilizing or destabilizing your own timestream, you can grant your allies a flash of insight into their future. Choose two allies. Those allies roll their initiative roll twice and take the better result; this is a fortune effect. You roll your initiative roll twice and take the worse result; this is a misfortune effect. The two effects are tied together: if you would avoid the misfortune effect for any reason, or if any of your allies would negate their fortune effect, your Combat Premonition does nothing.</p>"
+            "value": "<p>By narrowing your sense of the future, you can improve that of your allies. When you roll initiative, instead of stabilizing or destabilizing your own timestream, you can grant your allies a flash of insight into their future. Choose two allies. Those allies roll their initiative roll twice and take the better result; this is a fortune effect. You roll your initiative roll twice and take the worse result; this is a misfortune effect. The two effects are tied together: if you would avoid the misfortune effect for any reason, or if any of your allies would negate their fortune effect, your Combat Premonition does nothing.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Combat Premonition]</p>"
         },
         "level": {
             "value": 12

--- a/packs/feats/guide-the-timeline.json
+++ b/packs/feats/guide-the-timeline.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p><strong>Frequency</strong> once per day</p>\n<hr />\n<p>You know the result you want and subtly nudge the timeline to your intended destination. Choose an ally or a foe. If you choose an ally, the next time within the next round that ally makes an attack roll or skill check, they roll it twice and take the higher result; this is a fortune effect. If you choose a foe, the next time within the next round that foe makes an attack roll or skill check, they must roll twice and take the lower result unless they succeed at a Will save against your chronoskimmer DC; this is a misfortune effect. Regardless of your choice, the target becomes temporarily immune for 24 hours.</p>"
+            "value": "<p><strong>Frequency</strong> once per day</p><hr /><p>You know the result you want and subtly nudge the timeline to your intended destination. Choose an ally or a foe. If you choose an ally, the next time within the next round that ally makes an attack roll or skill check, they roll it twice and take the higher result; this is a fortune effect. If you choose a foe, the next time within the next round that foe makes an attack roll or skill check, they must roll twice and take the lower result unless they succeed at a @Check[type:will|dc:resolve(@actor.system.attributes.classOrSpellDC.value)] save against your chronoskimmer DC; this is a misfortune effect. Regardless of your choice, the target becomes temporarily immune for 24 hours.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Guide the Timeline]</p>"
         },
         "frequency": {
             "max": 1,

--- a/packs/feats/turn-back-the-clock.json
+++ b/packs/feats/turn-back-the-clock.json
@@ -33,6 +33,10 @@
             "title": "Pathfinder Dark Archive"
         },
         "rules": [],
+        "selfEffect": {
+            "name": "Effect: Turn Back The Clock",
+            "uuid": "Compendium.pf2e.feat-effects.Item.Effect: Turn Back The Clock"
+        },
         "traits": {
             "rarity": "common",
             "value": [

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2109,8 +2109,6 @@
             },
             "Chronoskimmer": {
                 "DestabilizeFailureLabel": "Destabilize timestream (Failure)",
-                "DestabilizeLabel": "Destabilize timestream",
-                "DestabilizeResult": "Destabilize timestream result",
                 "DestabilizeSuccessLabel": "Destabilize timestream (Success)",
                 "StabilizeLabel": "Stabilize timestream"
             },

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2109,6 +2109,8 @@
             },
             "Chronoskimmer": {
                 "DestabilizeFailureLabel": "Destabilize timestream (Failure)",
+                "DestabilizeLabel": "Destabilize timestream",
+                "DestabilizeResult": "Destabilize timestream result",
                 "DestabilizeSuccessLabel": "Destabilize timestream (Success)",
                 "StabilizeLabel": "Stabilize timestream"
             },


### PR DESCRIPTION
- Add suboptions for Chronoskimmer Dedication's stabilize and destabilize timestream
- Add effects for Combat Premonition, Guide the Timeline and Turn Back the Clock