### PR TITLE
Update Exploration activities to Remastered

### DIFF
--- a/packs/actions/affix-a-talisman.json
+++ b/packs/actions/affix-a-talisman.json
@@ -11,12 +11,12 @@
         },
         "category": null,
         "description": {
-            "value": "<p><strong>Requirements</strong> You must use a @UUID[Compendium.pf2e.equipment-srd.Item.Repair Toolkit]</p>\n<hr />\n<p>You spend 10 minutes affixing a talisman to an item, placing the item on a stable surface and using the repair kit with both hands. You can also use this activity to remove a talisman. If more than one talisman is affixed to an item, the talismans are suppressed; none of them can be activated.</p>"
+            "value": "<p><strong>Requirements</strong> You must use a @UUID[Compendium.pf2e.equipment-srd.Item.Repair Toolkit]</p><hr /><p>You spend 10 minutes affixing a talisman to an item, placing the item on a stable surface and using the repair toolkit with both hands. You can also use this activity to remove a talisman. Attaching more than one talisman to an item deactivates all the talismans. They must be removed and re-affixed before they can be used again.</p>"
         },
         "publication": {
-            "license": "OGL",
-            "remaster": false,
-            "title": "Pathfinder Core Rulebook"
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder GM Core"
         },
         "rules": [],
         "traits": {

--- a/packs/actions/avoid-notice.json
+++ b/packs/actions/avoid-notice.json
@@ -11,12 +11,12 @@
         },
         "category": "defensive",
         "description": {
-            "value": "<p>You attempt a <span data-pf2-action=\"avoidNotice\">Stealth</span> check to avoid notice while traveling at half speed. If you have the @UUID[Compendium.pf2e.feats-srd.Item.Swift Sneak] feat, you can move at full Speed rather than half, but you still can't use another exploration activity while you do so. If you have the @UUID[Compendium.pf2e.feats-srd.Item.Legendary Sneak] feat, you can move at full Speed and use a second exploration activity. If you're Avoiding Notice at the start of an encounter, you usually roll a Stealth check instead of a Perception check both to determine your initiative and to see if the enemies notice you (based on their Perception DCs, as normal for Sneak, regardless of their initiative check results).</p>"
+            "value": "<p>You attempt a <span data-pf2-action=\"avoidNotice\">Stealth</span> check to avoid notice while traveling at half speed. If you're Avoiding Notice at the start of an encounter, you usually roll a Stealth check instead of a Perception check both to determine your initiative and to see if the enemies notice you (based on their Perception DCs, as normal for Sneak, regardless of their initiative check results).</p>"
         },
         "publication": {
-            "license": "OGL",
-            "remaster": false,
-            "title": "Pathfinder Core Rulebook"
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
         },
         "rules": [],
         "traits": {

--- a/packs/actions/borrow-an-arcane-spell.json
+++ b/packs/actions/borrow-an-arcane-spell.json
@@ -11,12 +11,12 @@
         },
         "category": null,
         "description": {
-            "value": "<p>If you're an arcane spellcaster who prepares from a spellbook, you can attempt to prepare a spell from someone else's spellbook. The GM sets the DC for the check based on the spell's rank and rarity; it's typically a bit easier than @UUID[Compendium.pf2e.actionspf2e.Item.Learn a Spell]{Learning the Spell}.</p>\n<hr />\n<p><strong>Success</strong> You prepare the borrowed spell as part of your normal spell preparation.</p>\n<p><strong>Failure</strong> You fail to prepare the spell, but the spell slot remains available for you to prepare a different spell. You can't try to prepare this spell until the next time you prepare spells.</p>"
+            "value": "<p>If you’re an arcane spellcaster who prepares spells, you can attempt to prepare a spell from someone else’s arcane spellbook, arcane witch familiar, or the like. The GM sets the DC for the check based on the spell’s rank and rarity; it’s typically a bit easier than @UUID[Compendium.pf2e.actionspf2e.Item.Learn a Spell]{Learning the Spell}.</p><hr /><p><strong>Success</strong> You prepare the borrowed spell as part of your normal spell preparation.</p>\n<p><strong>Failure</strong> You fail to prepare the spell, but the spell slot remains available for you to prepare a different spell. You can't try to prepare this spell until the next time you prepare spells.</p>"
         },
         "publication": {
-            "license": "OGL",
-            "remaster": false,
-            "title": "Pathfinder Core Rulebook"
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
         },
         "rules": [],
         "traits": {

--- a/packs/actions/defend.json
+++ b/packs/actions/defend.json
@@ -14,9 +14,9 @@
             "value": "<p>You move at half your travel speed with your shield raised. If combat breaks out, you gain the benefits of @UUID[Compendium.pf2e.actionspf2e.Item.Raise a Shield]{Raising a Shield} before your first turn begins.</p>"
         },
         "publication": {
-            "license": "OGL",
-            "remaster": false,
-            "title": "Pathfinder Core Rulebook"
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
         },
         "rules": [],
         "traits": {

--- a/packs/actions/detect-magic.json
+++ b/packs/actions/detect-magic.json
@@ -14,9 +14,9 @@
             "value": "<p>You cast detect magic at regular intervals. You move at half your travel speed or slower. You have no chance of accidentally overlooking a magic aura at a travel speed up to 300 feet per minute, but must be traveling no more than 150 feet per minute to detect magic auras before the party moves into them.</p>"
         },
         "publication": {
-            "license": "OGL",
-            "remaster": false,
-            "title": "Pathfinder Core Rulebook"
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
         },
         "rules": [],
         "traits": {

--- a/packs/actions/follow-the-expert.json
+++ b/packs/actions/follow-the-expert.json
@@ -11,12 +11,12 @@
         },
         "category": "interaction",
         "description": {
-            "value": "<p>Choose an ally attempting a recurring skill check while exploring, such as climbing, or performing a different exploration tactic that requires a skill check (like @UUID[Compendium.pf2e.actionspf2e.Item.Avoid Notice]{Avoiding Notice}). The ally must be at least an expert in that skill and must be willing to provide assistance. While Following the Expert, you match their tactic or attempt similar skill checks. Thanks to your ally's assistance, you can add your level as a proficiency bonus to the associated skill check, even if you're untrained. Additionally, you gain a circumstance bonus to your skill check based on your ally's proficiency (+2 for expert, +3 for master, and +4 for legendary).</p>\n<p>@UUID[Compendium.pf2e.other-effects.Item.Effect: Follow The Expert]</p>"
+            "value": "<p>Choose an ally attempting a recurring skill check while exploring, such as climbing, or performing a different exploration tactic that requires a skill check (like @UUID[Compendium.pf2e.actionspf2e.Item.Avoid Notice]{Avoiding Notice}). The ally must be at least an expert in that skill and must be willing to provide assistance. While Following the Expert, you match their tactic or attempt similar skill checks.</p>\n<p>Thanks to your ally's assistance, you can add your level as a proficiency bonus to the associated skill check, even if you're untrained. Additionally, you gain a circumstance bonus to your skill check based on your ally's proficiency (+2 for expert, +3 for master, and +4 for legendary).</p>\n<p>@UUID[Compendium.pf2e.other-effects.Item.Effect: Follow The Expert]</p>"
         },
         "publication": {
-            "license": "OGL",
-            "remaster": false,
-            "title": "Pathfinder Core Rulebook"
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
         },
         "rules": [],
         "traits": {

--- a/packs/actions/hustle.json
+++ b/packs/actions/hustle.json
@@ -14,9 +14,9 @@
             "value": "<p>You strain yourself to move at double your travel speed. You can Hustle only for a number of minutes equal to your Constitution modifier × 10 (minimum 10 minutes). If you are in a group that is Hustling, use the lowest Constitution modifier among everyone to determine how fast the group can Hustle together.</p>"
         },
         "publication": {
-            "license": "OGL",
-            "remaster": false,
-            "title": "Pathfinder Core Rulebook"
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
         },
         "rules": [],
         "traits": {

--- a/packs/actions/investigate.json
+++ b/packs/actions/investigate.json
@@ -14,9 +14,9 @@
             "value": "<p>You seek out information about your surroundings while traveling at half speed. You use Recall Knowledge as a secret check to discover clues among the various things you can see and engage with as you journey along. You can use any skill that has a Recall Knowledge action while Investigating, but the GM determines whether the skill is relevant to the clues you could find.</p>"
         },
         "publication": {
-            "license": "OGL",
-            "remaster": false,
-            "title": "Pathfinder Core Rulebook"
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
         },
         "rules": [],
         "traits": {

--- a/packs/actions/repeat-a-spell.json
+++ b/packs/actions/repeat-a-spell.json
@@ -11,7 +11,7 @@
         },
         "category": "interaction",
         "description": {
-            "value": "<p>You repeatedly cast the same spell while moving at half speed. Typically, this spell is a cantrip that you want to have in effect in the event a combat breaks out, and it must be one you can cast in 2 actions or fewer. In order to prevent fatigue due to repeated casting, you'll likely use this activity only when something out of the ordinary occurs.</p>\n<p>You can instead use this activity to continue @UUID[Compendium.pf2e.actionspf2e.Item.Sustain]{Sustain a Spell} or @UUID[Compendium.pf2e.actionspf2e.Item.Sustain] with a sustained duration. Most such spells or item effects can be sustained for 10 minutes, though some specify they can be sustained for a different duration.</p>"
+            "value": "<p>You repeatedly cast the same spell while moving at half speed. Typically, this spell is a cantrip that you want to have in effect in the event a combat breaks out, and it must be one you can cast in 2 actions or fewer. Repeating a spell that requires making complex decisions, such as <em>figment</em>, can make you fatigued, as determined by the GM.</p>"
         },
         "publication": {
             "license": "ORC",

--- a/packs/actions/scout.json
+++ b/packs/actions/scout.json
@@ -14,9 +14,9 @@
             "value": "<p>You scout ahead and behind the group to watch danger, moving at half speed. At the start of the next encounter, every creature in your party gains a +1 circumstance bonus to their initiative rolls.</p>\n<p>@UUID[Compendium.pf2e.other-effects.Item.Effect: Scouting]</p>"
         },
         "publication": {
-            "license": "OGL",
-            "remaster": false,
-            "title": "Pathfinder Core Rulebook"
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
         },
         "rules": [],
         "traits": {

--- a/packs/actions/search.json
+++ b/packs/actions/search.json
@@ -14,9 +14,9 @@
             "value": "<p>You @UUID[Compendium.pf2e.actionspf2e.Item.Seek] meticulously for hidden doors, concealed hazards, and so on. You can usually make an educated guess as to which locations are best to check and move at half speed, but if you want to be thorough and guarantee you checked everything, you need to travel at a Speed of no more than 300 feet per minute, or 150 feet per minute to ensure you check everything before you walk into it. You can always move more slowly while Searching to cover the area more thoroughly, and the @UUID[Compendium.pf2e.feats-srd.Item.Expeditious Search] feat increases these maximum Speeds. If you come across a secret door, item, or hazard while Searching, the GM will attempt a free secret check to Seek to see if you notice the hidden object or hazard. In locations with many objects to search, you have to stop and spend significantly longer to search thoroughly.</p>"
         },
         "publication": {
-            "license": "OGL",
-            "remaster": false,
-            "title": "Pathfinder Core Rulebook"
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
         },
         "rules": [],
         "traits": {

--- a/packs/actions/squeeze.json
+++ b/packs/actions/squeeze.json
@@ -14,9 +14,9 @@
             "value": "<p>You contort yourself to <span data-pf2-action=\"squeeze\">squeeze</span> through a space so small you can barely fit through. This action is for exceptionally small spaces; many tight spaces are difficult terrain that you can move through more quickly and without a check.</p>\n<hr />\n<p><strong>Critical Success</strong> You squeeze through the tight space in 1 minute per 10 feet of squeezing.</p>\n<p><strong>Success</strong> You squeeze through in 1 minute per 5 feet.</p>\n<p><strong>Critical Failure</strong> You become stuck in the tight space. While you're stuck, you can spend 1 minute attempting another Acrobatics check at the same DC. Any result on that check other than a critical failure causes you to become unstuck.</p>\n<h2 class=\"title\">Sample Squeeze Tasks</h2>\n<ul>\n<li><strong>Trained</strong> space barely fitting your shoulders</li>\n<li><strong>Master</strong> space barely fitting your head</li>\n</ul>"
         },
         "publication": {
-            "license": "OGL",
-            "remaster": false,
-            "title": "Pathfinder Core Rulebook"
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
         },
         "rules": [],
         "traits": {


### PR DESCRIPTION
Update Exploration activities to the wording in Pathfinder Player Core and Pathfinder GM Core, and mark them as in the relevant publication under ORC and remastered.