### PR TITLE
RulerPF2e - Fix Hexagonal Snapping

### DIFF
--- a/src/module/canvas/ruler.ts
+++ b/src/module/canvas/ruler.ts
@@ -40,6 +40,7 @@ class RulerPF2e<TToken extends TokenPF2e | null = TokenPF2e | null> extends Rule
             case GT.HEXEVENQ:
             case GT.HEXEVENR:
                 return M.LEFT_SIDE_MIDPOINT;
+            case GT.HEXODDQ:
             case GT.HEXODDR:
                 return M.TOP_SIDE_MIDPOINT;
             case GT.SQUARE:


### PR DESCRIPTION
Adds support for "Hexagonal Columns - Odd" to RulerPF2e grid-snapping mode.