### PR TITLE
Fix issue with permanently hidden Campaign Features in Comp Browser

### DIFF
--- a/src/module/apps/compendium-browser/index.ts
+++ b/src/module/apps/compendium-browser/index.ts
@@ -951,14 +951,14 @@ class CompendiumBrowser extends Application {
         const settings = {
             settings: this.settings,
             sources: this.packLoader.sourcesSettings,
-            showCampaign: showCampaign,
+            showCampaign,
         };
 
         return {
             user: game.user,
             [activeTab]: activeTab === "settings" ? settings : { filterData: tab?.filterData },
             scrollLimit: tab?.scrollLimit,
-            showCampaign: showCampaign,
+            showCampaign,
         };
     }
 

--- a/src/module/apps/compendium-browser/index.ts
+++ b/src/module/apps/compendium-browser/index.ts
@@ -946,16 +946,19 @@ class CompendiumBrowser extends Application {
         const activeTab = this.activeTab;
         const tab = objectHasKey(this.tabs, activeTab) ? this.tabs[activeTab] : null;
 
+        const showCampaign = game.settings.get("pf2e", "campaignType") !== "none";
+
         const settings = {
             settings: this.settings,
             sources: this.packLoader.sourcesSettings,
+            showCampaign: showCampaign,
         };
 
         return {
             user: game.user,
             [activeTab]: activeTab === "settings" ? settings : { filterData: tab?.filterData },
             scrollLimit: tab?.scrollLimit,
-            showCampaign: game.settings.get("pf2e", "campaignType") !== "none",
+            showCampaign: showCampaign,
         };
     }
 

--- a/src/module/apps/compendium-browser/index.ts
+++ b/src/module/apps/compendium-browser/index.ts
@@ -946,19 +946,16 @@ class CompendiumBrowser extends Application {
         const activeTab = this.activeTab;
         const tab = objectHasKey(this.tabs, activeTab) ? this.tabs[activeTab] : null;
 
-        const showCampaign = game.settings.get("pf2e", "campaignType") !== "none";
-
         const settings = {
             settings: this.settings,
             sources: this.packLoader.sourcesSettings,
-            showCampaign,
         };
 
         return {
             user: game.user,
             [activeTab]: activeTab === "settings" ? settings : { filterData: tab?.filterData },
             scrollLimit: tab?.scrollLimit,
-            showCampaign,
+            showCampaign: game.settings.get("pf2e", "campaignType") !== "none",
         };
     }
 

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1811,7 +1811,8 @@
                 "UnequippedHint": "This armor is bulkier due to not being equipped."
             },
             "CampaignFeature": {
-                "CampaignLabel": "Campaign"
+                "CampaignLabel": "Campaign",
+                "Plural": "Campaign Features"
             },
             "CannotAddType": "{type} items cannot be added to this actor.",
             "Condition": {

--- a/static/templates/compendium-browser/settings/pack-settings.hbs
+++ b/static/templates/compendium-browser/settings/pack-settings.hbs
@@ -53,6 +53,7 @@
     </dl>
 </div>
 
+{{#if showCampaign}}
 <div class="setting-section">
     <h3>{{localize "PF2E.Item.CampaignFeature.Plural"}}</h3>
     <dl>
@@ -61,3 +62,4 @@
         {{/each}}
     </dl>
 </div>
+{{/if}}

--- a/static/templates/compendium-browser/settings/pack-settings.hbs
+++ b/static/templates/compendium-browser/settings/pack-settings.hbs
@@ -53,7 +53,7 @@
     </dl>
 </div>
 
-{{#if showCampaign}}
+{{#if @root.showCampaign}}
 <div class="setting-section">
     <h3>{{localize "PF2E.Item.CampaignFeature.Plural"}}</h3>
     <dl>

--- a/static/templates/compendium-browser/settings/pack-settings.hbs
+++ b/static/templates/compendium-browser/settings/pack-settings.hbs
@@ -52,3 +52,12 @@
         {{/each}}
     </dl>
 </div>
+
+<div class="setting-section">
+    <h3>{{localize "PF2E.Item.CampaignFeature.Plural"}}</h3>
+    <dl>
+        {{#each settings.campaignFeature as |conf pack|}}
+            <label><dt><input type="checkbox" name="campaignFeature-{{pack}}" {{checked conf.load}}></dt><dd>{{conf.name}} ({{conf.package}})</dd></label>
+        {{/each}}
+    </dl>
+</div>

--- a/static/templates/compendium-browser/settings/pack-settings.hbs
+++ b/static/templates/compendium-browser/settings/pack-settings.hbs
@@ -54,12 +54,12 @@
 </div>
 
 {{#if @root.showCampaign}}
-<div class="setting-section">
-    <h3>{{localize "PF2E.Item.CampaignFeature.Plural"}}</h3>
-    <dl>
-        {{#each settings.campaignFeature as |conf pack|}}
-            <label><dt><input type="checkbox" name="campaignFeature-{{pack}}" {{checked conf.load}}></dt><dd>{{conf.name}} ({{conf.package}})</dd></label>
-        {{/each}}
-    </dl>
-</div>
+    <div class="setting-section">
+        <h3>{{localize "PF2E.Item.CampaignFeature.Plural"}}</h3>
+        <dl>
+            {{#each settings.campaignFeature as |conf pack|}}
+                <label><dt><input type="checkbox" name="campaignFeature-{{pack}}" {{checked conf.load}}></dt><dd>{{conf.name}} ({{conf.package}})</dd></label>
+            {{/each}}
+        </dl>
+    </div>
 {{/if}}


### PR DESCRIPTION
Closes #15555

Issue was the campaignFeature sources were getting permanently set to load = false.

I noticed there was no pack settings to toggle it, so I added it and it fixed the issue.