### PR TITLE
Expose aura logic for other grid type support

### DIFF
--- a/src/module/scene/helpers.ts
+++ b/src/module/scene/helpers.ts
@@ -9,7 +9,7 @@ let auraCheckLock = Promise.resolve();
 
 /** Check for auras containing newly-placed or moved tokens */
 const checkAuras = foundry.utils.debounce(async function (this: ScenePF2e): Promise<void> {
-    if (!(canvas.ready && this.isInFocus && this.grid.type === CONST.GRID_TYPES.SQUARE)) {
+    if (!(canvas.ready && this.isInFocus)) {
         return;
     }
 

--- a/src/module/scene/token-document/aura/index.ts
+++ b/src/module/scene/token-document/aura/index.ts
@@ -69,7 +69,13 @@ class TokenAura implements TokenAuraData {
     /** Does this aura overlap with (at least part of) a token? */
     containsToken(token: TokenDocumentPF2e): boolean {
         // If either token is hidden or not rendered, return false early
-        if (this.token.hidden || token.hidden || !this.token.object || !token.object) {
+        if (
+            this.token.hidden ||
+            token.hidden ||
+            !this.token.object ||
+            !token.object ||
+            this.scene.grid.type !== CONST.GRID_TYPES.SQUARE
+        ) {
             return false;
         }
 

--- a/src/scripts/config/index.ts
+++ b/src/scripts/config/index.ts
@@ -76,6 +76,11 @@ import {
     weaponTraits,
 } from "./traits.ts";
 
+import { AuraRenderers } from "@module/canvas/token/aura/map.ts";
+import { AuraRenderer } from "@module/canvas/token/aura/renderer.ts";
+import { TokenAura } from "@scene/token-document/aura/index.ts";
+import { EffectAreaSquare } from "@module/canvas/effect-area-square.ts";
+
 export type StatusEffectIconTheme = "default" | "blackWhite";
 
 const actorTypes: Record<ActorType, string> = {
@@ -966,6 +971,13 @@ export const PF2ECONFIG = {
             treasure: TreasurePF2e,
             weapon: WeaponPF2e,
         },
+    },
+
+    Aura: {
+        renderers: AuraRenderers,
+        renderer: AuraRenderer,
+        token: TokenAura,
+        square: EffectAreaSquare,
     },
 
     JournalEntry: { sheetClass: JournalSheetPF2e },


### PR DESCRIPTION
## Description
This MR serves to expose the aura related classes and make a minor change. This will allow modules such as pf2e-hex to add support for additional grid types to the systems aura automation.
## Changes
- Move grid type check from `checkAuras` function to `containsToken`. This was done to make it so that modules extending the behavior only need to override `containsToken`.
- Expose `AuraRenderers`, `AuraRenderer`, `TokenAura`, and `EffectAreaSquare` classes via `CONFIG.PF2E` to allow modules to access them to wrap functions.
