### PR TITLE
Revert 'Fix divine health modifier'

### DIFF
--- a/packs/feat-effects/effect-divine-health.json
+++ b/packs/feat-effects/effect-divine-health.json
@@ -4,7 +4,7 @@
     "name": "Effect: Divine Health",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Divine Health]</p>\n<p>You gain a +2 status bonus to saves against diseases and poisons.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Divine Health]</p>\n<p>You gain a +1 status bonus to saves against diseases and poisons.</p>"
         },
         "duration": {
             "expiry": null,
@@ -33,7 +33,7 @@
                 ],
                 "selector": "saving-throw",
                 "type": "status",
-                "value": 2
+                "value": 1
             }
         ],
         "start": {


### PR DESCRIPTION
I commented on #16581, but I guess I should've closed it. This effect is meant to have only a +1, since it's the bonus that allies receive through the champion's aura. The champion's +2 is on the feat itself.