### PR TITLE
Brush up Champion reactions implementation

### DIFF
--- a/packs/actions/destructive-vengeance.json
+++ b/packs/actions/destructive-vengeance.json
@@ -11,31 +11,14 @@
         },
         "category": "offensive",
         "description": {
-            "value": "<p><strong>Trigger</strong> An enemy in your champion's aura damages you</p><hr /><p><strong>Effect</strong> Bloodshed begets bloodshed as you drag your enemy toward oblivion. You increase the amount of damage you take by @Damage[ (ternary(gte(@actor.level,19),6,ternary(gte(@actor.level,16),5,ternary(gte(@actor.level,12),4,ternary(gte(@actor.level,9),3,ternary(gte(@actor.level,5),2,1))))))d6], and you deal @Damage[(ternary(gte(@actor.level,19),6,ternary(gte(@actor.level,16),5,ternary(gte(@actor.level,12),4,ternary(gte(@actor.level,9),3,ternary(gte(@actor.level,5),2,1))))))d6[spirit]] damage to the triggering enemy. The damage you take and deal when you use this reaction increases to 2d6 at 5th level, 3d6 at 9th level, 4d6 at 12th level, 5d6 at 16th level, and 6d6 at 19th level. In addition, until the end of your next turn, your Strikes against the triggering creature deal 2 extra spirit damage. This extra damage increases to 4 at 9th level and 6 at 16th level.</p>"
+            "value": "<p><strong>Trigger</strong> An enemy in your champion's aura damages you</p><hr /><p><strong>Effect</strong> Bloodshed begets bloodshed as you drag your enemy toward oblivion. You increase the amount of damage you take by @Damage[ (ternary(gte(@actor.level,19),6,ternary(gte(@actor.level,16),5,ternary(gte(@actor.level,12),4,ternary(gte(@actor.level,9),3,ternary(gte(@actor.level,5),2,1))))))d6], and you deal @Damage[(ternary(gte(@actor.level,19),6,ternary(gte(@actor.level,16),5,ternary(gte(@actor.level,12),4,ternary(gte(@actor.level,9),3,ternary(gte(@actor.level,5),2,1))))))d6[spirit]] damage to the triggering enemy. The damage you take and deal when you use this reaction increases to 2d6 at 5th level, 3d6 at 9th level, 4d6 at 12th level, 5d6 at 16th level, and 6d6 at 19th level.</p>\n<p>In addition, until the end of your next turn, your Strikes against the triggering creature deal 2 extra spirit damage. This extra damage increases to 4 at 9th level and 6 at 16th level.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Champion's Extra Damage]</p>"
         },
         "publication": {
             "license": "ORC",
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [
-            {
-                "key": "RollOption",
-                "label": "PF2E.SpecificRule.Champion.TargetReaction",
-                "option": "destructive-vengeance",
-                "toggleable": true
-            },
-            {
-                "damageType": "spirit",
-                "key": "FlatModifier",
-                "predicate": [
-                    "destructive-vengeance"
-                ],
-                "selector": "strike-damage",
-                "slug": "destructive-vengeance-damage",
-                "value": "ternary(gte(@actor.level,16),6,ternary(gte(@actor.level,9),4,2))"
-            }
-        ],
+        "rules": [],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/actions/flash-of-grandeur.json
+++ b/packs/actions/flash-of-grandeur.json
@@ -18,14 +18,7 @@
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [
-            {
-                "key": "RollOption",
-                "label": "PF2E.SpecificRule.Champion.TargetReaction",
-                "option": "flash-of-grandeur",
-                "toggleable": true
-            }
-        ],
+        "rules": [],
         "traits": {
             "value": [
                 "champion",

--- a/packs/actions/glimpse-of-redemption.json
+++ b/packs/actions/glimpse-of-redemption.json
@@ -18,14 +18,7 @@
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [
-            {
-                "key": "RollOption",
-                "label": "PF2E.SpecificRule.Champion.TargetReaction",
-                "option": "glimpse-of-redemption",
-                "toggleable": true
-            }
-        ],
+        "rules": [],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/actions/iron-command.json
+++ b/packs/actions/iron-command.json
@@ -11,31 +11,14 @@
         },
         "category": "offensive",
         "description": {
-            "value": "<p><strong>Trigger</strong> An enemy in your champion's aura damages you</p><hr /><p><strong>Effect</strong> You put an impertinent foe who dared harm you in their proper place. You command your enemy to kneel before you in obedience. If they dare to refuse, they must pay the price in pain and anguish. The enemy must choose one of the following options.</p><ul><li><strong>Kneel</strong> The enemy drops @UUID[Compendium.pf2e.conditionitems.Item.Prone] as a free action.</li><li><p><strong>Refuse</strong> You deal @Damage[(ternary(gte(@actor.level,19),6,ternary(gte(@actor.level,16),5,ternary(gte(@actor.level,12),4,ternary(gte(@actor.level,9),3,ternary(gte(@actor.level,5),2,1))))))d6[mental]] damage to the enemy. This damage increases to 2d6 at 5th level, 3d6 at 9th level, 4d6 at 12th level, 5d6 at 16th level, and 6d6 at 19th level.</p></li></ul><p>Regardless of which option the enemy chose, your Strikes against it deal 1 extra spirit damage until the end of your next turn. This extra damage increases to 2 at 9th level and 3 at 16th level.</p>"
+            "value": "<p><strong>Trigger</strong> An enemy in your champion's aura damages you</p><hr /><p><strong>Effect</strong> You put an impertinent foe who dared harm you in their proper place. You command your enemy to kneel before you in obedience. If they dare to refuse, they must pay the price in pain and anguish. The enemy must choose one of the following options.</p><ul><li><strong>Kneel</strong> The enemy drops @UUID[Compendium.pf2e.conditionitems.Item.Prone] as a free action.</li><li><p><strong>Refuse</strong> You deal @Damage[(ternary(gte(@actor.level,19),6,ternary(gte(@actor.level,16),5,ternary(gte(@actor.level,12),4,ternary(gte(@actor.level,9),3,ternary(gte(@actor.level,5),2,1))))))d6[mental]] damage to the enemy. This damage increases to 2d6 at 5th level, 3d6 at 9th level, 4d6 at 12th level, 5d6 at 16th level, and 6d6 at 19th level.</p></li></ul><p>Regardless of which option the enemy chose, your Strikes against it deal 1 extra spirit damage until the end of your next turn. This extra damage increases to 2 at 9th level and 3 at 16th level.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Champion's Extra Damage]</p>"
         },
         "publication": {
             "license": "ORC",
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [
-            {
-                "key": "RollOption",
-                "label": "PF2E.SpecificRule.Champion.TargetReaction",
-                "option": "iron-command",
-                "toggleable": true
-            },
-            {
-                "damageType": "spirit",
-                "key": "FlatModifier",
-                "predicate": [
-                    "iron-command"
-                ],
-                "selector": "strike-damage",
-                "slug": "iron-command-damage",
-                "value": "ternary(gte(@actor.level,16),3,ternary(gte(@actor.level,9),2,1))"
-            }
-        ],
+        "rules": [],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/actions/liberating-step.json
+++ b/packs/actions/liberating-step.json
@@ -18,14 +18,7 @@
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [
-            {
-                "key": "RollOption",
-                "label": "PF2E.SpecificRule.Champion.TargetReaction",
-                "option": "liberating-step",
-                "toggleable": true
-            }
-        ],
+        "rules": [],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/actions/retributive-strike.json
+++ b/packs/actions/retributive-strike.json
@@ -21,8 +21,18 @@
         "rules": [
             {
                 "key": "RollOption",
-                "label": "PF2E.SpecificRule.Champion.TargetReaction",
                 "option": "retributive-strike",
+                "predicate": [
+                    {
+                        "or": [
+                            "feature:relentless-reaction",
+                            "feat:shining-oath",
+                            "feat:fiendsbane-oath",
+                            "feat:dragonslayer-oath",
+                            "feat:esoteric-oath"
+                        ]
+                    }
+                ],
                 "toggleable": true
             }
         ],

--- a/packs/actions/selfish-shield.json
+++ b/packs/actions/selfish-shield.json
@@ -11,36 +11,14 @@
         },
         "category": "defensive",
         "description": {
-            "value": "<p><strong>Trigger</strong> An enemy in your champion's aura damages you</p><hr /><p><strong>Effect</strong> Your self-interest keeps you safe. You gain resistance against the triggering damage equal to 2 + half your level, regardless of damage type. In addition, your Strikes against the triggering creature deal 1 extra spirit damage until the end of your next turn. This extra damage increases to 2 at 9th level and 3 at 16th level.</p>"
+            "value": "<p><strong>Trigger</strong> An enemy in your champion's aura damages you</p><hr /><p><strong>Effect</strong> Your self-interest keeps you safe. You gain resistance against the triggering damage equal to 2 + half your level, regardless of damage type.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Selfish Shield]</p>\n<p>In addition, your Strikes against the triggering creature deal 1 extra spirit damage until the end of your next turn. This extra damage increases to 2 at 9th level and 3 at 16th level.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Champion's Extra Damage]</p>"
         },
         "publication": {
             "license": "ORC",
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [
-            {
-                "domain": "damage",
-                "key": "RollOption",
-                "label": "PF2E.SpecificRule.Champion.TargetReaction",
-                "option": "selfish-shield",
-                "toggleable": true
-            },
-            {
-                "damageType": "spirit",
-                "key": "FlatModifier",
-                "predicate": [
-                    "selfish-shield"
-                ],
-                "selector": "strike-damage",
-                "slug": "selfish-shield-damage",
-                "value": "ternary(gte(@actor.level,16),3,ternary(gte(@actor.level,9),2,1))"
-            }
-        ],
-        "selfEffect": {
-            "name": "Effect: Selfish Shield",
-            "uuid": "Compendium.pf2e.feat-effects.Item.Effect: Selfish Shield"
-        },
+        "rules": [],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/classfeatures/exalted-reaction.json
+++ b/packs/classfeatures/exalted-reaction.json
@@ -54,13 +54,18 @@
                 ]
             },
             {
-                "key": "Note",
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "mode": "add",
                 "predicate": [
-                    "destructive-vengeance"
+                    "item:slug:destructive-vengeance"
                 ],
-                "selector": "strike-damage",
-                "text": "PF2E.SpecificRule.Champion.ExaltedReaction.Iniquity",
-                "title": "{item|name}"
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Champion.ExaltedReaction.Iniquity"
+                    }
+                ]
             },
             {
                 "itemType": "action",

--- a/packs/classfeatures/relentless-reaction.json
+++ b/packs/classfeatures/relentless-reaction.json
@@ -40,13 +40,18 @@
                 ]
             },
             {
-                "key": "Note",
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "mode": "add",
                 "predicate": [
-                    "destructive-vengeance"
+                    "item:slug:destructive-vengeance"
                 ],
-                "selector": "strike-damage",
-                "text": "PF2E.SpecificRule.Champion.RelentlessReaction.Iniquity",
-                "title": "{item|name}"
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Champion.RelentlessReaction.Iniquity"
+                    }
+                ]
             },
             {
                 "damageCategory": "persistent",

--- a/packs/feat-effects/effect-champions-extra-damage.json
+++ b/packs/feat-effects/effect-champions-extra-damage.json
@@ -1,0 +1,61 @@
+{
+    "_id": "2a6fuugiPpICe3Li",
+    "img": "icons/weapons/swords/sword-runed-glowing.webp",
+    "name": "Effect: Champion's Extra Damage",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.actionspf2e.Item.Destructive Vengeance], @UUID[Compendium.pf2e.actionspf2e.Item.Iron Command], and @UUID[Compendium.pf2e.actionspf2e.Item.Selfish Shield]</p>\n<p>Your strikes against the triggering creature deal extra spirit damage.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core 2"
+        },
+        "rules": [
+            {
+                "key": "TokenMark",
+                "slug": "champions-extra-damage"
+            },
+            {
+                "damageType": "spirit",
+                "key": "FlatModifier",
+                "predicate": [
+                    "target:mark:champions-extra-damage"
+                ],
+                "selector": "strike-damage",
+                "slug": "champions-extra-damage",
+                "value": "ternary(gte(@actor.level,16),3,ternary(gte(@actor.level,9),2,1))"
+            },
+            {
+                "key": "AdjustModifier",
+                "mode": "multiply",
+                "predicate": [
+                    "feature:iniquity"
+                ],
+                "selector": "strike-damage",
+                "slug": "champions-extra-damage",
+                "value": 2
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feat-effects/effect-selfish-shield.json
+++ b/packs/feat-effects/effect-selfish-shield.json
@@ -34,7 +34,7 @@
             {
                 "key": "Resistance",
                 "predicate": [
-                    "feature:divine-smite"
+                    "feature:relentless-reaction"
                 ],
                 "type": "all-damage",
                 "value": "floor(@actor.level/2)+max(2,@actor.system.abilities.cha.mod)"

--- a/packs/feats/dragonslayer-oath.json
+++ b/packs/feats/dragonslayer-oath.json
@@ -33,7 +33,6 @@
                 "key": "FlatModifier",
                 "predicate": [
                     "retributive-strike",
-                    "feature:paladin",
                     "target:trait:dragon"
                 ],
                 "selector": "strike-damage",

--- a/packs/feats/esoteric-oath.json
+++ b/packs/feats/esoteric-oath.json
@@ -33,7 +33,6 @@
                 "key": "FlatModifier",
                 "predicate": [
                     "retributive-strike",
-                    "feature:paladin",
                     "target:trait:aberration"
                 ],
                 "selector": "strike-damage",

--- a/packs/feats/fiendsbane-oath.json
+++ b/packs/feats/fiendsbane-oath.json
@@ -33,7 +33,6 @@
                 "key": "FlatModifier",
                 "predicate": [
                     "retributive-strike",
-                    "feature:paladin",
                     "target:trait:fiend"
                 ],
                 "selector": "strike-damage",

--- a/packs/feats/gruesome-strike.json
+++ b/packs/feats/gruesome-strike.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p><strong>Requirements</strong> Your Strikes currently deal extra damage from your champion's reaction.</p><hr /><p>Make a Strike against the creature that triggered your champion's reaction. If you hit, double the extra damage the target takes from your reaction, and the target must succeed at a Fortitude save against your class DC or be @UUID[Compendium.pf2e.conditionitems.Item.Drained]{Drained 1}. Regardless of the result, the creature is temporarily immune to your Gruesome Strike for 24 hours.</p>"
+            "value": "<p><strong>Requirements</strong> Your Strikes currently deal extra damage from your champion's reaction.</p><hr /><p>Make a Strike against the creature that triggered your champion's reaction. If you hit, double the extra damage the target takes from your reaction, and the target must succeed at a @Check[type:fortitude|dc:resolve(@actor.attributes.classDC.value)] save against your class DC or be @UUID[Compendium.pf2e.conditionitems.Item.Drained]{Drained 1}. Regardless of the result, the creature is temporarily immune to your Gruesome Strike for 24 hours.</p>"
         },
         "level": {
             "value": 12
@@ -30,20 +30,22 @@
         },
         "rules": [
             {
-                "domain": "damage",
                 "key": "RollOption",
                 "option": "gruesome-strike",
                 "toggleable": true
             },
             {
-                "key": "AdjustModifier",
-                "mode": "multiply",
+                "key": "Note",
+                "outcome": [
+                    "success",
+                    "criticalSuccess"
+                ],
                 "predicate": [
                     "gruesome-strike"
                 ],
-                "selector": "strike-damage",
-                "slug": "selfish-shield-damage",
-                "value": 2
+                "selector": "strike-attack-roll",
+                "text": "PF2E.SpecificRule.Champion.GruesomeStrike.Note",
+                "title": "{item|name}"
             },
             {
                 "key": "AdjustModifier",
@@ -52,17 +54,7 @@
                     "gruesome-strike"
                 ],
                 "selector": "strike-damage",
-                "slug": "destructive-vengeance-damage",
-                "value": 2
-            },
-            {
-                "key": "AdjustModifier",
-                "mode": "multiply",
-                "predicate": [
-                    "gruesome-strike"
-                ],
-                "selector": "strike-damage",
-                "slug": "iron-command-damage",
+                "slug": "champions-extra-damage",
                 "value": 2
             }
         ],

--- a/packs/feats/instrument-of-slaughter.json
+++ b/packs/feats/instrument-of-slaughter.json
@@ -35,13 +35,7 @@
                 "diceNumber": 2,
                 "key": "DamageDice",
                 "predicate": [
-                    {
-                        "or": [
-                            "destructive-vengeance",
-                            "iron-command",
-                            "selfish-shield"
-                        ]
-                    }
+                    "target:mark:champions-extra-damage"
                 ],
                 "selector": "strike-damage"
             }

--- a/packs/feats/instrument-of-zeal.json
+++ b/packs/feats/instrument-of-zeal.json
@@ -51,7 +51,7 @@
                 "predicate": [
                     {
                         "or": [
-                            "blade-justice",
+                            "blessed-counterstrike",
                             "retributive-strike"
                         ]
                     }

--- a/packs/feats/shining-oath.json
+++ b/packs/feats/shining-oath.json
@@ -33,7 +33,6 @@
                 "key": "FlatModifier",
                 "predicate": [
                     "retributive-strike",
-                    "feature:paladin",
                     "target:mode:undead"
                 ],
                 "selector": "strike-damage",

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2150,6 +2150,9 @@
                     "Obedience": "Each enemy in your champion's aura other than the triggering creature must also either drop @UUID[Compendium.pf2e.conditionitems.Item.j91X7x0XSomq8d60]{Prone} or take mental damage (each enemy chooses). These creatures take only minimum damage (typically @Damage[ternary(gte(@actor.level,19),6,ternary(gte(@actor.level,16),5,ternary(gte(@actor.level,12),4,ternary(gte(@actor.level,11),3)[mental]]), and the effects they take can't be adjusted by anything that changes your Iron Command. For instance, the Iron Repercussions feat couldn't turn the damage into persistent mental damage for creatures other than the triggering creature.",
                     "Redemption": "If the enemy refuses, you can choose to grant the resistance to yourself and all allies in your champion's aura, including the triggering ally. If you do, the resistance is reduced by 2 for all @UUID[Compendium.pf2e.feat-effects.Item.GFLiTESBmoyQ3sLx]{Effect: Exalted Reaction (Redemption)}"
                 },
+                "GruesomeStrike": {
+                    "Note": "The target must succeed at a @Check[type:fortitude|dc:resolve(@actor.attributes.classDC.value)] save against your class DC or be @UUID[Compendium.pf2e.conditionitems.Item.4D2KBtexWXa6oUMR]{Drained 1}."
+                },
                 "IronRepercussions": {
                     "Description": "Disobeying your Iron Command has lasting consequences. If an enemy refuses to kneel to you, you can deal @Damage[(ternary(gte(@actor.level,19),6,ternary(gte(@actor.level,16),5,ternary(gte(@actor.level,12),4,ternary(gte(@actor.level,9),3,ternary(gte(@actor.level,5),2,1))))))d6[persistent,mental]] instead of normal mental damage. You must decide whether the mental damage will be persistent before your enemy chooses whether to kneel or not. The amount of damage is unchanged."
                 },


### PR DESCRIPTION
- Remove unnecessary toggles on champion reactions, except on Retributive Strike, whose toggle is predicated on features that make use of it.
- Add effect for the extra spirit damage that Desecration, Iniquity and Obedience get, and implement Gruesome Strike and Implement of Slaughter through it.
- Turn erronously added Iniquity cause Notes into Item Alterations in Exalted Reaction and Relentless Reaction