### PR TITLE
Bump minimum core version to 12.328

### DIFF
--- a/static/system.json
+++ b/static/system.json
@@ -5,7 +5,7 @@
     "version": "6.2.2",
     "license": "./LICENSE",
     "compatibility": {
-        "minimum": "12.327",
+        "minimum": "12.328",
         "verified": "12.331",
         "maximum": "12"
     },


### PR DESCRIPTION
Necessary for referencing `game.compendiumArt`