### PR TITLE
Fix updating homebrew languages

### DIFF
--- a/src/module/system/settings/homebrew/languages.ts
+++ b/src/module/system/settings/homebrew/languages.ts
@@ -98,6 +98,14 @@ export class LanguagesManager {
         }
     }
 
+    #isValidLanguage(language: string | undefined): language is LanguageNotCommon {
+        return (
+            !!language &&
+            language !== "common" &&
+            (objectHasKey(CONFIG.PF2E.languages, language) || this.menu.cache.languages.some((l) => l.id === language))
+        );
+    }
+
     async #onDropLanguage(event: Sortable.SortableEvent): Promise<void> {
         const droppedEl = event.item;
         const dropTarget = htmlClosest(droppedEl, "ul[data-languages]");
@@ -107,7 +115,7 @@ export class LanguagesManager {
         if (oldRarity === newRarity) return;
 
         const language = droppedEl.dataset.slug;
-        if (!objectHasKey(CONFIG.PF2E.languages, language) || language === "common") {
+        if (!this.#isValidLanguage(language)) {
             throw ErrorPF2e("Unexpected update to language rarities");
         }
 
@@ -155,22 +163,18 @@ export class LanguagesManager {
         const languageSet = new Set(LANGUAGES);
         const updatedLanguages = [...this.moduleLanguages, ...languages.map((l) => l.id)];
 
-        let render = false;
-
         if (
             source.commonLanguage &&
             !languageSet.has(source.commonLanguage) &&
             !updatedLanguages.includes(source.commonLanguage)
         ) {
             source.commonLanguage = null;
-            render = true;
         }
 
         for (const rarity of ["uncommon", "rare", "secret", "unavailable"] as const) {
             for (const language of source[rarity]) {
                 if (!languageSet.has(language) && !updatedLanguages.includes(language)) {
                     source[rarity].findSplice((l) => l === language);
-                    render = true;
                 }
             }
         }
@@ -179,17 +183,13 @@ export class LanguagesManager {
         for (const language of data.common) {
             if (!languageSet.has(language) && !updatedLanguages.includes(language)) {
                 data.common.delete(language);
-                render = true;
             }
         }
 
         for (const language of updatedLanguages) {
             if (!LANGUAGE_RARITIES.some((r) => data[r].has(language))) {
                 data.common.add(language);
-                render = true;
             }
         }
-
-        if (render) this.menu.render();
     }
 }

--- a/static/templates/system/settings/homebrew.hbs
+++ b/static/templates/system/settings/homebrew.hbs
@@ -11,7 +11,7 @@
         <div class="form-group setting">
             <label for="{{options.id}}-languages">{{localize settings.languages.name}}</label>
             <div class="form-fields">
-                <input type="text" name="languages" class="homebrew pf2e-tagify" data-dtype="JSON" value="{{json traitSettings.languages.value}}">
+                <input type="text" name="languages" class="homebrew pf2e-tagify" data-dtype="JSON" value="{{json settings.languages.value}}">
             </div>
             <p class="hint">{{localize settings.languages.hint}}</p>
         </div>


### PR DESCRIPTION
The render in the languages update method was eating the update to the languages itself as well, and since updateObject always leads to a re-render it was unnecessary.