### PR TITLE
Limit bloodline blood magic suboption to sorcerer class

### DIFF
--- a/packs/classfeatures/bloodline-aberrant.json
+++ b/packs/classfeatures/bloodline-aberrant.json
@@ -100,6 +100,9 @@
                 "suboptions": [
                     {
                         "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Aberrant",
+                        "predicate": [
+                            "class:sorcerer"
+                        ],
                         "value": "aberrant"
                     }
                 ],

--- a/packs/classfeatures/bloodline-angelic.json
+++ b/packs/classfeatures/bloodline-angelic.json
@@ -100,6 +100,9 @@
                 "suboptions": [
                     {
                         "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Angelic",
+                        "predicate": [
+                            "class:sorcerer"
+                        ],
                         "value": "angelic"
                     }
                 ],

--- a/packs/classfeatures/bloodline-demonic.json
+++ b/packs/classfeatures/bloodline-demonic.json
@@ -100,6 +100,9 @@
                 "suboptions": [
                     {
                         "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Demonic",
+                        "predicate": [
+                            "class:sorcerer"
+                        ],
                         "value": "demonic"
                     }
                 ],

--- a/packs/classfeatures/bloodline-diabolic.json
+++ b/packs/classfeatures/bloodline-diabolic.json
@@ -100,6 +100,9 @@
                 "suboptions": [
                     {
                         "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Diabolic",
+                        "predicate": [
+                            "class:sorcerer"
+                        ],
                         "value": "diabolic"
                     }
                 ],

--- a/packs/classfeatures/bloodline-draconic.json
+++ b/packs/classfeatures/bloodline-draconic.json
@@ -608,6 +608,9 @@
                 "suboptions": [
                     {
                         "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Draconic",
+                        "predicate": [
+                            "class:sorcerer"
+                        ],
                         "value": "draconic"
                     }
                 ],

--- a/packs/classfeatures/bloodline-elemental.json
+++ b/packs/classfeatures/bloodline-elemental.json
@@ -224,6 +224,9 @@
                 "suboptions": [
                     {
                         "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Elemental",
+                        "predicate": [
+                            "class:sorcerer"
+                        ],
                         "value": "elemental"
                     }
                 ],

--- a/packs/classfeatures/bloodline-fey.json
+++ b/packs/classfeatures/bloodline-fey.json
@@ -100,6 +100,9 @@
                 "suboptions": [
                     {
                         "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Fey",
+                        "predicate": [
+                            "class:sorcerer"
+                        ],
                         "value": "fey"
                     }
                 ],

--- a/packs/classfeatures/bloodline-genie.json
+++ b/packs/classfeatures/bloodline-genie.json
@@ -185,6 +185,9 @@
                 "suboptions": [
                     {
                         "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Genie",
+                        "predicate": [
+                            "class:sorcerer"
+                        ],
                         "value": "genie"
                     }
                 ],

--- a/packs/classfeatures/bloodline-hag.json
+++ b/packs/classfeatures/bloodline-hag.json
@@ -100,6 +100,9 @@
                 "suboptions": [
                     {
                         "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Hag",
+                        "predicate": [
+                            "class:sorcerer"
+                        ],
                         "value": "hag"
                     }
                 ],

--- a/packs/classfeatures/bloodline-harrow.json
+++ b/packs/classfeatures/bloodline-harrow.json
@@ -100,6 +100,9 @@
                 "suboptions": [
                     {
                         "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Harrow",
+                        "predicate": [
+                            "class:sorcerer"
+                        ],
                         "value": "harrow"
                     }
                 ],

--- a/packs/classfeatures/bloodline-imperial.json
+++ b/packs/classfeatures/bloodline-imperial.json
@@ -100,6 +100,9 @@
                 "suboptions": [
                     {
                         "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Imperial",
+                        "predicate": [
+                            "class:sorcerer"
+                        ],
                         "value": "imperial"
                     }
                 ],

--- a/packs/classfeatures/bloodline-nymph.json
+++ b/packs/classfeatures/bloodline-nymph.json
@@ -100,6 +100,9 @@
                 "suboptions": [
                     {
                         "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Nymph",
+                        "predicate": [
+                            "class:sorcerer"
+                        ],
                         "value": "nymph"
                     }
                 ],

--- a/packs/classfeatures/bloodline-phoenix.json
+++ b/packs/classfeatures/bloodline-phoenix.json
@@ -100,6 +100,9 @@
                 "suboptions": [
                     {
                         "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Phoenix",
+                        "predicate": [
+                            "class:sorcerer"
+                        ],
                         "value": "phoenix"
                     }
                 ],

--- a/packs/classfeatures/bloodline-psychopomp.json
+++ b/packs/classfeatures/bloodline-psychopomp.json
@@ -100,6 +100,9 @@
                 "suboptions": [
                     {
                         "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Psychopomp",
+                        "predicate": [
+                            "class:sorcerer"
+                        ],
                         "value": "psychopomp"
                     }
                 ],

--- a/packs/classfeatures/bloodline-shadow.json
+++ b/packs/classfeatures/bloodline-shadow.json
@@ -100,6 +100,9 @@
                 "suboptions": [
                     {
                         "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Shadow",
+                        "predicate": [
+                            "class:sorcerer"
+                        ],
                         "value": "shadow"
                     }
                 ],

--- a/packs/classfeatures/bloodline-undead.json
+++ b/packs/classfeatures/bloodline-undead.json
@@ -100,6 +100,9 @@
                 "suboptions": [
                     {
                         "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Undead",
+                        "predicate": [
+                            "class:sorcerer"
+                        ],
                         "value": "undead"
                     }
                 ],

--- a/packs/classfeatures/bloodline-wyrmblessed.json
+++ b/packs/classfeatures/bloodline-wyrmblessed.json
@@ -255,6 +255,9 @@
                 "suboptions": [
                     {
                         "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Wyrmblessed",
+                        "predicate": [
+                            "class:sorcerer"
+                        ],
                         "value": "wyrmblessed"
                     }
                 ],


### PR DESCRIPTION
The archetype wasn't actually getting blood magic, but they were seeing a useless suboption.