### PR TITLE
Use `rollerRole` on remaining `resolve()` inline checks

### DIFF
--- a/packs/feat-effects/effect-fey-blood-magic.json
+++ b/packs/feat-effects/effect-fey-blood-magic.json
@@ -4,7 +4,7 @@
     "name": "Effect: Fey Blood Magic",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.classfeatures.Item.Bloodline: Fey]</p>\n<p>Either you gain a +2 status bonus to Performance checks.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.classfeatures.Item.Bloodline: Fey]</p>\n<p>You gain a +2 status bonus to Performance checks.</p>"
         },
         "duration": {
             "expiry": "turn-start",

--- a/packs/feats/winter-sleet.json
+++ b/packs/feats/winter-sleet.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>Bone-chilling, swirling sleet surrounds you, cruel as deepest winter. Surfaces in your kinetic aura are coated in slippery ice. A creature that moves on the ice immediately falls unless it succeeds at an @Check[acrobatics|dc:resolve(@actor.system.proficiencies.classDCs.kineticist.value -2)] check or @Check[reflex|dc:resolve(@actor.system.proficiencies.classDCs.kineticist.value -2)] save against your impulse DC – 2. A creature that Steps or Crawls doesn't have to attempt a check or save. You're immune to this effect.</p>\n<p>If a creature on the ice is critically hit by one of your water impulses or critically fails at a save against one, that creature is @UUID[Compendium.pf2e.conditionitems.Item.Slowed]{Slowed 1} until the end of its next turn.</p>"
+            "value": "<p>Bone-chilling, swirling sleet surrounds you, cruel as deepest winter. Surfaces in your kinetic aura are coated in slippery ice. A creature that moves on the ice immediately falls unless it succeeds at an @Check[acrobatics|against:kineticist|adjustment:-2|rollerRole:target] check or @Check[reflex|against:kineticist|adjustment:-2] save against your impulse DC – 2. A creature that Steps or Crawls doesn't have to attempt a check or save. You're immune to this effect.</p>\n<p>If a creature on the ice is critically hit by one of your water impulses or critically fails at a save against one, that creature is @UUID[Compendium.pf2e.conditionitems.Item.Slowed]{Slowed 1} until the end of its next turn.</p>"
         },
         "level": {
             "value": 4

--- a/packs/rage-of-elements-bestiary/living-magma.json
+++ b/packs/rage-of-elements-bestiary/living-magma.json
@@ -116,7 +116,7 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p><strong>Frequency</strong> once per round</p>\n<p><strong>Trigger</strong> A creature hits the living magma with a melee weapon</p>\n<hr />\n<p><strong>Effect</strong> The living magma attempts an @Check[athletics|defense:athletics] check against the triggering creature's Athletics DC. On a success, the living magma traps the weapon in its body and pulls it from the attacker's grasp. A creature can Interact to retrieve the weapon, but the attempt fails unless the creature succeeds at an @Check[athletics|dc:resolve(@actor.system.saves.fortitude.dc)] check against the living magma's Fortitude DC (typically 36). If the living magma uses Engulf, it also absorbs all trapped weapons, rendering them unreachable until it dies.</p>"
+                    "value": "<p><strong>Frequency</strong> once per round</p>\n<p><strong>Trigger</strong> A creature hits the living magma with a melee weapon</p><hr /><p><strong>Effect</strong> The living magma attempts an @Check[athletics|defense:athletics] check against the triggering creature's Athletics DC. On a success, the living magma traps the weapon in its body and pulls it from the attacker's grasp. A creature can Interact to retrieve the weapon, but the attempt fails unless the creature succeeds at an @Check[athletics|against:fortitude|rollerRole:target] check against the living magma's Fortitude DC (typically 36). If the living magma uses Engulf, it also absorbs all trapped weapons, rendering them unreachable until it dies.</p>"
                 },
                 "frequency": {
                     "max": 1,

--- a/packs/sky-kings-tomb-bestiary/giant-leech.json
+++ b/packs/sky-kings-tomb-bestiary/giant-leech.json
@@ -94,7 +94,7 @@
                 },
                 "category": "interaction",
                 "description": {
-                    "value": "<p>While burrowed into Lady Shimmersnip, a giant leech has cover, can't make attacks, and can Squirm. If a giant leech is @UUID[Compendium.pf2e.conditionitems.Item.Grabbed], @UUID[Compendium.pf2e.conditionitems.Item.Restrained], or @UUID[Compendium.pf2e.conditionitems.Item.Stunned], a creature can attempt to remove the leech by spending a single action, which has the attack and manipulate traits, attempting an @Check[athletics|dc:resolve(@actor.system.saves.fortitude.dc)] or @Check[medicine|dc:resolve(@actor.system.saves.fortitude.dc)] check against the giant leech's Fortitude DC. On a success, the creature extracts the leech, reduces Lady Shimmersnip's @UUID[Compendium.pf2e.conditionitems.Item.Clumsy] condition by 1, and places the leech in a space adjacent to the creature and Lady Shimmersnip.</p>"
+                    "value": "<p>While burrowed into Lady Shimmersnip, a giant leech has cover, can't make attacks, and can Squirm. If a giant leech is @UUID[Compendium.pf2e.conditionitems.Item.Grabbed], @UUID[Compendium.pf2e.conditionitems.Item.Restrained], or @UUID[Compendium.pf2e.conditionitems.Item.Stunned], a creature can attempt to remove the leech by spending a single action, which has the attack and manipulate traits, attempting an @Check[athletics|against:fortitude|rollerRole:target] or @Check[medicine|against:fortitude|rollerRole:target] check against the giant leech's Fortitude DC. On a success, the creature extracts the leech, reduces Lady Shimmersnip's @UUID[Compendium.pf2e.conditionitems.Item.Clumsy] condition by 1, and places the leech in a space adjacent to the creature and Lady Shimmersnip.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -236,6 +236,7 @@
                 "details": "",
                 "value": 17
             },
+            "adjustment": null,
             "allSaves": {
                 "value": ""
             },


### PR DESCRIPTION
Except the Kingmaker ones because I know nothing about them. Also fix description of the Fey Blood Magic effect.