### PR TITLE
Automate player core 2 improvised pummel

### DIFF
--- a/packs/equipment/handwraps-of-mighty-blows.json
+++ b/packs/equipment/handwraps-of-mighty-blows.json
@@ -51,7 +51,78 @@
         "reload": {
             "value": ""
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.handwrapsOfMightyBlows.potency",
+                "value": "@item.system.runes.potency"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.handwrapsOfMightyBlows.striking",
+                "value": "@item.system.runes.striking"
+            },
+            {
+                "key": "RollOption",
+                "domain": "all",
+                "option": "handwraps-of-mighty-blows"
+            },
+            {
+                "key": "RollOption",
+                "domain": "all",
+                "option": "handwraps-rune-property0",
+                "predicate": [{ "gt": ["{item|system.runes.property.length}", 0] }]
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.handwrapsOfMightyBlows.property0",
+                "value": { "value": "{item|system.runes.property.0}" },
+                "predicate": [{ "gt": ["{item|system.runes.property.length}", 0] }]
+            },
+            {
+                "key": "RollOption",
+                "domain": "all",
+                "option": "handwraps-rune-property1",
+                "predicate": [{ "gt": ["{item|system.runes.property.length}", 1] }]
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.handwrapsOfMightyBlows.property1",
+                "value": { "value": "{item|system.runes.property.1}" },
+                "predicate": [{ "gt": ["{item|system.runes.property.length}", 1] }]
+            },
+            {
+                "key": "RollOption",
+                "domain": "all",
+                "option": "handwraps-rune-property2",
+                "predicate": [{ "gt": ["{item|system.runes.property.length}", 2] }]
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.handwrapsOfMightyBlows.property2",
+                "value": { "value": "{item|system.runes.property.2}" },
+                "predicate": [{ "gt": ["{item|system.runes.property.length}", 2] }]
+            },
+            {
+                "key": "RollOption",
+                "domain": "all",
+                "option": "handwraps-rune-property3",
+                "predicate": [{ "gt": ["{item|system.runes.property.length}", 3] }]
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.handwrapsOfMightyBlows.property3",
+                "value": { "value": "{item|system.runes.property.3}" },
+                "predicate": [{ "gt": ["{item|system.runes.property.length}", 3] }]
+            }
+        ],
+
         "runes": {
             "potency": 1,
             "property": [],

--- a/packs/equipment/handwraps-of-mighty-blows.json
+++ b/packs/equipment/handwraps-of-mighty-blows.json
@@ -54,13 +54,13 @@
         "rules": [
             {
                 "key": "ActiveEffectLike",
-                "mode": "override",
+                "mode": "upgrade",
                 "path": "flags.pf2e.handwrapsOfMightyBlows.potency",
                 "value": "@item.system.runes.potency"
             },
             {
                 "key": "ActiveEffectLike",
-                "mode": "override",
+                "mode": "upgrade",
                 "path": "flags.pf2e.handwrapsOfMightyBlows.striking",
                 "value": "@item.system.runes.striking"
             },

--- a/packs/feats/improvised-pummel.json
+++ b/packs/feats/improvised-pummel.json
@@ -28,7 +28,104 @@
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "RollOption",
+                "domain": "all",
+                "option": "improvised-pummel-use-handwraps",
+                "toggleable": true,
+                "label": "PF2E.SpecificRule.WeaponImproviser.ImprovisedPummel.UseHandwrapsOfMightyBlows",
+                "value": true,
+                "disabledIf": [
+                    { "not": "handwraps-of-mighty-blows" }
+                ],
+                "disabledValue": false
+            },
+            {
+                "key": "WeaponPotency",
+                "selector": "attack",
+                "predicate": [
+                    "item:tag:improvised",
+                    { "not": "handwraps-of-mighty-blows" }
+                ],
+                "value": "ternary(gte(@actor.level,12),2,1)"
+            },
+            {
+                "key": "WeaponPotency",
+                "selector": "attack",
+                "predicate": [
+                    "item:tag:improvised", 
+                    "handwraps-of-mighty-blows"
+                ],
+                "value": "max(@actor.flags.pf2e.handwrapsOfMightyBlows.potency,ternary(gte(@actor.level,12),2,1))"
+            },
+            {
+                "key": "DamageDice",
+                "override": {
+                    "diceNumber": "max(ternary(gte(@actor.level,16),3,2))"
+                },
+                "selector": "strike-damage",
+                "predicate": [
+                    "item:tag:improvised",
+                    { "not": "improvised-pummel-use-handwraps" }
+                ]
+            },
+            {
+                "key": "DamageDice",
+                "override": {
+                    "diceNumber": "1+@actor.flags.pf2e.handwrapsOfMightyBlows.striking"
+                },
+                "selector": "strike-damage",
+                "predicate": [
+                    "item:tag:improvised", 
+                    "improvised-pummel-use-handwraps"
+                ]
+            },
+            {
+                "key": "AdjustStrike",
+                "mode": "add",
+                "property": "property-runes",
+                "value": "{actor|flags.pf2e.handwrapsOfMightyBlows.property0.value}",
+                "definition": ["item:tag:improvised"],
+                "predicate": [
+                    "improvised-pummel-use-handwraps",
+                    "handwraps-rune-property0"
+                ]
+            },
+            {
+                "key": "AdjustStrike",
+                "mode": "add",
+                "property": "property-runes",
+                "value": "{actor|flags.pf2e.handwrapsOfMightyBlows.property1.value}",
+                "definition": ["item:tag:improvised"],
+                "predicate": [
+                    "improvised-pummel-use-handwraps",
+                    "handwraps-rune-property1"
+                ]
+            },
+            {
+                "key": "AdjustStrike",
+                "mode": "add",
+                "property": "property-runes",
+                "value": "{actor|flags.pf2e.handwrapsOfMightyBlows.property2.value}",
+                "definition": ["item:tag:improvised"],
+                "predicate": [
+                    "improvised-pummel-use-handwraps",
+                    "handwraps-rune-property2"
+                ]
+            },
+            {
+                "key": "AdjustStrike",
+                "mode": "add",
+                "property": "property-runes",
+                "value": "{actor|flags.pf2e.handwrapsOfMightyBlows.property3.value}",
+                "definition": ["item:tag:improvised"],
+                "predicate": [
+                    "improvised-pummel-use-handwraps",
+                    "handwraps-rune-property3"
+                ]
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/improvised-pummel.json
+++ b/packs/feats/improvised-pummel.json
@@ -30,6 +30,18 @@
         },
         "rules": [
             {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "flags.pf2e.handwrapsOfMightyBlows.potency",
+                "value": 0
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "flags.pf2e.handwrapsOfMightyBlows.striking",
+                "value": 0
+            },
+            {
                 "key": "RollOption",
                 "domain": "all",
                 "option": "improvised-pummel-use-handwraps",
@@ -44,19 +56,7 @@
             {
                 "key": "WeaponPotency",
                 "selector": "attack",
-                "predicate": [
-                    "item:tag:improvised",
-                    { "not": "handwraps-of-mighty-blows" }
-                ],
-                "value": "ternary(gte(@actor.level,12),2,1)"
-            },
-            {
-                "key": "WeaponPotency",
-                "selector": "attack",
-                "predicate": [
-                    "item:tag:improvised", 
-                    "handwraps-of-mighty-blows"
-                ],
+                "predicate": ["item:tag:improvised"],
                 "value": "max(@actor.flags.pf2e.handwrapsOfMightyBlows.potency,ternary(gte(@actor.level,12),2,1))"
             },
             {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -4559,6 +4559,11 @@
             "Weapon": {
                 "Metal": "Using a metal weapon"
             },
+            "WeaponImproviser": {
+                "ImprovisedPummel": {
+                    "UseHandwrapsOfMightyBlows": "Use the handwraps' number of damage dice"
+                }
+            },
             "WeaponInfusion": {
                 "Melee": "Melee Infusion",
                 "Ranged": "Ranged Infusion"


### PR DESCRIPTION
So this is kind of a mess. Probably with some more features in the rule elements (not sure about which ones) it could be improved. The reason it's like this is because I didn't want to write out every single rune, otherwise it would be a nightmare to update every time a new property rune is added. 

The handwraps rule elements set some roll options to specify that the actor is using the handwraps (`handwraps-of-mighty-blows`) and which property runes are filled (`handwraps-rune-property0`, `handwraps-rune-property1`, ...). They also add some flags, i.e. potency and striking rune level and the property runes for each slot.

The Improvised Pummel rule elements functions as normal WeaponPotency that uses the max between what the feat gives and what the handwraps give. For the DamageDice it uses either what the feat does or the handwraps striking when `improvised-pummel-use-handwraps` RollOption is on. Also if the RollOption is on then it also applies the property runes. This should pretty much do exactly what the feat does.

It's a draft because maybe there is a better way to do it with less rule elements, or maybe new predicates that can check the items the actor have?