### PR TITLE
Add action to Resonant Reflection Campaign items.

### DIFF
--- a/packs/actions/activate-resonant-reflection.json
+++ b/packs/actions/activate-resonant-reflection.json
@@ -23,7 +23,7 @@
                 "key": "RollOption",
                 "domain": "all",
                 "option": "resonant-reflection"
-            },
+            }
         ],
         "traits": {
             "value": [

--- a/packs/actions/activate-resonant-reflection.json
+++ b/packs/actions/activate-resonant-reflection.json
@@ -11,7 +11,7 @@
         },
         "category": "interaction",
         "description": {
-            "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">2</span> envision</p>\n<p><strong>Frequency</strong> once per day</p><hr /><p>You activate one of your resonant reflections:</p>"
+            "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">2</span> envision</p>\n<p><strong>Frequency</strong> once per day for each reflection</p><hr /><p>You activate one of your resonant reflections:</p>"
         },
         "publication": {
             "license": "OGL",

--- a/packs/actions/activate-resonant-reflection.json
+++ b/packs/actions/activate-resonant-reflection.json
@@ -1,5 +1,5 @@
 {
-    "_id": "zRPCMQUY9g1Y9e3l",
+    "_id": "PpfkUdNMckFE22WI",
     "img": "systems/pf2e/icons/actions/TwoActions.webp",
     "name": "Activate Resonant Reflection",
     "system": {
@@ -11,7 +11,7 @@
         },
         "category": "interaction",
         "description": {
-            "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">2</span> envision</p>\n<p><strong>Frequency</strong> once per day</p><hr />\n<p>You activate one of your resonant reflections:</p>"
+            "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">2</span> envision</p>\n<p><strong>Frequency</strong> once per day</p><hr /><p>You activate one of your resonant reflections:</p>"
         },
         "publication": {
             "license": "OGL",

--- a/packs/actions/activate-resonant-reflection.json
+++ b/packs/actions/activate-resonant-reflection.json
@@ -1,0 +1,29 @@
+{
+    "_id": "zRPCMQUY9g1Y9e3l",
+    "img": "systems/pf2e/icons/actions/TwoActions.webp",
+    "name": "Activate Resonant Reflection",
+    "system": {
+        "actionType": {
+            "value": "action"
+        },
+        "actions": {
+            "value": 2
+        },
+        "category": "interaction",
+        "description": {
+            "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">2</span> envision</p>\n<p><strong>Frequency</strong> once per day</p><hr />"
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder #153: Life's Long Shadows"
+        },
+        "rules": [],
+        "traits": {
+            "value": [
+                "magical"
+            ]
+        }
+    },
+    "type": "action"
+}

--- a/packs/actions/activate-resonant-reflection.json
+++ b/packs/actions/activate-resonant-reflection.json
@@ -11,7 +11,7 @@
         },
         "category": "interaction",
         "description": {
-            "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">2</span> envision</p>\n<p><strong>Frequency</strong> once per day</p><hr />"
+            "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">2</span> envision</p>\n<p><strong>Frequency</strong> once per day</p><hr />\n<p>You activate one of your resonant reflections:</p>"
         },
         "publication": {
             "license": "OGL",

--- a/packs/actions/activate-resonant-reflection.json
+++ b/packs/actions/activate-resonant-reflection.json
@@ -18,7 +18,13 @@
             "remaster": false,
             "title": "Pathfinder #153: Life's Long Shadows"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "RollOption",
+                "domain": "all",
+                "option": "resonant-reflection"
+            },
+        ],
         "traits": {
             "value": [
                 "magical"

--- a/packs/campaign-effects/resonant-reflection-reflection-of-life.json
+++ b/packs/campaign-effects/resonant-reflection-reflection-of-life.json
@@ -63,16 +63,16 @@
                 "toggleable": true
             },
             {
+                "key": "RollOption",
+                "domain": "all",
+                "option": "resonant-reflection"
+            },
+            {
                 "allowDuplicate": false,
                 "key": "GrantItem",
                 "predicate": [
                     {
-                        "nor": [
-                            "item:slug:resonant-reflection-reflection-of-storm",
-                            "item:slug:resonant-reflection-reflection-of-stone",
-                            "item:slug:resonant-reflection-reflection-of-water",
-                            "item:slug:resonant-reflection-reflection-of-light"
-                        ]
+                        "not": "resonant-reflection"
                     }
                 ],
                 "reevaluateOnUpdate": true,

--- a/packs/campaign-effects/resonant-reflection-reflection-of-life.json
+++ b/packs/campaign-effects/resonant-reflection-reflection-of-life.json
@@ -30,6 +30,35 @@
                 "mode": "add",
                 "path": "system.attributes.hp.recoveryMultiplier",
                 "value": 1
+            },
+            {
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:resonant-reflection"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.ResonantReflection.ReflectionOfLife.Description"
+                    }
+                ]
+            },
+            {
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:resonant-reflection"
+                ],
+                "property": "traits",
+                "value": "healing"
+            },
+            {
+                "allowDuplicate": false,
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.actionspf2e.Item.Activate Resonant Reflection"
             }
         ],
         "traits": {

--- a/packs/campaign-effects/resonant-reflection-reflection-of-life.json
+++ b/packs/campaign-effects/resonant-reflection-reflection-of-life.json
@@ -63,11 +63,6 @@
                 "toggleable": true
             },
             {
-                "key": "RollOption",
-                "domain": "all",
-                "option": "resonant-reflection"
-            },
-            {
                 "allowDuplicate": false,
                 "key": "GrantItem",
                 "predicate": [

--- a/packs/campaign-effects/resonant-reflection-reflection-of-life.json
+++ b/packs/campaign-effects/resonant-reflection-reflection-of-life.json
@@ -36,28 +36,46 @@
                 "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
-                    "item:slug:resonant-reflection"
+                    "item:slug:activate-resonant-reflection",
+                    "resonant:reflection-of-life"
                 ],
                 "property": "description",
                 "value": [
                     {
-                        "text": "PF2E.SpecificRule.ResonantReflection.ReflectionOfLife.Description"
+                        "text": "PF2E.SpecificRule.ResonantReflection.ReflectionOfLife.Description",
+                        "title": "PF2E.SpecificRule.ResonantReflection.ReflectionOfLife.Title"
                     }
                 ]
             },
             {
-                "itemType": "action",
-                "key": "ItemAlteration",
-                "mode": "add",
-                "predicate": [
-                    "item:slug:resonant-reflection"
+                "alwaysActive": true,
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.ResonantReflection.Label",
+                "mergeable": true,
+                "option": "resonant",
+                "placement": "actions",
+                "suboptions": [
+                    {
+                        "label": "{item|name}",
+                        "value": "reflection-of-life"
+                    }
                 ],
-                "property": "traits",
-                "value": "healing"
+                "toggleable": true
             },
             {
                 "allowDuplicate": false,
                 "key": "GrantItem",
+                "predicate": [
+                    {
+                        "nor": [
+                            "item:slug:resonant-reflection-reflection-of-storm",
+                            "item:slug:resonant-reflection-reflection-of-stone",
+                            "item:slug:resonant-reflection-reflection-of-water",
+                            "item:slug:resonant-reflection-reflection-of-light"
+                        ]
+                    }
+                ],
+                "reevaluateOnUpdate": true,
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Activate Resonant Reflection"
             }
         ],

--- a/packs/campaign-effects/resonant-reflection-reflection-of-light.json
+++ b/packs/campaign-effects/resonant-reflection-reflection-of-light.json
@@ -41,12 +41,7 @@
                 "key": "GrantItem",
                 "predicate": [
                     {
-                        "nor": [
-                            "item:slug:resonant-reflection-reflection-of-stone",
-                            "item:slug:resonant-reflection-reflection-of-storm",
-                            "item:slug:resonant-reflection-reflection-of-life",
-                            "item:slug:resonant-reflection-reflection-of-water"
-                        ]
+                        "not": "resonant-reflection"
                     }
                 ],
                 "reevaluateOnUpdate": true,
@@ -63,8 +58,7 @@
                 "property": "description",
                 "value": [
                     {
-                        "text": "PF2E.SpecificRule.ResonantReflection.ReflectionOfLight.Description",
-                        "title": "PF2E.SpecificRule.ResonantReflection.ReflectionOfLight.Title"
+                        "not": "resonant-reflection"
                     }
                 ]
             },

--- a/packs/campaign-effects/resonant-reflection-reflection-of-light.json
+++ b/packs/campaign-effects/resonant-reflection-reflection-of-light.json
@@ -58,7 +58,8 @@
                 "property": "description",
                 "value": [
                     {
-                        "not": "resonant-reflection"
+                        "text": "PF2E.SpecificRule.ResonantReflection.ReflectionOfLight.Description",
+                        "title": "PF2E.SpecificRule.ResonantReflection.ReflectionOfLight.Title"
                     }
                 ]
             },

--- a/packs/campaign-effects/resonant-reflection-reflection-of-light.json
+++ b/packs/campaign-effects/resonant-reflection-reflection-of-light.json
@@ -35,6 +35,35 @@
                 "mode": "override",
                 "path": "flags.pf2e.colorDarkvision",
                 "value": true
+            },
+            {
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:resonant-reflection"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.ResonantReflection.ReflectionOfLight.Description"
+                    }
+                ]
+            },
+            {
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:resonant-reflection"
+                ],
+                "property": "traits",
+                "value": "light"
+            },
+            {
+                "allowDuplicate": false,
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.actionspf2e.Item.Activate Resonant Reflection"
             }
         ],
         "traits": {

--- a/packs/campaign-effects/resonant-reflection-reflection-of-light.json
+++ b/packs/campaign-effects/resonant-reflection-reflection-of-light.json
@@ -37,33 +37,51 @@
                 "value": true
             },
             {
+                "allowDuplicate": false,
+                "key": "GrantItem",
+                "predicate": [
+                    {
+                        "nor": [
+                            "item:slug:resonant-reflection-reflection-of-stone",
+                            "item:slug:resonant-reflection-reflection-of-storm",
+                            "item:slug:resonant-reflection-reflection-of-life",
+                            "item:slug:resonant-reflection-reflection-of-water"
+                        ]
+                    }
+                ],
+                "reevaluateOnUpdate": true,
+                "uuid": "Compendium.pf2e.actionspf2e.Item.Activate Resonant Reflection"
+            },
+            {
                 "itemType": "action",
                 "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
-                    "item:slug:resonant-reflection"
+                    "item:slug:activate-resonant-reflection",
+                    "resonant:reflection-of-light"
                 ],
                 "property": "description",
                 "value": [
                     {
-                        "text": "PF2E.SpecificRule.ResonantReflection.ReflectionOfLight.Description"
+                        "text": "PF2E.SpecificRule.ResonantReflection.ReflectionOfLight.Description",
+                        "title": "PF2E.SpecificRule.ResonantReflection.ReflectionOfLight.Title"
                     }
                 ]
             },
             {
-                "itemType": "action",
-                "key": "ItemAlteration",
-                "mode": "add",
-                "predicate": [
-                    "item:slug:resonant-reflection"
+                "alwaysActive": true,
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.ResonantReflection.Label",
+                "mergeable": true,
+                "option": "resonant",
+                "placement": "actions",
+                "suboptions": [
+                    {
+                        "label": "{item|name}",
+                        "value": "reflection-of-light"
+                    }
                 ],
-                "property": "traits",
-                "value": "light"
-            },
-            {
-                "allowDuplicate": false,
-                "key": "GrantItem",
-                "uuid": "Compendium.pf2e.actionspf2e.Item.Activate Resonant Reflection"
+                "toggleable": true
             }
         ],
         "traits": {

--- a/packs/campaign-effects/resonant-reflection-reflection-of-stone.json
+++ b/packs/campaign-effects/resonant-reflection-reflection-of-stone.json
@@ -24,7 +24,37 @@
             "remaster": false,
             "title": "Pathfinder #153: Life's Long Shadows"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:resonant-reflection"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.ResonantReflection.ReflectionOfStone.Description"
+                    }
+                ]
+            },
+            {
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:resonant-reflection"
+                ],
+                "property": "traits",
+                "value": "earth"
+            },
+            {
+                "allowDuplicate": false,
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.actionspf2e.Item.Activate Resonant Reflection"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/campaign-effects/resonant-reflection-reflection-of-stone.json
+++ b/packs/campaign-effects/resonant-reflection-reflection-of-stone.json
@@ -11,7 +11,7 @@
         },
         "category": "deityboon",
         "description": {
-            "value": "<p>Your body is infused with the resilience and durability of stone. You are protected against the effects of severe cold and severe heat. In addition, you can also focus this durability to gain an additional effect.</p>\n<hr />\n<p><strong>Activate</strong> <span class=\"action-glyph\">2</span> envision</p>\n<p><strong>Frequency</strong> once per day</p>\n<hr />\n<p><strong>Effect</strong> You cast @UUID[Compendium.pf2e.spells-srd.Item.Mountain Resilience] as an innate divine spell, heightened to a spell rank equal to half your level rounded up.</p>"
+            "value": "<p>Your body is infused with the resilience and durability of stone. You are protected against the effects of severe cold and severe heat. In addition, you can also focus this durability to gain an additional effect.</p><hr /><p><strong>Activate</strong> <span class=\"action-glyph\">2</span> envision</p>\n<p><strong>Frequency</strong> once per day</p><hr /><p><strong>Effect</strong> You cast @UUID[Compendium.pf2e.spells-srd.Item.Mountain Resilience] as an innate divine spell, heightened to a spell rank equal to half your level rounded up.</p>"
         },
         "level": {
             "value": 10
@@ -30,28 +30,46 @@
                 "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
-                    "item:slug:resonant-reflection"
+                    "item:slug:activate-resonant-reflection",
+                    "resonant:reflection-of-stone"
                 ],
                 "property": "description",
                 "value": [
                     {
-                        "text": "PF2E.SpecificRule.ResonantReflection.ReflectionOfStone.Description"
+                        "text": "PF2E.SpecificRule.ResonantReflection.ReflectionOfStone.Description",
+                        "title": "PF2E.SpecificRule.ResonantReflection.ReflectionOfStone.Title"
                     }
                 ]
             },
             {
-                "itemType": "action",
-                "key": "ItemAlteration",
-                "mode": "add",
-                "predicate": [
-                    "item:slug:resonant-reflection"
+                "alwaysActive": true,
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.ResonantReflection.Label",
+                "mergeable": true,
+                "option": "resonant",
+                "placement": "actions",
+                "suboptions": [
+                    {
+                        "label": "{item|name}",
+                        "value": "reflection-of-stone"
+                    }
                 ],
-                "property": "traits",
-                "value": "earth"
+                "toggleable": true
             },
             {
                 "allowDuplicate": false,
                 "key": "GrantItem",
+                "predicate": [
+                    {
+                        "nor": [
+                            "item:slug:resonant-reflection-reflection-of-life",
+                            "item:slug:resonant-reflection-reflection-of-storm",
+                            "item:slug:resonant-reflection-reflection-of-water",
+                            "item:slug:resonant-reflection-reflection-of-light"
+                        ]
+                    }
+                ],
+                "reevaluateOnUpdate": true,
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Activate Resonant Reflection"
             }
         ],

--- a/packs/campaign-effects/resonant-reflection-reflection-of-stone.json
+++ b/packs/campaign-effects/resonant-reflection-reflection-of-stone.json
@@ -57,11 +57,6 @@
                 "toggleable": true
             },
             {
-                "key": "RollOption", 
-                "domain": "all", 
-                "option": "resonant-reflection"
-            },
-            {
                 "allowDuplicate": false,
                 "key": "GrantItem",
                 "predicate": [

--- a/packs/campaign-effects/resonant-reflection-reflection-of-stone.json
+++ b/packs/campaign-effects/resonant-reflection-reflection-of-stone.json
@@ -57,17 +57,17 @@
                 "toggleable": true
             },
             {
+                "key": "RollOption", 
+                "domain": "all", 
+                "option": "resonant-reflection"
+            },
+            {
                 "allowDuplicate": false,
                 "key": "GrantItem",
                 "predicate": [
-                    {
-                        "nor": [
-                            "item:slug:resonant-reflection-reflection-of-life",
-                            "item:slug:resonant-reflection-reflection-of-storm",
-                            "item:slug:resonant-reflection-reflection-of-water",
-                            "item:slug:resonant-reflection-reflection-of-light"
-                        ]
-                    }
+                  {
+                      "not": "resonant-reflection"
+                  }
                 ],
                 "reevaluateOnUpdate": true,
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Activate Resonant Reflection"

--- a/packs/campaign-effects/resonant-reflection-reflection-of-storm.json
+++ b/packs/campaign-effects/resonant-reflection-reflection-of-storm.json
@@ -38,6 +38,45 @@
                 "key": "Resistance",
                 "type": "electricity",
                 "value": "@actor.level"
+            },
+            {
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:resonant-reflection"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.ResonantReflection.ReflectionOfStorm.Description"
+                    }
+                ]
+            },
+            {
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:resonant-reflection"
+                ],
+                "property": "traits",
+                "value": "air"
+            },
+            {
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:resonant-reflection"
+                ],
+                "property": "traits",
+                "value": "electricity"
+            },
+            {
+                "allowDuplicate": false,
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.actionspf2e.Item.Activate Resonant Reflection"
             }
         ],
         "traits": {

--- a/packs/campaign-effects/resonant-reflection-reflection-of-storm.json
+++ b/packs/campaign-effects/resonant-reflection-reflection-of-storm.json
@@ -71,16 +71,16 @@
                 "toggleable": true
             },
             {
+                "key": "RollOption", 
+                "domain": "all", 
+                "option": "resonant-reflection"
+            },
+            {
                 "allowDuplicate": false,
                 "key": "GrantItem",
                 "predicate": [
                     {
-                        "nor": [
-                            "item:slug:resonant-reflection-reflection-of-life",
-                            "item:slug:resonant-reflection-reflection-of-stone",
-                            "item:slug:resonant-reflection-reflection-of-water",
-                            "item:slug:resonant-reflection-reflection-of-light"
-                        ]
+                        "not": "resonant-reflection"
                     }
                 ],
                 "reevaluateOnUpdate": true,

--- a/packs/campaign-effects/resonant-reflection-reflection-of-storm.json
+++ b/packs/campaign-effects/resonant-reflection-reflection-of-storm.json
@@ -71,11 +71,6 @@
                 "toggleable": true
             },
             {
-                "key": "RollOption", 
-                "domain": "all", 
-                "option": "resonant-reflection"
-            },
-            {
                 "allowDuplicate": false,
                 "key": "GrantItem",
                 "predicate": [

--- a/packs/campaign-effects/resonant-reflection-reflection-of-storm.json
+++ b/packs/campaign-effects/resonant-reflection-reflection-of-storm.json
@@ -44,38 +44,46 @@
                 "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
-                    "item:slug:resonant-reflection"
+                    "item:slug:activate-resonant-reflection",
+                    "resonant:reflection-of-storm"
                 ],
                 "property": "description",
                 "value": [
                     {
-                        "text": "PF2E.SpecificRule.ResonantReflection.ReflectionOfStorm.Description"
+                        "text": "PF2E.SpecificRule.ResonantReflection.ReflectionOfStorm.Description",
+                        "title": "PF2E.SpecificRule.ResonantReflection.ReflectionOfStorm.Title"
                     }
                 ]
             },
             {
-                "itemType": "action",
-                "key": "ItemAlteration",
-                "mode": "add",
-                "predicate": [
-                    "item:slug:resonant-reflection"
+                "alwaysActive": true,
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.ResonantReflection.Label",
+                "mergeable": true,
+                "option": "resonant",
+                "placement": "actions",
+                "suboptions": [
+                    {
+                        "label": "{item|name}",
+                        "value": "reflection-of-storm"
+                    }
                 ],
-                "property": "traits",
-                "value": "air"
-            },
-            {
-                "itemType": "action",
-                "key": "ItemAlteration",
-                "mode": "add",
-                "predicate": [
-                    "item:slug:resonant-reflection"
-                ],
-                "property": "traits",
-                "value": "electricity"
+                "toggleable": true
             },
             {
                 "allowDuplicate": false,
                 "key": "GrantItem",
+                "predicate": [
+                    {
+                        "nor": [
+                            "item:slug:resonant-reflection-reflection-of-life",
+                            "item:slug:resonant-reflection-reflection-of-stone",
+                            "item:slug:resonant-reflection-reflection-of-water",
+                            "item:slug:resonant-reflection-reflection-of-light"
+                        ]
+                    }
+                ],
+                "reevaluateOnUpdate": true,
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Activate Resonant Reflection"
             }
         ],

--- a/packs/campaign-effects/resonant-reflection-reflection-of-water.json
+++ b/packs/campaign-effects/resonant-reflection-reflection-of-water.json
@@ -29,6 +29,35 @@
                 "key": "BaseSpeed",
                 "selector": "swim",
                 "value": 10
+            },
+            {
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:resonant-reflection"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.ResonantReflection.ReflectionOfWater.Description"
+                    }
+                ]
+            },
+            {
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:resonant-reflection"
+                ],
+                "property": "traits",
+                "value": "water"
+            },
+            {
+                "allowDuplicate": false,
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.actionspf2e.Item.Activate Resonant Reflection"
             }
         ],
         "traits": {

--- a/packs/campaign-effects/resonant-reflection-reflection-of-water.json
+++ b/packs/campaign-effects/resonant-reflection-reflection-of-water.json
@@ -62,16 +62,15 @@
                 "toggleable": true
             },
             {
+                "key": "RollOption", 
+                "domain": "all", 
+                "option": "resonant-reflection"},
+            {
                 "allowDuplicate": false,
                 "key": "GrantItem",
                 "predicate": [
                     {
-                        "nor": [
-                            "item:slug:resonant-reflection-reflection-of-stone",
-                            "item:slug:resonant-reflection-reflection-of-storm",
-                            "item:slug:resonant-reflection-reflection-of-life",
-                            "item:slug:resonant-reflection-reflection-of-light"
-                        ]
+                        "not": "resonant-reflection"
                     }
                 ],
                 "reevaluateOnUpdate": true,

--- a/packs/campaign-effects/resonant-reflection-reflection-of-water.json
+++ b/packs/campaign-effects/resonant-reflection-reflection-of-water.json
@@ -62,10 +62,6 @@
                 "toggleable": true
             },
             {
-                "key": "RollOption", 
-                "domain": "all", 
-                "option": "resonant-reflection"},
-            {
                 "allowDuplicate": false,
                 "key": "GrantItem",
                 "predicate": [

--- a/packs/campaign-effects/resonant-reflection-reflection-of-water.json
+++ b/packs/campaign-effects/resonant-reflection-reflection-of-water.json
@@ -35,28 +35,46 @@
                 "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
-                    "item:slug:resonant-reflection"
+                    "item:slug:activate-resonant-reflection",
+                    "resonant:reflection-of-water"
                 ],
                 "property": "description",
                 "value": [
                     {
-                        "text": "PF2E.SpecificRule.ResonantReflection.ReflectionOfWater.Description"
+                        "text": "PF2E.SpecificRule.ResonantReflection.ReflectionOfWater.Description",
+                        "title": "PF2E.SpecificRule.ResonantReflection.ReflectionOfWater.Title"
                     }
                 ]
             },
             {
-                "itemType": "action",
-                "key": "ItemAlteration",
-                "mode": "add",
-                "predicate": [
-                    "item:slug:resonant-reflection"
+                "alwaysActive": true,
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.ResonantReflection.Label",
+                "mergeable": true,
+                "option": "resonant",
+                "placement": "actions",
+                "suboptions": [
+                    {
+                        "label": "{item|name}",
+                        "value": "reflection-of-water"
+                    }
                 ],
-                "property": "traits",
-                "value": "water"
+                "toggleable": true
             },
             {
                 "allowDuplicate": false,
                 "key": "GrantItem",
+                "predicate": [
+                    {
+                        "nor": [
+                            "item:slug:resonant-reflection-reflection-of-stone",
+                            "item:slug:resonant-reflection-reflection-of-storm",
+                            "item:slug:resonant-reflection-reflection-of-life",
+                            "item:slug:resonant-reflection-reflection-of-light"
+                        ]
+                    }
+                ],
+                "reevaluateOnUpdate": true,
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Activate Resonant Reflection"
             }
         ],

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -3681,20 +3681,26 @@
                 }
             },
             "ResonantReflection": {
+                "Label":"Active Resonant Reflection",
                 "ReflectionOfLife": {
-                    "Description": "**Effect** You gain fast healing 3 for 1 minute. This amount of fast healing increases by 1 for every 2 levels you have beyond 5th level</p>\n<p>@UUID[Compendium.pf2e.campaign-effects.Item.DOxl0FDd21VMDOMP]{Effect: Reflection of Life (Fast Healing)}."
+                    "Description": "You gain fast healing 3 for 1 minute. This amount of fast healing increases by 1 for every 2 levels you have beyond 5th level</p>\n<p>@UUID[Compendium.pf2e.campaign-effects.Item.DOxl0FDd21VMDOMP]{Effect: Reflection of Life (Fast Healing)}.",
+                    "Title" : "Reflection of Life"
                 },
                 "ReflectionOfLight": {
-                    "Description": "**Effect** You cast @UUID[Compendium.pf2e.spells-srd.Item.DyiD239dNS7RIxZE]{Holy Light} as an innate divine spell, heightened to a spell rank equal to half your level rounded up."
+                    "Description": "You cast @UUID[Compendium.pf2e.spells-srd.Item.DyiD239dNS7RIxZE]{Holy Light} as an innate divine spell, heightened to a spell rank equal to half your level rounded up.",
+                    "Title" : "Reflection of Life"
                 },
                 "ReflectionOfStone": {
-                    "Description": "**Effect** You cast @UUID[Compendium.pf2e.spells-srd.Item.2BV2yYPfVJ5zirZt]{Mountain Resilience} as an innate divine spell, heightened to a spell rank equal to half your level rounded up."
+                    "Description": "You cast @UUID[Compendium.pf2e.spells-srd.Item.2BV2yYPfVJ5zirZt]{Mountain Resilience} as an innate divine spell, heightened to a spell rank equal to half your level rounded up.",
+                    "Title" : "Reflection of Stone"
                 },
                 "ReflectionOfStorm": {
-                    "Description": "**Effect** You cast @UUID[Compendium.pf2e.spells-srd.Item.4MOew29Z1oCX8O28]{Moment of Renewal} (self only) as an 8th-rank divine innate spell and regain 1 Focus Point."
+                    "Description": "You cast @UUID[Compendium.pf2e.spells-srd.Item.4MOew29Z1oCX8O28]{Moment of Renewal} (self only) as an 8th-rank divine innate spell and regain 1 Focus Point.",
+                    "Title" : "Reflection of Storm"
                 },
                 "ReflectionOfWater" : {
-                    "Description": "**Effect** You cast @UUID[Compendium.pf2e.spells-srd.Item.zfn5RqAdF63neqpP]{Control Water} as a 5th-rank innate divine spell. The area of water you control increases by 10 feet in length and width for every 2 levels you have beyond 10th level."
+                    "Description": "You cast @UUID[Compendium.pf2e.spells-srd.Item.zfn5RqAdF63neqpP]{Control Water} as a 5th-rank innate divine spell. The area of water you control increases by 10 feet in length and width for every 2 levels you have beyond 10th level.",
+                    "Title" : "Reflection of Water"
                 }
             },
             "Rogue": {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -3680,6 +3680,23 @@
                     "Success": "If the target is evil, it is also @UUID[Compendium.pf2e.conditionitems.Item.MIRkyAjyBeXivMa7]{Enfeebled 1} until the start of your next turn on a hit."
                 }
             },
+            "ResonantReflection": {
+                "ReflectionOfLife": {
+                    "Description": "**Effect** You gain fast healing 3 for 1 minute. This amount of fast healing increases by 1 for every 2 levels you have beyond 5th level</p>\n<p>@UUID[Compendium.pf2e.campaign-effects.Item.DOxl0FDd21VMDOMP]{Effect: Reflection of Life (Fast Healing)}."
+                },
+                "ReflectionOfLight": {
+                    "Description": "**Effect** You cast @UUID[Compendium.pf2e.spells-srd.Item.DyiD239dNS7RIxZE]{Holy Light} as an innate divine spell, heightened to a spell rank equal to half your level rounded up."
+                },
+                "ReflectionOfStone": {
+                    "Description": "**Effect** You cast @UUID[Compendium.pf2e.spells-srd.Item.2BV2yYPfVJ5zirZt]{Mountain Resilience} as an innate divine spell, heightened to a spell rank equal to half your level rounded up."
+                },
+                "ReflectionOfStorm": {
+                    "Description": "**Effect** You cast @UUID[Compendium.pf2e.spells-srd.Item.4MOew29Z1oCX8O28]{Moment of Renewal} (self only) as an 8th-rank divine innate spell and regain 1 Focus Point."
+                },
+                "ReflectionOfWater" : {
+                    "Description": "**Effect** You cast @UUID[Compendium.pf2e.spells-srd.Item.zfn5RqAdF63neqpP]{Control Water} as a 5th-rank innate divine spell. The area of water you control increases by 10 feet in length and width for every 2 levels you have beyond 10th level."
+                }
+            },
             "Rogue": {
                 "Debilitation": {
                     "Bloody": {


### PR DESCRIPTION
- Created `Activate Resonant Reflection` action.
- Added Item Alteration RE to the corresponding Resonant Reflection items to add the effect description and traits to the  `Activate Resonant Reflection` action.
- Added Grant Item RE to the above items.
- Localized the descriptions in re-en.json.