### PR TITLE
Count Domain Initiate Cleric feats toward Soul Warden feat count

### DIFF
--- a/packs/feats/advanced-domain.json
+++ b/packs/feats/advanced-domain.json
@@ -29,7 +29,14 @@
             "remaster": true,
             "title": "Pathfinder Player Core"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.soulWarden.featCount",
+                "value": 1
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/domain-initiate.json
+++ b/packs/feats/domain-initiate.json
@@ -31,6 +31,12 @@
                 "flag": "domainInitiate",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.DeitysDomain"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.soulWarden.featCount",
+                "value": 1
             }
         ],
         "traits": {

--- a/packs/feats/expanded-domain-initiate.json
+++ b/packs/feats/expanded-domain-initiate.json
@@ -28,7 +28,14 @@
             "remaster": false,
             "title": "Pathfinder Lost Omens: Gods & Magic"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.soulWarden.featCount",
+                "value": 1
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [


### PR DESCRIPTION
Soul Warden Dedication counts the number of Soul Warden feats towards the radius of the light it emits, but some of the Cleric feats like Domain Initiate, Expanded Domain Initiate, and Advanced Domain Initiate are also accessible to Soul Wardens. These now count towards the total feat count for the archetype.

Closes https://github.com/foundryvtt/pf2e/issues/16164