### PR TITLE
update rule elements on Iruxi Armaments feat

### DIFF
--- a/packs/feats/iruxi-armaments.json
+++ b/packs/feats/iruxi-armaments.json
@@ -55,6 +55,7 @@
                         "value": "tail"
                     }
                 ],
+                "flag": "iruxiArmaments",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.UnarmedAttack",
                 "rollOption": "iruxi-armaments"
@@ -91,11 +92,14 @@
                     }
                 },
                 "group": "brawling",
+                "img": "systems/pf2e/icons/unarmed-attacks/fangs.webp",
                 "key": "Strike",
+                "label": "PF2E.BattleForm.Attack.Fangs",
                 "predicate": [
                     "iruxi-armaments:fangs"
                 ],
                 "range": null,
+                "slug": "fangs",
                 "traits": [
                     "unarmed"
                 ]
@@ -110,7 +114,9 @@
                     }
                 },
                 "group": "brawling",
+                "img": "systems/pf2e/icons/unarmed-attacks/tail.webp",
                 "key": "Strike",
+                "label": "PF2E.BattleForm.Attack.Tail",
                 "predicate": [
                     {
                         "not": "self:effect:shed-tail"
@@ -118,6 +124,7 @@
                     "iruxi-armaments:tail"
                 ],
                 "range": null,
+                "slug": "tail",
                 "traits": [
                     "sweep",
                     "unarmed"

--- a/packs/feats/iruxi-armaments.json
+++ b/packs/feats/iruxi-armaments.json
@@ -16,6 +16,7 @@
         "level": {
             "value": 1
         },
+        "maxTakable": 3,
         "prerequisites": {
             "value": []
         },


### PR DESCRIPTION
- added slugs. labels and images for the tail and fang strikes.
- added a flag to the Roll Option.
- changed how many times the feat can be taken.