### PR TITLE
Remove `ScenePF2e#hasHexGrid` getter

### DIFF
--- a/src/module/canvas/layer/template.ts
+++ b/src/module/canvas/layer/template.ts
@@ -52,7 +52,7 @@ export class TemplateLayerPF2e<
 
         // Update the shape data
         if (["cone", "circle"].includes(document.t)) {
-            const snapAngle = Math.PI / (canvas.scene.hasHexGrid ? 6 : 4);
+            const snapAngle = Math.PI / (canvas.grid.isHexagonal ? 6 : 4);
             document.direction = Math.toDegrees(Math.floor((ray.angle + Math.PI * 0.125) / snapAngle) * snapAngle);
         } else {
             document.direction = Math.toDegrees(ray.angle);
@@ -76,7 +76,7 @@ export class TemplateLayerPF2e<
         const shapeType = template.document.t;
         const distance = template.document.distance ?? 5;
         const increment = event.shiftKey || distance <= 30 ? 15 : 5;
-        const coneMultiplier = shapeType === "cone" ? (canvas.scene.hasHexGrid ? 2 : 3) : 1;
+        const coneMultiplier = shapeType === "cone" ? (canvas.grid.isHexagonal ? 2 : 3) : 1;
         const snap = increment * coneMultiplier;
         const delta = snap * Math.sign(event.deltaY);
 

--- a/src/module/scene/document.ts
+++ b/src/module/scene/document.ts
@@ -47,11 +47,6 @@ class ScenePF2e extends Scene {
         return this.lightLevel <= LightLevels.DARKNESS;
     }
 
-    get hasHexGrid(): boolean {
-        const squareOrGridless: number[] = [CONST.GRID_TYPES.GRIDLESS, CONST.GRID_TYPES.SQUARE];
-        return !squareOrGridless.includes(this.grid.type);
-    }
-
     /** Whether this scene is "in focus": the active scene, or the viewed scene if only a single GM is logged in */
     get isInFocus(): boolean {
         const soleUserIsGM = game.user.isGM && game.users.filter((u) => u.active).length === 1;

--- a/src/scripts/hooks/canvas-ready.ts
+++ b/src/scripts/hooks/canvas-ready.ts
@@ -29,7 +29,7 @@ export const CanvasReady = {
 
             if (game.ready) canvas.scene.reset();
             // Accomodate hex grid play with a usable default cone angle
-            CONFIG.MeasuredTemplate.defaults.angle = canvas.scene.hasHexGrid ? 60 : 90;
+            CONFIG.MeasuredTemplate.defaults.angle = canvas.grid.isHexagonal ? 60 : 90;
 
             const hasSceneTerrains = !!canvas.scene.flags.pf2e.environmentTypes?.length;
             for (const token of canvas.tokens.placeables) {


### PR DESCRIPTION
`BaseGrid` now has boolean getters for each type