### PR TITLE
add rule element to Revolutionary Innovation class feature and tags

### DIFF
--- a/packs/classfeatures/advanced-rangefinder.json
+++ b/packs/classfeatures/advanced-rangefinder.json
@@ -45,6 +45,10 @@
             }
         ],
         "traits": {
+            "otherTags": [
+                "ranged",
+                "weapon-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/aerodynamic-construction.json
+++ b/packs/classfeatures/aerodynamic-construction.json
@@ -45,6 +45,10 @@
             }
         ],
         "traits": {
+            "otherTags": [
+                "melee",
+                "weapon-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/antimagic-plating.json
+++ b/packs/classfeatures/antimagic-plating.json
@@ -40,6 +40,9 @@
             }
         ],
         "traits": {
+            "otherTags": [
+                "armor-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/attack-refiner.json
+++ b/packs/classfeatures/attack-refiner.json
@@ -26,6 +26,9 @@
         },
         "rules": [],
         "traits": {
+            "otherTags": [
+                "weapon-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/automated-impediments.json
+++ b/packs/classfeatures/automated-impediments.json
@@ -26,6 +26,9 @@
         },
         "rules": [],
         "traits": {
+            "otherTags": [
+                "armor-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/blunt-shot.json
+++ b/packs/classfeatures/blunt-shot.json
@@ -14,7 +14,7 @@
         },
         "category": "classfeature",
         "description": {
-            "value": "<p>Your weapon innovation can file the edges off your ammunition and adjust the blunt force of the shot to deliver a bludgeoning attack when necessary, as well as to avoid striking a lethal blow with an otherwise deadly shot. Your innovation gains the nonlethal and versatile B traits. You can choose whether to apply the nonlethal trait on each attack with your innovation.</p>"
+            "value": "<p><strong>Ranged Only</strong></p><hr /><p>Your weapon innovation can file the edges off your ammunition and adjust the blunt force of the shot to deliver a bludgeoning attack when necessary, as well as to avoid striking a lethal blow with an otherwise deadly shot. Your innovation gains the nonlethal and versatile B traits. You can choose whether to apply the nonlethal trait on each attack with your innovation.</p>"
         },
         "level": {
             "value": 1
@@ -61,6 +61,10 @@
             }
         ],
         "traits": {
+            "otherTags": [
+                "ranged",
+                "weapon-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/camouflage-pigmentation.json
+++ b/packs/classfeatures/camouflage-pigmentation.json
@@ -26,6 +26,10 @@
         },
         "rules": [],
         "traits": {
+            "otherTags": [
+                "armor-innovation-modification",
+                "subterfuge-suit-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/complex-simplicity.json
+++ b/packs/classfeatures/complex-simplicity.json
@@ -123,6 +123,10 @@
             }
         ],
         "traits": {
+            "otherTags": [
+                "simple-weapon",
+                "weapon-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/deadly-strike.json
+++ b/packs/classfeatures/deadly-strike.json
@@ -26,6 +26,9 @@
         },
         "rules": [],
         "traits": {
+            "otherTags": [
+                "weapon-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/dense-plating.json
+++ b/packs/classfeatures/dense-plating.json
@@ -35,6 +35,9 @@
             }
         ],
         "traits": {
+            "otherTags": [
+                "armor-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/dynamic-weighting.json
+++ b/packs/classfeatures/dynamic-weighting.json
@@ -79,6 +79,14 @@
             }
         ],
         "traits": {
+            "otherTags": [
+                "melee",
+                "not-agile-trait",
+                "not-attached-trait",
+                "not-free-hand-trait",
+                "one-handed",
+                "weapon-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/energy-barrier.json
+++ b/packs/classfeatures/energy-barrier.json
@@ -44,6 +44,9 @@
             }
         ],
         "traits": {
+            "otherTags": [
+                "armor-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/enhanced-damage.json
+++ b/packs/classfeatures/enhanced-damage.json
@@ -26,6 +26,9 @@
         },
         "rules": [],
         "traits": {
+            "otherTags": [
+                "weapon-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/enhanced-resistance.json
+++ b/packs/classfeatures/enhanced-resistance.json
@@ -236,6 +236,9 @@
             }
         ],
         "traits": {
+            "otherTags": [
+                "armor-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/entangling-form.json
+++ b/packs/classfeatures/entangling-form.json
@@ -48,6 +48,10 @@
             }
         ],
         "traits": {
+            "otherTags": [
+                "melee",
+                "weapon-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/extensible-weapon.json
+++ b/packs/classfeatures/extensible-weapon.json
@@ -26,6 +26,10 @@
         },
         "rules": [],
         "traits": {
+            "otherTags": [
+                "melee",
+                "weapon-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/hampering-spikes.json
+++ b/packs/classfeatures/hampering-spikes.json
@@ -48,6 +48,10 @@
             }
         ],
         "traits": {
+            "otherTags": [
+                "melee",
+                "weapon-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/heavy-construction.json
+++ b/packs/classfeatures/heavy-construction.json
@@ -92,6 +92,10 @@
             }
         ],
         "traits": {
+            "otherTags": [
+                "armor-innovation-modification",
+                "power-suit-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/hefty-composition.json
+++ b/packs/classfeatures/hefty-composition.json
@@ -48,6 +48,9 @@
             }
         ],
         "traits": {
+            "otherTags": [
+                "weapon-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/hyper-boosters.json
+++ b/packs/classfeatures/hyper-boosters.json
@@ -68,6 +68,9 @@
             }
         ],
         "traits": {
+            "otherTags": [
+                "armor-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/impossible-alloy.json
+++ b/packs/classfeatures/impossible-alloy.json
@@ -26,6 +26,9 @@
         },
         "rules": [],
         "traits": {
+            "otherTags": [
+                "weapon-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/inconspicuous-appearance.json
+++ b/packs/classfeatures/inconspicuous-appearance.json
@@ -55,6 +55,10 @@
             }
         ],
         "traits": {
+            "otherTags": [
+                "melee",
+                "weapon-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/incredible-resistance.json
+++ b/packs/classfeatures/incredible-resistance.json
@@ -26,6 +26,9 @@
         },
         "rules": [],
         "traits": {
+            "otherTags": [
+                "armor-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/integrated-gauntlet.json
+++ b/packs/classfeatures/integrated-gauntlet.json
@@ -36,6 +36,12 @@
             }
         ],
         "traits": {
+            "otherTags": [
+                "not-fatal-trait",
+                "not-two-handed-trait",
+                "one-handed",
+                "weapon-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/layered-mesh.json
+++ b/packs/classfeatures/layered-mesh.json
@@ -35,6 +35,9 @@
             }
         ],
         "traits": {
+            "otherTags": [
+                "armor-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/manifold-alloy.json
+++ b/packs/classfeatures/manifold-alloy.json
@@ -45,6 +45,9 @@
             }
         ],
         "traits": {
+            "otherTags": [
+                "weapon-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/modular-head.json
+++ b/packs/classfeatures/modular-head.json
@@ -61,6 +61,9 @@
             }
         ],
         "traits": {
+            "otherTags": [
+                "weapon-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/momentum-retainer.json
+++ b/packs/classfeatures/momentum-retainer.json
@@ -26,6 +26,10 @@
         },
         "rules": [],
         "traits": {
+            "otherTags": [
+                "melee",
+                "weapon-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/multisensory-mask.json
+++ b/packs/classfeatures/multisensory-mask.json
@@ -26,6 +26,10 @@
         },
         "rules": [],
         "traits": {
+            "otherTags": [
+                "armor-innovation-modification",
+                "subterfuge-suit-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/omnirange-stabilizers.json
+++ b/packs/classfeatures/omnirange-stabilizers.json
@@ -26,6 +26,10 @@
         },
         "rules": [],
         "traits": {
+            "otherTags": [
+                "ranged",
+                "weapon-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/pacification-tools.json
+++ b/packs/classfeatures/pacification-tools.json
@@ -61,6 +61,10 @@
             }
         ],
         "traits": {
+            "otherTags": [
+                "melee",
+                "weapon-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/perfect-fortification.json
+++ b/packs/classfeatures/perfect-fortification.json
@@ -26,6 +26,10 @@
         },
         "rules": [],
         "traits": {
+            "otherTags": [
+                "armor-innovation-modification",
+                "power-suit-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/physical-protections.json
+++ b/packs/classfeatures/physical-protections.json
@@ -26,6 +26,9 @@
         },
         "rules": [],
         "traits": {
+            "otherTags": [
+                "armor-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/razor-prongs.json
+++ b/packs/classfeatures/razor-prongs.json
@@ -48,6 +48,10 @@
             }
         ],
         "traits": {
+            "otherTags": [
+                "melee",
+                "weapon-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/revolutionary-innovation.json
+++ b/packs/classfeatures/revolutionary-innovation.json
@@ -24,7 +24,474 @@
             "remaster": false,
             "title": "Pathfinder Guns & Gears"
         },
-        "rules": [],
+        "rules": [
+            {
+                "adjustName": false,
+                "allowedDrops": {
+                    "label": "PF2E.SpecificRule.Inventor.Modification.Revolutionary.AllowedDrops",
+                    "predicate": [
+                        {
+                            "lte": [
+                                "item:level",
+                                15
+                            ]
+                        },
+                        "item:type:feature",
+                        "item:trait:inventor"
+                    ]
+                },
+                "choices": [
+                    {
+                        "predicate": [
+                            "feature:armor-innovation",
+                            {
+                                "not": "feature:dense-plating"
+                            }
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Dense Plating"
+                    },
+                    {
+                        "predicate": [
+                            "feature:armor-innovation",
+                            {
+                                "not": "feature:harmonic-oscillator"
+                            }
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Harmonic Oscillator"
+                    },
+                    {
+                        "predicate": [
+                            "feature:armor-innovation",
+                            {
+                                "not": "feature:metallic-reactance"
+                            }
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Metallic Reactance"
+                    },
+                    {
+                        "predicate": [
+                            "armor-innovation:power-suit",
+                            {
+                                "not": "feature:muscular-exoskeleton"
+                            }
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Muscular Exoskeleton"
+                    },
+                    {
+                        "predicate": [
+                            "feature:armor-innovation",
+                            {
+                                "not": "feature:otherworldly-protection"
+                            }
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Otherworldly Protection"
+                    },
+                    {
+                        "predicate": [
+                            "feature:armor-innovation",
+                            {
+                                "not": "feature:phlogistonic-regulator"
+                            }
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Phlogistonic Regulator"
+                    },
+                    {
+                        "predicate": [
+                            "feature:armor-innovation",
+                            {
+                                "not": "feature:speed-boosters"
+                            }
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Speed Boosters"
+                    },
+                    {
+                        "predicate": [
+                            "armor-innovation:subterfuge-suit",
+                            {
+                                "not": "feature:subtle-dampeners"
+                            }
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Subtle Dampeners"
+                    },
+                    {
+                        "predicate": [
+                            "feature:armor-innovation",
+                            {
+                                "not": "feature:antimagic-plating"
+                            }
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Antimagic Plating"
+                    },
+                    {
+                        "predicate": [
+                            {
+                                "and": [
+                                    "feature:armor-innovation",
+                                    "armor-innovation:subterfuge-suit"
+                                ]
+                            },
+                            {
+                                "not": "feature:camouflage-pigmentation"
+                            }
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Camouflage Pigmentation"
+                    },
+                    {
+                        "predicate": [
+                            "feature:armor-innovation",
+                            {
+                                "or": [
+                                    "feature:harmonic-oscillator",
+                                    "feature:metallic-reactance",
+                                    "feature:otherworldly-protection",
+                                    "feature:phlogistonic-regulator"
+                                ]
+                            },
+                            {
+                                "not": "feature:enhanced-resistance"
+                            }
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Enhanced Resistance"
+                    },
+                    {
+                        "predicate": [
+                            {
+                                "and": [
+                                    "armor-innovation:power-suit",
+                                    "feature:armor-innovation"
+                                ]
+                            },
+                            {
+                                "not": "feature:heavy-construction"
+                            }
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Heavy Construction"
+                    },
+                    {
+                        "predicate": [
+                            "feature:armor-innovation",
+                            {
+                                "not": "feature:hyper-boosters"
+                            }
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Speed Boosters"
+                    },
+                    {
+                        "predicate": [
+                            "feature:armor-innovation",
+                            {
+                                "not": "feature:layered-mesh"
+                            }
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Layered Mesh"
+                    },
+                    {
+                        "predicate": [
+                            "feature:armor-innovation",
+                            {
+                                "not": "feature:tensile-absorption"
+                            }
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Tensile Absorption"
+                    },
+                    {
+                        "predicate": [
+                            "feature:armor-innovation",
+                            {
+                                "or": [
+                                    "feature:harmonic-oscillator",
+                                    "feature:metallic-reactance",
+                                    "feature:phlogistonic-regulator"
+                                ]
+                            }
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Energy Barrier"
+                    },
+                    {
+                        "predicate": [
+                            "feature:armor-innovation"
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Automated Impediments"
+                    },
+                    {
+                        "predicate": [
+                            "feature:armor-innovation"
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Incredible Resistance"
+                    },
+                    {
+                        "predicate": [
+                            "feature:armor-innovation",
+                            "armor-innovation:subterfuge-suit"
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Multisensory Mask"
+                    },
+                    {
+                        "predicate": [
+                            "feature:armor-innovation",
+                            "armor-innovation:power-suit"
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Perfect Fortification"
+                    },
+                    {
+                        "predicate": [
+                            "feature:armor-innovation"
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Physical Protections"
+                    },
+                    {
+                        "predicate": [
+                            "feature:armor-innovation"
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Rune Capacity"
+                    },
+                    {
+                        "predicate": [
+                            "weapon-innovation:ranged",
+                            {
+                                "not": [
+                                    "feature:advanced-rangefinder",
+                                    "weapon-innovation:thrown"
+                                ]
+                            }
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Advanced Rangefinder"
+                    },
+                    {
+                        "predicate": [
+                            "weapon-innovation:melee",
+                            {
+                                "not": "feature:aerodynamic-construction"
+                            }
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Aerodynamic Construction"
+                    },
+                    {
+                        "predicate": [
+                            "weapon-innovation:melee",
+                            {
+                                "not": "feature:inconspicuous-appearance"
+                            }
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Inconspicuous Appearance"
+                    },
+                    {
+                        "predicate": [
+                            "weapon-innovation:usage:hands:1",
+                            {
+                                "not": "weapon-innovation:trait:two-handed"
+                            }
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Integrated Gauntlet"
+                    },
+                    {
+                        "predicate": [
+                            "feature:weapon-innovation",
+                            {
+                                "not": "feature:manifold-alloy"
+                            }
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Manifold Alloy"
+                    },
+                    {
+                        "predicate": [
+                            "weapon-innovation:ranged",
+                            {
+                                "not": [
+                                    "weapon-innovation:thrown",
+                                    "feature:rope-shot"
+                                ]
+                            }
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Rope Shot"
+                    },
+                    {
+                        "predicate": [
+                            "weapon-innovation:thrown",
+                            "feature:tangle-line"
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Tangle Line"
+                    },
+                    {
+                        "predicate": [
+                            "weapon-innovation:ranged",
+                            {
+                                "nor": [
+                                    "feature:blunt-shot",
+                                    "weapon-innovation:thrown"
+                                ],
+                                "not": "feature:blunt-shot"
+                            }
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Blunt Shot"
+                    },
+                    {
+                        "predicate": [
+                            "weapon-innovation:category:simple",
+                            {
+                                "not": "feature:complex-simplicity"
+                            }
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Complex Simplicity"
+                    },
+                    {
+                        "predicate": [
+                            "weapon-innovation:usage:hands:1",
+                            "weapon-innovation:melee",
+                            {
+                                "nor": [
+                                    "feature:dynamic-weighting",
+                                    "weapon-innovation:trait:agile",
+                                    "weapon-innovation:trait:attached",
+                                    "weapon-innovation:trait:free-hand"
+                                ]
+                            }
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Dynamic Weighting"
+                    },
+                    {
+                        "predicate": [
+                            "weapon-innovation:melee",
+                            {
+                                "not": "feature:entangling-form"
+                            }
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Entangling Form"
+                    },
+                    {
+                        "predicate": [
+                            "weapon-innovation:melee",
+                            {
+                                "not": "feature:hampering-spikes"
+                            }
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Hampering Spikes"
+                    },
+                    {
+                        "predicate": [
+                            "weapon-innovation:melee",
+                            {
+                                "not": "feature:hefty-composition"
+                            }
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Hefty Composition"
+                    },
+                    {
+                        "predicate": [
+                            "feature:weapon-innovation",
+                            {
+                                "not": "feature:modular-head"
+                            }
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Modular Head"
+                    },
+                    {
+                        "predicate": [
+                            "weapon-innovation:melee",
+                            {
+                                "not": "feature:pacification-tools"
+                            }
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Pacification Tools"
+                    },
+                    {
+                        "predicate": [
+                            "weapon-innovation:melee",
+                            {
+                                "not": "feature:razor-prongs"
+                            }
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Razor Prongs"
+                    },
+                    {
+                        "predicate": [
+                            "weapon-innovation:melee",
+                            {
+                                "not": "feature:segmented-frame"
+                            }
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Segmented Frame"
+                    },
+                    {
+                        "predicate": [
+                            "feature:weapon-innovation"
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Attack Refiner"
+                    },
+                    {
+                        "predicate": [
+                            "feature:weapon-innovation"
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Deadly Strike"
+                    },
+                    {
+                        "predicate": [
+                            "feature:weapon-innovation"
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Enhanced Damage"
+                    },
+                    {
+                        "predicate": [
+                            "feature:weapon-innovation"
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Enhanced Damage"
+                    },
+                    {
+                        "predicate": [
+                            "weapon-innovation:melee"
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Extensible Weapon"
+                    },
+                    {
+                        "predicate": [
+                            "feature:weapon-innovation"
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Impossible Alloy"
+                    },
+                    {
+                        "predicate": [
+                            "feature:weapon-innovation"
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Impossible Alloy"
+                    },
+                    {
+                        "predicate": [
+                            "weapon-innovation:melee"
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Momentum Retainer"
+                    },
+                    {
+                        "predicate": [
+                            "weapon-innovation:ranged"
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Omnirange Stabilizers"
+                    },
+                    {
+                        "predicate": [
+                            "feature:weapon-innovation"
+                        ],
+                        "value": "Compendium.pf2e.classfeatures.Item.Rune Capacity"
+                    }
+                ],
+                "flag": "revolutionaryModification",
+                "key": "ChoiceSet",
+                "predicate": [
+                    "class:inventor",
+                    {
+                        "or": [
+                            "feature:armor-innovation",
+                            "feature:weapon-innovation"
+                        ]
+                    }
+                ],
+                "prompt": "PF2E.SpecificRule.Inventor.Modification.Revolutionary.Prompt"
+            },
+            {
+                "allowDuplicate": false,
+                "key": "GrantItem",
+                "uuid": "{item|flags.pf2e.rulesSelections.revolutionaryModification}"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/classfeatures/rope-shot.json
+++ b/packs/classfeatures/rope-shot.json
@@ -45,6 +45,10 @@
             }
         ],
         "traits": {
+            "otherTags": [
+                "ranged",
+                "weapon-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/rune-capacity.json
+++ b/packs/classfeatures/rune-capacity.json
@@ -26,6 +26,10 @@
         },
         "rules": [],
         "traits": {
+            "otherTags": [
+                "armor-innovation-modification",
+                "weapon-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/segmented-frame.json
+++ b/packs/classfeatures/segmented-frame.json
@@ -58,6 +58,9 @@
             }
         ],
         "traits": {
+            "otherTags": [
+                "weapon-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"

--- a/packs/classfeatures/tangle-line.json
+++ b/packs/classfeatures/tangle-line.json
@@ -45,6 +45,10 @@
             }
         ],
         "traits": {
+            "otherTags": [
+                "thrown",
+                "weapon-innovation-modification"
+            ],
             "rarity": "common",
             "value": [
                 "inventor"


### PR DESCRIPTION
Added tags to the Weapon and Armor Innovation class features. 

Tied to #14702

Please note - this should not close the issue. Still need to do a pass on the features to see if we can add automation, once this one is complete.