### PR TITLE
Remove weapon predicates from Athletic Strategist

### DIFF
--- a/packs/feats/athletic-strategist.json
+++ b/packs/feats/athletic-strategist.json
@@ -42,28 +42,6 @@
                             "action:shove",
                             "action:trip"
                         ]
-                    },
-                    {
-                        "or": [
-                            "item:trait:agile",
-                            "item:trait:finesse",
-                            {
-                                "and": [
-                                    "item:ranged",
-                                    {
-                                        "not": "item:thrown-melee"
-                                    }
-                                ]
-                            },
-                            "item:base:sap",
-                            {
-                                "and": [
-                                    "feat:takedown-expert",
-                                    "item:group:club",
-                                    "item:hands-held:1"
-                                ]
-                            }
-                        ]
                     }
                 ],
                 "selector": "athletics",


### PR DESCRIPTION
The skill actions are not checking for item roll options, so this predicate is never met. Alternatively, we could use a toggle in lieu of checking for what type of weapon is being used, if any. Closes #16405

~~This partially addresses #16405, but there seems to be a separate bug with FlatModifier which is wrongly suppressing the original attribute modifier, despite the predicate being false. Left more details on the discord.~~ Bug was fixed by #16415