### PR TITLE
Restrict Mutant Physique's effets to Bestial Mutagen Strikes only

### DIFF
--- a/packs/ancestryfeatures/horns-sarangay.json
+++ b/packs/ancestryfeatures/horns-sarangay.json
@@ -45,14 +45,14 @@
                 ]
             },
             {
-                "domain": "{item|id}-attack",
-                "key": "RollOption",
-                "option": "sarangay-horns"
-            },
-            {
-                "domain": "{item|id}-damage",
-                "key": "RollOption",
-                "option": "sarangay-horns"
+                "itemType": "weapon",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:id:{item|id}"
+                ],
+                "property": "other-tags",
+                "value": "sarangay-horns"
             }
         ],
         "traits": {

--- a/packs/classfeatures/animal-instinct.json
+++ b/packs/classfeatures/animal-instinct.json
@@ -1125,14 +1125,14 @@
                 ]
             },
             {
-                "domain": "{item|id}-attack",
-                "key": "RollOption",
-                "option": "instinct-unarmed-strike"
-            },
-            {
-                "domain": "{item|id}-damage",
-                "key": "RollOption",
-                "option": "instinct-unarmed-strike"
+                "itemType": "weapon",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:id:{item|id}"
+                ],
+                "property": "other-tags",
+                "value": "instinct-unarmed-strike"
             }
         ],
         "traits": {

--- a/packs/equipment-effects/effect-bestial-mutagen-greater.json
+++ b/packs/equipment-effects/effect-bestial-mutagen-greater.json
@@ -53,9 +53,6 @@
                 "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
                 "key": "Strike",
                 "label": "PF2E.Weapon.Base.jaws",
-                "options": [
-                    "bestial-mutagen-strike"
-                ],
                 "range": null,
                 "slug": "jaws",
                 "traits": [
@@ -76,15 +73,22 @@
                 "img": "icons/commodities/claws/claw-bear-brown-grey.webp",
                 "key": "Strike",
                 "label": "PF2E.Weapon.Base.claw",
-                "options": [
-                    "bestial-mutagen-strike"
-                ],
                 "range": null,
                 "slug": "claw",
                 "traits": [
                     "unarmed",
                     "agile"
                 ]
+            },
+            {
+                "itemType": "weapon",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:id:{item|id}"
+                ],
+                "property": "other-tags",
+                "value": "bestial-mutagen-strike"
             }
         ],
         "start": {

--- a/packs/equipment-effects/effect-bestial-mutagen-lesser.json
+++ b/packs/equipment-effects/effect-bestial-mutagen-lesser.json
@@ -53,9 +53,6 @@
                 "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
                 "key": "Strike",
                 "label": "PF2E.Weapon.Base.jaws",
-                "options": [
-                    "bestial-mutagen-strike"
-                ],
                 "range": null,
                 "slug": "jaws",
                 "traits": [
@@ -76,15 +73,22 @@
                 "img": "icons/commodities/claws/claw-bear-brown-grey.webp",
                 "key": "Strike",
                 "label": "PF2E.Weapon.Base.claw",
-                "options": [
-                    "bestial-mutagen-strike"
-                ],
                 "range": null,
                 "slug": "claw",
                 "traits": [
                     "unarmed",
                     "agile"
                 ]
+            },
+            {
+                "itemType": "weapon",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:id:{item|id}"
+                ],
+                "property": "other-tags",
+                "value": "bestial-mutagen-strike"
             }
         ],
         "start": {

--- a/packs/equipment-effects/effect-bestial-mutagen-major.json
+++ b/packs/equipment-effects/effect-bestial-mutagen-major.json
@@ -53,9 +53,6 @@
                 "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
                 "key": "Strike",
                 "label": "PF2E.Weapon.Base.jaws",
-                "options": [
-                    "bestial-mutagen-strike"
-                ],
                 "range": null,
                 "slug": "jaws",
                 "traits": [
@@ -76,15 +73,22 @@
                 "img": "icons/commodities/claws/claw-bear-brown-grey.webp",
                 "key": "Strike",
                 "label": "PF2E.Weapon.Base.claw",
-                "options": [
-                    "bestial-mutagen-strike"
-                ],
                 "range": null,
                 "slug": "claw",
                 "traits": [
                     "unarmed",
                     "agile"
                 ]
+            },
+            {
+                "itemType": "weapon",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:id:{item|id}"
+                ],
+                "property": "other-tags",
+                "value": "bestial-mutagen-strike"
             }
         ],
         "start": {

--- a/packs/equipment-effects/effect-bestial-mutagen-moderate.json
+++ b/packs/equipment-effects/effect-bestial-mutagen-moderate.json
@@ -53,9 +53,6 @@
                 "img": "icons/creatures/abilities/mouth-teeth-long-red.webp",
                 "key": "Strike",
                 "label": "PF2E.Weapon.Base.jaws",
-                "options": [
-                    "bestial-mutagen-strike"
-                ],
                 "range": null,
                 "slug": "jaws",
                 "traits": [
@@ -76,14 +73,21 @@
                 "img": "icons/commodities/claws/claw-bear-brown-grey.webp",
                 "key": "Strike",
                 "label": "PF2E.Weapon.Base.claw",
-                "options": [
-                    "bestial-mutagen-strike"
-                ],
                 "range": null,
                 "traits": [
                     "unarmed",
                     "agile"
                 ]
+            },
+            {
+                "itemType": "weapon",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:id:{item|id}"
+                ],
+                "property": "other-tags",
+                "value": "bestial-mutagen-strike"
             }
         ],
         "start": {

--- a/packs/equipment/berserkers-cloak-greater.json
+++ b/packs/equipment/berserkers-cloak-greater.json
@@ -99,7 +99,7 @@
             {
                 "key": "WeaponPotency",
                 "predicate": [
-                    "instinct-unarmed-strike"
+                    "item:tag:instinct-unarmed-strike"
                 ],
                 "selector": "unarmed-attack-roll",
                 "value": 3
@@ -107,7 +107,7 @@
             {
                 "key": "Striking",
                 "predicate": [
-                    "instinct-unarmed-strike"
+                    "item:tag:instinct-unarmed-strike"
                 ],
                 "selector": "unarmed-damage",
                 "value": 3

--- a/packs/equipment/berserkers-cloak.json
+++ b/packs/equipment/berserkers-cloak.json
@@ -99,7 +99,7 @@
             {
                 "key": "WeaponPotency",
                 "predicate": [
-                    "instinct-unarmed-strike"
+                    "item:tag:instinct-unarmed-strike"
                 ],
                 "selector": "unarmed-attack-roll",
                 "value": 2
@@ -107,7 +107,7 @@
             {
                 "key": "Striking",
                 "predicate": [
-                    "instinct-unarmed-strike"
+                    "item:tag:instinct-unarmed-strike"
                 ],
                 "selector": "unarmed-damage",
                 "value": 2

--- a/packs/feat-effects/effect-kishin-rage.json
+++ b/packs/feat-effects/effect-kishin-rage.json
@@ -36,7 +36,7 @@
                 "dieSize": "d4",
                 "key": "DamageDice",
                 "predicate": [
-                    "hungerseed-horns"
+                    "item:tag:hungerseed-horns"
                 ],
                 "selector": "horns-damage"
             }

--- a/packs/feats/crown-of-bone.json
+++ b/packs/feats/crown-of-bone.json
@@ -27,7 +27,7 @@
         "rules": [
             {
                 "definition": [
-                    "item:slug:horns"
+                    "item:tag:sarangay-horns"
                 ],
                 "key": "AdjustStrike",
                 "mode": "add",
@@ -35,17 +35,13 @@
                 "value": "concussive"
             },
             {
-                "key": "DamageAlteration",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "upgrade",
                 "predicate": [
-                    "sarangay-horns",
-                    "dice:slug:base"
+                    "item:tag:sarangay-horns"
                 ],
-                "property": "dice-faces",
-                "selectors": [
-                    "horns-damage"
-                ],
-                "value": 8
+                "property": "damage-dice-faces"
             }
         ],
         "traits": {

--- a/packs/feats/mutant-physique.json
+++ b/packs/feats/mutant-physique.json
@@ -30,22 +30,18 @@
                 "key": "ItemAlteration",
                 "mode": "upgrade",
                 "predicate": [
-                    {
-                        "or": [
-                            "item:slug:claw",
-                            "item:slug:jaws"
-                        ]
-                    },
-                    {
-                        "or": [
-                            "self:effect:bestial-mutagen-lesser",
-                            "self:effect:bestial-mutagen-moderate",
-                            "self:effect:bestial-mutagen-greater",
-                            "self:effect:bestial-mutagen-major"
-                        ]
-                    }
+                    "item:tag:bestial-mutagen-strike"
                 ],
                 "property": "damage-dice-faces"
+            },
+            {
+                "definition": [
+                    "item:tag:bestial-mutagen-strike"
+                ],
+                "key": "AdjustStrike",
+                "mode": "add",
+                "property": "weapon-traits",
+                "value": "deadly-d10"
             },
             {
                 "key": "FlatModifier",
@@ -93,16 +89,6 @@
                 "selector": "intimidation",
                 "slug": "mutant-physique-intimidation",
                 "value": 4
-            },
-            {
-                "key": "AdjustStrike",
-                "mode": "add",
-                "predicate": [
-                    "feat:mutant-physique"
-                ],
-                "property": "weapon-traits",
-                "selector": "bestial-mutagen-strike",
-                "value": "deadly-d10"
             },
             {
                 "key": "Resistance",

--- a/packs/feats/oni-weapon-familiarity.json
+++ b/packs/feats/oni-weapon-familiarity.json
@@ -57,7 +57,7 @@
                             "item:base:nodachi",
                             "item:base:ogre-hook",
                             "item:base:tetsubo",
-                            "hungerseed-horns"
+                            "item:tag:hungerseed-horns"
                         ]
                     }
                 ]

--- a/packs/heritages/versatile-heritages/hungerseed.json
+++ b/packs/heritages/versatile-heritages/hungerseed.json
@@ -33,14 +33,14 @@
                 ]
             },
             {
-                "domain": "{item|id}-attack",
-                "key": "RollOption",
-                "option": "hungerseed-horns"
-            },
-            {
-                "domain": "{item|id}-damage",
-                "key": "RollOption",
-                "option": "hungerseed-horns"
+                "itemType": "weapon",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:id:{item|id}"
+                ],
+                "property": "other-tags",
+                "value": "hungerseed-horns"
             }
         ],
         "traits": {


### PR DESCRIPTION
Closes #16479

Also move away from using Roll Options to tag RE-generated Strikes when needed, and instead use tag Item Alteration