### PR TITLE
remove duplicate traits from Versatile heritages

### DIFF
--- a/packs/heritages/versatile-heritages/aiuvarin.json
+++ b/packs/heritages/versatile-heritages/aiuvarin.json
@@ -24,8 +24,7 @@
             },
             {
                 "add": [
-                    "elf",
-                    "aiuvarin"
+                    "elf"
                 ],
                 "key": "ActorTraits"
             },

--- a/packs/heritages/versatile-heritages/aphorite.json
+++ b/packs/heritages/versatile-heritages/aphorite.json
@@ -15,12 +15,6 @@
         },
         "rules": [
             {
-                "add": [
-                    "aphorite"
-                ],
-                "key": "ActorTraits"
-            },
-            {
                 "key": "Sense",
                 "selector": "low-light-vision"
             },

--- a/packs/heritages/versatile-heritages/beastkin.json
+++ b/packs/heritages/versatile-heritages/beastkin.json
@@ -16,8 +16,7 @@
         "rules": [
             {
                 "add": [
-                    "beast",
-                    "beastkin"
+                    "beast"
                 ],
                 "key": "ActorTraits"
             },

--- a/packs/heritages/versatile-heritages/changeling.json
+++ b/packs/heritages/versatile-heritages/changeling.json
@@ -15,12 +15,6 @@
         },
         "rules": [
             {
-                "add": [
-                    "changeling"
-                ],
-                "key": "ActorTraits"
-            },
-            {
                 "key": "Sense",
                 "selector": "low-light-vision"
             },

--- a/packs/heritages/versatile-heritages/dromaar.json
+++ b/packs/heritages/versatile-heritages/dromaar.json
@@ -24,8 +24,7 @@
             },
             {
                 "add": [
-                    "orc",
-                    "dromaar"
+                    "orc"
                 ],
                 "key": "ActorTraits"
             },

--- a/packs/heritages/versatile-heritages/reflection.json
+++ b/packs/heritages/versatile-heritages/reflection.json
@@ -13,17 +13,12 @@
             "remaster": false,
             "title": "Pathfinder Dark Archive"
         },
-        "rules": [
-            {
-                "add": [
-                    "reflection"
-                ],
-                "key": "ActorTraits"
-            }
-        ],
+        "rules": [],
         "traits": {
             "rarity": "rare",
-            "value": []
+            "value": [
+                "reflection"
+            ]
         }
     },
     "type": "heritage"

--- a/packs/heritages/versatile-heritages/suli.json
+++ b/packs/heritages/versatile-heritages/suli.json
@@ -15,12 +15,6 @@
         },
         "rules": [
             {
-                "add": [
-                    "suli"
-                ],
-                "key": "ActorTraits"
-            },
-            {
                 "key": "Sense",
                 "selector": "low-light-vision"
             },


### PR DESCRIPTION
Removes duplicate traits already included in item from RE.