### PR TITLE
update Human ancestry publication source to remaster

### DIFF
--- a/packs/ancestries/human.json
+++ b/packs/ancestries/human.json
@@ -50,9 +50,9 @@
             ]
         },
         "publication": {
-            "license": "OGL",
-            "remaster": false,
-            "title": "Pathfinder Core Rulebook"
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
         },
         "reach": 5,
         "rules": [],


### PR DESCRIPTION
update source to Pathfinder Player Core, license to ORC and remaster to true. Closes  #16219