### PR TITLE
Include point sources in `testCollision` calls lacking them

### DIFF
--- a/src/module/canvas/measured-template.ts
+++ b/src/module/canvas/measured-template.ts
@@ -168,6 +168,7 @@ class MeasuredTemplatePF2e<
             };
         };
 
+        const pointSource = new foundry.canvas.sources.PointMovementSource({ object: this });
         const points: PointCollision[] = [];
         for (let a = -columnCount; a < columnCount; a++) {
             for (let b = -rowCount; b < rowCount; b++) {
@@ -203,6 +204,7 @@ class MeasuredTemplatePF2e<
                     canvas.ready &&
                     CONFIG.Canvas.polygonBackends.move.testCollision(origin, destination, {
                         type: "move",
+                        source: pointSource,
                         mode: "any",
                     });
 

--- a/src/module/canvas/token/aura/util.ts
+++ b/src/module/canvas/token/aura/util.ts
@@ -1,7 +1,8 @@
 import { EffectAreaSquare } from "@module/canvas/effect-area-square.ts";
 import { measureDistanceCuboid } from "@module/canvas/helpers.ts";
 import { TokenDocumentPF2e } from "@scene";
-import { TokenPF2e } from "../index.ts";
+import type BaseEffectSource from "types/foundry/client-esm/canvas/sources/base-effect-source.d.ts";
+import type { TokenPF2e } from "../index.ts";
 
 export function getAreaSquares(data: GetAreaSquaresParams): EffectAreaSquare[] {
     if (!canvas.ready) return [];
@@ -49,6 +50,17 @@ export function getAreaSquares(data: GetAreaSquaresParams): EffectAreaSquare[] {
         })),
     ];
 
+    const pointSource = (() => {
+        const sources = foundry.canvas.sources;
+        const PointSource: ConstructorOf<BaseEffectSource<TokenPF2e>> = {
+            sight: sources.PointVisionSource,
+            sound: sources.PointSoundSource,
+            move: sources.PointMovementSource,
+        }[collisionType];
+        const tokenObject = data.token instanceof TokenDocumentPF2e ? data.token.object : data.token;
+        return new PointSource({ object: tokenObject });
+    })();
+
     return emptyVector
         .reduce(
             (squares: EffectAreaSquare[][]) => {
@@ -69,6 +81,7 @@ export function getAreaSquares(data: GetAreaSquaresParams): EffectAreaSquare[] {
                     !CONFIG.Canvas.polygonBackends[collisionType].testCollision(c, square.center, {
                         type: collisionType,
                         mode: "any",
+                        source: pointSource,
                     }),
             );
             return square;

--- a/types/foundry/client/data/documents/client-document.d.ts
+++ b/types/foundry/client/data/documents/client-document.d.ts
@@ -13,6 +13,7 @@ declare global {
 
     interface CanvasDocument extends ClientDocument {
         readonly parent: ClientBaseScene | null;
+        object: PlaceableObject<this> | null;
         hidden?: boolean;
     }
 }


### PR DESCRIPTION
Inconsequential for our purposes, but some modules benefit from the data being present.