### PR TITLE
update Courageous Anthem effect to hide Discordant Voice damage dice

### DIFF
--- a/packs/spell-effects/spell-effect-courageous-anthem.json
+++ b/packs/spell-effects/spell-effect-courageous-anthem.json
@@ -43,6 +43,7 @@
                 "damageType": "sonic",
                 "diceNumber": 1,
                 "dieSize": "d6",
+                "hideIfDisabled": true,
                 "key": "DamageDice",
                 "label": "PF2E.SpecificRule.Bard.DiscordantVoice.Label",
                 "predicate": [


### PR DESCRIPTION
Should only show now when the roll is enabled.

Closes #15794