### PR TITLE
Update Sharp Teeth and Draconic Scent to not be bonus feats

### DIFF
--- a/packs/ancestryfeatures/sharp-teeth.json
+++ b/packs/ancestryfeatures/sharp-teeth.json
@@ -9,7 +9,7 @@
         "actions": {
             "value": null
         },
-        "category": "bonus",
+        "category": "ancestryfeature",
         "description": {
             "value": "<p>Your prominent incisors offer an alternative to the fists other humanoids bring to a fight. You have a jaws unarmed attack that deals 1d4 piercing damage, is in the brawling group, and has the agile and finesse traits.</p>"
         },
@@ -48,7 +48,9 @@
         ],
         "traits": {
             "rarity": "common",
-            "value": []
+            "value": [
+                "ratfolk"
+            ]
         }
     },
     "type": "feat"

--- a/packs/feats/draconic-scent-dragon-disciple.json
+++ b/packs/feats/draconic-scent-dragon-disciple.json
@@ -9,7 +9,7 @@
         "actions": {
             "value": null
         },
-        "category": "bonus",
+        "category": "class",
         "description": {
             "value": "<p>Your sense of smell is uncanny, much like a dragon's. You gain imprecise scent with a range of 30 feet. The GM might double the range if you're downwind from the creature or halve the range if you're upwind, at their discretion.</p>"
         },


### PR DESCRIPTION
Sharp Teeth should be a Ratfolk ancestry feature and should have the Ratfolk trait.
Draconic Scent (Dragon Disciple) should be a class feat.