### PR TITLE
brush up Sanctify Armament feat to account for the Lasting Armament feat

### DIFF
--- a/packs/feat-effects/effect-sanctify-armament-lasting-armament.json
+++ b/packs/feat-effects/effect-sanctify-armament-lasting-armament.json
@@ -1,0 +1,97 @@
+{
+    "_id": "MixwAykOaiBuIsoI",
+    "img": "icons/weapons/swords/sword-winged-pink.webp",
+    "name": "Effect: Sanctify Armament (Lasting Armament)",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Sanctify Armament]</p>\n<p>The weapon gains your holy or unholy trait. It also deals an additional 2d6 spirit damage to creatures of the opposed trait.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "hours",
+            "value": 1
+        },
+        "level": {
+            "value": 8
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "rules": [
+            {
+                "choices": {
+                    "ownedItems": true,
+                    "types": [
+                        "weapon"
+                    ]
+                },
+                "flag": "weapon",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.Weapon"
+            },
+            {
+                "damageType": "spirit",
+                "diceNumber": 2,
+                "dieSize": "d6",
+                "key": "DamageDice",
+                "predicate": [
+                    {
+                        "or": [
+                            {
+                                "and": [
+                                    "self:trait:holy",
+                                    "target:trait:unholy"
+                                ]
+                            },
+                            {
+                                "and": [
+                                    "self:trait:unholy",
+                                    "target:trait:holy"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-damage"
+            },
+            {
+                "definition": [
+                    "item:id:{item|flags.pf2e.rulesSelections.weapon}"
+                ],
+                "key": "AdjustStrike",
+                "mode": "add",
+                "predicate": [
+                    "self:trait:holy"
+                ],
+                "property": "traits",
+                "value": "holy"
+            },
+            {
+                "definition": [
+                    "item:id:{item|flags.pf2e.rulesSelections.weapon}"
+                ],
+                "key": "AdjustStrike",
+                "mode": "add",
+                "predicate": [
+                    "self:trait:unholy"
+                ],
+                "property": "traits",
+                "value": "unholy"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feats/sanctify-armament.json
+++ b/packs/feats/sanctify-armament.json
@@ -33,11 +33,41 @@
             "remaster": true,
             "title": "Pathfinder Player Core"
         },
-        "rules": [],
-        "selfEffect": {
-            "name": "Effect: Sanctify Armament",
-            "uuid": "Compendium.pf2e.feat-effects.Item.Effect: Sanctify Armament"
-        },
+        "rules": [
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:sanctify-armament",
+                    {
+                        "not": "feat:lasting-armament"
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Cleric.SantifyArmament.NormalDuration"
+                    }
+                ]
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Cleric.SantifyArmament.ExtendedDurationLabel",
+                "mode": "add",
+                "predicate": [
+                    "item:sanctify-armament",
+                    "feat:lasting-armament"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Cleric.SantifyArmament.ExtendedDuration"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2273,6 +2273,11 @@
                     "Harmful": "A creature that remains in the area for the entire 10 minutes regains @Damage[(@actor.level)[void,healing]]{Hit Points} equal to your level. This activity has the healing and void traits and heals undead creatures (or other creatures with void healing).",
                     "Healing": "A creature that remains in the area for the entire 10 minutes regains @Damage[(@actor.level)[vitality,healing]]{Hit Points} equal to your level. This activity has the healing and vitality traits and heals living creatures."
                 },
+                "SantifyArmament": {
+                    "ExtendedDuration": "When you sanctify a weapon, it remains sanctified for an extended period. The duration of Sanctify Armament is increased to 1 hour, but it still ends if you use Sanctify Armament on another weapon. @UUID[Compendium.pf2e.feat-effects.Item.MixwAykOaiBuIsoI]{Effect: Sanctify Armament (Lasting Armament)}", 
+                    "ExtendedDurationLabel": "Lasting Armament",
+                    "NormalDuration": "@UUID[Compendium.pf2e.feat-effects.Item.ImkjllInxmrdDCOq]{Effect: Sanctify Armament}"
+                },
                 "SapLife": {
                     "Note": "When you cast a <em>harm</em> spell and damage at least one living creature, you regain @Damage[(@item.rank)[healing]] Hit Points."
                 },


### PR DESCRIPTION
How this works
- Added a second effect for Sanctify Armament that has a 1-hour duration.
- Added an item alteration description that posts the corresponding effect - normal duration if you don't have the Lasting Armament feat, or extended duration if you do.
- Removed the self-applied effect.

If approved, 
closes #11498