### PR TITLE
Automate Player Core 2 Sorcerer Blood Magic Feats

### DIFF
--- a/packs/classfeatures/bloodline-aberrant.json
+++ b/packs/classfeatures/bloodline-aberrant.json
@@ -29,12 +29,22 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.intimidation.rank",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ],
                 "value": 1
             },
             {
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.occultism.rank",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ],
                 "value": 1
             },
             {
@@ -42,7 +52,9 @@
                 "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
-                    "class:sorcerer",
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    },
                     {
                         "or": [
                             "item:tag:ancestral-spell",
@@ -59,7 +71,7 @@
                                     "spellcasting:tradition:occult",
                                     {
                                         "or": [
-                                            "item:slug:spider-sting",
+                                            "item:slug:phantom-pain",
                                             "item:slug:stupefy",
                                             "item:slug:vampiric-feast",
                                             "item:slug:confusion",
@@ -75,11 +87,100 @@
                         ]
                     }
                 ],
+                "property": "other-tags",
+                "value": "blood-magic-spell"
+            },
+            {
+                "alwaysActive": true,
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
+                "mergeable": true,
+                "option": "blood-magic",
+                "placement": "spellcasting",
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Aberrant",
+                        "value": "aberrant"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.SecondBloodMagic",
+                "mergeable": true,
+                "option": "second-blood-magic",
+                "placement": "spellcasting",
+                "predicate": [
+                    {
+                        "or": [
+                            "feat:blood-ascendancy",
+                            "feat:blood-sovereignty"
+                        ]
+                    }
+                ],
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Aberrant",
+                        "value": "aberrant"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:tag:blood-magic-spell",
+                    {
+                        "or": [
+                            "blood-magic:aberrant",
+                            {
+                                "and": [
+                                    "second-blood-magic:aberrant",
+                                    "feat:blood-sovereignty"
+                                ]
+                            }
+                        ]
+                    }
+                ],
                 "property": "description",
                 "value": [
                     {
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Aberrant",
-                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title"
+                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Aberrant"
+                    },
+                    {
+                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Aberrant Blood Magic]"
+                    }
+                ]
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:slug:blood-rising",
+                    {
+                        "or": [
+                            "blood-magic:aberrant",
+                            {
+                                "and": [
+                                    "second-blood-magic:aberrant",
+                                    "feat:blood-ascendancy"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Aberrant",
+                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Aberrant"
                     },
                     {
                         "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Aberrant Blood Magic]"

--- a/packs/classfeatures/bloodline-aberrant.json
+++ b/packs/classfeatures/bloodline-aberrant.json
@@ -190,7 +190,12 @@
             {
                 "domain": "all",
                 "key": "RollOption",
-                "option": "feature:bloodline:tradition:occult"
+                "option": "feature:bloodline:tradition:occult",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ]
             }
         ],
         "traits": {

--- a/packs/classfeatures/bloodline-angelic.json
+++ b/packs/classfeatures/bloodline-angelic.json
@@ -29,12 +29,22 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.diplomacy.rank",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ],
                 "value": 1
             },
             {
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.religion.rank",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ],
                 "value": 1
             },
             {
@@ -42,7 +52,9 @@
                 "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
-                    "class:sorcerer",
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    },
                     {
                         "or": [
                             "item:tag:ancestral-spell",
@@ -75,11 +87,100 @@
                         ]
                     }
                 ],
+                "property": "other-tags",
+                "value": "blood-magic-spell"
+            },
+            {
+                "alwaysActive": true,
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
+                "mergeable": true,
+                "option": "blood-magic",
+                "placement": "spellcasting",
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Angelic",
+                        "value": "angelic"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.SecondBloodMagic",
+                "mergeable": true,
+                "option": "second-blood-magic",
+                "placement": "spellcasting",
+                "predicate": [
+                    {
+                        "or": [
+                            "feat:blood-ascendancy",
+                            "feat:blood-sovereignty"
+                        ]
+                    }
+                ],
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Angelic",
+                        "value": "angelic"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:tag:blood-magic-spell",
+                    {
+                        "or": [
+                            "blood-magic:angelic",
+                            {
+                                "and": [
+                                    "second-blood-magic:angelic",
+                                    "feat:blood-sovereignty"
+                                ]
+                            }
+                        ]
+                    }
+                ],
                 "property": "description",
                 "value": [
                     {
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Angelic",
-                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title"
+                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Angelic"
+                    },
+                    {
+                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Angelic Blood Magic]"
+                    }
+                ]
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:blood-rising",
+                    "class:sorcerer",
+                    {
+                        "or": [
+                            "blood-magic:angelic",
+                            {
+                                "and": [
+                                    "second-blood-magic:angelic",
+                                    "feat:blood-ascendancy"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Angelic",
+                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Angelic"
                     },
                     {
                         "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Angelic Blood Magic]"

--- a/packs/classfeatures/bloodline-angelic.json
+++ b/packs/classfeatures/bloodline-angelic.json
@@ -190,7 +190,12 @@
             {
                 "domain": "all",
                 "key": "RollOption",
-                "option": "feature:bloodline:tradition:divine"
+                "option": "feature:bloodline:tradition:divine",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ]
             }
         ],
         "traits": {

--- a/packs/classfeatures/bloodline-demonic.json
+++ b/packs/classfeatures/bloodline-demonic.json
@@ -190,7 +190,12 @@
             {
                 "domain": "all",
                 "key": "RollOption",
-                "option": "feature:bloodline:tradition:divine"
+                "option": "feature:bloodline:tradition:divine",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ]
             }
         ],
         "traits": {

--- a/packs/classfeatures/bloodline-demonic.json
+++ b/packs/classfeatures/bloodline-demonic.json
@@ -29,12 +29,22 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.intimidation.rank",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ],
                 "value": 1
             },
             {
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.religion.rank",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ],
                 "value": 1
             },
             {
@@ -42,7 +52,9 @@
                 "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
-                    "class:sorcerer",
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    },
                     {
                         "or": [
                             "item:tag:ancestral-spell",
@@ -75,11 +87,100 @@
                         ]
                     }
                 ],
+                "property": "other-tags",
+                "value": "blood-magic-spell"
+            },
+            {
+                "alwaysActive": true,
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
+                "mergeable": true,
+                "option": "blood-magic",
+                "placement": "spellcasting",
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Demonic",
+                        "value": "demonic"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.SecondBloodMagic",
+                "mergeable": true,
+                "option": "second-blood-magic",
+                "placement": "spellcasting",
+                "predicate": [
+                    {
+                        "or": [
+                            "feat:blood-ascendancy",
+                            "feat:blood-sovereignty"
+                        ]
+                    }
+                ],
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Demonic",
+                        "value": "demonic"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:tag:blood-magic-spell",
+                    {
+                        "or": [
+                            "blood-magic:demonic",
+                            {
+                                "and": [
+                                    "second-blood-magic:demonic",
+                                    "feat:blood-sovereignty"
+                                ]
+                            }
+                        ]
+                    }
+                ],
                 "property": "description",
                 "value": [
                     {
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Demonic",
-                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title"
+                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Demonic"
+                    },
+                    {
+                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Demonic Blood Magic]"
+                    }
+                ]
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:slug:blood-rising",
+                    {
+                        "or": [
+                            "blood-magic:demonic",
+                            {
+                                "and": [
+                                    "second-blood-magic:demonic",
+                                    "feat:blood-ascendancy"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Demonic",
+                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Demonic"
                     },
                     {
                         "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Demonic Blood Magic]"

--- a/packs/classfeatures/bloodline-diabolic.json
+++ b/packs/classfeatures/bloodline-diabolic.json
@@ -29,12 +29,22 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.deception.rank",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ],
                 "value": 1
             },
             {
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.religion.rank",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ],
                 "value": 1
             },
             {
@@ -42,7 +52,9 @@
                 "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
-                    "class:sorcerer",
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    },
                     {
                         "or": [
                             "item:tag:ancestral-spell",
@@ -75,11 +87,100 @@
                         ]
                     }
                 ],
+                "property": "other-tags",
+                "value": "blood-magic-spell"
+            },
+            {
+                "alwaysActive": true,
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
+                "mergeable": true,
+                "option": "blood-magic",
+                "placement": "spellcasting",
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Diabolic",
+                        "value": "diabolic"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.SecondBloodMagic",
+                "mergeable": true,
+                "option": "second-blood-magic",
+                "placement": "spellcasting",
+                "predicate": [
+                    {
+                        "or": [
+                            "feat:blood-ascendancy",
+                            "feat:blood-sovereignty"
+                        ]
+                    }
+                ],
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Diabolic",
+                        "value": "diabolic"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:tag:blood-magic-spell",
+                    {
+                        "or": [
+                            "blood-magic:diabolic",
+                            {
+                                "and": [
+                                    "second-blood-magic:diabolic",
+                                    "feat:blood-sovereignty"
+                                ]
+                            }
+                        ]
+                    }
+                ],
                 "property": "description",
                 "value": [
                     {
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Diabolic",
-                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title"
+                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Diabolic"
+                    },
+                    {
+                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Diabolic Blood Magic (Self)]"
+                    }
+                ]
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:slug:blood-rising",
+                    {
+                        "or": [
+                            "blood-magic:diabolic",
+                            {
+                                "and": [
+                                    "second-blood-magic:diabolic",
+                                    "feat:blood-ascendancy"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Diabolic",
+                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Diabolic"
                     },
                     {
                         "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Diabolic Blood Magic (Self)]"

--- a/packs/classfeatures/bloodline-diabolic.json
+++ b/packs/classfeatures/bloodline-diabolic.json
@@ -190,7 +190,12 @@
             {
                 "domain": "all",
                 "key": "RollOption",
-                "option": "feature:bloodline:tradition:divine"
+                "option": "feature:bloodline:tradition:divine",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ]
             }
         ],
         "traits": {

--- a/packs/classfeatures/bloodline-draconic.json
+++ b/packs/classfeatures/bloodline-draconic.json
@@ -326,12 +326,22 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.intimidation.rank",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ],
                 "value": 1
             },
             {
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.{item|flags.pf2e.rulesSelections.dragonBloodline.skill}.rank",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ],
                 "value": 1
             },
             {
@@ -340,16 +350,13 @@
                 "option": "feature:bloodline:draconic:{item|flags.pf2e.rulesSelections.dragonBloodline.slug}"
             },
             {
-                "domain": "all",
-                "key": "RollOption",
-                "option": "feature:bloodline:tradition:{item|flags.pf2e.rulesSelections.dragonBloodline.tradition}"
-            },
-            {
                 "itemType": "spell",
                 "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
-                    "class:sorcerer",
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    },
                     {
                         "or": [
                             "item:tag:ancestral-spell",
@@ -588,16 +595,110 @@
                         ]
                     }
                 ],
+                "property": "other-tags",
+                "value": "blood-magic-spell"
+            },
+            {
+                "alwaysActive": true,
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
+                "mergeable": true,
+                "option": "blood-magic",
+                "placement": "spellcasting",
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Draconic",
+                        "value": "draconic"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.SecondBloodMagic",
+                "mergeable": true,
+                "option": "second-blood-magic",
+                "placement": "spellcasting",
+                "predicate": [
+                    {
+                        "or": [
+                            "feat:blood-ascendancy",
+                            "feat:blood-sovereignty"
+                        ]
+                    }
+                ],
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Draconic",
+                        "value": "draconic"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:tag:blood-magic-spell",
+                    {
+                        "or": [
+                            "blood-magic:draconic",
+                            {
+                                "and": [
+                                    "second-blood-magic:draconic",
+                                    "feat:blood-sovereignty"
+                                ]
+                            }
+                        ]
+                    }
+                ],
                 "property": "description",
                 "value": [
                     {
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Draconic",
-                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title"
+                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Draconic"
                     },
                     {
                         "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Draconic Blood Magic]"
                     }
                 ]
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:slug:blood-rising",
+                    {
+                        "or": [
+                            "blood-magic:draconic",
+                            {
+                                "and": [
+                                    "second-blood-magic:draconic",
+                                    "feat:blood-ascendancy"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Draconic",
+                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Draconic"
+                    },
+                    {
+                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Draconic Blood Magic]"
+                    }
+                ]
+            },
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "option": "feature:bloodline:tradition:{item|flags.pf2e.rulesSelections.dragonBloodline.tradition}"
             }
         ],
         "traits": {

--- a/packs/classfeatures/bloodline-draconic.json
+++ b/packs/classfeatures/bloodline-draconic.json
@@ -698,7 +698,12 @@
             {
                 "domain": "all",
                 "key": "RollOption",
-                "option": "feature:bloodline:tradition:{item|flags.pf2e.rulesSelections.dragonBloodline.tradition}"
+                "option": "feature:bloodline:tradition:{item|flags.pf2e.rulesSelections.dragonBloodline.tradition}",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ]
             }
         ],
         "traits": {

--- a/packs/classfeatures/bloodline-elemental.json
+++ b/packs/classfeatures/bloodline-elemental.json
@@ -29,12 +29,22 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.intimidation.rank",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ],
                 "value": 1
             },
             {
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.nature.rank",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ],
                 "value": 1
             },
             {
@@ -97,7 +107,9 @@
                 "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
-                    "class:sorcerer",
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    },
                     {
                         "or": [
                             "item:tag:ancestral-spell",
@@ -199,11 +211,100 @@
                         ]
                     }
                 ],
+                "property": "other-tags",
+                "value": "blood-magic-spell"
+            },
+            {
+                "alwaysActive": true,
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
+                "mergeable": true,
+                "option": "blood-magic",
+                "placement": "spellcasting",
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Elemental",
+                        "value": "elemental"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.SecondBloodMagic",
+                "mergeable": true,
+                "option": "second-blood-magic",
+                "placement": "spellcasting",
+                "predicate": [
+                    {
+                        "or": [
+                            "feat:blood-ascendancy",
+                            "feat:blood-sovereignty"
+                        ]
+                    }
+                ],
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Elemental",
+                        "value": "elemental"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:tag:blood-magic-spell",
+                    {
+                        "or": [
+                            "blood-magic:elemental",
+                            {
+                                "and": [
+                                    "second-blood-magic:elemental",
+                                    "feat:blood-sovereignty"
+                                ]
+                            }
+                        ]
+                    }
+                ],
                 "property": "description",
                 "value": [
                     {
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Elemental",
-                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title"
+                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Elemental"
+                    },
+                    {
+                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Elemental Blood Magic (Self)]"
+                    }
+                ]
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:slug:blood-rising",
+                    {
+                        "or": [
+                            "blood-magic:elemental",
+                            {
+                                "and": [
+                                    "second-blood-magic:elemental",
+                                    "feat:blood-ascendancy"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Elemental",
+                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Elemental"
                     },
                     {
                         "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Elemental Blood Magic (Self)]"

--- a/packs/classfeatures/bloodline-elemental.json
+++ b/packs/classfeatures/bloodline-elemental.json
@@ -314,7 +314,12 @@
             {
                 "domain": "all",
                 "key": "RollOption",
-                "option": "feature:bloodline:tradition:primal"
+                "option": "feature:bloodline:tradition:primal",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ]
             }
         ],
         "traits": {

--- a/packs/classfeatures/bloodline-fey.json
+++ b/packs/classfeatures/bloodline-fey.json
@@ -190,7 +190,12 @@
             {
                 "domain": "all",
                 "key": "RollOption",
-                "option": "feature:bloodline:tradition:primal"
+                "option": "feature:bloodline:tradition:primal",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ]
             }
         ],
         "traits": {

--- a/packs/classfeatures/bloodline-fey.json
+++ b/packs/classfeatures/bloodline-fey.json
@@ -29,12 +29,22 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.deception.rank",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ],
                 "value": 1
             },
             {
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.nature.rank",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ],
                 "value": 1
             },
             {
@@ -42,7 +52,9 @@
                 "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
-                    "class:sorcerer",
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    },
                     {
                         "or": [
                             "item:tag:ancestral-spell",
@@ -75,11 +87,100 @@
                         ]
                     }
                 ],
+                "property": "other-tags",
+                "value": "blood-magic-spell"
+            },
+            {
+                "alwaysActive": true,
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
+                "mergeable": true,
+                "option": "blood-magic",
+                "placement": "spellcasting",
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Fey",
+                        "value": "fey"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.SecondBloodMagic",
+                "mergeable": true,
+                "option": "second-blood-magic",
+                "placement": "spellcasting",
+                "predicate": [
+                    {
+                        "or": [
+                            "feat:blood-ascendancy",
+                            "feat:blood-sovereignty"
+                        ]
+                    }
+                ],
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Fey",
+                        "value": "fey"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:tag:blood-magic-spell",
+                    {
+                        "or": [
+                            "blood-magic:fey",
+                            {
+                                "and": [
+                                    "second-blood-magic:fey",
+                                    "feat:blood-sovereignty"
+                                ]
+                            }
+                        ]
+                    }
+                ],
                 "property": "description",
                 "value": [
                     {
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Fey",
-                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title"
+                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Fey"
+                    },
+                    {
+                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Fey Blood Magic]"
+                    }
+                ]
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:slug:blood-rising",
+                    {
+                        "or": [
+                            "blood-magic:fey",
+                            {
+                                "and": [
+                                    "second-blood-magic:fey",
+                                    "feat:blood-ascendancy"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Fey",
+                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Fey"
                     },
                     {
                         "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Fey Blood Magic]"

--- a/packs/classfeatures/bloodline-genie.json
+++ b/packs/classfeatures/bloodline-genie.json
@@ -275,7 +275,12 @@
             {
                 "domain": "all",
                 "key": "RollOption",
-                "option": "feature:bloodline:tradition:arcane"
+                "option": "feature:bloodline:tradition:arcane",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ]
             }
         ],
         "traits": {

--- a/packs/classfeatures/bloodline-genie.json
+++ b/packs/classfeatures/bloodline-genie.json
@@ -29,12 +29,22 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.arcana.rank",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ],
                 "value": 1
             },
             {
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.deception.rank",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ],
                 "value": 1
             },
             {
@@ -70,7 +80,9 @@
                 "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
-                    "class:sorcerer",
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    },
                     {
                         "or": [
                             "item:tag:ancestral-spell",
@@ -160,11 +172,100 @@
                         ]
                     }
                 ],
+                "property": "other-tags",
+                "value": "blood-magic-spell"
+            },
+            {
+                "alwaysActive": true,
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
+                "mergeable": true,
+                "option": "blood-magic",
+                "placement": "spellcasting",
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Genie",
+                        "value": "genie"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.SecondBloodMagic",
+                "mergeable": true,
+                "option": "second-blood-magic",
+                "placement": "spellcasting",
+                "predicate": [
+                    {
+                        "or": [
+                            "feat:blood-ascendancy",
+                            "feat:blood-sovereignty"
+                        ]
+                    }
+                ],
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Genie",
+                        "value": "genie"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:tag:blood-magic-spell",
+                    {
+                        "or": [
+                            "blood-magic:genie",
+                            {
+                                "and": [
+                                    "second-blood-magic:genie",
+                                    "feat:blood-sovereignty"
+                                ]
+                            }
+                        ]
+                    }
+                ],
                 "property": "description",
                 "value": [
                     {
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Genie",
-                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title"
+                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Genie"
+                    },
+                    {
+                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Genie Blood Magic]"
+                    }
+                ]
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:slug:blood-rising",
+                    {
+                        "or": [
+                            "blood-magic:genie",
+                            {
+                                "and": [
+                                    "second-blood-magic:genie",
+                                    "feat:blood-ascendancy"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Genie",
+                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Genie"
                     },
                     {
                         "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Genie Blood Magic]"

--- a/packs/classfeatures/bloodline-hag.json
+++ b/packs/classfeatures/bloodline-hag.json
@@ -190,7 +190,12 @@
             {
                 "domain": "all",
                 "key": "RollOption",
-                "option": "feature:bloodline:tradition:occult"
+                "option": "feature:bloodline:tradition:occult",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ]
             }
         ],
         "traits": {

--- a/packs/classfeatures/bloodline-hag.json
+++ b/packs/classfeatures/bloodline-hag.json
@@ -29,12 +29,22 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.deception.rank",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ],
                 "value": 1
             },
             {
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.occultism.rank",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ],
                 "value": 1
             },
             {
@@ -42,7 +52,9 @@
                 "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
-                    "class:sorcerer",
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    },
                     {
                         "or": [
                             "item:tag:ancestral-spell",
@@ -75,11 +87,100 @@
                         ]
                     }
                 ],
+                "property": "other-tags",
+                "value": "blood-magic-spell"
+            },
+            {
+                "alwaysActive": true,
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
+                "mergeable": true,
+                "option": "blood-magic",
+                "placement": "spellcasting",
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Hag",
+                        "value": "hag"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.SecondBloodMagic",
+                "mergeable": true,
+                "option": "second-blood-magic",
+                "placement": "spellcasting",
+                "predicate": [
+                    {
+                        "or": [
+                            "feat:blood-ascendancy",
+                            "feat:blood-sovereignty"
+                        ]
+                    }
+                ],
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Hag",
+                        "value": "hag"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:tag:blood-magic-spell",
+                    {
+                        "or": [
+                            "blood-magic:hag",
+                            {
+                                "and": [
+                                    "second-blood-magic:hag",
+                                    "feat:blood-sovereignty"
+                                ]
+                            }
+                        ]
+                    }
+                ],
                 "property": "description",
                 "value": [
                     {
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Hag",
-                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title"
+                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Hag"
+                    },
+                    {
+                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Hag Blood Magic]"
+                    }
+                ]
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:slug:blood-rising",
+                    {
+                        "or": [
+                            "blood-magic:hag",
+                            {
+                                "and": [
+                                    "second-blood-magic:hag",
+                                    "feat:blood-ascendancy"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Hag",
+                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Hag"
                     },
                     {
                         "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Hag Blood Magic]"

--- a/packs/classfeatures/bloodline-harrow.json
+++ b/packs/classfeatures/bloodline-harrow.json
@@ -184,7 +184,12 @@
             {
                 "domain": "all",
                 "key": "RollOption",
-                "option": "feature:bloodline:tradition:occult"
+                "option": "feature:bloodline:tradition:occult",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ]
             }
         ],
         "traits": {

--- a/packs/classfeatures/bloodline-harrow.json
+++ b/packs/classfeatures/bloodline-harrow.json
@@ -29,12 +29,22 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.occultism.rank",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ],
                 "value": 1
             },
             {
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.performance.rank",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ],
                 "value": 1
             },
             {
@@ -42,7 +52,9 @@
                 "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
-                    "class:sorcerer",
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    },
                     {
                         "or": [
                             "item:tag:ancestral-spell",
@@ -75,11 +87,97 @@
                         ]
                     }
                 ],
+                "property": "other-tags",
+                "value": "blood-magic-spell"
+            },
+            {
+                "alwaysActive": true,
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
+                "mergeable": true,
+                "option": "blood-magic",
+                "placement": "spellcasting",
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Harrow",
+                        "value": "harrow"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.SecondBloodMagic",
+                "mergeable": true,
+                "option": "second-blood-magic",
+                "placement": "spellcasting",
+                "predicate": [
+                    {
+                        "or": [
+                            "feat:blood-ascendancy",
+                            "feat:blood-sovereignty"
+                        ]
+                    }
+                ],
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Harrow",
+                        "value": "harrow"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:tag:blood-magic-spell",
+                    {
+                        "or": [
+                            "blood-magic:harrow",
+                            {
+                                "and": [
+                                    "second-blood-magic:harrow",
+                                    "feat:blood-sovereignty"
+                                ]
+                            }
+                        ]
+                    }
+                ],
                 "property": "description",
                 "value": [
                     {
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Harrow",
-                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title"
+                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Harrow"
+                    }
+                ]
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:slug:blood-rising",
+                    {
+                        "or": [
+                            "blood-magic:harrow",
+                            {
+                                "and": [
+                                    "second-blood-magic:harrow",
+                                    "feat:blood-ascendancy"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Harrow",
+                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Harrow"
                     }
                 ]
             },

--- a/packs/classfeatures/bloodline-imperial.json
+++ b/packs/classfeatures/bloodline-imperial.json
@@ -136,10 +136,10 @@
                     "item:tag:blood-magic-spell",
                     {
                         "or": [
-                            "blood-magic:aberrant",
+                            "blood-magic:imperial",
                             {
                                 "and": [
-                                    "second-blood-magic:aberrant",
+                                    "second-blood-magic:imperial",
                                     "feat:blood-sovereignty"
                                 ]
                             }
@@ -190,7 +190,12 @@
             {
                 "domain": "all",
                 "key": "RollOption",
-                "option": "feature:bloodline:tradition:arcane"
+                "option": "feature:bloodline:tradition:arcane",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ]
             }
         ],
         "traits": {

--- a/packs/classfeatures/bloodline-imperial.json
+++ b/packs/classfeatures/bloodline-imperial.json
@@ -29,12 +29,22 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.arcana.rank",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ],
                 "value": 1
             },
             {
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.society.rank",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ],
                 "value": 1
             },
             {
@@ -42,7 +52,9 @@
                 "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
-                    "class:sorcerer",
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    },
                     {
                         "or": [
                             "item:tag:ancestral-spell",
@@ -75,11 +87,100 @@
                         ]
                     }
                 ],
+                "property": "other-tags",
+                "value": "blood-magic-spell"
+            },
+            {
+                "alwaysActive": true,
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
+                "mergeable": true,
+                "option": "blood-magic",
+                "placement": "spellcasting",
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Imperial",
+                        "value": "imperial"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.SecondBloodMagic",
+                "mergeable": true,
+                "option": "second-blood-magic",
+                "placement": "spellcasting",
+                "predicate": [
+                    {
+                        "or": [
+                            "feat:blood-ascendancy",
+                            "feat:blood-sovereignty"
+                        ]
+                    }
+                ],
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Imperial",
+                        "value": "imperial"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:tag:blood-magic-spell",
+                    {
+                        "or": [
+                            "blood-magic:aberrant",
+                            {
+                                "and": [
+                                    "second-blood-magic:aberrant",
+                                    "feat:blood-sovereignty"
+                                ]
+                            }
+                        ]
+                    }
+                ],
                 "property": "description",
                 "value": [
                     {
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Imperial",
-                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title"
+                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Imperial"
+                    },
+                    {
+                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Imperial Blood Magic]"
+                    }
+                ]
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:slug:blood-rising",
+                    {
+                        "or": [
+                            "blood-magic:imperial",
+                            {
+                                "and": [
+                                    "second-blood-magic:imperial",
+                                    "feat:blood-ascendancy"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Imperial",
+                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Imperial"
                     },
                     {
                         "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Imperial Blood Magic]"

--- a/packs/classfeatures/bloodline-nymph.json
+++ b/packs/classfeatures/bloodline-nymph.json
@@ -190,7 +190,12 @@
             {
                 "domain": "all",
                 "key": "RollOption",
-                "option": "feature:bloodline:tradition:primal"
+                "option": "feature:bloodline:tradition:primal",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ]
             }
         ],
         "traits": {

--- a/packs/classfeatures/bloodline-nymph.json
+++ b/packs/classfeatures/bloodline-nymph.json
@@ -29,12 +29,22 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.diplomacy.rank",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ],
                 "value": 1
             },
             {
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.nature.rank",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ],
                 "value": 1
             },
             {
@@ -42,7 +52,9 @@
                 "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
-                    "class:sorcerer",
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    },
                     {
                         "or": [
                             "item:tag:ancestral-spell",
@@ -75,11 +87,100 @@
                         ]
                     }
                 ],
+                "property": "other-tags",
+                "value": "blood-magic-spell"
+            },
+            {
+                "alwaysActive": true,
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
+                "mergeable": true,
+                "option": "blood-magic",
+                "placement": "spellcasting",
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Nymph",
+                        "value": "nymph"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.SecondBloodMagic",
+                "mergeable": true,
+                "option": "second-blood-magic",
+                "placement": "spellcasting",
+                "predicate": [
+                    {
+                        "or": [
+                            "feat:blood-ascendancy",
+                            "feat:blood-sovereignty"
+                        ]
+                    }
+                ],
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Nymph",
+                        "value": "nymph"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:tag:blood-magic-spell",
+                    {
+                        "or": [
+                            "blood-magic:nymph",
+                            {
+                                "and": [
+                                    "second-blood-magic:nymph",
+                                    "feat:blood-sovereignty"
+                                ]
+                            }
+                        ]
+                    }
+                ],
                 "property": "description",
                 "value": [
                     {
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Nymph",
-                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title"
+                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Nymph"
+                    },
+                    {
+                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Nymph Blood Magic]"
+                    }
+                ]
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:slug:blood-rising",
+                    {
+                        "or": [
+                            "blood-magic:nymph",
+                            {
+                                "and": [
+                                    "second-blood-magic:nymph",
+                                    "feat:blood-ascendancy"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Nymph",
+                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Nymph"
                     },
                     {
                         "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Nymph Blood Magic]"

--- a/packs/classfeatures/bloodline-phoenix.json
+++ b/packs/classfeatures/bloodline-phoenix.json
@@ -190,7 +190,12 @@
             {
                 "domain": "all",
                 "key": "RollOption",
-                "option": "feature:bloodline:tradition:primal"
+                "option": "feature:bloodline:tradition:primal",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ]
             }
         ],
         "traits": {

--- a/packs/classfeatures/bloodline-phoenix.json
+++ b/packs/classfeatures/bloodline-phoenix.json
@@ -29,12 +29,22 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.diplomacy.rank",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ],
                 "value": 1
             },
             {
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.nature.rank",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ],
                 "value": 1
             },
             {
@@ -42,7 +52,9 @@
                 "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
-                    "class:sorcerer",
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    },
                     {
                         "or": [
                             "item:tag:ancestral-spell",
@@ -75,11 +87,100 @@
                         ]
                     }
                 ],
+                "property": "other-tags",
+                "value": "blood-magic-spell"
+            },
+            {
+                "alwaysActive": true,
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
+                "mergeable": true,
+                "option": "blood-magic",
+                "placement": "spellcasting",
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Phoenix",
+                        "value": "phoenix"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.SecondBloodMagic",
+                "mergeable": true,
+                "option": "second-blood-magic",
+                "placement": "spellcasting",
+                "predicate": [
+                    {
+                        "or": [
+                            "feat:blood-ascendancy",
+                            "feat:blood-sovereignty"
+                        ]
+                    }
+                ],
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Phoenix",
+                        "value": "phoenix"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:tag:blood-magic-spell",
+                    {
+                        "or": [
+                            "blood-magic:phoenix",
+                            {
+                                "and": [
+                                    "second-blood-magic:phoenix",
+                                    "feat:blood-sovereignty"
+                                ]
+                            }
+                        ]
+                    }
+                ],
                 "property": "description",
                 "value": [
                     {
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Phoenix",
-                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title"
+                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Phoenix"
+                    },
+                    {
+                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Phoenix Blood Magic]"
+                    }
+                ]
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:slug:blood-rising",
+                    {
+                        "or": [
+                            "blood-magic:phoenix",
+                            {
+                                "and": [
+                                    "second-blood-magic:phoenix",
+                                    "feat:blood-ascendancy"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Phoenix",
+                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Phoenix"
                     },
                     {
                         "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Phoenix Blood Magic]"

--- a/packs/classfeatures/bloodline-psychopomp.json
+++ b/packs/classfeatures/bloodline-psychopomp.json
@@ -29,12 +29,22 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.intimidation.rank",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ],
                 "value": 1
             },
             {
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.religion.rank",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ],
                 "value": 1
             },
             {
@@ -42,7 +52,9 @@
                 "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
-                    "class:sorcerer",
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    },
                     {
                         "or": [
                             "item:tag:ancestral-spell",
@@ -75,11 +87,100 @@
                         ]
                     }
                 ],
+                "property": "other-tags",
+                "value": "blood-magic-spell"
+            },
+            {
+                "alwaysActive": true,
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
+                "mergeable": true,
+                "option": "blood-magic",
+                "placement": "spellcasting",
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Psychopomp",
+                        "value": "psychopomp"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.SecondBloodMagic",
+                "mergeable": true,
+                "option": "second-blood-magic",
+                "placement": "spellcasting",
+                "predicate": [
+                    {
+                        "or": [
+                            "feat:blood-ascendancy",
+                            "feat:blood-sovereignty"
+                        ]
+                    }
+                ],
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Psychopomp",
+                        "value": "psychopomp"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:tag:blood-magic-spell",
+                    {
+                        "or": [
+                            "blood-magic:psychopomp",
+                            {
+                                "and": [
+                                    "second-blood-magic:psychopomp",
+                                    "feat:blood-sovereignty"
+                                ]
+                            }
+                        ]
+                    }
+                ],
                 "property": "description",
                 "value": [
                     {
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Psychopomp",
-                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title"
+                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Psychopomp"
+                    },
+                    {
+                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Psychopomp Blood Magic (Self)]"
+                    }
+                ]
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:slug:blood-rising",
+                    {
+                        "or": [
+                            "blood-magic:psychopomp",
+                            {
+                                "and": [
+                                    "second-blood-magic:psychopomp",
+                                    "feat:blood-ascendancy"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Psychopomp",
+                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Psychopomp"
                     },
                     {
                         "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Psychopomp Blood Magic (Self)]"

--- a/packs/classfeatures/bloodline-psychopomp.json
+++ b/packs/classfeatures/bloodline-psychopomp.json
@@ -190,7 +190,12 @@
             {
                 "domain": "all",
                 "key": "RollOption",
-                "option": "feature:bloodline:tradition:divine"
+                "option": "feature:bloodline:tradition:divine",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ]
             }
         ],
         "traits": {

--- a/packs/classfeatures/bloodline-shadow.json
+++ b/packs/classfeatures/bloodline-shadow.json
@@ -190,7 +190,12 @@
             {
                 "domain": "all",
                 "key": "RollOption",
-                "option": "feature:bloodline:tradition:occult"
+                "option": "feature:bloodline:tradition:occult",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ]
             }
         ],
         "traits": {

--- a/packs/classfeatures/bloodline-shadow.json
+++ b/packs/classfeatures/bloodline-shadow.json
@@ -29,12 +29,22 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.occultism.rank",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ],
                 "value": 1
             },
             {
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.stealth.rank",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ],
                 "value": 1
             },
             {
@@ -42,7 +52,9 @@
                 "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
-                    "class:sorcerer",
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    },
                     {
                         "or": [
                             "item:tag:ancestral-spell",
@@ -75,11 +87,100 @@
                         ]
                     }
                 ],
+                "property": "other-tags",
+                "value": "blood-magic-spell"
+            },
+            {
+                "alwaysActive": true,
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
+                "mergeable": true,
+                "option": "blood-magic",
+                "placement": "spellcasting",
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.shadow",
+                        "value": "shadow"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.SecondBloodMagic",
+                "mergeable": true,
+                "option": "second-blood-magic",
+                "placement": "spellcasting",
+                "predicate": [
+                    {
+                        "or": [
+                            "feat:blood-ascendancy",
+                            "feat:blood-sovereignty"
+                        ]
+                    }
+                ],
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.shadow",
+                        "value": "shadow"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:tag:blood-magic-spell",
+                    {
+                        "or": [
+                            "blood-magic:shadow",
+                            {
+                                "and": [
+                                    "second-blood-magic:shadow",
+                                    "feat:blood-sovereignty"
+                                ]
+                            }
+                        ]
+                    }
+                ],
                 "property": "description",
                 "value": [
                     {
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Shadow.Text",
-                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title"
+                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Shadow"
+                    },
+                    {
+                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Shadow Blood Magic]"
+                    }
+                ]
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:slug:blood-rising",
+                    {
+                        "or": [
+                            "blood-magic:shadow",
+                            {
+                                "and": [
+                                    "second-blood-magic:shadow",
+                                    "feat:blood-ascendancy"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Shadow",
+                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Shadow"
                     },
                     {
                         "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Shadow Blood Magic]"

--- a/packs/classfeatures/bloodline-shadow.json
+++ b/packs/classfeatures/bloodline-shadow.json
@@ -121,7 +121,7 @@
                 ],
                 "suboptions": [
                     {
-                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.shadow",
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Shadow",
                         "value": "shadow"
                     }
                 ],

--- a/packs/classfeatures/bloodline-undead.json
+++ b/packs/classfeatures/bloodline-undead.json
@@ -29,12 +29,22 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.intimidation.rank",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ],
                 "value": 1
             },
             {
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.religion.rank",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ],
                 "value": 1
             },
             {
@@ -42,7 +52,9 @@
                 "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
-                    "class:sorcerer",
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    },
                     {
                         "or": [
                             "item:tag:ancestral-spell",
@@ -75,11 +87,100 @@
                         ]
                     }
                 ],
+                "property": "other-tags",
+                "value": "blood-magic-spell"
+            },
+            {
+                "alwaysActive": true,
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
+                "mergeable": true,
+                "option": "blood-magic",
+                "placement": "spellcasting",
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Undead",
+                        "value": "undead"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.SecondBloodMagic",
+                "mergeable": true,
+                "option": "second-blood-magic",
+                "placement": "spellcasting",
+                "predicate": [
+                    {
+                        "or": [
+                            "feat:blood-ascendancy",
+                            "feat:blood-sovereignty"
+                        ]
+                    }
+                ],
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Undead",
+                        "value": "undead"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:tag:blood-magic-spell",
+                    {
+                        "or": [
+                            "blood-magic:undead",
+                            {
+                                "and": [
+                                    "second-blood-magic:undead",
+                                    "feat:blood-sovereignty"
+                                ]
+                            }
+                        ]
+                    }
+                ],
                 "property": "description",
                 "value": [
                     {
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Undead",
-                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title"
+                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Undead"
+                    },
+                    {
+                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Undead Blood Magic]"
+                    }
+                ]
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:slug:blood-rising",
+                    {
+                        "or": [
+                            "blood-magic:undead",
+                            {
+                                "and": [
+                                    "second-blood-magic:undead",
+                                    "feat:blood-ascendancy"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Undead",
+                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Undead"
                     },
                     {
                         "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Undead Blood Magic]"

--- a/packs/classfeatures/bloodline-undead.json
+++ b/packs/classfeatures/bloodline-undead.json
@@ -190,7 +190,12 @@
             {
                 "domain": "all",
                 "key": "RollOption",
-                "option": "feature:bloodline:tradition:divine"
+                "option": "feature:bloodline:tradition:divine",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ]
             }
         ],
         "traits": {

--- a/packs/classfeatures/bloodline-wyrmblessed.json
+++ b/packs/classfeatures/bloodline-wyrmblessed.json
@@ -345,7 +345,12 @@
             {
                 "domain": "all",
                 "key": "RollOption",
-                "option": "feature:bloodline:tradition:divine"
+                "option": "feature:bloodline:tradition:divine",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ]
             }
         ],
         "traits": {

--- a/packs/classfeatures/bloodline-wyrmblessed.json
+++ b/packs/classfeatures/bloodline-wyrmblessed.json
@@ -29,12 +29,22 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.intimidation.rank",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ],
                 "value": 1
             },
             {
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.religion.rank",
+                "predicate": [
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    }
+                ],
                 "value": 1
             },
             {
@@ -197,7 +207,9 @@
                 "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
-                    "class:sorcerer",
+                    {
+                        "not": "parent:tag:crossblooded-evolution"
+                    },
                     {
                         "or": [
                             "item:tag:ancestral-spell",
@@ -230,11 +242,100 @@
                         ]
                     }
                 ],
+                "property": "other-tags",
+                "value": "blood-magic-spell"
+            },
+            {
+                "alwaysActive": true,
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
+                "mergeable": true,
+                "option": "blood-magic",
+                "placement": "spellcasting",
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Wyrmblessed",
+                        "value": "wyrmblessed"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.SecondBloodMagic",
+                "mergeable": true,
+                "option": "second-blood-magic",
+                "placement": "spellcasting",
+                "predicate": [
+                    {
+                        "or": [
+                            "feat:blood-ascendancy",
+                            "feat:blood-sovereignty"
+                        ]
+                    }
+                ],
+                "suboptions": [
+                    {
+                        "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Wyrmblessed",
+                        "value": "wyrmblessed"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:tag:blood-magic-spell",
+                    {
+                        "or": [
+                            "blood-magic:wyrmblessed",
+                            {
+                                "and": [
+                                    "second-blood-magic:wyrmblessed",
+                                    "feat:blood-sovereignty"
+                                ]
+                            }
+                        ]
+                    }
+                ],
                 "property": "description",
                 "value": [
                     {
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Wyrmblessed",
-                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title"
+                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Wyrmblessed"
+                    },
+                    {
+                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Wyrmblessed Blood Magic]"
+                    }
+                ]
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:slug:blood-rising",
+                    {
+                        "or": [
+                            "blood-magic:wyrmblessed",
+                            {
+                                "and": [
+                                    "second-blood-magic:wyrmblessed",
+                                    "feat:blood-ascendancy"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Wyrmblessed",
+                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Wyrmblessed"
                     },
                     {
                         "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Wyrmblessed Blood Magic]"

--- a/packs/classfeatures/strategic-strike.json
+++ b/packs/classfeatures/strategic-strike.json
@@ -27,13 +27,13 @@
         "rules": [
             {
                 "category": "precision",
+                "diceNumber": "floor((@actor.level+3)/4)",
                 "dieSize": "d6",
                 "key": "DamageDice",
                 "predicate": [
                     "check:substitution:devise-a-stratagem"
                 ],
-                "selector": "strike-damage",
-                "diceNumber": "floor((@actor.level+3)/4)"
+                "selector": "strike-damage"
             }
         ],
         "traits": {

--- a/packs/feat-effects/effect-blood-sovereignty.json
+++ b/packs/feat-effects/effect-blood-sovereignty.json
@@ -1,0 +1,41 @@
+{
+    "_id": "7hiwUPQY5aBEkpIt",
+    "img": "icons/skills/wounds/blood-cells-vessel-red.webp",
+    "name": "Effect: Blood Sovereignty",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Blood Sovereignty]</p>\n<p>You lose Hit Points equal to twice the spell's rank.</p>"
+        },
+        "duration": {
+            "expiry": "turn-end",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 0
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core 2"
+        },
+        "rules": [
+            {
+                "key": "LoseHitPoints",
+                "value": "2*@item.level"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feats/blood-rising.json
+++ b/packs/feats/blood-rising.json
@@ -29,74 +29,41 @@
                 "itemId": "{item|id}",
                 "key": "ItemAlteration",
                 "mode": "add",
-                "property": "description",
-                "value": [
-                    {
-                        "predicate": [
-                            "feature:bloodline-aberrant"
-                        ],
-                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Aberrant",
-                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title"
-                    },
-                    {
-                        "predicate": [
-                            "feature:bloodline-aberrant"
-                        ],
-                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Aberrant Blood Magic]"
-                    },
-                    {
-                        "predicate": [
-                            "feature:bloodline-angelic"
-                        ],
-                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Angelic",
-                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title"
-                    },
-                    {
-                        "predicate": [
-                            "feature:bloodline-angelic"
-                        ],
-                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Angelic Blood Magic]"
-                    },
-                    {
-                        "predicate": [
-                            "feature:bloodline-draconic"
-                        ],
-                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Draconic",
-                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title"
-                    },
-                    {
-                        "predicate": [
-                            "feature:bloodline-draconic"
-                        ],
-                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Draconic Blood Magic]"
-                    },
-                    {
-                        "predicate": [
-                            "feature:bloodline-imperial"
-                        ],
-                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Imperial",
-                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title"
-                    },
-                    {
-                        "predicate": [
-                            "feature:bloodline-imperial"
-                        ],
-                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Imperial Blood Magic]"
-                    },
-                    {
-                        "predicate": [
-                            "feature:bloodline-psychopomp"
-                        ],
-                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Psychopomp",
-                        "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title"
-                    },
-                    {
-                        "predicate": [
-                            "feature:bloodline-psychopomp"
-                        ],
-                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Psychopomp Blood Magic (Self)]"
-                    }
-                ]
+                "predicate": [
+                    "feature:bloodline:tradition:arcane"
+                ],
+                "property": "traits",
+                "value": "arcane"
+            },
+            {
+                "itemId": "{item|id}",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "feature:bloodline:tradition:divine"
+                ],
+                "property": "traits",
+                "value": "divine"
+            },
+            {
+                "itemId": "{item|id}",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "feature:bloodline:tradition:occult"
+                ],
+                "property": "traits",
+                "value": "occult"
+            },
+            {
+                "itemId": "{item|id}",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "feature:bloodline:tradition:primal"
+                ],
+                "property": "traits",
+                "value": "primal"
             }
         ],
         "traits": {

--- a/packs/feats/blood-sovereignty.json
+++ b/packs/feats/blood-sovereignty.json
@@ -24,7 +24,23 @@
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "second-blood-magic",
+                    "item:tag:blood-magic-spell"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Sorcerer.BloodSovereignty.Description"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/blood-sovereignty.json
+++ b/packs/feats/blood-sovereignty.json
@@ -37,6 +37,9 @@
                 "value": [
                     {
                         "text": "PF2E.SpecificRule.Sorcerer.BloodSovereignty.Description"
+                    },
+                    {
+                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Blood Sovereignty]"
                     }
                 ]
             }

--- a/packs/feats/crossblooded-evolution.json
+++ b/packs/feats/crossblooded-evolution.json
@@ -44,7 +44,6 @@
                         "value": "crossblooded-evolution"
                     }
                 ],
-                "flag": "bloodlineAberrant",
                 "key": "GrantItem",
                 "uuid": "{item|flags.pf2e.rulesSelections.bloodline}"
             }

--- a/packs/feats/crossblooded-evolution.json
+++ b/packs/feats/crossblooded-evolution.json
@@ -24,7 +24,31 @@
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [],
+        "rules": [
+            {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        "item:tag:sorcerer-bloodline"
+                    ]
+                },
+                "flag": "bloodline",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Sorcerer.Bloodline.Prompt"
+            },
+            {
+                "alterations": [
+                    {
+                        "mode": "add",
+                        "property": "other-tags",
+                        "value": "crossblooded-evolution"
+                    }
+                ],
+                "flag": "bloodlineAberrant",
+                "key": "GrantItem",
+                "uuid": "{item|flags.pf2e.rulesSelections.bloodline}"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/explosion-of-power.json
+++ b/packs/feats/explosion-of-power.json
@@ -24,7 +24,145 @@
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [],
+        "rules": [
+            {
+                "alwaysActive": true,
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
+                "mergeable": true,
+                "option": "blood-magic",
+                "placement": "spellcasting",
+                "suboptions": [
+                    {
+                        "label": "{item|name}",
+                        "value": "explosion-of-power"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.SecondBloodMagic",
+                "mergeable": true,
+                "option": "second-blood-magic",
+                "placement": "spellcasting",
+                "predicate": [
+                    {
+                        "or": [
+                            "feat:blood-ascendancy",
+                            "feat:blood-sovereignty"
+                        ]
+                    }
+                ],
+                "suboptions": [
+                    {
+                        "label": "{item|name}",
+                        "value": "explosion-of-power"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:tag:blood-magic-spell",
+                    {
+                        "or": [
+                            "blood-magic:explosion-of-power",
+                            {
+                                "and": [
+                                    "second-blood-magic:explosion-of-power",
+                                    "feat:blood-sovereignty"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.ExplosionOfPower"
+                    }
+                ]
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:slug:blood-rising",
+                    {
+                        "or": [
+                            "blood-magic:explosion-of-power",
+                            {
+                                "and": [
+                                    "second-blood-magic:explosion-of-power",
+                                    "feat:blood-ascendancy"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.ExplosionOfPower"
+                    }
+                ]
+            },
+            {
+                "key": "DamageAlteration",
+                "mode": "override",
+                "predicate": [
+                    "feature:bloodline:tradition:arcane"
+                ],
+                "property": "damage-type",
+                "selectors": [
+                    "inline-damage"
+                ],
+                "value": "force"
+            },
+            {
+                "key": "DamageAlteration",
+                "mode": "override",
+                "predicate": [
+                    "feature:bloodline:tradition:divine"
+                ],
+                "property": "damage-type",
+                "selectors": [
+                    "inline-damage"
+                ],
+                "value": "spirit"
+            },
+            {
+                "key": "DamageAlteration",
+                "mode": "override",
+                "predicate": [
+                    "feature:bloodline:tradition:occult"
+                ],
+                "property": "damage-type",
+                "selectors": [
+                    "inline-damage"
+                ],
+                "value": "mental"
+            },
+            {
+                "key": "DamageAlteration",
+                "mode": "override",
+                "predicate": [
+                    "feature:bloodline:tradition:primal"
+                ],
+                "property": "damage-type",
+                "selectors": [
+                    "inline-damage"
+                ],
+                "value": "fire"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/propelling-sorcery.json
+++ b/packs/feats/propelling-sorcery.json
@@ -24,7 +24,97 @@
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [],
+        "rules": [
+            {
+                "alwaysActive": true,
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
+                "mergeable": true,
+                "option": "blood-magic",
+                "placement": "spellcasting",
+                "suboptions": [
+                    {
+                        "label": "{item|name}",
+                        "value": "propelling-sorcery"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.SecondBloodMagic",
+                "mergeable": true,
+                "option": "second-blood-magic",
+                "placement": "spellcasting",
+                "predicate": [
+                    {
+                        "or": [
+                            "feat:blood-ascendancy",
+                            "feat:blood-sovereignty"
+                        ]
+                    }
+                ],
+                "suboptions": [
+                    {
+                        "label": "{item|name}",
+                        "value": "propelling-sorcery"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:tag:blood-magic-spell",
+                    {
+                        "or": [
+                            "blood-magic:propelling-sorcery",
+                            {
+                                "and": [
+                                    "second-blood-magic:propelling-sorcery",
+                                    "feat:blood-sovereignty"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.PropellingSorcery"
+                    }
+                ]
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:slug:blood-rising",
+                    {
+                        "or": [
+                            "blood-magic:propelling-sorcery",
+                            {
+                                "and": [
+                                    "second-blood-magic:propelling-sorcery",
+                                    "feat:blood-ascendancy"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.PropellingSorcery"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/reflect-harm.json
+++ b/packs/feats/reflect-harm.json
@@ -24,7 +24,97 @@
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [],
+        "rules": [
+            {
+                "alwaysActive": true,
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
+                "mergeable": true,
+                "option": "blood-magic",
+                "placement": "spellcasting",
+                "suboptions": [
+                    {
+                        "label": "{item|name}",
+                        "value": "reflect-harm"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.SecondBloodMagic",
+                "mergeable": true,
+                "option": "second-blood-magic",
+                "placement": "spellcasting",
+                "predicate": [
+                    {
+                        "or": [
+                            "feat:blood-ascendancy",
+                            "feat:blood-sovereignty"
+                        ]
+                    }
+                ],
+                "suboptions": [
+                    {
+                        "label": "{item|name}",
+                        "value": "reflect-harm"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:tag:blood-magic-spell",
+                    {
+                        "or": [
+                            "blood-magic:reflect-harm",
+                            {
+                                "and": [
+                                    "second-blood-magic:reflect-harm",
+                                    "feat:blood-sovereignty"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.ReflectHarm"
+                    }
+                ]
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:slug:blood-rising",
+                    {
+                        "or": [
+                            "blood-magic:reflect-harm",
+                            {
+                                "and": [
+                                    "second-blood-magic:reflect-harm",
+                                    "feat:blood-ascendancy"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.ReflectHarm"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/tap-into-blood.json
+++ b/packs/feats/tap-into-blood.json
@@ -4,10 +4,10 @@
     "name": "Tap into Blood",
     "system": {
         "actionType": {
-            "value": "passive"
+            "value": "action"
         },
         "actions": {
-            "value": null
+            "value": 1
         },
         "category": "class",
         "description": {

--- a/packs/feats/tap-into-blood.json
+++ b/packs/feats/tap-into-blood.json
@@ -4,10 +4,10 @@
     "name": "Tap into Blood",
     "system": {
         "actionType": {
-            "value": "action"
+            "value": "passive"
         },
         "actions": {
-            "value": 1
+            "value": null
         },
         "category": "class",
         "description": {

--- a/packs/feats/terraforming-trickery.json
+++ b/packs/feats/terraforming-trickery.json
@@ -24,7 +24,97 @@
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [],
+        "rules": [
+            {
+                "alwaysActive": true,
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
+                "mergeable": true,
+                "option": "blood-magic",
+                "placement": "spellcasting",
+                "suboptions": [
+                    {
+                        "label": "{item|name}",
+                        "value": "terraforming-trickery"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Sorcerer.SecondBloodMagic",
+                "mergeable": true,
+                "option": "second-blood-magic",
+                "placement": "spellcasting",
+                "predicate": [
+                    {
+                        "or": [
+                            "feat:blood-ascendancy",
+                            "feat:blood-sovereignty"
+                        ]
+                    }
+                ],
+                "suboptions": [
+                    {
+                        "label": "{item|name}",
+                        "value": "terraforming-trickery"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:tag:blood-magic-spell",
+                    {
+                        "or": [
+                            "blood-magic:terraforming-trickery",
+                            {
+                                "and": [
+                                    "second-blood-magic:terraforming-trickery",
+                                    "feat:blood-sovereignty"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.TerraformingTrickery"
+                    }
+                ]
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "class:sorcerer",
+                    "item:slug:blood-rising",
+                    {
+                        "or": [
+                            "blood-magic:terraforming-trickery",
+                            {
+                                "and": [
+                                    "second-blood-magic:terraforming-trickery",
+                                    "feat:blood-ascendancy"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.TerraformingTrickery"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -4038,22 +4038,22 @@
                 "Bloodline": {
                     "Prompt": "Select a bloodline.",
                     "BloodMagicLabel": {
-                        "Aberrant": "Eerie-Veil (Aberrant)",
-                        "Angelic": "Divine Aura (Angelic)",
-                        "Demonic": "Corruption of Sin (Demonic)",
-                        "Diabolic": "Tongue of Flame (Diabolic)",
-                        "Draconic": "Scaly Hide (Draconic)",
-                        "Elemental": "Elemental Fury (Elemental)",
-                        "Fey": "Cloak of Ribbons (Fey)",
+                        "Aberrant": "Eerie-Veil",
+                        "Angelic": "Divine Aura",
+                        "Demonic": "Corruption of Sin",
+                        "Diabolic": "Tongue of Flame",
+                        "Draconic": "Scaly Hide",
+                        "Elemental": "Elemental Fury",
+                        "Fey": "Cloak of Ribbons",
                         "Genie": "Genie Bloodline",
-                        "Hag": "Retributive Spite (Hag)",
+                        "Hag": "Retributive Spite",
                         "Harrow": "Harrow Bloodline",
-                        "Imperial": "Imperious Defense (Imperial)",
+                        "Imperial": "Imperious Defense",
                         "Nymph": "Nymph Bloodline",
                         "Phoenix": "Phoenix Bloodline",
                         "Psychopomp": "Psychopomp Bloodline",
                         "Shadow": "Shadow Bloodline",
-                        "Undead": "Stolen Life (Undead)",
+                        "Undead": "Stolen Life",
                         "Wyrmblessed": "Wyrmblessed Bloodline"
                     },
                     "BloodMagicDescription": {
@@ -4064,27 +4064,32 @@
                         "Diabolic": "Either a target takes @Damage[@item.level[fire]] (if the spell already deals initial fire damage, combine this with the spell's initial damage before determining weaknesses and resistances), or you gain a +2 status bonus to Deception checks for 1 round",
                         "Draconic": "You or one target is granted a +1 status bonus to AC for 1 round.",
                         "Elemental": "Either you gain a +2 status bonus to Intimidation checks for 1 round, or a target takes @Damage[@item.level[@actor.flags.pf2e.elementalBloodline.damageType]] damage. If the spell already deals that type of damage, combine it with the spell's initial damage before determining weaknesses and resistances.",
+                        "ExplosionOfPower": "Each creature within a @Template[type:emanation|distance:5] takes @Damage[(@item.level)d6|options:explosion-of-power] damage (@Check[type:reflex|basic:true|dc:resolve(@actor.system.attributes.spellDC.value)] save).",
                         "Fey": "Either you gain a +2 status bonus to Performance checks for 1 round, or you can become @UUID[Compendium.pf2e.conditionitems.Item.DmAIPqOBomZ7H95W]{Concealed} for 1 round. Such obvious concealment can't be used to @UUID[Compendium.pf2e.actionspf2e.Item.XMcnh4cSI32tljXa]{Hide}",
                         "Genie": "Your spellcasting warps reality and distracts your foes. Either you gain a +1 status bonus to Deception checks for 1 round, or a target takes a -1 status penalty to Perception for 1 round.",
                         "Hag": "You deal @Damage[(4*@item.level)[mental]] damage (@Check[type:will|basic:true|dc:resolve(@actor.system.attributes.spellDC.value)] save) to the first creature that deals damage to you before the end of your next turn; if no creature damages you in that time, you consume that spite to gain temporary Hit Points at the beginning of your next turn equal to the spell's rank. These temporary Hit Points last until the beginning of your following turn.",
                         "Harrow": "You become enveloped in possibility, represented as multiple versions of yourself from your possible futures overlaid on each other. You gain @UUID[Compendium.pf2e.conditionitems.Item.DmAIPqOBomZ7H95W]{Concealement} for 1 round, but can't use the concealment to @UUID[Compendium.pf2e.actionspf2e.Item.XMcnh4cSI32tljXa]{Hide}.",
                         "Imperial": "Until the start of your next turn, you gain your choice of either a +1 status bonus to AC or to saving throws.",
-                        "Title": "Blood Magic",
                         "Nymph": "Nymph grace accentuates your movements and distracts your foes, either granting you a +1 status bonus to Diplomacy checks for 1 round or imposing a -1 status penalty on one target's Will saves for 1 round.",
                         "Phoenix": "The primal fire of life and death flows through you or one target. Choose to have either you or a target of the spell gain temporary Hit Points equal to the spell's rank for 1 round, or to have a target of the spell take @Damage[@item.level[fire]] damage (if the spell already deals initial fire damage, combine this with the spell's initial damage before determining weaknesses and resistances).",
+                        "PropellingSorcery": "You channel your magic outward into a rush of movement. Either you Step as a free action or move the target 5 feet in a direction of your choice.",
                         "Psychopomp": "The border between life and death becomes blurred to you. Either you gain a +2 status bonus to Fortitude saving throws for 1 round, or a target takes @Damage[@item.level[void]] if it's alive or @Damage[@item.level[vitality]] if it's undead. If the spell already deals that type of damage, combine it with the spell's initial damage before determining weaknesses and resistances.",
+                        "ReflectHarm": "The first time you take damage from a spell before the beginning of your next turn, attempt spell attack roll against the creature who cast the triggering spell. On a hit, the creature takes the same amount and type of damage that you just took. If you critically hit, the creature takes twice the damage.",
                         "Shadow": {
                             "Text": "Shadows grow deeper around you or one target, either granting a +1 status bonus to Stealth or imposing a -1 status penalty to Perception for 1 round.",
                             "PerceptionPenalty": "-1 penalty to Perception",
                             "StealthBonus": "+1 bonus to Stealth"
                         },
+                        "TerraformingTrickery": "Either each space adjacent to you becomes difficult terrain, or each space adjacent to you is no longer difficult terrain. This doesn't have any effect on greater difficult terrain and doesn't remove the damaging effects of hazardous terrain.",
+                        "Title": "Blood Magic",
                         "Undead": "Either you gain temporary Hit Points equal to the spell's rank until the start of your next turn, or a target takes @Damage[@item.level[void]] damage (if the spell already deals initial void damage, combine this with the spell's initial damage before determining weaknesses and resistances).",
                         "Wyrmblessed": "Draconic might carries in your voice. Either you gain a +1 status bonus to Intimidation checks for 1 round, or a target takes a -1 status penalty to Will saves for 1 round."
                     }
                 },
                 "BloodSovereignty": {
                     "Description": "You lose Hit Points equal to twice the spell's rank, and you benefit from two different blood magic effects you know as a result. The two effects can have different targets."
-                }
+                },
+                "SecondBloodMagic": "Second Blood Magic"
             },
             "SoulWarden": {
                 "SafeguardSoul": {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -4037,6 +4037,25 @@
             "Sorcerer": {
                 "Bloodline": {
                     "Prompt": "Select a bloodline.",
+                    "BloodMagicLabel": {
+                        "Aberrant": "Eerie-Veil (Aberrant)",
+                        "Angelic": "Divine Aura (Angelic)",
+                        "Demonic": "Corruption of Sin (Demonic)",
+                        "Diabolic": "Tongue of Flame (Diabolic)",
+                        "Draconic": "Scaly Hide (Draconic)",
+                        "Elemental": "Elemental Fury (Elemental)",
+                        "Fey": "Cloak of Ribbons (Fey)",
+                        "Genie": "Genie Bloodline",
+                        "Hag": "Retributive Spite (Hag)",
+                        "Harrow": "Harrow Bloodline",
+                        "Imperial": "Imperious Defense (Imperial)",
+                        "Nymph": "Nymph Bloodline",
+                        "Phoenix": "Phoenix Bloodline",
+                        "Psychopomp": "Psychopomp Bloodline",
+                        "Shadow": "Shadow Bloodline",
+                        "Undead": "Stolen Life (Undead)",
+                        "Wyrmblessed": "Wyrmblessed Bloodline"
+                    },
                     "BloodMagicDescription": {
                         "Aberrant": "Either one target takes a –1 status penalty to Will saving throws for 1 round or you gain a +2 status bonus to Will saving throws for 1 round.",
                         "AncestralBloodMagic": "Casting an ancestral spell",
@@ -4062,6 +4081,9 @@
                         "Undead": "Either you gain temporary Hit Points equal to the spell's rank until the start of your next turn, or a target takes @Damage[@item.level[void]] damage (if the spell already deals initial void damage, combine this with the spell's initial damage before determining weaknesses and resistances).",
                         "Wyrmblessed": "Draconic might carries in your voice. Either you gain a +1 status bonus to Intimidation checks for 1 round, or a target takes a -1 status penalty to Will saves for 1 round."
                     }
+                },
+                "BloodSovereignty": {
+                    "Description": "You lose Hit Points equal to twice the spell's rank, and you benefit from two different blood magic effects you know as a result. The two effects can have different targets."
                 }
             },
             "SoulWarden": {


### PR DESCRIPTION
This is a lot. I recommend building and playing around with this, but the idea is using other-tags Item Alteration to tag which spells should get Blood Magic, that way additional Blood Magic can be added to the appropriate spells.

- Blood Sovereignty and Blood Ascendancy will make a Second Blood Magic toggle appear, which will add a second blood magic to a spell or to the Blood Rising feat respectively.
- Crossblooded Evolution adds a tag to the Bloodline class feature in order for it to only grant the Blood Magic effects, but none of the skills, tradition, and most importantly, the blood magic spell list, which is exclusive to what you receive at character creation. 
- Third-parties should be able to build their own bloodlines and blood magic feats following the format here, and they will work with the implementation.