### PR TITLE
undo breaking changes in en.json

### DIFF
--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -5532,12 +5532,6 @@
             "greaterDecaying": {
                 "Name": "Greater Decaying"
             },
-            "greaterDisrupting": {
-                "Name": "Greater Vitalizing",
-                "Note": {
-                    "criticalSuccess": "On a critical hit, the undead creature is @UUID[Compendium.pf2e.conditionitems.Item.MIRkyAjyBeXivMa7]{Enfeebled 1} and @UUID[Compendium.pf2e.conditionitems.Item.e1XGnhKNSQIm5IXg]{Stupefied 1} as long as it has the persistent damage from this rune."
-                }
-            },
             "greaterExtending": {
                 "Name": "Greater Extending"
             },
@@ -5598,6 +5592,12 @@
                 "Note": {
                     "criticalSuccess": "Sonic damage dealt by this weapon ignores the target's sonic resistance. On a critical hit, the target has to succeed at a @Check[type:fortitude|dc:34|name:Greater Thundering Rune] save or be @UUID[Compendium.pf2e.conditionitems.Item.9PR9y0bi4JPKnHPR]{Deafened} permanently.",
                     "success": "Sonic damage dealt by this weapon ignores the target's sonic resistance."
+                }
+            },
+            "greaterVitalizing": {
+                "Name": "Greater Vitalizing",
+                "Note": {
+                    "criticalSuccess": "On a critical hit, the undead creature is @UUID[Compendium.pf2e.conditionitems.Item.MIRkyAjyBeXivMa7]{Enfeebled 1} and @UUID[Compendium.pf2e.conditionitems.Item.e1XGnhKNSQIm5IXg]{Stupefied 1} as long as it has the persistent damage from this rune."
                 }
             },
             "grievous": {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -5361,7 +5361,7 @@
             "ancestralEchoing": {
                 "Name": "Ancestral Echoing"
             },
-            "animated": {
+            "dancing": {
                 "Name": "Animated"
             },
             "anchoring": {
@@ -5594,7 +5594,7 @@
                     "success": "Sonic damage dealt by this weapon ignores the target's sonic resistance."
                 }
             },
-            "greaterVitalizing": {
+            "greaterDisrupting": {
                 "Name": "Greater Vitalizing",
                 "Note": {
                     "criticalSuccess": "On a critical hit, the undead creature is @UUID[Compendium.pf2e.conditionitems.Item.MIRkyAjyBeXivMa7]{Enfeebled 1} and @UUID[Compendium.pf2e.conditionitems.Item.e1XGnhKNSQIm5IXg]{Stupefied 1} as long as it has the persistent damage from this rune."
@@ -5708,7 +5708,7 @@
                 "Name": "Shockwave",
                 "Note": "Strikes with this weapon deal bludgeoning splash damage equal to the number of weapon damage dice. You're immune to this splash damage."
             },
-            "spellReservoir": {
+            "spellStoring": {
                 "Name": "Spell Reservoir"
             },
             "swarming": {
@@ -5735,7 +5735,7 @@
                     "criticalSuccess": "Unholy Bloodshed <span class='pf2-icon'>R</span> (concentrate)</p><p><strong>Frequency</strong> once per day</p><p><strong>Trigger</strong> You critically succeed at an attack roll against a holy creature with the weapon</p><hr /><p><strong>Effect</strong> The target takes persistent bleed damage equal to 1d8 per weapon damage die of the etched weapon."
                 }
             },
-            "vitalizing": {
+            "disrupting": {
                 "Name": "Vitalizing",
                 "Note": {
                     "criticalSuccess": "On a critical hit, the undead is also @UUID[Compendium.pf2e.conditionitems.Item.MIRkyAjyBeXivMa7]{Enfeebled 1} until the end of your next turn."

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -5532,6 +5532,12 @@
             "greaterDecaying": {
                 "Name": "Greater Decaying"
             },
+            "greaterDisrupting": {
+                "Name": "Greater Vitalizing",
+                "Note": {
+                    "criticalSuccess": "On a critical hit, the undead creature is @UUID[Compendium.pf2e.conditionitems.Item.MIRkyAjyBeXivMa7]{Enfeebled 1} and @UUID[Compendium.pf2e.conditionitems.Item.e1XGnhKNSQIm5IXg]{Stupefied 1} as long as it has the persistent damage from this rune."
+                }
+            },
             "greaterExtending": {
                 "Name": "Greater Extending"
             },
@@ -5592,12 +5598,6 @@
                 "Note": {
                     "criticalSuccess": "Sonic damage dealt by this weapon ignores the target's sonic resistance. On a critical hit, the target has to succeed at a @Check[type:fortitude|dc:34|name:Greater Thundering Rune] save or be @UUID[Compendium.pf2e.conditionitems.Item.9PR9y0bi4JPKnHPR]{Deafened} permanently.",
                     "success": "Sonic damage dealt by this weapon ignores the target's sonic resistance."
-                }
-            },
-            "greaterDisrupting": {
-                "Name": "Greater Vitalizing",
-                "Note": {
-                    "criticalSuccess": "On a critical hit, the undead creature is @UUID[Compendium.pf2e.conditionitems.Item.MIRkyAjyBeXivMa7]{Enfeebled 1} and @UUID[Compendium.pf2e.conditionitems.Item.e1XGnhKNSQIm5IXg]{Stupefied 1} as long as it has the persistent damage from this rune."
                 }
             },
             "grievous": {


### PR DESCRIPTION
I caught this one while checking on an issue. This was a miss on my part.

As it turns out, changing the whole container breaks the labels on the drop-down menu in the Property Runes section. 

Will see about possibly updating this with proper guidance once we get over the PC2 rush