### PR TITLE
Avoid disabled modifiers suppressing enabled ones

### DIFF
--- a/src/module/actor/modifiers.ts
+++ b/src/module/actor/modifiers.ts
@@ -238,7 +238,10 @@ class ModifierPF2e implements RawModifier {
     }
 
     /** Return a copy of this ModifierPF2e instance */
-    clone(data: Partial<ModifierObjectParams> = {}, options: { test?: Set<string> | string[] } = {}): ModifierPF2e {
+    clone(
+        data: Partial<ModifierObjectParams> = {},
+        options: { test?: Set<string> | string[] | null } = {},
+    ): ModifierPF2e {
         const clone = new ModifierPF2e({ ...this, modifier: this.#originalValue, rule: this.rule, ...data });
         if (options.test) clone.test(options.test);
 
@@ -503,7 +506,8 @@ class StatisticModifier {
         this.slug = slug;
 
         // De-duplication. Prefer higher valued, and deprioritize disabled ones
-        // This behavior is used by kingmaker to create "custom modifier types" as well special skill modifiers when rolling manually
+        // This behavior is used by kingmaker to create "custom modifier types" via slugs,
+        // as well as special skill modifiers when rolling manually
         const seen = modifiers.reduce((result: Record<string, ModifierPF2e>, modifier) => {
             const existing = result[modifier.slug];
             if (!existing?.enabled || Math.abs(modifier.modifier) > Math.abs(result[modifier.slug].modifier)) {


### PR DESCRIPTION
Addresses https://github.com/foundryvtt/pf2e/issues/16405 but does not close it.

A modifier's enabled state persists in all clones of that modifiers even when retested. Changing this behavior by resetting enabled state when retesting is risky, however testing modifiers before applying stack resolution rules is much safer and fixes this and potentially other unreported issues. For example, if slugs collide now, the enabled one will always win out properly.

Could be worth waiting on if we're at the cusp of the release. This looks like an old bug.