### PR TITLE
Also await on user provided callbacks for weapons that consume ammo

### DIFF
--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -1605,6 +1605,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
                     createMessage: params.createMessage ?? true,
                 };
 
+                // consumeAmmo will add/wrap the callback to do the actual consumption of ammo at the end
                 if (params.consumeAmmo && !this.consumeAmmo(context.origin.item, params)) {
                     return null;
                 }
@@ -1733,8 +1734,8 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
             return false;
         } else {
             const existingCallback = params.callback;
-            params.callback = async (roll: Rolled<Roll>) => {
-                existingCallback?.(roll);
+            params.callback = async (...args) => {
+                await existingCallback?.(...args);
                 await weapon.consumeAmmo();
             };
             return true;

--- a/src/module/system/rolls.ts
+++ b/src/module/system/rolls.ts
@@ -24,7 +24,7 @@ interface RollParameters {
     /** Optional DC data for the roll */
     dc?: CheckDC | null;
     /** Callback called when the roll occurs. */
-    callback?: (roll: Rolled<Roll>) => void;
+    callback?: (roll: Rolled<Roll>) => void | Promise<void>;
     /** Additional modifiers */
     modifiers?: ModifierPF2e[];
     /** Whether to create a message from the roll */


### PR DESCRIPTION
The consumeAmmo logic wraps an existing caller supplied attack roll callback.  Unlike a RollParameter callback, which has only the Roll as an argument, an attack roll callback is a CheckRollCallback, which has four parameters.  The consumeAmmo wrapper would only pass along the first of these.

Since the wrapper doesn't care about any of the arguments, use the rest argument syntax to pass along whatever argument(s) the callback was called with.  This way the code can work with any callback.

The callback also can be async, so await it, otherwise it won't finish before the code in CheckPF2e.roll() that awaits the callback continues.