### PR TITLE
Fix save type of Banshee's Wail

### DIFF
--- a/packs/pathfinder-monster-core/banshee.json
+++ b/packs/pathfinder-monster-core/banshee.json
@@ -212,7 +212,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The banshee unleashes a soul-chilling @UUID[Compendium.pf2e.spells-srd.Item.Wails of the Damned] (@Check[will|dc:38|traits:void|options:damaging-effect,item:type:spell], @Damage[8d10[void]]). This Wail overcomes silence and similar effects of 5th rank or lower. The banshee can instead use Wail as a three-action activity to overcome such effects of up to 8th rank.</p>\n<p>The banshee's Wail resonates for 1 round, and any creature that comes within the area during that time must attempt a save against the effect. A creature can't be affected more than once by the same Wail. The banshee can't Wail again for [[/gmr 1d4 #Recharge Wail]] rounds.</p>"
+                    "value": "<p>The banshee unleashes a soul-chilling @UUID[Compendium.pf2e.spells-srd.Item.Wails of the Damned] (@Check[fortitude|dc:38|traits:void|options:damaging-effect,item:type:spell], @Damage[8d10[void]]). This Wail overcomes silence and similar effects of 5th rank or lower. The banshee can instead use Wail as a three-action activity to overcome such effects of up to 8th rank.</p>\n<p>The banshee's Wail resonates for 1 round, and any creature that comes within the area during that time must attempt a save against the effect. A creature can't be affected more than once by the same Wail. The banshee can't Wail again for [[/gmr 1d4 #Recharge Wail]] rounds.</p>"
                 },
                 "publication": {
                     "license": "ORC",


### PR DESCRIPTION
Monster Core page 37. Doesn't say anything about a changed save, unchanged from Bestiary 1. Must have snuck in via copy&paste.