### PR TITLE
Add traits and roll-options parameters to /act inline links

### DIFF
--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -427,6 +427,7 @@ class TextEditorPF2e extends TextEditor {
         // attributes
         const aliases: Record<string, string> = {
             ["difficulty-class"]: "dc",
+            ["roll-options"]: "options",
             stat: "skill",
             statistic: "skill",
         };
@@ -494,7 +495,10 @@ class TextEditorPF2e extends TextEditor {
         }
 
         // traits
-        const traits = variant?.traits ?? action.traits;
+        const additionalTraits = splitListString(params["traits"] ?? "").filter(
+            (trait): trait is ActionTrait => trait in CONFIG.PF2E.actionTraits,
+        );
+        const traits = R.unique([variant?.traits ?? action.traits, additionalTraits].flat());
 
         // traits as tooltip
         element.dataset["tooltip"] = traits

--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -94,17 +94,22 @@ export class InlineRollLinks {
     }
 
     static #onClickInlineAction(event: MouseEvent, link: HTMLAnchorElement | HTMLSpanElement): void {
-        const { pf2Action, pf2Glyph, pf2Variant, pf2Dc, pf2ShowDc, pf2Skill } = link.dataset;
+        const { pf2Action, pf2Glyph, pf2Variant, pf2Dc, pf2ShowDc, pf2Skill, pf2Options, pf2Traits } = link.dataset;
 
         const slug = sluggify(pf2Action ?? "");
         const visibility = pf2ShowDc ?? "all";
         const difficultyClass = Number.isNumeric(pf2Dc)
             ? { scope: "check", value: Number(pf2Dc) || 0, visibility }
             : pf2Dc;
+        const maybeTraits = splitListString(pf2Traits ?? "");
+        const traits = maybeTraits.filter((trait): trait is ActionTrait => trait in CONFIG.PF2E.actionTraits);
+        const rollOptions = R.unique(
+            [maybeTraits, traits.map((trait) => `item:trait:${trait}`), splitListString(pf2Options ?? "")].flat(),
+        );
         if (slug && game.pf2e.actions.has(slug)) {
             game.pf2e.actions
                 .get(slug)
-                ?.use({ event, variant: pf2Variant, difficultyClass, statistic: pf2Skill })
+                ?.use({ event, variant: pf2Variant, difficultyClass, rollOptions, statistic: pf2Skill, traits })
                 .catch((reason: string) => ui.notifications.warn(reason));
         } else {
             const action = game.pf2e.actions[pf2Action ? sluggify(pf2Action, { camel: "dromedary" }) : ""];
@@ -114,7 +119,9 @@ export class InlineRollLinks {
                     glyph: pf2Glyph,
                     variant: pf2Variant,
                     difficultyClass,
+                    rollOptions,
                     skill: pf2Skill,
+                    traits,
                 });
             } else {
                 console.warn(`PF2e System | Skip executing unknown action '${pf2Action}'`);


### PR DESCRIPTION
```
[[/act demoralise roll-options=some:other:option traits=bravado]]
```
Or using the `options` alias:
```
[[/act demoralise options=some:other:option traits=bravado]]
```