### PR TITLE
Reduce layout thrashing in activateListeners phase of encounter tracker update

### DIFF
--- a/src/module/apps/sidebar/encounter-tracker.ts
+++ b/src/module/apps/sidebar/encounter-tracker.ts
@@ -68,6 +68,8 @@ export class EncounterTrackerPF2e<TEncounter extends EncounterPF2e | null> exten
 
         const encounter = this.viewed;
         if (!encounter) return super.activateListeners($html);
+        const trackerPlaceholder = document.createElement("div");
+        tracker.replaceWith(trackerPlaceholder);
 
         const tokenSetsNameVisibility = game.pf2e.settings.tokens.nameVisibility;
         const allyColor = (c: CombatantPF2e<EncounterPF2e>) =>
@@ -129,7 +131,7 @@ export class EncounterTrackerPF2e<TEncounter extends EncounterPF2e | null> exten
                 }
             }
 
-            this.refreshTargetDisplay(combatant);
+            this.refreshTargetDisplay(combatant, [tracker]);
 
             // Hide names in the tracker of combatants with tokens that have unviewable nameplates
             if (tokenSetsNameVisibility) {
@@ -180,11 +182,12 @@ export class EncounterTrackerPF2e<TEncounter extends EncounterPF2e | null> exten
             }
         }
 
+        trackerPlaceholder.replaceWith(tracker);
         super.activateListeners($html);
     }
 
     /** Refresh the list of users targeting a combatant's token as well as the active state of the target toggle */
-    refreshTargetDisplay(combatantOrToken: CombatantPF2e | TokenDocumentPF2e): void {
+    refreshTargetDisplay(combatantOrToken: CombatantPF2e | TokenDocumentPF2e, trackers?: HTMLElement[]): void {
         if (!this.viewed || !canvas.ready) return;
 
         const { combatant, tokenDoc } = combatantAndTokenDoc(combatantOrToken);
@@ -192,7 +195,8 @@ export class EncounterTrackerPF2e<TEncounter extends EncounterPF2e | null> exten
             return;
         }
 
-        for (const tracker of htmlQueryAll(document, "#combat, #combat-popout")) {
+        trackers ??= htmlQueryAll(document, "#combat, #combat-popout");
+        for (const tracker of trackers) {
             const combatantRow = htmlQuery(tracker, `li.combatant[data-combatant-id="${combatant?.id ?? null}"]`);
             if (!combatantRow) return;
 


### PR DESCRIPTION
This PR aims to improve performance when updating the encounter tracker. The current problem is that `refreshTargetDisplay` forces a style recalculation each time it is executed, which is at least once per combatant per turn or whenever the status effects for any combatants change.

The cause for this repeated recalculation is that the combatants title is updated in a loop in `activateListeners` (modify) to add the user targets indicator. In the same loop, `refreshTargetDisplay` is then called to modify the newly created target indicator element, which first has to be found in the dom for this combatant (query). This combination leads to forced style recalculations, which can be quite expensive.
<img width="1199" alt="Bildschirmfoto 2024-09-10 um 17 22 47" src="https://github.com/user-attachments/assets/063f4be0-1c95-4f14-86a9-5e9930c9e527">
In the above case, just the `activateListeners` phase took over 100ms to complete, in a very reasonably sized encounter with 9 participants in total.

The good news is that these modifications can easily be done without forcing style recalculations and layout thrashing by first removing the tracker node from the document tree, doing all the modifications and finally re-inserting the tracker at the original position. This reduces the time needed for the `activateListeners` phase to just under 2ms.
<img width="1197" alt="Bildschirmfoto 2024-09-10 um 17 32 08" src="https://github.com/user-attachments/assets/2d7286b6-da9c-4022-a6cc-9f5613d94900">