### PR TITLE
Add traits to class features

### DIFF
--- a/packs/classes/inventor.json
+++ b/packs/classes/inventor.json
@@ -87,17 +87,17 @@
                 "name": "Complete Reconfiguration",
                 "uuid": "Compendium.pf2e.classfeatures.Item.Complete Reconfiguration"
             },
-            "796tt": {
-                "img": "systems/pf2e/icons/default-icons/feat.svg",
-                "level": 9,
-                "name": "Offensive Boost",
-                "uuid": "Compendium.pf2e.classfeatures.Item.Offensive Boost"
-            },
             "7aqni": {
                 "img": "systems/pf2e/icons/features/classes/master-overdrive.webp",
                 "level": 7,
                 "name": "Master Overdrive",
                 "uuid": "Compendium.pf2e.classfeatures.Item.Master Overdrive"
+            },
+            "XFLRf": {
+                "img": "systems/pf2e/icons/features/classes/offensive-boost.webp",
+                "level": 9,
+                "name": "Offensive Boost",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Offensive Boost"
             },
             "cqq8h": {
                 "img": "icons/equipment/chest/breastplate-collared-steel.webp",

--- a/packs/classes/magus.json
+++ b/packs/classes/magus.json
@@ -56,6 +56,12 @@
         },
         "hp": 8,
         "items": {
+            "06frE": {
+                "img": "icons/sundries/documents/document-torn-diagram-tan.webp",
+                "level": 7,
+                "name": "Studious Spells",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Studious Spells"
+            },
             "31b86": {
                 "img": "systems/pf2e/icons/features/classes/weapon-expertise.webp",
                 "level": 5,
@@ -74,11 +80,29 @@
                 "name": "Lightning Reflexes",
                 "uuid": "Compendium.pf2e.classfeatures.Item.Reflex Expertise"
             },
-            "bq0rq": {
-                "img": "systems/pf2e/icons/default-icons/feat.svg",
+            "EZGEs": {
+                "img": "systems/pf2e/icons/features/classes/arcane-cascade.webp",
                 "level": 1,
-                "name": "Conflux Spells",
-                "uuid": "Compendium.pf2e.classfeatures.Item.Conflux Spells"
+                "name": "Arcane Cascade",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Arcane Cascade"
+            },
+            "GP1fi": {
+                "img": "icons/skills/melee/blade-tips-double-blue.webp",
+                "level": 19,
+                "name": "Double Spellstrike",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Double Spellstrike"
+            },
+            "OaBCQ": {
+                "img": "systems/pf2e/icons/features/classes/spellstrike.webp",
+                "level": 1,
+                "name": "Spellstrike",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Spellstrike"
+            },
+            "PXu7W": {
+                "img": "icons/equipment/chest/breastplate-collared-steel.webp",
+                "level": 17,
+                "name": "Medium Armor Mastery",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Medium Armor Mastery"
             },
             "e0xpi": {
                 "img": "icons/sundries/books/book-backed-silver-gold.webp",
@@ -91,6 +115,12 @@
                 "level": 17,
                 "name": "Master Spellcaster",
                 "uuid": "Compendium.pf2e.classfeatures.Item.Master Spellcaster"
+            },
+            "hqK13": {
+                "img": "icons/skills/melee/blade-tip-chipped-blood-red.webp",
+                "level": 13,
+                "name": "Weapon Mastery",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Weapon Mastery"
             },
             "jbg78": {
                 "img": "icons/magic/symbols/question-stone-yellow.webp",
@@ -110,35 +140,17 @@
                 "name": "Weapon Specialization",
                 "uuid": "Compendium.pf2e.classfeatures.Item.Weapon Specialization"
             },
-            "lsnm7": {
-                "img": "systems/pf2e/icons/default-icons/feat.svg",
-                "level": 1,
-                "name": "Arcane Cascade",
-                "uuid": "Compendium.pf2e.classfeatures.Item.Arcane Cascade"
-            },
             "nkff5": {
                 "img": "icons/skills/melee/hand-grip-sword-orange.webp",
                 "level": 15,
                 "name": "Greater Weapon Specialization (Level 15)",
                 "uuid": "Compendium.pf2e.classfeatures.Item.Greater Weapon Specialization"
             },
-            "p6ina": {
-                "img": "systems/pf2e/icons/default-icons/feat.svg",
-                "level": 17,
-                "name": "Medium Armor Mastery",
-                "uuid": "Compendium.pf2e.classfeatures.Item.Medium Armor Mastery"
-            },
-            "se5i8": {
-                "img": "systems/pf2e/icons/features/classes/weapon-mastery.webp",
-                "level": 13,
-                "name": "Weapon Mastery",
-                "uuid": "Compendium.pf2e.classfeatures.Item.Martial Weapon Mastery"
-            },
-            "tgkm3": {
-                "img": "systems/pf2e/icons/default-icons/feat.svg",
-                "level": 19,
-                "name": "Double Spellstrike",
-                "uuid": "Compendium.pf2e.classfeatures.Item.Double Spellstrike"
+            "r4QQP": {
+                "img": "systems/pf2e/icons/features/classes/conflux-spells.webp",
+                "level": 1,
+                "name": "Conflux Spells",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Conflux Spells"
             },
             "tkzi2": {
                 "img": "icons/creatures/eyes/human-single-blue.webp",
@@ -152,23 +164,11 @@
                 "name": "Resolve",
                 "uuid": "Compendium.pf2e.classfeatures.Item.Resolve"
             },
-            "vcf45": {
-                "img": "systems/pf2e/icons/default-icons/feat.svg",
-                "level": 1,
-                "name": "Spellstrike",
-                "uuid": "Compendium.pf2e.classfeatures.Item.Spellstrike"
-            },
             "x3em9": {
                 "img": "icons/creatures/mammals/bull-horned-blue.webp",
                 "level": 15,
                 "name": "Juggernaut",
                 "uuid": "Compendium.pf2e.classfeatures.Item.Juggernaut"
-            },
-            "zn731": {
-                "img": "systems/pf2e/icons/default-icons/feat.svg",
-                "level": 7,
-                "name": "Studious Spells",
-                "uuid": "Compendium.pf2e.classfeatures.Item.Studious Spells"
             }
         },
         "keyAbility": {

--- a/packs/classes/swashbuckler.json
+++ b/packs/classes/swashbuckler.json
@@ -57,12 +57,6 @@
         },
         "hp": 10,
         "items": {
-            "12j4u": {
-                "img": "icons/magic/fire/explosion-embers-evade-silhouette.webp",
-                "level": 7,
-                "name": "Evasion",
-                "uuid": "Compendium.pf2e.classfeatures.Item.Evasion"
-            },
             "2v2xl": {
                 "img": "icons/commodities/treasure/crown-gold-laurel-wreath.webp",
                 "level": 1,
@@ -176,6 +170,12 @@
                 "level": 3,
                 "name": "Fortitude Expertise",
                 "uuid": "Compendium.pf2e.classfeatures.Item.Fortitude Expertise"
+            },
+            "wdKDW": {
+                "img": "icons/skills/movement/feet-winged-boots-brown.webp",
+                "level": 7,
+                "name": "Confident Evasion",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Confident Evasion"
             },
             "xi59r": {
                 "img": "systems/pf2e/icons/features/classes/keen-flair.webp",

--- a/packs/classes/thaumaturge.json
+++ b/packs/classes/thaumaturge.json
@@ -123,6 +123,12 @@
                 "name": "Implement Paragon",
                 "uuid": "Compendium.pf2e.classfeatures.Item.Implement Paragon"
             },
+            "Fg8iw": {
+                "img": "icons/skills/melee/blade-tip-chipped-blood-red.webp",
+                "level": 13,
+                "name": "Weapon Mastery",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Weapon Mastery"
+            },
             "HFk1R": {
                 "img": "systems/pf2e/icons/features/classes/intensify-vulnerability.webp",
                 "level": 9,
@@ -194,12 +200,6 @@
                 "level": 9,
                 "name": "Vigilant Senses",
                 "uuid": "Compendium.pf2e.classfeatures.Item.Perception Mastery"
-            },
-            "z3br4": {
-                "img": "systems/pf2e/icons/features/classes/weapon-mastery.webp",
-                "level": 13,
-                "name": "Weapon Mastery",
-                "uuid": "Compendium.pf2e.classfeatures.Item.Martial Weapon Mastery"
             }
         },
         "keyAbility": {

--- a/packs/classfeatures/alertness.json
+++ b/packs/classfeatures/alertness.json
@@ -34,7 +34,10 @@
         },
         "traits": {
             "rarity": "common",
-            "value": []
+            "value": [
+                "inventor",
+                "magus"
+            ]
         }
     },
     "type": "feat"

--- a/packs/classfeatures/armor-expertise.json
+++ b/packs/classfeatures/armor-expertise.json
@@ -116,7 +116,9 @@
         },
         "traits": {
             "rarity": "common",
-            "value": []
+            "value": [
+                "champion"
+            ]
         }
     },
     "type": "feat"

--- a/packs/classfeatures/armor-mastery.json
+++ b/packs/classfeatures/armor-mastery.json
@@ -43,7 +43,11 @@
         },
         "traits": {
             "rarity": "common",
-            "value": []
+            "value": [
+                "barbarian",
+                "champion",
+                "fighter"
+            ]
         }
     },
     "type": "feat"

--- a/packs/classfeatures/assured-evasion.json
+++ b/packs/classfeatures/assured-evasion.json
@@ -43,7 +43,9 @@
         },
         "traits": {
             "rarity": "common",
-            "value": []
+            "value": [
+                "swashbuckler"
+            ]
         }
     },
     "type": "feat"

--- a/packs/classfeatures/confident-evasion.json
+++ b/packs/classfeatures/confident-evasion.json
@@ -1,7 +1,7 @@
 {
-    "_id": "iwAzV1IlQ2pMHQoB",
-    "img": "icons/sundries/scrolls/scroll-yellow-teal.webp",
-    "name": "Divine Access",
+    "_id": "HBTLwREPKK3H4xVD",
+    "img": "icons/skills/movement/feet-winged-boots-brown.webp",
+    "name": "Confident Evasion",
     "system": {
         "actionType": {
             "value": "passive"
@@ -11,10 +11,10 @@
         },
         "category": "classfeature",
         "description": {
-            "value": "<p>Your mystery offers you strange access to spells typically reserved for more conventional worshippers. Choose one deity who grants one of your mystery's granted domains. Add up to three cleric spells of your choice granted by that deity to your spell list, and to your spell repertoire as soon as you can cast spells of the appropriate rank.</p>"
+            "value": "<p>You've learned to move quickly to avoid explosions, a dragon's breath, and worse. Your proficiency rank for Reflex saves increases to master. When you roll a success on a Reflex save, you get a critical success instead.</p>"
         },
         "level": {
-            "value": 11
+            "value": 7
         },
         "prerequisites": {
             "value": []
@@ -28,7 +28,7 @@
         "traits": {
             "rarity": "common",
             "value": [
-                "oracle"
+                "swashbuckler"
             ]
         }
     },

--- a/packs/classfeatures/deny-advantage.json
+++ b/packs/classfeatures/deny-advantage.json
@@ -11,7 +11,7 @@
         },
         "category": "classfeature",
         "description": {
-            "value": "<p><strong>Barbarian</strong> Your foes struggle to pass your defenses. You aren't off-guard to hidden, undetected, or flanking creatures of your level or lower, or creatures of your level or lower using surprise attack. However, they can still help their allies flank.</p>\n<hr />\n<p><strong>Rogue</strong> As someone who takes advantage of openings, you are careful not to leave such gaps yourself. You aren't @UUID[Compendium.pf2e.conditionitems.Item.Off-Guard] to @UUID[Compendium.pf2e.conditionitems.Item.Hidden], @UUID[Compendium.pf2e.conditionitems.Item.Undetected], or flanking creatures of your level or lower, or creatures of your level or lower using surprise attack. However, they can still help their allies flank.</p>"
+            "value": "<p>As someone who takes advantage of openings, you are careful not to leave such gaps yourself. You aren't @UUID[Compendium.pf2e.conditionitems.Item.Off-Guard] to @UUID[Compendium.pf2e.conditionitems.Item.Hidden], @UUID[Compendium.pf2e.conditionitems.Item.Undetected], or flanking creatures of your level or lower, or creatures of your level or lower using surprise attack. However, they can still help their allies flank.</p>"
         },
         "level": {
             "value": 3
@@ -35,7 +35,6 @@
         "traits": {
             "rarity": "common",
             "value": [
-                "barbarian",
                 "rogue"
             ]
         }

--- a/packs/classfeatures/evasion.json
+++ b/packs/classfeatures/evasion.json
@@ -22,7 +22,7 @@
         "publication": {
             "license": "OGL",
             "remaster": false,
-            "title": "Pathfinder Core Rulebook"
+            "title": "Pathfinder Guns & Gears"
         },
         "rules": [
             {
@@ -52,7 +52,9 @@
         },
         "traits": {
             "rarity": "common",
-            "value": []
+            "value": [
+                "gunslinger"
+            ]
         }
     },
     "type": "feat"

--- a/packs/classfeatures/extreme-curse.json
+++ b/packs/classfeatures/extreme-curse.json
@@ -27,7 +27,9 @@
         "rules": [],
         "traits": {
             "rarity": "common",
-            "value": []
+            "value": [
+                "oracle"
+            ]
         }
     },
     "type": "feat"

--- a/packs/classfeatures/fighter-expertise.json
+++ b/packs/classfeatures/fighter-expertise.json
@@ -28,6 +28,7 @@
         "subfeatures": {
             "proficiencies": {
                 "fighter": {
+                    "attribute": null,
                     "rank": 2
                 }
             }

--- a/packs/classfeatures/fortitude-expertise.json
+++ b/packs/classfeatures/fortitude-expertise.json
@@ -34,7 +34,12 @@
         },
         "traits": {
             "rarity": "common",
-            "value": []
+            "value": [
+                "bard",
+                "druid",
+                "investigator",
+                "swashbuckler"
+            ]
         }
     },
     "type": "feat"

--- a/packs/classfeatures/greater-performers-heart.json
+++ b/packs/classfeatures/greater-performers-heart.json
@@ -53,7 +53,9 @@
         },
         "traits": {
             "rarity": "common",
-            "value": []
+            "value": [
+                "bard"
+            ]
         }
     },
     "type": "feat"

--- a/packs/classfeatures/greater-weapon-specialization.json
+++ b/packs/classfeatures/greater-weapon-specialization.json
@@ -46,7 +46,8 @@
                 "monk",
                 "ranger",
                 "rogue",
-                "swashbuckler"
+                "swashbuckler",
+                "thaumaturge"
             ]
         }
     },

--- a/packs/classfeatures/gunslinger-expertise.json
+++ b/packs/classfeatures/gunslinger-expertise.json
@@ -28,6 +28,7 @@
         "subfeatures": {
             "proficiencies": {
                 "gunslinger": {
+                    "attribute": null,
                     "rank": 2
                 }
             }

--- a/packs/classfeatures/inventive-expertise.json
+++ b/packs/classfeatures/inventive-expertise.json
@@ -28,6 +28,7 @@
         "subfeatures": {
             "proficiencies": {
                 "inventor": {
+                    "attribute": null,
                     "rank": 2
                 }
             }

--- a/packs/classfeatures/inventive-mastery.json
+++ b/packs/classfeatures/inventive-mastery.json
@@ -28,6 +28,7 @@
         "subfeatures": {
             "proficiencies": {
                 "inventor": {
+                    "attribute": null,
                     "rank": 3
                 }
             }

--- a/packs/classfeatures/juggernaut.json
+++ b/packs/classfeatures/juggernaut.json
@@ -11,7 +11,7 @@
         },
         "category": "classfeature",
         "description": {
-            "value": "<p><strong>Barbarian, Champion, Inventor, Ranger</strong> Your body is accustomed to physical hardship and resistant to ailments. Your proficiency rank for Fortitude saves increases to master. When you roll a success on a Fortitude save, you get a critical success instead.</p>\n<p><strong>Magus</strong> Your body is accustomed to physical hardship and resistant to a wide range of ailments. Your proficiency rank for Fortitude saves increases to master. When you roll a success on a Fortitude save, you get a critical success instead.</p>\n<p><strong>Gunslinger</strong> Your body has become accustomed to physical hazards and resistant to ailments. Your proficiency rank for Fortitude saves increases to master. When you roll a success on a Fortitude save, you get a critical success instead.</p>"
+            "value": "<p><strong>Barbarian, Inventor, Thaumaturge</strong> Your body is accustomed to physical hardship and resistant to ailments. Your proficiency rank for Fortitude saves increases to master. When you roll a success on a Fortitude save, you get a critical success instead.</p>\n<p><strong>Magus</strong> Your body is accustomed to physical hardship and resistant to a wide range of ailments. Your proficiency rank for Fortitude saves increases to master. When you roll a success on a Fortitude save, you get a critical success instead.</p>\n<p><strong>Gunslinger</strong> Your body has become accustomed to physical hazards and resistant to ailments. Your proficiency rank for Fortitude saves increases to master. When you roll a success on a Fortitude save, you get a critical success instead.</p>"
         },
         "level": {
             "value": 7
@@ -52,7 +52,13 @@
         },
         "traits": {
             "rarity": "common",
-            "value": []
+            "value": [
+                "barbarian",
+                "gunslinger",
+                "inventor",
+                "magus",
+                "thaumaturge"
+            ]
         }
     },
     "type": "feat"

--- a/packs/classfeatures/kinetic-expertise.json
+++ b/packs/classfeatures/kinetic-expertise.json
@@ -28,6 +28,7 @@
         "subfeatures": {
             "proficiencies": {
                 "kineticist": {
+                    "attribute": null,
                     "rank": 2
                 }
             }

--- a/packs/classfeatures/kinetic-legend.json
+++ b/packs/classfeatures/kinetic-legend.json
@@ -28,6 +28,7 @@
         "subfeatures": {
             "proficiencies": {
                 "kineticist": {
+                    "attribute": null,
                     "rank": 4
                 }
             }

--- a/packs/classfeatures/kinetic-mastery.json
+++ b/packs/classfeatures/kinetic-mastery.json
@@ -28,6 +28,7 @@
         "subfeatures": {
             "proficiencies": {
                 "kineticist": {
+                    "attribute": null,
                     "rank": 3
                 }
             }

--- a/packs/classfeatures/light-armor-expertise.json
+++ b/packs/classfeatures/light-armor-expertise.json
@@ -40,6 +40,7 @@
             "value": [
                 "bard",
                 "investigator",
+                "kineticist",
                 "oracle",
                 "rogue",
                 "swashbuckler"

--- a/packs/classfeatures/light-armor-mastery.json
+++ b/packs/classfeatures/light-armor-mastery.json
@@ -39,6 +39,7 @@
             "rarity": "common",
             "value": [
                 "investigator",
+                "kineticist",
                 "rogue",
                 "swashbuckler"
             ]

--- a/packs/classfeatures/magical-fortitude.json
+++ b/packs/classfeatures/magical-fortitude.json
@@ -34,7 +34,12 @@
         },
         "traits": {
             "rarity": "common",
-            "value": []
+            "value": [
+                "oracle",
+                "sorcerer",
+                "witch",
+                "wizard"
+            ]
         }
     },
     "type": "feat"

--- a/packs/classfeatures/major-curse.json
+++ b/packs/classfeatures/major-curse.json
@@ -27,7 +27,9 @@
         "rules": [],
         "traits": {
             "rarity": "common",
-            "value": []
+            "value": [
+                "oracle"
+            ]
         }
     },
     "type": "feat"

--- a/packs/classfeatures/martial-weapon-mastery.json
+++ b/packs/classfeatures/martial-weapon-mastery.json
@@ -43,7 +43,6 @@
             "value": [
                 "champion",
                 "investigator",
-                "magus",
                 "ranger",
                 "swashbuckler"
             ]

--- a/packs/classfeatures/master-strike.json
+++ b/packs/classfeatures/master-strike.json
@@ -33,6 +33,7 @@
         "subfeatures": {
             "proficiencies": {
                 "rogue": {
+                    "attribute": null,
                     "rank": 3
                 }
             }

--- a/packs/classfeatures/masterful-hunter.json
+++ b/packs/classfeatures/masterful-hunter.json
@@ -123,6 +123,7 @@
         "subfeatures": {
             "proficiencies": {
                 "ranger": {
+                    "attribute": null,
                     "rank": 3
                 }
             }

--- a/packs/classfeatures/medium-armor-expertise-inventor.json
+++ b/packs/classfeatures/medium-armor-expertise-inventor.json
@@ -40,7 +40,9 @@
         },
         "traits": {
             "rarity": "common",
-            "value": []
+            "value": [
+                "inventor"
+            ]
         }
     },
     "type": "feat"

--- a/packs/classfeatures/medium-armor-expertise.json
+++ b/packs/classfeatures/medium-armor-expertise.json
@@ -40,7 +40,14 @@
         },
         "traits": {
             "rarity": "common",
-            "value": []
+            "value": [
+                "alchemist",
+                "barbarian",
+                "druid",
+                "gunslinger",
+                "magus",
+                "ranger"
+            ]
         }
     },
     "type": "feat"

--- a/packs/classfeatures/medium-armor-mastery.json
+++ b/packs/classfeatures/medium-armor-mastery.json
@@ -40,7 +40,14 @@
         },
         "traits": {
             "rarity": "common",
-            "value": []
+            "value": [
+                "alchemist",
+                "gunslinger",
+                "inventor",
+                "magus",
+                "ranger",
+                "thaumaturge"
+            ]
         }
     },
     "type": "feat"

--- a/packs/classfeatures/perception-expertise.json
+++ b/packs/classfeatures/perception-expertise.json
@@ -34,7 +34,17 @@
         },
         "traits": {
             "rarity": "common",
-            "value": []
+            "value": [
+                "alchemist",
+                "champion",
+                "cleric",
+                "druid",
+                "kineticist",
+                "monk",
+                "sorcerer",
+                "witch",
+                "wizard"
+            ]
         }
     },
     "type": "feat"

--- a/packs/classfeatures/perception-legend.json
+++ b/packs/classfeatures/perception-legend.json
@@ -34,7 +34,11 @@
         },
         "traits": {
             "rarity": "common",
-            "value": []
+            "value": [
+                "gunslinger",
+                "ranger",
+                "rogue"
+            ]
         }
     },
     "type": "feat"

--- a/packs/classfeatures/perception-mastery.json
+++ b/packs/classfeatures/perception-mastery.json
@@ -34,7 +34,13 @@
         },
         "traits": {
             "rarity": "common",
-            "value": []
+            "value": [
+                "barbarian",
+                "bard",
+                "ranger",
+                "rogue",
+                "swashbuckler"
+            ]
         }
     },
     "type": "feat"

--- a/packs/classfeatures/psi-cantrips-and-amps.json
+++ b/packs/classfeatures/psi-cantrips-and-amps.json
@@ -77,7 +77,9 @@
         ],
         "traits": {
             "rarity": "common",
-            "value": []
+            "value": [
+                "psychic"
+            ]
         }
     },
     "type": "feat"

--- a/packs/classfeatures/psychic-weapon-specialization.json
+++ b/packs/classfeatures/psychic-weapon-specialization.json
@@ -71,7 +71,9 @@
         ],
         "traits": {
             "rarity": "common",
-            "value": []
+            "value": [
+                "psychic"
+            ]
         }
     },
     "type": "feat"

--- a/packs/classfeatures/ranger-expertise.json
+++ b/packs/classfeatures/ranger-expertise.json
@@ -38,6 +38,7 @@
         "subfeatures": {
             "proficiencies": {
                 "ranger": {
+                    "attribute": null,
                     "rank": 2
                 }
             }

--- a/packs/classfeatures/reflex-expertise.json
+++ b/packs/classfeatures/reflex-expertise.json
@@ -34,7 +34,16 @@
         },
         "traits": {
             "rarity": "common",
-            "value": []
+            "value": [
+                "barbarian",
+                "bard",
+                "champion",
+                "cleric",
+                "druid",
+                "sorcerer",
+                "witch",
+                "wizard"
+            ]
         }
     },
     "type": "feat"

--- a/packs/classfeatures/resolve.json
+++ b/packs/classfeatures/resolve.json
@@ -52,7 +52,11 @@
         },
         "traits": {
             "rarity": "common",
-            "value": []
+            "value": [
+                "inventor",
+                "magus",
+                "thaumaturge"
+            ]
         }
     },
     "type": "feat"

--- a/packs/classfeatures/rogue-expertise.json
+++ b/packs/classfeatures/rogue-expertise.json
@@ -28,6 +28,7 @@
         "subfeatures": {
             "proficiencies": {
                 "rogue": {
+                    "attribute": null,
                     "rank": 2
                 }
             }

--- a/packs/classfeatures/shield-block.json
+++ b/packs/classfeatures/shield-block.json
@@ -35,7 +35,8 @@
             "value": [
                 "champion",
                 "druid",
-                "fighter"
+                "fighter",
+                "inventor"
             ]
         }
     },

--- a/packs/classfeatures/shootists-edge.json
+++ b/packs/classfeatures/shootists-edge.json
@@ -43,6 +43,7 @@
         "subfeatures": {
             "proficiencies": {
                 "gunslinger": {
+                    "attribute": null,
                     "rank": 3
                 }
             }

--- a/packs/classfeatures/thaumaturgic-mastery.json
+++ b/packs/classfeatures/thaumaturgic-mastery.json
@@ -28,6 +28,7 @@
         "subfeatures": {
             "proficiencies": {
                 "thaumaturge": {
+                    "attribute": null,
                     "rank": 3
                 }
             }

--- a/packs/classfeatures/unleash-psyche.json
+++ b/packs/classfeatures/unleash-psyche.json
@@ -32,7 +32,9 @@
         ],
         "traits": {
             "rarity": "common",
-            "value": []
+            "value": [
+                "psychic"
+            ]
         }
     },
     "type": "feat"

--- a/packs/classfeatures/versatile-legend.json
+++ b/packs/classfeatures/versatile-legend.json
@@ -31,6 +31,7 @@
                     "rank": 3
                 },
                 "fighter": {
+                    "attribute": null,
                     "rank": 3
                 },
                 "martial": {

--- a/packs/classfeatures/weapon-expertise.json
+++ b/packs/classfeatures/weapon-expertise.json
@@ -11,7 +11,7 @@
         },
         "category": "classfeature",
         "description": {
-            "value": "<p><strong>Champion, Investigator, Oracle, Magus</strong> You've dedicated yourself to learning the intricacies of your weapons. Your proficiency ranks for simple weapons, martial weapons, and unarmed attacks increase to expert.</p>\n<p><strong>Druid</strong> You've improved your combat skill. Your proficiency rank for simple weapons and unarmed attacks increases to expert.</p>\n<p><strong>Sorcerer</strong> Training and magic improved your weapon technique. Your proficiency rank for simple weapons and unarmed attacks increases to expert.</p>\n<p><strong>Summoner</strong> Training and magic improved your weapon technique. Your proficiency rank for simple weapons and unarmed attacks increases to expert. (<em>Note: this is called Simple Weapon Expertise in Secrets of Magic</em>)</p>\n<p><strong>Witch, Wizard</strong> Through sheer experience, you've improved your technique with your weapons. Your proficiency ranks for simple weapons and unarmed attacks increase to expert.</p>"
+            "value": "<p><strong>Champion, Investigator, Oracle, Magus</strong> You've dedicated yourself to learning the intricacies of your weapons. Your proficiency ranks for simple weapons, martial weapons, and unarmed attacks increase to expert.</p>\n<p><strong>Druid, Kineticist</strong> You've improved your combat skill. Your proficiency rank for simple weapons and unarmed attacks increases to expert.</p>\n<p><strong>Sorcerer</strong> Training and magic improved your weapon technique. Your proficiency rank for simple weapons and unarmed attacks increases to expert.</p>\n<p><strong>Summoner</strong> Training and magic improved your weapon technique. Your proficiency rank for simple weapons and unarmed attacks increases to expert. (<em>Note: this is called Simple Weapon Expertise in Secrets of Magic</em>)</p>\n<p><strong>Witch, Wizard</strong> Through sheer experience, you've improved your technique with your weapons. Your proficiency ranks for simple weapons and unarmed attacks increase to expert.</p>"
         },
         "level": {
             "value": 5
@@ -53,7 +53,18 @@
         },
         "traits": {
             "rarity": "common",
-            "value": []
+            "value": [
+                "champion",
+                "druid",
+                "investigator",
+                "kineticist",
+                "magus",
+                "oracle",
+                "sorcerer",
+                "summoner",
+                "witch",
+                "wizard"
+            ]
         }
     },
     "type": "feat"

--- a/packs/classfeatures/weapon-mastery.json
+++ b/packs/classfeatures/weapon-mastery.json
@@ -11,7 +11,7 @@
         },
         "category": "classfeature",
         "description": {
-            "value": "<p>Your rage makes you even more effective with the weapons you wield. Your proficiency ranks for simple weapons, martial weapons, and unarmed attacks increase to master.</p>"
+            "value": "<p><strong>Barbarian</strong> Your rage makes you even more effective with the weapons you wield. Your proficiency ranks for simple weapons, martial weapons, and unarmed attacks increase to master.</p>\n<p><strong>Magus, Thaumaturge</strong> You fully understand your weapons. Your proficiency ranks for simple and martial weapons increase to master.</p>"
         },
         "level": {
             "value": 13
@@ -41,7 +41,9 @@
         "traits": {
             "rarity": "common",
             "value": [
-                "barbarian"
+                "barbarian",
+                "magus",
+                "thaumaturge"
             ]
         }
     },

--- a/packs/classfeatures/weapon-specialization.json
+++ b/packs/classfeatures/weapon-specialization.json
@@ -66,7 +66,25 @@
         ],
         "traits": {
             "rarity": "common",
-            "value": []
+            "value": [
+                "alchemist",
+                "bard",
+                "champion",
+                "cleric",
+                "druid",
+                "fighter",
+                "gunslinger",
+                "inventor",
+                "investigator",
+                "kineticist",
+                "ranger",
+                "rogue",
+                "sorcerer",
+                "summoner",
+                "swashbuckler",
+                "witch",
+                "wizard"
+            ]
         }
     },
     "type": "feat"


### PR DESCRIPTION
Also refreshed some icon-less features on the list, and replaced some features with their correctly named counterpart according to the book. There are still a couple missing that I noticed, namely: Vigilant Senses, Lightning Reflexes and Perception Legend.