### PR TITLE
Remove tag_alt from character sheet trait tags

### DIFF
--- a/static/templates/actors/character/tabs/character.hbs
+++ b/static/templates/actors/character/tabs/character.hbs
@@ -16,7 +16,7 @@
                     <li class="tag size">{{localize (lookup actorSizes data.traits.size.value)}}</li>
                 {{/if}}
                 {{#each traits as |trait slug|}}
-                    <li class="tag tag_alt" data-slug="{{slug}}">{{trait.label}}</li>
+                    <li class="tag" data-slug="{{slug}}">{{trait.label}}</li>
                 {{/each}}
             </ul>
 


### PR DESCRIPTION
Certain elements like the character sheet and chat messages override padding to zero. Chat messages lost out due to specificity. 

A better solution is to remove the padding from the global styling but its not safe to do that during a patch release.