### PR TITLE
Fix Escape not picking unarmed attacks with negative modifiers

### DIFF
--- a/src/module/system/action-macros/basic/escape.ts
+++ b/src/module/system/action-macros/basic/escape.ts
@@ -14,7 +14,7 @@ import { CheckContextError } from "../helpers.ts";
 import { ActionMacroHelpers, SkillActionOptions } from "../index.ts";
 
 const toHighestModifier = (highest: StrikeData | null, current: StrikeData): StrikeData | null => {
-    return current.totalModifier > (highest?.totalModifier ?? 0) ? current : highest;
+    return current.totalModifier > (highest?.totalModifier ?? Number.MIN_SAFE_INTEGER) ? current : highest;
 };
 
 function unarmedStrikeWithHighestModifier<ItemType extends ItemPF2e<ActorPF2e>>(


### PR DESCRIPTION
The find best unarmed attack modifier code doesn't work if the best is less than zero.  This can easily happen when MAP -10 is used.