### PR TITLE
Add Action Frequency Tracking to Familiar and NPC sheets

### DIFF
--- a/src/module/actor/familiar/sheet.ts
+++ b/src/module/actor/familiar/sheet.ts
@@ -69,6 +69,7 @@ export class FamiliarSheetPF2e<TActor extends FamiliarPF2e> extends CreatureShee
                         _id: item.id,
                         name: item.name,
                         glyph: getActionGlyph(item.actionCost) || null,
+                        frequency: item.system.frequency || null,
                         traits,
                         has: {
                             aura: item.traits.has("aura") || item.system.rules.some((r) => r.key === "Aura"),

--- a/src/module/actor/familiar/sheet.ts
+++ b/src/module/actor/familiar/sheet.ts
@@ -38,7 +38,6 @@ export class FamiliarSheetPF2e<TActor extends FamiliarPF2e> extends CreatureShee
         );
 
         // list of abilities that can be selected as spellcasting ability
-
         const size = CONFIG.PF2E.actorSizes[familiar.system.traits.size.value] ?? null;
         const familiarAbilities = this.actor.master?.attributes?.familiarAbilities;
 

--- a/src/module/actor/npc/sheet.ts
+++ b/src/module/actor/npc/sheet.ts
@@ -373,7 +373,7 @@ class NPCSheetPF2e extends AbstractNPCSheet {
             const traits = item.system.traits.value.map((t) => traitSlugToObject(t, CONFIG.PF2E.actionTraits));
             const glyph = getActionGlyph(item.actionCost);
             const actionGroup = glyph ? "active" : "passive";
-            const frequency = item.system?.frequency || null
+            const frequency = item.system?.frequency || null;
             const has = {
                 aura: item.traits.has("aura") || item.system.rules.some((r) => r.key === "Aura"),
                 deathNote: item.system.deathNote,

--- a/src/module/actor/npc/sheet.ts
+++ b/src/module/actor/npc/sheet.ts
@@ -373,13 +373,14 @@ class NPCSheetPF2e extends AbstractNPCSheet {
             const traits = item.system.traits.value.map((t) => traitSlugToObject(t, CONFIG.PF2E.actionTraits));
             const glyph = getActionGlyph(item.actionCost);
             const actionGroup = glyph ? "active" : "passive";
+            const frequency = item.system?.frequency || null
             const has = {
                 aura: item.traits.has("aura") || item.system.rules.some((r) => r.key === "Aura"),
                 deathNote: item.system.deathNote,
                 selfEffect: !!item.system.selfEffect,
             };
 
-            actions[actionGroup].actions.push({ _id: item.id, name: item.name, glyph, traits, has });
+            actions[actionGroup].actions.push({ _id: item.id, name: item.name, glyph, traits, frequency, has });
         }
 
         sheetData.attacks = attacks;

--- a/src/module/actor/sheet/data-types.ts
+++ b/src/module/actor/sheet/data-types.ts
@@ -6,6 +6,7 @@ import type { PhysicalItemPF2e } from "@item";
 import type { Coins } from "@item/physical/data.ts";
 import type { RollOptionToggle } from "@module/rules/synthetics.ts";
 import type { SheetOptions } from "@module/sheet/helpers.ts";
+import type { Frequency } from "@item/base/data/index.ts";
 
 interface InventoryItem<TItem extends PhysicalItemPF2e = PhysicalItemPF2e> {
     item: TItem;
@@ -68,6 +69,7 @@ interface AbilityViewData {
     name: string;
     traits: TraitViewData[];
     glyph: string | null;
+    frequency: Frequency | null
     has: {
         aura: boolean;
         deathNote: boolean;

--- a/src/module/actor/sheet/data-types.ts
+++ b/src/module/actor/sheet/data-types.ts
@@ -69,7 +69,7 @@ interface AbilityViewData {
     name: string;
     traits: TraitViewData[];
     glyph: string | null;
-    frequency: Frequency | null
+    frequency: Frequency | null;
     has: {
         aura: boolean;
         deathNote: boolean;

--- a/src/styles/actor/_red-action-boxes.scss
+++ b/src/styles/actor/_red-action-boxes.scss
@@ -180,20 +180,20 @@
                 align-items: center;
                 display: flex;
                 flex-flow: row nowrap;
-                flex: 0;
+                font-size: 0.9rem;
                 margin-left: auto;
-                margin-right: var(--font-size-16);
+                margin-right: 0;
+                font-weight: normal;
+                font-family: sans-serif;
 
                 input {
-                    background: none;
-                    border: 0;
-                    flex: 0 1 4rem;
-                    font-family: inherit;
-                    font-size: 0.9rem;
-                    height: auto;
-                    padding: 0 var(--space-3);
-                    text-align: center;
                     width: 0;
+                    padding-bottom: 0px;
+                    height: calc(100% - 2px);
+                    flex: 0 1 4rem;
+                    text-align: center;
+                    font-weight: normal;
+                    font-family: sans-serif;
                 }
 
                 span {

--- a/static/templates/actors/npc/partials/action.hbs
+++ b/static/templates/actors/npc/partials/action.hbs
@@ -26,13 +26,24 @@
         {{/if}}
     </div>
 
-    {{#if action.has.selfEffect}}
         <div class="button-group">
+          {{#if action.has.selfEffect}}
             <button type="button" class="use-action" data-action="use-action">
                 <span>{{localize "PF2E.Action.Use"}}</span>
             </button>
+          {{/if}}
+          {{#if action.frequency}}
+            <div class="tracking">
+               <input type="number" value="{{action.frequency.value}}" data-item-id="{{action.id}}" data-item-property="system.frequency.value" />
+                 <span>
+                   /
+                   {{action.frequency.max}}
+                   {{localize "PF2E.Frequency.per"}}
+                   {{localize (lookup @root.frequencies action.frequency.per)}}
+                 </span>
+             </div>
+          {{/if}}
         </div>
-    {{/if}}
 
     <div class="item-summary" hidden></div>
 </li>


### PR DESCRIPTION
Updates action.hbs, _red-action-boxes.scss, data-types.ts familiar/sheets.ts and npc/sheets.ts to prepare frequency data for use in the .hbs file and updates the template to include it on the sheet. 
![image](https://github.com/foundryvtt/pf2e/assets/74130268/c69910f1-6c77-4db7-b7d3-5464d660be25)

the .tracking class in _red-action-boxes.scss appeared to be unused. With only the npc, familiar and hazard sheets importing the .scss file and none using the class. Thus I've updated the css to produce visually consistent results. 

Additional the interface AbilityViewData appeared to only be imported for the familiar and npc so it should have limited/no downstream effects. 