### PR TITLE
Prevent damage alterations from disabling override dice

### DIFF
--- a/src/module/rules/rule-element/damage-alteration/alteration.ts
+++ b/src/module/rules/rule-element/damage-alteration/alteration.ts
@@ -80,8 +80,11 @@ class DamageAlteration {
         const rule = this.#rule;
         if (rule.ignored) return damage;
 
-        if ("value" in damage && ["dice-faces", "dice-number"].includes(this.property)) {
-            // `damage` is a `ModifierPF2e`
+        // If this is a modifier or purely an override dice, skip
+        const isModifier = "value" in damage && ["dice-faces", "dice-number"].includes(this.property);
+        const isOverrideDice =
+            !("value" in damage) && !damage.damageType && !damage.diceNumber && !damage.dieSize && damage.override;
+        if (isModifier || isOverrideDice) {
             return damage;
         }
 


### PR DESCRIPTION
The title is the patch note version. The developer deets is that override dice use the properties at the base level as a pseudo-predicate to match to what entry to override. If an alteration hits one of them, the match will no longer succeed.