### PR TITLE
Remove Conjure Bullet grant from Spellshot Dedication

### DIFF
--- a/packs/feats/spellshot-dedication.json
+++ b/packs/feats/spellshot-dedication.json
@@ -32,10 +32,6 @@
         },
         "rules": [
             {
-                "key": "GrantItem",
-                "uuid": "Compendium.pf2e.actionspf2e.Item.Conjure Bullet"
-            },
-            {
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.arcana.rank",


### PR DESCRIPTION
Closes #15231

Conjure Bullet is not referenced anywhere else in the system. Let me know if you want me to delete the action while I'm at it, too.