### PR TITLE
add grant item to Clawdancer dedication

### DIFF
--- a/packs/actions/claw-stance.json
+++ b/packs/actions/claw-stance.json
@@ -1,0 +1,33 @@
+{
+    "_id": "zs4ZMcH9oFSCgkBx",
+    "img": "systems/pf2e/icons/actions/OneAction.webp",
+    "name": "Claw Stance",
+    "system": {
+        "actionType": {
+            "value": "action"
+        },
+        "actions": {
+            "value": 1
+        },
+        "category": "offensive",
+        "description": {
+            "value": "<p><strong>Effect</strong> You extend the claws in your hands and focus your attention to take down single targets. The only Strikes you can make are frenzied claw unarmed attacks. These deal @Damage[1d6[slashing]] damage, are in the brawling group, and have the agile, finesse, grapple, unarmed, and versatile piercing traits.</p>"
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Howl of the Wild"
+        },
+        "rules": [],
+        "selfEffect": {
+            "name": "Stance: Claw Stance",
+            "uuid": "Compendium.pf2e.feat-effects.Item.Stance: Claw Stance"
+        },
+        "traits": {
+            "value": [
+                "stance"
+            ]
+        }
+    },
+    "type": "action"
+}

--- a/packs/actions/talon-stance.json
+++ b/packs/actions/talon-stance.json
@@ -1,0 +1,33 @@
+{
+    "_id": "IR95FFdO7MtC8C0E",
+    "img": "systems/pf2e/icons/actions/OneAction.webp",
+    "name": "Talon Stance",
+    "system": {
+        "actionType": {
+            "value": "action"
+        },
+        "actions": {
+            "value": 1
+        },
+        "category": "offensive",
+        "description": {
+            "value": "<p><strong>Effect</strong> You sway in a loose stance that lets you sweep in wide arcs with the claws on your feet. The only Strikes you can make are spinning talon unarmed attacks. These deal @Damage[1d8[slashing]] damage, are in the brawling group, and have the finesse, sweep, and unarmed traits. You don't need a free hand to use spinning talon strikes.</p>"
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Howl of the Wild"
+        },
+        "rules": [],
+        "selfEffect": {
+            "name": "Stance: Talon Stance",
+            "uuid": "Compendium.pf2e.feat-effects.Item.Stance: Talon Stance"
+        },
+        "traits": {
+            "value": [
+                "stance"
+            ]
+        }
+    },
+    "type": "action"
+}

--- a/packs/feats/clawdancer-dedication.json
+++ b/packs/feats/clawdancer-dedication.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>You've practiced the art of fighting with your natural claws, hooking them into prey and thrashing at targets surrounding you. You gain the following two actions, which let you assume specific stances to strike more effectively with your claws.</p>\n<p><strong>Claw Stance</strong> <span class=\"action-glyph\">1</span> (stance) <strong>Effect</strong> You extend the claws in your hands and focus your attention to take down single targets. The only Strikes you can make are frenzied claw unarmed attacks. These deal 1d6 slashing damage, are in the brawling group, and have the agile, finesse, grapple, unarmed, and versatile piercing traits.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Stance: Claw Stance]</p>\n<p><strong>Talon Stance</strong> <span class=\"action-glyph\">1</span> (stance) <strong>Effect</strong> You sway in a loose stance that lets you sweep in wide arcs with the claws on your feet. The only Strikes you can make are spinning talon unarmed attacks. These deal 1d8 slashing damage, are in the brawling group, and have the finesse, sweep, and unarmed traits. You don't need a free hand to use spinning talon strikes.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Stance: Talon Stance]</p>"
+            "value": "<p>You've practiced the art of fighting with your natural claws, hooking them into prey and thrashing at targets surrounding you. You gain the following two actions, which let you assume specific stances to strike more effectively with your claws.</p>\n<p>@UUID[Compendium.pf2e.actionspf2e.Item.Claw Stance]</p>\n<p>@UUID[Compendium.pf2e.actionspf2e.Item.Talon Stance]</p>"
         },
         "level": {
             "value": 2
@@ -28,7 +28,16 @@
             "remaster": true,
             "title": "Pathfinder Howl of the Wild"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.actionspf2e.Item.Talon Stance"
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.actionspf2e.Item.Claw Stance"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [


### PR DESCRIPTION
- Created two actions for Claw Stance and Talon Stance that grant their respective stances.
- Added grant item rule element to Clawdancer dedication to grant the above.