### PR TITLE
Add rule element to Eternal Bane

### DIFF
--- a/packs/feats/eternal-bane.json
+++ b/packs/feats/eternal-bane.json
@@ -28,7 +28,21 @@
             "remaster": true,
             "title": "Pathfinder Player Core"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "Aura",
+                "radius": 15,
+                "traits": [
+                    "mental"
+                ],
+                "effects": [
+                    {
+                        "uuid": "Compendium.pf2e.spell-effects.Item.Spell Effect: Bane",
+                        "affects": "enemies"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [


### PR DESCRIPTION
Adds a rule element to Eternal Bane that adds aura that applies Bane spell effects to enemies in 15 feet, as per Player Core.