### PR TITLE
Implement dice upgrade for Diamond Fists

### DIFF
--- a/packs/feats/deadly-grace.json
+++ b/packs/feats/deadly-grace.json
@@ -47,7 +47,6 @@
                         ]
                     }
                 ],
-                "priority": 119,
                 "property": "other-tags",
                 "value": "deadly-from-deadly-grace"
             },
@@ -58,6 +57,7 @@
                 "predicate": [
                     "item:tag:deadly-from-deadly-grace"
                 ],
+                "priority": 121,
                 "property": "traits",
                 "value": "deadly-d8"
             },

--- a/packs/feats/diamond-fists.json
+++ b/packs/feats/diamond-fists.json
@@ -26,22 +26,54 @@
         },
         "rules": [
             {
-                "definition": [
+                "itemType": "weapon",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:category:unarmed",
+                    {
+                        "or": [
+                            "item:trait:deadly-d10",
+                            "item:trait:forceful"
+                        ]
+                    }
+                ],
+                "property": "other-tags",
+                "value": "diamond-fists-dice-upgrade"
+            },
+            {
+                "itemType": "weapon",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
                     "item:category:unarmed"
                 ],
-                "key": "AdjustStrike",
-                "mode": "add",
-                "property": "weapon-traits",
+                "priority": 121,
+                "property": "traits",
                 "value": "deadly-d10"
             },
             {
-                "definition": [
+                "itemType": "weapon",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
                     "item:category:unarmed"
                 ],
-                "key": "AdjustStrike",
-                "mode": "add",
-                "property": "weapon-traits",
+                "priority": 121,
+                "property": "traits",
                 "value": "forceful"
+            },
+            {
+                "key": "DamageAlteration",
+                "mode": "upgrade",
+                "predicate": [
+                    "dice:slug:base",
+                    "item:tag:diamond-fists-dice-upgrade"
+                ],
+                "property": "dice-faces",
+                "selectors": [
+                    "unarmed-damage"
+                ]
             }
         ],
         "traits": {


### PR DESCRIPTION
Regarding priorities, I figured it makes more sense to push back the trait-adding Item Alterations, and keep the tagging Item Alterations at the default 120, otherwise it will not be there in time for other Item Alterations possibly adding the trait it's checking for, and incorrectly leaving the unarmed attack/weapon untagged. I have gone back and done the same thing for Deadly Grace.

Please let me know if I'm missing something there.