### PR TITLE
Scale up dynamic tokens in chat messages

### DIFF
--- a/src/module/chat-message/document.ts
+++ b/src/module/chat-message/document.ts
@@ -198,10 +198,21 @@ class ChatMessagePF2e extends ChatMessage {
         const header = html?.querySelector("header.message-header");
         if (actor && header && this.isContentVisible) {
             const token = this.token ?? actor.prototypeToken;
-            const [imageUrl, scale] =
-                token.texture.src && ImageHelper.hasImageExtension(token.texture.src) && !isDefaultTokenImage(token)
-                    ? [token.texture.src, Math.max(1, token.texture.scaleX)]
-                    : [actor.img, 1];
+
+            const [imageUrl, scale] = (() => {
+                const tokenImage = token.texture.src;
+                const hasTokenImage = tokenImage && ImageHelper.hasImageExtension(tokenImage);
+                if (!hasTokenImage || isDefaultTokenImage(token)) {
+                    return [actor.img, 1];
+                }
+
+                // Calculate the correction factor for dynamic tokens.
+                // Prototype tokens do not have access to subjectScaleAdjustment so we recompute using default values
+                const defaultRingThickness = 0.1269848;
+                const defaultSubjectThickness = 0.6666666;
+                const scaleCorrection = token.ring.enabled ? 1 / (defaultRingThickness + defaultSubjectThickness) : 1;
+                return [tokenImage, Math.max(1, token.texture.scaleX) * scaleCorrection];
+            })();
 
             const image = document.createElement("img");
             image.alt = actor.name;

--- a/types/foundry/client-esm/canvas/module.d.ts
+++ b/types/foundry/client-esm/canvas/module.d.ts
@@ -2,3 +2,4 @@ export * as edges from "./edges/module.ts";
 export * as regions from "./regions/module.ts";
 export * from "./scene-manager.ts";
 export * as sources from "./sources/module.ts";
+export * as tokens from "./tokens/module.ts";

--- a/types/foundry/client-esm/canvas/tokens/module.ts
+++ b/types/foundry/client-esm/canvas/tokens/module.ts
@@ -1,0 +1,1 @@
+export { TokenRingConfig } from "./ring-config.js";

--- a/types/foundry/client-esm/canvas/tokens/ring-config.d.ts
+++ b/types/foundry/client-esm/canvas/tokens/ring-config.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Token Ring configuration Singleton Class.
+ */
+export class TokenRingConfig {
+    /**
+     * Get the current effects.
+     * @returns The current effects.
+     */
+    get effects(): Record<string, string>;
+
+    /**
+     * Get the current spritesheet.
+     * @returns The current spritesheet path.
+     */
+    get spritesheet(): string;
+
+    /** Is a custom fit mode active? */
+    get isGridFitMode(): boolean;
+}

--- a/types/foundry/client/config.d.ts
+++ b/types/foundry/client/config.d.ts
@@ -6,6 +6,7 @@ import type {
     PointSoundSource,
     PointVisionSource,
 } from "../client-esm/canvas/sources/module.ts";
+import type { TokenRingConfig } from "../client-esm/canvas/tokens/module.ts";
 import type * as terms from "../client-esm/dice/terms/module.d.ts";
 import abstract = foundry.abstract;
 import data = foundry.data;
@@ -316,6 +317,7 @@ declare global {
             documentClass: ConstructorOf<TTokenDocument>;
             objectClass: ConstructorOf<NonNullable<TTokenDocument["object"]>>;
             prototypeSheetClass: ConstructorOf<TTokenDocument["sheet"]>;
+            ring: TokenRingConfig;
         };
 
         /** Configuration for the Wall embedded document type and its representation on the game Canvas */


### PR DESCRIPTION
The type additions are incomplete, and were originally added to observe the grid fit mode. That setting is no longer observed, but there's no real reason to omit the typings I did include.