### PR TITLE
Set default `delimiters` value to `,` in `tagify` helper function

### DIFF
--- a/src/util/tags.ts
+++ b/src/util/tags.ts
@@ -43,7 +43,7 @@ function tagify(
         maxTags,
         enforceWhitelist = true,
         editTags = { clicks: 2, keepInvalid: true },
-        delimiters,
+        delimiters = ",",
     }: TagifyOptions = {},
 ): Tagify<TagRecord> | null {
     // Avoid importing the HTMLTagifyTagsElement class for an instanceof check which breaks pack building


### PR DESCRIPTION
Having the property in the settings, even as undefined, prevents Tagify from falling back to the default value.