### PR TITLE
correct book sources for certain Witch lesson feats

### DIFF
--- a/packs/classfeatures/lesson-of-bargains.json
+++ b/packs/classfeatures/lesson-of-bargains.json
@@ -20,9 +20,9 @@
             "value": []
         },
         "publication": {
-            "license": "ORC",
-            "remaster": true,
-            "title": "Pathfinder Player Core"
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Dark Archive"
         },
         "rules": [],
         "traits": {

--- a/packs/classfeatures/lesson-of-calamity.json
+++ b/packs/classfeatures/lesson-of-calamity.json
@@ -22,7 +22,7 @@
         "publication": {
             "license": "OGL",
             "remaster": false,
-            "title": " Pathfinder #169: Kindled Magic"
+            "title": "Pathfinder #169: Kindled Magic"
         },
         "rules": [],
         "traits": {

--- a/packs/classfeatures/lesson-of-calamity.json
+++ b/packs/classfeatures/lesson-of-calamity.json
@@ -20,9 +20,9 @@
             "value": []
         },
         "publication": {
-            "license": "ORC",
-            "remaster": true,
-            "title": "Pathfinder Player Core"
+            "license": "OGL",
+            "remaster": false,
+            "title": " Pathfinder #169: Kindled Magic"
         },
         "rules": [],
         "traits": {

--- a/packs/classfeatures/lesson-of-decay.json
+++ b/packs/classfeatures/lesson-of-decay.json
@@ -1,6 +1,6 @@
 {
     "_id": "hEsmQcEryweYweis",
-    "img": "systems/pf2e/icons/default-icons/feat.svg",
+    "img": "icons/magic/unholy/hand-claw-glow-orange.webp",
     "name": "Lesson of Decay",
     "system": {
         "actionType": {

--- a/packs/classfeatures/lesson-of-favors.json
+++ b/packs/classfeatures/lesson-of-favors.json
@@ -20,9 +20,9 @@
             "value": []
         },
         "publication": {
-            "license": "ORC",
-            "remaster": true,
-            "title": "Pathfinder Player Core"
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Dark Archive"
         },
         "rules": [],
         "traits": {

--- a/packs/classfeatures/lesson-of-the-flock.json
+++ b/packs/classfeatures/lesson-of-the-flock.json
@@ -1,6 +1,6 @@
 {
     "_id": "JjseD5wylg4Hg9O2",
-    "img": "systems/pf2e/icons/default-icons/feat.svg",
+    "img": "icons/creatures/birds/birds-flock-fly-yellow.webp",
     "name": "Lesson of the Flock",
     "system": {
         "actionType": {

--- a/packs/classfeatures/lesson-of-the-frozen-queen.json
+++ b/packs/classfeatures/lesson-of-the-frozen-queen.json
@@ -20,9 +20,9 @@
             "value": []
         },
         "publication": {
-            "license": "ORC",
-            "remaster": true,
-            "title": "Pathfinder Player Core"
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Lost Omens: Legends"
         },
         "rules": [],
         "traits": {

--- a/packs/classfeatures/lesson-of-the-shark.json
+++ b/packs/classfeatures/lesson-of-the-shark.json
@@ -1,6 +1,6 @@
 {
     "_id": "LP6PfKqwyRJmWqOJ",
-    "img": "systems/pf2e/icons/default-icons/feat.svg",
+    "img": "icons/creatures/fish/fish-shark-swimming.webp",
     "name": "Lesson of the Shark",
     "system": {
         "actionType": {


### PR DESCRIPTION
- Also added icons to the three lessons added in Howl of the Wild.

Closes #16030