### PR TITLE
Update Black Tear Cutthroat actor Dagger strikes

### DIFF
--- a/packs/kingmaker-bestiary/black-tear-cutthroat.json
+++ b/packs/kingmaker-bestiary/black-tear-cutthroat.json
@@ -432,7 +432,7 @@
             "type": "backpack"
         },
         {
-            "_id": "dX22wsxoPsGLzOQ0",
+            "_id": "4y1XYNFZEowbFOr5",
             "flags": {
                 "pf2e": {
                     "linkedWeapon": "c18HM9wgadyjyZhj"
@@ -442,9 +442,6 @@
             "name": "Dagger",
             "sort": 700000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
                     "value": []
                 },
@@ -452,7 +449,7 @@
                     "value": 6
                 },
                 "damageRolls": {
-                    "uDgJzSCHc0cQO5kv": {
+                    "XTaUCU5FGAq0YgtY": {
                         "damage": "1d4+2",
                         "damageType": "piercing"
                     }
@@ -466,24 +463,19 @@
                     "title": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "dagger",
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "agile",
                         "finesse",
-                        "thrown-10",
                         "versatile-s"
                     ]
-                },
-                "weaponType": {
-                    "value": "melee"
                 }
             },
             "type": "melee"
         },
         {
-            "_id": "LbdwyQgOrSBqDgv9",
+            "_id": "xVXEYV39VbPDMBnY",
             "flags": {
                 "pf2e": {
                     "linkedWeapon": "c18HM9wgadyjyZhj"
@@ -493,9 +485,6 @@
             "name": "Dagger",
             "sort": 800000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
                     "value": []
                 },
@@ -503,7 +492,7 @@
                     "value": 6
                 },
                 "damageRolls": {
-                    "BD5ok4nOoZZzpz6C": {
+                    "9Tz1aRw51QrJTh0k": {
                         "damage": "1d4+2",
                         "damageType": "piercing"
                     }
@@ -517,18 +506,13 @@
                     "title": ""
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "dagger",
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "agile",
-                        "finesse",
                         "thrown-10",
                         "versatile-s"
                     ]
-                },
-                "weaponType": {
-                    "value": "ranged"
                 }
             },
             "type": "melee"


### PR DESCRIPTION
The actor only had the ranged version of the strike. I checked the stat block and they should have a melee version as well.