### PR TITLE
Add check to Party swap method to avoid non-initiative actors

### DIFF
--- a/src/module/encounter/combatant.ts
+++ b/src/module/encounter/combatant.ts
@@ -38,8 +38,10 @@ class CombatantPF2e<
             for (const member of actor.members) {
                 const token = member.getDependentTokens({ scenes: [scene], linked: true }).at(0);
                 const alreadyAdded = operation.parent?.combatants.some((c) => c.actor === member);
+                const memberTraits = member.system.traits.value;
+                const validInEncounter = !memberTraits.some((t) => ["minion", "eidolon"].includes(t));
                 const alreadyBeingAdded = data.some((d) => d.actorId === member.id);
-                if (token && !alreadyAdded && !alreadyBeingAdded) {
+                if (token && !alreadyAdded && !alreadyBeingAdded && validInEncounter) {
                     data.push({
                         actorId: member.id,
                         sceneId: scene.id,


### PR DESCRIPTION
Closes #16101

Adding party to initiative bypasses the normal actor check, so I implemented a small actor trait check in the party swap method.