### PR TITLE
Add oracle curses as class features

### DIFF
--- a/packs/classfeatures/ancestors.json
+++ b/packs/classfeatures/ancestors.json
@@ -11,7 +11,7 @@
         },
         "category": "classfeature",
         "description": {
-            "value": "<p>The voices of generations past speak to you, and you hear their words. You might resent the constant interruption, or you might revere the spirits of those who came before. Perhaps you hail from a culture with strong ancestral traditions, such as the Shoanti Skoan-Quah (Skull Clan), a traditional dwarven community that worships Torag's family pantheon, or a group that reveres Erastil or Pharasma. You might commune with powerful psychopomps who shepherd souls to the afterlife, with the River of Souls itself, or with those spirits who have become trapped outside of the great cycle of spiritual rebirth. You learn from their whispers and the fragments of their memories, but opening your mind to their knowledge and experience also allows them to meddle in your worldly affairs.</p>\n<p><strong>Granted Spells</strong> cantrip: @UUID[Compendium.pf2e.spells-srd.Item.Guidance]; 1st: @UUID[Compendium.pf2e.spells-srd.Item.Ill Omen]; 2nd: @UUID[Compendium.pf2e.spells-srd.Item.Ghostly Carrier]; 5th: @UUID[Compendium.pf2e.adventure-specific-actions.Item.Dream Research]{Dreaming Potential}</p>\n<p><strong>Revelation Spells</strong> initial: @UUID[Compendium.pf2e.spells-srd.Item.Ancestral Touch]; advanced: @UUID[Compendium.pf2e.spells-srd.Item.Ancestral Defense]; greater: @UUID[Compendium.pf2e.spells-srd.Item.Ancestral Form]</p>\n<p><strong>Related Domains</strong> death, duty, family, soul</p>\n<p><strong>Mystery Skill</strong> Society</p>\n<p><strong>Oracle Feat</strong> @UUID[Compendium.pf2e.feats-srd.Item.Whispers of Weakness]</p><h2><strong>Curse of Ancestral Meddling</strong></h2><section class=\"traits\"><p>curse</p>\n<p>Divine</p>\n<p>Oracle</p>\n<p>Spirit</p></section><p>The ancestral spirits you commune with haunt you and meddle with your belongings and actions, either out of a wellintentioned (but ultimately detrimental) attempt to assist you, as punishment for your audacity in circumventing the traditional means of achieving divine power, for their own amusement, or a mixture of the above. When you have the @UUID[Compendium.pf2e.conditionitems.Item.Cursebound] condition, you are @UUID[Compendium.pf2e.conditionitems.Item.Clumsy] with a value equal to your cursebound value as the spirits of your ancestors temporarily possess you and vie for control in your mind, hindering your movements.</p>"
+            "value": "<p>The voices of generations past speak to you, and you hear their words. You might resent the constant interruption, or you might revere the spirits of those who came before. Perhaps you hail from a culture with strong ancestral traditions, such as the Shoanti Skoan-Quah (Skull Clan), a traditional dwarven community that worships Torag's family pantheon, or a group that reveres Erastil or Pharasma. You might commune with powerful psychopomps who shepherd souls to the afterlife, with the River of Souls itself, or with those spirits who have become trapped outside of the great cycle of spiritual rebirth. You learn from their whispers and the fragments of their memories, but opening your mind to their knowledge and experience also allows them to meddle in your worldly affairs.</p>\n<p><strong>Granted Spells</strong> cantrip: @UUID[Compendium.pf2e.spells-srd.Item.Guidance]; 1st: @UUID[Compendium.pf2e.spells-srd.Item.Ill Omen]; 2nd: @UUID[Compendium.pf2e.spells-srd.Item.Ghostly Carrier]; 5th: @UUID[Compendium.pf2e.adventure-specific-actions.Item.Dream Research]{Dreaming Potential}</p>\n<p><strong>Revelation Spells</strong> initial: @UUID[Compendium.pf2e.spells-srd.Item.Ancestral Touch]; advanced: @UUID[Compendium.pf2e.spells-srd.Item.Ancestral Defense]; greater: @UUID[Compendium.pf2e.spells-srd.Item.Ancestral Form]</p>\n<p><strong>Related Domains</strong> death, duty, family, soul</p>\n<p><strong>Mystery Skill</strong> Society</p>\n<p><strong>Oracle Feat</strong> @UUID[Compendium.pf2e.feats-srd.Item.Whispers of Weakness]</p>\n<p>@UUID[Compendium.pf2e.classfeatures.Item.Curse of Ancestral Meddling]</p>"
         },
         "level": {
             "value": 1
@@ -39,24 +39,8 @@
                 "uuid": "Compendium.pf2e.feats-srd.Item.Whispers of Weakness"
             },
             {
-                "allowDuplicate": false,
-                "alterations": [
-                    {
-                        "mode": "override",
-                        "property": "badge-value",
-                        "value": "@actor.conditions.cursebound.value"
-                    }
-                ],
-                "inMemoryOnly": true,
                 "key": "GrantItem",
-                "onDeleteActions": {
-                    "grantee": "restrict"
-                },
-                "predicate": [
-                    "self:condition:cursebound"
-                ],
-                "reevaluateOnUpdate": true,
-                "uuid": "Compendium.pf2e.conditionitems.Item.Clumsy"
+                "uuid": "Compendium.pf2e.classfeatures.Item.Curse of Ancestral Meddling"
             }
         ],
         "traits": {

--- a/packs/classfeatures/battle.json
+++ b/packs/classfeatures/battle.json
@@ -11,7 +11,7 @@
         },
         "category": "classfeature",
         "description": {
-            "value": "<p>Warlike forces fill you with physical might and tactical knowledge, aiming to have you uphold the glory of combat, fight to improve the world, prepare against the necessity of conflict, or endure the inevitability of war. You might draw upon deities such as Gorum, Iomedae, Rovagug, the Horseman of War Szuriel, the Queen of the Night Eiseth, the Vudrani god Diomazul, and others, or you might find power in the unending conflict between the armies of Heaven and Hell, the Elemental Planes, the Outer Gods, or even the collective spirits of those who fought in wars over the ages.</p>\n<p><strong>Granted Spells</strong> cantrip: @UUID[Compendium.pf2e.spells-srd.Item.Shield]; 1st: @UUID[Compendium.pf2e.spells-srd.Item.Sure Strike]; 2nd: @UUID[Compendium.pf2e.spells-srd.Item.Telekinetic Maneuver]; 4th: @UUID[Compendium.pf2e.spells-srd.Item.Weapon Storm]</p>\n<p><strong>Revelation Spells</strong> initial: @UUID[Compendium.pf2e.spells-srd.Item.Weapon Trance]; advanced: @UUID[Compendium.pf2e.spells-srd.Item.Battlefield Persistence]; greater: @UUID[Compendium.pf2e.spells-srd.Item.Revel in Retribution]</p>\n<p><strong>Related Domains</strong> destruction, might, protection, zeal</p>\n<p><strong>Mystery Skill</strong> Athletics</p>\n<p><strong>Oracle Feat</strong> @UUID[Compendium.pf2e.feats-srd.Item.Oracular Warning]</p><h2><strong>Curse of the Mortal Warrior</strong></h2><section class=\"traits\"><p>CURSE</p>\n<p>DIVINE</p>\n<p>ORACLE</p></section><p>You thrive in the thick of battle, but your mystery's sheer focus on the physical and material leaves your soul weak against the tricks of spellcraft. You smell faintly of steel and blood no matter how you try to remove or mask the scent, you appear more imposing and muscular than you actually are, and you hear the faint clash and clamor of battle in the distance at all times.</p>\n<p><strong>@UUID[Compendium.pf2e.conditionitems.Item.Cursebound]{Cursebound 1}</strong> Spells have an easier time wounding you. You gain weakness 2 to any damage dealt by a spell. Any immunity or resistance you have to spells is suppressed. This applies only to spells, not other magical abilities.</p>\n<p><strong>Cursebound 2</strong> You take a –1 status penalty to saving throws against spells.</p>\n<p><strong>Cursebound 3</strong> Your weakness to spells is equal to your level.</p>\n<p><strong>Cursebound 4</strong> Your status penalty to saving throws against spells increases to –2.</p>"
+            "value": "<p>Warlike forces fill you with physical might and tactical knowledge, aiming to have you uphold the glory of combat, fight to improve the world, prepare against the necessity of conflict, or endure the inevitability of war. You might draw upon deities such as Gorum, Iomedae, Rovagug, the Horseman of War Szuriel, the Queen of the Night Eiseth, the Vudrani god Diomazul, and others, or you might find power in the unending conflict between the armies of Heaven and Hell, the Elemental Planes, the Outer Gods, or even the collective spirits of those who fought in wars over the ages.</p>\n<p><strong>Granted Spells</strong> cantrip: @UUID[Compendium.pf2e.spells-srd.Item.Shield]; 1st: @UUID[Compendium.pf2e.spells-srd.Item.Sure Strike]; 2nd: @UUID[Compendium.pf2e.spells-srd.Item.Telekinetic Maneuver]; 4th: @UUID[Compendium.pf2e.spells-srd.Item.Weapon Storm]</p>\n<p><strong>Revelation Spells</strong> initial: @UUID[Compendium.pf2e.spells-srd.Item.Weapon Trance]; advanced: @UUID[Compendium.pf2e.spells-srd.Item.Battlefield Persistence]; greater: @UUID[Compendium.pf2e.spells-srd.Item.Revel in Retribution]</p>\n<p><strong>Related Domains</strong> destruction, might, protection, zeal</p>\n<p><strong>Mystery Skill</strong> Athletics</p>\n<p><strong>Oracle Feat</strong> @UUID[Compendium.pf2e.feats-srd.Item.Oracular Warning]</p>\n<p>@UUID[Compendium.pf2e.classfeatures.Item.Curse of the Mortal Warrior]</p>"
         },
         "level": {
             "value": 1
@@ -39,27 +39,8 @@
                 "uuid": "Compendium.pf2e.feats-srd.Item.Oracular Warning"
             },
             {
-                "key": "Weakness",
-                "predicate": [
-                    "self:condition:cursebound"
-                ],
-                "type": "spells",
-                "value": "ternary(gte(@actor.conditions.cursebound.value,3),@actor.level,2)"
-            },
-            {
-                "key": "FlatModifier",
-                "predicate": [
-                    "item:spell",
-                    {
-                        "gte": [
-                            "self:condition:cursebound",
-                            2
-                        ]
-                    }
-                ],
-                "selector": "saving-throw",
-                "type": "status",
-                "value": "ternary(gte(@actor.conditions.cursebound.value,4),-2,-1)"
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Curse of the Mortal Warrior"
             }
         ],
         "traits": {

--- a/packs/classfeatures/bones.json
+++ b/packs/classfeatures/bones.json
@@ -11,7 +11,7 @@
         },
         "category": "classfeature",
         "description": {
-            "value": "<p>Your mystery imparts an understanding of death and undeath in all their macabre complexity. You might have had a brush with death yourself—maybe even dying and returning to life—or carry the touch of undeath in your blood. If you commune with deities, you might speak with guardians of death like Pharasma and the psychopomp ushers (the most powerful among creatures that guide souls through the afterlife); a bringer of death like the Mantis God Achaekek or the Horseman of the Apocalypse Charon; or a herald of undeath such as Urgathoa.</p>\n<p><strong>Granted Spells</strong> cantrip: @UUID[Compendium.pf2e.spells-srd.Item.Void Warp]; 1st: @UUID[Compendium.pf2e.spells-srd.Item.Grim Tendrils]; 2nd: @UUID[Compendium.pf2e.spells-srd.Item.False Vitality]; 3rd: @UUID[Compendium.pf2e.spells-srd.Item.Ghostly Weapon]</p>\n<p><strong>Revelation Spells</strong> initial: @UUID[Compendium.pf2e.spells-srd.Item.Soul Siphon]; advanced: @UUID[Compendium.pf2e.spells-srd.Item.Armor of Bones]; greater: @UUID[Compendium.pf2e.spells-srd.Item.Claim Undead]</p>\n<p><strong>Related Domains</strong> death, decay, undeath, vigil</p>\n<p><strong>Mystery Skill</strong> Medicine</p>\n<p><strong>Oracle Feat</strong> @UUID[Compendium.pf2e.feats-srd.Item.Nudge the Scales]</p><h2><strong>Curse of the Mortal Warrior</strong></h2><section class=\"traits\"><p>CURSE</p>\n<p>DIVINE</p>\n<p>ORACLE</p>\n<p>VOID</p>\n<p>VITALITY</p></section><p>Your body is slowly decaying even though you are alive, and using your powers furthers this unnatural living death, making you susceptible to both void and vitality damage. You carry a touch of the grave about you, manifesting as bloodless pallor, a faint smell of earth, or deathly cold skin.</p>\n<p><strong>@UUID[Compendium.pf2e.conditionitems.Item.Cursebound]{Cursebound 1}</strong> You gain weakness 2 to vitality and void damage. You can be hurt by both vitality and void damage even if one or the other normally has no effect on you. Any immunity or resistance you have to vitality or void is suppressed.</p>\n<p><strong>Cursebound 2</strong> You take a –1 status penalty to Fortitude saves.</p>\n<p><strong>Cursebound 3</strong> Your weakness to vitality and void damage is equal to 5 + your level.</p>\n<p><strong>Cursebound 4</strong> Your status penalty to Fortitude saving throws increases to –2.</p>"
+            "value": "<p>Your mystery imparts an understanding of death and undeath in all their macabre complexity. You might have had a brush with death yourself—maybe even dying and returning to life—or carry the touch of undeath in your blood. If you commune with deities, you might speak with guardians of death like Pharasma and the psychopomp ushers (the most powerful among creatures that guide souls through the afterlife); a bringer of death like the Mantis God Achaekek or the Horseman of the Apocalypse Charon; or a herald of undeath such as Urgathoa.</p>\n<p><strong>Granted Spells</strong> cantrip: @UUID[Compendium.pf2e.spells-srd.Item.Void Warp]; 1st: @UUID[Compendium.pf2e.spells-srd.Item.Grim Tendrils]; 2nd: @UUID[Compendium.pf2e.spells-srd.Item.False Vitality]; 3rd: @UUID[Compendium.pf2e.spells-srd.Item.Ghostly Weapon]</p>\n<p><strong>Revelation Spells</strong> initial: @UUID[Compendium.pf2e.spells-srd.Item.Soul Siphon]; advanced: @UUID[Compendium.pf2e.spells-srd.Item.Armor of Bones]; greater: @UUID[Compendium.pf2e.spells-srd.Item.Claim Undead]</p>\n<p><strong>Related Domains</strong> death, decay, undeath, vigil</p>\n<p><strong>Mystery Skill</strong> Medicine</p>\n<p><strong>Oracle Feat</strong> @UUID[Compendium.pf2e.feats-srd.Item.Nudge the Scales]</p>\n<p>@UUID[Compendium.pf2e.classfeatures.Item.Curse of the Living Death]</p>"
         },
         "level": {
             "value": 1
@@ -39,29 +39,8 @@
                 "uuid": "Compendium.pf2e.feats-srd.Item.Nudge the Scales"
             },
             {
-                "key": "Weakness",
-                "predicate": [
-                    "self:condition:cursebound"
-                ],
-                "type": [
-                    "vitality",
-                    "void"
-                ],
-                "value": "ternary(gte(@actor.conditions.cursebound.value,3),5+@actor.level,2)"
-            },
-            {
-                "key": "FlatModifier",
-                "predicate": [
-                    {
-                        "gte": [
-                            "self:condition:cursebound",
-                            2
-                        ]
-                    }
-                ],
-                "selector": "fortitude",
-                "type": "status",
-                "value": "ternary(gte(@actor.conditions.cursebound.value,4),-2,-1)"
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Curse of the Living Death"
             }
         ],
         "traits": {

--- a/packs/classfeatures/cosmos.json
+++ b/packs/classfeatures/cosmos.json
@@ -11,7 +11,7 @@
         },
         "category": "classfeature",
         "description": {
-            "value": "<p>Celestial bodies great and small exert influence on you, giving you sublime cosmic power. Perhaps you see the glittering stars as a divine blessing, or perhaps you feel drawn to the infinitely dark spaces between. You might uphold deities like Desna, Sarenrae, or the deific lovers Shizuru and Tsukiyo who represent the sun and the moon—or you might draw power from dark entities from beyond the stars, like certain Outer Gods, or destructive gods of the night like Zon-Kuthon or the rat goddess Lao Shu Po.</p>\n<p><strong>Granted Spells</strong> cantrip: @UUID[Compendium.pf2e.spells-srd.Item.Light]; 1st: @UUID[Compendium.pf2e.spells-srd.Item.Dizzying Colors]; 2nd: @UUID[Compendium.pf2e.spells-srd.Item.Darkness]; 5th: @UUID[Compendium.pf2e.spells-srd.Item.Moon Frenzy]</p>\n<p><strong>Revelation Spells</strong> initial: @UUID[Compendium.pf2e.spells-srd.Item.Spray of Stars]; advanced: @UUID[Compendium.pf2e.spells-srd.Item.Interstellar Void]; greater: @UUID[Compendium.pf2e.spells-srd.Item.Moonlight Bridge]</p>\n<p><strong>Related Domains</strong> darkness, moon, nothingness, star</p>\n<p><strong>Mystery Skill</strong> Nature</p>\n<p><strong>Oracle Feat</strong> @UUID[Compendium.pf2e.feats-srd.Item.Oracular Warning]</p><h2><strong>Curse of the Sky's Call</strong></h2><section class=\"traits\"><p>CURSE</p>\n<p>DIVINE</p>\n<p>ORACLE</p></section><p>Your body is drawn toward the heavens, making you lighter and less substantial than you should be. Your eyes glow with starry light, and your hair and clothing float and drift around you. When you have the @UUID[Compendium.pf2e.conditionitems.Item.Cursebound] condition, you are @UUID[Compendium.pf2e.conditionitems.Item.Enfeebled] with a value equal to your cursebound value, and you take a status penalty to saves and DCs against all forms of forced movement equal to your cursebound value</p>"
+            "value": "<p>Celestial bodies great and small exert influence on you, giving you sublime cosmic power. Perhaps you see the glittering stars as a divine blessing, or perhaps you feel drawn to the infinitely dark spaces between. You might uphold deities like Desna, Sarenrae, or the deific lovers Shizuru and Tsukiyo who represent the sun and the moon—or you might draw power from dark entities from beyond the stars, like certain Outer Gods, or destructive gods of the night like Zon-Kuthon or the rat goddess Lao Shu Po.</p>\n<p><strong>Granted Spells</strong> cantrip: @UUID[Compendium.pf2e.spells-srd.Item.Light]; 1st: @UUID[Compendium.pf2e.spells-srd.Item.Dizzying Colors]; 2nd: @UUID[Compendium.pf2e.spells-srd.Item.Darkness]; 5th: @UUID[Compendium.pf2e.spells-srd.Item.Moon Frenzy]</p>\n<p><strong>Revelation Spells</strong> initial: @UUID[Compendium.pf2e.spells-srd.Item.Spray of Stars]; advanced: @UUID[Compendium.pf2e.spells-srd.Item.Interstellar Void]; greater: @UUID[Compendium.pf2e.spells-srd.Item.Moonlight Bridge]</p>\n<p><strong>Related Domains</strong> darkness, moon, nothingness, star</p>\n<p><strong>Mystery Skill</strong> Nature</p>\n<p><strong>Oracle Feat</strong> @UUID[Compendium.pf2e.feats-srd.Item.Oracular Warning]</p>\n<p>@UUID[Compendium.pf2e.classfeatures.Item.Curse of the Sky's Call]</p>"
         },
         "level": {
             "value": 1
@@ -39,34 +39,8 @@
                 "uuid": "Compendium.pf2e.feats-srd.Item.Oracular Warning"
             },
             {
-                "allowDuplicate": false,
-                "alterations": [
-                    {
-                        "mode": "override",
-                        "property": "badge-value",
-                        "value": "@actor.conditions.cursebound.value"
-                    }
-                ],
-                "inMemoryOnly": true,
                 "key": "GrantItem",
-                "onDeleteActions": {
-                    "grantee": "restrict"
-                },
-                "predicate": [
-                    "self:condition:cursebound"
-                ],
-                "reevaluateOnUpdate": true,
-                "uuid": "Compendium.pf2e.conditionitems.Item.Enfeebled"
-            },
-            {
-                "key": "FlatModifier",
-                "predicate": [
-                    "forced-movement",
-                    "self:condition:cursebound"
-                ],
-                "selector": "saving-throw",
-                "type": "status",
-                "value": "-@actor.conditions.cursebound.value"
+                "uuid": "Compendium.pf2e.classfeatures.Item.Curse of the Sky's Call"
             }
         ],
         "traits": {

--- a/packs/classfeatures/curse-of-ancestral-meddling.json
+++ b/packs/classfeatures/curse-of-ancestral-meddling.json
@@ -1,0 +1,60 @@
+{
+    "_id": "vXnMKFIxqLuCDW9q",
+    "img": "icons/creatures/magical/spirit-undead-masked-blue.webp",
+    "name": "Curse of Ancestral Meddling",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "classfeature",
+        "description": {
+            "value": "<p>The ancestral spirits you commune with haunt you and meddle with your belongings and actions, either out of a wellintentioned (but ultimately detrimental) attempt to assist you, as punishment for your audacity in circumventing the traditional means of achieving divine power, for their own amusement, or a mixture of the above. When you have the @UUID[Compendium.pf2e.conditionitems.Item.Cursebound] condition, you are @UUID[Compendium.pf2e.conditionitems.Item.Clumsy] with a value equal to your cursebound value as the spirits of your ancestors temporarily possess you and vie for control in your mind, hindering your movements.</p>"
+        },
+        "level": {
+            "value": 1
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core 2"
+        },
+        "rules": [
+            {
+                "allowDuplicate": false,
+                "alterations": [
+                    {
+                        "mode": "override",
+                        "property": "badge-value",
+                        "value": "@actor.conditions.cursebound.value"
+                    }
+                ],
+                "inMemoryOnly": true,
+                "key": "GrantItem",
+                "onDeleteActions": {
+                    "grantee": "restrict"
+                },
+                "predicate": [
+                    "self:condition:cursebound"
+                ],
+                "reevaluateOnUpdate": true,
+                "uuid": "Compendium.pf2e.conditionitems.Item.Clumsy"
+            }
+        ],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "curse",
+                "divine",
+                "oracle",
+                "spirit"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/packs/classfeatures/curse-of-engulfing-flames.json
+++ b/packs/classfeatures/curse-of-engulfing-flames.json
@@ -1,0 +1,132 @@
+{
+    "_id": "RI2UHuUZd3TC1OE8",
+    "img": "icons/magic/fire/flame-burning-skull-orange.webp",
+    "name": "Curse of Engulfing Flames",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "classfeature",
+        "description": {
+            "value": "<p>Fires flare noticeably (though not dangerously) in your presence, you occasionally smoke slightly, and your body is almost painfully hot to the touch. When you have the @UUID[Compendium.pf2e.conditionitems.Item.Cursebound] condition, you catch fire, taking persistent fire damage equal to your cursebound value. The flames shed light like a torch, and if you enter an environment where they could not burn (such as underwater), you simply seethe with flameless heat. The flames subside when you begin Refocusing to assuage your curse or if you fall @UUID[Compendium.pf2e.conditionitems.Item.Unconscious], but they resume if your Refocus activity is interrupted or when you return to consciousness.</p>"
+        },
+        "level": {
+            "value": 1
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core 2"
+        },
+        "rules": [
+            {
+                "allowDuplicate": false,
+                "alterations": [
+                    {
+                        "mode": "override",
+                        "property": "persistent-damage",
+                        "value": {
+                            "damageType": "fire",
+                            "formula": "1"
+                        }
+                    }
+                ],
+                "inMemoryOnly": true,
+                "key": "GrantItem",
+                "onDeleteActions": {
+                    "grantee": "restrict"
+                },
+                "predicate": [
+                    "self:condition:cursebound:1"
+                ],
+                "reevaluateOnUpdate": true,
+                "uuid": "Compendium.pf2e.conditionitems.Item.Persistent Damage"
+            },
+            {
+                "allowDuplicate": false,
+                "alterations": [
+                    {
+                        "mode": "override",
+                        "property": "persistent-damage",
+                        "value": {
+                            "damageType": "fire",
+                            "formula": "2"
+                        }
+                    }
+                ],
+                "inMemoryOnly": true,
+                "key": "GrantItem",
+                "onDeleteActions": {
+                    "grantee": "restrict"
+                },
+                "predicate": [
+                    "self:condition:cursebound:2"
+                ],
+                "reevaluateOnUpdate": true,
+                "uuid": "Compendium.pf2e.conditionitems.Item.Persistent Damage"
+            },
+            {
+                "allowDuplicate": false,
+                "alterations": [
+                    {
+                        "mode": "override",
+                        "property": "persistent-damage",
+                        "value": {
+                            "damageType": "fire",
+                            "formula": "3"
+                        }
+                    }
+                ],
+                "inMemoryOnly": true,
+                "key": "GrantItem",
+                "onDeleteActions": {
+                    "grantee": "restrict"
+                },
+                "predicate": [
+                    "self:condition:cursebound:3"
+                ],
+                "reevaluateOnUpdate": true,
+                "uuid": "Compendium.pf2e.conditionitems.Item.Persistent Damage"
+            },
+            {
+                "allowDuplicate": false,
+                "alterations": [
+                    {
+                        "mode": "override",
+                        "property": "persistent-damage",
+                        "value": {
+                            "damageType": "fire",
+                            "formula": "4"
+                        }
+                    }
+                ],
+                "inMemoryOnly": true,
+                "key": "GrantItem",
+                "onDeleteActions": {
+                    "grantee": "restrict"
+                },
+                "predicate": [
+                    "self:condition:cursebound:4"
+                ],
+                "reevaluateOnUpdate": true,
+                "uuid": "Compendium.pf2e.conditionitems.Item.Persistent Damage"
+            }
+        ],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "curse",
+                "divine",
+                "fire",
+                "oracle"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/packs/classfeatures/curse-of-inclement-headwinds.json
+++ b/packs/classfeatures/curse-of-inclement-headwinds.json
@@ -1,0 +1,70 @@
+{
+    "_id": "LIV2gH3ZUFlu0zu4",
+    "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
+    "name": "Curse of Inclement Headwinds",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "classfeature",
+        "description": {
+            "value": "<p>The weather seems to always oppose you in ways large and small. Even when you are calm and at rest, your hair and clothing are inconveniently blown about by gentle winds, you are slightly damp from the faintest drizzle, and your touch often comes with a static shock. When you have the @UUID[Compendium.pf2e.conditionitems.Item.Cursebound] condition, you are opposed by the elements, with the following effects.</p>\n<p><strong>Cursebound 1</strong> Lightning is drawn to you. You gain electricity weakness 2 and electricity spells or effects that have additional effects for a creature wearing or holding metal treat you as though you were wearing metal. Any immunity or resistance you have to such spells and effects is suppressed.</p>\n<p><strong>Cursebound 2</strong> Blowing winds impose a -2 circumstance penalty to ranged attack rolls you make.</p>\n<p><strong>Cursebound 3</strong> Your weakness to electricity is equal to 5 + your level.</p>\n<p><strong>Cursebound 4</strong> The raging winds push you back, imposing a -10-foot status penalty to all your Speeds.</p>"
+        },
+        "level": {
+            "value": 1
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core 2"
+        },
+        "rules": [
+            {
+                "key": "Weakness",
+                "predicate": [
+                    "self:condition:cursebound"
+                ],
+                "type": "electricity",
+                "value": "ternary(gte(@actor.conditions.cursebound.value,3),5+@actor.level,2)"
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "item:ranged",
+                    {
+                        "gte": [
+                            "self:condition:cursebound",
+                            2
+                        ]
+                    }
+                ],
+                "selector": "attack-roll",
+                "type": "circumstance",
+                "value": -2
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "self:condition:cursebound:4"
+                ],
+                "selector": "speed",
+                "value": -10
+            }
+        ],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "curse",
+                "divine",
+                "oracle"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/packs/classfeatures/curse-of-outpouring-life.json
+++ b/packs/classfeatures/curse-of-outpouring-life.json
@@ -1,0 +1,49 @@
+{
+    "_id": "zO7dvBgLuhdGfP5t",
+    "img": "icons/magic/life/heart-cross-strong-purple-orange.webp",
+    "name": "Curse of Outpouring Life",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "classfeature",
+        "description": {
+            "value": "<p>Life energy flows outward from you and connects you to all living things, but you expend your vital essence to do so. Your presence comforts the ill and injured, causes scars to fade slightly, spurs new growth in plants, and otherwise infuses your surroundings with vitality. As your life force seeps outward, it becomes more difficult to keep your body functioning. Magical effects that restore Hit Points to you take a status penalty equal to your level (minimum 1) times your @UUID[Compendium.pf2e.conditionitems.Item.Cursebound] value to the number of HP you recover.</p>"
+        },
+        "level": {
+            "value": 1
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core 2"
+        },
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "self:condition:cursebound",
+                    "item:magical"
+                ],
+                "selector": "healing-received",
+                "type": "status",
+                "value": "-@actor.level*@actor.conditions.cursebound.value"
+            }
+        ],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "curse",
+                "divine",
+                "oracle"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/packs/classfeatures/curse-of-the-living-death.json
+++ b/packs/classfeatures/curse-of-the-living-death.json
@@ -1,0 +1,66 @@
+{
+    "_id": "8ODGE24gqEdzWljj",
+    "img": "icons/magic/death/skeleton-skull-soul-blue.webp",
+    "name": "Curse of the Living Death",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "classfeature",
+        "description": {
+            "value": "<p>Your body is slowly decaying even though you are alive, and using your powers furthers this unnatural living death, making you susceptible to both void and vitality damage. You carry a touch of the grave about you, manifesting as bloodless pallor, a faint smell of earth, or deathly cold skin.</p>\n<p><strong>@UUID[Compendium.pf2e.conditionitems.Item.Cursebound]{Cursebound 1}</strong> You gain weakness 2 to vitality and void damage. You can be hurt by both vitality and void damage even if one or the other normally has no effect on you. Any immunity or resistance you have to vitality or void is suppressed.</p>\n<p><strong>Cursebound 2</strong> You take a –1 status penalty to Fortitude saves.</p>\n<p><strong>Cursebound 3</strong> Your weakness to vitality and void damage is equal to 5 + your level.</p>\n<p><strong>Cursebound 4</strong> Your status penalty to Fortitude saving throws increases to –2.</p>"
+        },
+        "level": {
+            "value": 1
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core 2"
+        },
+        "rules": [
+            {
+                "key": "Weakness",
+                "predicate": [
+                    "self:condition:cursebound"
+                ],
+                "type": [
+                    "vitality",
+                    "void"
+                ],
+                "value": "ternary(gte(@actor.conditions.cursebound.value,3),5+@actor.level,2)"
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    {
+                        "gte": [
+                            "self:condition:cursebound",
+                            2
+                        ]
+                    }
+                ],
+                "selector": "fortitude",
+                "type": "status",
+                "value": "ternary(gte(@actor.conditions.cursebound.value,4),-2,-1)"
+            }
+        ],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "curse",
+                "divine",
+                "oracle",
+                "vitality",
+                "void"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/packs/classfeatures/curse-of-the-mortal-warrior.json
+++ b/packs/classfeatures/curse-of-the-mortal-warrior.json
@@ -1,0 +1,62 @@
+{
+    "_id": "zLYqrQdheciiW2nm",
+    "img": "icons/skills/melee/sword-stuck-glowing-pink.webp",
+    "name": "Curse of the Mortal Warrior",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "classfeature",
+        "description": {
+            "value": "<p>You thrive in the thick of battle, but your mystery's sheer focus on the physical and material leaves your soul weak against the tricks of spellcraft. You smell faintly of steel and blood no matter how you try to remove or mask the scent, you appear more imposing and muscular than you actually are, and you hear the faint clash and clamor of battle in the distance at all times.</p>\n<p><strong>@UUID[Compendium.pf2e.conditionitems.Item.Cursebound]{Cursebound 1}</strong> Spells have an easier time wounding you. You gain weakness 2 to any damage dealt by a spell. Any immunity or resistance you have to spells is suppressed. This applies only to spells, not other magical abilities.</p>\n<p><strong>Cursebound 2</strong> You take a –1 status penalty to saving throws against spells.</p>\n<p><strong>Cursebound 3</strong> Your weakness to spells is equal to your level.</p>\n<p><strong>Cursebound 4</strong> Your status penalty to saving throws against spells increases to –2.</p>"
+        },
+        "level": {
+            "value": 1
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core 2"
+        },
+        "rules": [
+            {
+                "key": "Weakness",
+                "predicate": [
+                    "self:condition:cursebound"
+                ],
+                "type": "spells",
+                "value": "ternary(gte(@actor.conditions.cursebound.value,3),@actor.level,2)"
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "item:spell",
+                    {
+                        "gte": [
+                            "self:condition:cursebound",
+                            2
+                        ]
+                    }
+                ],
+                "selector": "saving-throw",
+                "type": "status",
+                "value": "ternary(gte(@actor.conditions.cursebound.value,4),-2,-1)"
+            }
+        ],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "curse",
+                "divine",
+                "oracle"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/packs/classfeatures/curse-of-the-skys-call.json
+++ b/packs/classfeatures/curse-of-the-skys-call.json
@@ -1,0 +1,69 @@
+{
+    "_id": "d03gBFLK4XJlDNNh",
+    "img": "icons/magic/nature/moon-crescent.webp",
+    "name": "Curse of the Sky's Call",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "classfeature",
+        "description": {
+            "value": "<p>Your body is drawn toward the heavens, making you lighter and less substantial than you should be. Your eyes glow with starry light, and your hair and clothing float and drift around you. When you have the @UUID[Compendium.pf2e.conditionitems.Item.Cursebound] condition, you are @UUID[Compendium.pf2e.conditionitems.Item.Enfeebled] with a value equal to your cursebound value, and you take a status penalty to saves and DCs against all forms of forced movement equal to your cursebound value</p>"
+        },
+        "level": {
+            "value": 1
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core 2"
+        },
+        "rules": [
+            {
+                "allowDuplicate": false,
+                "alterations": [
+                    {
+                        "mode": "override",
+                        "property": "badge-value",
+                        "value": "@actor.conditions.cursebound.value"
+                    }
+                ],
+                "inMemoryOnly": true,
+                "key": "GrantItem",
+                "onDeleteActions": {
+                    "grantee": "restrict"
+                },
+                "predicate": [
+                    "self:condition:cursebound"
+                ],
+                "reevaluateOnUpdate": true,
+                "uuid": "Compendium.pf2e.conditionitems.Item.Enfeebled"
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "forced-movement",
+                    "self:condition:cursebound"
+                ],
+                "selector": "saving-throw",
+                "type": "status",
+                "value": "-@actor.conditions.cursebound.value"
+            }
+        ],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "curse",
+                "divine",
+                "oracle"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/packs/classfeatures/curse-of-torrential-knowledge.json
+++ b/packs/classfeatures/curse-of-torrential-knowledge.json
@@ -1,0 +1,64 @@
+{
+    "_id": "XQjR07LkDedC7tkc",
+    "img": "icons/sundries/documents/document-symbol-circle-gold-red.webp",
+    "name": "Curse of Torrential Knowledge",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "classfeature",
+        "description": {
+            "value": "<p>You have a link to true divine knowledge, but your mortal mind struggles to process and act on what you know. Loose materials around you, such as dust, grains of rice, and droplets of water, slowly shift to form strange runes or faint, indecipherable writing, and you sometimes speak unintelligible truths or statements in unknown languages without realizing it. You take a status penalty to Perception checks and Will saving throws equal to your @UUID[Compendium.pf2e.conditionitems.Item.Cursebound] value due to the torrential distractions of unasked-for knowledge flooding your mind. If you are cursebound 4, you additionally can't speak, use linguistic effects, or otherwise communicate with your allies, and you are @UUID[Compendium.pf2e.conditionitems.Item.Stupefied]{Stupefied 1}</p>"
+        },
+        "level": {
+            "value": 1
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core 2"
+        },
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "self:condition:cursebound"
+                ],
+                "selector": [
+                    "perception",
+                    "will"
+                ],
+                "type": "status",
+                "value": "-@actor.conditions.cursebound.value"
+            },
+            {
+                "allowDuplicate": false,
+                "inMemoryOnly": true,
+                "key": "GrantItem",
+                "onDeleteActions": {
+                    "grantee": "restrict"
+                },
+                "predicate": [
+                    "self:condition:cursebound:4"
+                ],
+                "reevaluateOnUpdate": true,
+                "uuid": "Compendium.pf2e.conditionitems.Item.Stupefied"
+            }
+        ],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "curse",
+                "divine",
+                "oracle"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/packs/classfeatures/flames.json
+++ b/packs/classfeatures/flames.json
@@ -11,7 +11,7 @@
         },
         "category": "classfeature",
         "description": {
-            "value": "<p>Fire lives at the center of the world, the center of the sun, and the center of civilization. You might revere this elemental force, siphon power from the Elemental Plane of Fire, or venerate a collection of deities such as Asmodeus, Sarenrae, the Tian goddess of disasters and volcanoes Lady Nanbyo, or the elemental lord of fire Ymeri.</p>\n<p><strong>Granted Spells</strong> cantrip: @UUID[Compendium.pf2e.spells-srd.Item.Ignition]; 1st: @UUID[Compendium.pf2e.spells-srd.Item.Breathe Fire]; 2nd: @UUID[Compendium.pf2e.spells-srd.Item.Blazing Bolt]; 3rd: @UUID[Compendium.pf2e.spells-srd.Item.Fireball]</p>\n<p><strong>Revelation Spells</strong> initial: @UUID[Compendium.pf2e.spells-srd.Item.Incendiary Aura]; advanced: @UUID[Compendium.pf2e.spells-srd.Item.Whirling Flames]; greater: @UUID[Compendium.pf2e.spells-srd.Item.Flaming Fusillade]</p>\n<p><strong>Related Domains</strong> dust, fire, star, sun</p>\n<p><strong>Mystery Skill</strong> Acrobatics</p>\n<p><strong>Oracle Feat</strong> @UUID[Compendium.pf2e.feats-srd.Item.Foretell Harm]</p><h2><strong>Curse of Engulfing Flames</strong></h2><section class=\"traits\"><p>CURSE</p>\n<p>DIVINE</p>\n<p>fire</p>\n<p>ORACLE</p></section><p>Fires flare noticeably (though not dangerously) in your presence, you occasionally smoke slightly, and your body is almost painfully hot to the touch. When you have the @UUID[Compendium.pf2e.conditionitems.Item.Cursebound] condition, you catch fire, taking persistent fire damage equal to your cursebound value. The flames shed light like a torch, and if you enter an environment where they could not burn (such as underwater), you simply seethe with flameless heat. The flames subside when you begin Refocusing to assuage your curse or if you fall @UUID[Compendium.pf2e.conditionitems.Item.Unconscious], but they resume if your Refocus activity is interrupted or when you return to consciousness.</p>"
+            "value": "<p>Fire lives at the center of the world, the center of the sun, and the center of civilization. You might revere this elemental force, siphon power from the Elemental Plane of Fire, or venerate a collection of deities such as Asmodeus, Sarenrae, the Tian goddess of disasters and volcanoes Lady Nanbyo, or the elemental lord of fire Ymeri.</p>\n<p><strong>Granted Spells</strong> cantrip: @UUID[Compendium.pf2e.spells-srd.Item.Ignition]; 1st: @UUID[Compendium.pf2e.spells-srd.Item.Breathe Fire]; 2nd: @UUID[Compendium.pf2e.spells-srd.Item.Blazing Bolt]; 3rd: @UUID[Compendium.pf2e.spells-srd.Item.Fireball]</p>\n<p><strong>Revelation Spells</strong> initial: @UUID[Compendium.pf2e.spells-srd.Item.Incendiary Aura]; advanced: @UUID[Compendium.pf2e.spells-srd.Item.Whirling Flames]; greater: @UUID[Compendium.pf2e.spells-srd.Item.Flaming Fusillade]</p>\n<p><strong>Related Domains</strong> dust, fire, star, sun</p>\n<p><strong>Mystery Skill</strong> Acrobatics</p>\n<p><strong>Oracle Feat</strong> @UUID[Compendium.pf2e.feats-srd.Item.Foretell Harm]</p>\n<p>@UUID[Compendium.pf2e.classfeatures.Item.Curse of Engulfing Flames]</p>"
         },
         "level": {
             "value": 1
@@ -39,96 +39,8 @@
                 "uuid": "Compendium.pf2e.feats-srd.Item.Foretell Harm"
             },
             {
-                "allowDuplicate": false,
-                "alterations": [
-                    {
-                        "mode": "override",
-                        "property": "persistent-damage",
-                        "value": {
-                            "damageType": "fire",
-                            "formula": "1"
-                        }
-                    }
-                ],
-                "inMemoryOnly": true,
                 "key": "GrantItem",
-                "onDeleteActions": {
-                    "grantee": "restrict"
-                },
-                "predicate": [
-                    "self:condition:cursebound:1"
-                ],
-                "reevaluateOnUpdate": true,
-                "uuid": "Compendium.pf2e.conditionitems.Item.Persistent Damage"
-            },
-            {
-                "allowDuplicate": false,
-                "alterations": [
-                    {
-                        "mode": "override",
-                        "property": "persistent-damage",
-                        "value": {
-                            "damageType": "fire",
-                            "formula": "2"
-                        }
-                    }
-                ],
-                "inMemoryOnly": true,
-                "key": "GrantItem",
-                "onDeleteActions": {
-                    "grantee": "restrict"
-                },
-                "predicate": [
-                    "self:condition:cursebound:2"
-                ],
-                "reevaluateOnUpdate": true,
-                "uuid": "Compendium.pf2e.conditionitems.Item.Persistent Damage"
-            },
-            {
-                "allowDuplicate": false,
-                "alterations": [
-                    {
-                        "mode": "override",
-                        "property": "persistent-damage",
-                        "value": {
-                            "damageType": "fire",
-                            "formula": "3"
-                        }
-                    }
-                ],
-                "inMemoryOnly": true,
-                "key": "GrantItem",
-                "onDeleteActions": {
-                    "grantee": "restrict"
-                },
-                "predicate": [
-                    "self:condition:cursebound:3"
-                ],
-                "reevaluateOnUpdate": true,
-                "uuid": "Compendium.pf2e.conditionitems.Item.Persistent Damage"
-            },
-            {
-                "allowDuplicate": false,
-                "alterations": [
-                    {
-                        "mode": "override",
-                        "property": "persistent-damage",
-                        "value": {
-                            "damageType": "fire",
-                            "formula": "4"
-                        }
-                    }
-                ],
-                "inMemoryOnly": true,
-                "key": "GrantItem",
-                "onDeleteActions": {
-                    "grantee": "restrict"
-                },
-                "predicate": [
-                    "self:condition:cursebound:4"
-                ],
-                "reevaluateOnUpdate": true,
-                "uuid": "Compendium.pf2e.conditionitems.Item.Persistent Damage"
+                "uuid": "Compendium.pf2e.classfeatures.Item.Curse of Engulfing Flames"
             }
         ],
         "traits": {

--- a/packs/classfeatures/life.json
+++ b/packs/classfeatures/life.json
@@ -11,7 +11,7 @@
         },
         "category": "classfeature",
         "description": {
-            "value": "<p>The never-ending flow of life force within living beings is palpable to you. You might uphold the sanctity of life, or perhaps you seek to undermine it. You might draw power from the collective vitality of the world's living creatures, hold some connection to Creation's Forge, or revere a collection of deities including Irori, Pharasma, Sarenrae, and the god of medicine Qi Zhong.</p>\n<p><strong>Granted Spells</strong> cantrip: @UUID[Compendium.pf2e.spells-srd.Item.Vitality Lash]; 1st: @UUID[Compendium.pf2e.spells-srd.Item.Soothe]; 2nd: @UUID[Compendium.pf2e.spells-srd.Item.False Vitality]; 5th: @UUID[Compendium.pf2e.spells-srd.Item.Grisly Growths]</p>\n<p><strong>Revelation Spells</strong> initial: @UUID[Compendium.pf2e.spells-srd.Item.Life Link]; advanced: @UUID[Compendium.pf2e.spells-srd.Item.Delay Affliction]; greater: @UUID[Compendium.pf2e.spells-srd.Item.Life-Giving Form]</p>\n<p><strong>Related Domains</strong> death, healing, pain, soul</p>\n<p><strong>Mystery Skill</strong> Medicine</p>\n<p><strong>Oracle Feat</strong> @UUID[Compendium.pf2e.feats-srd.Item.Nudge the Scales]</p><h2><strong>Curse of Outpouring Life</strong></h2><section class=\"traits\"><p>CURSE</p>\n<p>DIVINE</p>\n<p>ORACLE</p></section><p>Life energy flows outward from you and connects you to all living things, but you expend your vital essence to do so. Your presence comforts the ill and injured, causes scars to fade slightly, spurs new growth in plants, and otherwise infuses your surroundings with vitality. As your life force seeps outward, it becomes more difficult to keep your body functioning. Magical effects that restore Hit Points to you take a status penalty equal to your level (minimum 1) times your @UUID[Compendium.pf2e.conditionitems.Item.Cursebound] value to the number of HP you recover.</p>"
+            "value": "<p>The never-ending flow of life force within living beings is palpable to you. You might uphold the sanctity of life, or perhaps you seek to undermine it. You might draw power from the collective vitality of the world's living creatures, hold some connection to Creation's Forge, or revere a collection of deities including Irori, Pharasma, Sarenrae, and the god of medicine Qi Zhong.</p>\n<p><strong>Granted Spells</strong> cantrip: @UUID[Compendium.pf2e.spells-srd.Item.Vitality Lash]; 1st: @UUID[Compendium.pf2e.spells-srd.Item.Soothe]; 2nd: @UUID[Compendium.pf2e.spells-srd.Item.False Vitality]; 5th: @UUID[Compendium.pf2e.spells-srd.Item.Grisly Growths]</p>\n<p><strong>Revelation Spells</strong> initial: @UUID[Compendium.pf2e.spells-srd.Item.Life Link]; advanced: @UUID[Compendium.pf2e.spells-srd.Item.Delay Affliction]; greater: @UUID[Compendium.pf2e.spells-srd.Item.Life-Giving Form]</p>\n<p><strong>Related Domains</strong> death, healing, pain, soul</p>\n<p><strong>Mystery Skill</strong> Medicine</p>\n<p><strong>Oracle Feat</strong> @UUID[Compendium.pf2e.feats-srd.Item.Nudge the Scales]</p>\n<p>@UUID[Compendium.pf2e.classfeatures.Item.Curse of Outpouring Life]</p>"
         },
         "level": {
             "value": 1
@@ -39,14 +39,8 @@
                 "uuid": "Compendium.pf2e.feats-srd.Item.Nudge the Scales"
             },
             {
-                "key": "FlatModifier",
-                "predicate": [
-                    "self:condition:cursebound",
-                    "item:magical"
-                ],
-                "selector": "healing-received",
-                "type": "status",
-                "value": "-@actor.level*@actor.conditions.cursebound.value"
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Curse of Outpouring Life"
             }
         ],
         "traits": {

--- a/packs/classfeatures/lore.json
+++ b/packs/classfeatures/lore.json
@@ -11,7 +11,7 @@
         },
         "category": "classfeature",
         "description": {
-            "value": "<p>Knowledge and information come freely to you. You might use this lore to gain power or perhaps to understand the divine mysteries of the multiverse. You might have a conduit to the fabled Akashic Record, maintain a subtle telepathic connection to the collective subconscious of all living creatures, or follow in the footsteps of deities such as Abadar, Irori, Nethys, Irori's scholarly nephew Gruhastha, the fey triune goddess of fate Magdh, or the aeon god figure known as the Monad.</p>\n<p><strong>Granted Spells</strong> cantrip: @UUID[Compendium.pf2e.spells-srd.Item.Read Aura]; 1st: @UUID[Compendium.pf2e.spells-srd.Item.Mindlink]; 3rd: @UUID[Compendium.pf2e.spells-srd.Item.Hypercognition]; 6th: @UUID[Compendium.pf2e.spells-srd.Item.Never Mind]</p>\n<p><strong>Revelation Spells</strong> initial: @UUID[Compendium.pf2e.spells-srd.Item.Brain Drain]; advanced: @UUID[Compendium.pf2e.spells-srd.Item.Access Lore]; greater: @UUID[Compendium.pf2e.spells-srd.Item.Dread Secret]</p>\n<p><strong>Related Domains</strong> knowledge, magic, secrecy, truth</p>\n<p><strong>Mystery Skill</strong> Occultism and one Lore skill of your choice</p>\n<p><strong>Oracle Feat</strong> @UUID[Compendium.pf2e.feats-srd.Item.Whispers of Weakness]</p><h2><strong>Curse of Torrential Knowledge</strong></h2><section class=\"traits\"><p>CURSE</p>\n<p>DIVINE</p>\n<p>ORACLE</p></section><p>You have a link to true divine knowledge, but your mortal mind struggles to process and act on what you know. Loose materials around you, such as dust, grains of rice, and droplets of water, slowly shift to form strange runes or faint, indecipherable writing, and you sometimes speak unintelligible truths or statements in unknown languages without realizing it. You take a status penalty to Perception checks and Will saving throws equal to your @UUID[Compendium.pf2e.conditionitems.Item.Cursebound] value due to the torrential distractions of unasked-for knowledge flooding your mind. If you are cursebound 4, you additionally can't speak, use linguistic effects, or otherwise communicate with your allies, and you are @UUID[Compendium.pf2e.conditionitems.Item.Stupefied]{Stupefied 1}</p>"
+            "value": "<p>Knowledge and information come freely to you. You might use this lore to gain power or perhaps to understand the divine mysteries of the multiverse. You might have a conduit to the fabled Akashic Record, maintain a subtle telepathic connection to the collective subconscious of all living creatures, or follow in the footsteps of deities such as Abadar, Irori, Nethys, Irori's scholarly nephew Gruhastha, the fey triune goddess of fate Magdh, or the aeon god figure known as the Monad.</p>\n<p><strong>Granted Spells</strong> cantrip: @UUID[Compendium.pf2e.spells-srd.Item.Read Aura]; 1st: @UUID[Compendium.pf2e.spells-srd.Item.Mindlink]; 3rd: @UUID[Compendium.pf2e.spells-srd.Item.Hypercognition]; 6th: @UUID[Compendium.pf2e.spells-srd.Item.Never Mind]</p>\n<p><strong>Revelation Spells</strong> initial: @UUID[Compendium.pf2e.spells-srd.Item.Brain Drain]; advanced: @UUID[Compendium.pf2e.spells-srd.Item.Access Lore]; greater: @UUID[Compendium.pf2e.spells-srd.Item.Dread Secret]</p>\n<p><strong>Related Domains</strong> knowledge, magic, secrecy, truth</p>\n<p><strong>Mystery Skill</strong> Occultism and one Lore skill of your choice</p>\n<p><strong>Oracle Feat</strong> @UUID[Compendium.pf2e.feats-srd.Item.Whispers of Weakness]</p>\n<p>@UUID[Compendium.pf2e.classfeatures.Item.Curse of Torrential Knowledge]</p>"
         },
         "level": {
             "value": 1
@@ -39,29 +39,8 @@
                 "uuid": "Compendium.pf2e.feats-srd.Item.Whispers of Weakness"
             },
             {
-                "key": "FlatModifier",
-                "predicate": [
-                    "self:condition:cursebound"
-                ],
-                "selector": [
-                    "perception",
-                    "will"
-                ],
-                "type": "status",
-                "value": "-@actor.conditions.cursebound.value"
-            },
-            {
-                "allowDuplicate": false,
-                "inMemoryOnly": true,
                 "key": "GrantItem",
-                "onDeleteActions": {
-                    "grantee": "restrict"
-                },
-                "predicate": [
-                    "self:condition:cursebound:4"
-                ],
-                "reevaluateOnUpdate": true,
-                "uuid": "Compendium.pf2e.conditionitems.Item.Stupefied"
+                "uuid": "Compendium.pf2e.classfeatures.Item.Curse of Torrential Knowledge"
             }
         ],
         "traits": {

--- a/packs/classfeatures/tempest.json
+++ b/packs/classfeatures/tempest.json
@@ -11,7 +11,7 @@
         },
         "category": "classfeature",
         "description": {
-            "value": "<p>The fury of the wind and waves pounds in your heart, whether your power flows from natural storms, a conduit to the elemental Planes of Air and Water, or through reverence of deities such as Gozreh, the tengu god of storms Hei Feng, the pirate queen Besmara, or the elemental lords of air and water.</p>\n<p><strong>Granted Spells</strong> cantrip: @UUID[Compendium.pf2e.spells-srd.Item.Electric Arc]{Electric Arc;} 1st: @UUID[Compendium.pf2e.spells-srd.Item.Thunderstrike]; 4th: @UUID[Compendium.pf2e.spells-srd.Item.Hydraulic Torrent]; 6th: @UUID[Compendium.pf2e.spells-srd.Item.Chain Lightning]</p>\n<p><strong>Revelation Spells</strong> initial: @UUID[Compendium.pf2e.spells-srd.Item.Tempest Touch]; advanced: @UUID[Compendium.pf2e.spells-srd.Item.Thunderburst]; greater: @UUID[Compendium.pf2e.spells-srd.Item.Tempest Form]</p>\n<p><strong>Related Domains</strong> air, cold, lightning, water</p>\n<p><strong>Mystery Skill</strong> Nature</p>\n<p><strong>Oracle Feat</strong> @UUID[Compendium.pf2e.feats-srd.Item.Foretell Harm]</p><h2><strong>Curse of Inclement Headwinds</strong></h2><section class=\"traits\"><p>CURSE</p>\n<p>DIVINE</p>\n<p>ORACLE</p></section><p>The weather seems to always oppose you in ways large and small. Even when you are calm and at rest, your hair and clothing are inconveniently blown about by gentle winds, you are slightly damp from the faintest drizzle, and your touch often comes with a static shock. When you have the @UUID[Compendium.pf2e.conditionitems.Item.Cursebound] condition, you are opposed by the elements, with the following effects.</p>\n<p><strong>Cursebound 1</strong> Lightning is drawn to you. You gain electricity weakness 2 and electricity spells or effects that have additional effects for a creature wearing or holding metal treat you as though you were wearing metal. Any immunity or resistance you have to such spells and effects is suppressed.</p>\n<p><strong>Cursebound 2</strong> Blowing winds impose a -2 circumstance penalty to ranged attack rolls you make.</p>\n<p><strong>Cursebound 3</strong> Your weakness to electricity is equal to 5 + your level.</p>\n<p><strong>Cursebound 4</strong> The raging winds push you back, imposing a -10-foot status penalty to all your Speeds.</p>"
+            "value": "<p>The fury of the wind and waves pounds in your heart, whether your power flows from natural storms, a conduit to the elemental Planes of Air and Water, or through reverence of deities such as Gozreh, the tengu god of storms Hei Feng, the pirate queen Besmara, or the elemental lords of air and water.</p>\n<p><strong>Granted Spells</strong> cantrip: @UUID[Compendium.pf2e.spells-srd.Item.Electric Arc]{Electric Arc;} 1st: @UUID[Compendium.pf2e.spells-srd.Item.Thunderstrike]; 4th: @UUID[Compendium.pf2e.spells-srd.Item.Hydraulic Torrent]; 6th: @UUID[Compendium.pf2e.spells-srd.Item.Chain Lightning]</p>\n<p><strong>Revelation Spells</strong> initial: @UUID[Compendium.pf2e.spells-srd.Item.Tempest Touch]; advanced: @UUID[Compendium.pf2e.spells-srd.Item.Thunderburst]; greater: @UUID[Compendium.pf2e.spells-srd.Item.Tempest Form]</p>\n<p><strong>Related Domains</strong> air, cold, lightning, water</p>\n<p><strong>Mystery Skill</strong> Nature</p>\n<p><strong>Oracle Feat</strong> @UUID[Compendium.pf2e.feats-srd.Item.Foretell Harm]</p>\n<p>@UUID[Compendium.pf2e.classfeatures.Item.Curse of Inclement Headwinds]</p>"
         },
         "level": {
             "value": 1
@@ -39,35 +39,8 @@
                 "uuid": "Compendium.pf2e.feats-srd.Item.Foretell Harm"
             },
             {
-                "key": "Weakness",
-                "predicate": [
-                    "self:condition:cursebound"
-                ],
-                "type": "electricity",
-                "value": "ternary(gte(@actor.conditions.cursebound.value,3),5+@actor.level,2)"
-            },
-            {
-                "key": "FlatModifier",
-                "predicate": [
-                    "item:ranged",
-                    {
-                        "gte": [
-                            "self:condition:cursebound",
-                            2
-                        ]
-                    }
-                ],
-                "selector": "attack-roll",
-                "type": "circumstance",
-                "value": -2
-            },
-            {
-                "key": "FlatModifier",
-                "predicate": [
-                    "self:condition:cursebound:4"
-                ],
-                "selector": "speed",
-                "value": -10
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.classfeatures.Item.Curse of Inclement Headwinds"
             }
         ],
         "traits": {


### PR DESCRIPTION
Before
![image](https://github.com/user-attachments/assets/025ab56e-37c4-4cb6-bca6-016a5d7fcce7)
After
![image](https://github.com/user-attachments/assets/755b9512-6e96-46bd-9de6-2ea2dd734a2c)
Perhaps how I should've entered them to begin with, this allows them to be sent to chat nicely formatted and compact, and gives a more accurate picture on where the penalties come from on tooltips and roll breakdowns.
![image](https://github.com/user-attachments/assets/c07d930f-20ea-4071-b0f2-ab066afce55b)
![image](https://github.com/user-attachments/assets/39cdaa6b-86c1-4dbc-a531-62df189213db)