### PR TITLE
Add 2 Action version to Inner Radiance Torrent

### DIFF
--- a/packs/spells/inner-radiance-torrent.json
+++ b/packs/spells/inner-radiance-torrent.json
@@ -71,7 +71,11 @@
                 "_id": "qrxkquqbapot642g",
                 "overlayType": "override",
                 "sort": 1,
-                "system": {}
+                "system": {
+                    "time": {
+                        "value": "2"
+                    }
+                }
             },
             "zzgj6vleao856t2k": {
                 "_id": "zzgj6vleao856t2k",


### PR DESCRIPTION
Without this, it is missing a `origin:item:cast:actions` roll option. The 2 round version can be predicated on by excluding the 2 and 3-action ones.