### PR TITLE
Add support for Shockwave rune

### DIFF
--- a/src/module/actor/modifiers.ts
+++ b/src/module/actor/modifiers.ts
@@ -793,6 +793,7 @@ export {
     createProficiencyModifier,
     ensureProficiencyOption,
 };
+
 export type {
     DamageDiceOverride,
     DamageDiceParameters,
@@ -801,6 +802,7 @@ export type {
     DeferredValue,
     DeferredValueParams,
     ModifierAdjustment,
+    ModifierObjectParams,
     ModifierType,
     RawDamageDice,
     RawModifier,

--- a/src/module/item/weapon/document.ts
+++ b/src/module/item/weapon/document.ts
@@ -583,14 +583,15 @@ class WeaponPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
             };
         })();
         const fromPropertyRunes = this.system.runes.property
-            .flatMap((r) => RUNE_DATA.weapon.property[r].damage?.dice ?? [])
-            .map(
-                (d): NPCAttackDamage => ({
-                    damage: `${d.diceNumber}${d.dieSize}`,
-                    damageType: d.damageType ?? baseDamage.damageType,
-                    category: d.category ?? null,
-                }),
-            );
+            .flatMap((r) => RUNE_DATA.weapon.property[r].damage?.additional ?? [])
+            .map((additional): NPCAttackDamage => {
+                const [category = null, damage] =
+                    "diceNumber" in additional
+                        ? [additional.category, `${additional.diceNumber}${additional.dieSize}`]
+                        : [additional.damageCategory, additional.modifier.toString()];
+                const damageType = additional.damageType ?? baseDamage.damageType;
+                return { damage, damageType, category };
+            });
 
         const reachTraitToNPCReach = {
             tiny: null,

--- a/src/module/item/weapon/values.ts
+++ b/src/module/item/weapon/values.ts
@@ -110,6 +110,7 @@ const WEAPON_PROPERTY_RUNE_TYPES = new Set([
     "serrating",
     "shifting",
     "shock",
+    "shockwave",
     "speed",
     "spellStoring",
     "swarming",

--- a/src/module/system/damage/weapon.ts
+++ b/src/module/system/damage/weapon.ts
@@ -3,7 +3,7 @@ import { DamageDicePF2e, ModifierPF2e, createAttributeModifier } from "@actor/mo
 import { ATTRIBUTE_ABBREVIATIONS } from "@actor/values.ts";
 import { MeleePF2e, WeaponPF2e } from "@item";
 import type { NPCAttackDamage } from "@item/melee/data.ts";
-import { RUNE_DATA, getPropertyRuneDice, getPropertyRuneModifierAdjustments } from "@item/physical/runes.ts";
+import { RUNE_DATA, getPropertyRuneDamage, getPropertyRuneModifierAdjustments } from "@item/physical/runes.ts";
 import type { WeaponDamage } from "@item/weapon/data.ts";
 import type { ZeroToThree } from "@module/data.ts";
 import { RollNotePF2e } from "@module/notes.ts";
@@ -247,7 +247,9 @@ class WeaponDamagePF2e {
 
         // Property Runes
         const propertyRunes = weapon.system.runes.property;
-        damageDice.push(...getPropertyRuneDice(propertyRunes, options));
+        const runeDamage = getPropertyRuneDamage(weapon, propertyRunes, options);
+        damageDice.push(...runeDamage.filter((d): d is DamageDicePF2e => "diceNumber" in d));
+        modifiers.push(...runeDamage.filter((d): d is ModifierPF2e => "modifier" in d));
         const propertyRuneAdjustments = getPropertyRuneModifierAdjustments(propertyRunes);
 
         const irBypassData: DamageIRBypassData = {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -5712,7 +5712,7 @@
             },
             "shockwave": {
                 "Name": "Shockwave",
-                "Note": "Strikes with this weapon deal bludgeoning splash damage equal to the number of weapon damage dice. You're immune to this splash damage."
+                "Note": "The attacker is immune to the splash damage."
             },
             "spellStoring": {
                 "Name": "Spell Reservoir"


### PR DESCRIPTION
Surprisingly, this is the first rune (at least among those with system support) that deals an additional flat amount of damage.

Closes #15617

![image](https://github.com/user-attachments/assets/310f27da-d3f0-4526-ac8a-5d11e4c17fa0)
