### PR TITLE
Automate dragonblood's Draconic Exemplar feats

### DIFF
--- a/packs/feats/breath-of-the-dragon-dragonblood.json
+++ b/packs/feats/breath-of-the-dragon-dragonblood.json
@@ -24,7 +24,133 @@
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [],
+        "rules": [
+            {
+                "actorFlag": true,
+                "choices": [
+                    {
+                        "label": "PF2E.Dragon.Adamantine",
+                        "value": [
+                            {
+                                "damageType": "bludgeoning",
+                                "distance": 15,
+                                "dragon": "adamantine",
+                                "save": "reflex",
+                                "shape": "cone",
+                                "speed": "burrow",
+                                "tradition": "primal"
+                            }
+                        ]
+                    },
+                    {
+                        "label": "PF2E.Dragon.Conspirator",
+                        "value": [
+                            {
+                                "damageType": "poison",
+                                "distance": 15,
+                                "dragon": "conspirator",
+                                "save": "fortitude",
+                                "shape": "cone",
+                                "speed": "climb",
+                                "tradition": "occult"
+                            }
+                        ]
+                    },
+                    {
+                        "label": "PF2E.Dragon.Diabolic",
+                        "value": [
+                            {
+                                "damageType": "fire",
+                                "distance": 15,
+                                "dragon": "diabolic",
+                                "save": "reflex",
+                                "shape": "cone",
+                                "tradition": "divine"
+                            }
+                        ]
+                    },
+                    {
+                        "label": "PF2E.Dragon.Empyreal",
+                        "value": [
+                            {
+                                "damageType": "spirit",
+                                "distance": 15,
+                                "dragon": "empyreal",
+                                "save": "reflex",
+                                "shape": "cone",
+                                "tradition": "divine"
+                            }
+                        ]
+                    },
+                    {
+                        "label": "PF2E.Dragon.Fortune",
+                        "value": [
+                            {
+                                "damageType": "force",
+                                "distance": 15,
+                                "dragon": "empyreal",
+                                "save": "reflex",
+                                "shape": "cone",
+                                "tradition": "arcane"
+                            }
+                        ]
+                    },
+                    {
+                        "label": "PF2E.Dragon.Horned",
+                        "value": [
+                            {
+                                "damageType": "poison",
+                                "distance": 15,
+                                "dragon": "horned",
+                                "save": "fortitude",
+                                "shape": "cone",
+                                "speed": "swim",
+                                "tradition": "primal"
+                            }
+                        ]
+                    },
+                    {
+                        "label": "PF2E.Dragon.Mirage",
+                        "value": [
+                            {
+                                "damageType": "mental",
+                                "distance": 15,
+                                "dragon": "mirage",
+                                "save": "will",
+                                "shape": "cone",
+                                "speed": "climb",
+                                "tradition": "arcane"
+                            }
+                        ]
+                    },
+                    {
+                        "label": "PF2E.Dragon.Omen",
+                        "value": [
+                            {
+                                "damageType": "mental",
+                                "distance": 15,
+                                "dragon": "omen",
+                                "save": "will",
+                                "shape": "cone",
+                                "tradition": "occult"
+                            }
+                        ]
+                    }
+                ],
+                "flag": "draconicExemplar",
+                "key": "ChoiceSet",
+                "predicate": [
+                    "draconic-exemplar:delayed"
+                ]
+            },
+            {
+                "itemId": "{item|id}",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "property": "traits",
+                "value": "{actor|flags.pf2e.rulesSelections.draconicExemplar.tradition}"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/breath-of-the-dragon-dragonblood.json
+++ b/packs/feats/breath-of-the-dragon-dragonblood.json
@@ -11,7 +11,7 @@
         },
         "category": "ancestry",
         "description": {
-            "value": "<p>Tapping into the physiology of your draconic ancestor, you can exhale a torrent of energy in a @Template[type:cone|distance:15] or a @Template[type:line|distance:30], dealing @Damage[1d4[untyped]] damage. Each creature in the area must attempt a basic saving throw against the higher of your class DC or spell DC. You can't use this ability again for [[/r 1d4 #Recharge this ability]]{1d4 rounds}.</p>\n<p>At 3rd level and every 2 levels thereafter, the damage increases by 1d4. The shape of the breath, the damage type, and the saving throw match those of your draconic exemplar. This ability has the trait associated with the type of damage it deals.</p>"
+            "value": "<p>Tapping into the physiology of your draconic ancestor, you can exhale a torrent of energy in a @Template[type:cone|distance:15] or a @Template[type:line|distance:30], dealing 1d4 damage. Each creature in the area must attempt a basic saving throw against the higher of your class DC or spell DC. You can't use this ability again for [[/r 1d4 #Recharge this ability]]{1d4 rounds}.</p>\n<p>At 3rd level and every 2 levels thereafter, the damage increases by 1d4. The shape of the breath, the damage type, and the saving throw match those of your draconic exemplar. This ability has the trait associated with the type of damage it deals.</p>"
         },
         "level": {
             "value": 1
@@ -26,129 +26,69 @@
         },
         "rules": [
             {
-                "actorFlag": true,
-                "choices": [
-                    {
-                        "label": "PF2E.Dragon.Adamantine",
-                        "value": [
-                            {
-                                "damageType": "bludgeoning",
-                                "distance": 15,
-                                "dragon": "adamantine",
-                                "save": "reflex",
-                                "shape": "cone",
-                                "speed": "burrow",
-                                "tradition": "primal"
-                            }
-                        ]
-                    },
-                    {
-                        "label": "PF2E.Dragon.Conspirator",
-                        "value": [
-                            {
-                                "damageType": "poison",
-                                "distance": 15,
-                                "dragon": "conspirator",
-                                "save": "fortitude",
-                                "shape": "cone",
-                                "speed": "climb",
-                                "tradition": "occult"
-                            }
-                        ]
-                    },
-                    {
-                        "label": "PF2E.Dragon.Diabolic",
-                        "value": [
-                            {
-                                "damageType": "fire",
-                                "distance": 15,
-                                "dragon": "diabolic",
-                                "save": "reflex",
-                                "shape": "cone",
-                                "tradition": "divine"
-                            }
-                        ]
-                    },
-                    {
-                        "label": "PF2E.Dragon.Empyreal",
-                        "value": [
-                            {
-                                "damageType": "spirit",
-                                "distance": 15,
-                                "dragon": "empyreal",
-                                "save": "reflex",
-                                "shape": "cone",
-                                "tradition": "divine"
-                            }
-                        ]
-                    },
-                    {
-                        "label": "PF2E.Dragon.Fortune",
-                        "value": [
-                            {
-                                "damageType": "force",
-                                "distance": 15,
-                                "dragon": "empyreal",
-                                "save": "reflex",
-                                "shape": "cone",
-                                "tradition": "arcane"
-                            }
-                        ]
-                    },
-                    {
-                        "label": "PF2E.Dragon.Horned",
-                        "value": [
-                            {
-                                "damageType": "poison",
-                                "distance": 15,
-                                "dragon": "horned",
-                                "save": "fortitude",
-                                "shape": "cone",
-                                "speed": "swim",
-                                "tradition": "primal"
-                            }
-                        ]
-                    },
-                    {
-                        "label": "PF2E.Dragon.Mirage",
-                        "value": [
-                            {
-                                "damageType": "mental",
-                                "distance": 15,
-                                "dragon": "mirage",
-                                "save": "will",
-                                "shape": "cone",
-                                "speed": "climb",
-                                "tradition": "arcane"
-                            }
-                        ]
-                    },
-                    {
-                        "label": "PF2E.Dragon.Omen",
-                        "value": [
-                            {
-                                "damageType": "mental",
-                                "distance": 15,
-                                "dragon": "omen",
-                                "save": "will",
-                                "shape": "cone",
-                                "tradition": "occult"
-                            }
-                        ]
-                    }
-                ],
-                "flag": "draconicExemplar",
-                "key": "ChoiceSet",
-                "predicate": [
-                    "draconic-exemplar:delayed"
-                ]
-            },
-            {
                 "itemId": "{item|id}",
                 "key": "ItemAlteration",
                 "mode": "add",
                 "property": "traits",
-                "value": "{actor|flags.pf2e.rulesSelections.draconicExemplar.tradition}"
+                "value": "{actor|flags.pf2e.dragonblood.tradition}"
+            },
+            {
+                "key": "RollOption",
+                "option": "breath-of-the-dragon:{actor|flags.pf2e.dragonblood.shape}"
+            },
+            {
+                "key": "RollOption",
+                "option": "breath-of-the-dragon:{actor|flags.pf2e.dragonblood.save}"
+            },
+            {
+                "itemId": "{item|id}",
+                "key": "ItemAlteration",
+                "mode": "override",
+                "property": "description",
+                "value": [
+                    {
+                        "predicate": [
+                            "breath-of-the-dragon:cone",
+                            "breath-of-the-dragon:fortitude"
+                        ],
+                        "text": "PF2E.SpecificRule.Dragonblood.BreathOfTheDragon.Cone.Fortitude"
+                    },
+                    {
+                        "predicate": [
+                            "breath-of-the-dragon:cone",
+                            "breath-of-the-dragon:reflex"
+                        ],
+                        "text": "PF2E.SpecificRule.Dragonblood.BreathOfTheDragon.Cone.Reflex"
+                    },
+                    {
+                        "predicate": [
+                            "breath-of-the-dragon:cone",
+                            "breath-of-the-dragon:will"
+                        ],
+                        "text": "PF2E.SpecificRule.Dragonblood.BreathOfTheDragon.Cone.Will"
+                    },
+                    {
+                        "predicate": [
+                            "breath-of-the-dragon:line",
+                            "breath-of-the-dragon:fortitude"
+                        ],
+                        "text": "PF2E.SpecificRule.Dragonblood.BreathOfTheDragon.Line.Fortitude"
+                    },
+                    {
+                        "predicate": [
+                            "breath-of-the-dragon:line",
+                            "breath-of-the-dragon:reflex"
+                        ],
+                        "text": "PF2E.SpecificRule.Dragonblood.BreathOfTheDragon.Line.Reflex"
+                    },
+                    {
+                        "predicate": [
+                            "breath-of-the-dragon:line",
+                            "breath-of-the-dragon:will"
+                        ],
+                        "text": "PF2E.SpecificRule.Dragonblood.BreathOfTheDragon.Line.Will"
+                    }
+                ]
             }
         ],
         "traits": {

--- a/packs/feats/draconic-resistance.json
+++ b/packs/feats/draconic-resistance.json
@@ -24,7 +24,76 @@
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "RollOption",
+                "option": "draconic-resistance:{actor|flags.pf2e.dragonblood.damageType}"
+            },
+            {
+                "choices": [
+                    {
+                        "label": "PF2E.TraitAcid",
+                        "value": "acid"
+                    },
+                    {
+                        "label": "PF2E.TraitCold",
+                        "value": "cold"
+                    },
+                    {
+                        "label": "PF2E.TraitElectricity",
+                        "value": "electricity"
+                    },
+                    {
+                        "label": "PF2E.TraitFire",
+                        "value": "fire"
+                    },
+                    {
+                        "label": "PF2E.TraitSonic",
+                        "value": "sonic"
+                    }
+                ],
+                "flag": "resistance",
+                "key": "ChoiceSet",
+                "predicate": [
+                    {
+                        "or": [
+                            "draconic-resistance:bludgeoning",
+                            "draconic-resistance:slashing",
+                            "draconic-resistance:piercing"
+                        ]
+                    }
+                ],
+                "prompt": "PF2E.SpecificRule.Prompt.EnergyType"
+            },
+            {
+                "key": "Resistance",
+                "predicate": [
+                    {
+                        "nor": [
+                            "draconic-resistance:bludgeoning",
+                            "draconic-resistance:piercing",
+                            "draconic-resistance:slashing"
+                        ]
+                    }
+                ],
+                "type": "{actor|flags.pf2e.dragonblood.damageType}",
+                "value": "max(1,floor(@actor.level/2))"
+            },
+            {
+                "key": "Resistance",
+                "predicate": [
+                    {
+                        "or": [
+                            "draconic-resistance:bludgeoning",
+                            "draconic-resistance:piercing",
+                            "draconic-resistance:slashing"
+                        ]
+                    }
+                ],
+                "type": "{item|flags.pf2e.rulesSelections.resistance}",
+                "value": "max(1,floor(@actor.level/2))"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/formidable-breath.json
+++ b/packs/feats/formidable-breath.json
@@ -28,7 +28,62 @@
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "override",
+                "predicate": [
+                    "item:slug:breath-of-the-dragon-dragonblood"
+                ],
+                "priority": 151,
+                "property": "description",
+                "value": [
+                    {
+                        "predicate": [
+                            "breath-of-the-dragon:cone",
+                            "breath-of-the-dragon:fortitude"
+                        ],
+                        "text": "PF2E.SpecificRule.Dragonblood.FormidableBreath.Cone.Fortitude"
+                    },
+                    {
+                        "predicate": [
+                            "breath-of-the-dragon:cone",
+                            "breath-of-the-dragon:reflex"
+                        ],
+                        "text": "PF2E.SpecificRule.Dragonblood.FormidableBreath.Cone.Reflex"
+                    },
+                    {
+                        "predicate": [
+                            "breath-of-the-dragon:cone",
+                            "breath-of-the-dragon:will"
+                        ],
+                        "text": "PF2E.SpecificRule.Dragonblood.FormidableBreath.Cone.Will"
+                    },
+                    {
+                        "predicate": [
+                            "breath-of-the-dragon:line",
+                            "breath-of-the-dragon:fortitude"
+                        ],
+                        "text": "PF2E.SpecificRule.Dragonblood.FormidableBreath.Line.Fortitude"
+                    },
+                    {
+                        "predicate": [
+                            "breath-of-the-dragon:line",
+                            "breath-of-the-dragon:reflex"
+                        ],
+                        "text": "PF2E.SpecificRule.Dragonblood.FormidableBreath.Line.Reflex"
+                    },
+                    {
+                        "predicate": [
+                            "breath-of-the-dragon:line",
+                            "breath-of-the-dragon:will"
+                        ],
+                        "text": "PF2E.SpecificRule.Dragonblood.FormidableBreath.Line.Will"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/lingering-breath.json
+++ b/packs/feats/lingering-breath.json
@@ -28,7 +28,22 @@
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:breath-of-the-dragon-dragonblood"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Dragonblood.LingeringBreath.Description"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/heritages/versatile-heritages/dragonblood.json
+++ b/packs/heritages/versatile-heritages/dragonblood.json
@@ -15,6 +15,140 @@
         },
         "rules": [
             {
+                "adjustName": false,
+                "choices": [
+                    {
+                        "label": "PF2E.UI.RuleElements.ChoiceSet.YesLabel",
+                        "value": "chosen"
+                    },
+                    {
+                        "label": "PF2E.UI.RuleElements.ChoiceSet.NoLabel",
+                        "value": "delayed"
+                    }
+                ],
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Dragonblood.DraconicExemplar.Prompt",
+                "rollOption": "draconic-exemplar"
+            },
+            {
+                "actorFlag": true,
+                "choices": [
+                    {
+                        "label": "PF2E.Dragon.Adamantine",
+                        "value": [
+                            {
+                                "damageType": "bludgeoning",
+                                "distance": 15,
+                                "dragon": "adamantine",
+                                "save": "reflex",
+                                "shape": "cone",
+                                "speed": "burrow",
+                                "tradition": "primal"
+                            }
+                        ]
+                    },
+                    {
+                        "label": "PF2E.Dragon.Conspirator",
+                        "value": [
+                            {
+                                "damageType": "poison",
+                                "distance": 15,
+                                "dragon": "conspirator",
+                                "save": "fortitude",
+                                "shape": "cone",
+                                "speed": "climb",
+                                "tradition": "occult"
+                            }
+                        ]
+                    },
+                    {
+                        "label": "PF2E.Dragon.Diabolic",
+                        "value": [
+                            {
+                                "damageType": "fire",
+                                "distance": 15,
+                                "dragon": "diabolic",
+                                "save": "reflex",
+                                "shape": "cone",
+                                "tradition": "divine"
+                            }
+                        ]
+                    },
+                    {
+                        "label": "PF2E.Dragon.Empyreal",
+                        "value": [
+                            {
+                                "damageType": "spirit",
+                                "distance": 15,
+                                "dragon": "empyreal",
+                                "save": "reflex",
+                                "shape": "cone",
+                                "tradition": "divine"
+                            }
+                        ]
+                    },
+                    {
+                        "label": "PF2E.Dragon.Fortune",
+                        "value": [
+                            {
+                                "damageType": "force",
+                                "distance": 15,
+                                "dragon": "empyreal",
+                                "save": "reflex",
+                                "shape": "cone",
+                                "tradition": "arcane"
+                            }
+                        ]
+                    },
+                    {
+                        "label": "PF2E.Dragon.Horned",
+                        "value": [
+                            {
+                                "damageType": "poison",
+                                "distance": 15,
+                                "dragon": "horned",
+                                "save": "fortitude",
+                                "shape": "cone",
+                                "speed": "swim",
+                                "tradition": "primal"
+                            }
+                        ]
+                    },
+                    {
+                        "label": "PF2E.Dragon.Mirage",
+                        "value": [
+                            {
+                                "damageType": "mental",
+                                "distance": 15,
+                                "dragon": "mirage",
+                                "save": "will",
+                                "shape": "cone",
+                                "speed": "climb",
+                                "tradition": "arcane"
+                            }
+                        ]
+                    },
+                    {
+                        "label": "PF2E.Dragon.Omen",
+                        "value": [
+                            {
+                                "damageType": "mental",
+                                "distance": 15,
+                                "dragon": "omen",
+                                "save": "will",
+                                "shape": "cone",
+                                "tradition": "occult"
+                            }
+                        ]
+                    }
+                ],
+                "flag": "draconicExemplar",
+                "key": "ChoiceSet",
+                "predicate": [
+                    "draconic-exemplar:chosen"
+                ]
+            },
+            {
                 "adjustment": {
                     "success": "one-degree-better"
                 },

--- a/packs/heritages/versatile-heritages/dragonblood.json
+++ b/packs/heritages/versatile-heritages/dragonblood.json
@@ -15,138 +15,95 @@
         },
         "rules": [
             {
-                "adjustName": false,
-                "choices": [
-                    {
-                        "label": "PF2E.UI.RuleElements.ChoiceSet.YesLabel",
-                        "value": "chosen"
-                    },
-                    {
-                        "label": "PF2E.UI.RuleElements.ChoiceSet.NoLabel",
-                        "value": "delayed"
-                    }
-                ],
-                "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.Dragonblood.DraconicExemplar.Prompt",
-                "rollOption": "draconic-exemplar"
-            },
-            {
                 "actorFlag": true,
                 "choices": [
                     {
                         "label": "PF2E.Dragon.Adamantine",
-                        "value": [
-                            {
-                                "damageType": "bludgeoning",
-                                "distance": 15,
-                                "dragon": "adamantine",
-                                "save": "reflex",
-                                "shape": "cone",
-                                "speed": "burrow",
-                                "tradition": "primal"
-                            }
-                        ]
+                        "value": {
+                            "damageType": "bludgeoning",
+                            "dragon": "adamantine",
+                            "save": "reflex",
+                            "shape": "cone",
+                            "speed": "burrow",
+                            "tradition": "primal"
+                        }
                     },
                     {
                         "label": "PF2E.Dragon.Conspirator",
-                        "value": [
-                            {
-                                "damageType": "poison",
-                                "distance": 15,
-                                "dragon": "conspirator",
-                                "save": "fortitude",
-                                "shape": "cone",
-                                "speed": "climb",
-                                "tradition": "occult"
-                            }
-                        ]
+                        "value": {
+                            "damageType": "poison",
+                            "dragon": "conspirator",
+                            "save": "fortitude",
+                            "shape": "cone",
+                            "speed": "climb",
+                            "tradition": "occult"
+                        }
                     },
                     {
                         "label": "PF2E.Dragon.Diabolic",
-                        "value": [
-                            {
-                                "damageType": "fire",
-                                "distance": 15,
-                                "dragon": "diabolic",
-                                "save": "reflex",
-                                "shape": "cone",
-                                "tradition": "divine"
-                            }
-                        ]
+                        "value": {
+                            "damageType": "fire",
+                            "dragon": "diabolic",
+                            "save": "reflex",
+                            "shape": "cone",
+                            "tradition": "divine"
+                        }
                     },
                     {
                         "label": "PF2E.Dragon.Empyreal",
-                        "value": [
-                            {
-                                "damageType": "spirit",
-                                "distance": 15,
-                                "dragon": "empyreal",
-                                "save": "reflex",
-                                "shape": "cone",
-                                "tradition": "divine"
-                            }
-                        ]
+                        "value": {
+                            "damageType": "spirit",
+                            "dragon": "empyreal",
+                            "save": "reflex",
+                            "shape": "cone",
+                            "tradition": "divine"
+                        }
                     },
                     {
                         "label": "PF2E.Dragon.Fortune",
-                        "value": [
-                            {
-                                "damageType": "force",
-                                "distance": 15,
-                                "dragon": "empyreal",
-                                "save": "reflex",
-                                "shape": "cone",
-                                "tradition": "arcane"
-                            }
-                        ]
+                        "value": {
+                            "damageType": "force",
+                            "dragon": "empyreal",
+                            "save": "reflex",
+                            "shape": "cone",
+                            "tradition": "arcane"
+                        }
                     },
                     {
                         "label": "PF2E.Dragon.Horned",
-                        "value": [
-                            {
-                                "damageType": "poison",
-                                "distance": 15,
-                                "dragon": "horned",
-                                "save": "fortitude",
-                                "shape": "cone",
-                                "speed": "swim",
-                                "tradition": "primal"
-                            }
-                        ]
+                        "value": {
+                            "damageType": "poison",
+                            "dragon": "horned",
+                            "save": "fortitude",
+                            "shape": "cone",
+                            "speed": "swim",
+                            "tradition": "primal"
+                        }
                     },
                     {
                         "label": "PF2E.Dragon.Mirage",
-                        "value": [
-                            {
-                                "damageType": "mental",
-                                "distance": 15,
-                                "dragon": "mirage",
-                                "save": "will",
-                                "shape": "cone",
-                                "speed": "climb",
-                                "tradition": "arcane"
-                            }
-                        ]
+                        "value": {
+                            "damageType": "mental",
+                            "dragon": "mirage",
+                            "save": "will",
+                            "shape": "cone",
+                            "speed": "climb",
+                            "tradition": "arcane"
+                        }
                     },
                     {
                         "label": "PF2E.Dragon.Omen",
-                        "value": [
-                            {
-                                "damageType": "mental",
-                                "distance": 15,
-                                "dragon": "omen",
-                                "save": "will",
-                                "shape": "cone",
-                                "tradition": "occult"
-                            }
-                        ]
+                        "value": {
+                            "damageType": "mental",
+                            "dragon": "omen",
+                            "save": "will",
+                            "shape": "cone",
+                            "tradition": "occult"
+                        }
                     }
                 ],
-                "flag": "draconicExemplar",
-                "key": "ChoiceSet",
-                "predicate": [
-                    "draconic-exemplar:chosen"
-                ]
+                "flag": "dragonblood",
+                "key": "ChoiceSet"
             },
             {
                 "adjustment": {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2419,6 +2419,35 @@
                     }
                 }
             },
+            "Dragonblood": {
+                "BreathOfTheDragon": {
+                    "Cone": {
+                        "Fortitude": "Tapping into the physiology of your draconic ancestor, you can exhale a torrent of energy in a @Template[type:cone|distance:15], dealing @Damage[ceil(@actor.level/2)d4[@actor.flags.pf2e.dragonblood.damageType]|traits:area-damage] damage. Each creature in the area must attempt a @Check[type:fortitude|dc:resolve(@actor.attributes.classOrSpellDC.value)|basic:true]. You can't use this ability again for [[/r 1d4 #Recharge this ability]]{1d4 rounds}.",
+                        "Reflex": "Tapping into the physiology of your draconic ancestor, you can exhale a torrent of energy in a @Template[type:cone|distance:15], dealing @Damage[ceil(@actor.level/2)d4[@actor.flags.pf2e.dragonblood.damageType]|traits:area-damage] damage. Each creature in the area must attempt a @Check[type:reflex|dc:resolve(@actor.attributes.classOrSpellDC.value)|basic:true]. You can't use this ability again for [[/r 1d4 #Recharge this ability]]{1d4 rounds}.",
+                        "Will": "Tapping into the physiology of your draconic ancestor, you can exhale a torrent of energy in a @Template[type:cone|distance:15], dealing @Damage[ceil(@actor.level/2)d4[@actor.flags.pf2e.dragonblood.damageType]|traits:area-damage] damage. Each creature in the area must attempt a @Check[type:will|dc:resolve(@actor.attributes.classOrSpellDC.value)|basic:true]. You can't use this ability again for [[/r 1d4 #Recharge this ability]]{1d4 rounds}."
+                    },
+                    "Line": {
+                        "Fortitude": "Tapping into the physiology of your draconic ancestor, you can exhale a torrent of energy in a @Template[type:line|distance:30], dealing @Damage[ceil(@actor.level/2)d4[@actor.flags.pf2e.dragonblood.damageType]|traits:area-damage] damage. Each creature in the area must attempt a @Check[type:fortitude|dc:resolve(@actor.attributes.classOrSpellDC.value)|basic:true]. You can't use this ability again for [[/r 1d4 #Recharge this ability]]{1d4 rounds}.",
+                        "Reflex": "Tapping into the physiology of your draconic ancestor, you can exhale a torrent of energy in a @Template[type:line|distance:30], dealing @Damage[ceil(@actor.level/2)d4[@actor.flags.pf2e.dragonblood.damageType]|traits:area-damage] damage. Each creature in the area must attempt a @Check[type:reflex|dc:resolve(@actor.attributes.classOrSpellDC.value)|basic:true]. You can't use this ability again for [[/r 1d4 #Recharge this ability]]{1d4 rounds}.",
+                        "Will": "Tapping into the physiology of your draconic ancestor, you can exhale a torrent of energy in a @Template[type:line|distance:30], dealing @Damage[ceil(@actor.level/2)d4[@actor.flags.pf2e.dragonblood.damageType]|traits:area-damage] damage. Each creature in the area must attempt a @Check[type:will|dc:resolve(@actor.attributes.classOrSpellDC.value)|basic:true]. You can't use this ability again for [[/r 1d4 #Recharge this ability]]{1d4 rounds}."
+                    }
+                },
+                "FormidableBreath": {
+                    "Cone": {
+                        "Fortitude": "Tapping into the physiology of your draconic ancestor, you can exhale a torrent of energy in a @Template[type:cone|distance:30], dealing @Damage[ceil(@actor.level/2)d6[@actor.flags.pf2e.dragonblood.damageType]|traits:area-damage] damage. Each creature in the area must attempt a @Check[type:fortitude|dc:resolve(@actor.attributes.classOrSpellDC.value)|basic:true]. You can't use this ability again for [[/r 1d4 #Recharge this ability]]{1d4 rounds}.",
+                        "Reflex": "Tapping into the physiology of your draconic ancestor, you can exhale a torrent of energy in a @Template[type:cone|distance:30], dealing @Damage[ceil(@actor.level/2)d6[@actor.flags.pf2e.dragonblood.damageType]|traits:area-damage] damage. Each creature in the area must attempt a @Check[type:reflex|dc:resolve(@actor.attributes.classOrSpellDC.value)|basic:true]. You can't use this ability again for [[/r 1d4 #Recharge this ability]]{1d4 rounds}.",
+                        "Will": "Tapping into the physiology of your draconic ancestor, you can exhale a torrent of energy in a @Template[type:cone|distance:30], dealing @Damage[ceil(@actor.level/2)d6[@actor.flags.pf2e.dragonblood.damageType]|traits:area-damage] damage. Each creature in the area must attempt a @Check[type:will|dc:resolve(@actor.attributes.classOrSpellDC.value)|basic:true]. You can't use this ability again for [[/r 1d4 #Recharge this ability]]{1d4 rounds}."
+                    },
+                    "Line": {
+                        "Fortitude": "Tapping into the physiology of your draconic ancestor, you can exhale a torrent of energy in a @Template[type:line|distance:60], dealing @Damage[ceil(@actor.level/2)d6[@actor.flags.pf2e.dragonblood.damageType]|traits:area-damage] damage. Each creature in the area must attempt a @Check[type:fortitude|dc:resolve(@actor.attributes.classOrSpellDC.value)|basic:true]. You can't use this ability again for [[/r 1d4 #Recharge this ability]]{1d4 rounds}.",
+                        "Reflex": "Tapping into the physiology of your draconic ancestor, you can exhale a torrent of energy in a @Template[type:line|distance:60], dealing @Damage[ceil(@actor.level/2)d6[@actor.flags.pf2e.dragonblood.damageType]|traits:area-damage] damage. Each creature in the area must attempt a @Check[type:reflex|dc:resolve(@actor.attributes.classOrSpellDC.value)|basic:true]. You can't use this ability again for [[/r 1d4 #Recharge this ability]]{1d4 rounds}.",
+                        "Will": "Tapping into the physiology of your draconic ancestor, you can exhale a torrent of energy in a @Template[type:line|distance:60], dealing @Damage[ceil(@actor.level/2)d6[@actor.flags.pf2e.dragonblood.damageType]|traits:area-damage] damage. Each creature in the area must attempt a @Check[type:will|dc:resolve(@actor.attributes.classOrSpellDC.value)|basic:true]. You can't use this ability again for [[/r 1d4 #Recharge this ability]]{1d4 rounds}."
+                    }
+                },
+                "LingeringBreath": {
+                    "Description": "When you use Breath of the Dragon, the area of your breath becomes difficult terrain for 1 minute. In addition, a creature who fails or critically fails its saving throw takes @Damage[2d6[persistent,@actor.flags.pf2e.dragonblood.damageType]] damage of the same type"
+                }
+            },
             "DragonDisciple": {
                 "DragonChoice": {
                     "Black": "Black Dragon",


### PR DESCRIPTION
Every current option only has cones, but should be future-proofed if line options are ever added, as Breath of the Dragon implies. Same with Draconic Resistance, no dragon offers piercing or slashing damage, but should work if they're ever added.

Draconic Exemplar must be chosen at character creation in this implementation, as we don't have a great way to implement the delay that the book allows.

Partially addressess #15726