### PR TITLE
Update Champion and Sentinel dedication to account for armor expertise class feature

### DIFF
--- a/packs/feats/champion-dedication.json
+++ b/packs/feats/champion-dedication.json
@@ -144,7 +144,7 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.proficiencies.defenses.{item|flags.pf2e.rulesSelections.armor}.rank",
-                "value": "ternary(gte(@actor.level,13),2,1)"
+                "value": "ternary(gte(@actor.system.proficiencies.defenses.unarmored.rank,2),2,1)"
             }
         ],
         "subfeatures": {

--- a/packs/feats/sentinel-dedication.json
+++ b/packs/feats/sentinel-dedication.json
@@ -94,7 +94,7 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.proficiencies.defenses.{item|flags.pf2e.rulesSelections.armor}.rank",
-                "value": "ternary(gte(@actor.level,13),2,1)"
+                "value": "ternary(gte(@actor.system.proficiencies.defenses.unarmored.rank,2),2,1)"
             }
         ],
         "subfeatures": {


### PR DESCRIPTION
As noted by @websterguy. This should resolve the issue.