### PR TITLE
Fix background label in the attribute boosts menu

### DIFF
--- a/static/templates/actors/character/attribute-builder.hbs
+++ b/static/templates/actors/character/attribute-builder.hbs
@@ -82,7 +82,7 @@
                     {{#if backgroundBoosts.remaining}}<div class="remaining extra">{{backgroundBoosts.remaining}}</div>{{/if}}
                     <img src="{{background.img}}" alt="{{background.name}}" loading="lazy" />
                     <div class="label">
-                        <div class="title">{{localize "PF2E.Background"}}</div>
+                        <div class="title">{{localize "TYPES.Item.background"}}</div>
                         <div class="description">{{background.name}}</div>
                     </div>
                 </div>


### PR DESCRIPTION
Just a little issue with `PF2E.Background` leading to no localization key.