### PR TITLE
RulerPF2e - Add Hexagonal Segment Highlighting

### DIFF
--- a/src/module/canvas/ruler.ts
+++ b/src/module/canvas/ruler.ts
@@ -224,13 +224,19 @@ class RulerPF2e<TToken extends TokenPF2e | null = TokenPF2e | null> extends Rule
             }
 
             // We are going to get the direct path from the start of the segment offset by centerOffset to the end of the segment offset by centerOffset
-            for (const offset of canvas.grid.getDirectPath([{ x: segment.ray.A.x - centerOffset.x, y: segment.ray.A.y - centerOffset.y }, { x: segment.ray.B.x - centerOffset.x, y: segment.ray.B.y - centerOffset.y }])) {
+            for (const offset of canvas.grid.getDirectPath([
+                { x: segment.ray.A.x - centerOffset.x, y: segment.ray.A.y - centerOffset.y },
+                { x: segment.ray.B.x - centerOffset.x, y: segment.ray.B.y - centerOffset.y },
+            ])) {
                 for (const stomp of this.#footprint) {
                     // Get the center point of  the offset we are currently at
                     const offsetCenter = canvas.grid.getCenterPoint(offset);
                     // Reverse the offset we originally did plus, this will put us back at the true center of the token
                     // We then add the offset from the current grid we are working with on the token's footprint, which is an offset from the token's center
-                    const newPoint = { x: offsetCenter.x + centerOffset.x + stomp.x, y: offsetCenter.y + centerOffset.y + stomp.y };
+                    const newPoint = {
+                        x: offsetCenter.x + centerOffset.x + stomp.x,
+                        y: offsetCenter.y + centerOffset.y + stomp.y,
+                    };
                     // Now we get the top-left point of the grid we end up at
                     const point = canvas.grid.getTopLeftPoint(newPoint);
                     // We then highlight that grid space, this already has a way of checking to make sure we don't double highlight a grid space

--- a/src/module/canvas/token/object.ts
+++ b/src/module/canvas/token/object.ts
@@ -47,11 +47,11 @@ class TokenPF2e<TDocument extends TokenDocumentPF2e = TokenDocumentPF2e> extends
         }
     }
 
-    /** The grid offsets representing this token's shape */
-    get footprint(): GridOffset[] {
+    /** The center points of the grid spaces that a token occupies on the grid */
+    get footprint(): Point[] {
         const shape = this.isTiny ? this.mechanicalBounds : this.localShape;
         const seen = new Set<number>();
-        const offsets: GridOffset[] = [];
+        const points: Point[] = [];
         const [i0, j0, i1, j1] = canvas.grid.getOffsetRange(this.mechanicalBounds);
         for (let i = i0; i < i1; i++) {
             for (let j = j0; j < j1; j++) {
@@ -61,11 +61,11 @@ class TokenPF2e<TDocument extends TokenDocumentPF2e = TokenDocumentPF2e> extends
                 seen.add(packed);
                 const point = canvas.grid.getCenterPoint(offset);
                 if (shape.contains(point.x, point.y)) {
-                    offsets.push(offset);
+                    points.push(point);
                 }
             }
         }
-        return offsets.sort((a, b) => a.j - b.j).sort((a, b) => a.i - b.i);
+        return points.sort((a, b) => a.x - b.x).sort((a, b) => a.y - b.y);
     }
 
     get #isDragMeasuring(): boolean {


### PR DESCRIPTION
This adds "fat ruler" highlighting to the ruler for hexagonal grids. It does this in a universal way for both square grids and hexagonal grids.

Using grid offsets on a hexagonal grid leads to some wonky behaviour if you are only using them to get neighboring hexes. For example, the hex to the top-left might be to the top-left in offset notation but depending on the grid layout and the current row/hex it might be to the top or the left in offset notation.

The proper way would probably use offset coordinates for square grids, and cube coordinates for hexagonal grids. However, a third option is to just use x/y offsets from the origin to represent a token's shape which works on both types of grids.

This leads to another wonky behaviour with hexagonal grids. On a square grid if a point is on the vertex touching four different squares then Foundry is always going to pick the same grid when you get the offset coordinates of that point. However, on a hexagonal grid this is not always the case when the point is on the vertex touching three different hexes thanks to floating point math. So depending on the layout of the hexagonal grid and if you are on an odd or even row/column it will pick different hexes when you get the offset/cube coordinates of that point. This leads to some wonky behaviour when you ask Foundry to get a direct path between the two points, it can pick the hex to the top-left of the start point and the hex to the top-right of the end point which means the token appears to be going to far.

To resolve that problem we instead standardize which grid we are going to use for the direct path, if the token's center is in-between squares/hexes it always using the grid that is to the top-left of both the start and end point when getting the direct path for a segment. Then we can reverse this offset to determine where a token's center is at any point along the direct path, then use the offsets' from the token's center we get from the token's shape to get all the squares/hexes we need to highlight.

Below is a sample from moving a large creature on a hexagonal map.

[Foundry_Virtual_Tabletop_VmE6gGwnKK.webm](https://github.com/user-attachments/assets/2fbd5ec5-fbd6-4275-be02-db980fe898bc)

Below is a sample from moving a large creature on a square map, showing that it still behaves the same.

[Foundry_Virtual_Tabletop_x9NUxKYfpl.webm](https://github.com/user-attachments/assets/f68690b1-a69d-4857-a40c-38d0063f0634)
