### PR TITLE
Use tag-based Choice Set for Blessing of the Devoted

### DIFF
--- a/packs/classfeatures/blessed-armament.json
+++ b/packs/classfeatures/blessed-armament.json
@@ -26,6 +26,9 @@
         },
         "rules": [],
         "traits": {
+            "otherTags": [
+                "blessing-of-the-devoted"
+            ],
             "rarity": "common",
             "value": [
                 "champion"

--- a/packs/classfeatures/blessed-shield.json
+++ b/packs/classfeatures/blessed-shield.json
@@ -26,6 +26,9 @@
         },
         "rules": [],
         "traits": {
+            "otherTags": [
+                "blessing-of-the-devoted"
+            ],
             "rarity": "common",
             "value": [
                 "champion"

--- a/packs/classfeatures/blessed-swiftness.json
+++ b/packs/classfeatures/blessed-swiftness.json
@@ -33,6 +33,9 @@
             }
         ],
         "traits": {
+            "otherTags": [
+                "blessing-of-the-devoted"
+            ],
             "rarity": "common",
             "value": [
                 "champion"

--- a/packs/classfeatures/blessing-of-the-devoted.json
+++ b/packs/classfeatures/blessing-of-the-devoted.json
@@ -34,17 +34,12 @@
                         "item:trait:champion"
                     ]
                 },
-                "choices": [
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Blessed Armament"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Blessed Shield"
-                    },
-                    {
-                        "value": "Compendium.pf2e.classfeatures.Item.Blessed Swiftness"
-                    }
-                ],
+                "choices": {
+                    "filter": [
+                        "item:type:feature",
+                        "item:tag:blessing-of-the-devoted"
+                    ]
+                },
                 "flag": "blessing",
                 "key": "ChoiceSet"
             },

--- a/packs/feats/expand-aura.json
+++ b/packs/feats/expand-aura.json
@@ -35,6 +35,7 @@
                 "predicate": [
                     "champions-aura"
                 ],
+                "priority": 51,
                 "toggleable": true
             },
             {


### PR DESCRIPTION
Allows 3rd party blessings to show in the Choice Set
Closes #15893

Also increase the priority on Expand Aura, as its toggle was not working due to depending on the Champion's Aura roll option