### PR TITLE
Update Typescript to 5.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,12 +64,15 @@
                 "tinymce": "6.8.4",
                 "tsconfig-paths": "^4.2.0",
                 "tsx": "^4.15.6",
-                "typescript": "5.3.3",
+                "typescript": "^5.5.3",
                 "vite": "^5.3.1",
                 "vite-plugin-checker": "^0.6.4",
                 "vite-plugin-static-copy": "^1.0.5",
                 "vite-tsconfig-paths": "^4.3.2",
                 "yargs": "^17.7.2"
+            },
+            "engines": {
+                "node": ">=20.15.0"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -7480,9 +7483,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.3.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-            "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+            "version": "5.5.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
+            "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "tinymce": "6.8.4",
         "tsconfig-paths": "^4.2.0",
         "tsx": "^4.15.6",
-        "typescript": "5.3.3",
+        "typescript": "^5.5.3",
         "vite": "^5.3.1",
         "vite-plugin-checker": "^0.6.4",
         "vite-plugin-static-copy": "^1.0.5",

--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -1124,8 +1124,8 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
                 .filter((s) => !s.isStowed && !s.isBroken && !s.isDestroyed)
                 .map((s) => s.generateWeapon()),
             this.inventory.flatMap((i) =>
-                i.isEquipped ? i.subitems.filter((i): i is WeaponPF2e<this> => i.isOfType("weapon")) : [],
-            ),
+                i.isEquipped ? (i.subitems as Collection<PhysicalItemPF2e>).filter((i) => i.isOfType("weapon")) : [],
+            ) as WeaponPF2e<this>[],
         ]
             .flat()
             .filter(R.isTruthy) as WeaponPF2e<this>[];
@@ -1479,7 +1479,10 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
             });
             return penalty;
         };
-        const initialMAPs = calculateMAPs(weapon, { domains: attackDomains, options: initialRollOptions });
+        const initialMAPs = calculateMAPs(weapon as WeaponPF2e, {
+            domains: attackDomains,
+            options: initialRollOptions,
+        });
 
         const checkModifiers = [
             (statistic: StrikeData, otherModifiers: ModifierPF2e[]) =>
@@ -1537,7 +1540,10 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
                 if (!context.origin) return null;
 
                 const statistic = context.origin.statistic ?? action;
-                const maps = calculateMAPs(context.origin.item, { domains: context.domains, options: context.options });
+                const maps = calculateMAPs(context.origin.item as WeaponPF2e, {
+                    domains: context.domains,
+                    options: context.options,
+                });
                 const maPenalty = createMAPenalty(maps, mapIncreases);
                 const allModifiers = [maPenalty, params.modifiers, context.origin.modifiers].flat().filter(R.isTruthy);
                 const check = checkModifiers[mapIncreases](statistic, allModifiers);

--- a/src/module/actor/creature/document.ts
+++ b/src/module/actor/creature/document.ts
@@ -4,7 +4,7 @@ import { CreatureSource } from "@actor/data/index.ts";
 import { MODIFIER_TYPES, ModifierPF2e, RawModifier, StatisticModifier } from "@actor/modifiers.ts";
 import { ActorSpellcasting } from "@actor/spellcasting.ts";
 import { MovementType, SaveType, SkillSlug } from "@actor/types.ts";
-import { ArmorPF2e, ItemPF2e, type PhysicalItemPF2e, type ShieldPF2e } from "@item";
+import { ArmorPF2e, ConsumablePF2e, ItemPF2e, type PhysicalItemPF2e, type ShieldPF2e } from "@item";
 import { ArmorSource, ItemType } from "@item/base/data/index.ts";
 import { isContainerCycle } from "@item/container/helpers.ts";
 import { EquippedData, ItemCarryType } from "@item/physical/data.ts";
@@ -251,7 +251,10 @@ abstract class CreaturePF2e<
             const spell = consumable.embeddedSpell;
             if (!spell?.id) continue;
             const ability = this.spellcasting
-                .filter((e): e is SpellcastingEntry<this> => !!e.statistic && e.canCast(spell, { origin: consumable }))
+                .filter(
+                    (e): e is SpellcastingEntry<this> =>
+                        !!e.statistic && e.canCast(spell, { origin: consumable as ConsumablePF2e }),
+                )
                 .reduce(
                     (best: SpellcastingEntry<this> | null, e) =>
                         best === null ? e : e.statistic.dc.value > best.statistic.dc.value ? e : best,

--- a/src/module/actor/creature/spell-preparation-sheet.ts
+++ b/src/module/actor/creature/spell-preparation-sheet.ts
@@ -165,7 +165,7 @@ class SpellPreparationSheet<TActor extends CreaturePF2e> extends ActorSheet<TAct
 
         const spell = this.actor.items.get(itemData._id!);
         if (itemData.system.location.value !== this.item.id && spell?.isOfType("spell")) {
-            const addedSpell = await this.item.spells?.addSpell(spell);
+            const addedSpell = (await this.item.spells?.addSpell(spell)) as SpellPF2e | null;
             return [addedSpell ?? []].flat();
         }
 

--- a/src/module/item/helpers.ts
+++ b/src/module/item/helpers.ts
@@ -2,6 +2,7 @@ import type { ActorPF2e } from "@actor";
 import type { EnrichmentOptionsPF2e } from "@system/text-editor.ts";
 import { createHTMLElement, setHasElement } from "@util";
 import * as R from "remeda";
+import type { Converter } from "showdown";
 import type { ItemSourcePF2e, ItemType, RawItemChatData } from "./base/data/index.ts";
 import { ItemDescriptionData } from "./base/data/system.ts";
 import type { ItemPF2e } from "./base/document.ts";
@@ -47,7 +48,7 @@ class ItemChatData {
     htmlOptions: EnrichmentOptionsPF2e;
 
     /** A showdown markdown converter */
-    static #mdConverter: showdown.Converter | null = null;
+    static #mdConverter: Converter | null = null;
 
     constructor({ item, data, htmlOptions = {} }: ItemChatDataConstructorOptions) {
         this.item = item;


### PR DESCRIPTION
The type assertions are still necessary to prevent the `Type instantiation is excessively deep and possibly infinite.ts(2589)` errors.
Feel free to close this if there is a better way to handle it.