### PR TITLE
Fix hp for thickskin tripkee heritage

### DIFF
--- a/packs/heritages/tripkee/thickskin-tripkee.json
+++ b/packs/heritages/tripkee/thickskin-tripkee.json
@@ -23,7 +23,7 @@
                 "mode": "upgrade",
                 "path": "system.attributes.ancestryhp",
                 "priority": 51,
-                "value": 20
+                "value": 8
             },
             {
                 "key": "FlatModifier",


### PR DESCRIPTION
Heritage HP was set to 20, changed it to 8 as intended.

Closes #16046