### PR TITLE
Update Kobold Ancestry for PC2

### DIFF
--- a/packs/ancestries/kobold.json
+++ b/packs/ancestries/kobold.json
@@ -9,10 +9,12 @@
             "value": [
                 "aklo",
                 "diabolic",
+                "draconic",
                 "dwarven",
+                "empyrean",
+                "fey",
                 "gnomish",
-                "petran",
-                "sakvroth"
+                "petran"
             ]
         },
         "boosts": {
@@ -48,19 +50,12 @@
             }
         },
         "hp": 6,
-        "items": {
-            "xhq7h": {
-                "img": "systems/pf2e/icons/features/ancestry/draconic-exemplar.webp",
-                "level": "1",
-                "name": "Draconic Exemplar",
-                "uuid": "Compendium.pf2e.ancestryfeatures.Item.Draconic Exemplar"
-            }
-        },
+        "items": {},
         "languages": {
             "custom": "",
             "value": [
                 "common",
-                "draconic"
+                "sakvroth"
             ]
         },
         "publication": {


### PR DESCRIPTION
- Kobolds no longer have Draconic Exemplar as an ancestry feature
- Kobolds have Sakvroth instead of Draconic as a base language
- Draconic, Empyrean, and Fey were added to their additional language list