### PR TITLE
localize Soulforger dedication text and add GrantItem to Soulforger feat

### DIFF
--- a/packs/feats/soulforger-dedication.json
+++ b/packs/feats/soulforger-dedication.json
@@ -28,7 +28,72 @@
             "remaster": false,
             "title": "Pathfinder Secrets of Magic"
         },
-        "rules": [],
+        "rules": [
+            {
+                "allowDuplicate": false,
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.actionspf2e.Item.Manifest Soulforged Armament"
+            },
+            {
+                "choices": [
+                    {
+                        "label": "PF2e.SpecificRule.SoulForger.AdaptablePersona.Label",
+                        "value": "PF2e.SpecificRule.SoulForger.AdaptablePersona"
+                    },
+                    {
+                        "label": "PF2e.SpecificRule.SoulForger.BoundingSpirit.Label",
+                        "value": "PF2e.SpecificRule.SoulForger.BoundingSpirit"
+                    },
+                    {
+                        "label": "PF2e.SpecificRule.SoulForger.DeepSeededFear.Label",
+                        "value": "deep-seeded-fear"
+                    },
+                    {
+                        "label": "PF2e.SpecificRule.SoulForger.DeterminedToughness.Label",
+                        "value": "PF2e.SpecificRule.SoulForger.DeterminedToughness"
+                    },
+                    {
+                        "label": "PF2e.SpecificRule.SoulForger.HarmfulMalice.Label",
+                        "value": "PF2e.SpecificRule.SoulForger.HarmfulMalice"
+                    },
+                    {
+                        "label": "PF2e.SpecificRule.SoulForger.HeroicHeart.Label",
+                        "value": "PF2e.SpecificRule.SoulForger.HeroicHeart"
+                    },
+                    {
+                        "label": "PF2e.SpecificRule.SoulForger.HealingGrace.Label",
+                        "value": "PF2e.SpecificRule.SoulForger.HealingGrace"
+                    },
+                    {
+                        "label": "PF2e.SpecificRule.SoulForger.MagicalResilience.Label",
+                        "value": "PF2e.SpecificRule.SoulForger.MagicalResilience"
+                    },
+                    {
+                        "label": "PF2e.SpecificRule.SoulForger.PlanarBond.Label",
+                        "value": "PF2e.SpecificRule.SoulForger.PlanarBond"
+                    },
+                    {
+                        "label": "PF2e.SpecificRule.SoulForger.PlanarPain.Label",
+                        "value": "PF2e.SpecificRule.SoulForger.PlanarPain"
+                    },
+                    {
+                        "label": "PF2e.SpecificRule.SoulForger.PullOfStasis.Label",
+                        "value": "PF2e.SpecificRule.SoulForger.PullOfStasis"
+                    },
+                    {
+                        "label": "PF2e.SpecificRule.SoulForger.ReflectingSpirit.Label",
+                        "value": "PF2e.SpecificRule.SoulForger.ReflectingSpirit"
+                    },
+                    {
+                        "label": "PF2e.SpecificRule.SoulForger.ResoluteDefiance.Label",
+                        "value": "PF2e.SpecificRule.SoulForger.ResoluteDefiance"
+                    }
+                ],
+                "flag": "essence",
+                "key": "ChoiceSet",
+                "prompt": "PF2e.SpecificRule.SoulForger.Prompt"
+            }
+        ],
         "traits": {
             "rarity": "uncommon",
             "value": [

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -3852,6 +3852,74 @@
                     }
                 }
             },
+            "SoulForger": {
+                "AdaptablePersona": {
+                    "CorruptionFlaw": "You take a -10-foot penalty to all your Speeds.",
+                    "Essence": "Armor only. When you manifest the essence form, gain your choice of a climb Speed or swim Speed equal to your land Speed. If you're 8th level or higher, you can choose a fly Speed instead",
+                    "Label": "Adaptable Persona"
+                },
+                "BoundingSpirit": {
+                    "CorruptionFlaw": "When you make a Strike with a thrown or ranged weapon and miss, reroll the Strike, targeting your ally nearest to the target. This Strike uses the same multiple attack penalty as the missed Strike and doesn't count toward your multiple attack penalty.",
+                    "Essence": "Melee weapon only. The weapon gains the thrown 30 feet trait and has the returning rune (even if it already has its maximum number of property runes).",
+                    "Label": "Bounding Spirit"
+                },
+                "DeepSeededFear": {
+                    "CorruptionFlaw": "If you attempt to Demoralize an enemy, your Demoralize also targets the ally closest to you.",
+                    "Essence": "You gain a +2 status bonus to your Intimidation checks and don't take any penalties for not sharing a language when Demoralizing foes who can perceive your armament's essence form. When you manifest the essence form, you can attempt to Demoralize an enemy who can perceive the manifestation.",
+                    "Label": "Deep-Seeded Fear"
+                },
+                "DeterminedToughness": {
+                    "CorruptionFlaw": "Whenever you take a status penalty from the listed conditions, you also take a -1 penalty to the same statistics.",
+                    "Essence": "Any status penalties you take from the following conditions are 1 less than their condition's value: Clumsy, Drained, Enfeebled, Frightened, Sickened, Stupefied. This doesn't change the actual condition value, or any other effects of the condition (such as stupefied's disruption and its DC).",
+                    "Label": "Determined Toughness"
+                },
+                "HarmfulMalice": {
+                    "CorruptionFlaw": "Reduce any damage you would deal by half your level",
+                    "Essence": "Your Strikes deal an additional 1d4 void damage. Once while the armament is manifested, you can cast harm as an innate spell, with a level equal to half your level rounded up.",
+                    "Label": "Harmful Malice"
+                },
+                "HeroicHeart": {
+                    "CorruptionFlaw": "You take a -1 penalty to attack rolls.",
+                    "Essence": "You gain a +1 status bonus to attack rolls, Perception checks, skill checks, and saves.",
+                    "Label": "Heroic Heart"
+                },
+                "HealingGrace": {
+                    "CorruptionFlaw": "Reduce all healing you would receive or grant with a spell by half your level.",
+                    "Essence": "You gain fast healing equal to half your level. You can cast Heal once as an innate spell with a level equal to half your level rounded up.",
+                    "Label": "Healing Grace"
+                },
+                "MagicalResilience": {
+                    "CorruptionFlaw": "You take a -1 penalty to saving throws and AC against spells.",
+                    "Essence": "You gain a +2 status bonus to saving throws and AC against spells. If you're 5th level or higher, you can cast Dispel Magic once as an innate spell. The spell rank is equal to 1 lower than half your level rounded up (2nd level if you're 5th or 6th level, and so on).",
+                    "Label": "Magical Resilience"
+                },
+                "PlanarBond": {
+                    "CorruptionFlaw": "You gain weakness 1 to all damage.",
+                    "Essence": "Armor or shield only. When you manifest the essence form, choose one damage type: acid, cold, electricity, fire, sonic, spirit, vitality, or void. You gain resistance equal to your level + 2 to damage of the selected type.",
+                    "Label": "Planar Bond"
+                },
+                "PlanarPain": {
+                    "CorruptionFlaw": "When you deal damage with a weapon or unarmed attack, you take 2 damage of the last type you chose for planar pain, even if the damage type normally wouldn't harm you, such as good damage if you aren't evil.",
+                    "Essence": "When you manifest the essence form, choose one damage type: acid, cold, electricity, fire, sonic, spirit, vitality, or void. Attacks with the weapon deal this type of damage instead of their physical damage with a +2 status bonus to the damage.",
+                    "Label": "Planar Pain"
+                },
+                "PullOfStasis": {
+                    "CorruptionFlaw": "When you deal damage with a weapon or unarmed attack, you take 2 damage of the last type you chose for planar pain, even if the damage type normally wouldn't harm you, such as good damage if you aren't evil.",
+                    "Essence": "Weapon only. Any time you hit with the soulforged weapon, the target takes a -10-foot penalty to its Speeds for 1 round. On a critical hit, the creature is Immobilized for 1 round instead.",
+                    "Label": "Pull of Stasis"
+                },
+                "ReflectingSpirit": {
+                    "CorruptionFlaw": "You have weakness 5 to physical ranged attacks.",
+                    "Essence": "Armor or shield only. You gain a +2 status bonus to AC against physical ranged attacks. If an enemy's physical ranged attack misses you, you can use your reaction to immediately attempt a ranged Strike against the attacker using the projectile that missed.",
+                    "Label": "Reflecting Spirit"
+                },
+                "ResoluteDefiance": {
+                    "CorruptionFlaw": "When you take damage while Raising a Shield or use Shield Block, attempt a DC 5 flat check. If you fail, the shield is Dismissed if it's your soulforged armament or Dropped if it's a different shield.",
+                    "Essence": "Shield only. The shield gains a +2 status bonus to its Hardness and gains temporary Hit Points equal to your level + 2 that last until the essence effect ends. If you don't have the Shield Block reaction, you gain it while your shield is manifested. ",
+                    "Label": "Resolute Defiance"
+                },
+                "Prompt":"Choose an Essence."
+            },
             "SoulWarden": {
                 "SafeguardSoul": {
                     "Label": "Defending against manipulation of your soul"


### PR DESCRIPTION
I localized the Soulforger dedication text and added a GrantItem RE to the dedication so that it adds `Manifest Soulforged Armament` as part of the actions.

Still in the early stages of figuring out the best approach for applying automation to this dedication. 