### PR TITLE
Fix tagify tags overflow in item sheet header and allow `,` delimiter in feat sheet prerequesites

### DIFF
--- a/src/module/item/feat/sheet.ts
+++ b/src/module/item/feat/sheet.ts
@@ -212,7 +212,7 @@ class FeatSheetPF2e extends ItemSheetPF2e<FeatPF2e> {
         const getInput = (name: string): HTMLTagifyTagsElement | null =>
             htmlQuery<HTMLTagifyTagsElement>(html, `tagify-tags[name="${name}"]`);
 
-        tagify(getInput("system.prerequisites.value"), { maxTags: 6 });
+        tagify(getInput("system.prerequisites.value"), { maxTags: 6, delimiters: ";" });
         tagify(getInput("system.subfeatures.keyOptions"), { whitelist: CONFIG.PF2E.abilities, maxTags: 3 });
 
         // Disable the "add subfeature" anchor unless a corresponding option is selected

--- a/src/styles/item/_header.scss
+++ b/src/styles/item/_header.scss
@@ -14,6 +14,10 @@
         .level {
             font: 700 var(--font-size-36) var(--serif-condensed);
         }
+
+        tagify-tags {
+            height: auto;
+        }
     }
 
     input[type="text"],

--- a/src/util/tags.ts
+++ b/src/util/tags.ts
@@ -3,8 +3,6 @@ import type { HTMLTagifyTagsElement } from "@system/html-elements/tagify-tags.ts
 import Tagify, { TagifySettings } from "@yaireo/tagify";
 import { objectHasKey } from "./misc.ts";
 
-type WhitelistData = string[] | Record<string, string | { label: string }>;
-
 function traitSlugToObject(trait: string, dictionary: Record<string, string | undefined>): TraitViewData {
     // Look up trait labels from `npcAttackTraits` instead of `weaponTraits` in case a battle form attack is
     // in use, which can include what are normally NPC-only traits
@@ -40,7 +38,13 @@ function tagify(
 ): Tagify<TagRecord> | null;
 function tagify(
     element: HTMLInputElement | HTMLTagifyTagsElement | null,
-    { whitelist, maxTags, enforceWhitelist = true, editTags }: TagifyOptions = {},
+    {
+        whitelist,
+        maxTags,
+        enforceWhitelist = true,
+        editTags = { clicks: 2, keepInvalid: true },
+        delimiters,
+    }: TagifyOptions = {},
 ): Tagify<TagRecord> | null {
     // Avoid importing the HTMLTagifyTagsElement class for an instanceof check which breaks pack building
     const isTagifyTagsElement = (element: HTMLElement | null): element is HTMLTagifyTagsElement => {
@@ -66,6 +70,7 @@ function tagify(
             searchKeys: ["id", "value"],
         },
         editTags,
+        delimiters,
         whitelist: whitelistTransformed,
     });
 
@@ -87,6 +92,8 @@ function tagify(
  */
 type TagRecord = Record<"id" | "value", string>;
 
+type WhitelistData = string[] | Record<string, string | { label: string }>;
+
 interface TagifyOptions {
     /** The maximum number of tags that may be added to the input */
     maxTags?: number;
@@ -100,6 +107,11 @@ interface TagifyOptions {
      * @default {clicks: 2, keepInvalid: true}
      */
     editTags?: TagifySettings["editTags"];
+    /**
+     * RegEx string. Split tags by any of these delimiters. Example delimiters: ",|.| " (comma, dot, or whitespace)
+     * @default ','
+     */
+    delimiters?: TagifySettings["delimiters"];
 }
 
 export { tagify, traitSlugToObject };


### PR DESCRIPTION
<img width="524" alt="Screenshot 2024-07-03 120524" src="https://github.com/foundryvtt/pf2e/assets/41452412/d525159f-85ac-4b3c-a857-4e2842df7549">

<img width="521" alt="Screenshot 2024-07-03 141637" src="https://github.com/foundryvtt/pf2e/assets/41452412/2eed976c-05a0-4235-a604-8c721d5301ef">
