### PR TITLE
Add toggle to the Mighty Rage feature

### DIFF
--- a/packs/classfeatures/mighty-rage.json
+++ b/packs/classfeatures/mighty-rage.json
@@ -35,7 +35,6 @@
                 "key": "AdjustModifier",
                 "mode": "multiply",
                 "predicate": [
-                    "self:effect:rage",
                     "mighty-rage-attack"
                 ],
                 "priority": 95,

--- a/packs/classfeatures/mighty-rage.json
+++ b/packs/classfeatures/mighty-rage.json
@@ -24,7 +24,26 @@
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "RollOption",
+                "domain": "all",
+                "option": "mighty-rage-attack",
+                "toggleable": true
+            },
+            {
+                "key": "AdjustModifier",
+                "mode": "multiply",
+                "predicate": [
+                    "self:effect:rage",
+                    "mighty-rage-attack"
+                ],
+                "priority": 95,
+                "selector": "strike-damage",
+                "slug": "rage",
+                "value": 2
+            }
+        ],
         "subfeatures": {
             "proficiencies": {
                 "barbarian": {


### PR DESCRIPTION
Added a simple toggle for Mighty Rage which doubles the rage damage which satisfies the requirement of mighty rage. 

Fixes #15777