### PR TITLE
remove duplicate options from Revolutionary Innovation Choice Set

### DIFF
--- a/packs/classfeatures/revolutionary-innovation.json
+++ b/packs/classfeatures/revolutionary-innovation.json
@@ -432,21 +432,9 @@
                     },
                     {
                         "predicate": [
-                            "feature:weapon-innovation"
-                        ],
-                        "value": "Compendium.pf2e.classfeatures.Item.Enhanced Damage"
-                    },
-                    {
-                        "predicate": [
                             "weapon-innovation:melee"
                         ],
                         "value": "Compendium.pf2e.classfeatures.Item.Extensible Weapon"
-                    },
-                    {
-                        "predicate": [
-                            "feature:weapon-innovation"
-                        ],
-                        "value": "Compendium.pf2e.classfeatures.Item.Impossible Alloy"
                     },
                     {
                         "predicate": [


### PR DESCRIPTION
I thought these were corrected in a previous PR, but that was not the case. This should correct for that.