### PR TITLE
Allow Marvelous Medicines to be used when not held

### DIFF
--- a/packs/equipment/marvelous-medicines-greater.json
+++ b/packs/equipment/marvelous-medicines-greater.json
@@ -37,6 +37,7 @@
         "rules": [
             {
                 "key": "FlatModifier",
+                "requiresEquipped": false,
                 "selector": "medicine",
                 "type": "item",
                 "value": 3

--- a/packs/equipment/marvelous-medicines.json
+++ b/packs/equipment/marvelous-medicines.json
@@ -37,6 +37,7 @@
         "rules": [
             {
                 "key": "FlatModifier",
+                "requiresEquipped": false,
                 "selector": "medicine",
                 "type": "item",
                 "value": 2


### PR DESCRIPTION
added `"requiresEquipped": false` to enable use of bonus when not held.

Closes #13907