### PR TITLE
Choker-Arm Mutagen fix to account for size changes

### DIFF
--- a/packs/equipment-effects/effect-choker-arm-mutagen-greater.json
+++ b/packs/equipment-effects/effect-choker-arm-mutagen-greater.json
@@ -25,7 +25,8 @@
                 "key": "ActiveEffectLike",
                 "mode": "add",
                 "path": "system.attributes.reach.base",
-                "value": 10
+                "value": 10,
+                "phase": "afterDerived"
             },
             {
                 "key": "FlatModifier",

--- a/packs/equipment-effects/effect-choker-arm-mutagen-lesser.json
+++ b/packs/equipment-effects/effect-choker-arm-mutagen-lesser.json
@@ -25,7 +25,8 @@
                 "key": "ActiveEffectLike",
                 "mode": "add",
                 "path": "system.attributes.reach.base",
-                "value": 5
+                "value": 5,
+                "phase": "afterDerived"
             },
             {
                 "key": "FlatModifier",

--- a/packs/equipment-effects/effect-choker-arm-mutagen-major.json
+++ b/packs/equipment-effects/effect-choker-arm-mutagen-major.json
@@ -25,7 +25,8 @@
                 "key": "ActiveEffectLike",
                 "mode": "add",
                 "path": "system.attributes.reach.base",
-                "value": 15
+                "value": 15,
+                "phase": "afterDerived"
             },
             {
                 "key": "FlatModifier",

--- a/packs/equipment-effects/effect-choker-arm-mutagen-moderate.json
+++ b/packs/equipment-effects/effect-choker-arm-mutagen-moderate.json
@@ -25,7 +25,8 @@
                 "key": "ActiveEffectLike",
                 "mode": "add",
                 "path": "system.attributes.reach.base",
-                "value": 5
+                "value": 5,
+                "phase": "afterDerived"
             },
             {
                 "key": "FlatModifier",


### PR DESCRIPTION
Added the afterDerived phase to the mutagen effects so that it combines with size increases from spells and effects instead of being ignored.

Fixes #15316