### PR TITLE
Allow Strike REs to have a null weapon group

### DIFF
--- a/src/module/rules/rule-element/strike.ts
+++ b/src/module/rules/rule-element/strike.ts
@@ -251,7 +251,7 @@ class StrikeRuleElement extends RuleElementPF2e<StrikeSchema> {
         }
 
         const group = this.resolveInjectedProperties(this.group);
-        if (!objectHasKey(CONFIG.PF2E.weaponGroups, group)) {
+        if (group !== null && !objectHasKey(CONFIG.PF2E.weaponGroups, group)) {
             this.failValidation(`Unrecognized weapon group: ${group}`);
             return null;
         }


### PR DESCRIPTION
Fixes these warnings:
```
pf2e.mjs:1580 PF2e System | Strike rules element on item Cloud Form (Compendium.pf2e.lost-omens-tian-xia-world-guide.Actor.9jvXTVcMNTx3kGfU.Item.5J06Ku4CI2tpvzEV) failed to validate: Unrecognized weapon group: null
pf2e.mjs:1580 PF2e System | Strike rules element on item Change Shape (Compendium.pf2e.lost-omens-tian-xia-world-guide.Actor.zrx1qjf1WbSYllvz.Item.DFXZDYeKTRu6SKvv) failed to validate: Unrecognized weapon group: null
pf2e.mjs:1580 PF2e System | Strike rules element on item Phantom Flames (Compendium.pf2e.lost-omens-tian-xia-world-guide.Actor.zrx1qjf1WbSYllvz.Item.EuFSoclL9h9ZYg1y) failed to validate: Unrecognized weapon group: null
pf2e.mjs:1580 PF2e System | Strike rules element on item Torch (Compendium.pf2e.menace-under-otari-bestiary.Actor.shT19KaQjWRVrHLI.Item.SScGd7XGz9e2sOLE) failed to validate: Unrecognized weapon group: null
pf2e.mjs:1580 PF2e System | Strike rules element on item Effect: Active Mutagen (Compendium.pf2e.one-shot-bestiary.Actor.ODOBHqugzvfGkZVS.Item.KVCx0qW7ozoFIZ5b) failed to validate: Unrecognized weapon group: null
pf2e.mjs:1580 PF2e System | Strike rules element on item Change Shape (Compendium.pf2e.kingmaker-bestiary.Actor.1vsQlCVwa9kVmgRi.Item.CDUrtwX9v7aZEVjj) failed to validate: Unrecognized weapon group: null
pf2e.mjs:1580 PF2e System | Strike rules element on item Torch (Compendium.pf2e.pathfinder-bestiary.Actor.z0l0lHc79NbMxiqZ.Item.SScGd7XGz9e2sOLE) failed to validate: Unrecognized weapon group: null
pf2e.mjs:1580 PF2e System | Strike rules element on item Change Shape (Compendium.pf2e.pathfinder-monster-core.Actor.8CYHgj4SV2LvlaUs.Item.shEp3scXXBxti42q) failed to validate: Unrecognized weapon group: null
pf2e.mjs:1580 PF2e System | Strike rules element on item Torch (Compendium.pf2e.pathfinder-monster-core.Actor.Ky5eNRvN71O0tY9l.Item.QtFwdsixI3MjuE0k) failed to validate: Unrecognized weapon group: null
pf2e.mjs:1580 PF2e System | Strike rules element on item Marrowlance (Compendium.pf2e.pfs-season-5-bestiary.Actor.Hfh8jRPyXBw4B4ic.Item.LE6KUpPto7uLf1bD) failed to validate: Unrecognized weapon group: null
pf2e.mjs:1580 PF2e System | Strike rules element on item Change Shape (Compendium.pf2e.seven-dooms-for-sandpoint-bestiary.Actor.FHxjkYIzoQ53mYp7.Item.E11uRLNnDwbjSmiw) failed to validate: Unrecognized weapon group: null
pf2e.mjs:1580 PF2e System | Strike rules element on item Change Shape (Compendium.pf2e.wardens-of-wildwood-bestiary.Actor.YU2EwouEWCKNcjGK.Item.e81mjeZGp9mKBDKv) failed to validate: Unrecognized weapon group: null
```