### PR TITLE
Module-configurable A(H)BCD sheet compendia

### DIFF
--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -417,6 +417,8 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
             };
         });
 
+        sheetData.compendium = CONFIG.PF2E.sheetCompendium;
+
         // Return data for rendering
         return sheetData;
     }
@@ -1667,6 +1669,7 @@ interface CharacterSheetData<TActor extends CharacterPF2e = CharacterPF2e> exten
     elementalBlasts: ElementalBlastSheetConfig[];
     senses: Sense[];
     speeds: SpeedSheetData[];
+    compendium: Record<string, string>;
 }
 
 type LanguageSheetData = {

--- a/src/scripts/config/index.ts
+++ b/src/scripts/config/index.ts
@@ -826,6 +826,14 @@ export const PF2ECONFIG = {
         urban: "PF2E.Environment.Type.Urban",
     },
 
+    sheetCompendium: {
+        ancestries: "pf2e.ancestries",
+        heritages: "pf2e.heritages",
+        backgrounds: "pf2e.backgrounds",
+        classes: "pf2e.classes",
+        deities: "pf2e.deities",
+    },
+
     SETTINGS: {
         automation: {
             rulesBasedVision: {

--- a/static/templates/actors/character/tabs/character.hbs
+++ b/static/templates/actors/character/tabs/character.hbs
@@ -21,23 +21,23 @@
             </ul>
 
             <div class="detail ancestry{{#if ancestry}} selected{{/if}}">
-                {{> detailItem item=ancestry type="ancestry" compendium="pf2e.ancestries"}}
+                {{> detailItem item=ancestry type="ancestry" compendium=compendium.ancestries}}
             </div>
 
             <div class="detail heritage{{#if heritage}} selected{{/if}}">
-                {{> detailItem item=heritage type="heritage" compendium="pf2e.heritages"}}
+                {{> detailItem item=heritage type="heritage" compendium=compendium.heritages}}
             </div>
 
             <div class="detail background{{#if background}} selected{{/if}}">
-                {{> detailItem item=background type="background" compendium="pf2e.backgrounds"}}
+                {{> detailItem item=background type="background" compendium=compendium.backgrounds}}
             </div>
 
             <div class="detail class{{#if class}} selected{{/if}}">
-                {{> detailItem item=class type="class" compendium="pf2e.classes"}}
+                {{> detailItem item=class type="class" compendium=compendium.classes}}
             </div>
 
             <div class="detail deity{{#if deity}} selected{{/if}}">
-                {{> detailItem item=deity type="deity" compendium="pf2e.deities" showEmblem=deity}}
+                {{> detailItem item=deity type="deity" compendium=compendium.deities showEmblem=deity}}
             </div>
         </div>
 


### PR DESCRIPTION
Allow modules to change which compendia are opened from the player character sheet when clicking the magnifying glass icons for ancestries, heritages, backgrounds, classes, and deities. Useful for modules like the Starfinder 2E playtest.