### PR TITLE
add roll option to Inventor feats to add the `Unstable` trait

### DIFF
--- a/packs/feats/deep-freeze.json
+++ b/packs/feats/deep-freeze.json
@@ -24,7 +24,37 @@
             "remaster": false,
             "title": "Pathfinder Guns & Gears"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "RollOption",
+                "label": "PF2E.TraitUnstable",
+                "mergeable": true,
+                "option": "unstable",
+                "predicate": [
+                    {
+                        "not": "feature:construct-innovation"
+                    }
+                ],
+                "suboptions": [
+                    {
+                        "label": "{item|name}",
+                        "value": "deep-freeze"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "unstable:deep-freeze",
+                    "item:deep-freeze"
+                ],
+                "property": "traits",
+                "value": "unstable"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/distracting-explosion.json
+++ b/packs/feats/distracting-explosion.json
@@ -28,7 +28,37 @@
             "remaster": false,
             "title": "Pathfinder Guns & Gears"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "RollOption",
+                "label": "PF2E.TraitUnstable",
+                "mergeable": true,
+                "option": "unstable",
+                "predicate": [
+                    {
+                        "not": "feature:construct-innovation"
+                    }
+                ],
+                "suboptions": [
+                    {
+                        "label": "{item|name}",
+                        "value": "distracting-explosion"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "unstable:distracting-explosion",
+                    "item:distracting-explosion"
+                ],
+                "property": "traits",
+                "value": "unstable"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/electrify-armor.json
+++ b/packs/feats/electrify-armor.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p><strong>Requirements</strong> You are wearing your armor innovation.</p>\n<p>You electrify your armor to punish foes who dare to attack you. For 1 round, any creature that touches you, or that hits you with a melee unarmed attack or a non-reach melee weapon attack, takes @Damage[1d4[electricity]|overrideTraits] damage. The effect ends if you cease wearing your armor innovation.</p>\n<p>If you have the revolutionary innovation class feature, the damage increases to @Damage[2d4[electricity]|overrideTraits]{2d4}.</p>\n<p><strong>Unstable Function</strong> You create an unstable chain reaction, sending countless sparks dancing across your armor. Add the unstable trait to Electrify Armor. The effects last for 1 minute instead of 1 round, and the damage dice increase from d4s to d12s (@Damage[1d12[electricity]] / @Damage[2d12[electricity]]).</p>\n<hr />\n<p>@Check[flat|dc:15|options:unstable-check|name:PF2E.SpecificRule.Inventor.Unstable.FlatCheck.Label]{PF2E.SpecificRule.Inventor.Unstable.FlatCheck.Label}</p>"
+            "value": "<p><strong>Requirements</strong> You are wearing your armor innovation.</p>\n<p>You electrify your armor to punish foes who dare to attack you. For 1 round, any creature that touches you, or that hits you with a melee unarmed attack or a non-reach melee weapon attack, takes @Damage[1d4[electricity]|overrideTraits] damage. The effect ends if you cease wearing your armor innovation.</p>\n<p>If you have the revolutionary innovation class feature, the damage increases to @Damage[2d4[electricity]|overrideTraits]{2d4}.</p>\n<p><strong>Unstable Function</strong> You create an unstable chain reaction, sending countless sparks dancing across your armor. Add the unstable trait to Electrify Armor. The effects last for 1 minute instead of 1 round, and the damage dice increase from d4s to d12s (@Damage[1d12[electricity]] / @Damage[2d12[electricity]]).</p><hr /><p>@Check[flat|dc:15|options:unstable-check|name:PF2E.SpecificRule.Inventor.Unstable.FlatCheck.Label]{PF2E.SpecificRule.Inventor.Unstable.FlatCheck.Label}</p>"
         },
         "level": {
             "value": 10
@@ -28,7 +28,37 @@
             "remaster": false,
             "title": "Pathfinder Guns & Gears"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "RollOption",
+                "label": "PF2E.TraitUnstable",
+                "mergeable": true,
+                "option": "unstable",
+                "predicate": [
+                    {
+                        "not": "feature:construct-innovation"
+                    }
+                ],
+                "suboptions": [
+                    {
+                        "label": "{item|name}",
+                        "value": "electrify-armor"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "unstable:electrify-armor",
+                    "item:electrify-armor"
+                ],
+                "property": "traits",
+                "value": "unstable"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/megaton-strike.json
+++ b/packs/feats/megaton-strike.json
@@ -105,6 +105,17 @@
                     }
                 ],
                 "selector": "strike-damage"
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "megaton:unstable",
+                    "item:megaton-strike"
+                ],
+                "property": "traits",
+                "value": "unstable"
             }
         ],
         "traits": {

--- a/packs/feats/megavolt.json
+++ b/packs/feats/megavolt.json
@@ -24,7 +24,37 @@
             "remaster": false,
             "title": "Pathfinder Guns & Gears"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "RollOption",
+                "label": "PF2E.TraitUnstable",
+                "mergeable": true,
+                "option": "unstable",
+                "predicate": [
+                    {
+                        "not": "feature:construct-innovation"
+                    }
+                ],
+                "suboptions": [
+                    {
+                        "label": "{item|name}",
+                        "value": "megavolt"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "unstable:megavolt",
+                    "item:megavolt"
+                ],
+                "property": "traits",
+                "value": "unstable"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/negate-damage.json
+++ b/packs/feats/negate-damage.json
@@ -28,7 +28,37 @@
             "remaster": false,
             "title": "Pathfinder Guns & Gears"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "RollOption",
+                "label": "PF2E.TraitUnstable",
+                "mergeable": true,
+                "option": "unstable",
+                "predicate": [
+                    {
+                        "not": "feature:construct-innovation"
+                    }
+                ],
+                "suboptions": [
+                    {
+                        "label": "{item|name}",
+                        "value": "negate-damage"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "unstable:negate-damage",
+                    "item:negate-damage"
+                ],
+                "property": "traits",
+                "value": "unstable"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [


### PR DESCRIPTION
Once this PR is merged, the plan is to go back and localize the unstable check and text of the feats referencing these options.