### PR TITLE
Update Storm Breath icon to use core icon

### DIFF
--- a/packs/equipment-effects/effect-storm-breath.json
+++ b/packs/equipment-effects/effect-storm-breath.json
@@ -1,13 +1,13 @@
 {
     "_id": "CDfixYwjfjoXkOVq",
-    "img": "systems/pf2e/icons/equipment/consumables/potions/serum-of-sex-shift.webp",
+    "img": "icons/consumables/potions/potion-bottle-fumes-blue.webp",
     "name": "Effect: Storm Breath",
     "system": {
         "description": {
-            "value": "<p>You gain resistance 5 to both electricity and sonic.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.equipment-srd.Item.Storm Breath]</p>\n<p>You gain resistance 5 to both electricity and sonic.</p>"
         },
         "duration": {
-            "expiry": "turn-start",
+            "expiry": null,
             "sustained": false,
             "unit": "unlimited",
             "value": -1

--- a/packs/equipment/storm-breath.json
+++ b/packs/equipment/storm-breath.json
@@ -1,6 +1,6 @@
 {
     "_id": "XPIsejlpyvHvR0Ma",
-    "img": "systems/pf2e/icons/equipment/consumables/potions/serum-of-sex-shift.webp",
+    "img": "icons/consumables/potions/potion-bottle-fumes-blue.webp",
     "name": "Storm Breath",
     "system": {
         "baseItem": null,

--- a/packs/extinction-curse-bestiary/abberton-ruffian.json
+++ b/packs/extinction-curse-bestiary/abberton-ruffian.json
@@ -94,7 +94,7 @@
         },
         {
             "_id": "kQzJhTzViDZxfegS",
-            "img": "systems/pf2e/icons/equipment/consumables/potions/serum-of-sex-shift.webp",
+            "img": "icons/consumables/drinks/alcohol-spirits-bottle-green.webp",
             "name": "Bottle",
             "sort": 200000,
             "system": {


### PR DESCRIPTION
also update a Bottle from some Extinction Curse ruffians. Both of these had the Serum of Sex Shift icon, presumably from way before it was replaced with TangleLion's icon.