### PR TITLE
Automate Advanced Weapon Training

### DIFF
--- a/packs/feats/advanced-weapon-training.json
+++ b/packs/feats/advanced-weapon-training.json
@@ -24,7 +24,23 @@
             "remaster": true,
             "title": "Pathfinder Player Core"
         },
-        "rules": [],
+        "rules": [
+            {
+                "choices": "weaponGroups",
+                "flag": "advancedWeaponTraining",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.WeaponGroup"
+            },
+            {
+                "definition": [
+                    "item:group:{item|flags.pf2e.rulesSelections}",
+                    "item:category:advanced"
+                ],
+                "key": "MartialProficiency",
+                "sameAs": "martial",
+                "slug": "advanced-weapon-training"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/advanced-weapon-training.json
+++ b/packs/feats/advanced-weapon-training.json
@@ -26,14 +26,16 @@
         },
         "rules": [
             {
-                "choices": "weaponGroups",
-                "flag": "advancedWeaponTraining",
+                "choices": {
+                    "config": "weaponGroups"
+                },
+                "flag": "group",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.WeaponGroup"
             },
             {
                 "definition": [
-                    "item:group:{item|flags.pf2e.rulesSelections}",
+                    "item:group:{item|flags.pf2e.rulesSelections.group}",
                     "item:category:advanced"
                 ],
                 "key": "MartialProficiency",

--- a/packs/feats/scars-of-steel.json
+++ b/packs/feats/scars-of-steel.json
@@ -36,11 +36,11 @@
             },
             {
                 "key": "Resistance",
-                "type": "all-damage",
-                "value": "floor(@actor.level/2)+@actor.abilities.con.mod",
                 "predicate": [
                     "scars-of-steel"
-                ]
+                ],
+                "type": "all-damage",
+                "value": "floor(@actor.level/2)+@actor.abilities.con.mod"
             }
         ],
         "traits": {

--- a/packs/feats/untamed-form.json
+++ b/packs/feats/untamed-form.json
@@ -92,7 +92,7 @@
                     },
                     {
                         "value": "Compendium.pf2e.spell-effects.Item.Spell Effect: Animal Form (Shark)"
-                    },  
+                    },
                     {
                         "value": "Compendium.pf2e.spell-effects.Item.Spell Effect: Animal Form (Snake)"
                     }


### PR DESCRIPTION
One gap in this is that it doesn't work in conjunction with fighter weapon mastery, etc that use MartialProficiency to create subgroups of weapons, but better to have a 90% solution than a 0% solution.

Closes #7605