### PR TITLE
Move Werecreature Dedication automation from effect to feat

### DIFF
--- a/packs/feats/werecreature-dedication.json
+++ b/packs/feats/werecreature-dedication.json
@@ -126,7 +126,7 @@
                 "itemType": "action",
                 "key": "ItemAlteration",
                 "label": "PF2E.SpecificRule.Werecreature.ChangeShape.AlterationLabel",
-                "mode": "add",
+                "mode": "override",
                 "predicate": [
                     "item:slug:change-shape"
                 ],
@@ -191,6 +191,410 @@
                         ],
                         "text": "PF2E.SpecificRule.Werecreature.Werewolf.Description"
                     }
+                ]
+            },
+            {
+                "key": "BaseSpeed",
+                "predicate": [
+                    "werecreature:werebat",
+                    {
+                        "or": [
+                            "change-shape:hybrid",
+                            "change-shape:animal"
+                        ]
+                    }
+                ],
+                "selector": "land",
+                "value": 10
+            },
+            {
+                "key": "BaseSpeed",
+                "predicate": [
+                    "werecreature:werebat",
+                    {
+                        "or": [
+                            "change-shape:hybrid",
+                            "change-shape:animal"
+                        ]
+                    }
+                ],
+                "selector": "fly",
+                "value": 15
+            },
+            {
+                "key": "BaseSpeed",
+                "predicate": [
+                    {
+                        "or": [
+                            "werecreature:werebear",
+                            "werecreature:werecrocodile",
+                            "werecreature:weremoose",
+                            "werecreature:wererat",
+                            "werecreature:weretiger"
+                        ]
+                    },
+                    {
+                        "or": [
+                            "change-shape:hybrid",
+                            "change-shape:animal"
+                        ]
+                    }
+                ],
+                "selector": "land",
+                "value": 25
+            },
+            {
+                "key": "BaseSpeed",
+                "predicate": [
+                    {
+                        "or": [
+                            "werecreature:wereboar",
+                            "werecreature:werewolf"
+                        ]
+                    },
+                    {
+                        "or": [
+                            "change-shape:hybrid",
+                            "change-shape:animal"
+                        ]
+                    }
+                ],
+                "selector": "land",
+                "value": 30
+            },
+            {
+                "key": "BaseSpeed",
+                "predicate": [
+                    "werecreature:werecrocodile",
+                    {
+                        "or": [
+                            "change-shape:hybrid",
+                            "change-shape:animal"
+                        ]
+                    }
+                ],
+                "selector": "swim",
+                "value": 15
+            },
+            {
+                "key": "BaseSpeed",
+                "predicate": [
+                    "werecreature:wereshark",
+                    "change-shape:hybrid"
+                ],
+                "selector": "land",
+                "value": 15
+            },
+            {
+                "key": "BaseSpeed",
+                "predicate": [
+                    "werecreature:wereshark",
+                    "change-shape:hybrid"
+                ],
+                "selector": "swim",
+                "value": 25
+            },
+            {
+                "key": "BaseSpeed",
+                "predicate": [
+                    "werecreature:wereshark",
+                    "change-shape:animal"
+                ],
+                "selector": "swim",
+                "value": 35
+            },
+            {
+                "category": "unarmed",
+                "damage": {
+                    "base": {
+                        "damageType": "piercing",
+                        "dice": 1,
+                        "die": "d8"
+                    }
+                },
+                "group": "brawling",
+                "img": "systems/pf2e/icons/unarmed-attacks/fangs.webp",
+                "key": "Strike",
+                "label": "PF2E.BattleForm.Attack.Fangs",
+                "predicate": [
+                    "werecreature:werebat",
+                    {
+                        "or": [
+                            "change-shape:hybrid",
+                            "change-shape:animal"
+                        ]
+                    }
+                ],
+                "slug": "fangs",
+                "traits": [
+                    "unarmed"
+                ]
+            },
+            {
+                "category": "unarmed",
+                "damage": {
+                    "base": {
+                        "damageType": "piercing",
+                        "dice": 1,
+                        "die": "d8"
+                    }
+                },
+                "group": "brawling",
+                "img": "systems/pf2e/icons/unarmed-attacks/jaws.webp",
+                "key": "Strike",
+                "label": "PF2E.BattleForm.Attack.Jaws",
+                "predicate": [
+                    {
+                        "or": [
+                            "werecreature:werebear",
+                            "werecreature:weretiger"
+                        ]
+                    },
+                    {
+                        "or": [
+                            "change-shape:hybrid",
+                            "change-shape:animal"
+                        ]
+                    }
+                ],
+                "slug": "jaws",
+                "traits": [
+                    "unarmed"
+                ]
+            },
+            {
+                "category": "unarmed",
+                "damage": {
+                    "base": {
+                        "damageType": "slashing",
+                        "dice": 1,
+                        "die": "d6"
+                    }
+                },
+                "group": "brawling",
+                "img": "systems/pf2e/icons/unarmed-attacks/claw.webp",
+                "key": "Strike",
+                "label": "PF2E.BattleForm.Attack.Claw",
+                "predicate": [
+                    {
+                        "or": [
+                            "werecreature:werebear",
+                            "werecreature:weretiger"
+                        ]
+                    },
+                    {
+                        "or": [
+                            "change-shape:hybrid",
+                            "change-shape:animal"
+                        ]
+                    }
+                ],
+                "slug": "claw",
+                "traits": [
+                    "agile",
+                    "unarmed"
+                ]
+            },
+            {
+                "category": "unarmed",
+                "damage": {
+                    "base": {
+                        "damageType": "slashing",
+                        "dice": 1,
+                        "die": "d8"
+                    }
+                },
+                "group": "brawling",
+                "img": "systems/pf2e/icons/unarmed-attacks/tusk.webp",
+                "key": "Strike",
+                "label": "PF2E.BattleForm.Attack.Tusk",
+                "predicate": [
+                    "werecreature:wereboar",
+                    {
+                        "or": [
+                            "change-shape:hybrid",
+                            "change-shape:animal"
+                        ]
+                    }
+                ],
+                "slug": "tusk",
+                "traits": [
+                    "sweep",
+                    "unarmed"
+                ]
+            },
+            {
+                "category": "unarmed",
+                "damage": {
+                    "base": {
+                        "damageType": "piercing",
+                        "dice": 1,
+                        "die": "d8"
+                    }
+                },
+                "group": "brawling",
+                "img": "systems/pf2e/icons/unarmed-attacks/jaws.webp",
+                "key": "Strike",
+                "label": "PF2E.BattleForm.Attack.Jaws",
+                "predicate": [
+                    {
+                        "or": [
+                            "werecreature:werecrocodile",
+                            "werecreature:wereshark"
+                        ]
+                    },
+                    {
+                        "or": [
+                            "change-shape:hybrid",
+                            "change-shape:animal"
+                        ]
+                    }
+                ],
+                "slug": "jaws",
+                "traits": [
+                    "grapple",
+                    "unarmed"
+                ]
+            },
+            {
+                "category": "unarmed",
+                "damage": {
+                    "base": {
+                        "damageType": "piercing",
+                        "dice": 1,
+                        "die": "d8"
+                    }
+                },
+                "group": "brawling",
+                "img": "systems/pf2e/icons/unarmed-attacks/antler.webp",
+                "key": "Strike",
+                "label": "PF2E.BattleForm.Attack.Antler",
+                "predicate": [
+                    "werecreature:weremoose",
+                    {
+                        "or": [
+                            "change-shape:hybrid",
+                            "change-shape:animal"
+                        ]
+                    }
+                ],
+                "slug": "antler",
+                "traits": [
+                    "shove",
+                    "unarmed"
+                ]
+            },
+            {
+                "category": "unarmed",
+                "damage": {
+                    "base": {
+                        "damageType": "piercing",
+                        "dice": 1,
+                        "die": "d6"
+                    }
+                },
+                "group": "brawling",
+                "img": "systems/pf2e/icons/unarmed-attacks/jaws.webp",
+                "key": "Strike",
+                "label": "PF2E.BattleForm.Attack.Jaws",
+                "predicate": [
+                    "werecreature:wererat",
+                    {
+                        "or": [
+                            "change-shape:hybrid",
+                            "change-shape:animal"
+                        ]
+                    }
+                ],
+                "slug": "jaws",
+                "traits": [
+                    "finesse",
+                    "unarmed"
+                ]
+            },
+            {
+                "category": "unarmed",
+                "damage": {
+                    "base": {
+                        "damageType": "slashing",
+                        "dice": 1,
+                        "die": "d4"
+                    }
+                },
+                "group": "brawling",
+                "img": "systems/pf2e/icons/unarmed-attacks/claw.webp",
+                "key": "Strike",
+                "label": "PF2E.BattleForm.Attack.Claw",
+                "predicate": [
+                    "werecreature:wererat",
+                    {
+                        "or": [
+                            "change-shape:hybrid",
+                            "change-shape:animal"
+                        ]
+                    }
+                ],
+                "slug": "claw",
+                "traits": [
+                    "agile",
+                    "finesse",
+                    "unarmed"
+                ]
+            },
+            {
+                "category": "unarmed",
+                "damage": {
+                    "base": {
+                        "damageType": "piercing",
+                        "dice": 1,
+                        "die": "d8"
+                    }
+                },
+                "group": "brawling",
+                "img": "systems/pf2e/icons/unarmed-attacks/jaws.webp",
+                "key": "Strike",
+                "label": "PF2E.BattleForm.Attack.Jaws",
+                "predicate": [
+                    "werecreature:werewolf",
+                    {
+                        "or": [
+                            "change-shape:hybrid",
+                            "change-shape:animal"
+                        ]
+                    }
+                ],
+                "slug": "jaws",
+                "traits": [
+                    "trip",
+                    "unarmed"
+                ]
+            },
+            {
+                "key": "CreatureSize",
+                "predicate": [
+                    "werecreature:wererat",
+                    "change-shape:animal"
+                ],
+                "value": "small"
+            },
+            {
+                "add": [
+                    "amphibious"
+                ],
+                "key": "ActorTraits",
+                "predicate": [
+                    "werecreature:wereshark",
+                    "change-shape:hybrid"
+                ]
+            },
+            {
+                "add": [
+                    "aquatic"
+                ],
+                "key": "ActorTraits",
+                "predicate": [
+                    "werecreature:wereshark",
+                    "change-shape:animal"
                 ]
             }
         ],


### PR DESCRIPTION
@DocSchlock contributed this automation originally in the form of an effect (#14854). In order for it to work with the Change Shape refactor, I moved it to the Werecreature Dedication feat and modified predicates accordingly.

Closes #16497