### PR TITLE
Fix regression with loot sheet type

### DIFF
--- a/src/styles/actor/loot/_index.scss
+++ b/src/styles/actor/loot/_index.scss
@@ -97,16 +97,14 @@
         align-items: center;
         gap: 0.2rem;
 
-        padding-top: 0.25rem;
+        padding: var(--space-4) var(--space-8) 0 var(--space-8);
         border-bottom: 1px solid var(--color-text-light-7);
-        box-shadow: 0 0 0.5rem rgba(0, 0, 0, 0.2);
+        box-shadow: 0 0 var(--space-8) rgba(0, 0, 0, 0.2);
 
         h1 {
             margin: 0;
             border: none;
             flex: 1;
-
-            padding-left: 0.5rem;
 
             > input {
                 height: 40px;
@@ -125,8 +123,26 @@
 
         .sheet-type {
             i {
-                padding: 0 0.25rem 0 0.5rem;
+                padding: 0 var(--space-4) 0 var(--space-8);
                 font-size: var(--font-size-16);
+            }
+
+            .type,
+            .type option {
+                background-color: var(--color-pf-primary);
+                border-radius: 0;
+                color: var(--text-light);
+                display: inline-block;
+                font-family: var(--sans-serif);
+                font-size: var(--font-size-16);
+                font-weight: 500;
+                height: var(--form-field-height);
+                line-height: var(--form-field-height);
+                text-transform: uppercase;
+
+                &:not(select) {
+                    padding: 0 var(--space-8);
+                }
             }
         }
 

--- a/static/templates/actors/loot/sheet.hbs
+++ b/static/templates/actors/loot/sheet.hbs
@@ -12,18 +12,18 @@
             {{else}}
                 <h1 class="charname">{{actor.name}}</h1>
             {{/if}}
-            <section class="sheet-type tags">
+            <section class="sheet-type">
                 {{#if owner}}
                     <i
                         class="fa-solid fa-info-circle"
                         data-tooltip="<div>{{localize "PF2E.loot.LootLabel"}}: {{localize "PF2E.loot.LootDescription"}}</div><div>{{localize "PF2E.loot.MerchantLabel"}}: {{localize "PF2E.loot.MerchantDescription"}}</div>"
                         data-tooltip-direction="LEFT"
                     ></i>
-                    <select name="system.lootSheetType" class="tag">
+                    <select name="system.lootSheetType" class="type">
                         {{selectOptions lootSheetTypeOptions selected=data.lootSheetType localize=true}}
                     </select>
                 {{else}}
-                    <span class="tag">{{data.lootSheetType}}</span>
+                    <span class="type">{{data.lootSheetType}}</span>
                 {{/if}}
             </section>
         </div>


### PR DESCRIPTION
Tag styling has changed a bit, which broke the layout. Loot shouldn't be using tag styling for this anyways.