### PR TITLE
update Crystal Luminescence RE and create effect for secondary condition

### DIFF
--- a/packs/feat-effects/effect-crystal-luminescence.json
+++ b/packs/feat-effects/effect-crystal-luminescence.json
@@ -1,0 +1,49 @@
+{
+    "_id": "ZDvVpEEZkdC5XlH5",
+    "img": "systems/pf2e/icons/spells/prismatic-wall.webp",
+    "name": "Effect: Crystal Luminescence",
+    "system": {
+        "description": {
+            "value": ""
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Lost Omens: Impossible Lands"
+        },
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.crystalLuminescence.brightRadius",
+                "value": 30
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.crystalLuminescence.dimRadius",
+                "value": 50
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feats/crystal-luminescence.json
+++ b/packs/feats/crystal-luminescence.json
@@ -11,7 +11,7 @@
         },
         "category": "ancestry",
         "description": {
-            "value": "<p>Your horn glows with bioluminescent color, casting bright light in a @Template[type:emanation|distance:20] (and dim light for the next 20 feet). This light can be any color. The most common colors are blue and purple, except for trogloshi, who normally shed white light. The light shuts off when you take this action again or fall @UUID[Compendium.pf2e.conditionitems.Item.Unconscious].</p>\n<p>If a spell or ability would activate your glowing horn while Crystal Luminescence is active, it instead increases the radius of the bright light and dim light by 10 feet each until the start of your next turn. This isn't cumulative, so using another such ability doesn't increase the radius again.</p>\n<p><strong>Special</strong> If you have the trogloshi heritage, you can select this feat a second time (in addition to gaining it automatically from your heritage). If you do, you increase the area to a @Template[type:emanation|distance:40] (and dim light for the next 40 feet). In addition, you can use Crystal Luminescence as a free action the first time you use it on each of your turns.</p>"
+            "value": "<p>Your horn glows with bioluminescent color, casting bright light in a @Template[type:emanation|distance:20] (and dim light for the next 20 feet). This light can be any color. The most common colors are blue and purple, except for trogloshi, who normally shed white light. The light shuts off when you take this action again or fall @UUID[Compendium.pf2e.conditionitems.Item.Unconscious].</p>\n<p>If a spell or ability would activate your glowing horn while Crystal Luminescence is active, it instead increases the radius of the bright light and dim light by 10 feet each until the start of your next turn. This isn't cumulative, so using another such ability doesn't increase the radius again.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.ZDvVpEEZkdC5XlH5]{Effect: Crystal Luminescence}</p>\n<p><strong>Special</strong> If you have the trogloshi heritage, you can select this feat a second time (in addition to gaining it automatically from your heritage). If you do, you increase the area to a @Template[type:emanation|distance:40] (and dim light for the next 40 feet). In addition, you can use Crystal Luminescence as a free action the first time you use it on each of your turns.</p>"
         },
         "level": {
             "value": 1
@@ -25,7 +25,83 @@
             "remaster": false,
             "title": "Pathfinder Lost Omens: Impossible Lands"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "TokenLight",
+                "predicate": [
+                    "crystal-luminescence"
+                ],
+                "value": {
+                    "animation": {
+                        "type": "flame"
+                    },
+                    "bright": "@actor.flags.pf2e.crystalLuminescence.dimRadius",
+                    "color": "{item|flags.pf2e.rulesSelections.crystalLuminescence}",
+                    "dim": "@actor.flags.pf2e.crystalLuminescence.brightRadius"
+                }
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.crystalLuminescence.brightRadius",
+                "value": 20
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.crystalLuminescence.dimRadius",
+                "value": 40
+            },
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "option": "crystal-luminescence",
+                "prompt": "PF2E.SpecificRule.Prompt.Color",
+                "suboptions": [
+                    {
+                        "label": "PF2E.Color.Blue",
+                        "value": "#0000FF"
+                    },
+                    {
+                        "label": "PF2E.Color.Cyan",
+                        "value": "#43D6D6"
+                    },
+                    {
+                        "label": "PF2E.Color.Green",
+                        "value": "#00FF00"
+                    },
+                    {
+                        "label": "PF2E.Color.Indigo",
+                        "value": "#4B0082"
+                    },
+                    {
+                        "label": "PF2E.Color.Magenta",
+                        "value": "#FF00FF"
+                    },
+                    {
+                        "label": "PF2E.Color.Orange",
+                        "value": "#FFA400"
+                    },
+                    {
+                        "label": "PF2E.Color.Red",
+                        "value": "#FF0000"
+                    },
+                    {
+                        "label": "PF2E.Color.Violet",
+                        "value": "#9400D3"
+                    },
+                    {
+                        "label": "PF2E.Color.White",
+                        "value": "#AAAAAA"
+                    },
+                    {
+                        "label": "PF2E.Color.Yellow",
+                        "value": "#FAFA00"
+                    }
+                ],
+                "toggleable": true
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [


### PR DESCRIPTION
Update RE for Crystal Luminescence.

Add effect to account for the extension of light if a spell is cast.