### PR TITLE
Fix missing spell sourceIds for Azi

### DIFF
--- a/packs/quest-for-the-frozen-flame-bestiary/azi.json
+++ b/packs/quest-for-the-frozen-flame-bestiary/azi.json
@@ -674,6 +674,11 @@
         },
         {
             "_id": "Eb5w7VRBRAYyNBB3",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.Item.S708JF3E0kuhuRzG"
+                }
+            },
             "img": "icons/commodities/bones/bones-stack-tan.webp",
             "name": "Bone Spray",
             "sort": 1000000,
@@ -770,6 +775,11 @@
         },
         {
             "_id": "eCQGMZDQrjZhszRZ",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.Item.zdNUbHqqZzjA07oM"
+                }
+            },
             "img": "icons/skills/wounds/bone-broken-marrow-red.webp",
             "name": "Boneshaker",
             "sort": 1100000,
@@ -964,7 +974,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You create a reservoir of vitality from necromantic energy, gaining a number of temporary Hit Points equal to 6 plus your spellcasting ability modifier.</p><hr /><p><strong>Heightened (+1)</strong> The temporary Hit Points increase by 3.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: False Vitality]{Spell Effect: False Life}</p>"
+                    "value": "<p>You augment your flesh with the energies typically used to manipulate the undead. You gain 10 temporary Hit Points.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The temporary Hit Points increase by 3.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: False Vitality]</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -977,16 +987,16 @@
                     "value": "WlQ8TPYFvQxT0xKJ"
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": "Pathfinder Core Rulebook"
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
                 },
                 "range": {
                     "value": ""
                 },
                 "requirements": "",
                 "rules": [],
-                "slug": "false-life",
+                "slug": "false-vitality",
                 "target": {
                     "value": ""
                 },
@@ -1009,6 +1019,11 @@
         },
         {
             "_id": "PtGNJfL3QplEj26x",
+            "flags": {
+                "core": {
+                    "sourceId": "Compendium.pf2e.spells-srd.Item.8ViwItUgwT4lOvvb"
+                }
+            },
             "img": "systems/pf2e/icons/spells/false-life.webp",
             "name": "False Life",
             "sort": 1400000,
@@ -1021,7 +1036,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You create a reservoir of vitality from necromantic energy, gaining a number of temporary Hit Points equal to 6 plus your spellcasting ability modifier.</p><hr /><p><strong>Heightened (+1)</strong> The temporary Hit Points increase by 3.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: False Vitality]</p>"
+                    "value": "<p>You augment your flesh with the energies typically used to manipulate the undead. You gain 10 temporary Hit Points.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The temporary Hit Points increase by 3.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: False Vitality]</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -2182,7 +2197,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>When Azi casts @UUID[Compendium.pf2e.spells-srd.Item.Bind Undead], @UUID[Compendium.pf2e.spells-srd.Item.Drain Life], @UUID[Compendium.pf2e.spells-srd.Item.False Vitality], @UUID[Compendium.pf2e.spells-srd.Item.Harm], @UUID[Compendium.pf2e.spells-srd.Item.Talking Corpse], or @UUID[Compendium.pf2e.spells-srd.Item.Undeath's Blessing], either Azi gains temporary Hit Points equal to the spell's rank for 1 round, or a target takes @Damage[1[void]]{1 negative} per spell rank (if the spell already deals initial void damage, combine this with the spell's initial damage before determining weaknesses and resistances).</p>"
+                    "value": "<p>When Azi casts @UUID[Compendium.pf2e.spells-srd.Item.Bind Undead], @UUID[Compendium.pf2e.spells-srd.Item.Drain Life], @UUID[Compendium.pf2e.spells-srd.Item.False Vitality], @UUID[Compendium.pf2e.spells-srd.Item.Harm], @UUID[Compendium.pf2e.spells-srd.Item.Talking Corpse], or @UUID[Compendium.pf2e.spells-srd.Item.Undeath's Blessing], either Azi gains temporary Hit Points equal to the spell's rank for 1 round, or a target takes @Damage[1[void]] per spell rank (if the spell already deals initial void damage, combine this with the spell's initial damage before determining weaknesses and resistances).</p>"
                 },
                 "publication": {
                     "license": "OGL",


### PR DESCRIPTION
Also refresh copies of False Life (False Vitality)

They were inadvertently removed by https://github.com/foundryvtt/pf2e/pull/16234