### PR TITLE
Fix divine health modifier

### DIFF
--- a/packs/feat-effects/effect-divine-health.json
+++ b/packs/feat-effects/effect-divine-health.json
@@ -4,7 +4,7 @@
     "name": "Effect: Divine Health",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Divine Health]</p>\n<p>You gain a +1 status bonus to saves against diseases and poisons</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Divine Health]</p>\n<p>You gain a +2 status bonus to saves against diseases and poisons.</p>"
         },
         "duration": {
             "expiry": null,
@@ -33,7 +33,7 @@
                 ],
                 "selector": "saving-throw",
                 "type": "status",
-                "value": 1
+                "value": 2
             }
         ],
         "start": {


### PR DESCRIPTION
I'm not 100% sure about this one, because people in the champion's aura get that +1, but the champion himself gets +2. 