### PR TITLE
Refer to trait color in default red tag styling

### DIFF
--- a/src/styles/_tags.scss
+++ b/src/styles/_tags.scss
@@ -14,7 +14,7 @@
     .tag option {
         @include micro;
         align-items: center;
-        background-color: var(--color-pf-primary);
+        background-color: var(--color-bg-trait);
         border-radius: 2px;
         box-shadow: inset 0 0 0 1px rgba(black, 0.5);
         color: var(--color-text-trait);


### PR DESCRIPTION
For the purpose of the red attack tag in a strike becoming blue in starfinder.