### PR TITLE
Loot tokens from party stash

### DIFF
--- a/src/module/actor/party/sheet.ts
+++ b/src/module/actor/party/sheet.ts
@@ -6,13 +6,14 @@ import { ActorSheetPF2e } from "@actor/sheet/base.ts";
 import { ActorSheetDataPF2e, ActorSheetRenderOptionsPF2e } from "@actor/sheet/data-types.ts";
 import { condenseSenses } from "@actor/sheet/helpers.ts";
 import { DistributeCoinsPopup } from "@actor/sheet/popups/distribute-coins-popup.ts";
+import { LootNPCsPopup } from "@actor/sheet/popups/loot-npcs-popup.js";
 import { ItemPF2e } from "@item";
 import { ItemSourcePF2e } from "@item/base/data/index.ts";
 import { Bulk } from "@item/physical/index.ts";
 import { PHYSICAL_ITEM_TYPES } from "@item/physical/values.ts";
 import { DropCanvasItemDataPF2e } from "@module/canvas/drop-canvas-data.ts";
 import { ValueAndMax, ZeroToFour } from "@module/data.ts";
-import { SheetOptions, createSheetTags } from "@module/sheet/helpers.ts";
+import { createSheetTags, SheetOptions } from "@module/sheet/helpers.ts";
 import { eventToRollParams } from "@scripts/sheet-util.ts";
 import { SocketMessage } from "@scripts/socket.ts";
 import { SettingsMenuOptions } from "@system/settings/menu.ts";
@@ -413,6 +414,14 @@ class PartySheetPF2e extends ActorSheetPF2e<PartyPF2e> {
 
         htmlQuery(html, "[data-action=prompt]")?.addEventListener("click", () => {
             game.pf2e.gm.checkPrompt({ actors: this.actor.members });
+        });
+
+        htmlQuery(html, "button[data-action=loot-npcs]")?.addEventListener("click", () => {
+            if (canvas.tokens.controlled.some((token) => token.actor?.id !== this.actor.id)) {
+                new LootNPCsPopup(this.actor).render(true);
+            } else {
+                ui.notifications.warn("No tokens selected.");
+            }
         });
     }
 

--- a/src/styles/actor/party/_inventory.scss
+++ b/src/styles/actor/party/_inventory.scss
@@ -1,3 +1,29 @@
+.gm-sidebar {
+    border-top: 1px solid var(--color-text-light-7);
+    display: flex;
+    flex-direction: column;
+    padding: 0.25rem;
+    margin-top: 0.5rem;
+
+    .loot-distribution {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+
+        button {
+            background-color: var(--tertiary);
+
+            &:not(:hover) {
+                @include button;
+            }
+        }
+    }
+
+    label {
+        font-weight: 500;
+    }
+}
+
 .inventory-members {
     .box {
         .content {

--- a/static/templates/actors/party/regions/inventory-members.hbs
+++ b/static/templates/actors/party/regions/inventory-members.hbs
@@ -43,3 +43,11 @@
 {{else}}
     {{localize "PF2E.Actor.Party.BlankSlate"}}
 {{/if}}
+
+{{#if user.isGM}}
+    <div class="gm-sidebar">
+        <div class="loot-distribution">
+            <button type="button" data-action="loot-npcs"><i class="fa-solid fa-box-open"></i> {{localize "PF2E.loot.LootNPCsLabel"}}</button>
+        </div>
+    </div>
+{{/if}}


### PR DESCRIPTION
Adds a button to the party stash (inventory sidebar) to loot selected tokens, similar to how `Loot` tokens can loot

Resolves #10184