### PR TITLE
Tag feats granting ancestral spells (A)

### DIFF
--- a/packs/classfeatures/bloodline-aberrant.json
+++ b/packs/classfeatures/bloodline-aberrant.json
@@ -86,6 +86,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "other-tags",
                 "value": "blood-magic-spell"
             },
@@ -148,6 +149,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {
@@ -178,6 +180,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {

--- a/packs/classfeatures/bloodline-aberrant.json
+++ b/packs/classfeatures/bloodline-aberrant.json
@@ -57,7 +57,6 @@
                     },
                     {
                         "or": [
-                            "item:tag:ancestral-spell",
                             {
                                 "and": [
                                     "item:trait:focus",

--- a/packs/classfeatures/bloodline-angelic.json
+++ b/packs/classfeatures/bloodline-angelic.json
@@ -86,6 +86,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "other-tags",
                 "value": "blood-magic-spell"
             },
@@ -148,6 +149,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {
@@ -178,6 +180,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {

--- a/packs/classfeatures/bloodline-angelic.json
+++ b/packs/classfeatures/bloodline-angelic.json
@@ -57,7 +57,6 @@
                     },
                     {
                         "or": [
-                            "item:tag:ancestral-spell",
                             {
                                 "and": [
                                     "item:trait:focus",

--- a/packs/classfeatures/bloodline-demonic.json
+++ b/packs/classfeatures/bloodline-demonic.json
@@ -86,6 +86,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "other-tags",
                 "value": "blood-magic-spell"
             },
@@ -148,6 +149,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {
@@ -178,6 +180,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {

--- a/packs/classfeatures/bloodline-demonic.json
+++ b/packs/classfeatures/bloodline-demonic.json
@@ -57,7 +57,6 @@
                     },
                     {
                         "or": [
-                            "item:tag:ancestral-spell",
                             {
                                 "and": [
                                     "item:trait:focus",

--- a/packs/classfeatures/bloodline-diabolic.json
+++ b/packs/classfeatures/bloodline-diabolic.json
@@ -86,6 +86,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "other-tags",
                 "value": "blood-magic-spell"
             },
@@ -148,6 +149,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {
@@ -178,6 +180,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {

--- a/packs/classfeatures/bloodline-diabolic.json
+++ b/packs/classfeatures/bloodline-diabolic.json
@@ -57,7 +57,6 @@
                     },
                     {
                         "or": [
-                            "item:tag:ancestral-spell",
                             {
                                 "and": [
                                     "item:trait:focus",

--- a/packs/classfeatures/bloodline-draconic.json
+++ b/packs/classfeatures/bloodline-draconic.json
@@ -594,6 +594,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "other-tags",
                 "value": "blood-magic-spell"
             },
@@ -656,6 +657,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {
@@ -686,6 +688,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {

--- a/packs/classfeatures/bloodline-draconic.json
+++ b/packs/classfeatures/bloodline-draconic.json
@@ -359,7 +359,6 @@
                     },
                     {
                         "or": [
-                            "item:tag:ancestral-spell",
                             {
                                 "and": [
                                     "item:trait:focus",

--- a/packs/classfeatures/bloodline-elemental.json
+++ b/packs/classfeatures/bloodline-elemental.json
@@ -210,6 +210,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "other-tags",
                 "value": "blood-magic-spell"
             },
@@ -272,6 +273,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {
@@ -302,6 +304,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {

--- a/packs/classfeatures/bloodline-elemental.json
+++ b/packs/classfeatures/bloodline-elemental.json
@@ -112,7 +112,6 @@
                     },
                     {
                         "or": [
-                            "item:tag:ancestral-spell",
                             {
                                 "and": [
                                     "item:trait:focus",

--- a/packs/classfeatures/bloodline-fey.json
+++ b/packs/classfeatures/bloodline-fey.json
@@ -86,6 +86,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "other-tags",
                 "value": "blood-magic-spell"
             },
@@ -148,6 +149,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {
@@ -178,6 +180,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {

--- a/packs/classfeatures/bloodline-fey.json
+++ b/packs/classfeatures/bloodline-fey.json
@@ -57,7 +57,6 @@
                     },
                     {
                         "or": [
-                            "item:tag:ancestral-spell",
                             {
                                 "and": [
                                     "item:trait:focus",

--- a/packs/classfeatures/bloodline-genie.json
+++ b/packs/classfeatures/bloodline-genie.json
@@ -171,6 +171,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "other-tags",
                 "value": "blood-magic-spell"
             },
@@ -233,6 +234,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {
@@ -263,6 +265,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {

--- a/packs/classfeatures/bloodline-genie.json
+++ b/packs/classfeatures/bloodline-genie.json
@@ -85,7 +85,6 @@
                     },
                     {
                         "or": [
-                            "item:tag:ancestral-spell",
                             {
                                 "and": [
                                     "item:trait:focus",

--- a/packs/classfeatures/bloodline-hag.json
+++ b/packs/classfeatures/bloodline-hag.json
@@ -86,6 +86,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "other-tags",
                 "value": "blood-magic-spell"
             },
@@ -148,6 +149,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {
@@ -178,6 +180,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {

--- a/packs/classfeatures/bloodline-hag.json
+++ b/packs/classfeatures/bloodline-hag.json
@@ -57,7 +57,6 @@
                     },
                     {
                         "or": [
-                            "item:tag:ancestral-spell",
                             {
                                 "and": [
                                     "item:trait:focus",

--- a/packs/classfeatures/bloodline-harrow.json
+++ b/packs/classfeatures/bloodline-harrow.json
@@ -57,7 +57,6 @@
                     },
                     {
                         "or": [
-                            "item:tag:ancestral-spell",
                             {
                                 "and": [
                                     "item:trait:focus",

--- a/packs/classfeatures/bloodline-harrow.json
+++ b/packs/classfeatures/bloodline-harrow.json
@@ -86,6 +86,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "other-tags",
                 "value": "blood-magic-spell"
             },
@@ -148,6 +149,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {
@@ -175,6 +177,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {

--- a/packs/classfeatures/bloodline-imperial.json
+++ b/packs/classfeatures/bloodline-imperial.json
@@ -86,6 +86,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "other-tags",
                 "value": "blood-magic-spell"
             },
@@ -148,6 +149,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {
@@ -178,6 +180,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {

--- a/packs/classfeatures/bloodline-imperial.json
+++ b/packs/classfeatures/bloodline-imperial.json
@@ -57,7 +57,6 @@
                     },
                     {
                         "or": [
-                            "item:tag:ancestral-spell",
                             {
                                 "and": [
                                     "item:trait:focus",

--- a/packs/classfeatures/bloodline-nymph.json
+++ b/packs/classfeatures/bloodline-nymph.json
@@ -86,6 +86,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "other-tags",
                 "value": "blood-magic-spell"
             },
@@ -148,6 +149,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {
@@ -178,6 +180,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {

--- a/packs/classfeatures/bloodline-nymph.json
+++ b/packs/classfeatures/bloodline-nymph.json
@@ -57,7 +57,6 @@
                     },
                     {
                         "or": [
-                            "item:tag:ancestral-spell",
                             {
                                 "and": [
                                     "item:trait:focus",

--- a/packs/classfeatures/bloodline-phoenix.json
+++ b/packs/classfeatures/bloodline-phoenix.json
@@ -86,6 +86,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "other-tags",
                 "value": "blood-magic-spell"
             },
@@ -148,6 +149,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {
@@ -178,6 +180,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {

--- a/packs/classfeatures/bloodline-phoenix.json
+++ b/packs/classfeatures/bloodline-phoenix.json
@@ -57,7 +57,6 @@
                     },
                     {
                         "or": [
-                            "item:tag:ancestral-spell",
                             {
                                 "and": [
                                     "item:trait:focus",

--- a/packs/classfeatures/bloodline-psychopomp.json
+++ b/packs/classfeatures/bloodline-psychopomp.json
@@ -86,6 +86,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "other-tags",
                 "value": "blood-magic-spell"
             },
@@ -148,6 +149,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {
@@ -178,6 +180,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {

--- a/packs/classfeatures/bloodline-psychopomp.json
+++ b/packs/classfeatures/bloodline-psychopomp.json
@@ -57,7 +57,6 @@
                     },
                     {
                         "or": [
-                            "item:tag:ancestral-spell",
                             {
                                 "and": [
                                     "item:trait:focus",

--- a/packs/classfeatures/bloodline-shadow.json
+++ b/packs/classfeatures/bloodline-shadow.json
@@ -86,6 +86,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "other-tags",
                 "value": "blood-magic-spell"
             },
@@ -148,6 +149,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {
@@ -178,6 +180,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {

--- a/packs/classfeatures/bloodline-shadow.json
+++ b/packs/classfeatures/bloodline-shadow.json
@@ -57,7 +57,6 @@
                     },
                     {
                         "or": [
-                            "item:tag:ancestral-spell",
                             {
                                 "and": [
                                     "item:trait:focus",

--- a/packs/classfeatures/bloodline-undead.json
+++ b/packs/classfeatures/bloodline-undead.json
@@ -86,6 +86,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "other-tags",
                 "value": "blood-magic-spell"
             },
@@ -148,6 +149,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {
@@ -178,6 +180,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {

--- a/packs/classfeatures/bloodline-undead.json
+++ b/packs/classfeatures/bloodline-undead.json
@@ -57,7 +57,6 @@
                     },
                     {
                         "or": [
-                            "item:tag:ancestral-spell",
                             {
                                 "and": [
                                     "item:trait:focus",

--- a/packs/classfeatures/bloodline-wyrmblessed.json
+++ b/packs/classfeatures/bloodline-wyrmblessed.json
@@ -212,7 +212,6 @@
                     },
                     {
                         "or": [
-                            "item:tag:ancestral-spell",
                             {
                                 "and": [
                                     "item:trait:focus",

--- a/packs/classfeatures/bloodline-wyrmblessed.json
+++ b/packs/classfeatures/bloodline-wyrmblessed.json
@@ -241,6 +241,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "other-tags",
                 "value": "blood-magic-spell"
             },
@@ -303,6 +304,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {
@@ -333,6 +335,7 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {

--- a/packs/feats/advanced-targeting-system.json
+++ b/packs/feats/advanced-targeting-system.json
@@ -24,7 +24,34 @@
             "remaster": false,
             "title": "Pathfinder Lost Omens: Ancestry Guide"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:sure-strike",
+                    "spellcasting:innate",
+                    "item:rank:1"
+                ],
+                "priority": 119,
+                "property": "other-tags",
+                "value": "ancestral-spell"
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:sure-strike",
+                    "spellcasting:innate",
+                    "item:rank:1"
+                ],
+                "priority": 119,
+                "property": "other-tags",
+                "value": "ancestral-spell:android"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/advanced-targeting-system.json
+++ b/packs/feats/advanced-targeting-system.json
@@ -31,10 +31,8 @@
                 "mode": "add",
                 "predicate": [
                     "item:slug:sure-strike",
-                    "spellcasting:innate",
-                    "item:rank:1"
+                    "spellcasting:innate"
                 ],
-                "priority": 119,
                 "property": "other-tags",
                 "value": "ancestral-spell"
             },
@@ -44,10 +42,8 @@
                 "mode": "add",
                 "predicate": [
                     "item:slug:sure-strike",
-                    "spellcasting:innate",
-                    "item:rank:1"
+                    "spellcasting:innate"
                 ],
-                "priority": 119,
                 "property": "other-tags",
                 "value": "ancestral-spell:android"
             }

--- a/packs/feats/analyze-information.json
+++ b/packs/feats/analyze-information.json
@@ -24,7 +24,34 @@
             "remaster": false,
             "title": "Pathfinder Lost Omens: Ancestry Guide"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:hypercognition",
+                    "spellcasting:innate",
+                    "item:rank:3"
+                ],
+                "priority": 119,
+                "property": "other-tags",
+                "value": "ancestral-spell"
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:hypercognition",
+                    "spellcasting:innate",
+                    "item:rank:3"
+                ],
+                "priority": 119,
+                "property": "other-tags",
+                "value": "ancestral-spell:aphorite"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/analyze-information.json
+++ b/packs/feats/analyze-information.json
@@ -31,10 +31,8 @@
                 "mode": "add",
                 "predicate": [
                     "item:slug:hypercognition",
-                    "spellcasting:innate",
-                    "item:rank:3"
+                    "spellcasting:innate"
                 ],
-                "priority": 119,
                 "property": "other-tags",
                 "value": "ancestral-spell"
             },
@@ -44,10 +42,8 @@
                 "mode": "add",
                 "predicate": [
                     "item:slug:hypercognition",
-                    "spellcasting:innate",
-                    "item:rank:3"
+                    "spellcasting:innate"
                 ],
-                "priority": 119,
                 "property": "other-tags",
                 "value": "ancestral-spell:aphorite"
             }

--- a/packs/feats/ancestral-blood-magic.json
+++ b/packs/feats/ancestral-blood-magic.json
@@ -26,11 +26,14 @@
         },
         "rules": [
             {
-                "key": "RollOption",
-                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.AncestralBloodMagic",
-                "option": "ancestral-blood-magic",
-                "placement": "spellcasting",
-                "toggleable": true
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:tag:ancestral-spell"
+                ],
+                "property": "other-tags",
+                "value": "blood-magic-spell"
             }
         ],
         "traits": {

--- a/packs/feats/ancestral-blood-magic.json
+++ b/packs/feats/ancestral-blood-magic.json
@@ -35,6 +35,7 @@
                         "not": "item:trait:cantrip"
                     }
                 ],
+                "priority": 121,
                 "property": "other-tags",
                 "value": "blood-magic-spell"
             }

--- a/packs/feats/ancestral-blood-magic.json
+++ b/packs/feats/ancestral-blood-magic.json
@@ -30,7 +30,10 @@
                 "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
-                    "item:tag:ancestral-spell"
+                    "item:tag:ancestral-spell",
+                    {
+                        "not": "item:trait:cantrip"
+                    }
                 ],
                 "property": "other-tags",
                 "value": "blood-magic-spell"

--- a/packs/feats/crones-cruelty.json
+++ b/packs/feats/crones-cruelty.json
@@ -24,7 +24,34 @@
             "remaster": false,
             "title": "Pathfinder Lost Omens: Ancestry Guide"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:warp-mind",
+                    "spellcasting:innate",
+                    "item:rank:7"
+                ],
+                "priority": 119,
+                "property": "other-tags",
+                "value": "ancestral-spell"
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:warp-mind",
+                    "spellcasting:innate",
+                    "item:rank:7"
+                ],
+                "priority": 119,
+                "property": "other-tags",
+                "value": "ancestral-spell:changeling"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/crones-cruelty.json
+++ b/packs/feats/crones-cruelty.json
@@ -31,10 +31,8 @@
                 "mode": "add",
                 "predicate": [
                     "item:slug:warp-mind",
-                    "spellcasting:innate",
-                    "item:rank:7"
+                    "spellcasting:innate"
                 ],
-                "priority": 119,
                 "property": "other-tags",
                 "value": "ancestral-spell"
             },
@@ -44,10 +42,8 @@
                 "mode": "add",
                 "predicate": [
                     "item:slug:warp-mind",
-                    "spellcasting:innate",
-                    "item:rank:7"
+                    "spellcasting:innate"
                 ],
-                "priority": 119,
                 "property": "other-tags",
                 "value": "ancestral-spell:changeling"
             }

--- a/packs/feats/hag-magic.json
+++ b/packs/feats/hag-magic.json
@@ -103,10 +103,8 @@
                 "mode": "add",
                 "predicate": [
                     "spellcasting:innate",
-                    "item:slug:{item|flags.pf2e.rulesSelections.hagMagic}",
-                    "item:rank:4"
+                    "item:slug:{item|flags.pf2e.rulesSelections.hagMagic}"
                 ],
-                "priority": 119,
                 "property": "other-tags",
                 "value": "ancestral-spell"
             },
@@ -116,10 +114,8 @@
                 "mode": "add",
                 "predicate": [
                     "spellcasting:innate",
-                    "item:slug:{item|flags.pf2e.rulesSelections.hagMagic}",
-                    "item:rank:4"
+                    "item:slug:{item|flags.pf2e.rulesSelections.hagMagic}"
                 ],
-                "priority": 119,
                 "property": "other-tags",
                 "value": "ancestral-spell:changeling"
             }

--- a/packs/feats/hag-magic.json
+++ b/packs/feats/hag-magic.json
@@ -24,7 +24,106 @@
             "remaster": true,
             "title": "Pathfinder Player Core"
         },
-        "rules": [],
+        "rules": [
+            {
+                "choices": {
+                    "filter": [
+                        {
+                            "or": [
+                                "item:slug:augury",
+                                "item:slug:charm",
+                                "item:slug:clairaudience",
+                                "item:slug:clairvoyance",
+                                "item:slug:dream-message",
+                                "item:slug:illusory-disguise",
+                                {
+                                    "and": [
+                                        "feat:brine-may",
+                                        {
+                                            "or": [
+                                                "item:slug:humanoid-form",
+                                                "item:slug:water-walk"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "and": [
+                                        "feat:callow-may",
+                                        {
+                                            "or": [
+                                                "item:slug:honeyed-words",
+                                                "item:slug:outcasts-curse"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "and": [
+                                        {
+                                            "or": [
+                                                "feat:dream-may",
+                                                "feat:veil-may"
+                                            ]
+                                        },
+                                        "item:slug:nightmare"
+                                    ]
+                                },
+                                {
+                                    "and": [
+                                        "feat:slag-may",
+                                        "item:slug:earthbind"
+                                    ]
+                                },
+                                {
+                                    "and": [
+                                        "feat:snow-may",
+                                        "item:slug:solid-fog"
+                                    ]
+                                },
+                                {
+                                    "and": [
+                                        "feat:virga-may",
+                                        "item:slug:hydraulic-torrent"
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "itemType": "spell",
+                    "slugsAsValues": true
+                },
+                "flag": "hagMagic",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.Spell"
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "spellcasting:innate",
+                    "item:slug:{item|flags.pf2e.rulesSelections.hagMagic}",
+                    "item:rank:4"
+                ],
+                "priority": 119,
+                "property": "other-tags",
+                "value": "ancestral-spell"
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "spellcasting:innate",
+                    "item:slug:{item|flags.pf2e.rulesSelections.hagMagic}",
+                    "item:rank:4"
+                ],
+                "priority": 119,
+                "property": "other-tags",
+                "value": "ancestral-spell:changeling"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/kizidhar-magic.json
+++ b/packs/feats/kizidhar-magic.json
@@ -36,10 +36,8 @@
                             "item:slug:one-with-plants"
                         ]
                     },
-                    "spellcasting:innate",
-                    "item:rank:2"
+                    "spellcasting:innate"
                 ],
-                "priority": 119,
                 "property": "other-tags",
                 "value": "ancestral-spell"
             },
@@ -54,10 +52,8 @@
                             "item:slug:one-with-plants"
                         ]
                     },
-                    "spellcasting:innate",
-                    "item:rank:2"
+                    "spellcasting:innate"
                 ],
-                "priority": 119,
                 "property": "other-tags",
                 "value": "ancestral-spell:ardande"
             }

--- a/packs/feats/kizidhar-magic.json
+++ b/packs/feats/kizidhar-magic.json
@@ -11,7 +11,7 @@
         },
         "category": "ancestry",
         "description": {
-            "value": "<p>You can wield the arcane magic of a kizidhar, casting <em>entangling flora</em> and <em>one with plants</em> once per day each as 2nd-rank arcane innate spells.</p>"
+            "value": "<p>You can wield the arcane magic of a kizidhar, casting @UUID[Compendium.pf2e.spells-srd.Item.Entangling Flora] and @UUID[Compendium.pf2e.spells-srd.Item.One with Plants] once per day each as 2nd-rank arcane innate spells.</p>"
         },
         "level": {
             "value": 9
@@ -24,7 +24,44 @@
             "remaster": true,
             "title": "Pathfinder Rage of Elements"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    {
+                        "or": [
+                            "item:slug:enangling-flora",
+                            "item:slug:one-with-plants"
+                        ]
+                    },
+                    "spellcasting:innate",
+                    "item:rank:2"
+                ],
+                "priority": 119,
+                "property": "other-tags",
+                "value": "ancestral-spell"
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    {
+                        "or": [
+                            "item:slug:enangling-flora",
+                            "item:slug:one-with-plants"
+                        ]
+                    },
+                    "spellcasting:innate",
+                    "item:rank:2"
+                ],
+                "priority": 119,
+                "property": "other-tags",
+                "value": "ancestral-spell:ardande"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/moon-may.json
+++ b/packs/feats/moon-may.json
@@ -25,7 +25,32 @@
             "remaster": false,
             "title": "Pathfinder Lost Omens: Ancestry Guide"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:guidance",
+                    "spellcasting:innate"
+                ],
+                "priority": 119,
+                "property": "other-tags",
+                "value": "ancestral-spell"
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:guidance",
+                    "spellcasting:innate"
+                ],
+                "priority": 119,
+                "property": "other-tags",
+                "value": "ancestral-spell:changeling"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/moon-may.json
+++ b/packs/feats/moon-may.json
@@ -34,7 +34,6 @@
                     "item:slug:guidance",
                     "spellcasting:innate"
                 ],
-                "priority": 119,
                 "property": "other-tags",
                 "value": "ancestral-spell"
             },
@@ -46,7 +45,6 @@
                     "item:slug:guidance",
                     "spellcasting:innate"
                 ],
-                "priority": 119,
                 "property": "other-tags",
                 "value": "ancestral-spell:changeling"
             }

--- a/packs/feats/offensive-analysis.json
+++ b/packs/feats/offensive-analysis.json
@@ -24,7 +24,34 @@
             "remaster": false,
             "title": "Pathfinder Lost Omens: Ancestry Guide"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:sure-strike",
+                    "spellcasting:innate",
+                    "item:rank:1"
+                ],
+                "priority": 119,
+                "property": "other-tags",
+                "value": "ancestral-spell"
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:sure-strike",
+                    "spellcasting:innate",
+                    "item:rank:1"
+                ],
+                "priority": 119,
+                "property": "other-tags",
+                "value": "ancestral-spell:aphorite"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/offensive-analysis.json
+++ b/packs/feats/offensive-analysis.json
@@ -31,10 +31,8 @@
                 "mode": "add",
                 "predicate": [
                     "item:slug:sure-strike",
-                    "spellcasting:innate",
-                    "item:rank:1"
+                    "spellcasting:innate"
                 ],
-                "priority": 119,
                 "property": "other-tags",
                 "value": "ancestral-spell"
             },
@@ -44,10 +42,8 @@
                 "mode": "add",
                 "predicate": [
                     "item:slug:sure-strike",
-                    "spellcasting:innate",
-                    "item:rank:1"
+                    "spellcasting:innate"
                 ],
-                "priority": 119,
                 "property": "other-tags",
                 "value": "ancestral-spell:aphorite"
             }

--- a/packs/feats/springsoul.json
+++ b/packs/feats/springsoul.json
@@ -11,7 +11,7 @@
         },
         "category": "ancestry",
         "description": {
-            "value": "<p>Your connection to elemental wood manifests as fresh blossoms, spring fruits, and the seeds of new life, and you harness this power to spread vitality and abundance. You can cast the <em>tangle vine</em> cantrip as an innate primal or arcane spell at will. A cantrip is heightened to a spell rank equal to half your level rounded up.</p>"
+            "value": "<p>Your connection to elemental wood manifests as fresh blossoms, spring fruits, and the seeds of new life, and you harness this power to spread vitality and abundance. You can cast the @UUID[Compendium.pf2e.spells-srd.Item.Tangle Vine] cantrip as an innate primal or arcane spell at will. A cantrip is heightened to a spell rank equal to half your level rounded up.</p>"
         },
         "level": {
             "value": 1
@@ -24,7 +24,32 @@
             "remaster": true,
             "title": "Pathfinder Rage of Elements"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:tangle-vine",
+                    "spellcasting:innate"
+                ],
+                "priority": 119,
+                "property": "other-tags",
+                "value": "ancestral-spell"
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:tangle-vine",
+                    "spellcasting:innate"
+                ],
+                "priority": 119,
+                "property": "other-tags",
+                "value": "ancestral-spell:ardande"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/springsoul.json
+++ b/packs/feats/springsoul.json
@@ -33,7 +33,6 @@
                     "item:slug:tangle-vine",
                     "spellcasting:innate"
                 ],
-                "priority": 119,
                 "property": "other-tags",
                 "value": "ancestral-spell"
             },
@@ -45,7 +44,6 @@
                     "item:slug:tangle-vine",
                     "spellcasting:innate"
                 ],
-                "priority": 119,
                 "property": "other-tags",
                 "value": "ancestral-spell:ardande"
             }

--- a/packs/feats/studious-adept.json
+++ b/packs/feats/studious-adept.json
@@ -40,10 +40,8 @@
                             "item:slug:mirror-image"
                         ]
                     },
-                    "spellcasting:innate",
-                    "item:rank:2"
+                    "spellcasting:innate"
                 ],
-                "priority": 119,
                 "property": "other-tags",
                 "value": "ancestral-spell"
             },
@@ -58,10 +56,8 @@
                             "item:slug:mirror-image"
                         ]
                     },
-                    "spellcasting:innate",
-                    "item:rank:2"
+                    "spellcasting:innate"
                 ],
-                "priority": 119,
                 "property": "other-tags",
                 "value": "ancestral-spell:anadi"
             }

--- a/packs/feats/studious-adept.json
+++ b/packs/feats/studious-adept.json
@@ -28,7 +28,44 @@
             "remaster": false,
             "title": "Pathfinder Lost Omens: The Mwangi Expanse"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    {
+                        "or": [
+                            "item:slug:humanoid-form",
+                            "item:slug:mirror-image"
+                        ]
+                    },
+                    "spellcasting:innate",
+                    "item:rank:2"
+                ],
+                "priority": 119,
+                "property": "other-tags",
+                "value": "ancestral-spell"
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    {
+                        "or": [
+                            "item:slug:humanoid-form",
+                            "item:slug:mirror-image"
+                        ]
+                    },
+                    "spellcasting:innate",
+                    "item:rank:2"
+                ],
+                "priority": 119,
+                "property": "other-tags",
+                "value": "ancestral-spell:anadi"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/summon-wood-elemental.json
+++ b/packs/feats/summon-wood-elemental.json
@@ -30,7 +30,7 @@
                 "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
-                    "item:rank:5"
+                    "item:rank:5",
                     "item:slug:summon-elemental",
                     "spellcasting:innate"
                 ],

--- a/packs/feats/summon-wood-elemental.json
+++ b/packs/feats/summon-wood-elemental.json
@@ -30,11 +30,9 @@
                 "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
-                    "item:rank:5",
                     "item:slug:summon-elemental",
                     "spellcasting:innate"
                 ],
-                "priority": 119,
                 "property": "other-tags",
                 "value": "ancestral-spell"
             },
@@ -43,11 +41,9 @@
                 "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
-                    "item:rank:5",
                     "item:slug:summon-elemental",
                     "spellcasting:innate"
                 ],
-                "priority": 119,
                 "property": "other-tags",
                 "value": "ancestral-spell:ardande"
             }

--- a/packs/feats/summon-wood-elemental.json
+++ b/packs/feats/summon-wood-elemental.json
@@ -24,7 +24,34 @@
             "remaster": true,
             "title": "Pathfinder Rage of Elements"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:rank:5"
+                    "item:slug:summon-elemental",
+                    "spellcasting:innate"
+                ],
+                "priority": 119,
+                "property": "other-tags",
+                "value": "ancestral-spell"
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:rank:5",
+                    "item:slug:summon-elemental",
+                    "spellcasting:innate"
+                ],
+                "priority": 119,
+                "property": "other-tags",
+                "value": "ancestral-spell:ardande"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/supernatural-charm.json
+++ b/packs/feats/supernatural-charm.json
@@ -31,10 +31,8 @@
                 "mode": "add",
                 "predicate": [
                     "item:slug:charm",
-                    "spellcasting:innate",
-                    "item:rank:1"
+                    "spellcasting:innate"
                 ],
-                "priority": 119,
                 "property": "other-tags",
                 "value": "ancestral-spell"
             },
@@ -44,10 +42,8 @@
                 "mode": "add",
                 "predicate": [
                     "item:slug:charm",
-                    "spellcasting:innate",
-                    "item:rank:1"
+                    "spellcasting:innate"
                 ],
-                "priority": 119,
                 "property": "other-tags",
                 "value": "ancestral-spell:aiuvarin"
             }

--- a/packs/feats/supernatural-charm.json
+++ b/packs/feats/supernatural-charm.json
@@ -24,7 +24,34 @@
             "remaster": true,
             "title": "Pathfinder Player Core"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:charm",
+                    "spellcasting:innate",
+                    "item:rank:1"
+                ],
+                "priority": 119,
+                "property": "other-tags",
+                "value": "ancestral-spell"
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:charm",
+                    "spellcasting:innate",
+                    "item:rank:1"
+                ],
+                "priority": 119,
+                "property": "other-tags",
+                "value": "ancestral-spell:aiuvarin"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/unfettered-growth.json
+++ b/packs/feats/unfettered-growth.json
@@ -30,30 +30,13 @@
         },
         "rules": [
             {
-                "choices": [
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Second",
-                        "value": 2
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Fourth",
-                        "value": 4
-                    }
-                ],
-                "flag": "rank",
-                "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.SpellRank.Prompt"
-            },
-            {
                 "itemType": "spell",
                 "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
                     "item:slug:enlarge",
-                    "spellcasting:innate",
-                    "item:rank:{item|flags.pf2e.rulesSelections.rank}"
+                    "spellcasting:innate"
                 ],
-                "priority": 119,
                 "property": "other-tags",
                 "value": "ancestral-spell"
             },
@@ -64,10 +47,8 @@
                 "predicate": [
                     "item:slug:enlarge",
                     "self:heritage:ardande",
-                    "spellcasting:innate",
-                    "item:rank:{item|flags.pf2e.rulesSelections.rank}"
+                    "spellcasting:innate"
                 ],
-                "priority": 119,
                 "property": "other-tags",
                 "value": "ancestral-spell:ardande"
             }

--- a/packs/feats/unfettered-growth.json
+++ b/packs/feats/unfettered-growth.json
@@ -28,7 +28,50 @@
             "remaster": true,
             "title": "Pathfinder #202: Severed at the Root"
         },
-        "rules": [],
+        "rules": [
+            {
+                "choices": [
+                    {
+                        "label": "PF2E.SpecificRule.SpellRank.Second",
+                        "value": 2
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.SpellRank.Fourth",
+                        "value": 4
+                    }
+                ],
+                "flag": "rank",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.SpellRank.Prompt"
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:enlarge",
+                    "spellcasting:innate",
+                    "item:rank:{item|flags.pf2e.rulesSelections.rank}"
+                ],
+                "priority": 119,
+                "property": "other-tags",
+                "value": "ancestral-spell"
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:enlarge",
+                    "self:heritage:ardande",
+                    "spellcasting:innate",
+                    "item:rank:{item|flags.pf2e.rulesSelections.rank}"
+                ],
+                "priority": 119,
+                "property": "other-tags",
+                "value": "ancestral-spell:ardande"
+            }
+        ],
         "traits": {
             "rarity": "uncommon",
             "value": []

--- a/packs/feats/virga-may.json
+++ b/packs/feats/virga-may.json
@@ -34,7 +34,6 @@
                     "item:slug:electric-arc",
                     "spellcasting:innate"
                 ],
-                "priority": 119,
                 "property": "other-tags",
                 "value": "ancestral-spell"
             },
@@ -46,7 +45,6 @@
                     "item:slug:electric-arc",
                     "spellcasting:innate"
                 ],
-                "priority": 119,
                 "property": "other-tags",
                 "value": "ancestral-spell:changeling"
             }

--- a/packs/feats/virga-may.json
+++ b/packs/feats/virga-may.json
@@ -25,7 +25,32 @@
             "remaster": false,
             "title": "Pathfinder Lost Omens: Ancestry Guide"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:electric-arc",
+                    "spellcasting:innate"
+                ],
+                "priority": 119,
+                "property": "other-tags",
+                "value": "ancestral-spell"
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:electric-arc",
+                    "spellcasting:innate"
+                ],
+                "priority": 119,
+                "property": "other-tags",
+                "value": "ancestral-spell:changeling"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/wooden-mantle.json
+++ b/packs/feats/wooden-mantle.json
@@ -31,10 +31,8 @@
                 "mode": "add",
                 "predicate": [
                     "item:slug:mantle-of-the-unwavering-heart",
-                    "spellcasting:innate",
-                    "item:rank:5"
+                    "spellcasting:innate"
                 ],
-                "priority": 119,
                 "property": "other-tags",
                 "value": "ancestral-spell"
             },
@@ -44,10 +42,8 @@
                 "mode": "add",
                 "predicate": [
                     "item:slug:mantle-of-the-unwavering-heart",
-                    "spellcasting:innate",
-                    "item:rank:5"
+                    "spellcasting:innate"
                 ],
-                "priority": 119,
                 "property": "other-tags",
                 "value": "ancestral-spell:ardande"
             }

--- a/packs/feats/wooden-mantle.json
+++ b/packs/feats/wooden-mantle.json
@@ -24,7 +24,34 @@
             "remaster": true,
             "title": "Pathfinder Rage of Elements"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:mantle-of-the-unwavering-heart",
+                    "spellcasting:innate",
+                    "item:rank:5"
+                ],
+                "priority": 119,
+                "property": "other-tags",
+                "value": "ancestral-spell"
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:mantle-of-the-unwavering-heart",
+                    "spellcasting:innate",
+                    "item:rank:5"
+                ],
+                "priority": 119,
+                "property": "other-tags",
+                "value": "ancestral-spell:ardande"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [


### PR DESCRIPTION
Only for ancestries and heritages beginning with A, as a starting point.
Also adds a rule element to Ancestral Blood Magic that tags non-cantrips ancestral spells as elegible for blood magic.