### PR TITLE
Allow DamageAlteration REs to have resolvable selectors

### DIFF
--- a/src/module/rules/rule-element/damage-alteration/rule-element.ts
+++ b/src/module/rules/rule-element/damage-alteration/rule-element.ts
@@ -90,7 +90,7 @@ class DamageAlterationRuleElement extends RuleElementPF2e<DamageAlterationSchema
         if (this.ignored) return;
 
         const alteration = new DamageAlteration(this);
-        for (const selector of this.selectors) {
+        for (const selector of this.resolveInjectedProperties(this.selectors)) {
             const synthetics = (this.actor.synthetics.damageAlterations[selector] ??= []);
             synthetics.push(alteration);
         }


### PR DESCRIPTION
This allows DamageAlteration to support selectors like:
```
"selectors": [
	"{item|id}-inline-damage"
]
```

Cribbed from /src/module/rules/rule-element/damage-dice.ts:59