### PR TITLE
Update Herbalist Dedication batch size to match PC2

### DIFF
--- a/packs/feats/herbalist-dedication.json
+++ b/packs/feats/herbalist-dedication.json
@@ -39,6 +39,9 @@
                 "value": 2
             },
             {
+                "batchSizes": {
+                    "default": 1
+                },
                 "craftableItems": [
                     {
                         "or": [


### PR DESCRIPTION
Changed Herbalist Dedication batch size to 1 in order to better match PC2 while we wait for the Alchemist UI update