### PR TITLE
Separate You're Next feat into Rogue and Swashbuckler feats

### DIFF
--- a/packs/feats/youre-next-rogue.json
+++ b/packs/feats/youre-next-rogue.json
@@ -1,0 +1,54 @@
+{
+    "_id": "gjec0ts3wkFbjvHN",
+    "img": "icons/sundries/books/book-red-exclamation.webp",
+    "name": "You're Next (Rogue)",
+    "system": {
+        "actionType": {
+            "value": "reaction"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "class",
+        "description": {
+            "value": "<p><strong>Trigger</strong> You reduce an enemy to 0 Hit Points.</p>\n<hr />\n<p>After downing a foe, you menace another. Attempt to @UUID[Compendium.pf2e.actionspf2e.Item.Demoralize] a creature within 60 feet, with a +2 circumstance bonus. If you have legendary proficiency in Intimidation, you can use this as a free action with the same trigger.</p>"
+        },
+        "level": {
+            "value": 1
+        },
+        "prerequisites": {
+            "value": [
+                {
+                    "value": "trained in Intimidation"
+                }
+            ]
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "action:demoralize",
+                    "youre-next"
+                ],
+                "selector": "intimidation",
+                "type": "circumstance",
+                "value": 2
+            }
+        ],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "emotion",
+                "fear",
+                "mental",
+                "rogue"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/packs/feats/youre-next-swashbuckler.json
+++ b/packs/feats/youre-next-swashbuckler.json
@@ -1,7 +1,7 @@
 {
-    "_id": "gjec0ts3wkFbjvHN",
+    "_id": "qtEql62r9p24FN26",
     "img": "icons/sundries/books/book-red-exclamation.webp",
-    "name": "You're Next",
+    "name": "You're Next (Swashbuckler)",
     "system": {
         "actionType": {
             "value": "reaction"
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p><strong>Trigger</strong> You reduce an enemy to 0 Hit Points.</p>\n<hr />\n<p>After downing a foe, you menace another. Attempt to @UUID[Compendium.pf2e.actionspf2e.Item.Demoralize] a creature within 60 feet, with a +2 circumstance bonus. If you have legendary proficiency in Intimidation, you can use this as a free action with the same trigger.</p>"
+            "value": "<p><strong>Trigger</strong> You reduce an enemy to 0 Hit Points.</p><hr /><p>After downing a foe, you promise another that you're coming after them next. Attempt an Intimidation check with a +2 circumstance bonus to @UUID[Compendium.pf2e.actionspf2e.Item.Demoralize] a single creature that you can see and that can see you. If you're legendary in Intimidation, you can use this as a free action with the same trigger.</p>"
         },
         "level": {
             "value": 1
@@ -26,7 +26,7 @@
         "publication": {
             "license": "ORC",
             "remaster": true,
-            "title": "Pathfinder Player Core"
+            "title": "Pathfinder Player Core 2"
         },
         "rules": [
             {
@@ -46,7 +46,6 @@
                 "emotion",
                 "fear",
                 "mental",
-                "rogue",
                 "swashbuckler"
             ]
         }


### PR DESCRIPTION
As much as I dislike having duplicates, these are different enough to warrant it, imo
- They have different restrictions (within 60 ft. vs can see/be seen by)
- One calls out an Intimidation check explicitly, while the other doesn't, thus being elligible for Versatile Performance, for example.