### PR TITLE
Change styling of stowed strikes toggle

### DIFF
--- a/src/styles/actor/_index.scss
+++ b/src/styles/actor/_index.scss
@@ -433,9 +433,17 @@
                 }
             }
 
-            a.inactive,
-            button.inactive {
-                color: var(--color-text-dark-6);
+            a,
+            button {
+                &.inactive {
+                    color: var(--color-text-dark-6);
+                }
+
+                input[type="checkbox"] {
+                    margin: 0;
+                    height: var(--font-size-10);
+                    width: var(--font-size-10);
+                }
             }
         }
 

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -248,7 +248,6 @@
                 "Rest": {
                     "Label": "Rest for the Night"
                 },
-                "ShowStowed": "Show Stowed",
                 "Spellcasting": {
                     "Tab": {
                         "Activations": "Activations",

--- a/static/templates/actors/character/tabs/actions.hbs
+++ b/static/templates/actors/character/tabs/actions.hbs
@@ -14,8 +14,8 @@
                     <header>
                         {{localize "PF2E.Actor.Attacks"}}
                         <button type="button" data-action="toggle-hide-stowed" {{#if actor.flags.pf2e.hideStowed}} class="inactive"{{/if}}>
-                            <i class="fa-solid fa-backpack"></i>
-                            {{localize "PF2E.Actor.Character.ShowStowed"}}
+                            <input type="checkbox" {{checked (not actor.flags.pf2e.hideStowed)}}/>
+                            {{localize "PF2E.CarryType.stowed"}}
                         </button>
                     </header>
 


### PR DESCRIPTION
Feel free to close if you think its not an improvement. I was worried that the previous button didn't properly communicate what it was.

![image](https://github.com/user-attachments/assets/4e27991d-2932-41e6-81b6-180a46a4a74a)

![image](https://github.com/user-attachments/assets/1442af42-e75a-4de2-af80-5bc35b55fc80)
