### PR TITLE
Use the values of other objects at runtime for determining valid dc slugs

### DIFF
--- a/src/module/actor/actions/single-check.ts
+++ b/src/module/actor/actions/single-check.ts
@@ -1,7 +1,7 @@
 import { ActorPF2e } from "@actor";
 import { ModifierPF2e, RawModifier, StatisticModifier } from "@actor/modifiers.ts";
 import { DCSlug } from "@actor/types.ts";
-import { DC_SLUGS } from "@actor/values.ts";
+import { SAVE_TYPES, SKILL_SLUGS } from "@actor/values.ts";
 import type { ItemPF2e } from "@item";
 import { TokenPF2e } from "@module/canvas/index.ts";
 import { RollNotePF2e, RollNoteSource } from "@module/notes.ts";
@@ -14,7 +14,7 @@ import {
     CheckResultCallback,
 } from "@system/action-macros/types.ts";
 import { CheckDC } from "@system/degree-of-success.ts";
-import { getActionGlyph, isObject, setHasElement } from "@util";
+import { getActionGlyph, isObject, setHasElement, tupleHasValue } from "@util";
 import { BaseAction, BaseActionData, BaseActionVariant, BaseActionVariantData } from "./base.ts";
 import { ActionUseOptions } from "./types.ts";
 
@@ -25,7 +25,16 @@ function toRollNoteSource(data: SingleCheckActionRollNoteData): RollNoteSource {
 }
 
 function isValidDifficultyClass(dc: unknown): dc is CheckDC | DCSlug {
-    return setHasElement(DC_SLUGS, dc) || (isObject<{ value: unknown }>(dc) && typeof dc.value === "number");
+    if (isObject<{ value: unknown }>(dc) && typeof dc.value === "number") {
+        return true;
+    }
+
+    const slug = String(dc);
+    return (
+        ["ac", "armor", "perception"].includes(slug) ||
+        tupleHasValue(SAVE_TYPES, slug) ||
+        setHasElement(SKILL_SLUGS, slug)
+    );
 }
 
 interface SingleCheckActionVariantData extends BaseActionVariantData {

--- a/src/module/actor/types.ts
+++ b/src/module/actor/types.ts
@@ -13,7 +13,6 @@ import type { Predicate } from "@system/predication.ts";
 import type {
     ACTOR_TYPES,
     ATTRIBUTE_ABBREVIATIONS,
-    DC_SLUGS,
     MOVEMENT_TYPES,
     SAVE_TYPES,
     SKILL_SLUGS,
@@ -50,9 +49,9 @@ type SkillSlug = SetElement<typeof SKILL_SLUGS>;
 
 type ActorAlliance = "party" | "opposition" | null;
 
-type DCSlug = SetElement<typeof DC_SLUGS>;
-
 type SaveType = (typeof SAVE_TYPES)[number];
+
+type DCSlug = "ac" | "armor" | "perception" | SaveType | SkillSlug;
 
 type MovementType = (typeof MOVEMENT_TYPES)[number];
 

--- a/src/module/actor/values.ts
+++ b/src/module/actor/values.ts
@@ -36,8 +36,6 @@ const SKILL_SLUGS = new Set([
     "thievery",
 ] as const);
 
-const DC_SLUGS = new Set(["ac", "armor", "perception", ...SAVE_TYPES, ...SKILL_SLUGS] as const);
-
 interface SkillExpanded {
     attribute: AttributeString;
 }
@@ -70,7 +68,6 @@ export {
     ACTOR_TYPES,
     ATTRIBUTE_ABBREVIATIONS,
     CREATURE_ACTOR_TYPES,
-    DC_SLUGS,
     IMMUNITY_TYPES,
     MOVEMENT_TYPES,
     RESISTANCE_TYPES,


### PR DESCRIPTION
This is only used by action macros and its a bit confusing to understand what its being used for there. Please review @nikolaj-a when you get the chance, since I don't know how to actually test this.