### PR TITLE
Add implement selection to Thaumaturge Dedication

### DIFF
--- a/packs/feats/implement-initiate.json
+++ b/packs/feats/implement-initiate.json
@@ -28,7 +28,12 @@
             "remaster": false,
             "title": "Pathfinder Dark Archive"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "GrantItem",
+                "uuid": "{actor|flags.pf2e.implementDedication}"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/thaumaturge-dedication.json
+++ b/packs/feats/thaumaturge-dedication.json
@@ -30,6 +30,17 @@
         },
         "rules": [
             {
+                "actorFlag": true,
+                "choices": {
+                    "filter": [
+                        "item:tag:thaumaturge-implement"
+                    ]
+                },
+                "flag": "implementDedication",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.FirstImplement"
+            },
+            {
                 "adjustName": false,
                 "choices": [
                     {


### PR DESCRIPTION
A ChoiceSet will present an implement selection upon taking the Dedication.  It does _not_ GrantItem the chosen implement class feature (e.g. Weapon), as none of the implement's benefits are provided yet.

The archetype feat Implement Initiate will GrantItem the chosen implement class feature, using the choice made in the Dedication above.  This is when the implement's benefits should show up, e.g. Weapon will grant the action Implement's Interruption.