### PR TITLE
Do not persist other tags added via item alterations

### DIFF
--- a/src/module/actor/npc/types.ts
+++ b/src/module/actor/npc/types.ts
@@ -5,7 +5,7 @@ import type { MovementType, SaveType, SkillSlug } from "@actor/types.ts";
 import type { ItemPF2e } from "@item";
 import type { SpellcastingSheetData } from "@item/spellcasting-entry/index.ts";
 import type { ZeroToFour } from "@module/data.ts";
-import type { TraitTagifyEntry } from "@module/sheet/helpers.ts";
+import type { TagifyEntry } from "@module/sheet/helpers.ts";
 import type { ArmorClassTraceData } from "@system/statistic/index.ts";
 import type { NPCAttributes, NPCPerceptionData, NPCSaveData, NPCSkillData, NPCSystemData } from "./data.ts";
 import type { NPCPF2e, NPCStrike } from "./index.ts";
@@ -92,7 +92,7 @@ interface NPCSheetData extends CreatureSheetData<NPCPF2e> {
     hasShield?: boolean;
     hasHardness?: boolean;
     configLootableNpc?: boolean;
-    traitTagifyData: TraitTagifyEntry[];
+    traitTagifyData: TagifyEntry[];
     speeds: Record<"land", NPCSpeedSheetData & { details: string }> &
         Record<Exclude<MovementType, "land">, NPCSpeedSheetData | null>;
 }

--- a/src/module/item/base/sheet/sheet.ts
+++ b/src/module/item/base/sheet/sheet.ts
@@ -7,7 +7,7 @@ import {
     createTagifyTraits,
     maintainFocusInRender,
     SheetOptions,
-    TraitTagifyEntry,
+    TagifyEntry,
 } from "@module/sheet/helpers.ts";
 import type { HTMLTagifyTagsElement } from "@system/html-elements/tagify-tags.ts";
 import {
@@ -115,6 +115,9 @@ class ItemSheetPF2e<TItem extends ItemPF2e> extends ItemSheet<TItem, ItemSheetOp
         const traitTagifyData = validTraits
             ? createTagifyTraits(itemTraits, { sourceTraits, record: validTraits })
             : null;
+        const otherTagsTagifyData = createTagifyTraits(item.system.traits.otherTags, {
+            sourceTraits: item._source.system.traits.otherTags,
+        });
 
         return {
             itemType: null,
@@ -143,6 +146,7 @@ class ItemSheetPF2e<TItem extends ItemPF2e> extends ItemSheet<TItem, ItemSheetOp
             rarities: CONFIG.PF2E.rarityTraits,
             traits,
             traitTagifyData,
+            otherTagsTagifyData,
             enabledRulesUI: game.user.hasRole(game.settings.get("pf2e", "minimumRulesUI")),
             ruleEditing: !!this.editingRuleElement,
             rules: {
@@ -655,7 +659,8 @@ interface ItemSheetDataPF2e<TItem extends ItemPF2e> extends ItemSheetData<TItem>
     rarity: Rarity | null;
     rarities: typeof CONFIG.PF2E.rarityTraits;
     traits: SheetOptions | null;
-    traitTagifyData: TraitTagifyEntry[] | null;
+    traitTagifyData: TagifyEntry[] | null;
+    otherTagsTagifyData: TagifyEntry[] | null;
     rules: {
         selection: {
             selected: string | null;

--- a/src/module/item/spell/sheet.ts
+++ b/src/module/item/spell/sheet.ts
@@ -1,7 +1,7 @@
 import type { ActorPF2e } from "@actor";
 import { ItemSheetDataPF2e, ItemSheetOptions, ItemSheetPF2e } from "@item/base/sheet/sheet.ts";
 import { OneToTen } from "@module/data.ts";
-import { TraitTagifyEntry, createTagifyTraits } from "@module/sheet/helpers.ts";
+import { TagifyEntry, createTagifyTraits } from "@module/sheet/helpers.ts";
 import { DamageCategoryUnique, DamageType } from "@system/damage/types.ts";
 import { DAMAGE_CATEGORIES_UNIQUE } from "@system/damage/values.ts";
 import { HTMLTagifyTagsElement } from "@system/html-elements/tagify-tags.ts";
@@ -527,5 +527,5 @@ interface SpellSheetHeightenOverlayData extends SpellSheetOverlayData {
     system: Partial<SpellSystemSource>;
     heightenLevels: FormSelectOption[];
     missing: { key: keyof SpellSystemData; label: string }[];
-    traits?: TraitTagifyEntry[] | null;
+    traits?: TagifyEntry[] | null;
 }

--- a/src/module/sheet/helpers.ts
+++ b/src/module/sheet/helpers.ts
@@ -112,10 +112,10 @@ type SheetSelections = { value: (string | number)[] } | (string[] & { custom?: n
 
 interface TagifyTraitOptions {
     sourceTraits?: Iterable<string>;
-    record: Record<string, string>;
+    record?: Record<string, string>;
 }
 
-interface TraitTagifyEntry {
+interface TagifyEntry {
     id: string;
     value: string;
     readonly: boolean;
@@ -129,4 +129,4 @@ export {
     getAdjustment,
     maintainFocusInRender,
 };
-export type { AdjustedValue, SheetOption, SheetOptions, TraitTagifyEntry };
+export type { AdjustedValue, SheetOption, SheetOptions, TagifyEntry };

--- a/src/module/system/html-elements/tagify-tags.ts
+++ b/src/module/system/html-elements/tagify-tags.ts
@@ -1,3 +1,4 @@
+import { TagifyEntry } from "@module/sheet/helpers.ts";
 import * as R from "remeda";
 
 /**
@@ -5,7 +6,7 @@ import * as R from "remeda";
  * `Tagify` must be bound to the child input element that can be accessed at `HTMLTagifyTagsElement#input`
  */
 class HTMLTagifyTagsElement extends foundry.applications.elements.AbstractFormInputElement<
-    TagifySelection[] | string[],
+    TagifyEntry[] | string[],
     string
 > {
     static override tagName = "tagify-tags";
@@ -85,7 +86,5 @@ class HTMLTagifyTagsElement extends foundry.applications.elements.AbstractFormIn
         });
     }
 }
-
-type TagifySelection = { id?: string; value?: string; readonly?: boolean };
 
 export { HTMLTagifyTagsElement };

--- a/static/templates/items/partials/other-tags.hbs
+++ b/static/templates/items/partials/other-tags.hbs
@@ -4,7 +4,7 @@
         class="pf2e-tagify"
         name="system.traits.otherTags"
         id="{{fieldIdPrefix}}other-tags"
-        value="{{json item.system.traits.otherTags}}"
+        value="{{json otherTagsTagifyData}}"
     />
     <p class="hint">{{localize "PF2E.Item.OtherTags.Hint"}}</p>
 </div>


### PR DESCRIPTION
The otherTags property name was already taken by armor and consumable which wants different data entirely.