### PR TITLE
add separate effect for aura to the Bane spell

### DIFF
--- a/packs/spell-effects/aura-bane.json
+++ b/packs/spell-effects/aura-bane.json
@@ -1,0 +1,54 @@
+{
+    "_id": "8vKTSlpWnGPnL1UB",
+    "img": "systems/pf2e/icons/spells/bane.webp",
+    "name": "Aura: Bane",
+    "system": {
+        "badge": {
+            "labels": [
+                "10 ft.",
+                "20 ft.",
+                "30 ft.",
+                "40 ft.",
+                "50 ft.",
+                "60 ft."
+            ],
+            "loop": false,
+            "type": "counter",
+            "value": 1
+        },
+        "description": {
+            "value": "<p><span style=\"font-family:Roboto, sans-serif\">Granted by @UUID[Compendium.pf2e.spells-srd.Item.Bane]</span></p>\n<p><span style=\"font-family:Roboto, sans-serif\">You fill the minds of your enemies with doubt. Enemies in the area must succeed at a Will save or take a –1 status penalty to attack rolls as long as they are in the area. Once per round on subsequent turns, you can Sustain the spell to increase the emanation's radius by 10 feet and force enemies in the area that weren't yet affected to attempt another saving throw.</span></p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "minutes",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "rules": [
+            {
+                "key": "Aura",
+                "radius": "@item.badge.value * 10"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/spell-effects/aura-bane.json
+++ b/packs/spell-effects/aura-bane.json
@@ -17,7 +17,7 @@
             "value": 1
         },
         "description": {
-            "value": "<p><span style=\"font-family:Roboto, sans-serif\">Granted by @UUID[Compendium.pf2e.spells-srd.Item.Bane]</span></p>\n<p><span style=\"font-family:Roboto, sans-serif\">You fill the minds of your enemies with doubt. Enemies in the area must succeed at a Will save or take a –1 status penalty to attack rolls as long as they are in the area. Once per round on subsequent turns, you can Sustain the spell to increase the emanation's radius by 10 feet and force enemies in the area that weren't yet affected to attempt another saving throw.</span></p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Bane]</p>\n<p>Once per round on subsequent turns, you can Sustain the spell to increase the emanation's radius by 10 feet.</p>"
         },
         "duration": {
             "expiry": "turn-start",

--- a/packs/spell-effects/spell-effect-bane.json
+++ b/packs/spell-effects/spell-effect-bane.json
@@ -7,10 +7,10 @@
             "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Bane].</p>\n<p>You take a -1 status penalty to attack rolls.</p>"
         },
         "duration": {
-            "expiry": null,
+            "expiry": "turn-start",
             "sustained": false,
-            "unit": "unlimited",
-            "value": -1
+            "unit": "minutes",
+            "value": 1
         },
         "level": {
             "value": 1
@@ -21,6 +21,9 @@
             "title": "Pathfinder Player Core"
         },
         "rules": [
+            {
+                "key": "RollOption"
+            },
             {
                 "key": "FlatModifier",
                 "selector": "attack",

--- a/packs/spell-effects/spell-effect-bane.json
+++ b/packs/spell-effects/spell-effect-bane.json
@@ -22,9 +22,6 @@
         },
         "rules": [
             {
-                "key": "RollOption"
-            },
-            {
                 "key": "FlatModifier",
                 "selector": "attack",
                 "type": "status",

--- a/packs/spell-effects/spell-effect-bane.json
+++ b/packs/spell-effects/spell-effect-bane.json
@@ -7,10 +7,10 @@
             "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Bane].</p>\n<p>You take a -1 status penalty to attack rolls.</p>"
         },
         "duration": {
-            "expiry": "turn-start",
+            "expiry": null,
             "sustained": false,
-            "unit": "minutes",
-            "value": 1
+            "unit": "unlimited",
+            "value": -1
         },
         "level": {
             "value": 1

--- a/packs/spells/bane.json
+++ b/packs/spells/bane.json
@@ -19,7 +19,7 @@
             }
         },
         "description": {
-            "value": "<p>You fill the minds of your enemies with doubt. Enemies in the area must succeed at a Will save or take a –1 status penalty to attack rolls as long as they are in the area. Once per round on subsequent turns, you can Sustain the spell to increase the emanation's radius by 10 feet and force enemies in the area that weren't yet affected to attempt another saving throw.</p>\n<p>Bane can counteract @UUID[Compendium.pf2e.spells-srd.Item.Bless].</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Bane]</p>"
+            "value": "<p>You fill the minds of your enemies with doubt. Enemies in the area must succeed at a Will save or take a –1 status penalty to attack rolls as long as they are in the area. Once per round on subsequent turns, you can Sustain the spell to increase the emanation's radius by 10 feet and force enemies in the area that weren't yet affected to attempt another saving throw.</p>\n<p>Bane can counteract @UUID[Compendium.pf2e.spells-srd.Item.Bless].</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Aura: Bane]</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Bane]</p>"
         },
         "duration": {
             "sustained": false,


### PR DESCRIPTION
I was in a session of Kingmaker and noticed the spell didn't have an aura :|

There is no fancy automation, this is more for tracking purposes to see how far the Aura has been extended via sustain.