### PR TITLE
Fix Performance bonus for Dancing Scarf

### DIFF
--- a/packs/equipment/dancing-scarf.json
+++ b/packs/equipment/dancing-scarf.json
@@ -9,7 +9,7 @@
         },
         "containerId": null,
         "description": {
-            "value": "<p>This long and billowing scarf is typically woven of silk or sheer fabric and adorned with bells or other jangling bits of shiny metal. It grants a +2 item bonus to Performance checks to dance.</p>\n<hr />\n<p><strong>Activate—Swirling Scarf</strong> <span class=\"action-glyph\">A</span> (manipulate)</p>\n<p><strong>Requirements</strong> On your most recent action, you succeeded at a Performance check to dance</p>\n<p><strong>Effect</strong> You become @UUID[Compendium.pf2e.conditionitems.Item.Concealed] until the beginning of your next turn.</p>"
+            "value": "<p>This long and billowing scarf is typically woven of silk or sheer fabric and adorned with bells or other jangling bits of shiny metal. It grants a +1 item bonus to Performance checks to dance.</p>\n<hr />\n<p><strong>Activate—Swirling Scarf</strong> <span class=\"action-glyph\">A</span> (manipulate)</p>\n<p><strong>Requirements</strong> On your most recent action, you succeeded at a Performance check to dance</p>\n<p><strong>Effect</strong> You become @UUID[Compendium.pf2e.conditionitems.Item.Concealed] until the beginning of your next turn.</p>"
         },
         "hardness": 0,
         "hp": {


### PR DESCRIPTION
Fixing a typo I noticed today.
The Performance bonus for the base Dancing Scarf is only +1, not +2. (+2 comes in at the Greater level.)
The modifier is already configured correctly, but the description text is confusing as it uses the wrong value.

https://2e.aonprd.com/Equipment.aspx?ID=3074

