### PR TITLE
Increase duration of Enduring Might spell effect

### DIFF
--- a/packs/spell-effects/spell-effect-enduring-might.json
+++ b/packs/spell-effects/spell-effect-enduring-might.json
@@ -4,13 +4,13 @@
     "name": "Spell Effect: Enduring Might",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Enduring Might]</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Enduring Might]</p>\n<p>You gain resistance equal to 8 plus your Strength modifier against all damage from the triggering attack or effect.</p>"
         },
         "duration": {
             "expiry": "turn-start",
             "sustained": false,
             "unit": "rounds",
-            "value": 0
+            "value": 1
         },
         "level": {
             "value": 4

--- a/packs/spell-effects/spell-effect-enduring-might.json
+++ b/packs/spell-effects/spell-effect-enduring-might.json
@@ -7,10 +7,10 @@
             "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Enduring Might]</p>\n<p>You gain resistance equal to 8 plus your Strength modifier against all damage from the triggering attack or effect.</p>"
         },
         "duration": {
-            "expiry": "turn-start",
+            "expiry": "turn-end",
             "sustained": false,
             "unit": "rounds",
-            "value": 1
+            "value": 0
         },
         "level": {
             "value": 4


### PR DESCRIPTION
Closes #11392
Increasing the duration slightly so the resistance doesn't instantly expire if used on the user's own turn. We already rely on manually removing the effect for things like Champion's Resistance, better to keep it functional imo.