### PR TITLE
Fix "Force Open" table footnote.

### DIFF
--- a/packs/journals/gm-screen.json
+++ b/packs/journals/gm-screen.json
@@ -789,7 +789,7 @@
             "src": null,
             "system": {},
             "text": {
-                "content": "<table class=\"pf2e\"><tbody><tr><th><strong>Structure</strong></th><th><p><strong>Force Open DC</strong></p><p></p></th></tr><tr><td><strong>Stuck door or window</strong></td><td>15</td></tr><tr><td><strong>Exceptionally stuck</strong></td><td>20</td></tr><tr><td><strong>Lift wooden portcullis</strong></td><td>20*</td></tr><tr><td><strong>Lift iron portcullis</strong></td><td>30*</td></tr><tr><td><strong>Bend metal bars</strong></td><td>30</td></tr><tr><td colspan=\"2\">* Use the Thievery DC of the locking mechanism if it's higher.</td></tr></tbody></table>",
+                "content": "<table class=\"pf2e\"><tbody><tr><th><strong>Structure</strong></th><th><p><strong>Force Open DC</strong></p><p></p></th></tr><tr><td><strong>Stuck door or window</strong></td><td>15</td></tr><tr><td><strong>Exceptionally stuck</strong></td><td>20</td></tr><tr><td><strong>Lift wooden portcullis</strong></td><td>20*</td></tr><tr><td><strong>Lift iron portcullis</strong></td><td>30*</td></tr><tr><td><strong>Bend metal bars</strong></td><td>30</td></tr><tr><td colspan=\"2\">* Use the Thievery DC of the locking mechanism +5 if it's higher.</td></tr></tbody></table>",
                 "format": 1,
                 "markdown": ""
             },


### PR DESCRIPTION
This journal lacks the "+5" shown in the GM Core Screen in both physical and PDF forms.  See this forum thread for more discussion on it: https://paizo.com/threads/rzs4s2nj?GM-Core-and-GM-Screen-disagree-on-Force-Open#2