### PR TITLE
Use AdjustModifier on Oracular Warning initiative effect

### DIFF
--- a/packs/feat-effects/effect-oracular-warning-initiative.json
+++ b/packs/feat-effects/effect-oracular-warning-initiative.json
@@ -25,8 +25,34 @@
                 "key": "FlatModifier",
                 "removeAfterRoll": true,
                 "selector": "initiative",
+                "slug": "oracular-warning",
                 "type": "status",
-                "value": "min(1+@item.origin.conditions.cursebound.value,4)"
+                "value": 2
+            },
+            {
+                "key": "AdjustModifier",
+                "mode": "upgrade",
+                "predicate": [
+                    "parent:granter:origin:condition:cursebound:2"
+                ],
+                "selector": "initiative",
+                "slug": "oracular-warning",
+                "value": 3
+            },
+            {
+                "key": "AdjustModifier",
+                "mode": "upgrade",
+                "predicate": [
+                    {
+                        "gte": [
+                            "parent:granter:origin:condition:cursebound",
+                            3
+                        ]
+                    }
+                ],
+                "selector": "initiative",
+                "slug": "oracular-warning",
+                "value": 4
             }
         ],
         "start": {


### PR DESCRIPTION
This avoids needing to resolve the origin's cursebound value, which may not be there if the user is not following the exact rules (cursebound value increases before the action's effects take place if you weren't already cursebound).