### PR TITLE
Prevent Awakened Animal's fist Strike from overriding other Strikes

### DIFF
--- a/packs/ancestryfeatures/animal-attack.json
+++ b/packs/ancestryfeatures/animal-attack.json
@@ -167,27 +167,10 @@
                 ]
             },
             {
-                "category": "unarmed",
-                "damage": {
-                    "base": {
-                        "damageType": "bludgeoning",
-                        "dice": 1,
-                        "die": "d4"
-                    }
-                },
-                "group": "brawling",
-                "img": "systems/pf2e/icons/unarmed-attacks/fist.webp",
+                "fist": true,
                 "key": "Strike",
-                "label": "PF2E.BattleForm.Attack.Fist",
                 "predicate": [
                     "animal-attack:fist"
-                ],
-                "slug": "fist",
-                "traits": [
-                    "agile",
-                    "finesse",
-                    "nonlethal",
-                    "unarmed"
                 ]
             },
             {

--- a/packs/feats/tooth-and-claw.json
+++ b/packs/feats/tooth-and-claw.json
@@ -225,7 +225,7 @@
                 "fist": true,
                 "key": "Strike",
                 "predicate": [
-                    "animal-attack:fist"
+                    "tooth-and-claw:fist"
                 ]
             },
             {

--- a/packs/feats/tooth-and-claw.json
+++ b/packs/feats/tooth-and-claw.json
@@ -222,27 +222,10 @@
                 ]
             },
             {
-                "category": "unarmed",
-                "damage": {
-                    "base": {
-                        "damageType": "bludgeoning",
-                        "dice": 1,
-                        "die": "d4"
-                    }
-                },
-                "group": "brawling",
-                "img": "systems/pf2e/icons/unarmed-attacks/fist.webp",
+                "fist": true,
                 "key": "Strike",
-                "label": "PF2E.BattleForm.Attack.Fist",
                 "predicate": [
-                    "tooth-and-claw:fist"
-                ],
-                "slug": "fist",
-                "traits": [
-                    "agile",
-                    "finesse",
-                    "nonlethal",
-                    "unarmed"
+                    "animal-attack:fist"
                 ]
             },
             {


### PR DESCRIPTION
as discussed in the Discord, using `"fist": true` instead of creating a fist Strike from scratch suffices