### PR TITLE
Fix regression with character strike name not wrapping

### DIFF
--- a/src/styles/actor/character/_actions.scss
+++ b/src/styles/actor/character/_actions.scss
@@ -80,19 +80,16 @@
                 grid-area: "img";
                 width: 2rem;
                 height: 2rem;
-                margin-top: var(--space-4);
+                margin-top: var(--space-2);
             }
 
-            .item-name {
+            h4.name {
                 align-items: baseline;
                 display: flex;
                 width: 100%;
                 gap: var(--space-4);
-
-                h4 {
-                    margin: 0;
-                    flex: 0 0 auto;
-                }
+                margin: 0;
+                line-height: 1;
 
                 // Elemental blasts
                 .item-controls {
@@ -107,7 +104,7 @@
                 flex-wrap: nowrap;
                 font-size: var(--font-size-14);
                 margin-bottom: 0;
-                padding: 2px 0;
+                padding: var(--space-2) 0;
 
                 button {
                     border: none;
@@ -179,6 +176,7 @@
             .auxiliary-actions {
                 display: flex;
                 gap: 3px;
+                padding: var(--space-2) 0;
 
                 button {
                     // Modular damage select menu

--- a/src/styles/actor/tabs/_actions.scss
+++ b/src/styles/actor/tabs/_actions.scss
@@ -158,56 +158,6 @@ ol.actions-list {
         }
 
         &.action {
-            .item-name {
-                align-items: center;
-                display: flex;
-                gap: var(--space-8);
-                grid-area: icon-name;
-                margin: 0;
-
-                h4 {
-                    margin: 0;
-                    max-width: fit-content;
-                }
-
-                .actions-title {
-                    flex: 1;
-
-                    .action-name {
-                        align-items: baseline;
-                        display: flex;
-                        flex-direction: row;
-                        gap: 0.5em;
-
-                        > h4 {
-                            a:hover {
-                                color: var(--color-pf-primary);
-                            }
-
-                            .action-glyph {
-                                color: var(--text-dark);
-                            }
-                        }
-                    }
-                }
-            }
-
-            .item-controls {
-                font-size: var(--font-size-12);
-                grid-area: controls;
-                white-space: nowrap;
-            }
-
-            .item-summary {
-                flex-basis: 100%;
-            }
-
-            &.hidden {
-                display: none;
-            }
-        }
-
-        &.action {
             align-items: center;
             column-gap: var(--space-8);
             display: grid;
@@ -216,6 +166,10 @@ ol.actions-list {
                 "icon    buttons tracking controls" auto
                 "summary summary summary   summary" auto
                 / min-content 1fr min-content 2rem;
+
+            &.hidden {
+                display: none;
+            }
 
             > .icon {
                 grid-area: icon;
@@ -235,6 +189,12 @@ ol.actions-list {
                 > a:hover {
                     color: var(--color-pf-primary);
                 }
+            }
+
+            .item-controls {
+                font-size: var(--font-size-12);
+                grid-area: controls;
+                white-space: nowrap;
             }
 
             .button-group {

--- a/static/templates/actors/character/partials/elemental-blast.hbs
+++ b/static/templates/actors/character/partials/elemental-blast.hbs
@@ -9,14 +9,14 @@
     </div>
     <section>
         {{#unless omitName}}
-            <div class="item-name" data-tooltip-direction="UP">
-                <h4 class="name"><a data-action="toggle-summary">{{localize action.label}}</a></h4>
+            <h4 class="name" data-tooltip-direction="UP">
+                <a data-action="toggle-summary">{{localize action.label}}</a>
                 <div class="item-controls">
                     {{#if (and @root.editable (eq @index 0))}}
                         <a data-action="edit-item" data-tooltip="PF2E.EditItemTitle"><i class="fa-solid fa-fw fa-edit"></i></a>
                     {{/if}}
                 </div>
-            </div>
+            </h4>
         {{/unless}}
 
         {{#> attackDamage action=action melee=true}}{{/attackDamage}}

--- a/static/templates/actors/character/partials/strike.hbs
+++ b/static/templates/actors/character/partials/strike.hbs
@@ -5,8 +5,8 @@
     </div>
     <section>
         {{#unless omitName}}
-            <div class="item-name">
-                <h4 class="name"><a data-action="toggle-summary">{{action.label}}</a></h4>
+            <h4 class="name">
+                <a data-action="toggle-summary">{{action.label}}</a>
                 {{#if action.item.isTemporary}}
                     <i
                         class="fa-solid fa-info-circle"
@@ -14,7 +14,7 @@
                         data-tooltip-direction="RIGHT"
                     ></i>
                 {{/if}}
-            </div>
+            </h4>
         {{/unless}}
 
         {{#if action.ready}}


### PR DESCRIPTION
Also simplifies the HTML a bit and reduces vertical space expenditure when wrapping occurs.

![image](https://github.com/user-attachments/assets/5da425f9-68fd-4f27-a6c0-0e5baf4a3ff5)
