### PR TITLE
brush up Inventor Unstable Check rule element and effect

### DIFF
--- a/packs/classfeatures/explode.json
+++ b/packs/classfeatures/explode.json
@@ -37,7 +37,7 @@
                 "predicate": [
                     "item:trait:unstable",
                     {
-                        "not": "item:megaton-strike"
+                        "not": "self:effect:unstable-check-failure"
                     }
                 ],
                 "property": "description",

--- a/packs/feat-effects/effect-unstable-check-failure.json
+++ b/packs/feat-effects/effect-unstable-check-failure.json
@@ -9,11 +9,11 @@
         "duration": {
             "expiry": null,
             "sustained": false,
-            "unit": "encounter",
+            "unit": "unlimited",
             "value": -1
         },
         "level": {
-            "value": 0
+            "value": 1
         },
         "publication": {
             "license": "OGL",


### PR DESCRIPTION
- Change the Item Alteration RE predicate only to proc when the failure effect is not on the actor.
- Changed the duration of the Unstable Check Failure Effect to Unlimited, as it's supposed to persist until action is taken per the rules.