### PR TITLE
Remove gap between name and buttons for unready strikes

### DIFF
--- a/src/styles/actor/character/_actions.scss
+++ b/src/styles/actor/character/_actions.scss
@@ -70,23 +70,34 @@
         }
 
         li.strike {
-            .item-name {
-                align-items: start;
+            display: grid;
+            grid-template:
+                "img content" min-content
+                "summary summary" min-content /
+                2.5rem 1fr;
 
-                .actions-title {
-                    display: flex;
-                    flex-direction: column;
-                }
-
-                .item-image {
-                    flex: 0 0 2rem;
-                    height: 2rem;
-                }
+            .item-image {
+                grid-area: "img";
+                width: 2rem;
+                height: 2rem;
+                margin-top: var(--space-4);
             }
 
-            // Elemental blasts
-            .action-name .item-controls {
-                margin-left: auto;
+            .item-name {
+                align-items: baseline;
+                display: flex;
+                width: 100%;
+                gap: var(--space-4);
+
+                h4 {
+                    margin: 0;
+                    flex: 0 0 auto;
+                }
+
+                // Elemental blasts
+                .item-controls {
+                    margin-left: auto;
+                }
             }
 
             .button-group {
@@ -117,7 +128,6 @@
 
             .alt-usage {
                 flex-basis: 100%;
-                margin-left: calc(3em - 2px);
                 position: relative;
 
                 .alt-usage-icon {
@@ -127,11 +137,6 @@
                     left: -1.5em;
                     top: 0.2em;
                 }
-            }
-
-            .ammo,
-            .auxiliary-actions {
-                margin-left: 2.5rem;
             }
 
             .ammo {
@@ -196,6 +201,10 @@
                         text-shadow: none;
                     }
                 }
+            }
+
+            .item-summary {
+                grid-area: summary;
             }
 
             &:not(.ready) {

--- a/src/styles/actor/tabs/_actions.scss
+++ b/src/styles/actor/tabs/_actions.scss
@@ -45,46 +45,12 @@ ol.actions-list {
                 display: none;
             }
 
-            .item-name {
-                align-items: center;
-                display: flex;
-                gap: var(--space-8);
-                grid-area: icon-name;
-                margin: 0;
-
-                h4 {
-                    margin: 0;
-                    max-width: fit-content;
-                }
-
-                .item-image {
-                    @include flex-center;
-                    background-repeat: no-repeat;
-                    background-size: contain;
-                    cursor: pointer;
-                    font-size: var(--font-size-18);
-                }
-
-                .actions-title {
-                    flex: 1;
-
-                    .action-name {
-                        align-items: baseline;
-                        display: flex;
-                        flex-direction: row;
-                        gap: 0.5em;
-
-                        > h4 {
-                            a:hover {
-                                color: var(--color-pf-primary);
-                            }
-
-                            .action-glyph {
-                                color: var(--text-dark);
-                            }
-                        }
-                    }
-                }
+            .item-image {
+                @include flex-center;
+                background-repeat: no-repeat;
+                background-size: contain;
+                cursor: pointer;
+                font-size: var(--font-size-18);
             }
 
             button.use-action {
@@ -124,14 +90,9 @@ ol.actions-list {
                 }
             }
 
-            .item-controls {
-                font-size: var(--font-size-12);
-                grid-area: controls;
-                white-space: nowrap;
-            }
-
             .item-summary {
-                flex-basis: 100%;
+                @include frame-elegant;
+                padding: 0.5rem 1rem 1rem;
                 margin: var(--space-8) 0;
 
                 .title,
@@ -184,11 +145,6 @@ ol.actions-list {
                         }
                     }
                 }
-            }
-
-            .item-summary {
-                @include frame-elegant;
-                padding: 0.5rem 1rem 1rem;
 
                 dd {
                     margin: 0;
@@ -198,6 +154,52 @@ ol.actions-list {
                 .tag.tag_secondary {
                     background-color: rgba(0, 0, 0, 0.8);
                 }
+            }
+        }
+
+        &.action {
+            .item-name {
+                align-items: center;
+                display: flex;
+                gap: var(--space-8);
+                grid-area: icon-name;
+                margin: 0;
+
+                h4 {
+                    margin: 0;
+                    max-width: fit-content;
+                }
+
+                .actions-title {
+                    flex: 1;
+
+                    .action-name {
+                        align-items: baseline;
+                        display: flex;
+                        flex-direction: row;
+                        gap: 0.5em;
+
+                        > h4 {
+                            a:hover {
+                                color: var(--color-pf-primary);
+                            }
+
+                            .action-glyph {
+                                color: var(--text-dark);
+                            }
+                        }
+                    }
+                }
+            }
+
+            .item-controls {
+                font-size: var(--font-size-12);
+                grid-area: controls;
+                white-space: nowrap;
+            }
+
+            .item-summary {
+                flex-basis: 100%;
             }
 
             &.hidden {

--- a/static/templates/actors/character/partials/elemental-blast.hbs
+++ b/static/templates/actors/character/partials/elemental-blast.hbs
@@ -4,13 +4,12 @@
     data-item-id="{{action.item.id}}"
     data-item-type="{{action.item.type}}"
 >
-    <div class="item-name rollable" data-tooltip-direction="UP">
-        <div class="item-image strike framed">
-            <img src="{{action.img}}" /> <i class="fa-solid fa-message"></i>
-        </div>
-        <div class="actions-title">
+    <div class="item-image strike framed">
+        <img src="{{action.img}}" /> <i class="fa-solid fa-message"></i>
+    </div>
+    <section>
         {{#unless omitName}}
-            <div class="action-name">
+            <div class="item-name" data-tooltip-direction="UP">
                 <h4 class="name"><a data-action="toggle-summary">{{localize action.label}}</a></h4>
                 <div class="item-controls">
                     {{#if (and @root.editable (eq @index 0))}}
@@ -19,15 +18,14 @@
                 </div>
             </div>
         {{/unless}}
+
         {{#> attackDamage action=action melee=true}}{{/attackDamage}}
+
+        <div class="alt-usage" data-tooltip-direction="UP">
+            <i class="fa-regular fa-meteor fa-rotate-180 alt-usage-icon" data-tooltip="{{action.range.label}}"></i>
+            {{#> attackDamage action=action melee=false}}{{/attackDamage}}
         </div>
-    </div>
-
-    <div class="alt-usage" data-tooltip-direction="UP">
-        <i class="fa-regular fa-meteor fa-rotate-180 alt-usage-icon" data-tooltip="{{action.range.label}}"></i>
-        {{#> attackDamage action=action melee=false}}{{/attackDamage}}
-    </div>
-
+    </section>
     <div class="item-summary" hidden="hidden"></div>
 </li>
 

--- a/static/templates/actors/character/partials/strike.hbs
+++ b/static/templates/actors/character/partials/strike.hbs
@@ -1,80 +1,78 @@
 <li class="strike{{#if action.ready}} ready{{/if}}{{#unless action.visible}} hidden{{/unless}}" data-strike data-action-index="{{index}}">
-    <div class="item-name rollable">
-        <div class="item-image variant-strike framed{{#if action.ready}} ready{{/if}}" data-action="strike-attack" data-variant-index="0">
-            <img src="{{action.item.img}}" />
-            <i class="fa-solid fa-dice-d20"></i>
-        </div>
-        <div class="actions-title">
-            {{#unless omitName}}
-                <div class="action-name">
-                    <h4 class="name"><a data-action="toggle-summary">{{action.label}}</a></h4>
-                    {{#if action.item.isTemporary}}
-                        <i
-                            class="fa-solid fa-info-circle"
-                            data-tooltip="PF2E.TemporaryItemToolTip"
-                            data-tooltip-direction="RIGHT"
-                        ></i>
-                    {{/if}}
-                </div>
-            {{/unless}}
-
-            {{#if action.ready}}
-                <!-- ATTACK/DAMAGE -->
-                {{#if action.canStrike}}{{#> attackDamage action}}{{/attackDamage}}{{/if}}
-            {{else if (not action.handsAvailable)}}
-                <span class="hands-occupied">{{localize "PF2E.Actor.Character.HandsOccupied"}}</span>
-            {{/if}}
-        </div>
+    <div class="item-image variant-strike framed{{#if action.ready}} ready{{/if}}" data-action="strike-attack" data-variant-index="0">
+        <img src="{{action.item.img}}" />
+        <i class="fa-solid fa-dice-d20"></i>
     </div>
-
-    {{#if (and action.altUsages action.ready)}}
-        {{#each action.altUsages as |usage|}}
-            <div class="alt-usage" data-tooltip-direction="LEFT">
-                {{#if usage.item.isThrown}}
-                    <img class="alt-usage-icon" src="systems/pf2e/icons/mdi/thrown.svg" data-tooltip="{{localize "PF2E.Item.Weapon.ThrownUsage.Label"}}" />
-                {{else}}
-                    <img class="alt-usage-icon" src="systems/pf2e/icons/mdi/sword.svg" data-tooltip="{{localize "PF2E.Item.Weapon.MeleeUsage.Label"}}" />
+    <section>
+        {{#unless omitName}}
+            <div class="item-name">
+                <h4 class="name"><a data-action="toggle-summary">{{action.label}}</a></h4>
+                {{#if action.item.isTemporary}}
+                    <i
+                        class="fa-solid fa-info-circle"
+                        data-tooltip="PF2E.TemporaryItemToolTip"
+                        data-tooltip-direction="RIGHT"
+                    ></i>
                 {{/if}}
-                {{#> attackDamage usage isAltUsage=true}}{{/attackDamage}}
             </div>
-        {{/each}}
-    {{/if}}
+        {{/unless}}
 
-    {{#if (and action.ammunition action.ready)}}
-        <div class="ammo auxiliary-actions">
-            <select class="linked"
-                data-action="link-ammo"
-                {{#if action.ammunition.selected}} data-compatible="{{action.ammunition.selected.compatible}}"{{/if}}>
-                {{selectOptions action.ammunition.compatible selected=action.ammunition.selected.id valueAttr="id" blank="PF2E.NoAmmoLabel" localize=true}}
-            </select>
+        {{#if action.ready}}
+            <!-- ATTACK/DAMAGE -->
+            {{#if action.canStrike}}{{#> attackDamage action}}{{/attackDamage}}{{/if}}
+        {{else if (not action.handsAvailable)}}
+            <span class="hands-occupied">{{localize "PF2E.Actor.Character.HandsOccupied"}}</span>
+        {{/if}}
 
-            <span class="magazine" data-item-id="{{action.item.id}}">
-                {{#if (gt action.item.ammo.uses.max 1)}}
-                    <span class="remaining"><i class="icon"></i> {{action.item.ammo.uses.value}}</span>
-                {{/if}}
-            </span>
-        </div>
-    {{/if}}
-
-    {{#if action.handsAvailable}}
-        <div class="auxiliary-actions{{#if action.ready}} weapon-drawn{{/if}}">
-            {{#each action.auxiliaryActions as |aux index|}}
-                <button class="use-action" type="button" data-action="auxiliary-action" data-auxiliary-action-index="{{index}}">
-                    <span>{{aux.label}}</span>
-                    <span class="action-glyph">{{aux.glyph}}</span>
-                    {{#if aux.options}}
-                    <select class="modular" data-action="auxiliary-action" data-auxiliary-action-index="{{index}}">
-                        {{#each aux.options as |option|}}
-                            <option value="{{option.value}}"{{#if option.selected}} selected{{/if}}>
-                                {{option.label}} {{#if option.selected}}✔️{{/if}}
-                            </option>
-                        {{/each}}
-                    </select>
+        {{#if (and action.altUsages action.ready)}}
+            {{#each action.altUsages as |usage|}}
+                <div class="alt-usage" data-tooltip-direction="LEFT">
+                    {{#if usage.item.isThrown}}
+                        <img class="alt-usage-icon" src="systems/pf2e/icons/mdi/thrown.svg" data-tooltip="{{localize "PF2E.Item.Weapon.ThrownUsage.Label"}}" />
+                    {{else}}
+                        <img class="alt-usage-icon" src="systems/pf2e/icons/mdi/sword.svg" data-tooltip="{{localize "PF2E.Item.Weapon.MeleeUsage.Label"}}" />
                     {{/if}}
-                </button>
+                    {{#> attackDamage usage isAltUsage=true}}{{/attackDamage}}
+                </div>
             {{/each}}
-        </div>
-    {{/if}}
+        {{/if}}
+
+        {{#if (and action.ammunition action.ready)}}
+            <div class="ammo auxiliary-actions">
+                <select class="linked"
+                    data-action="link-ammo"
+                    {{#if action.ammunition.selected}} data-compatible="{{action.ammunition.selected.compatible}}"{{/if}}>
+                    {{selectOptions action.ammunition.compatible selected=action.ammunition.selected.id valueAttr="id" blank="PF2E.NoAmmoLabel" localize=true}}
+                </select>
+
+                <span class="magazine" data-item-id="{{action.item.id}}">
+                    {{#if (gt action.item.ammo.uses.max 1)}}
+                        <span class="remaining"><i class="icon"></i> {{action.item.ammo.uses.value}}</span>
+                    {{/if}}
+                </span>
+            </div>
+        {{/if}}
+
+        {{#if action.handsAvailable}}
+            <div class="auxiliary-actions{{#if action.ready}} weapon-drawn{{/if}}">
+                {{#each action.auxiliaryActions as |aux index|}}
+                    <button class="use-action" type="button" data-action="auxiliary-action" data-auxiliary-action-index="{{index}}">
+                        <span>{{aux.label}}</span>
+                        <span class="action-glyph">{{aux.glyph}}</span>
+                        {{#if aux.options}}
+                        <select class="modular" data-action="auxiliary-action" data-auxiliary-action-index="{{index}}">
+                            {{#each aux.options as |option|}}
+                                <option value="{{option.value}}"{{#if option.selected}} selected{{/if}}>
+                                    {{option.label}} {{#if option.selected}}✔️{{/if}}
+                                </option>
+                            {{/each}}
+                        </select>
+                        {{/if}}
+                    </button>
+                {{/each}}
+            </div>
+        {{/if}}
+    </section>
 
     <div class="item-summary" hidden="hidden">
         <div class="item-description">


### PR DESCRIPTION
I recommend hiding whitespace for this diff.

![image](https://github.com/user-attachments/assets/a6a774ab-49c1-4750-be6b-0277ca0c2b19)
