### PR TITLE
Update Raise Symbol to handle unified Emblazon Armament

### DIFF
--- a/packs/feat-effects/effect-raise-symbol.json
+++ b/packs/feat-effects/effect-raise-symbol.json
@@ -47,7 +47,7 @@
                 "predicate": [
                     {
                         "or": [
-                            "self:effect:emblazon-armament-shield",
+                            "emblazon-armament:item:shield",
                             "shield-religious-symbol"
                         ]
                     }

--- a/packs/feats/raise-symbol.json
+++ b/packs/feats/raise-symbol.json
@@ -32,7 +32,7 @@
                 "predicate": [
                     "self:shield:equipped",
                     {
-                        "not": "self:effect:emblazon-armament-shield"
+                        "not": "emblazon-armament:item:shield"
                     }
                 ],
                 "toggleable": true


### PR DESCRIPTION
Emblazon Armament was unified in https://github.com/foundryvtt/pf2e/pull/14748