### PR TITLE
Fix choice set homebrew item dropzone for button lists

### DIFF
--- a/packs/feats/pitborn.json
+++ b/packs/feats/pitborn.json
@@ -37,7 +37,7 @@
                 "allowedDrops": {
                     "label": "PF2E.SpecificRule.Nephilim.Pitborn.AllowedDrops",
                     "predicate": [
-                        "item:feat-type:skill",
+                        "item:category:skill",
                         "item:level:1",
                         "item:rarity:common"
                     ]

--- a/src/module/rules/rule-element/choice-set/prompt.ts
+++ b/src/module/rules/rule-element/choice-set/prompt.ts
@@ -204,6 +204,7 @@ class ChoiceSetPrompt extends PickAThingPrompt<ItemPF2e<ActorPF2e>, string | num
             const newButton = createHTMLElement("button", {
                 classes: ["with-image"],
                 children: [img, createHTMLElement("span", { children: [droppedItem.name] })],
+                dataset: { action: "pick" },
             });
             newButton.type = "button";
             newButton.value = String(choicesLength - 1);


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/16339. Sneakily also fixes pitborn