### PR TITLE
Allow "roller role" (target/origin status) of inline check rolls to be overridden

### DIFF
--- a/src/module/system/statistic/statistic.ts
+++ b/src/module/system/statistic/statistic.ts
@@ -418,7 +418,7 @@ class StatisticCheck<TParent extends Statistic = Statistic> {
         const self = this.actor;
         const domains = this.domains;
         const selfToken = args.token ?? self.getActiveTokens(true, true).shift() ?? null;
-        const selfIsTarget = this.type === "saving-throw";
+        const selfIsTarget = self === args.target || (!args.target && this.type === "saving-throw");
         const item = args.item ?? null;
         const originToken = selfIsTarget ? args.origin?.getActiveTokens(true, true).shift() : selfToken;
         const targetToken = selfIsTarget
@@ -428,6 +428,7 @@ class StatisticCheck<TParent extends Statistic = Statistic> {
               null;
 
         const selfIsTargeting =
+            !selfIsTarget &&
             !!targetToken &&
             ((this.domains.includes("spell-attack-roll") && item?.isOfType("spell")) ||
                 (!["flat-check", "saving-throw"].includes(this.type) &&

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1671,6 +1671,7 @@
         "InlineCheck": {
             "BasicWithSave": "Basic {save}",
             "DCWithName": "{name} DC",
+            "DCAdjustment": "DC Adjustment",
             "Invalid": "Invalid @Check expression: {message}",
             "Errors": {
                 "AdjustmentLengthMismatch": "mismatch between number of type and adjustment parameters",


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fb7bcf37-a84b-44ea-b8bb-3759394d383b)
