### PR TITLE
Add Alliance RollOptions to Creatures

### DIFF
--- a/src/module/actor/creature/document.ts
+++ b/src/module/actor/creature/document.ts
@@ -394,7 +394,7 @@ abstract class CreaturePF2e<
 
         // set alliance roll options
         const allianceText =
-            this.alliance === null ? "neutral" : this.alliance ?? this.hasPlayerOwner ? "party" : "opposition";
+            this.alliance === null ? "neutral" : this.alliance === undefined ? (this.hasPlayerOwner ? "party" : "opposition") : this.alliance;
         this.rollOptions.all[`self:alliance:${allianceText}`] = true;
 
         // Set labels for attributes

--- a/src/module/actor/creature/document.ts
+++ b/src/module/actor/creature/document.ts
@@ -394,7 +394,13 @@ abstract class CreaturePF2e<
 
         // set alliance roll options
         const allianceText =
-            this.alliance === null ? "neutral" : this.alliance === undefined ? (this.hasPlayerOwner ? "party" : "opposition") : this.alliance;
+            this.alliance === null
+                ? "neutral"
+                : this.alliance === undefined
+                  ? this.hasPlayerOwner
+                      ? "party"
+                      : "opposition"
+                  : this.alliance;
         this.rollOptions.all[`self:alliance:${allianceText}`] = true;
 
         // Set labels for attributes

--- a/src/module/actor/creature/document.ts
+++ b/src/module/actor/creature/document.ts
@@ -392,6 +392,11 @@ abstract class CreaturePF2e<
     override prepareDerivedData(): void {
         super.prepareDerivedData();
 
+        // set alliance roll options
+        const allianceText =
+            this.alliance === null ? "neutral" : this.alliance ?? this.hasPlayerOwner ? "party" : "opposition";
+        this.rollOptions.all[`self:alliance:${allianceText}`] = true;
+
         // Set labels for attributes
         if (this.system.abilities) {
             for (const [shortForm, data] of R.entries.strict(this.system.abilities)) {


### PR DESCRIPTION
Closes #16169

Wasn't sure which stage of prep this goes into, so if it needs moved, just let me know.

The logic here checks if alliance is null, which is neutral.

Undefined is default, which is based on if the token is player-owned.

If both of those checks pass, the alliance is already defined and we can return it.