### PR TITLE
Fix Bestial Mutagen Strikes

### DIFF
--- a/packs/equipment-effects/effect-bestial-mutagen-greater.json
+++ b/packs/equipment-effects/effect-bestial-mutagen-greater.json
@@ -40,6 +40,29 @@
                 "value": -2
             },
             {
+                "baseType": "jaws",
+                "category": "unarmed",
+                "damage": {
+                    "base": {
+                        "damageType": "piercing",
+                        "dice": 3,
+                        "die": "d10"
+                    }
+                },
+                "group": "brawling",
+                "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
+                "key": "Strike",
+                "label": "PF2E.Weapon.Base.jaws",
+                "options": [
+                    "bestial-mutagen-strike"
+                ],
+                "range": null,
+                "slug": "jaws",
+                "traits": [
+                    "unarmed"
+                ]
+            },
+            {
                 "baseType": "claw",
                 "category": "unarmed",
                 "damage": {
@@ -56,109 +79,8 @@
                 "options": [
                     "bestial-mutagen-strike"
                 ],
-                "predicate": [
-                    {
-                        "not": "feat:mutant-physique"
-                    }
-                ],
                 "range": null,
-                "traits": [
-                    "unarmed",
-                    "agile"
-                ]
-            },
-            {
-                "baseType": "jaws",
-                "category": "unarmed",
-                "damage": {
-                    "base": {
-                        "damageType": "piercing",
-                        "dice": 3,
-                        "die": "d10"
-                    }
-                },
-                "group": "brawling",
-                "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
-                "key": "Strike",
-                "label": "PF2E.Weapon.Base.jaws",
-                "options": [
-                    "bestial-mutagen-strike"
-                ],
-                "predicate": [
-                    {
-                        "not": "feat:mutant-physique"
-                    }
-                ],
-                "range": null,
-                "traits": [
-                    "unarmed"
-                ]
-            },
-            {
-                "key": "FlatModifier",
-                "predicate": [
-                    "feat:mutant-physique"
-                ],
-                "selector": "intimidation",
-                "type": "item",
-                "value": 3
-            },
-            {
-                "key": "AdjustStrike",
-                "mode": "add",
-                "predicate": [
-                    "feat:mutant-physique"
-                ],
-                "property": "weapon-traits",
-                "selector": "bestial-mutagen-strike",
-                "value": "deadly-d10"
-            },
-            {
-                "baseType": "jaws",
-                "category": "unarmed",
-                "damage": {
-                    "base": {
-                        "damageType": "piercing",
-                        "dice": 3,
-                        "die": "d12"
-                    }
-                },
-                "group": "brawling",
-                "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
-                "key": "Strike",
-                "label": "PF2E.Weapon.Base.jaws",
-                "options": [
-                    "bestial-mutagen-strike"
-                ],
-                "predicate": [
-                    "feat:mutant-physique"
-                ],
-                "range": null,
-                "traits": [
-                    "unarmed"
-                ]
-            },
-            {
-                "baseType": "claw",
-                "category": "unarmed",
-                "damage": {
-                    "base": {
-                        "damageType": "slashing",
-                        "dice": 3,
-                        "die": "d10"
-                    }
-                },
-                "group": "brawling",
-                "img": "icons/commodities/claws/claw-bear-brown-grey.webp",
-                "key": "Strike",
-                "label": "PF2E.Weapon.Base.claw",
-                "options": [
-                    "bestial-mutagen-strike"
-                ],
-                "predicate": [
-                    "feat:mutant-physique"
-                ],
-                "range": null,
+                "slug": "claw",
                 "traits": [
                     "unarmed",
                     "agile"

--- a/packs/equipment-effects/effect-bestial-mutagen-lesser.json
+++ b/packs/equipment-effects/effect-bestial-mutagen-lesser.json
@@ -56,12 +56,8 @@
                 "options": [
                     "bestial-mutagen-strike"
                 ],
-                "predicate": [
-                    {
-                        "not": "feat:mutant-physique"
-                    }
-                ],
                 "range": null,
+                "slug": "jaws",
                 "traits": [
                     "unarmed"
                 ]
@@ -83,82 +79,8 @@
                 "options": [
                     "bestial-mutagen-strike"
                 ],
-                "predicate": [
-                    {
-                        "not": "feat:mutant-physique"
-                    }
-                ],
                 "range": null,
-                "traits": [
-                    "unarmed",
-                    "agile"
-                ]
-            },
-            {
-                "key": "FlatModifier",
-                "predicate": [
-                    "feat:mutant-physique"
-                ],
-                "selector": "intimidation",
-                "type": "item",
-                "value": 1
-            },
-            {
-                "key": "AdjustStrike",
-                "mode": "add",
-                "predicate": [
-                    "feat:mutant-physique"
-                ],
-                "property": "weapon-traits",
-                "selector": "bestial-mutagen-strike",
-                "value": "deadly-d10"
-            },
-            {
-                "baseType": "jaws",
-                "category": "unarmed",
-                "damage": {
-                    "base": {
-                        "damageType": "piercing",
-                        "dice": 1,
-                        "die": "d8"
-                    }
-                },
-                "group": "brawling",
-                "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
-                "key": "Strike",
-                "label": "PF2E.Weapon.Base.jaws",
-                "options": [
-                    "bestial-mutagen-strike"
-                ],
-                "predicate": [
-                    "feat:mutant-physique"
-                ],
-                "range": null,
-                "traits": [
-                    "unarmed"
-                ]
-            },
-            {
-                "baseType": "claw",
-                "category": "unarmed",
-                "damage": {
-                    "base": {
-                        "damageType": "slashing",
-                        "dice": 1,
-                        "die": "d6"
-                    }
-                },
-                "group": "brawling",
-                "img": "icons/commodities/claws/claw-bear-brown-grey.webp",
-                "key": "Strike",
-                "label": "PF2E.Weapon.Base.claw",
-                "options": [
-                    "bestial-mutagen-strike"
-                ],
-                "predicate": [
-                    "feat:mutant-physique"
-                ],
-                "range": null,
+                "slug": "claw",
                 "traits": [
                     "unarmed",
                     "agile"

--- a/packs/equipment-effects/effect-bestial-mutagen-major.json
+++ b/packs/equipment-effects/effect-bestial-mutagen-major.json
@@ -56,12 +56,8 @@
                 "options": [
                     "bestial-mutagen-strike"
                 ],
-                "predicate": [
-                    {
-                        "not": "feat:mutant-physique"
-                    }
-                ],
                 "range": null,
+                "slug": "jaws",
                 "traits": [
                     "unarmed"
                 ]
@@ -83,82 +79,8 @@
                 "options": [
                     "bestial-mutagen-strike"
                 ],
-                "predicate": [
-                    {
-                        "not": "feat:mutant-physique"
-                    }
-                ],
                 "range": null,
-                "traits": [
-                    "unarmed",
-                    "agile"
-                ]
-            },
-            {
-                "key": "FlatModifier",
-                "predicate": [
-                    "feat:mutant-physique"
-                ],
-                "selector": "intimidation",
-                "type": "item",
-                "value": 4
-            },
-            {
-                "key": "AdjustStrike",
-                "mode": "add",
-                "predicate": [
-                    "feat:mutant-physique"
-                ],
-                "property": "weapon-traits",
-                "selector": "bestial-mutagen-strike",
-                "value": "deadly-d10"
-            },
-            {
-                "baseType": "jaws",
-                "category": "unarmed",
-                "damage": {
-                    "base": {
-                        "damageType": "piercing",
-                        "dice": 4,
-                        "die": "d12"
-                    }
-                },
-                "group": "brawling",
-                "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
-                "key": "Strike",
-                "label": "PF2E.Weapon.Base.jaws",
-                "options": [
-                    "bestial-mutagen-strike"
-                ],
-                "predicate": [
-                    "feat:mutant-physique"
-                ],
-                "range": null,
-                "traits": [
-                    "unarmed"
-                ]
-            },
-            {
-                "baseType": "claw",
-                "category": "unarmed",
-                "damage": {
-                    "base": {
-                        "damageType": "slashing",
-                        "dice": 4,
-                        "die": "d10"
-                    }
-                },
-                "group": "brawling",
-                "img": "icons/commodities/claws/claw-bear-brown-grey.webp",
-                "key": "Strike",
-                "label": "PF2E.Weapon.Base.claw",
-                "options": [
-                    "bestial-mutagen-strike"
-                ],
-                "predicate": [
-                    "feat:mutant-physique"
-                ],
-                "range": null,
+                "slug": "claw",
                 "traits": [
                     "unarmed",
                     "agile"

--- a/packs/equipment-effects/effect-bestial-mutagen-moderate.json
+++ b/packs/equipment-effects/effect-bestial-mutagen-moderate.json
@@ -56,12 +56,8 @@
                 "options": [
                     "bestial-mutagen-strike"
                 ],
-                "predicate": [
-                    {
-                        "not": "feat:mutant-physique"
-                    }
-                ],
                 "range": null,
+                "slug": "jaws",
                 "traits": [
                     "unarmed"
                 ]
@@ -82,82 +78,6 @@
                 "label": "PF2E.Weapon.Base.claw",
                 "options": [
                     "bestial-mutagen-strike"
-                ],
-                "predicate": [
-                    {
-                        "not": "feat:mutant-physique"
-                    }
-                ],
-                "range": null,
-                "traits": [
-                    "unarmed",
-                    "agile"
-                ]
-            },
-            {
-                "hideIfDisabled": true,
-                "key": "FlatModifier",
-                "predicate": [
-                    "feat:mutant-physique"
-                ],
-                "selector": "intimidation",
-                "type": "item",
-                "value": 2
-            },
-            {
-                "key": "AdjustStrike",
-                "mode": "add",
-                "predicate": [
-                    "feat:mutant-physique"
-                ],
-                "property": "weapon-traits",
-                "selector": "bestial-mutagen-strike",
-                "value": "deadly-d10"
-            },
-            {
-                "baseType": "jaws",
-                "category": "unarmed",
-                "damage": {
-                    "base": {
-                        "damageType": "piercing",
-                        "dice": 2,
-                        "die": "d10"
-                    }
-                },
-                "group": "brawling",
-                "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
-                "key": "Strike",
-                "label": "PF2E.Weapon.Base.jaws",
-                "options": [
-                    "bestial-mutagen-strike"
-                ],
-                "predicate": [
-                    "feat:mutant-physique"
-                ],
-                "range": null,
-                "traits": [
-                    "unarmed"
-                ]
-            },
-            {
-                "baseType": "claw",
-                "category": "unarmed",
-                "damage": {
-                    "base": {
-                        "damageType": "slashing",
-                        "dice": 2,
-                        "die": "d8"
-                    }
-                },
-                "group": "brawling",
-                "img": "icons/commodities/claws/claw-bear-brown-grey.webp",
-                "key": "Strike",
-                "label": "PF2E.Weapon.Base.claw",
-                "options": [
-                    "bestial-mutagen-strike"
-                ],
-                "predicate": [
-                    "feat:mutant-physique"
                 ],
                 "range": null,
                 "traits": [

--- a/packs/feats/mutant-physique.json
+++ b/packs/feats/mutant-physique.json
@@ -115,7 +115,7 @@
                         ]
                     }
                 ],
-                "type": "all-damage",
+                "type": "physical",
                 "value": "floor(@actor.level/2)"
             }
         ],

--- a/packs/feats/mutant-physique.json
+++ b/packs/feats/mutant-physique.json
@@ -26,76 +26,26 @@
         },
         "rules": [
             {
-                "key": "DamageAlteration",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "upgrade",
                 "predicate": [
-                    "dice:slug:base",
+                    {
+                        "or": [
+                            "item:slug:claw",
+                            "item:slug:jaws"
+                        ]
+                    },
                     {
                         "or": [
                             "self:effect:bestial-mutagen-lesser",
-                            "self:effect:bestial-mutagen-moderate"
-                        ]
-                    }
-                ],
-                "property": "dice-faces",
-                "selectors": [
-                    "claw-damage"
-                ],
-                "value": 6
-            },
-            {
-                "key": "DamageAlteration",
-                "mode": "upgrade",
-                "predicate": [
-                    "dice:slug:base",
-                    {
-                        "or": [
-                            "self:effect:bestial-mutagen-lesser",
-                            "self:effect:bestial-mutagen-moderate"
-                        ]
-                    }
-                ],
-                "property": "dice-faces",
-                "selectors": [
-                    "jaws-damage"
-                ],
-                "value": 8
-            },
-            {
-                "key": "DamageAlteration",
-                "mode": "upgrade",
-                "predicate": [
-                    "dice:slug:base",
-                    {
-                        "or": [
+                            "self:effect:bestial-mutagen-moderate",
                             "self:effect:bestial-mutagen-greater",
                             "self:effect:bestial-mutagen-major"
                         ]
                     }
                 ],
-                "property": "dice-faces",
-                "selectors": [
-                    "claw-damage"
-                ],
-                "value": 10
-            },
-            {
-                "key": "DamageAlteration",
-                "mode": "upgrade",
-                "predicate": [
-                    "dice:slug:base",
-                    {
-                        "or": [
-                            "self:effect:bestial-mutagen-greater",
-                            "self:effect:bestial-mutagen-major"
-                        ]
-                    }
-                ],
-                "property": "dice-faces",
-                "selectors": [
-                    "jaws-damage"
-                ],
-                "value": 12
+                "property": "damage-dice-faces"
             },
             {
                 "key": "FlatModifier",

--- a/packs/feats/mutant-physique.json
+++ b/packs/feats/mutant-physique.json
@@ -24,7 +24,151 @@
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "DamageAlteration",
+                "mode": "upgrade",
+                "predicate": [
+                    "dice:slug:base",
+                    {
+                        "or": [
+                            "self:effect:bestial-mutagen-lesser",
+                            "self:effect:bestial-mutagen-moderate"
+                        ]
+                    }
+                ],
+                "property": "dice-faces",
+                "selectors": [
+                    "claw-damage"
+                ],
+                "value": 6
+            },
+            {
+                "key": "DamageAlteration",
+                "mode": "upgrade",
+                "predicate": [
+                    "dice:slug:base",
+                    {
+                        "or": [
+                            "self:effect:bestial-mutagen-lesser",
+                            "self:effect:bestial-mutagen-moderate"
+                        ]
+                    }
+                ],
+                "property": "dice-faces",
+                "selectors": [
+                    "jaws-damage"
+                ],
+                "value": 8
+            },
+            {
+                "key": "DamageAlteration",
+                "mode": "upgrade",
+                "predicate": [
+                    "dice:slug:base",
+                    {
+                        "or": [
+                            "self:effect:bestial-mutagen-greater",
+                            "self:effect:bestial-mutagen-major"
+                        ]
+                    }
+                ],
+                "property": "dice-faces",
+                "selectors": [
+                    "claw-damage"
+                ],
+                "value": 10
+            },
+            {
+                "key": "DamageAlteration",
+                "mode": "upgrade",
+                "predicate": [
+                    "dice:slug:base",
+                    {
+                        "or": [
+                            "self:effect:bestial-mutagen-greater",
+                            "self:effect:bestial-mutagen-major"
+                        ]
+                    }
+                ],
+                "property": "dice-faces",
+                "selectors": [
+                    "jaws-damage"
+                ],
+                "value": 12
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    {
+                        "or": [
+                            "self:effect:bestial-mutagen-lesser",
+                            "self:effect:bestial-mutagen-moderate",
+                            "self:effect:bestial-mutagen-greater",
+                            "self:effect:bestial-mutagen-major"
+                        ]
+                    }
+                ],
+                "selector": "intimidation",
+                "slug": "mutant-physique-intimidation",
+                "value": 1
+            },
+            {
+                "key": "AdjustModifier",
+                "mode": "upgrade",
+                "predicate": [
+                    "self:effect:bestial-mutagen-moderate"
+                ],
+                "selector": "intimidation",
+                "slug": "mutant-physique-intimidation",
+                "value": 2
+            },
+            {
+                "key": "AdjustModifier",
+                "mode": "upgrade",
+                "predicate": [
+                    "self:effect:bestial-mutagen-greater"
+                ],
+                "selector": "intimidation",
+                "slug": "mutant-physique-intimidation",
+                "value": 3
+            },
+            {
+                "key": "AdjustModifier",
+                "mode": "upgrade",
+                "predicate": [
+                    "self:effect:bestial-mutagen-major"
+                ],
+                "selector": "intimidation",
+                "slug": "mutant-physique-intimidation",
+                "value": 4
+            },
+            {
+                "key": "AdjustStrike",
+                "mode": "add",
+                "predicate": [
+                    "feat:mutant-physique"
+                ],
+                "property": "weapon-traits",
+                "selector": "bestial-mutagen-strike",
+                "value": "deadly-d10"
+            },
+            {
+                "key": "Resistance",
+                "predicate": [
+                    {
+                        "or": [
+                            "self:effect:juggernaut-mutagen-lesser",
+                            "self:effect:juggernaut-mutagen-moderate",
+                            "self:effect:juggernaut-mutagen-greater",
+                            "self:effect:juggernaut-mutagen-major"
+                        ]
+                    }
+                ],
+                "type": "all-damage",
+                "value": "floor(@actor.level/2)"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/mutant-physique.json
+++ b/packs/feats/mutant-physique.json
@@ -49,7 +49,6 @@
             },
             {
                 "key": "FlatModifier",
-                "type": "item",
                 "predicate": [
                     {
                         "or": [
@@ -62,6 +61,7 @@
                 ],
                 "selector": "intimidation",
                 "slug": "mutant-physique-intimidation",
+                "type": "item",
                 "value": 1
             },
             {

--- a/packs/feats/mutant-physique.json
+++ b/packs/feats/mutant-physique.json
@@ -49,6 +49,7 @@
             },
             {
                 "key": "FlatModifier",
+                "type": "item",
                 "predicate": [
                     {
                         "or": [


### PR DESCRIPTION
By moving the damage dice upgrades to the Mutant Physique feat, as well as its intimidation bonus and the resistance to physical damage from Juggernaut Mutagen.

Closes #16090