### PR TITLE
Add variant of bane and elemental ammo.

### DIFF
--- a/packs/equipment/bane-ammunition-aberrations-greater.json
+++ b/packs/equipment/bane-ammunition-aberrations-greater.json
@@ -1,0 +1,88 @@
+{
+  "_id": "E8KcLjp5Nsm3Leeg",
+  "img": "systems/pf2e/icons/default-icons/consumable.svg",
+  "name": "Bane Ammunition - Aberrations (Greater)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p>\n<hr />\n<p>Monster hunters favor bane ammunition that contains a capsule of reagents tailored to a particular type of creature—aberration, animal, beast, dragon, fey, giant, ooze, or both fungus and plant. Each type requires a different formula. When activated bane ammunition hits a target that has a trait matching the selected type, it takes @Damage[3d6[persistent,poison]] damage in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "DamageDice",
+        "selector": "strike-damage",
+        "diceNumber": 3,
+        "dieSize": "d6",
+        "category": "persistent",
+        "damageType": "poison",
+        "predicate": [
+          "target:trait:aberration"
+        ]
+      }
+    ],
+    "slug": "bane-ammunition-aberrations-greater",
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "consumable",
+        "poison"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 11
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 250
+      }
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    }
+  },
+  "type": "consumable"
+}

--- a/packs/equipment/bane-ammunition-aberrations-lesser.json
+++ b/packs/equipment/bane-ammunition-aberrations-lesser.json
@@ -1,0 +1,88 @@
+{
+  "_id": "JZNi0XlVf33OAAp8",
+  "img": "systems/pf2e/icons/default-icons/consumable.svg",
+  "name": "Bane Ammunition - Aberrations (Lesser)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p><p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p><hr /><p>Monster hunters favor bane ammunition that contains a capsule of reagents tailored to a particular type of creature—aberration, animal, beast, dragon, fey, giant, ooze, or both fungus and plant. Each type requires a different formula. When activated bane ammunition hits a target that has a trait matching the selected type, it takes @Damage[1d4[persistent,poison]] damage in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "DamageDice",
+        "selector": "strike-damage",
+        "diceNumber": 1,
+        "dieSize": "d4",
+        "category": "persistent",
+        "damageType": "poison",
+        "predicate": [
+          "target:trait:aberration"
+        ]
+      }
+    ],
+    "slug": "bane-ammunition-aberrations-lesser",
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "consumable",
+        "poison"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 1
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 3
+      }
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    }
+  },
+  "type": "consumable"
+}

--- a/packs/equipment/bane-ammunition-aberrations-moderate.json
+++ b/packs/equipment/bane-ammunition-aberrations-moderate.json
@@ -1,0 +1,88 @@
+{
+  "_id": "zVpUiILFCcuTeUoe",
+  "img": "systems/pf2e/icons/default-icons/consumable.svg",
+  "name": "Bane Ammunition - Aberrations (Moderate)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p>\n<hr />\n<p>Monster hunters favor bane ammunition that contains a capsule of reagents tailored to a particular type of creature—aberration, animal, beast, dragon, fey, giant, ooze, or both fungus and plant. Each type requires a different formula. When activated bane ammunition hits a target that has a trait matching the selected type, it takes @Damage[2d6[persistent,poison]] damage in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "DamageDice",
+        "selector": "strike-damage",
+        "diceNumber": 2,
+        "dieSize": "d6",
+        "category": "persistent",
+        "damageType": "poison",
+        "predicate": [
+          "target:trait:aberration"
+        ]
+      }
+    ],
+    "slug": "bane-ammunition-aberrations-moderate",
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "consumable",
+        "poison"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 5
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 25
+      }
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    }
+  },
+  "type": "consumable"
+}

--- a/packs/equipment/bane-ammunition-animals-greater.json
+++ b/packs/equipment/bane-ammunition-animals-greater.json
@@ -1,0 +1,88 @@
+{
+  "_id": "AIBt2CpkdJ8a0vjj",
+  "img": "systems/pf2e/icons/default-icons/consumable.svg",
+  "name": "Bane Ammunition - Animals (Greater)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p>\n<hr />\n<p>Monster hunters favor bane ammunition that contains a capsule of reagents tailored to a particular type of creature—aberration, animal, beast, dragon, fey, giant, ooze, or both fungus and plant. Each type requires a different formula. When activated bane ammunition hits a target that has a trait matching the selected type, it takes @Damage[3d6[persistent,poison]] damage in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "DamageDice",
+        "selector": "strike-damage",
+        "diceNumber": 3,
+        "dieSize": "d6",
+        "category": "persistent",
+        "damageType": "poison",
+        "predicate": [
+          "target:trait:animal"
+        ]
+      }
+    ],
+    "slug": "bane-ammunition-animals-greater",
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "consumable",
+        "poison"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 11
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 250
+      }
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    }
+  },
+  "type": "consumable"
+}

--- a/packs/equipment/bane-ammunition-animals-lesser.json
+++ b/packs/equipment/bane-ammunition-animals-lesser.json
@@ -1,0 +1,88 @@
+{
+  "_id": "DlZn7EKLk8cRE0B4",
+  "img": "systems/pf2e/icons/default-icons/consumable.svg",
+  "name": "Bane Ammunition - Animals (Lesser)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p>\n<hr />\n<p>Monster hunters favor bane ammunition that contains a capsule of reagents tailored to a particular type of creature—aberration, animal, beast, dragon, fey, giant, ooze, or both fungus and plant. Each type requires a different formula. When activated bane ammunition hits a target that has a trait matching the selected type, it takes @Damage[1d4[persistent,poison]] damage in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "DamageDice",
+        "selector": "strike-damage",
+        "diceNumber": 1,
+        "dieSize": "d4",
+        "category": "persistent",
+        "damageType": "poison",
+        "predicate": [
+          "target:trait:animal"
+        ]
+      }
+    ],
+    "slug": "bane-ammunition-animal-lesser",
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "consumable",
+        "poison"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 1
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 3
+      }
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    }
+  },
+  "type": "consumable"
+}

--- a/packs/equipment/bane-ammunition-animals-moderate.json
+++ b/packs/equipment/bane-ammunition-animals-moderate.json
@@ -1,0 +1,88 @@
+{
+  "_id": "XWFNj3FIxIgRKNC9",
+  "img": "systems/pf2e/icons/default-icons/consumable.svg",
+  "name": "Bane Ammunition - Animals (Moderate)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p>\n<hr />\n<p>Monster hunters favor bane ammunition that contains a capsule of reagents tailored to a particular type of creature—aberration, animal, beast, dragon, fey, giant, ooze, or both fungus and plant. Each type requires a different formula. When activated bane ammunition hits a target that has a trait matching the selected type, it takes @Damage[2d6[persistent,poison]] damage in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "DamageDice",
+        "selector": "strike-damage",
+        "diceNumber": 2,
+        "dieSize": "d6",
+        "category": "persistent",
+        "damageType": "poison",
+        "predicate": [
+          "target:trait:animal"
+        ]
+      }
+    ],
+    "slug": "bane-ammunition-animals-moderate",
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "consumable",
+        "poison"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 5
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 25
+      }
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    }
+  },
+  "type": "consumable"
+}

--- a/packs/equipment/bane-ammunition-beasts-greater.json
+++ b/packs/equipment/bane-ammunition-beasts-greater.json
@@ -1,0 +1,88 @@
+{
+  "_id": "bqbsX8F6ZjiD1JKJ",
+  "img": "systems/pf2e/icons/default-icons/consumable.svg",
+  "name": "Bane Ammunition - Beasts (Greater)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p>\n<hr />\n<p>Monster hunters favor bane ammunition that contains a capsule of reagents tailored to a particular type of creature—aberration, animal, beast, dragon, fey, giant, ooze, or both fungus and plant. Each type requires a different formula. When activated bane ammunition hits a target that has a trait matching the selected type, it takes @Damage[3d6[persistent,poison]] damage in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "DamageDice",
+        "selector": "strike-damage",
+        "diceNumber": 3,
+        "dieSize": "d6",
+        "category": "persistent",
+        "damageType": "poison",
+        "predicate": [
+          "target:trait:beast"
+        ]
+      }
+    ],
+    "slug": "bane-ammunition-beasts-greater",
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "consumable",
+        "poison"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 11
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 250
+      }
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    }
+  },
+  "type": "consumable"
+}

--- a/packs/equipment/bane-ammunition-beasts-lesser.json
+++ b/packs/equipment/bane-ammunition-beasts-lesser.json
@@ -1,0 +1,88 @@
+{
+  "_id": "SJCmX7CjALJv9OVT",
+  "img": "systems/pf2e/icons/default-icons/consumable.svg",
+  "name": "Bane Ammunition - Beasts (Lesser)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p>\n<hr />\n<p>Monster hunters favor bane ammunition that contains a capsule of reagents tailored to a particular type of creature—aberration, animal, beast, dragon, fey, giant, ooze, or both fungus and plant. Each type requires a different formula. When activated bane ammunition hits a target that has a trait matching the selected type, it takes @Damage[1d4[persistent,poison]] damage in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "DamageDice",
+        "selector": "strike-damage",
+        "diceNumber": 1,
+        "dieSize": "d4",
+        "category": "persistent",
+        "damageType": "poison",
+        "predicate": [
+          "target:trait:beast"
+        ]
+      }
+    ],
+    "slug": "bane-ammunition-beasts-lesser",
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "consumable",
+        "poison"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 1
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 3
+      }
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    }
+  },
+  "type": "consumable"
+}

--- a/packs/equipment/bane-ammunition-beasts-moderate.json
+++ b/packs/equipment/bane-ammunition-beasts-moderate.json
@@ -1,0 +1,88 @@
+{
+  "_id": "bRVoERNbrQG11lZc",
+  "img": "systems/pf2e/icons/default-icons/consumable.svg",
+  "name": "Bane Ammunition - Beasts (Moderate)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p>\n<hr />\n<p>Monster hunters favor bane ammunition that contains a capsule of reagents tailored to a particular type of creature—aberration, animal, beast, dragon, fey, giant, ooze, or both fungus and plant. Each type requires a different formula. When activated bane ammunition hits a target that has a trait matching the selected type, it takes @Damage[2d6[persistent,poison]] damage in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "DamageDice",
+        "selector": "strike-damage",
+        "diceNumber": 2,
+        "dieSize": "d6",
+        "category": "persistent",
+        "damageType": "poison",
+        "predicate": [
+          "target:trait:beast"
+        ]
+      }
+    ],
+    "slug": "bane-ammunition-beasts-moderate",
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "consumable",
+        "poison"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 5
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 25
+      }
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    }
+  },
+  "type": "consumable"
+}

--- a/packs/equipment/bane-ammunition-dragons-greater.json
+++ b/packs/equipment/bane-ammunition-dragons-greater.json
@@ -1,0 +1,88 @@
+{
+  "_id": "iAG3kVB7ApjTe7h1",
+  "img": "systems/pf2e/icons/default-icons/consumable.svg",
+  "name": "Bane Ammunition - Dragons (Greater)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p>\n<hr />\n<p>Monster hunters favor bane ammunition that contains a capsule of reagents tailored to a particular type of creature—aberration, animal, beast, dragon, fey, giant, ooze, or both fungus and plant. Each type requires a different formula. When activated bane ammunition hits a target that has a trait matching the selected type, it takes @Damage[3d6[persistent,poison]] damage in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "DamageDice",
+        "selector": "strike-damage",
+        "diceNumber": 3,
+        "dieSize": "d6",
+        "category": "persistent",
+        "damageType": "poison",
+        "predicate": [
+          "target:trait:dragon"
+        ]
+      }
+    ],
+    "slug": "bane-ammunition-dragons-greater",
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "consumable",
+        "poison"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 11
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 250
+      }
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    }
+  },
+  "type": "consumable"
+}

--- a/packs/equipment/bane-ammunition-dragons-lesser.json
+++ b/packs/equipment/bane-ammunition-dragons-lesser.json
@@ -1,0 +1,88 @@
+{
+  "_id": "gfXbPD4J7W1EbdXY",
+  "img": "systems/pf2e/icons/default-icons/consumable.svg",
+  "name": "Bane Ammunition - Dragons (Lesser)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p>\n<hr />\n<p>Monster hunters favor bane ammunition that contains a capsule of reagents tailored to a particular type of creature—aberration, animal, beast, dragon, fey, giant, ooze, or both fungus and plant. Each type requires a different formula. When activated bane ammunition hits a target that has a trait matching the selected type, it takes @Damage[1d4[persistent,poison]] damage in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "DamageDice",
+        "selector": "strike-damage",
+        "diceNumber": 1,
+        "dieSize": "d4",
+        "category": "persistent",
+        "damageType": "poison",
+        "predicate": [
+          "target:trait:dragon"
+        ]
+      }
+    ],
+    "slug": "bane-ammunition-dragons-lesser",
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "consumable",
+        "poison"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 1
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 3
+      }
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    }
+  },
+  "type": "consumable"
+}

--- a/packs/equipment/bane-ammunition-dragons-moderate.json
+++ b/packs/equipment/bane-ammunition-dragons-moderate.json
@@ -1,0 +1,88 @@
+{
+  "_id": "vtfrzlPc4dFpgh41",
+  "img": "systems/pf2e/icons/default-icons/consumable.svg",
+  "name": "Bane Ammunition - Dragons (Moderate)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p>\n<hr />\n<p>Monster hunters favor bane ammunition that contains a capsule of reagents tailored to a particular type of creature—aberration, animal, beast, dragon, fey, giant, ooze, or both fungus and plant. Each type requires a different formula. When activated bane ammunition hits a target that has a trait matching the selected type, it takes @Damage[2d6[persistent,poison]] damage in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "DamageDice",
+        "selector": "strike-damage",
+        "diceNumber": 2,
+        "dieSize": "d6",
+        "category": "persistent",
+        "damageType": "poison",
+        "predicate": [
+          "target:trait:dragon"
+        ]
+      }
+    ],
+    "slug": "bane-ammunition-dragons-moderate",
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "consumable",
+        "poison"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 5
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 25
+      }
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    }
+  },
+  "type": "consumable"
+}

--- a/packs/equipment/bane-ammunition-feys-greater.json
+++ b/packs/equipment/bane-ammunition-feys-greater.json
@@ -1,0 +1,88 @@
+{
+  "_id": "sfFbXYJS8xs3emc6",
+  "img": "systems/pf2e/icons/default-icons/consumable.svg",
+  "name": "Bane Ammunition - Feys (Greater)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p>\n<hr />\n<p>Monster hunters favor bane ammunition that contains a capsule of reagents tailored to a particular type of creature—aberration, animal, beast, dragon, fey, giant, ooze, or both fungus and plant. Each type requires a different formula. When activated bane ammunition hits a target that has a trait matching the selected type, it takes @Damage[3d6[persistent,poison]] damage in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "DamageDice",
+        "selector": "strike-damage",
+        "diceNumber": 3,
+        "dieSize": "d6",
+        "category": "persistent",
+        "damageType": "poison",
+        "predicate": [
+          "target:trait:fey"
+        ]
+      }
+    ],
+    "slug": "bane-ammunition-feys-greater",
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "consumable",
+        "poison"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 11
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 250
+      }
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    }
+  },
+  "type": "consumable"
+}

--- a/packs/equipment/bane-ammunition-feys-lesser.json
+++ b/packs/equipment/bane-ammunition-feys-lesser.json
@@ -1,0 +1,88 @@
+{
+  "_id": "amRiJayQFgvk4hWQ",
+  "img": "systems/pf2e/icons/default-icons/consumable.svg",
+  "name": "Bane Ammunition - Feys (Lesser)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p>\n<hr />\n<p>Monster hunters favor bane ammunition that contains a capsule of reagents tailored to a particular type of creature—aberration, animal, beast, dragon, fey, giant, ooze, or both fungus and plant. Each type requires a different formula. When activated bane ammunition hits a target that has a trait matching the selected type, it takes @Damage[1d4[persistent,poison]] damage in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "DamageDice",
+        "selector": "strike-damage",
+        "diceNumber": 1,
+        "dieSize": "d4",
+        "category": "persistent",
+        "damageType": "poison",
+        "predicate": [
+          "target:trait:fey"
+        ]
+      }
+    ],
+    "slug": "bane-ammunition-feys-lesser",
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "consumable",
+        "poison"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 1
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 3
+      }
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    }
+  },
+  "type": "consumable"
+}

--- a/packs/equipment/bane-ammunition-feys-moderate.json
+++ b/packs/equipment/bane-ammunition-feys-moderate.json
@@ -1,0 +1,88 @@
+{
+  "_id": "k0vdoKQRufmBaAri",
+  "img": "systems/pf2e/icons/default-icons/consumable.svg",
+  "name": "Bane Ammunition - Feys (Moderate)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p>\n<hr />\n<p>Monster hunters favor bane ammunition that contains a capsule of reagents tailored to a particular type of creature—aberration, animal, beast, dragon, fey, giant, ooze, or both fungus and plant. Each type requires a different formula. When activated bane ammunition hits a target that has a trait matching the selected type, it takes @Damage[2d6[persistent,poison]] damage in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "DamageDice",
+        "selector": "strike-damage",
+        "diceNumber": 2,
+        "dieSize": "d6",
+        "category": "persistent",
+        "damageType": "poison",
+        "predicate": [
+          "target:trait:fey"
+        ]
+      }
+    ],
+    "slug": "bane-ammunition-feys-moderate",
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "consumable",
+        "poison"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 5
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 25
+      }
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    }
+  },
+  "type": "consumable"
+}

--- a/packs/equipment/bane-ammunition-fungus-plants-greater.json
+++ b/packs/equipment/bane-ammunition-fungus-plants-greater.json
@@ -1,0 +1,93 @@
+{
+  "_id": "0keDOtdMVskcMGiE",
+  "img": "systems/pf2e/icons/default-icons/consumable.svg",
+  "name": "Bane Ammunition -  Fungus & Plants (Greater)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p>\n<hr />\n<p>Monster hunters favor bane ammunition that contains a capsule of reagents tailored to a particular type of creature—aberration, animal, beast, dragon, fey, giant, ooze, or both fungus and plant. Each type requires a different formula. When activated bane ammunition hits a target that has a trait matching the selected type, it takes @Damage[3d6[persistent,poison]] damage in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "DamageDice",
+        "selector": "strike-damage",
+        "diceNumber": 3,
+        "dieSize": "d6",
+        "category": "persistent",
+        "damageType": "poison",
+        "predicate": [
+          {
+            "or": [
+              "target:trait:fungus",
+              "target:trait:plant"
+            ]
+          }
+        ]
+      }
+    ],
+    "slug": "bane-ammunition-fungus-plants-greater",
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "consumable",
+        "poison"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 11
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 250
+      }
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    }
+  },
+  "type": "consumable"
+}

--- a/packs/equipment/bane-ammunition-fungus-plants-lesser.json
+++ b/packs/equipment/bane-ammunition-fungus-plants-lesser.json
@@ -1,0 +1,93 @@
+{
+  "_id": "mgMJVlcsdNoZeEyp",
+  "img": "systems/pf2e/icons/default-icons/consumable.svg",
+  "name": "Bane Ammunition - Fungus & Plants (Lesser)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p>\n<hr />\n<p>Monster hunters favor bane ammunition that contains a capsule of reagents tailored to a particular type of creature—aberration, animal, beast, dragon, fey, giant, ooze, or both fungus and plant. Each type requires a different formula. When activated bane ammunition hits a target that has a trait matching the selected type, it takes @Damage[1d4[persistent,poison]] damage in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "DamageDice",
+        "selector": "strike-damage",
+        "diceNumber": 1,
+        "dieSize": "d4",
+        "category": "persistent",
+        "damageType": "poison",
+        "predicate": [
+          {
+            "or": [
+              "target:trait:fungus",
+              "target:trait:plant"
+            ]
+          }
+        ]
+      }
+    ],
+    "slug": "bane-ammunition-fungus-plants-lesser",
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "consumable",
+        "poison"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 1
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 3
+      }
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    }
+  },
+  "type": "consumable"
+}

--- a/packs/equipment/bane-ammunition-fungus-plants-moderate.json
+++ b/packs/equipment/bane-ammunition-fungus-plants-moderate.json
@@ -1,0 +1,93 @@
+{
+  "_id": "uQPIXTXqgDCGti4Z",
+  "img": "systems/pf2e/icons/default-icons/consumable.svg",
+  "name": "Bane Ammunition - Fungus & Plants (Moderate)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p>\n<hr />\n<p>Monster hunters favor bane ammunition that contains a capsule of reagents tailored to a particular type of creature—aberration, animal, beast, dragon, fey, giant, ooze, or both fungus and plant. Each type requires a different formula. When activated bane ammunition hits a target that has a trait matching the selected type, it takes @Damage[2d6[persistent,poison]] damage in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "DamageDice",
+        "selector": "strike-damage",
+        "diceNumber": 2,
+        "dieSize": "d6",
+        "category": "persistent",
+        "damageType": "poison",
+        "predicate": [
+          {
+            "or": [
+              "target:trait:fungus",
+              "target:trait:plant"
+            ]
+          }
+        ]
+      }
+    ],
+    "slug": "bane-ammunition-fungus-plants-moderate",
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "consumable",
+        "poison"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 5
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 25
+      }
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    }
+  },
+  "type": "consumable"
+}

--- a/packs/equipment/bane-ammunition-giants-greater.json
+++ b/packs/equipment/bane-ammunition-giants-greater.json
@@ -1,0 +1,88 @@
+{
+  "_id": "H0Yka5mf5wDcYnr6",
+  "img": "systems/pf2e/icons/default-icons/consumable.svg",
+  "name": "Bane Ammunition - Giants (Greater)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p>\n<hr />\n<p>Monster hunters favor bane ammunition that contains a capsule of reagents tailored to a particular type of creature—aberration, animal, beast, dragon, fey, giant, ooze, or both fungus and plant. Each type requires a different formula. When activated bane ammunition hits a target that has a trait matching the selected type, it takes @Damage[3d6[persistent,poison]] damage in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "DamageDice",
+        "selector": "strike-damage",
+        "diceNumber": 3,
+        "dieSize": "d6",
+        "category": "persistent",
+        "damageType": "poison",
+        "predicate": [
+          "target:trait:giant"
+        ]
+      }
+    ],
+    "slug": "bane-ammunition-giants-greater",
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "consumable",
+        "poison"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 11
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 250
+      }
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    }
+  },
+  "type": "consumable"
+}

--- a/packs/equipment/bane-ammunition-giants-lesser.json
+++ b/packs/equipment/bane-ammunition-giants-lesser.json
@@ -1,0 +1,88 @@
+{
+  "_id": "h2NSbqaliWi9ogny",
+  "img": "systems/pf2e/icons/default-icons/consumable.svg",
+  "name": "Bane Ammunition - Giants (Lesser)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p>\n<hr />\n<p>Monster hunters favor bane ammunition that contains a capsule of reagents tailored to a particular type of creature—aberration, animal, beast, dragon, fey, giant, ooze, or both fungus and plant. Each type requires a different formula. When activated bane ammunition hits a target that has a trait matching the selected type, it takes @Damage[1d4[persistent,poison]] damage in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "DamageDice",
+        "selector": "strike-damage",
+        "diceNumber": 1,
+        "dieSize": "d4",
+        "category": "persistent",
+        "damageType": "poison",
+        "predicate": [
+          "target:trait:giant"
+        ]
+      }
+    ],
+    "slug": "bane-ammunition-giants-lesser",
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "consumable",
+        "poison"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 1
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 3
+      }
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    }
+  },
+  "type": "consumable"
+}

--- a/packs/equipment/bane-ammunition-giants-moderate.json
+++ b/packs/equipment/bane-ammunition-giants-moderate.json
@@ -1,0 +1,88 @@
+{
+  "_id": "mrlzkN41vCAHv9th",
+  "img": "systems/pf2e/icons/default-icons/consumable.svg",
+  "name": "Bane Ammunition - Giants (Moderate)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p>\n<hr />\n<p>Monster hunters favor bane ammunition that contains a capsule of reagents tailored to a particular type of creature—aberration, animal, beast, dragon, fey, giant, ooze, or both fungus and plant. Each type requires a different formula. When activated bane ammunition hits a target that has a trait matching the selected type, it takes @Damage[2d6[persistent,poison]] damage in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "DamageDice",
+        "selector": "strike-damage",
+        "diceNumber": 2,
+        "dieSize": "d6",
+        "category": "persistent",
+        "damageType": "poison",
+        "predicate": [
+          "target:trait:giant"
+        ]
+      }
+    ],
+    "slug": "bane-ammunition-giants-moderate",
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "consumable",
+        "poison"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 5
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 25
+      }
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    }
+  },
+  "type": "consumable"
+}

--- a/packs/equipment/bane-ammunition-oozes-greater.json
+++ b/packs/equipment/bane-ammunition-oozes-greater.json
@@ -1,0 +1,88 @@
+{
+  "_id": "zIB2fNUxwAnQUDXE",
+  "img": "systems/pf2e/icons/default-icons/consumable.svg",
+  "name": "Bane Ammunition - Oozes (Greater)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p>\n<hr />\n<p>Monster hunters favor bane ammunition that contains a capsule of reagents tailored to a particular type of creature—aberration, animal, beast, dragon, fey, giant, ooze, or both fungus and plant. Each type requires a different formula. When activated bane ammunition hits a target that has a trait matching the selected type, it takes @Damage[3d6[persistent,poison]] damage in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "DamageDice",
+        "selector": "strike-damage",
+        "diceNumber": 3,
+        "dieSize": "d6",
+        "category": "persistent",
+        "damageType": "poison",
+        "predicate": [
+          "target:trait:ooze"
+        ]
+      }
+    ],
+    "slug": "bane-ammunition-oozes-greater",
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "consumable",
+        "poison"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 11
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 250
+      }
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    }
+  },
+  "type": "consumable"
+}

--- a/packs/equipment/bane-ammunition-oozes-lesser.json
+++ b/packs/equipment/bane-ammunition-oozes-lesser.json
@@ -1,0 +1,88 @@
+{
+  "_id": "ifrpmTmZJZC9v7u3",
+  "img": "systems/pf2e/icons/default-icons/consumable.svg",
+  "name": "Bane Ammunition - Oozes (Lesser)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p>\n<hr />\n<p>Monster hunters favor bane ammunition that contains a capsule of reagents tailored to a particular type of creature—aberration, animal, beast, dragon, fey, giant, ooze, or both fungus and plant. Each type requires a different formula. When activated bane ammunition hits a target that has a trait matching the selected type, it takes @Damage[1d4[persistent,poison]] damage in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "DamageDice",
+        "selector": "strike-damage",
+        "diceNumber": 1,
+        "dieSize": "d4",
+        "category": "persistent",
+        "damageType": "poison",
+        "predicate": [
+          "target:trait:ooze"
+        ]
+      }
+    ],
+    "slug": "bane-ammunition-oozes-lesser",
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "consumable",
+        "poison"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 1
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 3
+      }
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    }
+  },
+  "type": "consumable"
+}

--- a/packs/equipment/bane-ammunition-oozes-moderate.json
+++ b/packs/equipment/bane-ammunition-oozes-moderate.json
@@ -1,0 +1,88 @@
+{
+  "_id": "x3RFxrnvFaLb34ip",
+  "img": "systems/pf2e/icons/default-icons/consumable.svg",
+  "name": "Bane Ammunition - Oozes (Moderate)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p>\n<hr />\n<p>Monster hunters favor bane ammunition that contains a capsule of reagents tailored to a particular type of creature—aberration, animal, beast, dragon, fey, giant, ooze, or both fungus and plant. Each type requires a different formula. When activated bane ammunition hits a target that has a trait matching the selected type, it takes @Damage[2d6[persistent,poison]] damage in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "DamageDice",
+        "selector": "strike-damage",
+        "diceNumber": 2,
+        "dieSize": "d6",
+        "category": "persistent",
+        "damageType": "poison",
+        "predicate": [
+          "target:trait:ooze"
+        ]
+      }
+    ],
+    "slug": "bane-ammunition-oozes-moderate",
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "consumable",
+        "poison"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 5
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 25
+      }
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    }
+  },
+  "type": "consumable"
+}

--- a/packs/equipment/elemental-ammunition-acid-greater.json
+++ b/packs/equipment/elemental-ammunition-acid-greater.json
@@ -1,0 +1,124 @@
+{
+  "_id": "oBidTU30adKQR4wS",
+  "img": "icons/weapons/ammunition/bullet-ice-blue.webp",
+  "name": "Elemental Ammunition - Acid (Greater)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p><p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p><hr /><p>When activated, the reservoir of alchemical reagents in elemental ammunition atomizes on impact, dealing @Damage[3d4[persistent,acid]] damage to the target and [[/r (3[splash])[acid]]]{3 acid splash damage} in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "FlatModifier",
+        "selector": "strike-damage",
+        "value": 3,
+        "damageType": "acid",
+        "damageCategory": "splash"
+      },
+      {
+        "key": "DamageDice",
+        "selector": "strike-damage",
+        "diceNumber": 3,
+        "dieSize": "d4",
+        "category": "persistent",
+        "damageType": "acid"
+      }
+    ],
+    "slug": "elemental-ammunition-acid-greater",
+    "_migration": {
+      "version": 0.932,
+      "lastMigration": null,
+      "previous": null
+    },
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "acid",
+        "alchemical",
+        "consumable",
+        "splash"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 11
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 210
+      }
+    },
+    "equipped": {
+      "carryType": "worn"
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    },
+    "stackGroup": null,
+    "spell": null
+  },
+  "type": "consumable",
+  "_stats": {
+    "coreVersion": "12.330",
+    "systemId": "pf2e",
+    "systemVersion": "6.2.0",
+    "createdTime": 1722996076417,
+    "modifiedTime": 1722996488412,
+    "lastModifiedBy": "0djxAWBUKnXGzoJY"
+  },
+  "flags": {
+    "core": {
+      "sourceId": "Compendium.pf2e.equipment-srd.Item.q2TpCwdlLGdcasKD"
+    },
+    "exportSource": {
+      "world": "dev-test-pf2",
+      "system": "pf2e",
+      "coreVersion": "12.330",
+      "systemVersion": "6.2.0"
+    }
+  },
+  "effects": [],
+  "folder": "IZIEPNLn9gYUeDVV"
+}

--- a/packs/equipment/elemental-ammunition-acid-lesser.json
+++ b/packs/equipment/elemental-ammunition-acid-lesser.json
@@ -1,0 +1,124 @@
+{
+  "_id": "LgXaNRKbROb2gALJ",
+  "img": "icons/weapons/ammunition/bullet-ice-blue.webp",
+  "name": "Elemental Ammunition - Acid (Lesser)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p><p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p><hr /><p>When activated, the reservoir of alchemical reagents in elemental ammunition atomizes on impact, dealing @Damage[1[persistent,acid]] damage to the target and [[/r (1[splash])[acid]]]{1 acid splash damage} in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "FlatModifier",
+        "selector": "strike-damage",
+        "value": 1,
+        "damageType": "acid",
+        "damageCategory": "persistent",
+        "label": "Elemental Ammunition - Acid(Lesser)"
+      },
+      {
+        "key": "FlatModifier",
+        "selector": "strike-damage",
+        "value": 1,
+        "damageType": "acid",
+        "damageCategory": "splash"
+      }
+    ],
+    "slug": "elemental-ammunition-acid-lesser",
+    "_migration": {
+      "version": 0.932,
+      "lastMigration": null,
+      "previous": null
+    },
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "acid",
+        "alchemical",
+        "consumable",
+        "splash"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 1
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 3
+      }
+    },
+    "equipped": {
+      "carryType": "worn"
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    },
+    "stackGroup": null,
+    "spell": null
+  },
+  "type": "consumable",
+  "_stats": {
+    "coreVersion": "12.330",
+    "systemId": "pf2e",
+    "systemVersion": "6.2.0",
+    "createdTime": 1722988688887,
+    "modifiedTime": 1722993730580,
+    "lastModifiedBy": "0djxAWBUKnXGzoJY"
+  },
+  "flags": {
+    "core": {
+      "sourceId": "Compendium.pf2e.equipment-srd.Item.zHzAZRDVtl2NFqyh"
+    },
+    "exportSource": {
+      "world": "dev-test-pf2",
+      "system": "pf2e",
+      "coreVersion": "12.330",
+      "systemVersion": "6.2.0"
+    }
+  },
+  "effects": [],
+  "folder": "ovR6x3jEqETGmnF0"
+}

--- a/packs/equipment/elemental-ammunition-acid-moderate.json
+++ b/packs/equipment/elemental-ammunition-acid-moderate.json
@@ -1,0 +1,124 @@
+{
+  "_id": "tgfd7z7U7SOsInmb",
+  "img": "icons/weapons/ammunition/bullet-ice-blue.webp",
+  "name": "Elemental Ammunition - Acid (Moderate)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p><p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p><hr /><p>When activated, the reservoir of alchemical reagents in elemental ammunition atomizes on impact, dealing @Damage[2d4[persistent,acid]] damage to the target and [[/r (2[splash])[acid]]]{2 acid splash damage} in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "FlatModifier",
+        "selector": "strike-damage",
+        "value": 2,
+        "damageType": "acid",
+        "damageCategory": "splash"
+      },
+      {
+        "key": "DamageDice",
+        "selector": "strike-damage",
+        "diceNumber": 2,
+        "dieSize": "d4",
+        "category": "persistent",
+        "damageType": "acid"
+      }
+    ],
+    "slug": "elemental-ammunition-acid-moderate",
+    "_migration": {
+      "version": 0.932,
+      "lastMigration": null,
+      "previous": null
+    },
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "acid",
+        "alchemical",
+        "consumable",
+        "splash"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 5
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 21
+      }
+    },
+    "equipped": {
+      "carryType": "worn"
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    },
+    "stackGroup": null,
+    "spell": null
+  },
+  "type": "consumable",
+  "_stats": {
+    "coreVersion": "12.330",
+    "systemId": "pf2e",
+    "systemVersion": "6.2.0",
+    "createdTime": 1722994165050,
+    "modifiedTime": 1722996321960,
+    "lastModifiedBy": "0djxAWBUKnXGzoJY"
+  },
+  "flags": {
+    "core": {
+      "sourceId": "Compendium.pf2e.equipment-srd.Item.2pB7AsbE0c7HvoZZ"
+    },
+    "exportSource": {
+      "world": "dev-test-pf2",
+      "system": "pf2e",
+      "coreVersion": "12.330",
+      "systemVersion": "6.2.0"
+    }
+  },
+  "effects": [],
+  "folder": "Vlpzn6EaLaxG6OgI"
+}

--- a/packs/equipment/elemental-ammunition-cold-greater.json
+++ b/packs/equipment/elemental-ammunition-cold-greater.json
@@ -1,0 +1,124 @@
+{
+  "_id": "XnE0bMoXwWpZifR0",
+  "img": "icons/weapons/ammunition/bullet-ice-blue.webp",
+  "name": "Elemental Ammunition - Cold (Greater)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p><p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p><hr /><p>When activated, the reservoir of alchemical reagents in elemental ammunition atomizes on impact, dealing @Damage[3d4[persistent,cold]] damage to the target and [[/r (3[splash])[cold]]]{3 cold splash damage} in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "FlatModifier",
+        "selector": "strike-damage",
+        "value": 3,
+        "damageType": "cold",
+        "damageCategory": "splash"
+      },
+      {
+        "key": "DamageDice",
+        "selector": "strike-damage",
+        "diceNumber": 3,
+        "dieSize": "d4",
+        "category": "persistent",
+        "damageType": "cold"
+      }
+    ],
+    "slug": "elemental-ammunition-cold-greater",
+    "_migration": {
+      "version": 0.932,
+      "lastMigration": null,
+      "previous": null
+    },
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "cold",
+        "consumable",
+        "splash"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 11
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 210
+      }
+    },
+    "equipped": {
+      "carryType": "worn"
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    },
+    "stackGroup": null,
+    "spell": null
+  },
+  "type": "consumable",
+  "_stats": {
+    "coreVersion": "12.330",
+    "systemId": "pf2e",
+    "systemVersion": "6.2.0",
+    "createdTime": 1722996330437,
+    "modifiedTime": 1722996485059,
+    "lastModifiedBy": "0djxAWBUKnXGzoJY"
+  },
+  "flags": {
+    "core": {
+      "sourceId": "Compendium.pf2e.equipment-srd.Item.q2TpCwdlLGdcasKD"
+    },
+    "exportSource": {
+      "world": "dev-test-pf2",
+      "system": "pf2e",
+      "coreVersion": "12.330",
+      "systemVersion": "6.2.0"
+    }
+  },
+  "effects": [],
+  "folder": "IZIEPNLn9gYUeDVV"
+}

--- a/packs/equipment/elemental-ammunition-cold-lesser.json
+++ b/packs/equipment/elemental-ammunition-cold-lesser.json
@@ -1,0 +1,124 @@
+{
+  "_id": "WEXNiLU8z7YaSfta",
+  "img": "icons/weapons/ammunition/bullet-ice-blue.webp",
+  "name": "Elemental Ammunition - Cold (Lesser)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p><p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p><hr /><p>When activated, the reservoir of alchemical reagents in elemental ammunition atomizes on impact, dealing @Damage[1[persistent,cold]] damage to the target and [[/r (1[splash])[cold]]]{1 cold splash damage} in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "FlatModifier",
+        "selector": "strike-damage",
+        "value": 1,
+        "damageType": "cold",
+        "damageCategory": "persistent",
+        "label": "Elemental Ammunition - Acid(Lesser)"
+      },
+      {
+        "key": "FlatModifier",
+        "selector": "strike-damage",
+        "value": 1,
+        "damageType": "cold",
+        "damageCategory": "splash"
+      }
+    ],
+    "slug": "elemental-ammunition-cold-lesser",
+    "_migration": {
+      "version": 0.932,
+      "lastMigration": null,
+      "previous": null
+    },
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "cold",
+        "consumable",
+        "splash"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 1
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 3
+      }
+    },
+    "equipped": {
+      "carryType": "worn"
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    },
+    "stackGroup": null,
+    "spell": null
+  },
+  "type": "consumable",
+  "_stats": {
+    "coreVersion": "12.330",
+    "systemId": "pf2e",
+    "systemVersion": "6.2.0",
+    "createdTime": 1722993427022,
+    "modifiedTime": 1722993727791,
+    "lastModifiedBy": "0djxAWBUKnXGzoJY"
+  },
+  "flags": {
+    "core": {
+      "sourceId": "Compendium.pf2e.equipment-srd.Item.zHzAZRDVtl2NFqyh"
+    },
+    "exportSource": {
+      "world": "dev-test-pf2",
+      "system": "pf2e",
+      "coreVersion": "12.330",
+      "systemVersion": "6.2.0"
+    }
+  },
+  "effects": [],
+  "folder": "ovR6x3jEqETGmnF0"
+}

--- a/packs/equipment/elemental-ammunition-cold-moderate.json
+++ b/packs/equipment/elemental-ammunition-cold-moderate.json
@@ -1,0 +1,124 @@
+{
+  "_id": "EWZ4dHPxyGfgdv7s",
+  "img": "icons/weapons/ammunition/bullet-ice-blue.webp",
+  "name": "Elemental Ammunition - Cold (Moderate)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p><p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p><hr /><p>When activated, the reservoir of alchemical reagents in elemental ammunition atomizes on impact, dealing @Damage[2d4[persistent,cold]] damage to the target and [[/r (2[splash])[cold]]]{2 cold splash damage} in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "FlatModifier",
+        "selector": "strike-damage",
+        "value": 2,
+        "damageType": "cold",
+        "damageCategory": "splash"
+      },
+      {
+        "key": "DamageDice",
+        "selector": "strike-damage",
+        "diceNumber": 2,
+        "dieSize": "d4",
+        "category": "persistent",
+        "damageType": "cold"
+      }
+    ],
+    "slug": "elemental-ammunition-cold-moderate",
+    "_migration": {
+      "version": 0.932,
+      "lastMigration": null,
+      "previous": null
+    },
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "cold",
+        "consumable",
+        "splash"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 5
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 21
+      }
+    },
+    "equipped": {
+      "carryType": "worn"
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    },
+    "stackGroup": null,
+    "spell": null
+  },
+  "type": "consumable",
+  "_stats": {
+    "coreVersion": "12.330",
+    "systemId": "pf2e",
+    "systemVersion": "6.2.0",
+    "createdTime": 1722995664430,
+    "modifiedTime": 1722995919392,
+    "lastModifiedBy": "0djxAWBUKnXGzoJY"
+  },
+  "flags": {
+    "core": {
+      "sourceId": "Compendium.pf2e.equipment-srd.Item.2pB7AsbE0c7HvoZZ"
+    },
+    "exportSource": {
+      "world": "dev-test-pf2",
+      "system": "pf2e",
+      "coreVersion": "12.330",
+      "systemVersion": "6.2.0"
+    }
+  },
+  "effects": [],
+  "folder": "Vlpzn6EaLaxG6OgI"
+}

--- a/packs/equipment/elemental-ammunition-electricity-greater.json
+++ b/packs/equipment/elemental-ammunition-electricity-greater.json
@@ -1,0 +1,124 @@
+{
+  "_id": "Cqz3qT3OIzk0GiOU",
+  "img": "icons/weapons/ammunition/bullet-ice-blue.webp",
+  "name": "Elemental Ammunition - Electricity (Greater)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p><p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p><hr /><p>When activated, the reservoir of alchemical reagents in elemental ammunition atomizes on impact, dealing @Damage[3d4[persistent,electricity]] damage to the target and [[/r (3[splash])[electricity]]]{3 electricity splash damage} in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "FlatModifier",
+        "selector": "strike-damage",
+        "value": 3,
+        "damageType": "electricity",
+        "damageCategory": "splash"
+      },
+      {
+        "key": "DamageDice",
+        "selector": "strike-damage",
+        "diceNumber": 3,
+        "dieSize": "d4",
+        "category": "persistent",
+        "damageType": "electricity"
+      }
+    ],
+    "slug": "elemental-ammunition-electricity-greater",
+    "_migration": {
+      "version": 0.932,
+      "lastMigration": null,
+      "previous": null
+    },
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "consumable",
+        "electricity",
+        "splash"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 11
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 210
+      }
+    },
+    "equipped": {
+      "carryType": "worn"
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    },
+    "stackGroup": null,
+    "spell": null
+  },
+  "type": "consumable",
+  "_stats": {
+    "coreVersion": "12.330",
+    "systemId": "pf2e",
+    "systemVersion": "6.2.0",
+    "createdTime": 1722996326201,
+    "modifiedTime": 1722996510513,
+    "lastModifiedBy": "0djxAWBUKnXGzoJY"
+  },
+  "flags": {
+    "core": {
+      "sourceId": "Compendium.pf2e.equipment-srd.Item.q2TpCwdlLGdcasKD"
+    },
+    "exportSource": {
+      "world": "dev-test-pf2",
+      "system": "pf2e",
+      "coreVersion": "12.330",
+      "systemVersion": "6.2.0"
+    }
+  },
+  "effects": [],
+  "folder": "IZIEPNLn9gYUeDVV"
+}

--- a/packs/equipment/elemental-ammunition-electricity-lesser.json
+++ b/packs/equipment/elemental-ammunition-electricity-lesser.json
@@ -1,0 +1,124 @@
+{
+  "_id": "FdbcM5m0qZcSHMWw",
+  "img": "icons/weapons/ammunition/bullet-ice-blue.webp",
+  "name": "Elemental Ammunition - Electricity (Lesser)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p><p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p><hr /><p>When activated, the reservoir of alchemical reagents in elemental ammunition atomizes on impact, dealing @Damage[1[persistent,electricity]] damage to the target and [[/r (1[splash])[electricity]]]{1 electricity splash damage} in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "FlatModifier",
+        "selector": "strike-damage",
+        "value": 1,
+        "damageType": "electricity",
+        "damageCategory": "persistent",
+        "label": "Elemental Ammunition - Acid(Lesser)"
+      },
+      {
+        "key": "FlatModifier",
+        "selector": "strike-damage",
+        "value": 1,
+        "damageType": "electricity",
+        "damageCategory": "splash"
+      }
+    ],
+    "slug": "elemental-ammunition-electricity-lesser",
+    "_migration": {
+      "version": 0.932,
+      "lastMigration": null,
+      "previous": null
+    },
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "consumable",
+        "electricity",
+        "splash"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 1
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 3
+      }
+    },
+    "equipped": {
+      "carryType": "worn"
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    },
+    "stackGroup": null,
+    "spell": null
+  },
+  "type": "consumable",
+  "_stats": {
+    "coreVersion": "12.330",
+    "systemId": "pf2e",
+    "systemVersion": "6.2.0",
+    "createdTime": 1722993575097,
+    "modifiedTime": 1722993724417,
+    "lastModifiedBy": "0djxAWBUKnXGzoJY"
+  },
+  "flags": {
+    "core": {
+      "sourceId": "Compendium.pf2e.equipment-srd.Item.zHzAZRDVtl2NFqyh"
+    },
+    "exportSource": {
+      "world": "dev-test-pf2",
+      "system": "pf2e",
+      "coreVersion": "12.330",
+      "systemVersion": "6.2.0"
+    }
+  },
+  "effects": [],
+  "folder": "ovR6x3jEqETGmnF0"
+}

--- a/packs/equipment/elemental-ammunition-electricity-moderate.json
+++ b/packs/equipment/elemental-ammunition-electricity-moderate.json
@@ -1,0 +1,124 @@
+{
+  "_id": "cHwx7XGz6oX0alN9",
+  "img": "icons/weapons/ammunition/bullet-ice-blue.webp",
+  "name": "Elemental Ammunition - Electricity (Moderate)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p><p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p><hr /><p>When activated, the reservoir of alchemical reagents in elemental ammunition atomizes on impact, dealing @Damage[2d4[persistent,electricity]] damage to the target and [[/r (2[splash])[electricity]]]{2 electricity splash damage} in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "FlatModifier",
+        "selector": "strike-damage",
+        "value": 2,
+        "damageType": "electricity",
+        "damageCategory": "splash"
+      },
+      {
+        "key": "DamageDice",
+        "selector": "strike-damage",
+        "diceNumber": 2,
+        "dieSize": "d4",
+        "category": "persistent",
+        "damageType": "electricity"
+      }
+    ],
+    "slug": "elemental-ammunition-electricity-moderate",
+    "_migration": {
+      "version": 0.932,
+      "lastMigration": null,
+      "previous": null
+    },
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "consumable",
+        "electricity",
+        "splash"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 5
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 21
+      }
+    },
+    "equipped": {
+      "carryType": "worn"
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    },
+    "stackGroup": null,
+    "spell": null
+  },
+  "type": "consumable",
+  "_stats": {
+    "coreVersion": "12.330",
+    "systemId": "pf2e",
+    "systemVersion": "6.2.0",
+    "createdTime": 1722995813515,
+    "modifiedTime": 1722995990580,
+    "lastModifiedBy": "0djxAWBUKnXGzoJY"
+  },
+  "flags": {
+    "core": {
+      "sourceId": "Compendium.pf2e.equipment-srd.Item.2pB7AsbE0c7HvoZZ"
+    },
+    "exportSource": {
+      "world": "dev-test-pf2",
+      "system": "pf2e",
+      "coreVersion": "12.330",
+      "systemVersion": "6.2.0"
+    }
+  },
+  "effects": [],
+  "folder": "Vlpzn6EaLaxG6OgI"
+}

--- a/packs/equipment/elemental-ammunition-fire-greater.json
+++ b/packs/equipment/elemental-ammunition-fire-greater.json
@@ -1,0 +1,124 @@
+{
+  "_id": "dbri25dmWXBr0yop",
+  "img": "icons/weapons/ammunition/bullet-ice-blue.webp",
+  "name": "Elemental Ammunition - Fire (Greater)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p><p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p><hr /><p>When activated, the reservoir of alchemical reagents in elemental ammunition atomizes on impact, dealing @Damage[3d4[persistent,fire]] damage to the target and [[/r (3[splash])[fire]]]{3 fire splash damage} in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "FlatModifier",
+        "selector": "strike-damage",
+        "value": 3,
+        "damageType": "fire",
+        "damageCategory": "splash"
+      },
+      {
+        "key": "DamageDice",
+        "selector": "strike-damage",
+        "diceNumber": 3,
+        "dieSize": "d4",
+        "category": "persistent",
+        "damageType": "fire"
+      }
+    ],
+    "slug": "elemental-ammunition-fire-greater",
+    "_migration": {
+      "version": 0.932,
+      "lastMigration": null,
+      "previous": null
+    },
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "consumable",
+        "fire",
+        "splash"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 11
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 210
+      }
+    },
+    "equipped": {
+      "carryType": "worn"
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    },
+    "stackGroup": null,
+    "spell": null
+  },
+  "type": "consumable",
+  "_stats": {
+    "coreVersion": "12.330",
+    "systemId": "pf2e",
+    "systemVersion": "6.2.0",
+    "createdTime": 1722996331839,
+    "modifiedTime": 1722996554345,
+    "lastModifiedBy": "0djxAWBUKnXGzoJY"
+  },
+  "flags": {
+    "core": {
+      "sourceId": "Compendium.pf2e.equipment-srd.Item.q2TpCwdlLGdcasKD"
+    },
+    "exportSource": {
+      "world": "dev-test-pf2",
+      "system": "pf2e",
+      "coreVersion": "12.330",
+      "systemVersion": "6.2.0"
+    }
+  },
+  "effects": [],
+  "folder": "IZIEPNLn9gYUeDVV"
+}

--- a/packs/equipment/elemental-ammunition-fire-lesser.json
+++ b/packs/equipment/elemental-ammunition-fire-lesser.json
@@ -1,0 +1,124 @@
+{
+  "_id": "x0k0UFhNpIDKn6xr",
+  "img": "icons/weapons/ammunition/bullet-ice-blue.webp",
+  "name": "Elemental Ammunition - Fire (Lesser)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p><p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p><hr /><p>When activated, the reservoir of alchemical reagents in elemental ammunition atomizes on impact, dealing @Damage[1[persistent,fire]] damage to the target and [[/r (1[splash])[fire]]]{1 fire splash damage} in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "FlatModifier",
+        "selector": "strike-damage",
+        "value": 1,
+        "damageType": "fire",
+        "damageCategory": "persistent",
+        "label": "Elemental Ammunition - Acid(Lesser)"
+      },
+      {
+        "key": "FlatModifier",
+        "selector": "strike-damage",
+        "value": 1,
+        "damageType": "fire",
+        "damageCategory": "splash"
+      }
+    ],
+    "slug": "elemental-ammunition-fire-lesser",
+    "_migration": {
+      "version": 0.932,
+      "lastMigration": null,
+      "previous": null
+    },
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "consumable",
+        "fire",
+        "splash"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 1
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 3
+      }
+    },
+    "equipped": {
+      "carryType": "worn"
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    },
+    "stackGroup": null,
+    "spell": null
+  },
+  "type": "consumable",
+  "_stats": {
+    "coreVersion": "12.330",
+    "systemId": "pf2e",
+    "systemVersion": "6.2.0",
+    "createdTime": 1722993733418,
+    "modifiedTime": 1722993795678,
+    "lastModifiedBy": "0djxAWBUKnXGzoJY"
+  },
+  "flags": {
+    "core": {
+      "sourceId": "Compendium.pf2e.equipment-srd.Item.zHzAZRDVtl2NFqyh"
+    },
+    "exportSource": {
+      "world": "dev-test-pf2",
+      "system": "pf2e",
+      "coreVersion": "12.330",
+      "systemVersion": "6.2.0"
+    }
+  },
+  "effects": [],
+  "folder": "ovR6x3jEqETGmnF0"
+}

--- a/packs/equipment/elemental-ammunition-fire-moderate.json
+++ b/packs/equipment/elemental-ammunition-fire-moderate.json
@@ -1,0 +1,124 @@
+{
+  "_id": "e9dHIY8UBPOCWbvN",
+  "img": "icons/weapons/ammunition/bullet-ice-blue.webp",
+  "name": "Elemental Ammunition - Fire (Moderate)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p><p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p><hr /><p>When activated, the reservoir of alchemical reagents in elemental ammunition atomizes on impact, dealing @Damage[2d4[persistent,fire]] damage to the target and [[/r (2[splash])[fire]]]{2 fire splash damage} in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "FlatModifier",
+        "selector": "strike-damage",
+        "value": 2,
+        "damageType": "fire",
+        "damageCategory": "splash"
+      },
+      {
+        "key": "DamageDice",
+        "selector": "strike-damage",
+        "diceNumber": 2,
+        "dieSize": "d4",
+        "category": "persistent",
+        "damageType": "fire"
+      }
+    ],
+    "slug": "elemental-ammunition-fire-moderate",
+    "_migration": {
+      "version": 0.932,
+      "lastMigration": null,
+      "previous": null
+    },
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "consumable",
+        "fire",
+        "splash"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 5
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 21
+      }
+    },
+    "equipped": {
+      "carryType": "worn"
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    },
+    "stackGroup": null,
+    "spell": null
+  },
+  "type": "consumable",
+  "_stats": {
+    "coreVersion": "12.330",
+    "systemId": "pf2e",
+    "systemVersion": "6.2.0",
+    "createdTime": 1722995940744,
+    "modifiedTime": 1722996019383,
+    "lastModifiedBy": "0djxAWBUKnXGzoJY"
+  },
+  "flags": {
+    "core": {
+      "sourceId": "Compendium.pf2e.equipment-srd.Item.2pB7AsbE0c7HvoZZ"
+    },
+    "exportSource": {
+      "world": "dev-test-pf2",
+      "system": "pf2e",
+      "coreVersion": "12.330",
+      "systemVersion": "6.2.0"
+    }
+  },
+  "effects": [],
+  "folder": "Vlpzn6EaLaxG6OgI"
+}

--- a/packs/equipment/elemental-ammunition-poison-greater.json
+++ b/packs/equipment/elemental-ammunition-poison-greater.json
@@ -1,0 +1,124 @@
+{
+  "_id": "qVWvndvcCrsGvp7i",
+  "img": "icons/weapons/ammunition/bullet-ice-blue.webp",
+  "name": "Elemental Ammunition - Poison (Greater)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p><p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p><hr /><p>When activated, the reservoir of alchemical reagents in elemental ammunition atomizes on impact, dealing @Damage[3d4[persistent,poison]] damage to the target and [[/r (3[splash])[poison]]]{3 poison splash damage} in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "FlatModifier",
+        "selector": "strike-damage",
+        "value": 3,
+        "damageType": "poison",
+        "damageCategory": "splash"
+      },
+      {
+        "key": "DamageDice",
+        "selector": "strike-damage",
+        "diceNumber": 3,
+        "dieSize": "d4",
+        "category": "persistent",
+        "damageType": "poison"
+      }
+    ],
+    "slug": "elemental-ammunition-poison-greater",
+    "_migration": {
+      "version": 0.932,
+      "lastMigration": null,
+      "previous": null
+    },
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "consumable",
+        "poison",
+        "splash"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 11
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 210
+      }
+    },
+    "equipped": {
+      "carryType": "worn"
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    },
+    "stackGroup": null,
+    "spell": null
+  },
+  "type": "consumable",
+  "_stats": {
+    "coreVersion": "12.330",
+    "systemId": "pf2e",
+    "systemVersion": "6.2.0",
+    "createdTime": 1722996333197,
+    "modifiedTime": 1722996587346,
+    "lastModifiedBy": "0djxAWBUKnXGzoJY"
+  },
+  "flags": {
+    "core": {
+      "sourceId": "Compendium.pf2e.equipment-srd.Item.q2TpCwdlLGdcasKD"
+    },
+    "exportSource": {
+      "world": "dev-test-pf2",
+      "system": "pf2e",
+      "coreVersion": "12.330",
+      "systemVersion": "6.2.0"
+    }
+  },
+  "effects": [],
+  "folder": "IZIEPNLn9gYUeDVV"
+}

--- a/packs/equipment/elemental-ammunition-poison-lesser.json
+++ b/packs/equipment/elemental-ammunition-poison-lesser.json
@@ -1,0 +1,124 @@
+{
+  "_id": "nF0S5fKgpK1ibnar",
+  "img": "icons/weapons/ammunition/bullet-ice-blue.webp",
+  "name": "Elemental Ammunition - Poison (Lesser)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p><p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p><hr /><p>When activated, the reservoir of alchemical reagents in elemental ammunition atomizes on impact, dealing @Damage[1[persistent,poison]] damage to the target and [[/r (1[splash])[poison]]]{1 poison splash damage} in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "FlatModifier",
+        "selector": "strike-damage",
+        "value": 1,
+        "damageType": "poison",
+        "damageCategory": "persistent",
+        "label": "Elemental Ammunition - Acid(Lesser)"
+      },
+      {
+        "key": "FlatModifier",
+        "selector": "strike-damage",
+        "value": 1,
+        "damageType": "poison",
+        "damageCategory": "splash"
+      }
+    ],
+    "slug": "elemental-ammunition-poison-lesser",
+    "_migration": {
+      "version": 0.932,
+      "lastMigration": null,
+      "previous": null
+    },
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "consumable",
+        "poison",
+        "splash"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 1
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 3
+      }
+    },
+    "equipped": {
+      "carryType": "worn"
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    },
+    "stackGroup": null,
+    "spell": null
+  },
+  "type": "consumable",
+  "_stats": {
+    "coreVersion": "12.330",
+    "systemId": "pf2e",
+    "systemVersion": "6.2.0",
+    "createdTime": 1722993800155,
+    "modifiedTime": 1722993834256,
+    "lastModifiedBy": "0djxAWBUKnXGzoJY"
+  },
+  "flags": {
+    "core": {
+      "sourceId": "Compendium.pf2e.equipment-srd.Item.zHzAZRDVtl2NFqyh"
+    },
+    "exportSource": {
+      "world": "dev-test-pf2",
+      "system": "pf2e",
+      "coreVersion": "12.330",
+      "systemVersion": "6.2.0"
+    }
+  },
+  "effects": [],
+  "folder": "ovR6x3jEqETGmnF0"
+}

--- a/packs/equipment/elemental-ammunition-poison-moderate.json
+++ b/packs/equipment/elemental-ammunition-poison-moderate.json
@@ -1,0 +1,124 @@
+{
+  "_id": "Tb78XSf7VDZ0KDfa",
+  "img": "icons/weapons/ammunition/bullet-ice-blue.webp",
+  "name": "Elemental Ammunition - Poison (Moderate)",
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Ammunition</strong> any</p><p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Interact</p><hr /><p>When activated, the reservoir of alchemical reagents in elemental ammunition atomizes on impact, dealing @Damage[2d4[persistent,poison]] damage to the target and [[/r (2[splash])[poison]]]{2 poison splash damage} in addition to the damage the attack normally deals.</p>"
+    },
+    "rules": [
+      {
+        "key": "FlatModifier",
+        "selector": "strike-damage",
+        "value": 2,
+        "damageType": "poison",
+        "damageCategory": "splash"
+      },
+      {
+        "key": "DamageDice",
+        "selector": "strike-damage",
+        "diceNumber": 2,
+        "dieSize": "d4",
+        "category": "persistent",
+        "damageType": "poison"
+      }
+    ],
+    "slug": "elemental-ammunition-poison-moderate",
+    "_migration": {
+      "version": 0.932,
+      "lastMigration": null,
+      "previous": null
+    },
+    "traits": {
+      "otherTags": [],
+      "value": [
+        "alchemical",
+        "consumable",
+        "poison",
+        "splash"
+      ],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Pathfinder Treasure Vault",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 5
+    },
+    "quantity": 1,
+    "baseItem": null,
+    "bulk": {
+      "value": 0
+    },
+    "hp": {
+      "value": 0,
+      "max": 0
+    },
+    "hardness": 0,
+    "price": {
+      "value": {
+        "gp": 21
+      }
+    },
+    "equipped": {
+      "carryType": "worn"
+    },
+    "containerId": null,
+    "size": "med",
+    "material": {
+      "type": null,
+      "grade": null
+    },
+    "identification": {
+      "status": "identified",
+      "unidentified": {
+        "name": "Unusual Ammunition",
+        "img": "systems/pf2e/icons/unidentified_item_icons/ammunition.webp",
+        "data": {
+          "description": {
+            "value": ""
+          }
+        }
+      },
+      "misidentified": {}
+    },
+    "category": "ammo",
+    "uses": {
+      "value": 1,
+      "max": 1,
+      "autoDestroy": true
+    },
+    "damage": null,
+    "usage": {
+      "value": "held-in-one-hand"
+    },
+    "stackGroup": null,
+    "spell": null
+  },
+  "type": "consumable",
+  "_stats": {
+    "coreVersion": "12.330",
+    "systemId": "pf2e",
+    "systemVersion": "6.2.0",
+    "createdTime": 1722996022973,
+    "modifiedTime": 1722996239928,
+    "lastModifiedBy": "0djxAWBUKnXGzoJY"
+  },
+  "flags": {
+    "core": {
+      "sourceId": "Compendium.pf2e.equipment-srd.Item.2pB7AsbE0c7HvoZZ"
+    },
+    "exportSource": {
+      "world": "dev-test-pf2",
+      "system": "pf2e",
+      "coreVersion": "12.330",
+      "systemVersion": "6.2.0"
+    }
+  },
+  "effects": [],
+  "folder": "Vlpzn6EaLaxG6OgI"
+}


### PR DESCRIPTION
Added all of the variants for Bane and Elemental ammo with automation for damage and creature types when used as ammo.

Closes #6641