### PR TITLE
Add action:recall-knowledge to diverse-lore FlatModifier predicate

### DIFF
--- a/packs/feats/diverse-lore.json
+++ b/packs/feats/diverse-lore.json
@@ -28,6 +28,7 @@
             {
                 "key": "FlatModifier",
                 "predicate": [
+                    "action:recall-knowledge",
                     "diverse-lore"
                 ],
                 "selector": [


### PR DESCRIPTION
The text of the feat clearly states it only applies to recall knowledge checks.

This also helps the RK macro in workbench identify this modifier as relating to recall-knowledge.