### PR TITLE
Add Map Location Journal

### DIFF
--- a/src/module/canvas/map-location-control-icon.ts
+++ b/src/module/canvas/map-location-control-icon.ts
@@ -1,0 +1,110 @@
+/** Custom control icon used to display Map Location journal pages when pinned to the map. */
+class MapLocationControlIcon extends PIXI.Container {
+    constructor({ code, size = 40, ...style }: MapLocationControlIconParams & MapLocationStyle = {}) {
+        super();
+
+        this.code = code;
+        this.size = size;
+        this.style = style;
+
+        this.radius = size / 2;
+        this.circle = [this.radius, this.radius, this.radius];
+        this.backgroundColor = this.style.backgroundColor;
+        this.borderColor = this.style.borderHoverColor;
+
+        // Define hit area
+        this.eventMode = "static";
+        this.interactiveChildren = false;
+        this.hitArea = new PIXI.Circle(...this.circle);
+        this.cursor = "pointer";
+
+        // Text
+        this.text = new PreciseText(this.code, this._getTextStyle(this.code.length, this.size));
+        this.text.anchor.set(0.5, 0.5);
+        this.text.position.set(this.radius, this.radius);
+        this.addChild(this.text);
+
+        // Border
+        this.border = this.addChild(new PIXI.Graphics());
+        this.border.visible = false;
+
+        this.refresh();
+    }
+
+    /* -------------------------------------------- */
+
+    backgroundColor: number;
+
+    border: PIXI.Graphics;
+
+    borderColor: string | number;
+
+    circle: number[];
+
+    code: string | undefined;
+
+    radius: number;
+
+    size: number;
+
+    style: MapLocationStyle;
+
+    text: PreciseText;
+
+    /* -------------------------------------------- */
+
+    refresh({ visible, borderColor, borderVisible }: MapLocationControlIconRefreshParams = {}): this {
+        if (borderColor) this.borderColor = borderColor;
+        this.border
+            .clear()
+            .lineStyle(2, this.borderColor, 1.0)
+            .drawCircle(...this.circle)
+            .endFill();
+        if (borderVisible !== undefined) this.border.visible = borderVisible;
+        if (visible !== undefined) this.visible = visible;
+        return this;
+    }
+
+    /* -------------------------------------------- */
+
+    /**
+     * Define PIXI TestStyle object for rendering the map location code.
+     * @param {number} characterCount  Number of characters in the code.
+     * @param {number} size            Size of the icon in the Scene.
+     */
+    _getTextStyle(characterCount: number, size: number): PIXI.TextStyle {
+        const style = CONFIG.canvasTextStyle.clone();
+        style.dropShadow = false;
+        style.fill = Color.from(this.style.textColor) as number;
+        style.strokeThickness = 2;
+        style.fontFamily = ["Signika"];
+        if (this.style.fontFamily) style.fontFamily.unshift(this.style.fontFamily);
+        style.fontSize = characterCount > 2 ? size * 0.5 : size * 0.6;
+        style.lineJoin = "round";
+        return style;
+    }
+}
+
+interface MapLocationStyle {
+    backgroundColor: number;
+    borderColor: string | number;
+    borderHoverColor: string | number;
+    fontFamily?: string;
+    shadowColor: number;
+    textColor: number | string;
+    tint: number;
+}
+
+interface MapLocationControlIconParams {
+    code: string;
+    size: number;
+    // style: MapLocationStyle;
+}
+
+interface MapLocationControlIconRefreshParams {
+    visible?: boolean;
+    borderColor?: string | number;
+    borderVisible?: boolean;
+}
+
+export { MapLocationControlIcon };

--- a/src/module/canvas/note.ts
+++ b/src/module/canvas/note.ts
@@ -1,0 +1,12 @@
+class NotePF2e extends Note {
+    override _drawControlIcon(): ControlIcon {
+        const { texture, iconSize } = this.document;
+        const systemIcon = this.page?.system?.getControlIcon?.({ size: iconSize, tint: texture.tint });
+        if (!systemIcon) return super._drawControlIcon();
+        systemIcon.x -= iconSize / 2;
+        systemIcon.y -= iconSize / 2;
+        return systemIcon;
+    }
+}
+
+export { NotePF2e };

--- a/src/module/journal-entry/sheet.ts
+++ b/src/module/journal-entry/sheet.ts
@@ -2,9 +2,22 @@ class JournalSheetPF2e<TJournalEntry extends JournalEntry> extends JournalSheet<
     /** Start pagination at 1 🤫 */
     override async getData(options?: Partial<DocumentSheetOptions>): Promise<JournalSheetData<TJournalEntry>> {
         const sheetData = await super.getData(options);
+
+        let adjustment = 1;
         for (const entry of sheetData.toc) {
-            entry.number += 1;
+            const pageDocument = this.document.pages.get(entry._id);
+            let needsAdjustment = true;
+            if (pageDocument) {
+                const numbering = pageDocument.system?.adjustTOCNumbering?.(entry.number);
+                if (numbering) {
+                    entry.number = numbering.number;
+                    adjustment += numbering.adjustment ?? 0;
+                    needsAdjustment = false;
+                }
+            }
+            if (needsAdjustment) entry.number += adjustment;
         }
+
         return sheetData;
     }
 }

--- a/src/module/journal-page/map/data.ts
+++ b/src/module/journal-page/map/data.ts
@@ -1,0 +1,43 @@
+import { MapLocationControlIcon } from "@module/canvas/map-location-control-icon.ts";
+import type { StringField } from "types/foundry/common/data/fields.d.ts";
+
+type JournalMapLocationPageSystemSchema = {
+    code: StringField<string, string, false, false, true>;
+};
+
+class JournalMapLocationPageSystemData extends foundry.abstract.TypeDataModel<
+    JournalEntryPage,
+    JournalMapLocationPageSystemSchema
+> {
+    static override defineSchema(): JournalMapLocationPageSystemSchema {
+        const fields = foundry.data.fields;
+        return {
+            code: new fields.StringField(),
+        };
+    }
+
+    /**
+     * Adjust the number of this entry in the table of contents.
+     * @param {number} number  Current position number.
+     */
+    adjustTOCNumbering(): { number: string; adjustment: number } | void {
+        if (!this.code) return;
+        return { number: this.code, adjustment: -1 };
+    }
+
+    /**
+     * Create a control icon for rendering this page on a scene.
+     * @param {object} options  Options passed through to ControlIcon construction.
+     */
+    getControlIcon(options: object): PIXI.Container | void {
+        if (!this.code) return;
+        const style = foundry.utils.mergeObject(
+            CONFIG.PF2E.mapLocationMarker.default,
+            CONFIG.PF2E.mapLocationMarker[this.parent.getFlag("pf2e", "mapMarkerStyle")] ?? {},
+            { inplace: false },
+        );
+        return new MapLocationControlIcon({ code: this.code, ...options, ...style });
+    }
+}
+
+export { JournalMapLocationPageSystemData };

--- a/src/module/journal-page/map/sheet.ts
+++ b/src/module/journal-page/map/sheet.ts
@@ -1,0 +1,31 @@
+class JournalMapLocationPageSheet extends JournalTextPageSheet<JournalEntryPage> {
+    static override get defaultOptions(): DocumentSheetOptions {
+        const options = super.defaultOptions;
+        options.classes.push("map");
+        return options;
+    }
+
+    override get template(): string {
+        return `templates/journal/page-text-${this.isEditable ? "edit" : "view"}.html`;
+    }
+
+    override async _renderInner(data: Record<string, unknown>, options: RenderOptions): Promise<JQuery> {
+        const jQuery = await super._renderInner(data, options);
+        const editingHeader = jQuery[0].querySelector(".journal-header");
+        const viewingHeader = jQuery[0].querySelector(":is(h1, h2, h3)");
+
+        if (editingHeader) {
+            const input = document.createElement("input");
+            input.name = "system.code";
+            input.type = "text";
+            input.value = this.document.system.code ?? "";
+            editingHeader.insertAdjacentElement("afterbegin", input);
+        } else if (viewingHeader && this.document.system.code) {
+            viewingHeader.dataset.mapLocationCode = this.document.system.code;
+        }
+
+        return jQuery;
+    }
+}
+
+export { JournalMapLocationPageSheet };

--- a/src/scripts/config/index.ts
+++ b/src/scripts/config/index.ts
@@ -994,6 +994,17 @@ export const PF2ECONFIG = {
 
     JournalEntry: { sheetClass: JournalSheetPF2e },
 
+    mapLocationMarker: {
+        default: {
+            backgroundColor: 0x000000,
+            borderColor: 0x000000,
+            borderHoverColor: 0xff6400, // --color-border-highlight
+            fontFamily: "Signika",
+            shadowColor: 0x000000,
+            textColor: 0xfbf8f5,
+        },
+    },
+
     Canvas: {
         darkness: {
             default: CONFIG.Canvas.darknessColor,

--- a/src/scripts/hooks/init.ts
+++ b/src/scripts/hooks/init.ts
@@ -10,7 +10,9 @@ import {
     ItemDirectoryPF2e,
 } from "@module/apps/sidebar/index.ts";
 import { AmbientLightPF2e, LightingLayerPF2e, MeasuredTemplatePF2e, TemplateLayerPF2e } from "@module/canvas/index.ts";
+import { NotePF2e } from "@module/canvas/note.ts";
 import { setPerceptionModes } from "@module/canvas/perception/modes.ts";
+import { JournalMapLocationPageSystemData } from "@module/journal-page/map/data.ts";
 import { PF2ECONFIG } from "@scripts/config/index.ts";
 import { registerHandlebarsHelpers } from "@scripts/handlebars.ts";
 import { registerFonts } from "@scripts/register-fonts.ts";
@@ -35,10 +37,14 @@ export const Init = {
             CONFIG.Item.dataModels.kit = KitSystemData;
             CONFIG.Item.dataModels.melee = MeleeSystemData;
 
+            CONFIG.JournalEntryPage.dataModels.map = JournalMapLocationPageSystemData;
+
             CONFIG.MeasuredTemplate.objectClass = MeasuredTemplatePF2e;
             CONFIG.MeasuredTemplate.layerClass = TemplateLayerPF2e;
             CONFIG.MeasuredTemplate.defaults.angle = 90;
             CONFIG.MeasuredTemplate.defaults.width = 1;
+
+            CONFIG.Note.objectClass = NotePF2e;
 
             setPerceptionModes();
 

--- a/src/scripts/register-sheets.ts
+++ b/src/scripts/register-sheets.ts
@@ -33,6 +33,7 @@ import { SpellSheetPF2e } from "@item/spell/sheet.ts";
 import { TreasureSheetPF2e } from "@item/treasure/sheet.ts";
 import { WeaponSheetPF2e } from "@item/weapon/sheet.ts";
 import { JournalSheetPF2e } from "@module/journal-entry/sheet.ts";
+import { JournalMapLocationPageSheet } from "@module/journal-page/map/sheet.ts";
 import { UserConfigPF2e } from "@module/user/sheet.ts";
 import { SceneConfigPF2e } from "@scene/sheet.ts";
 import { TokenDocumentPF2e } from "@scene/token-document/document.ts";
@@ -173,6 +174,13 @@ export function registerSheets(): void {
         label: () =>
             game.i18n.format("SHEETS.DefaultDocumentSheet", { document: game.i18n.localize("DOCUMENT.JournalEntry") }),
         makeDefault: true,
+    });
+
+    // JOURNAL PAGE
+    DocumentSheetConfig.registerSheet(JournalEntryPage, "pf2e", JournalMapLocationPageSheet, {
+        label: game.i18n.format(sheetLabel, { type: game.i18n.localize("TYPES.JournalEntryPage.map") }),
+        makeDefault: true,
+        types: ["map"],
     });
 
     // USER

--- a/src/styles/system/journal/_index.scss
+++ b/src/styles/system/journal/_index.scss
@@ -1,4 +1,26 @@
 .journal-entry-page {
+    &.map {
+        .journal-header {
+            gap: 1rem;
+
+            [name="system.code"] {
+                height: 50px;
+                block-size: 100%;
+                inline-size: 3em;
+                background: rgb(0 0 0 / 0.1);
+                font-size: var(--font-size-24);
+                text-align: center;
+            }
+
+            .page-level {
+                margin-inline-start: 0;
+            }
+        }
+        [data-map-location-code]::before {
+            content: attr(data-map-location-code) ": ";
+        }
+    }
+
     .journal-page-content {
         @include journal-styling;
         @import "critical-fumble-deck";

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -6170,6 +6170,9 @@
             "spellcastingEntry": "Spellcasting Entry",
             "treasure": "Treasure",
             "weapon": "Weapon"
+        },
+        "JournalEntryPage": {
+            "map": "Map Location"
         }
     }
 }

--- a/static/template.json
+++ b/static/template.json
@@ -1145,5 +1145,8 @@
             "weapons": [],
             "spells": {}
         }
+    },
+    "JournalEntryPage": {
+        "types": ["map"]
     }
 }

--- a/types/foundry/client/pixi/placeables/note.d.ts
+++ b/types/foundry/client/pixi/placeables/note.d.ts
@@ -13,6 +13,9 @@ declare class Note<
     /** The associated JournalEntry which is referenced by this Note */
     get entry(): JournalEntry;
 
+    /** The specific JournalEntryPage within the associated JournalEntry referenced by this Note. */
+    get page(): JournalEntryPage;
+
     /** The text label used to annotate this Note */
     get text(): string;
 

--- a/types/foundry/common/abstract/embedded-collection.d.ts
+++ b/types/foundry/common/abstract/embedded-collection.d.ts
@@ -74,7 +74,10 @@ export default class EmbeddedCollection<
      * @throws If strict is true and the Embedded Document cannot be found.
      */
     override get<T extends TDocument = TDocument>(key: Maybe<string>, options: { strict: true; invalid?: boolean }): T;
-    override get<T extends TDocument = TDocument>(key: string, options?: EmbeddedCollectionGetOptions): T | undefined;
+    override get<T extends TDocument = TDocument>(
+        key: Maybe<string>,
+        options?: EmbeddedCollectionGetOptions,
+    ): T | undefined;
 
     /**
      * Add an item to the collection.


### PR DESCRIPTION
This adds a "Map Location" Page (`map`), which is very similar to a Text Page, except it has a `code` data that can replace its number when displayed on a JournalSheet.

![image](https://github.com/foundryvtt/pf2e/assets/5288872/c546d9e0-363c-461c-bbd8-7dd0d48f4952)

When dropped onto the canvas, it creates an icon with the code displayed (if any).

https://github.com/foundryvtt/pf2e/assets/5288872/d2df78a6-ef06-47c5-806f-20652c19dff9

This code has been modified from the [dnd5e ](https://github.com/foundryvtt/dnd5e) project.

---

My knowledge of Typescript is really limited, so I've fixed all the errors I could that didn't increase the number of errors (e.g. adding "Note" to "ConfigPF2e" added 100+ errors).

I'm not sure if the way MapLocationControlIcon's properties were written is "up to code" or if there's a better way. Let me know if you need any changes to it.

Some caveats I've noticed when adding it:
- The text's color can't be changed on the NoteConfig. You can change the colors by setting a flag to the journal page.
- The icon's size is based on `NoteDocument#iconSize` (default = 40), which I personally find it too small.
  - `canvas.grid.size * 0.6` (60 on 100 grid size) looks nice to me, but I'm not sure if it should be hard-coded or not, or if I should add a whole new NoteDocument to the system to handle it.
- Editing the code on the JournalPage (e.g. A1 -> A2) does not change the notes on the canvas. Not an issue since this would be the case for screwing up normal Notes anyway, just something to pay close attention to.
- The Notes control group could use a new "Create Map Location" button, but that would require subclassing `NotesLayer` to override `NotesLayer#_onClickLeft` or copying its whole method to the control button's onClick.
- I've noticed there's "Default {Document} Sheet" and "{Type} Sheet" and went with the latter, but I am not sure if that was correct.