### PR TITLE
Fix domain on Artokus's Fire RollOption

### DIFF
--- a/packs/feats/artokuss-fire.json
+++ b/packs/feats/artokuss-fire.json
@@ -31,7 +31,7 @@
         },
         "rules": [
             {
-                "domain": "attack-roll",
+                "domain": "damage",
                 "key": "RollOption",
                 "option": "artokuss-fire",
                 "toggleable": true


### PR DESCRIPTION
Artokus's Fire has a RollOption with the domain of `attack-roll` but the Note and DamageDice predicated on that are both on damage rolls.