### PR TITLE
Fix ranged attack penalty on Tempest curse

### DIFF
--- a/packs/classfeatures/tempest.json
+++ b/packs/classfeatures/tempest.json
@@ -49,6 +49,7 @@
             {
                 "key": "FlatModifier",
                 "predicate": [
+                    "item:ranged",
                     {
                         "gte": [
                             "self:condition:cursebound",
@@ -56,7 +57,7 @@
                         ]
                     }
                 ],
-                "selector": "ranged-attack-roll",
+                "selector": "attack-roll",
                 "type": "circumstance",
                 "value": -2
             },


### PR DESCRIPTION
Not sure if spell attack rolls are supposed to have the ranged attack roll selector, but here's a workaround for now if it is.