### PR TITLE
Split certain crafting functions and defer use of async

### DIFF
--- a/src/module/actor/character/crafting/ability.ts
+++ b/src/module/actor/character/crafting/ability.ts
@@ -13,7 +13,7 @@ class CraftingAbility implements CraftingAbilityData {
 
     selector: string;
 
-    /** This crafting entry's parent actor */
+    /** This crafting ability's parent actor */
     actor: CharacterPF2e;
 
     preparedFormulaData: PreparedFormulaData[];

--- a/src/module/actor/character/crafting/crafting.ts
+++ b/src/module/actor/character/crafting/crafting.ts
@@ -1,0 +1,90 @@
+import { ItemPF2e, type PhysicalItemPF2e } from "@item";
+import type { PhysicalItemSource } from "@item/base/data/index.ts";
+import { itemIsOfType } from "@item/helpers.ts";
+import { UUIDUtils } from "@util/uuid.ts";
+import type { CharacterPF2e } from "../document.ts";
+import { CraftingAbility, type CraftingAbilityData } from "./ability.ts";
+import { CraftingFormula } from "./formula.ts";
+
+/** Caches and performs operations on elements related to crafting */
+class CharacterCrafting {
+    actor: CharacterPF2e;
+    abilities: CraftingAbility[];
+
+    #formulas: CraftingFormula[] | null = null;
+
+    constructor(actor: CharacterPF2e) {
+        this.actor = actor;
+
+        this.abilities = Object.values(actor.system.crafting.entries)
+            .filter((entry): entry is CraftingAbilityData => CraftingAbility.isValid(entry))
+            .map((entry) => new CraftingAbility(this.actor, entry));
+    }
+
+    /**
+     * Retrieves all formulas this actor knows including their associated items.
+     * The result is cached until next data prep.
+     */
+    async getFormulas(): Promise<CraftingFormula[]> {
+        if (this.#formulas) return this.#formulas;
+
+        const formulas = this.actor.system.crafting.formulas;
+        formulas.sort((a, b) => (a.sort ?? 0) - (b.sort ?? 0));
+        const formulaMap = new Map(formulas.map((data) => [data.uuid, data]));
+        const items = await UUIDUtils.fromUUIDs(formulas.map((f) => f.uuid));
+
+        const result = items
+            .filter((i): i is PhysicalItemPF2e => i instanceof ItemPF2e && i.isOfType("physical"))
+            .map((item) => {
+                const { dc, batchSize, deletable } = formulaMap.get(item.uuid) ?? { deletable: false };
+                return new CraftingFormula(item, { dc, batchSize, deletable });
+            });
+        this.#formulas = result;
+        return result;
+    }
+
+    getAbility(selector: string): CraftingAbility | null {
+        return this.abilities.find((a) => a.selector === selector) ?? null;
+    }
+
+    async performDailyCrafting(): Promise<void> {
+        const entries = this.abilities.filter((e) => e.isDailyPrep);
+        const alchemicalEntries = entries.filter((e) => e.isAlchemical);
+        const reagentCost = (await Promise.all(alchemicalEntries.map((e) => e.calculateReagentCost()))).reduce(
+            (sum, cost) => sum + cost,
+            0,
+        );
+        const reagentValue = (this.actor.system.resources.crafting.infusedReagents.value || 0) - reagentCost;
+        if (reagentValue < 0) {
+            ui.notifications.warn(game.i18n.localize("PF2E.CraftingTab.Alerts.MissingReagents"));
+            return;
+        } else {
+            await this.actor.update({ "system.resources.crafting.infusedReagents.value": reagentValue });
+            const key = reagentCost === 0 ? "ZeroConsumed" : reagentCost === 1 ? "OneConsumed" : "NConsumed";
+            ui.notifications.info(
+                game.i18n.format(`PF2E.Actor.Character.Crafting.Daily.Complete.${key}`, { quantity: reagentCost }),
+            );
+        }
+
+        // Remove infused/temp items
+        for (const item of this.actor.inventory) {
+            if (item.system.temporary) await item.delete();
+        }
+
+        for (const entry of entries) {
+            for (const formula of await entry.getPreparedCraftingFormulas()) {
+                const itemSource: PhysicalItemSource = formula.item.toObject();
+                itemSource.system.quantity = formula.quantity;
+                itemSource.system.temporary = true;
+                itemSource.system.size = this.actor.ancestry?.size === "tiny" ? "tiny" : "med";
+
+                if (entry.isAlchemical && itemIsOfType(itemSource, "consumable", "equipment", "weapon")) {
+                    itemSource.system.traits.value.push("infused");
+                }
+                await this.actor.addToInventory(itemSource);
+            }
+        }
+    }
+}
+
+export { CharacterCrafting };

--- a/src/module/actor/character/crafting/index.ts
+++ b/src/module/actor/character/crafting/index.ts
@@ -1,3 +1,4 @@
-export { CraftingAbility, type CraftingAbilityData } from "./ability.ts";
+export { CraftingAbility, type CraftingAbilityData, type CraftingAbilitySheetData } from "./ability.ts";
+export { CharacterCrafting } from "./crafting.ts";
 export { CraftingFormula, type CraftingFormulaData } from "./formula.ts";
 export { craftItem, craftSpellConsumable } from "./helpers.ts";

--- a/src/module/rules/rule-element/crafting-entry.ts
+++ b/src/module/rules/rule-element/crafting-entry.ts
@@ -77,7 +77,6 @@ class CraftingEntryRuleElement extends RuleElementPF2e<CraftingEntryRuleSchema> 
         const entryData = {
             selector: selector,
             name: this.label,
-            item: this.item,
             isAlchemical: this.isAlchemical,
             isDailyPrep: this.isDailyPrep,
             isPrepared: this.isPrepared,
@@ -87,7 +86,6 @@ class CraftingEntryRuleElement extends RuleElementPF2e<CraftingEntryRuleSchema> 
             maxSlots: this.maxSlots,
             preparedFormulaData: this.preparedFormulas,
         };
-        Object.defineProperty(entryData, "item", { enumerable: false });
         this.actor.system.crafting.entries[this.selector] = entryData;
 
         // Set a roll option to cue any subsequent max-item-level-increasing `ActiveEffectLike`s


### PR DESCRIPTION
This is a split of multiple refactors from an inprogress branch, in a more finalized state. To go into more detail, this is what changes:

* Scope several crafting functions in Character to actor.crafting.
* Lazily cache the list of known actor formulas instead of receiving each time 
* Add CraftingAbility#getSheetData() and pass that instead of CraftingAbility itself. Also remove the sheet data only formula getter. 
* Construct crafting abilities during data preparation instead of during sheet rendering. The sheet based functions that required the formulas to be preloaded have been converted to async.
* When updating the list of prepared formulas, updates all rule elements with the same selector instead of only the parent item. This makes it so we no longer need to pass the parent item, and allows merging to work in the future (required for advanced alchemy). 

Crafting 3 of a field discovery bomb doesn't work after nor before this change. You might get reports of that later, but its unimportant since we're throwing out the infused reagents handling anyways.

More refactoring will occur, but these parts can be done independently of all current dev.