### PR TITLE
Add toggle to hide strikes from stowed weapons

### DIFF
--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -651,11 +651,6 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
         // ACTIONS
         const actionsPanel = htmlQuery(html, ".tab[data-tab=actions]");
 
-        // Filter strikes
-        htmlQuery(actionsPanel, ".toggle-unready-strikes")?.addEventListener("click", () => {
-            this.actor.setFlag("pf2e", "showUnreadyStrikes", !this.actor.flags.pf2e.showUnreadyStrikes);
-        });
-
         for (const strikeElem of htmlQueryAll(actionsPanel, "ol[data-strikes] > li")) {
             // Auxiliary actions
             const auxActionButtons = htmlQueryAll<HTMLButtonElement>(
@@ -884,6 +879,10 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
         };
 
         // ACTIONS
+
+        handlers["toggle-hide-stowed"] = () => {
+            this.actor.update({ "flags.pf2e.hideStowed": !this.actor.flags.pf2e.hideStowed });
+        };
 
         // Toggle certain weapon traits: currently Double Barrel or Versatile
         handlers["toggle-weapon-trait"] = async (_, button) => {

--- a/src/module/actor/data/base.ts
+++ b/src/module/actor/data/base.ts
@@ -29,6 +29,7 @@ type ActorFlagsPF2e = foundry.documents.ActorFlags & {
         rollOptions: RollOptionFlags;
         /** IDs of granted items that are tracked */
         trackedItems: Record<string, string>;
+        hideStowed?: boolean;
         [key: string]: unknown;
     };
 };

--- a/src/styles/actor/_index.scss
+++ b/src/styles/actor/_index.scss
@@ -432,6 +432,11 @@
                     @include requires-user-attention;
                 }
             }
+
+            a.inactive,
+            button.inactive {
+                color: var(--color-text-dark-6);
+            }
         }
 
         section.major > .subsection {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -248,6 +248,7 @@
                 "Rest": {
                     "Label": "Rest for the Night"
                 },
+                "ShowStowed": "Show Stowed",
                 "Spellcasting": {
                     "Tab": {
                         "Activations": "Activations",
@@ -3764,7 +3765,6 @@
         "ToggleSignatureSpellTitle": "Toggle Signature Spell",
         "ToggleSlotlessSpellLevelsTitle": "Toggle visibility of spell ranks without slots",
         "ToggleSpellVisibilityTitle": "Spell Preparation",
-        "ToggleUnreadyStrikes": "Toggle unequipped weapons",
         "ToggleWithName": "Toggle: {property}",
         "TogglesLabel": "Toggles",
         "Token": {

--- a/static/templates/actors/character/partials/strike.hbs
+++ b/static/templates/actors/character/partials/strike.hbs
@@ -18,16 +18,16 @@
                 </div>
             {{/unless}}
 
-            {{#if (any action.ready ../actor.flags.pf2e.showUnreadyStrikes)}}
+            {{#if action.ready}}
                 <!-- ATTACK/DAMAGE -->
                 {{#if action.canStrike}}{{#> attackDamage action}}{{/attackDamage}}{{/if}}
-            {{else if (and (not action.ready) (not action.handsAvailable))}}
+            {{else if (not action.handsAvailable)}}
                 <span class="hands-occupied">{{localize "PF2E.Actor.Character.HandsOccupied"}}</span>
             {{/if}}
         </div>
     </div>
 
-    {{#if (and action.altUsages (or action.ready ../actor.flags.pf2e.showUnreadyStrikes))}}
+    {{#if (and action.altUsages action.ready)}}
         {{#each action.altUsages as |usage|}}
             <div class="alt-usage" data-tooltip-direction="LEFT">
                 {{#if usage.item.isThrown}}
@@ -40,7 +40,7 @@
         {{/each}}
     {{/if}}
 
-    {{#if (and action.ammunition (or action.ready ../actor.flags.pf2e.showUnreadyStrikes))}}
+    {{#if (and action.ammunition action.ready)}}
         <div class="ammo auxiliary-actions">
             <select class="linked"
                 data-action="link-ammo"

--- a/static/templates/actors/character/tabs/actions.hbs
+++ b/static/templates/actors/character/tabs/actions.hbs
@@ -13,8 +13,9 @@
 
                     <header>
                         {{localize "PF2E.Actor.Attacks"}}
-                        <button type="button" class="toggle-unready-strikes" data-tooltip="{{localize "PF2E.ToggleUnreadyStrikes"}}">
-                            <i class="fa-solid fa-tshirt"{{#if actor.flags.pf2e.showUnreadyStrikes}} style="color: rgba(0, 0, 0, 0.4);"{{/if}}></i>
+                        <button type="button" data-action="toggle-hide-stowed" {{#if actor.flags.pf2e.hideStowed}} class="inactive"{{/if}}>
+                            <i class="fa-solid fa-backpack"></i>
+                            {{localize "PF2E.Actor.Character.ShowStowed"}}
                         </button>
                     </header>
 
@@ -29,7 +30,9 @@
 
                     <ol class="actions-list item-list directory-list strikes-list" data-strikes>
                         {{#each data.actions as |strike ai|}}
-                            {{> "systems/pf2e/templates/actors/character/partials/strike.hbs" action=strike index=ai}}
+                            {{#unless (and strike.item.isStowed @root.actor.flags.pf2e.hideStowed)}}
+                                {{> "systems/pf2e/templates/actors/character/partials/strike.hbs" action=strike index=ai}}
+                            {{/unless}}
                         {{/each}}
                     </ol>
 


### PR DESCRIPTION
Show Unready Strikes hasn't worked for a long time, so its been removed.

![image](https://github.com/foundryvtt/pf2e/assets/1286721/58791427-4bb3-4297-a7dd-7671fdebd04f)
