### PR TITLE
Rename Sulfur Bomb effect

### DIFF
--- a/packs/equipment-effects/effect-sulfur-bomb.json
+++ b/packs/equipment-effects/effect-sulfur-bomb.json
@@ -1,16 +1,16 @@
 {
     "_id": "fuQVJiPPUsvL6fi5",
-    "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/sulfur-bomb-effect.webp",
-    "name": "Effect: Sulfur Bomb (Failure)",
+    "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/sulfur-bomb.webp",
+    "name": "Effect: Sulfur Bomb",
     "system": {
         "description": {
-            "value": "<p>On a hit (but not a critical hit), the target takes a -1 status penalty to Perception checks and attack rolls until the end of its next turn.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.equipment-srd.Item.Sulfur Bomb (Lesser)]{Sulfur Bomb}</p>\n<p>The target takes a -1 status penalty to Perception checks and attack rolls until the end of its next turn.</p>"
         },
         "duration": {
             "expiry": "turn-start",
             "sustained": false,
-            "unit": "unlimited",
-            "value": -1
+            "unit": "rounds",
+            "value": 1
         },
         "level": {
             "value": 1

--- a/packs/equipment/sulfur-bomb-greater.json
+++ b/packs/equipment/sulfur-bomb-greater.json
@@ -21,7 +21,7 @@
             "die": "d4"
         },
         "description": {
-            "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Strike</p>\n<hr />\n<p>A thick, sulfurous, irritating gas fills this golden-yellow flask. You gain a +2 item bonus to attack rolls. The bomb deals @Damage[3d4[acid]] damage and [[/r (3[splash])[acid]]]{3 acid splash damage}. On a hit, the target takes a -1 status penalty to Perception checks and attack rolls until the end of its next turn, or becomes @UUID[Compendium.pf2e.conditionitems.Item.Sickened]{Sickened 1} on a critical hit. Creatures hit with this bomb are temporarily immune to the effects of the bomb for 1 minute.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Sulfur Bomb (Failure)]</p>"
+            "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Strike</p><hr /><p>A thick, sulfurous, irritating gas fills this golden-yellow flask. You gain a +2 item bonus to attack rolls. The bomb deals @Damage[3d4[acid]] damage and [[/r (3[splash])[acid]]]{3 acid splash damage}. On a hit, the target takes a -1 status penalty to Perception checks and attack rolls until the end of its next turn, or becomes @UUID[Compendium.pf2e.conditionitems.Item.Sickened]{Sickened 1} on a critical hit. Creatures hit with this bomb are temporarily immune to the effects of the bomb for 1 minute.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Sulfur Bomb]</p>"
         },
         "group": "bomb",
         "hardness": 0,
@@ -90,6 +90,7 @@
             ]
         },
         "usage": {
+            "canBeAmmo": false,
             "value": "held-in-one-hand"
         }
     },

--- a/packs/equipment/sulfur-bomb-lesser.json
+++ b/packs/equipment/sulfur-bomb-lesser.json
@@ -21,7 +21,7 @@
             "die": "d4"
         },
         "description": {
-            "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Strike</p>\n<hr />\n<p>A thick, sulfurous, irritating gas fills this golden-yellow flask. The bomb deals @Damage[1d4[acid]] damage and [[/r (1[splash])[acid]]]{1 acid splash damage}. On a hit, the target takes a -1 status penalty to Perception checks and attack rolls until the end of its next turn, or becomes @UUID[Compendium.pf2e.conditionitems.Item.Sickened]{Sickened 1} on a critical hit. Creatures hit with this bomb are temporarily immune to the effects of the bomb for 1 minute.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Sulfur Bomb (Failure)]</p>"
+            "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Strike</p><hr /><p>A thick, sulfurous, irritating gas fills this golden-yellow flask. The bomb deals @Damage[1d4[acid]] damage and [[/r (1[splash])[acid]]]{1 acid splash damage}. On a hit, the target takes a -1 status penalty to Perception checks and attack rolls until the end of its next turn, or becomes @UUID[Compendium.pf2e.conditionitems.Item.Sickened]{Sickened 1} on a critical hit. Creatures hit with this bomb are temporarily immune to the effects of the bomb for 1 minute.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Sulfur Bomb]</p>"
         },
         "group": "bomb",
         "hardness": 0,
@@ -90,6 +90,7 @@
             ]
         },
         "usage": {
+            "canBeAmmo": false,
             "value": "held-in-one-hand"
         }
     },

--- a/packs/equipment/sulfur-bomb-major.json
+++ b/packs/equipment/sulfur-bomb-major.json
@@ -21,7 +21,7 @@
             "die": "d4"
         },
         "description": {
-            "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Strike</p>\n<hr />\n<p>A thick, sulfurous, irritating gas fills this golden-yellow flask. You gain a +3 item bonus to attack rolls. The bomb deals @Damage[4d4[acid]] damage and [[/r (4[splash])[acid]]]{4 acid splash damage}. On a hit, the target takes a -1 status penalty to Perception checks and attack rolls until the end of its next turn, or becomes @UUID[Compendium.pf2e.conditionitems.Item.Sickened]{Sickened 1} on a critical hit. Creatures hit with this bomb are temporarily immune to the effects of the bomb for 1 minute.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Sulfur Bomb (Failure)]</p>"
+            "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Strike</p><hr /><p>A thick, sulfurous, irritating gas fills this golden-yellow flask. You gain a +3 item bonus to attack rolls. The bomb deals @Damage[4d4[acid]] damage and [[/r (4[splash])[acid]]]{4 acid splash damage}. On a hit, the target takes a -1 status penalty to Perception checks and attack rolls until the end of its next turn, or becomes @UUID[Compendium.pf2e.conditionitems.Item.Sickened]{Sickened 1} on a critical hit. Creatures hit with this bomb are temporarily immune to the effects of the bomb for 1 minute.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Sulfur Bomb]</p>"
         },
         "group": "bomb",
         "hardness": 0,
@@ -90,6 +90,7 @@
             ]
         },
         "usage": {
+            "canBeAmmo": false,
             "value": "held-in-one-hand"
         }
     },

--- a/packs/equipment/sulfur-bomb-moderate.json
+++ b/packs/equipment/sulfur-bomb-moderate.json
@@ -21,7 +21,7 @@
             "die": "d4"
         },
         "description": {
-            "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Strike</p>\n<hr />\n<p>A thick, sulfurous, irritating gas fills this golden-yellow flask. You gain a +1 item bonus to attack rolls. The bomb deals @Damage[2d4[acid]] damage and [[/r (2[splash])[acid]]]{2 acid splash damage}. On a hit, the target takes a -1 status penalty to Perception checks and attack rolls until the end of its next turn, or becomes @UUID[Compendium.pf2e.conditionitems.Item.Sickened]{Sickened 1} on a critical hit. Creatures hit with this bomb are temporarily immune to the effects of the bomb for 1 minute.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Sulfur Bomb (Failure)]</p>"
+            "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Strike</p><hr /><p>A thick, sulfurous, irritating gas fills this golden-yellow flask. You gain a +1 item bonus to attack rolls. The bomb deals @Damage[2d4[acid]] damage and [[/r (2[splash])[acid]]]{2 acid splash damage}. On a hit, the target takes a -1 status penalty to Perception checks and attack rolls until the end of its next turn, or becomes @UUID[Compendium.pf2e.conditionitems.Item.Sickened]{Sickened 1} on a critical hit. Creatures hit with this bomb are temporarily immune to the effects of the bomb for 1 minute.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Sulfur Bomb]</p>"
         },
         "group": "bomb",
         "hardness": 0,
@@ -90,6 +90,7 @@
             ]
         },
         "usage": {
+            "canBeAmmo": false,
             "value": "held-in-one-hand"
         }
     },

--- a/packs/sky-kings-tomb-bestiary/ashrin.json
+++ b/packs/sky-kings-tomb-bestiary/ashrin.json
@@ -129,7 +129,7 @@
                     "die": "d4"
                 },
                 "description": {
-                    "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Strike</p>\n<hr />\n<p>A thick, sulfurous, irritating gas fills this golden-yellow flask. You gain a +1 item bonus to attack rolls. The bomb deals @Damage[2d4[acid]] damage and [[/r (2[splash])[acid]]]{2 acid splash damage}. On a hit, the target takes a -1 status penalty to Perception checks and attack rolls until the end of its next turn, or becomes @UUID[Compendium.pf2e.conditionitems.Item.Sickened]{Sickened 1} on a critical hit. Creatures hit with this bomb are temporarily immune to the effects of the bomb for 1 minute.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Sulfur Bomb (Failure)]</p>"
+                    "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Strike</p>\n<hr />\n<p>A thick, sulfurous, irritating gas fills this golden-yellow flask. You gain a +1 item bonus to attack rolls. The bomb deals @Damage[2d4[acid]] damage and [[/r (2[splash])[acid]]]{2 acid splash damage}. On a hit, the target takes a -1 status penalty to Perception checks and attack rolls until the end of its next turn, or becomes @UUID[Compendium.pf2e.conditionitems.Item.Sickened]{Sickened 1} on a critical hit. Creatures hit with this bomb are temporarily immune to the effects of the bomb for 1 minute.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Sulfur Bomb]</p>"
                 },
                 "equipped": {
                     "carryType": "worn",

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -459,19 +459,19 @@
             "SulfurBomb": {
                 "Greater": {
                     "criticalSuccess": "<strong>Effect</strong> The bomb also deals @Damage[(3[splash])[acid]]{3 acid splash damage} and the target becomes @UUID[Compendium.pf2e.conditionitems.Item.fesd1n5eVhpCSS18]{Sickened 1}.",
-                    "success": "<strong>Effect</strong> The bomb also deals @Damage[(3[splash])[acid]]{3 acid splash damage} and the target takes a -1 status penalty to Perception checks and attack rolls until the end of its next turn (@UUID[Compendium.pf2e.equipment-effects.Item.fuQVJiPPUsvL6fi5]{Effect: Sulfur Bomb (Failure)})."
+                    "success": "<strong>Effect</strong> The bomb also deals @Damage[(3[splash])[acid]]{3 acid splash damage} and the target takes a -1 status penalty to Perception checks and attack rolls until the end of its next turn (@UUID[Compendium.pf2e.equipment-effects.Item.fuQVJiPPUsvL6fi5]{Effect: Sulfur Bomb})."
                 },
                 "Lesser": {
                     "criticalSuccess": "<strong>Effect</strong> The bomb also deals @Damage[(1[splash])[acid]]{1 acid splash damage} and the target becomes @UUID[Compendium.pf2e.conditionitems.Item.fesd1n5eVhpCSS18]{Sickened 1}.",
-                    "success": "<strong>Effect</strong> The bomb also deals @Damage[(1[splash])[acid]]{1 acid splash damage} and the target takes a -1 status penalty to Perception checks and attack rolls until the end of its next turn (@UUID[Compendium.pf2e.equipment-effects.Item.fuQVJiPPUsvL6fi5]{Effect: Sulfur Bomb (Failure)})."
+                    "success": "<strong>Effect</strong> The bomb also deals @Damage[(1[splash])[acid]]{1 acid splash damage} and the target takes a -1 status penalty to Perception checks and attack rolls until the end of its next turn (@UUID[Compendium.pf2e.equipment-effects.Item.fuQVJiPPUsvL6fi5]{Effect: Sulfur Bomb})."
                 },
                 "Major": {
                     "criticalSuccess": "<strong>Effect</strong> The bomb also deals @Damage[(4[splash])[acid]]{4 acid splash damage} and the target becomes @UUID[Compendium.pf2e.conditionitems.Item.fesd1n5eVhpCSS18]{Sickened 1}.",
-                    "success": "<strong>Effect</strong> The bomb also deals @Damage[(4[splash])[acid]]{4 acid splash damage} and the target takes a -1 status penalty to Perception checks and attack rolls until the end of its next turn (@UUID[Compendium.pf2e.equipment-effects.Item.fuQVJiPPUsvL6fi5]{Effect: Sulfur Bomb (Failure)})."
+                    "success": "<strong>Effect</strong> The bomb also deals @Damage[(4[splash])[acid]]{4 acid splash damage} and the target takes a -1 status penalty to Perception checks and attack rolls until the end of its next turn (@UUID[Compendium.pf2e.equipment-effects.Item.fuQVJiPPUsvL6fi5]{Effect: Sulfur Bomb})."
                 },
                 "Moderate": {
                     "criticalSuccess": "<strong>Effect</strong> The bomb also deals @Damage[(2[splash])[acid]]{2 acid splash damage} and the target becomes @UUID[Compendium.pf2e.conditionitems.Item.fesd1n5eVhpCSS18]{Sickened 1}.",
-                    "success": "<strong>Effect</strong> The bomb also deals @Damage[(2[splash])[acid]]{2 acid splash damage} and the target takes a -1 status penalty to Perception checks and attack rolls until the end of its next turn (@UUID[Compendium.pf2e.equipment-effects.Item.fuQVJiPPUsvL6fi5]{Effect: Sulfur Bomb (Failure)})."
+                    "success": "<strong>Effect</strong> The bomb also deals @Damage[(2[splash])[acid]]{2 acid splash damage} and the target takes a -1 status penalty to Perception checks and attack rolls until the end of its next turn (@UUID[Compendium.pf2e.equipment-effects.Item.fuQVJiPPUsvL6fi5]{Effect: Sulfur Bomb})."
                 }
             },
             "TallowBomb": {


### PR DESCRIPTION
I believe it's clear enough that the effect is meant to be on the successful, but not critically successful hit, but I'm open to suggestions on renaming it something else. Like `Sulfur Bomb (Success)` or `Sulfur Bomb (Hit)` perhaps

Closes #15752