### PR TITLE
Brush up Hand of the Apprentice wizard focus spell

### DIFF
--- a/packs/spell-effects/spell-effect-hand-of-the-apprentice.json
+++ b/packs/spell-effects/spell-effect-hand-of-the-apprentice.json
@@ -61,8 +61,7 @@
                     "focus-spell:wisdom"
                 ],
                 "selector": "{item|flags.pf2e.rulesSelections.weapon}-damage",
-                "type": "ability",
-                "value": 0
+                "type": "ability"
             },
             {
                 "key": "CriticalSpecialization",

--- a/packs/spell-effects/spell-effect-hand-of-the-apprentice.json
+++ b/packs/spell-effects/spell-effect-hand-of-the-apprentice.json
@@ -33,10 +33,36 @@
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
             {
-                "ability": "int",
+                "ability": "cha",
+                "hideIfDisabled": true,
                 "key": "FlatModifier",
+                "predicate": [
+                    "focus-spell:charisma"
+                ],
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-damage",
+                "type": "ability",
+                "value": "charisma"
+            },
+            {
+                "ability": "int",
+                "hideIfDisabled": true,
+                "key": "FlatModifier",
+                "predicate": [
+                    "focus-spell:intelligence"
+                ],
                 "selector": "{item|flags.pf2e.rulesSelections.weapon}-damage",
                 "type": "ability"
+            },
+            {
+                "ability": "wis",
+                "hideIfDisabled": true,
+                "key": "FlatModifier",
+                "predicate": [
+                    "focus-spell:wisdom"
+                ],
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-damage",
+                "type": "ability",
+                "value": 0
             },
             {
                 "key": "CriticalSpecialization",

--- a/packs/spells/hand-of-the-apprentice.json
+++ b/packs/spells/hand-of-the-apprentice.json
@@ -29,7 +29,37 @@
             "value": "500 feet"
         },
         "requirements": "",
-        "rules": [],
+        "rules": [
+            {
+                "adjustName": false,
+                "choices": [
+                    {
+                        "predicate": [
+                            "spellcasting:cha"
+                        ],
+                        "value": "charisma"
+                    },
+                    {
+                        "predicate": [
+                            "spellcasting:int"
+                        ],
+                        "value": "intelligence"
+                    },
+                    {
+                        "predicate": [
+                            "spellcasting:wis"
+                        ],
+                        "value": "wisdom"
+                    }
+                ],
+                "flag": "handOfApprentice",
+                "key": "ChoiceSet"
+            },
+            {
+                "key": "RollOption",
+                "option": "focus-spell:{item|flags.pf2e.rulesSelections.handOfApprentice}"
+            }
+        ],
         "target": {
             "value": "1 creature"
         },


### PR DESCRIPTION
- Added a choice set and roll option to get the spellcasting attribute used in the spellcasting entry.
- Added additional Flat Modifiers for the charisma and wisdom that only proc on the corresponding roll option