### PR TITLE
Change Strategic Strike's `DamageDice` RE to use `diceNumber` instead of `value`

### DIFF
--- a/packs/classfeatures/strategic-strike.json
+++ b/packs/classfeatures/strategic-strike.json
@@ -33,7 +33,7 @@
                     "check:substitution:devise-a-stratagem"
                 ],
                 "selector": "strike-damage",
-                "value": "floor((@actor.level+3)/4)"
+                "diceNumber": "floor((@actor.level+3)/4)"
             }
         ],
         "traits": {


### PR DESCRIPTION
Simple presumably copy-paste error fix.