### PR TITLE
More consistent origin flags on templates

### DIFF
--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -4,7 +4,6 @@ import { ActorSheetPF2e } from "@actor/sheet/base.ts";
 import { SAVE_TYPES } from "@actor/values.ts";
 import { ItemPF2e, ItemSheetPF2e } from "@item";
 import { ActionTrait } from "@item/ability/types.ts";
-import { ItemSystemData } from "@item/base/data/system.ts";
 import { EFFECT_AREA_SHAPES } from "@item/spell/values.ts";
 import { ChatMessagePF2e } from "@module/chat-message/index.ts";
 import {
@@ -236,7 +235,7 @@ class TextEditorPF2e extends TextEditor {
             case "Localize":
                 return this.#localize(paramString, options);
             case "Template":
-                return this.#createTemplate(paramString, inlineLabel, item?.system);
+                return this.#createTemplate(paramString, inlineLabel, item);
             default:
                 return null;
         }
@@ -288,7 +287,7 @@ class TextEditorPF2e extends TextEditor {
     }
 
     /** Create inline template button from @template command */
-    static #createTemplate(paramString: string, label?: string, itemData?: ItemSystemData): HTMLSpanElement | null {
+    static #createTemplate(paramString: string, label?: string, item?: ItemPF2e | null): HTMLSpanElement | null {
         // Get parameters from data
         const params = this.#parseInlineParams(paramString, { first: "type" });
         if (!params) return null;
@@ -316,7 +315,8 @@ class TextEditorPF2e extends TextEditor {
             return null;
         } else {
             // If no traits are entered manually use the traits from rollOptions if available
-            params.traits ||= itemData?.traits?.value?.toString() ?? "";
+            params.traits ||= item?.system?.traits?.value?.toString() ?? "";
+            params.itemUuid ||= item?.uuid ?? "";
 
             // If no button label is entered directly create default label
             if (!label) {
@@ -334,6 +334,7 @@ class TextEditorPF2e extends TextEditor {
             html.setAttribute("data-pf2-distance", params.distance);
             if (params.traits !== "") html.setAttribute("data-pf2-traits", params.traits);
             if (params.type === "line") html.setAttribute("data-pf2-width", params.width ?? "5");
+            if (params.itemUuid !== "") html.setAttribute("data-item-uuid", params.itemUuid);
             return html;
         }
         return null;

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -315,7 +315,7 @@ class TextEditorPF2e extends TextEditor {
             return null;
         } else {
             // If no traits are entered manually use the traits from rollOptions if available
-            params.traits ||= item?.system.traits.value.toString() ?? "";
+            params.traits ||= item?.system.traits.value?.toString() ?? "";
             params.itemUuid ||= item?.uuid ?? "";
 
             // If no button label is entered directly create default label

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -315,7 +315,7 @@ class TextEditorPF2e extends TextEditor {
             return null;
         } else {
             // If no traits are entered manually use the traits from rollOptions if available
-            params.traits ||= item?.system?.traits?.value?.toString() ?? "";
+            params.traits ||= item?.system.traits.value.toString() ?? "";
             params.itemUuid ||= item?.uuid ?? "";
 
             // If no button label is entered directly create default label

--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -228,10 +228,10 @@ export class InlineRollLinks {
                     const defenseStat = targetActor?.getStatistic(pf2Defense);
                     return defenseStat
                         ? {
-                              statistic: defenseStat.dc,
-                              scope: "check",
-                              value: defenseStat.dc.value,
-                          }
+                            statistic: defenseStat.dc,
+                            scope: "check",
+                            value: defenseStat.dc.value,
+                        }
                         : null;
                 }
                 return null;
@@ -246,8 +246,8 @@ export class InlineRollLinks {
                     foundryDoc instanceof ItemPF2e
                         ? foundryDoc
                         : foundryDoc instanceof ChatMessagePF2e
-                          ? foundryDoc.item
-                          : null;
+                            ? foundryDoc.item
+                            : null;
 
                 return itemFromDoc?.isOfType("action", "feat", "campaignFeature") ||
                     (isSavingThrow && !itemFromDoc?.isOfType("weapon"))
@@ -275,8 +275,8 @@ export class InlineRollLinks {
                     pf2Check in CONFIG.PF2E.magicTraditions
                         ? "PF2E.ActionsCheck.spell"
                         : statistic.check.type === "attack-roll"
-                          ? "PF2E.ActionsCheck.x-attack-roll"
-                          : "PF2E.ActionsCheck.x";
+                            ? "PF2E.ActionsCheck.x-attack-roll"
+                            : "PF2E.ActionsCheck.x";
                 args.label = await renderTemplate("systems/pf2e/templates/chat/action/header.hbs", {
                     glyph: getActionGlyph(item.actionCost),
                     subtitle: game.i18n.format(subtitleLocKey, { type: statistic.label }),
@@ -354,6 +354,10 @@ export class InlineRollLinks {
             const origin: Record<string, unknown> = {};
             if (item) {
                 for (const [key, value] of Object.entries(item.getOriginData())) {
+                    if (key === "uuid") {
+                        origin["item"] = value;
+                        continue;
+                    }
                     origin[key] = value;
                 }
                 origin.name = item.name;
@@ -406,8 +410,8 @@ export class InlineRollLinks {
             foundryDoc instanceof JournalEntry
                 ? { pf2e: { journalEntry: foundryDoc.uuid } }
                 : message?.flags.pf2e.origin
-                  ? { pf2e: { origin: fu.deepClone(message.flags.pf2e.origin) } }
-                  : {};
+                    ? { pf2e: { origin: fu.deepClone(message.flags.pf2e.origin) } }
+                    : {};
 
         return ChatMessagePF2e.create({ speaker, content, flags });
     }

--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -349,7 +349,12 @@ export class InlineRollLinks {
         }
 
         const actor = resolveActor(foundryDoc);
-        const item = foundryDoc instanceof ItemPF2e ? foundryDoc : null;
+        const item =
+            foundryDoc instanceof ItemPF2e
+                ? foundryDoc
+                : foundryDoc instanceof ChatMessagePF2e
+                  ? foundryDoc.item
+                  : null;
         if (actor || pf2Traits || item) {
             const origin: Record<string, unknown> = {};
             if (item) {

--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -228,10 +228,10 @@ export class InlineRollLinks {
                     const defenseStat = targetActor?.getStatistic(pf2Defense);
                     return defenseStat
                         ? {
-                            statistic: defenseStat.dc,
-                            scope: "check",
-                            value: defenseStat.dc.value,
-                        }
+                              statistic: defenseStat.dc,
+                              scope: "check",
+                              value: defenseStat.dc.value,
+                          }
                         : null;
                 }
                 return null;
@@ -246,8 +246,8 @@ export class InlineRollLinks {
                     foundryDoc instanceof ItemPF2e
                         ? foundryDoc
                         : foundryDoc instanceof ChatMessagePF2e
-                            ? foundryDoc.item
-                            : null;
+                          ? foundryDoc.item
+                          : null;
 
                 return itemFromDoc?.isOfType("action", "feat", "campaignFeature") ||
                     (isSavingThrow && !itemFromDoc?.isOfType("weapon"))
@@ -275,8 +275,8 @@ export class InlineRollLinks {
                     pf2Check in CONFIG.PF2E.magicTraditions
                         ? "PF2E.ActionsCheck.spell"
                         : statistic.check.type === "attack-roll"
-                            ? "PF2E.ActionsCheck.x-attack-roll"
-                            : "PF2E.ActionsCheck.x";
+                          ? "PF2E.ActionsCheck.x-attack-roll"
+                          : "PF2E.ActionsCheck.x";
                 args.label = await renderTemplate("systems/pf2e/templates/chat/action/header.hbs", {
                     glyph: getActionGlyph(item.actionCost),
                     subtitle: game.i18n.format(subtitleLocKey, { type: statistic.label }),
@@ -410,8 +410,8 @@ export class InlineRollLinks {
             foundryDoc instanceof JournalEntry
                 ? { pf2e: { journalEntry: foundryDoc.uuid } }
                 : message?.flags.pf2e.origin
-                    ? { pf2e: { origin: fu.deepClone(message.flags.pf2e.origin) } }
-                    : {};
+                  ? { pf2e: { origin: fu.deepClone(message.flags.pf2e.origin) } }
+                  : {};
 
         return ChatMessagePF2e.create({ speaker, content, flags });
     }

--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -349,12 +349,7 @@ export class InlineRollLinks {
         }
 
         const actor = resolveActor(foundryDoc);
-        const item =
-            foundryDoc instanceof ItemPF2e
-                ? foundryDoc
-                : foundryDoc instanceof ChatMessagePF2e
-                  ? foundryDoc.item
-                  : null;
+        const item = foundryDoc instanceof ItemPF2e ? foundryDoc : null;
         if (actor || pf2Traits || item) {
             const origin: Record<string, unknown> = {};
             if (item) {

--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -349,8 +349,16 @@ export class InlineRollLinks {
         }
 
         const actor = resolveActor(foundryDoc ?? resolveDocument(link));
-        if (actor || pf2Traits) {
+        const item = resolveItem(foundryDoc ?? resolveDocument(link));
+        if (actor || pf2Traits || item) {
             const origin: Record<string, unknown> = {};
+            if (item) {
+                for (const [key, value] of Object.entries(item.getOriginData())) {
+                    origin[key] = value;
+                }
+                origin.name = item.name;
+                origin.slug = item.slug;
+            }
             if (actor) {
                 origin.actor = actor.uuid;
             }
@@ -445,5 +453,12 @@ function resolveDocument(html: HTMLElement): ClientDocument | null {
 function resolveActor(foundryDoc: ClientDocument | null): ActorPF2e | null {
     if (foundryDoc instanceof ActorPF2e) return foundryDoc;
     if (foundryDoc instanceof ItemPF2e || foundryDoc instanceof ChatMessagePF2e) return foundryDoc.actor;
+    return null;
+}
+
+/** Retrieve a token via a passed document. Handles item owners and chat message actors. */
+function resolveItem(foundryDoc: ClientDocument | null): ItemPF2e | null {
+    if (foundryDoc instanceof ItemPF2e) return foundryDoc;
+    if (foundryDoc instanceof ChatMessagePF2e) return foundryDoc.item;
     return null;
 }

--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -348,8 +348,8 @@ export class InlineRollLinks {
             flags.pf2e.messageId = messageId;
         }
 
-        const actor = resolveActor(foundryDoc ?? resolveDocument(link));
-        const item = resolveItem(foundryDoc ?? resolveDocument(link));
+        const actor = resolveActor(foundryDoc);
+        const item = foundryDoc instanceof ItemPF2e ? foundryDoc : null;
         if (actor || pf2Traits || item) {
             const origin: Record<string, unknown> = {};
             if (item) {
@@ -457,12 +457,5 @@ function resolveDocument(html: HTMLElement): ClientDocument | null {
 function resolveActor(foundryDoc: ClientDocument | null): ActorPF2e | null {
     if (foundryDoc instanceof ActorPF2e) return foundryDoc;
     if (foundryDoc instanceof ItemPF2e || foundryDoc instanceof ChatMessagePF2e) return foundryDoc.actor;
-    return null;
-}
-
-/** Retrieve a token via a passed document. Handles item owners and chat message actors. */
-function resolveItem(foundryDoc: ClientDocument | null): ItemPF2e | null {
-    if (foundryDoc instanceof ItemPF2e) return foundryDoc;
-    if (foundryDoc instanceof ChatMessagePF2e) return foundryDoc.item;
     return null;
 }

--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -350,19 +350,12 @@ export class InlineRollLinks {
 
         const actor = resolveActor(foundryDoc);
         const item = foundryDoc instanceof ItemPF2e ? foundryDoc : null;
-        if (actor || pf2Traits || item) {
+        if (item) {
+            const origin = item.getOriginData();
+            flags.pf2e.origin = origin;
+        } else if (actor || pf2Traits) {
             const origin: Record<string, unknown> = {};
-            if (item) {
-                for (const [key, value] of Object.entries(item.getOriginData())) {
-                    if (key === "uuid") {
-                        origin["item"] = value;
-                        continue;
-                    }
-                    origin[key] = value;
-                }
-                origin.name = item.name;
-                origin.slug = item.slug;
-            }
+
             if (actor) {
                 origin.actor = actor.uuid;
             }


### PR DESCRIPTION
Adds `itemUuid` data attribute to `@Template` tags and adds `item.getOriginData()` results to templates created from inline buttons.

Example: `@Template` tag from Blazing Wave kineticist feat. Includes Fireball spell for comparison.
| Before | After |
| :-----: | :----: |
| ![image](https://github.com/foundryvtt/pf2e/assets/32039708/f244a94f-0d03-4a10-ba34-c3730e422b0e) | ![chrome_yvI9kHcZya](https://github.com/foundryvtt/pf2e/assets/32039708/90ff28c9-396e-4a91-b925-6bd0d7f32c6d) |
