### PR TITLE
Move unleash psyche's toggle to spellcasting tab

### DIFF
--- a/packs/feat-effects/effect-unleash-psyche.json
+++ b/packs/feat-effects/effect-unleash-psyche.json
@@ -29,7 +29,12 @@
                     "damaging-effect",
                     {
                         "or": [
-                            "item:trait:psychic",
+                            {
+                                "and": [
+                                    "item:trait:cantrip",
+                                    "item:trait:psychic"
+                                ]
+                            },
                             {
                                 "and": [
                                     "spellcasting:category:spontaneous",

--- a/packs/feat-effects/effect-unleash-psyche.json
+++ b/packs/feat-effects/effect-unleash-psyche.json
@@ -4,7 +4,7 @@
     "name": "Effect: Unleash Psyche",
     "system": {
         "description": {
-            "value": "<p>When you cast a damaging spell, you gain a status bonus to its damage equal to double the spell's rank. This applies only to spells that don't have a duration and that you cast using psychic spellcasting.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.actionspf2e.Item.Unleash Psyche]</p>\n<p>When you cast a damaging spell, you gain a status bonus to its damage equal to double the spell's rank. This applies only to spells that don't have a duration and that you cast using psychic spellcasting.</p>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -26,7 +26,18 @@
                 "predicate": [
                     "unleash-psyche-damage",
                     "item:duration:0",
-                    "damaging-effect"
+                    "damaging-effect",
+                    {
+                        "or": [
+                            "item:trait:psychic",
+                            {
+                                "and": [
+                                    "spellcasting:category:spontaneous",
+                                    "spellcasting:tradition:occult"
+                                ]
+                            }
+                        ]
+                    }
                 ],
                 "selector": "spell-damage",
                 "type": "status",
@@ -37,6 +48,7 @@
                 "key": "RollOption",
                 "label": "PF2E.SpecificRule.Psychic.UnleashPsyche.DamageLabel",
                 "option": "unleash-psyche-damage",
+                "placement": "spellcasting",
                 "toggleable": true,
                 "value": true
             }


### PR DESCRIPTION
and limit its damage bonus to a spontenous occult spellcasting entry, or psychic cantrips