### PR TITLE
Add support for damage alterations of base weapon damage

### DIFF
--- a/src/module/actor/modifiers.ts
+++ b/src/module/actor/modifiers.ts
@@ -1,5 +1,5 @@
 import type { ActorPF2e, CharacterPF2e, NPCPF2e } from "@actor";
-import { AttributeString } from "@actor/types.ts";
+import type { AttributeString } from "@actor/types.ts";
 import type { ItemPF2e } from "@item";
 import { ZeroToFour } from "@module/data.ts";
 import type { RollNotePF2e } from "@module/notes.ts";
@@ -7,7 +7,7 @@ import { extractModifierAdjustments } from "@module/rules/helpers.ts";
 import type { RuleElementPF2e } from "@module/rules/index.ts";
 import { DamageAlteration } from "@module/rules/rule-element/damage-alteration/alteration.ts";
 import { DamageCategorization } from "@system/damage/helpers.ts";
-import { DamageCategoryUnique, DamageDieSize, DamageType } from "@system/damage/types.ts";
+import type { DamageCategoryUnique, DamageDiceFaces, DamageDieSize, DamageType } from "@system/damage/types.ts";
 import { Predicate, RawPredicate } from "@system/predication.ts";
 import { ErrorPF2e, objectHasKey, setHasElement, signedInteger, sluggify, tupleHasValue } from "@util";
 import * as R from "remeda";
@@ -725,6 +725,11 @@ class DamageDicePF2e {
         this.hideIfDisabled = params.hideIfDisabled ?? false;
     }
 
+    /** The `dieSize` as a number (or null) */
+    get faces(): DamageDiceFaces | null {
+        return (Number(this.dieSize?.replace("d", "")) || null) as DamageDiceFaces | null;
+    }
+
     /** Test the `predicate` against a set of roll options */
     test(options: Set<string>): void {
         this.enabled = this.predicate.test(options);
@@ -781,17 +786,17 @@ class DamageDicePF2e {
 interface RawDamageDice extends Required<DamageDiceParameters> {}
 
 export {
+    adjustModifiers,
+    applyStackingRules,
     CheckModifier,
+    createAttributeModifier,
+    createProficiencyModifier,
     DamageDicePF2e,
+    ensureProficiencyOption,
     MODIFIER_TYPES,
     ModifierPF2e,
     PROFICIENCY_RANK_OPTION,
     StatisticModifier,
-    adjustModifiers,
-    applyStackingRules,
-    createAttributeModifier,
-    createProficiencyModifier,
-    ensureProficiencyOption,
 };
 
 export type {

--- a/src/module/item/melee/document.ts
+++ b/src/module/item/melee/document.ts
@@ -97,7 +97,7 @@ class MeleePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
     }
 
     get dealsDamage(): boolean {
-        const { baseDamage } = this;
+        const baseDamage = this.baseDamage;
         return (
             baseDamage.dice > 0 ||
             baseDamage.modifier > 0 ||

--- a/src/module/rules/rule-element/damage-alteration/alteration.ts
+++ b/src/module/rules/rule-element/damage-alteration/alteration.ts
@@ -102,7 +102,18 @@ class DamageAlteration {
         }
 
         if (this.property === "dice-faces" && "dieSize" in damage && tupleHasValue(DAMAGE_DICE_FACES, value)) {
-            damage.dieSize = `d${value}`;
+            const stringValue = `d${value}` as const;
+            // Ensure that weapon damage isn't being upgraded multiple times
+            if (
+                this.#rule.slug === "base" &&
+                this.#rule.mode === "upgrade" &&
+                damage.dieSize !== stringValue &&
+                options.item.isOfType("weapon")
+            ) {
+                if (options.item.flags.pf2e.damageFacesUpgraded) return damage;
+                options.item.flags.pf2e.damageFacesUpgraded = true;
+            }
+            damage.dieSize = stringValue;
         }
 
         if (this.property === "dice-number" && "diceNumber" in damage && typeof value === "number") {


### PR DESCRIPTION
A worthy refactor will be to process such damage as `ModifierPF2e`/`DamageDicePF2e` throughout