### PR TITLE
Separate Fortress Shields from Tower Shield material restrictions

### DIFF
--- a/src/module/item/physical/materials.ts
+++ b/src/module/item/physical/materials.ts
@@ -27,7 +27,7 @@ function getMaterialValuationData(item: PhysicalItemPF2e): MaterialGradeData | n
           : item.isOfType("shield")
             ? item.isBuckler
                 ? MATERIAL_DATA.shield.buckler
-                : item.isTowerShield
+                : item.isMaterialTowerShield
                   ? MATERIAL_DATA.shield.towerShield
                   : MATERIAL_DATA.shield.shield
             : null;

--- a/src/module/item/shield/document.ts
+++ b/src/module/item/shield/document.ts
@@ -32,6 +32,10 @@ class ShieldPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
         return ["fortress-shield", "tower-shield"].includes(this.system.baseItem ?? "");
     }
 
+    get isMaterialTowerShield(): boolean {
+        return ["tower-shield"].includes(this.system.baseItem ?? "");
+    }
+
     get speedPenalty(): number {
         return this.system.speedPenalty || 0;
     }

--- a/src/module/item/shield/sheet.ts
+++ b/src/module/item/shield/sheet.ts
@@ -37,7 +37,7 @@ class ShieldSheetPF2e extends PhysicalItemSheetPF2e<ShieldPF2e> {
         }));
         const materialData = shield.isBuckler
             ? MATERIAL_DATA.shield.buckler
-            : shield.isTowerShield
+            : shield.isMaterialTowerShield
               ? MATERIAL_DATA.shield.towerShield
               : MATERIAL_DATA.shield.shield;
 


### PR DESCRIPTION
Closes #12917

Keeps the isTowerShield getter to allow for the cover action to continue working but creates another material-specific getter to allow Fortress Shields to operate on their own. Swaps the getter in where materials are referenced.