### PR TITLE
Fix damage dialog toggles not reflecting correct state

### DIFF
--- a/static/templates/chat/check-modifiers-dialog.hbs
+++ b/static/templates/chat/check-modifiers-dialog.hbs
@@ -35,7 +35,7 @@
                 <span class="value">{{numberFormat modifier.modifier decimals=0 sign=true}}</span>
                 <div class="exclude">
                     <label class="toggle">
-                        <input type="checkbox" data-modifier-index="{{idx}}" {{checked (not modifier.ignored)}} />
+                        <input type="checkbox" data-modifier-index="{{idx}}" {{checked modifier.enabled}} />
                         <span class="widget"></span>
                     </label>
                 </div>

--- a/static/templates/chat/damage/damage-modifier-dialog.hbs
+++ b/static/templates/chat/damage/damage-modifier-dialog.hbs
@@ -117,7 +117,7 @@
         </div>
         <div class="exclude">
             <label class="toggle">
-                <input type="checkbox" data-modifier-index="{{modifier.idx}}" {{checked (not modifier.ignored)}} />
+                <input type="checkbox" data-modifier-index="{{modifier.idx}}" {{checked modifier.enabled}} />
                 <span class="widget"></span>
             </label>
         </div>
@@ -134,7 +134,7 @@
         </div>
         <div class="exclude">
             <label class="toggle">
-                <input type="checkbox" data-dice-index="{{dice.idx}}" data-slug="{{dice.slug}}" {{checked (not dice.ignored)}} />
+                <input type="checkbox" data-dice-index="{{dice.idx}}" data-slug="{{dice.slug}}" {{checked dice.enabled}} />
                 <span class="widget"></span>
             </label>
         </div>


### PR DESCRIPTION
Refactor for check, surface level bugfix for damage. All computations check "enabled", but the dialog was checking "ignored". This makes them both check the same properties.