### PR TITLE
Correct usage and description of Silver Salve

### DIFF
--- a/packs/equipment/silver-salve.json
+++ b/packs/equipment/silver-salve.json
@@ -11,7 +11,7 @@
         "containerId": null,
         "damage": null,
         "description": {
-            "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> (manipulate)</p>\n<hr />\n<p>You can slather this silvery paste onto one melee weapon, one thrown weapon, or 10 pieces of ammunition. Silver salve spoils quickly, so once you open a vial, you must use it all at once, rather than saving it.</p>\n<p>For the next hour, the weapon or ammunition counts as silver instead of its normal precious material (such as cold iron) for any physical damage it deals.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Silver Salve]</p>"
+            "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> (manipulate)</p><hr /><p>You can slather this silvery paste onto one melee weapon, one thrown weapon, or 10 pieces of ammunition. Silver salve spoils quickly, so once you open a vial, you must use it all at once, rather than saving it. For the next hour, the weapon or ammunition counts as silver instead of its normal material (such as cold iron) for any physical damage it deals.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Silver Salve]</p>"
         },
         "hardness": 0,
         "hp": {
@@ -46,7 +46,7 @@
             ]
         },
         "usage": {
-            "value": "held-in-one-hand"
+            "value": "held-in-two-hands"
         },
         "uses": {
             "autoDestroy": true,

--- a/packs/equipment/silver-salve.json
+++ b/packs/equipment/silver-salve.json
@@ -11,7 +11,7 @@
         "containerId": null,
         "damage": null,
         "description": {
-            "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> (manipulate)</p><hr /><p>You can slather this silvery paste onto one melee weapon, one thrown weapon, or 10 pieces of ammunition. Silver salve spoils quickly, so once you open a vial, you must use it all at once, rather than saving it. For the next hour, the weapon or ammunition counts as silver instead of its normal material (such as cold iron) for any physical damage it deals.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Silver Salve]</p>"
+            "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> (manipulate)</p><hr /><p>You can slather this silvery paste onto one melee weapon, one thrown weapon, or 10 pieces of ammunition. Silver salve spoils quickly, so once you open a vial, you must use it all at once, rather than saving it.</p>\n<p>For the next hour, the weapon or ammunition counts as silver instead of its normal material (such as cold iron) for any physical damage it deals.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Silver Salve]</p>"
         },
         "hardness": 0,
         "hp": {


### PR DESCRIPTION
From "instead of its normal precious material" to "instead of its normal material", and usage to "held in two hands"