### PR TITLE
Improve actor getRollOptions performance

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -1558,8 +1558,9 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
         const toReturn: Set<string> = new Set();
 
         for (const domain of withAll) {
-            for (const [option, value] of Object.entries(rollOptions[domain] ?? {})) {
-                if (value) toReturn.add(option);
+            const optionsRecord = rollOptions[domain] ?? {};
+            for (const option of Object.keys(optionsRecord)) {
+                if (optionsRecord[option]) toReturn.add(option);
             }
         }
 


### PR DESCRIPTION
This PR aims to improve the performance of the actors `getRollOptions` function.

Performance is quite difficult to measure in the best of times, but from my profiling, this change alone means the function only takes about 60% the time to execute.
Absolute terms are even more complicated as they depend on even more variables, but in my test world this shaves off about 17ms when changing turns in the encounter tracker. This function is also a hot path when adding effects or manipulating actors in other ways. 

previous function:
<img width="1201" alt="Bildschirmfoto 2024-09-17 um 22 10 23" src="https://github.com/user-attachments/assets/a21a6c9a-ee86-406e-bc3e-3e22b98686be">

with `Object.keys`
<img width="1201" alt="Bildschirmfoto 2024-09-17 um 22 09 57" src="https://github.com/user-attachments/assets/b165e6d4-55bc-4f8f-bd9d-7b90b3d6b88c">

The reason `Object.keys` is faster in this case is due to the fact that no additional arrays have to be created for the [key, value] pair.