### PR TITLE
Add Formula roll to Lucky Number Spell Effect

### DIFF
--- a/packs/spell-effects/spell-effect-lucky-number.json
+++ b/packs/spell-effects/spell-effect-lucky-number.json
@@ -3,11 +3,18 @@
     "img": "icons/sundries/gaming/dice-pair-white-green.webp",
     "name": "Spell Effect: Lucky Number",
     "system": {
+        "badge": {
+            "evaluate": true,
+            "max": 20,
+            "reevaluate": null,
+            "type": "formula",
+            "value": "1d20"
+        },
         "description": {
             "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Lucky Number].</p>\n<p>You gain the @UUID[Compendium.pf2e.actionspf2e.Item.That's My Number] reaction; once you use the reaction, the spell ends.</p>"
         },
         "duration": {
-            "expiry": "turn-start",
+            "expiry": null,
             "sustained": false,
             "unit": "unlimited",
             "value": -1


### PR DESCRIPTION
Lucky Number needs to be associated with a 1d20 roll, so this sets the Effect to Formula to roll the d20 for the player when the effect is attached.