### PR TITLE
Allow `@Embed` of Items

### DIFF
--- a/src/module/item/base/document.ts
+++ b/src/module/item/base/document.ts
@@ -862,6 +862,33 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
             this.actor.update(actorUpdates);
         }
     }
+
+    /** To be overridden by subclasses to extend the HTML string that will become part of the embed */
+    embedHTMLString(_config: DocumentHTMLEmbedConfig, _options: EnrichmentOptions) : string {
+        return this.description;
+    }
+
+    async _buildEmbedHTML(config: DocumentHTMLEmbedConfig, options: EnrichmentOptions) {
+        //const embed = await super._buildEmbedHTML(config, options);
+        //if (embed) return embed;
+
+        // As per foundry.js: JournalEntryPage#_embedTextPage
+        options = { ...options, relativeTo: this };
+        const {
+          secrets = options.secrets,
+          documents = options.documents,
+          links = options.links,
+          rolls = options.rolls,
+          embeds = options.embeds
+        } = config;
+        foundry.utils.mergeObject(options, { secrets, documents, links, rolls, embeds });
+    
+        // Get correct HTML
+        const container = document.createElement("div");
+        container.innerHTML = await TextEditor.enrichHTML(this.embedHTMLString(config, options), options);
+        return container.children;
+      }
+    
 }
 
 interface ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item<TParent> {

--- a/src/module/item/base/document.ts
+++ b/src/module/item/base/document.ts
@@ -32,7 +32,6 @@ import type {
 } from "./data/index.ts";
 import type { ItemTrait } from "./data/system.ts";
 import type { ItemSheetPF2e } from "./sheet/sheet.ts";
-import { FeatSystemData } from "@item/feat/data.ts";
 
 /** The basic `Item` subclass for the system */
 class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item<TParent> {
@@ -866,19 +865,7 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
 
     /** To be overridden by subclasses to extend the HTML string that will become part of the embed */
     protected embedHTMLString(_config: DocumentHTMLEmbedConfig, _options: EnrichmentOptions): string {
-        // in some types of Item, prerequisites (PrerequisiteTagData[])
-        // item.system = CampaignFeatureSystemSource || FeatSystemSource || something-else
-        const prereq: { value: string }[] | null = (this.system as FeatSystemData).prerequisites?.value;
-        let result: string = "";
-        if (prereq && prereq?.length > 0) {
-            const list = prereq.map((item) => item.value).join(",");
-            result += `<p><strong>${game.i18n.localize("PF2E.FeatPrereqLabel")}</strong> ${list}</p>`;
-            // Allow option to NOT display the HR after the prerequisites (e.g. some entries in Archetypes journal)
-            if (_config.hr !== false) result += "<hr>";
-        }
-        // description
-        result += this.description;
-        return result;
+        return this.description;
     }
 
     async _buildEmbedHTML(config: DocumentHTMLEmbedConfig, options: EnrichmentOptions): Promise<HTMLCollection> {

--- a/src/module/item/base/document.ts
+++ b/src/module/item/base/document.ts
@@ -865,8 +865,8 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
 
     /** To be overridden by subclasses to extend the HTML string that will become part of the embed */
     protected embedHTMLString(_config: DocumentHTMLEmbedConfig, _options: EnrichmentOptions): string {
-        // @ts-ignore
         // in some types of Item, prerequisites (PrerequisiteTagData[])
+        // @ts-ignore
         const prereq: { value: string }[] | null = this.system.prerequisites?.value;
         let result: string = "";
         if (prereq && prereq?.length > 0) {

--- a/src/module/item/base/document.ts
+++ b/src/module/item/base/document.ts
@@ -864,10 +864,11 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
     }
 
     /** To be overridden by subclasses to extend the HTML string that will become part of the embed */
-    _embedHTMLString(_config: DocumentHTMLEmbedConfig, _options: EnrichmentOptions): string {
-        // prerequisites (PrerequisiteTagData[])
-        const prereq: { value: string }[] | null = foundry.utils.getProperty(this, "system.prerequisites.value");
-        let result = "";
+    protected embedHTMLString(_config: DocumentHTMLEmbedConfig, _options: EnrichmentOptions): string {
+        // @ts-ignore
+        // in some types of Item, prerequisites (PrerequisiteTagData[])
+        const prereq: { value: string }[] | null = this.system.prerequisites?.value;
+        let result: string = "";
         if (prereq && prereq?.length > 0) {
             const list = prereq.map((item) => item.value).join(",");
             result += `<p><strong>${game.i18n.localize("PF2E.FeatPrereqLabel")}</strong> ${list}</p>`;

--- a/src/module/item/base/document.ts
+++ b/src/module/item/base/document.ts
@@ -864,14 +864,22 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
     }
 
     /** To be overridden by subclasses to extend the HTML string that will become part of the embed */
-    embedHTMLString(_config: DocumentHTMLEmbedConfig, _options: EnrichmentOptions) : string {
-        return this.description;
+    _embedHTMLString(_config: DocumentHTMLEmbedConfig, _options: EnrichmentOptions) : string {
+        // prerequisites (PrerequisiteTagData[])
+        let prereq:Array<{value:string}>|null = foundry.utils.getProperty(this, "system.prerequisites.value");
+        let result = "";
+        if (prereq && prereq?.length > 0) {
+            const list = prereq.map(item => item.value).join(",");
+            result += `<p><strong>${game.i18n.localize("PF2E.FeatPrereqLabel")}</strong> ${list}</p>`;
+            // Allow option to NOT display the HR after the prerequisites (e.g. some entries in Archetypes journal)
+            if (_config.hr!==false) result += "<hr>";
+        }
+        // description
+        result += this.description;
+        return result;
     }
 
     async _buildEmbedHTML(config: DocumentHTMLEmbedConfig, options: EnrichmentOptions) {
-        //const embed = await super._buildEmbedHTML(config, options);
-        //if (embed) return embed;
-
         // As per foundry.js: JournalEntryPage#_embedTextPage
         options = { ...options, relativeTo: this };
         const {
@@ -885,10 +893,9 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
     
         // Get correct HTML
         const container = document.createElement("div");
-        container.innerHTML = await TextEditor.enrichHTML(this.embedHTMLString(config, options), options);
+        container.innerHTML = await TextEditor.enrichHTML(this._embedHTMLString(config, options), options);
         return container.children;
-      }
-    
+    }
 }
 
 interface ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item<TParent> {

--- a/src/module/item/base/document.ts
+++ b/src/module/item/base/document.ts
@@ -866,7 +866,7 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
     /** To be overridden by subclasses to extend the HTML string that will become part of the embed */
     protected embedHTMLString(_config: DocumentHTMLEmbedConfig, _options: EnrichmentOptions): string {
         // in some types of Item, prerequisites (PrerequisiteTagData[])
-        // @ts-ignore
+        // @ts-expect-error
         const prereq: { value: string }[] | null = this.system.prerequisites?.value;
         let result: string = "";
         if (prereq && prereq?.length > 0) {

--- a/src/module/item/base/document.ts
+++ b/src/module/item/base/document.ts
@@ -894,7 +894,7 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
 
         // Get correct HTML
         const container = document.createElement("div");
-        container.innerHTML = await TextEditor.enrichHTML(this._embedHTMLString(config, options), options);
+        container.innerHTML = await TextEditor.enrichHTML(this.embedHTMLString(config, options), options);
         return container.children;
     }
 }

--- a/src/module/item/base/document.ts
+++ b/src/module/item/base/document.ts
@@ -114,10 +114,10 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
     isOfType<T extends "physical" | ItemType>(
         ...types: T[]
     ): this is T extends "physical"
-    ? PhysicalItemPF2e<TParent>
-    : T extends ItemType
-    ? ItemInstances<TParent>[T]
-    : never;
+        ? PhysicalItemPF2e<TParent>
+        : T extends ItemType
+          ? ItemInstances<TParent>[T]
+          : never;
     isOfType(...types: string[]): boolean {
         return types.some((t) => (t === "physical" ? setHasElement(PHYSICAL_ITEM_TYPES, this.type) : this.type === t));
     }
@@ -507,7 +507,7 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
     }
 
     /** Include the item type along with data from upstream */
-    override toDragData(): { type: string; itemType: string;[key: string]: unknown } {
+    override toDragData(): { type: string; itemType: string; [key: string]: unknown } {
         return { ...super.toDragData(), itemType: this.type };
     }
 

--- a/src/module/item/base/document.ts
+++ b/src/module/item/base/document.ts
@@ -32,6 +32,7 @@ import type {
 } from "./data/index.ts";
 import type { ItemTrait } from "./data/system.ts";
 import type { ItemSheetPF2e } from "./sheet/sheet.ts";
+import { FeatSystemData } from "@item/feat/data.ts";
 
 /** The basic `Item` subclass for the system */
 class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item<TParent> {
@@ -866,8 +867,8 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
     /** To be overridden by subclasses to extend the HTML string that will become part of the embed */
     protected embedHTMLString(_config: DocumentHTMLEmbedConfig, _options: EnrichmentOptions): string {
         // in some types of Item, prerequisites (PrerequisiteTagData[])
-        // @ts-ignore
-        const prereq: { value: string }[] | null = this.system.prerequisites?.value;
+        // item.system = CampaignFeatureSystemSource || FeatSystemSource || something-else
+        const prereq: { value: string }[] | null = (this.system as FeatSystemData).prerequisites?.value;
         let result: string = "";
         if (prereq && prereq?.length > 0) {
             const list = prereq.map((item) => item.value).join(",");

--- a/src/module/item/base/document.ts
+++ b/src/module/item/base/document.ts
@@ -866,7 +866,7 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
     /** To be overridden by subclasses to extend the HTML string that will become part of the embed */
     protected embedHTMLString(_config: DocumentHTMLEmbedConfig, _options: EnrichmentOptions): string {
         // in some types of Item, prerequisites (PrerequisiteTagData[])
-        // @ts-expect-error
+        // @ts-ignore
         const prereq: { value: string }[] | null = this.system.prerequisites?.value;
         let result: string = "";
         if (prereq && prereq?.length > 0) {

--- a/src/module/item/base/document.ts
+++ b/src/module/item/base/document.ts
@@ -114,10 +114,10 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
     isOfType<T extends "physical" | ItemType>(
         ...types: T[]
     ): this is T extends "physical"
-        ? PhysicalItemPF2e<TParent>
-        : T extends ItemType
-          ? ItemInstances<TParent>[T]
-          : never;
+    ? PhysicalItemPF2e<TParent>
+    : T extends ItemType
+    ? ItemInstances<TParent>[T]
+    : never;
     isOfType(...types: string[]): boolean {
         return types.some((t) => (t === "physical" ? setHasElement(PHYSICAL_ITEM_TYPES, this.type) : this.type === t));
     }
@@ -507,7 +507,7 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
     }
 
     /** Include the item type along with data from upstream */
-    override toDragData(): { type: string; itemType: string; [key: string]: unknown } {
+    override toDragData(): { type: string; itemType: string;[key: string]: unknown } {
         return { ...super.toDragData(), itemType: this.type };
     }
 
@@ -864,33 +864,33 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
     }
 
     /** To be overridden by subclasses to extend the HTML string that will become part of the embed */
-    _embedHTMLString(_config: DocumentHTMLEmbedConfig, _options: EnrichmentOptions) : string {
+    _embedHTMLString(_config: DocumentHTMLEmbedConfig, _options: EnrichmentOptions): string {
         // prerequisites (PrerequisiteTagData[])
-        let prereq:Array<{value:string}>|null = foundry.utils.getProperty(this, "system.prerequisites.value");
+        const prereq: { value: string }[] | null = foundry.utils.getProperty(this, "system.prerequisites.value");
         let result = "";
         if (prereq && prereq?.length > 0) {
-            const list = prereq.map(item => item.value).join(",");
+            const list = prereq.map((item) => item.value).join(",");
             result += `<p><strong>${game.i18n.localize("PF2E.FeatPrereqLabel")}</strong> ${list}</p>`;
             // Allow option to NOT display the HR after the prerequisites (e.g. some entries in Archetypes journal)
-            if (_config.hr!==false) result += "<hr>";
+            if (_config.hr !== false) result += "<hr>";
         }
         // description
         result += this.description;
         return result;
     }
 
-    async _buildEmbedHTML(config: DocumentHTMLEmbedConfig, options: EnrichmentOptions) {
+    async _buildEmbedHTML(config: DocumentHTMLEmbedConfig, options: EnrichmentOptions): Promise<HTMLCollection> {
         // As per foundry.js: JournalEntryPage#_embedTextPage
         options = { ...options, relativeTo: this };
         const {
-          secrets = options.secrets,
-          documents = options.documents,
-          links = options.links,
-          rolls = options.rolls,
-          embeds = options.embeds
+            secrets = options.secrets,
+            documents = options.documents,
+            links = options.links,
+            rolls = options.rolls,
+            embeds = options.embeds,
         } = config;
         foundry.utils.mergeObject(options, { secrets, documents, links, rolls, embeds });
-    
+
         // Get correct HTML
         const container = document.createElement("div");
         container.innerHTML = await TextEditor.enrichHTML(this._embedHTMLString(config, options), options);

--- a/src/module/item/campaign-feature/document.ts
+++ b/src/module/item/campaign-feature/document.ts
@@ -166,10 +166,10 @@ class CampaignFeaturePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> e
     protected override embedHTMLString(_config: DocumentHTMLEmbedConfig, _options: EnrichmentOptions): string {
         const list = this.system.prerequisites?.value?.map((item) => item.value).join(",") ?? "";
         return (
-            (list.length
+            (list
                 ? `<p><strong>${game.i18n.localize("PF2E.FeatPrereqLabel")}</strong> ${list}</p>` +
-                  (_config.hr !== false ? "<hr>" : "")
-                : "") + super.embedHTMLString(_config, _options)
+                  (_config.hr === false ? "" : "<hr>")
+                : "") + this.description
         );
     }
 }

--- a/src/module/item/campaign-feature/document.ts
+++ b/src/module/item/campaign-feature/document.ts
@@ -162,6 +162,13 @@ class CampaignFeaturePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> e
 
         await super._preUpdate(changed, operation, user);
     }
+
+    protected override embedHTMLString(_config: DocumentHTMLEmbedConfig, _options: EnrichmentOptions): string {
+        const list = this.system.prerequisites?.value?.map((item) => item.value).join(",") ?? "";
+        return (list.length ? `<p><strong>${game.i18n.localize("PF2E.FeatPrereqLabel")}</strong> ${list}</p>` +
+            (_config.hr !== false ? "<hr>" : "") : "") +
+            super.embedHTMLString(_config, _options);
+    }
 }
 
 interface CampaignFeaturePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends ItemPF2e<TParent> {

--- a/src/module/item/campaign-feature/document.ts
+++ b/src/module/item/campaign-feature/document.ts
@@ -165,12 +165,14 @@ class CampaignFeaturePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> e
 
     protected override embedHTMLString(_config: DocumentHTMLEmbedConfig, _options: EnrichmentOptions): string {
         const list = this.system.prerequisites?.value?.map((item) => item.value).join(",") ?? "";
-        return (list.length ? `<p><strong>${game.i18n.localize("PF2E.FeatPrereqLabel")}</strong> ${list}</p>` +
-            (_config.hr !== false ? "<hr>" : "") : "") +
-            super.embedHTMLString(_config, _options);
+        return (
+            list.length 
+                ? `<p><strong>${game.i18n.localize("PF2E.FeatPrereqLabel")}</strong> ${list}</p>`
+                  + (_config.hr !== false ? "<hr>" : "")
+                : "")
+            + super.embedHTMLString(_config, _options);
     }
 }
-
 interface CampaignFeaturePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends ItemPF2e<TParent> {
     readonly _source: CampaignFeatureSource;
     system: CampaignFeatureSystemData;

--- a/src/module/item/campaign-feature/document.ts
+++ b/src/module/item/campaign-feature/document.ts
@@ -166,13 +166,14 @@ class CampaignFeaturePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> e
     protected override embedHTMLString(_config: DocumentHTMLEmbedConfig, _options: EnrichmentOptions): string {
         const list = this.system.prerequisites?.value?.map((item) => item.value).join(",") ?? "";
         return (
-            list.length 
-                ? `<p><strong>${game.i18n.localize("PF2E.FeatPrereqLabel")}</strong> ${list}</p>`
-                  + (_config.hr !== false ? "<hr>" : "")
-                : "")
-            + super.embedHTMLString(_config, _options);
+            (list.length 
+                ? `<p><strong>${game.i18n.localize("PF2E.FeatPrereqLabel")}</strong> ${list}</p>` +
+                  (_config.hr !== false ? "<hr>" : "")
+                : "") + super.embedHTMLString(_config, _options)
+        );
     }
 }
+
 interface CampaignFeaturePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends ItemPF2e<TParent> {
     readonly _source: CampaignFeatureSource;
     system: CampaignFeatureSystemData;

--- a/src/module/item/campaign-feature/document.ts
+++ b/src/module/item/campaign-feature/document.ts
@@ -166,7 +166,7 @@ class CampaignFeaturePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> e
     protected override embedHTMLString(_config: DocumentHTMLEmbedConfig, _options: EnrichmentOptions): string {
         const list = this.system.prerequisites?.value?.map((item) => item.value).join(",") ?? "";
         return (
-            (list.length 
+            (list.length
                 ? `<p><strong>${game.i18n.localize("PF2E.FeatPrereqLabel")}</strong> ${list}</p>` +
                   (_config.hr !== false ? "<hr>" : "")
                 : "") + super.embedHTMLString(_config, _options)

--- a/src/module/item/feat/document.ts
+++ b/src/module/item/feat/document.ts
@@ -418,7 +418,7 @@ class FeatPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
     protected override embedHTMLString(_config: DocumentHTMLEmbedConfig, _options: EnrichmentOptions): string {
         const list = this.system.prerequisites?.value?.map((item) => item.value).join(",") ?? "";
         return (
-            (list.length 
+            (list.length
                 ? `<p><strong>${game.i18n.localize("PF2E.FeatPrereqLabel")}</strong> ${list}</p>` +
                   (_config.hr !== false ? "<hr>" : "")
                 : "") + super.embedHTMLString(_config, _options)

--- a/src/module/item/feat/document.ts
+++ b/src/module/item/feat/document.ts
@@ -418,11 +418,11 @@ class FeatPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
     protected override embedHTMLString(_config: DocumentHTMLEmbedConfig, _options: EnrichmentOptions): string {
         const list = this.system.prerequisites?.value?.map((item) => item.value).join(",") ?? "";
         return (
-            list.length 
-                ? `<p><strong>${game.i18n.localize("PF2E.FeatPrereqLabel")}</strong> ${list}</p>`
-                  + (_config.hr !== false ? "<hr>" : "")
-                : "")
-            + super.embedHTMLString(_config, _options);
+            (list.length 
+                ? `<p><strong>${game.i18n.localize("PF2E.FeatPrereqLabel")}</strong> ${list}</p>` +
+                  (_config.hr !== false ? "<hr>" : "")
+                : "") + super.embedHTMLString(_config, _options)
+        );
     }
 }
 

--- a/src/module/item/feat/document.ts
+++ b/src/module/item/feat/document.ts
@@ -417,9 +417,12 @@ class FeatPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
 
     protected override embedHTMLString(_config: DocumentHTMLEmbedConfig, _options: EnrichmentOptions): string {
         const list = this.system.prerequisites?.value?.map((item) => item.value).join(",") ?? "";
-        return (list.length ? `<p><strong>${game.i18n.localize("PF2E.FeatPrereqLabel")}</strong> ${list}</p>` +
-            (_config.hr !== false ? "<hr>" : "") : "") +
-            super.embedHTMLString(_config, _options);
+        return (
+            list.length 
+                ? `<p><strong>${game.i18n.localize("PF2E.FeatPrereqLabel")}</strong> ${list}</p>`
+                  + (_config.hr !== false ? "<hr>" : "")
+                : "")
+            + super.embedHTMLString(_config, _options);
     }
 }
 

--- a/src/module/item/feat/document.ts
+++ b/src/module/item/feat/document.ts
@@ -418,10 +418,10 @@ class FeatPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
     protected override embedHTMLString(_config: DocumentHTMLEmbedConfig, _options: EnrichmentOptions): string {
         const list = this.system.prerequisites?.value?.map((item) => item.value).join(",") ?? "";
         return (
-            (list.length
+            (list
                 ? `<p><strong>${game.i18n.localize("PF2E.FeatPrereqLabel")}</strong> ${list}</p>` +
-                  (_config.hr !== false ? "<hr>" : "")
-                : "") + super.embedHTMLString(_config, _options)
+                  (_config.hr === false ? "" : "<hr>")
+                : "") + this.description
         );
     }
 }

--- a/src/module/item/feat/document.ts
+++ b/src/module/item/feat/document.ts
@@ -414,6 +414,13 @@ class FeatPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
             ui.notifications.warn(game.i18n.format("PF2E.Item.Feat.Warning.TakenMoreThanMax", formatParams));
         }
     }
+
+    protected override embedHTMLString(_config: DocumentHTMLEmbedConfig, _options: EnrichmentOptions): string {
+        const list = this.system.prerequisites?.value?.map((item) => item.value).join(",") ?? "";
+        return (list.length ? `<p><strong>${game.i18n.localize("PF2E.FeatPrereqLabel")}</strong> ${list}</p>` +
+            (_config.hr !== false ? "<hr>" : "") : "") +
+            super.embedHTMLString(_config, _options);
+    }
 }
 
 interface FeatPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends ItemPF2e<TParent> {


### PR DESCRIPTION
Adds _buildEmbedHTML to ItemPF2e so that `@Embed` can be used to reference the description (and prerequisites if present) stored in the item directly.

This will simplify the maintenance of the Archetypes journal (as well as anywhere else that text is duplicated from Items into Journal entries.

For example, in the Acrobat page of the Archetypes journal, the first feat reference would be replaced by:

```
<H2> @UUID[Compendium.pf2e.feats-srd.Item.aFygWxgSv82WyCsl]{Acrobat Dedication} Feat 2
<p> @Embed[Compendium.pf2e.feats-srd.Item.aFygWxgSv82WyCsl inline]
```

whereas **Dodge Away** would require an additional new parameter to prevent the HR being added immediately after the prerequisites (since a HR is added in the body of the feat description):

```
<H2> @UUID[Compendium.pf2e.feats-srd.Item.0qGLCpggCcOVkbtT]{Dodge Away} Feat 6
<p> @Embed[Compendium.pf2e.feats-srd.Item.0qGLCpggCcOVkbtT inline hr=false]
```