### PR TITLE
Fix-alchemical-power-feat

### DIFF
--- a/packs/feats/alchemical-power.json
+++ b/packs/feats/alchemical-power.json
@@ -31,35 +31,20 @@
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [
-            {
-                "key": "ActiveEffectLike",
-                "mode": "upgrade",
-                "path": "system.crafting.entries.alchemist.maxItemLevel",
-                "phase": "beforeDerived",
-                "predicate": [
-                    "crafting:entry:alchemist"
-                ],
-                "value": {
-                    "brackets": [
-                        {
-                            "end": 12,
-                            "start": 12,
-                            "value": 7
-                        },
-                        {
-                            "start": 13,
-                            "value": "@actor.level - 5"
-                        }
-                    ]
-                }
-            }
-        ],
+        "rules": [],
         "traits": {
             "rarity": "common",
             "value": [
                 "archetype"
             ]
+        },
+        "subfeatures": {
+            "proficiencies": {
+                "alchemist": {
+                    "rank": 2,
+                    "attribute": null
+                }
+            }
         }
     },
     "type": "feat"

--- a/packs/heritages/tripkee/thickskin-tripkee.json
+++ b/packs/heritages/tripkee/thickskin-tripkee.json
@@ -23,7 +23,7 @@
                 "mode": "upgrade",
                 "path": "system.attributes.ancestryhp",
                 "priority": 51,
-                "value": 20
+                "value": 8
             },
             {
                 "key": "FlatModifier",


### PR DESCRIPTION
Removed erroneous RE from the feat as well as added the expert proficiency for Alchemist class DC.

I don't believe there is automation for the adjustment of the DC on crafted items (checked the history on the old Toxicologist that used to be the one doing that).

Closes #16045