### PR TITLE
Make Crossbow Crackshot's additional precision damage untyped and add increased backstabber damage

### DIFF
--- a/packs/feats/crossbow-crack-shot.json
+++ b/packs/feats/crossbow-crack-shot.json
@@ -38,17 +38,17 @@
                     "crossbow-crack-shot"
                 ],
                 "selector": "crossbow-weapon-group-damage",
+                "slug": "crossbow-crack-shot-bonus",
                 "value": "@weapon.system.damage.dice"
             },
             {
                 "key": "AdjustModifier",
-                "mode": "upgrade",
                 "predicate": [
                     "crossbow-crack-shot"
                 ],
                 "selector": "crossbow-weapon-group-damage",
                 "slug": "backstabber",
-                "value": "2*@weapon.system.damage.dice"
+                "suppress": true
             },
             {
                 "definition": [
@@ -61,6 +61,19 @@
                 ],
                 "property": "range-increment",
                 "value": 10
+            },
+            {
+                "damageCategory": "precision",
+                "key": "FlatModifier",
+                "label": "PF2E.TraitBackstabber",
+                "predicate": [
+                    "crossbow-crack-shot",
+                    "item:trait:backstabber",
+                    "target:condition:off-guard"
+                ],
+                "selector": "crossbow-weapon-group-damage",
+                "slug": "crossbow-crack-shot-backstabber",
+                "value": "2*@weapon.system.damage.dice"
             }
         ],
         "traits": {

--- a/packs/feats/crossbow-crack-shot.json
+++ b/packs/feats/crossbow-crack-shot.json
@@ -35,11 +35,9 @@
                 "damageCategory": "precision",
                 "key": "FlatModifier",
                 "predicate": [
-                    "crossbow-crack-shot",
-                    "item:group:crossbow"
+                    "crossbow-crack-shot"
                 ],
-                "selector": "strike-damage",
-                "type": "circumstance",
+                "selector": "crossbow-weapon-group-damage",
                 "value": "@weapon.system.damage.dice"
             },
             {
@@ -48,7 +46,7 @@
                 "predicate": [
                     "crossbow-crack-shot"
                 ],
-                "selector": "crossbow-group-damage",
+                "selector": "crossbow-weapon-group-damage",
                 "slug": "backstabber",
                 "value": "2*@weapon.system.damage.dice"
             },


### PR DESCRIPTION
also fix weapon group selectors. The AdjustModifier on the backstabber damage is not working due to some bug in retrieving the weapon damage dice, it seems. I'll try to confirm that, but that's unrelated to this particular fix.

Closes #14769 though the general limitation of AdjustModifier remains.