### PR TITLE
Allow posting action macros from Generate Check Prompt macro

### DIFF
--- a/src/scripts/macros/check-prompt/helpers.ts
+++ b/src/scripts/macros/check-prompt/helpers.ts
@@ -23,4 +23,10 @@ async function getActions(): Promise<Record<string, string>> {
     }
 }
 
-export { getActions, loreSkillsFromActors };
+function getVariants(slug: string): Record<string, string> {
+    const action = game.pf2e.actions.get(slug);
+    const variants = action?.variants.map((v) => [v.slug, v.name])
+    return variants ? Object.fromEntries(variants) : {}
+}
+
+export { getActions, getVariants, loreSkillsFromActors };

--- a/src/scripts/macros/check-prompt/helpers.ts
+++ b/src/scripts/macros/check-prompt/helpers.ts
@@ -23,10 +23,15 @@ async function getActions(): Promise<Record<string, string>> {
     }
 }
 
-function getVariants(slug: string): Record<string, string> {
-    const action = game.pf2e.actions.get(slug);
-    const variants = action?.variants.map((v) => [v.slug, v.name])
+function getMacros(): Record<string, string> {
+    const actions = game.pf2e.actions.map((a) => [a.slug, a.name]);
+    return actions ? Object.fromEntries(actions) : {}
+}
+
+function getVariants(): Record<string, string> {
+    const actions = game.pf2e.actions;
+    const variants = actions.map((a) => a.variants.map((v) => [v.slug, v.name])).flat();
     return variants ? Object.fromEntries(variants) : {}
 }
 
-export { getActions, getVariants, loreSkillsFromActors };
+export { getActions, getMacros, getVariants, loreSkillsFromActors };

--- a/src/scripts/macros/check-prompt/prompt.ts
+++ b/src/scripts/macros/check-prompt/prompt.ts
@@ -5,7 +5,7 @@ import { adjustDC, calculateDC, calculateSimpleDC, DCAdjustment } from "@module/
 import { ActionDefaultOptions } from "@system/action-macros/types.ts";
 import { htmlQuery, signedInteger, tagify, tupleHasValue } from "@util";
 import * as R from "remeda";
-import { getActions, getVariants, loreSkillsFromActors } from "./helpers.ts";
+import { getActions, getMacros, getVariants, loreSkillsFromActors } from "./helpers.ts";
 
 interface CheckPromptDialogOptions extends ApplicationOptions {
     actors: CharacterPF2e[];
@@ -30,6 +30,7 @@ interface TagifyValue {
 class CheckPromptDialog extends Application<CheckPromptDialogOptions> {
     #actions?: Record<string, string>;
     #lores?: Record<string, string>;
+    #macros?: Record<string, string>;
     #variants?: Record<string, string>;
 
     static override get defaultOptions(): ApplicationOptions {
@@ -50,7 +51,8 @@ class CheckPromptDialog extends Application<CheckPromptDialogOptions> {
 
     override async getData(): Promise<CheckPromptDialogData> {
         this.#actions = await getActions();
-        this.#variants = {};
+        this.#macros = getMacros();
+        this.#variants = getVariants();
         this.#lores = loreSkillsFromActors(this.options.actors ?? game.actors.party?.members ?? []);
 
         return {
@@ -94,15 +96,15 @@ class CheckPromptDialog extends Application<CheckPromptDialogOptions> {
         tagify(saveEl, { whitelist: CONFIG.PF2E.saves });
 
         const actionEl = html.querySelector<HTMLInputElement>("input#check-prompt-actions");
-        const actionOptions = R.isEmpty(this.#actions || {})
+        const actionOptions = R.isEmpty(this.#macros || {})
             ? {}
-            : { whitelist: this.#actions, enforceWhitelist: false };
+            : { whitelist: this.#macros, maxTags: 1 };
         tagify(actionEl, actionOptions);
 
         const variantsEl = html.querySelector<HTMLInputElement>("input#check-prompt-variants");
         const variants = R.isEmpty(this.#variants || {})
             ? {}
-            : { whitelist: this.#variants, enforceWhitelist: false };
+            : { whitelist: this.#variants, maxTags: 1 };
         tagify(variantsEl, variants);
 
         const traitEl = html.querySelector<HTMLInputElement>("input#check-prompt-traits");
@@ -172,16 +174,14 @@ class CheckPromptDialog extends Application<CheckPromptDialogOptions> {
             const flavor = titleEl?.value ? `<h4 class="action"><strong>${titleEl.value}</strong></h4><hr>` : "";
 
             const dc = this.#getDC(html);
-            const content =
-                actions.length > 0 && types.length === 0
-                    ? actions.map((action) => this.#constructAction(action, variants[0], dc, null)).join("")
-                    : actions.length === types.length
-                      ? R.zip(actions, types)
-                            .map((value) => this.#constructAction(value[0], variants[0], dc, value[1]))
-                            .join("")
-                      : actions.length === 1
-                        ? types.map((type) => this.#constructAction(actions[0], variants[0], dc, type)).join("")
-                        : types.map((type) => this.#constructCheck(type, dc, traits, extras)).join("");
+            let content: string = "";
+            if (actions.length > 0 && types.length > 0) {
+                content = types.map((type) => this.#constructAction(actions[0], variants[0], dc, type)).join("")
+            } else if (actions.length > 0 && types.length === 0) {
+                content = actions.map((action) => this.#constructAction(action, variants[0], dc, null)).join("")
+            } else {
+                content = types.map((type) => this.#constructCheck(type, dc, traits, extras)).join("");
+            }
 
             ChatMessagePF2e.create({ author: game.user.id, flavor, content });
         }

--- a/src/scripts/macros/check-prompt/prompt.ts
+++ b/src/scripts/macros/check-prompt/prompt.ts
@@ -125,6 +125,7 @@ class CheckPromptDialog extends Application<CheckPromptDialogOptions> {
         const html = this.element[0];
         const types: string[] = [];
         const traits: string[] = [];
+        const actions: string[] = [];
         const extras: string[] = [];
         const activeSkillSaveTab = htmlQuery(html, "section.check-prompt-content section.tab.active");
         if (activeSkillSaveTab?.dataset.tab === "skills") {
@@ -136,6 +137,7 @@ class CheckPromptDialog extends Application<CheckPromptDialogOptions> {
             // get trait tags
             traits.push(...this.#htmlQueryTags(html, "input#check-prompt-traits"));
             // get action tags
+            actions.push(...this.#htmlQueryTags(html, "input#check-prompt-actions").map((a) => a.toLowerCase().replace("action:", "").trim()));
             traits.push(
                 ...this.#htmlQueryTags(html, "input#check-prompt-actions").map((a) => this.#formatActionType(a)),
             );
@@ -153,7 +155,9 @@ class CheckPromptDialog extends Application<CheckPromptDialogOptions> {
             const flavor = titleEl?.value ? `<h4 class="action"><strong>${titleEl.value}</strong></h4><hr>` : "";
 
             const dc = this.#getDC(html);
-            const content = types.map((type) => this.#constructCheck(type, dc, traits, extras)).join("");
+            const content = actions.length !== 0 ?
+                actions.map((action) => this.#constructAction(action, dc, types[0])).join("") :
+                types.map((type) => this.#constructCheck(type, dc, traits, extras)).join("")
 
             ChatMessagePF2e.create({ author: game.user.id, flavor, content });
         }
@@ -211,6 +215,15 @@ class CheckPromptDialog extends Application<CheckPromptDialogOptions> {
             .concat(...extras)
             .filter((p) => p);
         return `<p>@Check[${parts.join("|")}]</p>`;
+    }
+
+    #constructAction(action: string, dc: number | null, statistic: string): string {
+        const parts = [
+            action,
+            statistic ? `statistic=${statistic}` : null,
+            Number.isInteger(dc) ? `dc=${dc}` : null,            
+        ]
+        return `<p>[[/act ${parts.join(" ")}]]</p>`;
     }
 }
 

--- a/src/scripts/macros/check-prompt/prompt.ts
+++ b/src/scripts/macros/check-prompt/prompt.ts
@@ -83,10 +83,10 @@ class CheckPromptDialog extends Application<CheckPromptDialogOptions> {
         const skillsAndLoresEl = html.querySelector<HTMLInputElement>("input#check-prompt-skills");
         const skillsAndLores = {
             ...R.mapValues(CONFIG.PF2E.skills, (s) => s.label),
-            ...R.isEmpty(this.#lores || {}) ? {} : this.#lores,
+            ...(R.isEmpty(this.#lores || {}) ? {} : this.#lores),
             perception: "PF2E.PerceptionLabel",
-        }
-        tagify(skillsAndLoresEl, { whitelist: skillsAndLores })
+        };
+        tagify(skillsAndLoresEl, { whitelist: skillsAndLores });
 
         const saveEl = html.querySelector<HTMLInputElement>("input#check-prompt-saves");
         tagify(saveEl, { whitelist: CONFIG.PF2E.saves });
@@ -160,14 +160,16 @@ class CheckPromptDialog extends Application<CheckPromptDialogOptions> {
             const flavor = titleEl?.value ? `<h4 class="action"><strong>${titleEl.value}</strong></h4><hr>` : "";
 
             const dc = this.#getDC(html);
-            const content = actions.length > 0 && types.length === 0 ? actions.map((action) => this.#constructAction(action, dc, null)).join("") :
-                actions.length === types.length
-                    ? R.zip(actions, types)
-                          .map((value) => this.#constructAction(value[0], dc, value[1]))
-                          .join("")
-                    : actions.length === 1
-                      ? types.map((type) => this.#constructAction(actions[0], dc, type)).join("")
-                      : types.map((type) => this.#constructCheck(type, dc, traits, extras)).join("");
+            const content =
+                actions.length > 0 && types.length === 0
+                    ? actions.map((action) => this.#constructAction(action, dc, null)).join("")
+                    : actions.length === types.length
+                      ? R.zip(actions, types)
+                            .map((value) => this.#constructAction(value[0], dc, value[1]))
+                            .join("")
+                      : actions.length === 1
+                        ? types.map((type) => this.#constructAction(actions[0], dc, type)).join("")
+                        : types.map((type) => this.#constructCheck(type, dc, traits, extras)).join("");
 
             ChatMessagePF2e.create({ author: game.user.id, flavor, content });
         }

--- a/src/scripts/macros/check-prompt/prompt.ts
+++ b/src/scripts/macros/check-prompt/prompt.ts
@@ -97,6 +97,9 @@ class CheckPromptDialog extends Application<CheckPromptDialogOptions> {
             : { whitelist: this.#actions, enforceWhitelist: false };
         tagify(actionEl, actionOptions);
 
+        const variantsEl = html.querySelector<HTMLInputElement>("input#check-prompt-variants");
+        tagify(variantsEl)
+
         const traitEl = html.querySelector<HTMLInputElement>("input#check-prompt-traits");
         tagify(traitEl, { whitelist: CONFIG.PF2E.actionTraits, enforceWhitelist: false });
 
@@ -127,6 +130,7 @@ class CheckPromptDialog extends Application<CheckPromptDialogOptions> {
         const types: string[] = [];
         const traits: string[] = [];
         const actions: string[] = [];
+        const variants: string[] = [];
         const extras: string[] = [];
         const activeSkillSaveTab = htmlQuery(html, "section.check-prompt-content section.tab.active");
         if (activeSkillSaveTab?.dataset.tab === "skills") {
@@ -134,6 +138,11 @@ class CheckPromptDialog extends Application<CheckPromptDialogOptions> {
             actions.push(
                 ...this.#htmlQueryTags(html, "input#check-prompt-actions").map((a) =>
                     a.toLowerCase().replace("action:", "").trim(),
+                ),
+            );
+            variants.push(
+                ...this.#htmlQueryTags(html, "input#check-prompt-variants").map((v) =>
+                    v.toLowerCase().trim(),
                 ),
             );
             // get skill tags
@@ -162,13 +171,13 @@ class CheckPromptDialog extends Application<CheckPromptDialogOptions> {
             const dc = this.#getDC(html);
             const content =
                 actions.length > 0 && types.length === 0
-                    ? actions.map((action) => this.#constructAction(action, dc, null)).join("")
+                    ? actions.map((action) => this.#constructAction(action, variants[0], dc, null)).join("")
                     : actions.length === types.length
                       ? R.zip(actions, types)
-                            .map((value) => this.#constructAction(value[0], dc, value[1]))
+                            .map((value) => this.#constructAction(value[0], variants[0], dc, value[1]))
                             .join("")
                       : actions.length === 1
-                        ? types.map((type) => this.#constructAction(actions[0], dc, type)).join("")
+                        ? types.map((type) => this.#constructAction(actions[0], variants[0], dc, type)).join("")
                         : types.map((type) => this.#constructCheck(type, dc, traits, extras)).join("");
 
             ChatMessagePF2e.create({ author: game.user.id, flavor, content });
@@ -229,8 +238,8 @@ class CheckPromptDialog extends Application<CheckPromptDialogOptions> {
         return `<p>@Check[${parts.join("|")}]</p>`;
     }
 
-    #constructAction(action: string, dc: number | null, statistic: string | null): string {
-        const parts = [action, statistic ? `statistic=${statistic}` : null, Number.isInteger(dc) ? `dc=${dc}` : null];
+    #constructAction(action: string, variant: string | null, dc: number | null, statistic: string | null): string {
+        const parts = [action, variant ? `variant=${variant}` : null, statistic ? `statistic=${statistic}` : null, Number.isInteger(dc) ? `dc=${dc}` : null];
         return `[[/act ${parts.join(" ")}]]`;
     }
 }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -99,6 +99,7 @@
             }
         },
         "ActionActionTypeLabel": "Action Type",
+        "ActionActionVariants": "Action Variants",
         "ActionActionsLabel": "Actions",
         "ActionBrowserSearchHint": "You can search for name or custom attributes. Possible searchable attributes are:<br> source, spellType, level, materials, target, range, time, duration, damage, damageType, save, concentration, ritual, ability and classes. <br>Example: 'fire, damage:d6' to show all spells that have fire in their name and a d6 in the damage",
         "ActionDeathNoteLabel": "Death Note",

--- a/static/templates/gm/check-prompt.hbs
+++ b/static/templates/gm/check-prompt.hbs
@@ -56,10 +56,10 @@
         <section class="check-prompt-content">
             <section class="tab skill-prompt active" data-tab="skills">
                 <div class="form-group">
+                        <input id="check-prompt-actions" placeholder="{{localize "PF2E.ActionActionsLabel"}}" />
+                    </div>
+                <div class="form-group">
                     <input id="check-prompt-skills" placeholder="{{localize "PF2E.Actor.Party.CheckPrompt.ChooseSkills"}}" />
-                </div>
-                <div class="form-group lores">
-                    <input id="check-prompt-lores" placeholder="{{localize "PF2E.Actor.Party.CheckPrompt.ChooseLores"}}" />
                 </div>
                 <div class="form-group">
                     <div class="form-group add-roll-options-group">
@@ -72,7 +72,7 @@
                 </div>
                 <div class="roll-options hidden">
                     <div class="form-group">
-                        <input id="check-prompt-actions" placeholder="{{localize "PF2E.ActionActionsLabel"}}" />
+                        <input id="check-prompt-action-traits" placeholder="{{localize "PF2E.ActionActionsLabel"}}" />
                     </div>
                     <div class="form-group">
                         <input id="check-prompt-traits" placeholder="{{localize "PF2E.ChatRollDetails.RollOptions"}}" />

--- a/static/templates/gm/check-prompt.hbs
+++ b/static/templates/gm/check-prompt.hbs
@@ -57,7 +57,10 @@
             <section class="tab skill-prompt active" data-tab="skills">
                 <div class="form-group">
                         <input id="check-prompt-actions" placeholder="{{localize "PF2E.ActionActionsLabel"}}" />
-                    </div>
+                </div>
+                <div class="form-group">
+                        <input id="check-prompt-variants" placeholder="{{localize "PF2E.ActionActionVariants"}}" />
+                </div>
                 <div class="form-group">
                     <input id="check-prompt-skills" placeholder="{{localize "PF2E.Actor.Party.CheckPrompt.ChooseSkills"}}" />
                 </div>


### PR DESCRIPTION
This adds an ability to (optionally) post checks using inline action macro syntax.
![image](https://github.com/user-attachments/assets/5606ccf9-3422-462c-88f1-3da391baa12c)
Action and variant field are limited to 1 item each, to preserve old functionality and to avoid over-complicated logic.
One action can be used with multiple skills (including lore skills, which were combined with skills to one input field).