### PR TITLE
Add inline acrobatics action and circumstance bonus to Acrobatic Performer

### DIFF
--- a/packs/feats/acrobatic-performer.json
+++ b/packs/feats/acrobatic-performer.json
@@ -11,7 +11,7 @@
         },
         "category": "skill",
         "description": {
-            "value": "<p>You're an incredible acrobat, evoking wonder and enrapturing audiences with your prowess. You can roll an Acrobatics check instead of a Performance check when using the @UUID[Compendium.pf2e.actionspf2e.Item.Perform] action. If you are trained in both Acrobatics and Performance, you gain a +1 circumstances bonus on Acrobatics checks made to Perform.</p>"
+            "value": "<p>You're an incredible acrobat, evoking wonder and enrapturing audiences with your prowess. You can roll an [[/act perform skill=acrobatics variant=dance]]{Acrobatics} check instead of a Performance check when using the @UUID[Compendium.pf2e.actionspf2e.Item.Perform] action. If you are trained in both Acrobatics and Performance, you gain a +1 circumstances bonus on Acrobatics checks made to Perform.</p>"
         },
         "level": {
             "value": 1
@@ -28,7 +28,29 @@
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "action:perform",
+                    {
+                        "gte": [
+                            "skill:acrobatics:rank",
+                            1
+                        ]
+                    },
+                    {
+                        "gte": [
+                            "skill:performance:rank",
+                            1
+                        ]
+                    }
+                ],
+                "selector": "acrobatics",
+                "type": "circumstance",
+                "value": 1
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [


### PR DESCRIPTION
The perform action demands a variant be used, and dance seemed like the closest one.
Closes #16487