### PR TITLE
Create drawAuras hook

### DIFF
--- a/src/module/canvas/token/aura/map.ts
+++ b/src/module/canvas/token/aura/map.ts
@@ -19,6 +19,7 @@ export class AuraRenderers extends Map<string, AuraRenderer> {
      * @param [slugs] A specific list of slugs to limit which auras are cleared
      */
     async reset(slugs?: string[]): Promise<void> {
+        const preUpdateSlugs = Array.from(this.keys());
         if (!slugs) {
             this.clear();
         } else {
@@ -29,11 +30,21 @@ export class AuraRenderers extends Map<string, AuraRenderer> {
 
         if (!this.token.actor) return;
 
-        const data = Array.from(this.token.document.auras.values()).filter((a) => slugs?.includes(a.slug) ?? true);
+        const documentAuras = Array.from(this.token.document.auras.values());
+        const data = documentAuras.filter((a) => slugs?.includes(a.slug) ?? true);
+        const removedAuras = preUpdateSlugs.filter((a) => !documentAuras.map((b) => b.slug).includes(a));
         for (const datum of data) {
             const renderer = new AuraRenderer({ ...datum, token: this.token });
             this.set(datum.slug, this.token.addChild(renderer));
         }
+
+        if (removedAuras.length) Hooks.callAll("pf2e.deletedAuras", this, removedAuras);
+
+        const createdAuras = Array.from(this.keys()).filter((a) => !preUpdateSlugs.includes(a));
+        if (createdAuras.length) Hooks.callAll("pf2e.createdAuras", this, createdAuras);
+
+        const updatedAuras = data.map((a) => a.slug).filter((a) => !createdAuras.includes(a));
+        if (updatedAuras.length) Hooks.callAll("pf2e.updatedAuras", this, updatedAuras);
 
         return this.draw();
     }

--- a/src/module/canvas/token/aura/map.ts
+++ b/src/module/canvas/token/aura/map.ts
@@ -30,23 +30,13 @@ export class AuraRenderers extends Map<string, AuraRenderer> {
 
         if (!this.token.actor) return;
 
-        const documentAuras = Array.from(this.token.document.auras.values());
-        const data = documentAuras.filter((a) => slugs?.includes(a.slug) ?? true);
-        const removedAuras = preUpdateSlugs.filter((a) => !documentAuras.map((b) => b.slug).includes(a));
         for (const datum of data) {
             const renderer = new AuraRenderer({ ...datum, token: this.token });
             this.set(datum.slug, this.token.addChild(renderer));
         }
 
-        if (removedAuras.length) Hooks.callAll("pf2e.deletedAuras", this, removedAuras);
-
-        const createdAuras = Array.from(this.keys()).filter((a) => !preUpdateSlugs.includes(a));
-        if (createdAuras.length) Hooks.callAll("pf2e.createdAuras", this, createdAuras);
-
-        const updatedAuras = data.map((a) => a.slug).filter((a) => !createdAuras.includes(a));
-        if (updatedAuras.length) Hooks.callAll("pf2e.updatedAuras", this, updatedAuras);
-
-        return this.draw();
+        await this.draw();
+        Hooks.callAll("drawAuras", this.token, { preUpdateSlugs })
     }
 
     /** Reposition aura textures after the token moves. */

--- a/src/module/canvas/token/aura/map.ts
+++ b/src/module/canvas/token/aura/map.ts
@@ -30,6 +30,7 @@ export class AuraRenderers extends Map<string, AuraRenderer> {
 
         if (!this.token.actor) return;
 
+        const data = Array.from(this.token.document.auras.values()).filter((a) => slugs?.includes(a.slug) ?? true);
         for (const datum of data) {
             const renderer = new AuraRenderer({ ...datum, token: this.token });
             this.set(datum.slug, this.token.addChild(renderer));

--- a/src/module/canvas/token/aura/map.ts
+++ b/src/module/canvas/token/aura/map.ts
@@ -37,7 +37,7 @@ export class AuraRenderers extends Map<string, AuraRenderer> {
         }
 
         await this.draw();
-        Hooks.callAll("drawAuras", this.token, { preUpdateSlugs })
+        Hooks.callAll("drawAuras", this.token, { preUpdateSlugs });
     }
 
     /** Reposition aura textures after the token moves. */

--- a/src/module/canvas/token/aura/map.ts
+++ b/src/module/canvas/token/aura/map.ts
@@ -19,7 +19,6 @@ export class AuraRenderers extends Map<string, AuraRenderer> {
      * @param [slugs] A specific list of slugs to limit which auras are cleared
      */
     async reset(slugs?: string[]): Promise<void> {
-        const preUpdateSlugs = Array.from(this.keys());
         if (!slugs) {
             this.clear();
         } else {
@@ -37,7 +36,7 @@ export class AuraRenderers extends Map<string, AuraRenderer> {
         }
 
         await this.draw();
-        Hooks.callAll("drawAuras", this.token, { preUpdateSlugs });
+        Hooks.callAll("drawAuras", this.token);
     }
 
     /** Reposition aura textures after the token moves. */


### PR DESCRIPTION
Creates 3 informational hooks, `deletedAuras`, `createdAuras`, and `updatedAuras`. Hopefully self-explanatory.
The arguments they give are the `AuraRenderers` object itself, and then an array of slugs of the auras that were somehow changed.

Primarily for use with the WIP PF2e Graphics module, such as animating size-changing auras. Ex. Issue https://github.com/MrVauxs/pf2e-jb2a-macros/issues/157