### PR TITLE
Fix dimensions of pathfinder logo on PC sheet

### DIFF
--- a/src/styles/actor/character/_sidebar.scss
+++ b/src/styles/actor/character/_sidebar.scss
@@ -14,6 +14,10 @@ aside {
     grid-area: sidebar;
     margin-left: 8px; // ignore font-size setting
 
+    img.logo {
+        width: calc(14rem + var(--space-10));
+    }
+
     input[type="number"] {
         color: var(--text-light);
         font-size: var(--font-size-28);

--- a/static/templates/actors/character/sheet.hbs
+++ b/static/templates/actors/character/sheet.hbs
@@ -1,6 +1,6 @@
 <form class="{{cssClass}} crb-style{{#if isProficiencyLocked}} proficiency-lock{{/if}}" data-tooltip-class="pf2e" autocomplete="off">
     <aside>
-        <img class="logo" src="systems/pf2e/assets/pathfinder_logo.webp" height="56" alt="" srcset="" />
+        <img class="logo" src="systems/pf2e/assets/pathfinder_logo.webp" />
         <div class="sidebar" data-tab="sidebar">
             {{> "systems/pf2e/templates/actors/character/partials/sidebar.hbs"}}
         </div>


### PR DESCRIPTION
The inline height attribute was vertically stretching it a few pixels; current width is preserved.

Before:
![image](https://github.com/user-attachments/assets/dad90c9f-cf14-4386-b471-295de1c226d1)

After:
![image](https://github.com/user-attachments/assets/be4b340f-2802-4339-85b9-2762c0393522)
