### PR TITLE
Fix Choker of Elocution (Greater) craft requirements

### DIFF
--- a/packs/equipment/choker-of-elocution-greater.json
+++ b/packs/equipment/choker-of-elocution-greater.json
@@ -9,7 +9,7 @@
         },
         "containerId": null,
         "description": {
-            "value": "<p>This platinum choker bears characters from three language's alphabet, and it gives knowledge of those languages and the associated culture's customs.</p>\n<p>You gain a +2 item bonus to Society checks and the ability to understand, speak, and write the chosen languages.</p>\n<p>Your excellent elocution reduces the DC of the flat check to perform an auditory action while deafened from 5 to 3.</p>\n<p><strong>Craft Requirements</strong> The choker bears characters from three languages and grants fluency in all three.</p>"
+            "value": "<p>This platinum choker bears characters from three language's alphabet, and it gives knowledge of those languages and the associated culture's customs.</p>\n<p>You gain a +2 item bonus to Society checks and the ability to understand, speak, and write the chosen languages.</p>\n<p>Your excellent elocution reduces the DC of the flat check to perform an auditory action while deafened from 5 to 3.</p>\n<p><strong>Craft Requirements</strong> You know the languages the choker grants.</p>"
         },
         "hardness": 0,
         "hp": {

--- a/packs/equipment/choker-of-elocution.json
+++ b/packs/equipment/choker-of-elocution.json
@@ -9,7 +9,7 @@
         },
         "containerId": null,
         "description": {
-            "value": "<p>This platinum choker bears characters from a language's alphabet, and it gives knowledge of that language and the associated culture's customs.</p>\n<p>You gain a +1 item bonus to Society checks and the ability to understand, speak, and write the chosen language.</p>\n<p>Your excellent elocution reduces the DC of the flat check to perform an auditory action while deafened from 5 to 3.</p>\n<p><strong>Craft Requirements</strong> You know the language or languages the choker grants.</p>"
+            "value": "<p>This platinum choker bears characters from a language's alphabet, and it gives knowledge of that language and the associated culture's customs.</p>\n<p>You gain a +1 item bonus to Society checks and the ability to understand, speak, and write the chosen language.</p>\n<p>Your excellent elocution reduces the DC of the flat check to perform an auditory action while deafened from 5 to 3.</p>\n<p><strong>Craft Requirements</strong> You know the language the choker grants.</p>"
         },
         "hardness": 0,
         "hp": {


### PR DESCRIPTION
Also, removed plural languages from the base item craft requirements as it refers to the Greater version

Also, please check if the wording in the Greater version would be better as "This platinum choker bears characters from alphabets of three languages". It's kind of editorializing, but the Greater item has no distinct description in the source anyway.