### PR TITLE
Add CSS root variable for the parchment background

### DIFF
--- a/src/styles/_globals.scss
+++ b/src/styles/_globals.scss
@@ -20,6 +20,8 @@
     --space-13: 0.8125rem;
     --space-14: 0.875rem;
     --space-15: 0.9375rem;
+
+    --background-primary: var(--color-select-option-bg) url("../../../ui/parchment.jpg") repeat;
 }
 
 /* ----------------------------------------- */


### PR DESCRIPTION
Useful for modules to use in a way that is easily modifiable by UI modules.

Example:
```css
background: var(--background-primary);
```