### PR TITLE
Fix typos in Grazing Deer hazard

### DIFF
--- a/packs/one-shot-bestiary/grazing-deer.json
+++ b/packs/one-shot-bestiary/grazing-deer.json
@@ -16,7 +16,7 @@
                 },
                 "category": null,
                 "description": {
-                    "value": "<p><strong>Trigger</strong> The PCs emerge from the forest's edge</p>\n<hr />\n<p><strong>Effect</strong> A deer approaches the party and attempts a nibble Strike against a randomly determined PC. THe grazing deer rolls initiative.</p>"
+                    "value": "<p><strong>Trigger</strong> The PCs emerge from the forest's edge</p>\n<hr />\n<p><strong>Effect</strong> A deer approaches the party and attempts a nibble Strike against a randomly determined PC. The grazing deer rolls initiative.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -108,7 +108,7 @@
                 "title": "Pathfinder Adventure: A Fistful of Flowers"
             },
             "reset": "",
-            "routine": "<p>(2 actions) The grazing deer takes one action to move about, and then one action to eagerly nibble at a randomly chosen NPC. A character who spends three actions on their turn to Stride can avoid being nibbled by the grazing deer during the hazard's next turn. If all of the PCs do so, attempt a @Check[type:flat|dc:5|name:Escape the Deer]-on a success, the party escapes the deer and can proceed onward to Petalbrook, but they become delayed as a result of having to flee the pack of ravenous deer.</p>"
+            "routine": "<p>(2 actions) The grazing deer takes one action to move about, and then one action to eagerly nibble at a randomly chosen PC. A character who spends three actions on their turn to Stride can avoid being nibbled by the grazing deer during the hazard's next turn. If all of the PCs do so, attempt a @Check[type:flat|dc:5|name:Escape the Deer]-on a success, the party escapes the deer and can proceed onward to Petalbrook, but they become delayed as a result of having to flee the pack of ravenous deer.</p>"
         },
         "saves": {
             "fortitude": {


### PR DESCRIPTION
Two small adjustments to match the module text: "THe" -> "The" and "NPCs" -> "PCs"