### PR TITLE
Enable Martial Weapon expertise for Swashbuckler in Weapon Expertise class feature

### DIFF
--- a/packs/classfeatures/weapon-expertise.json
+++ b/packs/classfeatures/weapon-expertise.json
@@ -34,7 +34,8 @@
                         "or": [
                             "class:champion",
                             "class:investigator",
-                            "class:magus"
+                            "class:magus",
+                            "class:swashbuckler"
                         ]
                     }
                 ],


### PR DESCRIPTION
Closes #16569