### PR TITLE
Add implement choiceset rules to Intense Implement feat

### DIFF
--- a/packs/feats/intense-implement.json
+++ b/packs/feats/intense-implement.json
@@ -24,7 +24,32 @@
             "remaster": false,
             "title": "Pathfinder Dark Archive"
         },
-        "rules": [],
+        "rules": [
+            {
+                "choices": {
+                    "ownedItems": true,
+                    "predicate": [
+                        "item:tag:thaumaturge-implement",
+                        {
+                            "not": "item:tag:thaumaturge-implement-adept"
+                        }
+                    ],
+                    "types": [
+                        "feat"
+                    ]
+                },
+                "flag": "intenseImplement",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.UI.RuleElements.ChoiceSet.Prompt"
+            },
+            {
+                "itemId": "{item|flags.pf2e.rulesSelections.intenseImplement}",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "property": "other-tags",
+                "value": "thaumaturge-implement-adept"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [


### PR DESCRIPTION
Works just like the 1st and 2nd adept feats to select an owned implement feature that does not yet have the adept tag.

This works fine with the Thaum EV module, which picks up the adept tag just as it does with the other feats that add it.