### PR TITLE
Allow Champion's Aura to be granted to archetype champions

### DIFF
--- a/packs/classfeatures/deity-champion.json
+++ b/packs/classfeatures/deity-champion.json
@@ -159,9 +159,6 @@
             },
             {
                 "key": "GrantItem",
-                "predicate": [
-                    "class:champion"
-                ],
                 "uuid": "Compendium.pf2e.classfeatures.Item.Champion's Aura"
             }
         ],


### PR DESCRIPTION
per the PFS clarification https://paizo.com/pathfindersociety/characteroptions
![image](https://github.com/user-attachments/assets/8c2914b2-2f9e-4172-8422-20b1adb8e418)
