### PR TITLE
Fix DamageAlteration predicates for base damage

### DIFF
--- a/src/module/system/damage/weapon.ts
+++ b/src/module/system/damage/weapon.ts
@@ -146,7 +146,12 @@ class WeaponDamagePF2e {
             rule.beforeRoll?.(domains, options);
         }
 
-        const baseDamage = WeaponDamagePF2e.#processBaseDamage(unprocessedBaseDamage, { actor, item: weapon, domains });
+        const baseDamage = WeaponDamagePF2e.#processBaseDamage(unprocessedBaseDamage, {
+            actor,
+            item: weapon,
+            domains,
+            options,
+        });
 
         // Splash damage
         const hasScatterTrait = weaponTraits.some((t) => t.startsWith("scatter-"));
@@ -539,7 +544,12 @@ class WeaponDamagePF2e {
     /** Apply damage alterations to weapon base damage. */
     static #processBaseDamage(
         unprocessed: ConvertedNPCDamage | WeaponDamage,
-        { actor, item, domains }: { actor: ActorPF2e; item: ItemPF2e<ActorPF2e>; domains: string[] },
+        {
+            actor,
+            item,
+            domains,
+            options,
+        }: { actor: ActorPF2e; item: ItemPF2e<ActorPF2e>; domains: string[]; options: string[] | Set<string> },
     ): ConvertedNPCDamage | WeaponDamage {
         const damageCategory = "category" in unprocessed ? unprocessed.category : null;
         const dice =
@@ -583,9 +593,9 @@ class WeaponDamagePF2e {
             : null;
         const alterations = extractDamageAlterations(actor.synthetics.damageAlterations, domains, "base");
         for (const alteration of alterations) {
-            if (dice) alteration.applyTo(dice, { item, test: domains });
-            if (modifier) alteration.applyTo(modifier, { item, test: domains });
-            if (persistent) alteration.applyTo(persistent, { item, test: domains });
+            if (dice) alteration.applyTo(dice, { item, test: options });
+            if (modifier) alteration.applyTo(modifier, { item, test: options });
+            if (persistent) alteration.applyTo(persistent, { item, test: options });
         }
 
         return {


### PR DESCRIPTION
processBaseDamage() wasn't getting passed the roll options and was using the domains (also a string[]) as if they were the roll options when it applied alterations.