### PR TITLE
Automate increase and decrease to item repair

### DIFF
--- a/packs/equipment/crafters-eyepiece-greater.json
+++ b/packs/equipment/crafters-eyepiece-greater.json
@@ -40,6 +40,25 @@
                 "selector": "crafting",
                 "type": "item",
                 "value": 2
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "system.crafting.repairValue",
+                "value": 5
+            },
+            {
+                "key": "Note",
+                "text": "PF2E.SpecificRule.CraftersEyepiece.Note",
+                "title": "{item|name}",
+                "selector": "crafting-check",
+                "outcome": [
+                    "success",
+                    "criticalSuccess"
+                ],
+                "predicate": [
+                    "action:repair"
+                ]
             }
         ],
         "size": "med",

--- a/packs/equipment/crafters-eyepiece.json
+++ b/packs/equipment/crafters-eyepiece.json
@@ -40,6 +40,25 @@
                 "selector": "crafting",
                 "type": "item",
                 "value": 1
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "system.crafting.repairValue",
+                "value": 5
+            },
+            {
+                "key": "Note",
+                "text": "PF2E.SpecificRule.CraftersEyepiece.Note",
+                "title": "{item|name}",
+                "selector": "crafting-check",
+                "outcome": [
+                    "success",
+                    "criticalSuccess"
+                ],
+                "predicate": [
+                    "action:repair"
+                ]
             }
         ],
         "size": "med",

--- a/src/module/actor/character/data.ts
+++ b/src/module/actor/character/data.ts
@@ -404,6 +404,7 @@ interface VersatileWeaponOption {
 interface CharacterCraftingData {
     formulas: CraftingFormulaData[];
     entries: Record<string, Partial<CraftingEntryData>>;
+    repairValue: 5;
 }
 
 interface CharacterResources extends CreatureResources {

--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -456,7 +456,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
         }
 
         // Indicate that crafting formulas stored directly on the actor are deletable
-        system.crafting = fu.mergeObject({ formulas: [], entries: {} }, system.crafting ?? {});
+        system.crafting = fu.mergeObject({ formulas: [], entries: {}, repairValue: 5 }, system.crafting ?? {});
         for (const formula of this.system.crafting.formulas) {
             formula.deletable = true;
         }

--- a/src/module/system/action-macros/crafting/repair.ts
+++ b/src/module/system/action-macros/crafting/repair.ts
@@ -68,17 +68,18 @@ async function repair(options: RepairActionOptions): Promise<void> {
         callback: async (result) => {
             // react to check result by posting a chat message with appropriate follow-up options
             const { actor } = result;
-            if (item && result.message instanceof ChatMessagePF2e && actor.isOfType("creature")) {
+            if (item && result.message instanceof ChatMessagePF2e && actor.isOfType("character")) {
                 const messageSource = result.message.toObject();
                 const flavor = await (async () => {
                     const proficiencyRank = actor.skills.crafting.rank ?? 0;
+                    const repairValue = actor.system.crafting.repairValue;
                     if ("criticalSuccess" === result.outcome) {
                         const label = "PF2E.Actions.Repair.Labels.RestoreItemHitPoints";
-                        const restored = String(10 + proficiencyRank * 10);
+                        const restored = String(repairValue + 5 + proficiencyRank * (repairValue + 5));
                         return renderRepairResult(item, "restore", label, restored);
                     } else if ("success" === result.outcome) {
                         const label = "PF2E.Actions.Repair.Labels.RestoreItemHitPoints";
-                        const restored = String(5 + proficiencyRank * 5);
+                        const restored = String(repairValue + proficiencyRank * repairValue);
                         return renderRepairResult(item, "restore", label, restored);
                     } else if ("criticalFailure" === result.outcome) {
                         const label = "PF2E.Actions.Repair.Labels.RollItemDamage";

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2320,6 +2320,9 @@
                 "Prone": "Prone",
                 "Standard": "Standard"
             },
+            "CraftersEyepiece": {
+                "Note": "When you Repair an item, increase the Hit Points restored to 10 + 10 per proficiency rank on a success or 15 + 15 per proficiency rank on a critical success."
+            },
             "CriticalDeck": {
                 "Effect": {
                     "Label": "Critical Effect"


### PR DESCRIPTION
Added automation for the repair macro.

It will now check the new "repairValue" data point under actor.system.crafting to allow for customization of the amount of HP that can be repaired with the macro. The default is set to 5 as per the base repair action.

Crafter's Eyepiece has been updated with two new rules to add to repairValue and to add a flavor note about the updated repair numbers.

This should close #10958

(Apologies for the two closed PRs, I had some issues with them but it's all resolved now)