### PR TITLE
Brush up some Player Core general feats

### DIFF
--- a/packs/feats/breath-control.json
+++ b/packs/feats/breath-control.json
@@ -35,15 +35,6 @@
                 "value": 1
             },
             {
-                "key": "Note",
-                "predicate": [
-                    "inhaled"
-                ],
-                "selector": "saving-throw",
-                "text": "If you roll a success on a saving throw against an inhaled threat, you get a critical success instead.",
-                "title": "{item|name}"
-            },
-            {
                 "adjustment": {
                     "success": "one-degree-better"
                 },

--- a/packs/feats/experienced-professional.json
+++ b/packs/feats/experienced-professional.json
@@ -31,11 +31,20 @@
         "rules": [
             {
                 "key": "Note",
-                "predicate": [
-                    "action:earn-income"
+                "outcome": [
+                    "failure"
                 ],
-                "selector": "skill-check",
-                "text": "When you use Lore to Earn Income, if you roll a critical failure, you instead get a failure. If you're an expert in Lore, you gain twice as much income from a failed check to Earn Income, unless it was originally a critical failure.",
+                "predicate": [
+                    {
+                        "or": [
+                            "proficiency:expert",
+                            "proficiency:master",
+                            "proficiency:legendary"
+                        ]
+                    }
+                ],
+                "selector": "lore-skill-check",
+                "text": "PF2E.SpecificRule.Feat.ExperiencedProfessional.Note",
                 "title": "{item|name}"
             },
             {

--- a/packs/feats/fast-recovery.json
+++ b/packs/feats/fast-recovery.json
@@ -31,6 +31,10 @@
         "rules": [
             {
                 "key": "Note",
+                "outcome": [
+                    "success",
+                    "criticalSuccess"
+                ],
                 "predicate": [
                     "ongoing",
                     {
@@ -41,7 +45,7 @@
                     }
                 ],
                 "selector": "fortitude",
-                "text": "If you roll a success on a Fortitude save against an ongoing posion or disease, reduce its stage by 2, or by 1 if its virulent. If you roll a critical success, reduce its stage by 3, or by 2 if its virulent.",
+                "text": "PF2E.SpecificRule.Feat.FastRecovery.Note",
                 "title": "{item|name}"
             },
             {

--- a/packs/feats/lengthy-diversion.json
+++ b/packs/feats/lengthy-diversion.json
@@ -28,7 +28,20 @@
             "remaster": true,
             "title": "Pathfinder Player Core"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "Note",
+                "outcome": [
+                    "criticalSuccess"
+                ],
+                "predicate": [
+                    "action:create-a-diversion"
+                ],
+                "selector": "deception",
+                "text": "{item|description}",
+                "title": "{item|name}"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/oddity-identification.json
+++ b/packs/feats/oddity-identification.json
@@ -31,7 +31,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "PF2E.SpecificRule.Feat.OddityIdentification.FlatModifierLabel",
                 "predicate": [
                     "action:identify-magic",
                     {

--- a/packs/feats/oddity-identification.json
+++ b/packs/feats/oddity-identification.json
@@ -31,7 +31,7 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Oddity Identification (identify magic with specific traits)",
+                "label": "PF2E.SpecificRule.Feat.OddityIdentification.FlatModifierLabel",
                 "predicate": [
                     "action:identify-magic",
                     {

--- a/packs/feats/schooled-in-secrets.json
+++ b/packs/feats/schooled-in-secrets.json
@@ -11,7 +11,7 @@
         },
         "category": "skill",
         "description": {
-            "value": "<p>You notice the signs and symbols that members of mystery cults and other secret societies use to declare their affiliation to fellow members. You can use Occultism in place of Diplomacy to @UUID[Compendium.pf2e.actionspf2e.Item.Gather Information] about such groups and in place of Deception to Impersonate a member of these groups.</p>\n<p>If you belong to a secret cult, lodge, sect, or similar organization, you automatically recognize members of your group unless they are specifically attempting to conceal their presence from you. They also recognize your standing unless you are specifically concealing it.</p>"
+            "value": "<p>You notice the signs and symbols that members of mystery cults and other secret societies use to declare their affiliation to fellow members. You can use Occultism in place of Diplomacy to [[/act gather-information skill=occultism]]{Gather Information} about such groups and in place of Deception to [[/act impersonate skill=occultism]]{Impersonate} a member of these groups.</p>\n<p>If you belong to a secret cult, lodge, sect, or similar organization, you automatically recognize members of your group unless they are specifically attempting to conceal their presence from you. They also recognize your standing unless you are specifically concealing it.</p>"
         },
         "level": {
             "value": 1

--- a/packs/feats/streetwise.json
+++ b/packs/feats/streetwise.json
@@ -11,7 +11,7 @@
         },
         "category": "skill",
         "description": {
-            "value": "<p>You know about life on the streets and feel the pulse of your local settlement. You can use your Society modifier instead of your Diplomacy modifier to Gather Information. In any settlement you frequent regularly, you can use the Recall Knowledge action with Society to know the same sorts of information that you could discover with Diplomacy to Gather Information. The DC is usually significantly higher, but you know the information without spending time gathering it. If you fail to recall the information, you can still subsequently attempt to Gather Information normally.</p>"
+            "value": "<p>You know about life on the streets and feel the pulse of your local settlement. You can use your Society modifier instead of your Diplomacy modifier to [[/act gather-information skill=society]]{Gather Information}. In any settlement you frequent regularly, you can use the Recall Knowledge action with Society to know the same sorts of information that you could discover with Diplomacy to Gather Information. The DC is usually significantly higher, but you know the information without spending time gathering it. If you fail to recall the information, you can still subsequently attempt to Gather Information normally.</p>"
         },
         "level": {
             "value": 1

--- a/packs/feats/student-of-the-canon.json
+++ b/packs/feats/student-of-the-canon.json
@@ -30,32 +30,31 @@
         },
         "rules": [
             {
-                "key": "Note",
-                "predicate": [
-                    {
-                        "or": [
-                            "action:recall-knowledge",
-                            "action:decipher-writing"
-                        ]
-                    }
-                ],
-                "selector": "religion",
-                "text": "When you roll a critical failure at a Religion check to Decipher Writing of a religious nature or to Recall Knowledge about the tenets of faiths, you get a failure instead.",
-                "title": "{item|name}"
+                "key": "RollOption",
+                "option": "student-of-the-canon",
+                "toggleable": true
             },
             {
-                "key": "Note",
+                "adjustment": {
+                    "failure": "one-degree-better"
+                },
+                "key": "AdjustDegreeOfSuccess",
                 "predicate": [
-                    {
-                        "or": [
-                            "action:recall-knowledge",
-                            "your-faith"
-                        ]
-                    }
+                    "action:decipher-writing",
+                    "student-of-the-canon"
                 ],
-                "selector": "religion",
-                "text": "When attempting to Recall Knowledge about the tenets of your own faith, if you roll a failure, you get a success instead, and if you roll a success, you get a critical success instead.",
-                "title": "{item|name}"
+                "selector": "religion"
+            },
+            {
+                "adjustment": {
+                    "all": "one-degree-better"
+                },
+                "key": "AdjustDegreeOfSuccess",
+                "predicate": [
+                    "action:recall-knowledge",
+                    "student-of-the-canon"
+                ],
+                "selector": "religion"
             }
         ],
         "traits": {

--- a/packs/feats/subtle-theft.json
+++ b/packs/feats/subtle-theft.json
@@ -11,7 +11,7 @@
         },
         "category": "skill",
         "description": {
-            "value": "<p>When you successfully @UUID[Compendium.pf2e.actionspf2e.Item.Steal] something, observers (creatures other than the creature you stole from) take a –2 circumstance penalty to their Perception DCs to detect your theft. Additionally, if you first @UUID[Compendium.pf2e.actionspf2e.Item.Create a Diversion] using Deception, taking a single Palm an Object or Steal action doesn't end your undetected condition.</p>"
+            "value": "<p>When you successfully @UUID[Compendium.pf2e.actionspf2e.Item.Steal] something, observers (creatures other than the creature you stole from) take a –2 circumstance penalty to their Perception DCs to detect your theft. Additionally, if you first @UUID[Compendium.pf2e.actionspf2e.Item.Create a Diversion] using Deception, taking a single @UUID[Compendium.pf2e.actionspf2e.Item.Palm an Object] or Steal action doesn't end your @UUID[Compendium.pf2e.conditionitems.Item.Undetected] condition.</p>"
         },
         "level": {
             "value": 1

--- a/packs/feats/terrain-stalker.json
+++ b/packs/feats/terrain-stalker.json
@@ -11,7 +11,7 @@
         },
         "category": "skill",
         "description": {
-            "value": "<p>Select one type of difficult terrain from the following list: rubble, snow, or underbrush. While undetected by all non-allies in that type of terrain, you can @UUID[Compendium.pf2e.actionspf2e.Item.Sneak] without attempting a Stealth check as long as you move no more than 5 feet and do not pass within 10 feet of an enemy during your movement.</p>\n<p>During exploration, this also allows you to automatically approach within 15 feet of other creatures while @UUID[Compendium.pf2e.actionspf2e.Item.Avoid Notice]{Avoiding their Notice}, as long as they aren't actively Searching or on guard.</p>\n<hr />\n<p><strong>Special</strong> You can select this feat multiple times. Each time, choose a different type of terrain.</p>"
+            "value": "<p>Select one type of difficult terrain from the following list: rubble, snow, or underbrush. While @UUID[Compendium.pf2e.conditionitems.Item.Undetected] by all non-allies in that type of terrain, you can @UUID[Compendium.pf2e.actionspf2e.Item.Sneak] without attempting a Stealth check as long as you move no more than 5 feet and do not pass within 10 feet of an enemy during your movement.</p>\n<p>During exploration, this also allows you to automatically approach within 15 feet of other creatures while @UUID[Compendium.pf2e.actionspf2e.Item.Avoid Notice]{Avoiding their Notice}, as long as they aren't actively @UUID[Compendium.pf2e.actionspf2e.Item.Search]{Searching} or on guard.</p><hr /><p><strong>Special</strong> You can select this feat multiple times. Each time, choose a different type of terrain.</p>"
         },
         "level": {
             "value": 1

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2640,6 +2640,12 @@
                     "FrenziedClaw": "Frenzied Claw",
                     "SpinningTalon": "Spinning Talon"
                 },
+                "ExperiencedProfessional": {
+                    "Note": "If you're an expert in Lore, you gain twice as much income from a failed check to Earn Income, unless it was originally a critical failure."
+                },
+                "FastRecovery": {
+                    "Note": "If you roll a success on a Fortitude save against an ongoing posion or disease, reduce its stage by 2, or by 1 if its virulent. If you roll a critical success, reduce its stage by 3, or by 2 if its virulent."
+                },
                 "FeyInfluence": {
                     "Anteater": "Anteater",
                     "CatSith": "Cat Sith",
@@ -2652,6 +2658,9 @@
                 },
                 "Forager": {
                     "Note": "While using Survival to Subsist, if you roll any result worse than a success, you get a success. You can also provide for multiple creatures."
+                },
+                "OddityIdentification": {
+                    "FlatModifierLabel": "Oddity Identification (Identify Magic with specific traits)"
                 },
                 "PeerBeyond": {
                     "Note": "You can roll a Spirit Lore or Haunt Lore check for initiative if you know that an incorporeal undead or a haunt is present."

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2659,9 +2659,6 @@
                 "Forager": {
                     "Note": "While using Survival to Subsist, if you roll any result worse than a success, you get a success. You can also provide for multiple creatures."
                 },
-                "OddityIdentification": {
-                    "FlatModifierLabel": "Oddity Identification (Identify Magic with specific traits)"
-                },
                 "PeerBeyond": {
                     "Note": "You can roll a Spirit Lore or Haunt Lore check for initiative if you know that an incorporeal undead or a haunt is present."
                 },


### PR DESCRIPTION
- Remove unnecessary note from Breath Control
- Localise and narrow down Experienced Professional and Fast Recovery notes
- Add note on critically successful Create a Diversion action to Lengthy Diversion
- Add alternative skill action macros to Schooled in Secrets and Streetwise
- Replace unlocalised notes in Student of the Canon with predicated Adjust Degree of Success rule elements
- Add compendium links to Subtle Theft and Terrain Stalker