### PR TITLE
Fix untrained bonus in Trick Magic Item

### DIFF
--- a/src/module/item/spellcasting-entry/trick.ts
+++ b/src/module/item/spellcasting-entry/trick.ts
@@ -80,7 +80,7 @@ class TrickMagicItemEntry<TActor extends ActorPF2e = ActorPF2e> implements Spell
         const skillRank = actor.skills[skill].rank;
         const trickRank = skillRank === 4 ? 2 : skillRank === 3 ? 1 : 0;
         const levelProficiencyBonus =
-            trickRank === 0 && !game.pf2e.settings.variants.pwol
+            trickRank === 0 && !game.pf2e.settings.variants.pwol.enabled
                 ? createProficiencyModifier({ actor, rank: 0, domains, addLevel: true })
                 : null;
 


### PR DESCRIPTION
Because the Trick Magic Item spell entry checks  `game.pf2e.settings.variants.pwol` to see if it should add the character's level, and `game.pf2e.settings.variants.pwol` is an object, it is always truthy and the level isn't added