### PR TITLE
Fix warnings on Tengu Weapon Familiarity

### DIFF
--- a/packs/feats/godless-healing.json
+++ b/packs/feats/godless-healing.json
@@ -11,7 +11,7 @@
         },
         "category": "skill",
         "description": {
-            "value": "<p>You recover an additional 5 Hit Points from a successful attempt to @UUID[Compendium.pf2e.actionspf2e.Item.Treat Wounds]{Treat your Wounds} or use @UUID[Compendium.pf2e.feats-srd.Item.Battle Medicine]{Battle Medicine} on you. After you or an ally use Battle Medicine on you, you become temporarily immune to that Battle Medicine for only 1 hour, instead of 1 day.</p>"
+            "value": "<p>You recover an additional 5 Hit Points from a successful attempt to @UUID[Compendium.pf2e.actionspf2e.Item.Treat Wounds]{Treat your Wounds} or use @UUID[Compendium.pf2e.feats-srd.Item.Battle Medicine] on you. After you or an ally use Battle Medicine on you, you become temporarily immune to that Battle Medicine for only 1 hour, instead of 1 day.</p>"
         },
         "level": {
             "value": 2

--- a/packs/feats/tengu-weapon-familiarity.json
+++ b/packs/feats/tengu-weapon-familiarity.json
@@ -31,9 +31,10 @@
                 "path": "flags.pf2e.tenguFamiliarSword",
                 "predicate": [
                     {
-                        "not": "self:effect:weapon-practice"
+                        "not": "self:effect:sword-practice"
                     }
                 ],
+                "priority": 8,
                 "value": "none"
             },
             {

--- a/packs/iconics/korakai-level-1.json
+++ b/packs/iconics/korakai-level-1.json
@@ -1607,103 +1607,6 @@
             "type": "consumable"
         },
         {
-            "_id": "Mr5DIVreV2fi13oq",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.Item.EzB9i7R6aBRAtJCh"
-                }
-            },
-            "img": "systems/pf2e/icons/spells/tempest-touch.webp",
-            "name": "Tempest Touch",
-            "sort": 0,
-            "system": {
-                "area": null,
-                "cost": {
-                    "value": ""
-                },
-                "counteraction": false,
-                "damage": {
-                    "0": {
-                        "applyMod": false,
-                        "category": null,
-                        "formula": "1d4",
-                        "kinds": [
-                            "damage"
-                        ],
-                        "materials": [],
-                        "type": "bludgeoning"
-                    },
-                    "fl86wl21hskrqrcy": {
-                        "applyMod": false,
-                        "category": null,
-                        "formula": "1d4",
-                        "kinds": [
-                            "damage"
-                        ],
-                        "materials": [],
-                        "type": "cold"
-                    }
-                },
-                "defense": {
-                    "save": {
-                        "basic": false,
-                        "statistic": "fortitude"
-                    }
-                },
-                "description": {
-                    "value": "<p>Your touch calls forth a churning mass of icy water that clings to your target, dealing 1d4 bludgeoning damage and 1d4 cold damage. The target must attempt a Fortitude save.</p>\n<hr />\n<p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target takes half damage and a -5-foot circumstance penalty to its Speeds until the end of your next turn.</p>\n<p><strong>Failure</strong> The target takes full damage and a -10-foot circumstance penalty to its Speeds until the end of your next turn.</p>\n<p><strong>Critical Failure</strong> As failure, but the target takes double damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning and cold damage each increase by 1d4.</p>"
-                },
-                "duration": {
-                    "sustained": false,
-                    "value": ""
-                },
-                "heightening": {
-                    "damage": {
-                        "0": "1d4",
-                        "fl86wl21hskrqrcy": "1d4"
-                    },
-                    "interval": 1,
-                    "type": "interval"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": {
-                    "value": "facIZNDbA0QjjG27"
-                },
-                "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": "Pathfinder Advanced Player's Guide"
-                },
-                "range": {
-                    "value": "touch"
-                },
-                "requirements": "",
-                "rules": [],
-                "slug": "tempest-touch",
-                "target": {
-                    "value": "1 creature"
-                },
-                "time": {
-                    "value": "1"
-                },
-                "traits": {
-                    "rarity": "uncommon",
-                    "traditions": [],
-                    "value": [
-                        "cold",
-                        "cursebound",
-                        "focus",
-                        "manipulate",
-                        "oracle",
-                        "water"
-                    ]
-                }
-            },
-            "type": "spell"
-        },
-        {
             "_id": "kWVUsdWIJz5CX1Yl",
             "flags": {
                 "core": {
@@ -2776,475 +2679,6 @@
             "type": "class"
         },
         {
-            "_id": "5N0sPZNwewgYu5uz",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.classfeatures.Item.PRJYLksQEwT39bTl"
-                },
-                "pf2e": {
-                    "itemGrants": {
-                        "tempest": {
-                            "id": "VUIRoJTNGDrlBrAU",
-                            "onDelete": "detach"
-                        }
-                    }
-                }
-            },
-            "img": "icons/magic/symbols/question-stone-yellow.webp",
-            "name": "Mystery",
-            "sort": 100,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "classfeature",
-                "description": {
-                    "value": "<p>An oracle wields divine power, but not from a single divine being. This power could come from a potent concept or ideal, the attention of multiple divine entities whose areas of concern all touch on that subject, or a direct and dangerous conduit to raw divine power. This is the oracle's mystery, a source of divine magic not beholden to any deity.</p>\n<p>Choose the mystery that empowers your magic. Your mystery grants you additional spells, and special focus spells called revelation spells. Your mystery also gives you a unique cursebound ability that lets you draw upon the divine, as well as dictating the effects of the oracular curse that falls upon you when you touch too much of this power.</p><hr /><ul><li>@UUID[Compendium.pf2e.classfeatures.Item.Ancestors] Voices of past generations teach and haunt you.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Battle] You embody the virtues upheld by heroes of legend.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Bones] Death always seems near, and the dead speak to you.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Cosmos] You draw power from the stars and the spaces between.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Flames] You dance with fire and do your best to remain unscorched by it.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Life] The teeming energies of life flow through you out into the world.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Lore] You gain access to unparalleled, overwhelming knowledge.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Tempest] Wind, waves, and storms rage at your beck and call.</li></ul><h3>Reading a Mystery Entry</h3><p>A mystery entry contains the following information, followed by a description of that mystery's curse.</p>\n<p><strong>Granted Spells</strong> You automatically add the spells listed here to your spell repertoire, as described in Spell Repertoire on page 130. At 1st level, you gain a cantrip and a 1st-rank spell. You learn the other spells on the list as soon as you gain the ability to cast oracle spells of that rank.</p>\n<p><strong>Revelation Spells</strong> You automatically gain your mystery's initial revelation spell at 1st level and can gain more by selecting the Advanced Revelation, Greater Revelation, and Diverse Mystery oracle feats. These spells start on page 259.</p>\n<p><strong>Related Domains</strong> These are the cleric domains associated with your mystery. You gain domain spells, which you can cast as revelation spells, by taking the Domain Acumen and Domain Fluency feats. At 11th level, the divine access class feature also gives you additional slotted spells based on your domains. The domains and their domain spells appear on page 372 of Player Core. Domains marked with an asterisk (*) are found in Pathfinder Lost Omens Divine Mysteries.</p>\n<p><strong>Mystery Skill</strong> You become trained in the listed skill. A few mysteries make you trained in more than one skill.</p>\n<p><strong>Oracle Feat</strong> You gain this 1st-level oracle feat. This is a cursebound feat, so using it aggravates your oracular curse.</p>"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": "mg3AigJNRTx32n51",
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core 2"
-                },
-                "rules": [
-                    {
-                        "adjustName": false,
-                        "choices": {
-                            "filter": [
-                                "item:tag:oracle-mystery"
-                            ]
-                        },
-                        "flag": "mystery",
-                        "key": "ChoiceSet",
-                        "prompt": "PF2E.SpecificRule.Oracle.Mystery.Prompt",
-                        "selection": "Compendium.pf2e.classfeatures.Item.Tempest"
-                    },
-                    {
-                        "flag": "tempest",
-                        "key": "GrantItem",
-                        "uuid": "{item|flags.pf2e.rulesSelections.mystery}"
-                    }
-                ],
-                "slug": "mystery",
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "oracle"
-                    ]
-                }
-            },
-            "type": "feat"
-        },
-        {
-            "_id": "VUIRoJTNGDrlBrAU",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.classfeatures.Item.W9cF7wZztLDb1WGY"
-                },
-                "pf2e": {
-                    "grantedBy": {
-                        "id": "5N0sPZNwewgYu5uz",
-                        "onDelete": "cascade"
-                    },
-                    "itemGrants": {
-                        "foretellHarm": {
-                            "id": "Z8SzuX9kns4iBooX",
-                            "onDelete": "detach"
-                        }
-                    }
-                }
-            },
-            "img": "icons/magic/water/pseudopod-swirl-blue.webp",
-            "name": "Tempest",
-            "sort": 0,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "classfeature",
-                "description": {
-                    "value": "<p>The fury of the wind and waves pounds in your heart, whether your power flows from natural storms, a conduit to the elemental Planes of Air and Water, or through reverence of deities such as Gozreh, the tengu god of storms Hei Feng, the pirate queen Besmara, or the elemental lords of air and water.</p>\n<p><strong>Granted Spells</strong> cantrip: @UUID[Compendium.pf2e.spells-srd.Item.Electric Arc]{Electric Arc;} 1st: @UUID[Compendium.pf2e.spells-srd.Item.Thunderstrike]; 4th: @UUID[Compendium.pf2e.spells-srd.Item.Hydraulic Torrent]; 6th: @UUID[Compendium.pf2e.spells-srd.Item.Chain Lightning]</p>\n<p><strong>Revelation Spells</strong> initial: @UUID[Compendium.pf2e.spells-srd.Item.Tempest Touch]; advanced: @UUID[Compendium.pf2e.spells-srd.Item.Thunderburst]; greater: @UUID[Compendium.pf2e.spells-srd.Item.Tempest Form]</p>\n<p><strong>Related Domains</strong> air, cold, lightning, water</p>\n<p><strong>Mystery Skill</strong> Nature</p>\n<p><strong>Oracle Feat</strong> @UUID[Compendium.pf2e.feats-srd.Item.Foretell Harm]</p><h2><strong>Curse of Inclement Headwinds</strong></h2><section class=\"traits\"><p>CURSE</p>\n<p>DIVINE</p>\n<p>ORACLE</p></section><p>The weather seems to always oppose you in ways large and small. Even when you are calm and at rest, your hair and clothing are inconveniently blown about by gentle winds, you are slightly damp from the faintest drizzle, and your touch often comes with a static shock. When you have the cursebound condition, you are opposed by the elements, with the following effects.</p>\n<p><strong>Cursebound 1</strong> Lightning is drawn to you. You gain electricity weakness 2 and electricity spells or effects that have additional effects for a creature wearing or holding metal treat you as though you were wearing metal. Any immunity or resistance you have to such spells and effects is suppressed.</p>\n<p><strong>Cursebound 2</strong> Blowing winds impose a -2 circumstance penalty to ranged attack rolls you make.</p>\n<p><strong>Cursebound 3</strong> Your weakness to electricity is equal to 5 + your level.</p>\n<p><strong>Cursebound 4</strong> The raging winds push you back, imposing a -10-foot status penalty to all your Speeds.</p>"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": null,
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core 2"
-                },
-                "rules": [
-                    {
-                        "key": "ActiveEffectLike",
-                        "mode": "upgrade",
-                        "path": "system.skills.nature.rank",
-                        "value": 1
-                    },
-                    {
-                        "flag": "foretellHarm",
-                        "key": "GrantItem",
-                        "predicate": [
-                            "class:oracle"
-                        ],
-                        "uuid": "Compendium.pf2e.feats-srd.Item.Foretell Harm"
-                    },
-                    {
-                        "key": "Weakness",
-                        "predicate": [
-                            "self:condition:cursebound"
-                        ],
-                        "type": "electricity",
-                        "value": "ternary(gte(@actor.conditions.cursebound.value,3),5+@actor.level,2)"
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "predicate": [
-                            {
-                                "gte": [
-                                    "self:condition:cursebound",
-                                    2
-                                ]
-                            }
-                        ],
-                        "selector": "ranged-attack-roll",
-                        "type": "circumstance",
-                        "value": -2
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "predicate": [
-                            "self:condition:cursebound:4"
-                        ],
-                        "selector": "speed",
-                        "value": -10
-                    }
-                ],
-                "slug": "tempest",
-                "traits": {
-                    "otherTags": [
-                        "oracle-mystery"
-                    ],
-                    "rarity": "common",
-                    "value": [
-                        "oracle"
-                    ]
-                }
-            },
-            "type": "feat"
-        },
-        {
-            "_id": "Z8SzuX9kns4iBooX",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.feats-srd.Item.CuVvDrBaVP9nYJlt"
-                },
-                "pf2e": {
-                    "grantedBy": {
-                        "id": "VUIRoJTNGDrlBrAU",
-                        "onDelete": "cascade"
-                    }
-                }
-            },
-            "img": "icons/sundries/books/book-red-exclamation.webp",
-            "name": "Foretell Harm",
-            "sort": 0,
-            "system": {
-                "actionType": {
-                    "value": "free"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "class",
-                "description": {
-                    "value": "<p><strong>Frequency</strong> once per round</p>\n<p><strong>Requirements</strong> Your previous action was to Cast a non-cantrip Spell that dealt damage.</p><hr /><p>Your magic echoes ominously as you glimpse injury in the target's future. At the beginning of your target's next turn, it takes damage equal to twice the triggering spell's rank as a seemingly random and minor misfortune finds it. The damage and type of misfortune is of a type matching the spell; for instance, if you dealt fire damage, a flame might spontaneous ignite on them or they might burn a hand on their torch. The target is then temporarily immune to Foretell Harm for 24 hours.</p>"
-                },
-                "frequency": {
-                    "max": 1,
-                    "per": "round"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": null,
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core 2"
-                },
-                "rules": [],
-                "slug": "foretell-harm",
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "cursebound",
-                        "divine",
-                        "oracle"
-                    ]
-                }
-            },
-            "type": "feat"
-        },
-        {
-            "_id": "rnuOFRiZse3ywwur",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.classfeatures.Item.7AVspOB6ITNzGFZi"
-                }
-            },
-            "img": "icons/weapons/axes/axe-double-gold.webp",
-            "name": "Oracle Spellcasting",
-            "sort": 0,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "classfeature",
-                "description": {
-                    "value": "<p>You have an unfiltered connection to the great powers of the universe and the planes beyond, and you can let this power spill forth in the form of divine magic. You are a spellcaster, and you can cast spells of the divine tradition using the Cast a Spell activity. As an oracle, when you cast spells, your incantations may spill from your lips rapidly as you speak in tongues or intone in a voice not quite your own, and your gestures might be wild and unrestrained as religious ecstasy briefly touches your mind.</p>\n<p>Each day, you can cast up to two 1st-rank spells. You must know spells to cast them, and you learn them via the spell repertoire class feature. The number of spells you can cast each day is called your spell slots.</p>\n<p>As you increase in level as an oracle, your number of spells per day increases, as does the highest rank of spells you can cast, as shown on the Oracle Spells per Day table (shown below).</p>\n<p>Some of your spells require you to attempt a spell attack to see how effective they are, or have your enemies roll against your spell DC (typically by attempting a saving throw). Since your key attribute is Charisma, your spell attack modifiers and spell DCs use your Charisma modifier.</p><h3>Heightening Spells</h3><p>When you get spell slots of 2nd rank and higher, you can fill those slots with stronger versions of lower-rank spells. This increases the spell's rank, heightening it to match the spell slot. You must have a spell in your spell repertoire at the rank you want to cast in order to heighten it to that rank. Many spells have specific improvements when they are heightened to certain ranks. The signature spells class feature lets you heighten certain spells freely.</p><h3>Cantrips</h3><p>Some of your spells are cantrips. A cantrip is a special type of spell that doesn't use spell slots. You can cast a cantrip at will, any number of times per day. A cantrip is automatically heightened to half your level rounded up—this is usually equal to the highest rank of oracle spell slot you have. For example, as a 1st-level oracle, your cantrips are 1st-rank spells, and as a 5th-level oracle, your cantrips are 3rd-rank spells.</p><table class=\"pf2e\"><thead><tr><th>Your Level</th><th>Cantrips</th><th>1st</th><th>2nd</th><th>3rd</th><th>4th</th><th>5th</th><th>6th</th><th>7th</th><th>8th</th><th>9th</th><th>10th</th></tr></thead><tbody><tr><td>1</td><td>5</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>2</td><td>5</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>3</td><td>5</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>4</td><td>5</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>5</td><td>5</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>6</td><td>5</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>7</td><td>5</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>8</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>9</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>10</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>11</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>12</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>13</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td></tr><tr><td>14</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td></tr><tr><td>15</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td></tr><tr><td>16</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td></tr><tr><td>17</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td></tr><tr><td>18</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td></tr><tr><td>19</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>1*</td></tr><tr><td>20</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>1*</td></tr><tr><td colspan=\"12\">* The oracular clarity class feature gives you a 10th-rank spell slot that works a bit differently from other spell slots.</td></tr></tbody></table>"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": "mg3AigJNRTx32n51",
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core 2"
-                },
-                "rules": [],
-                "slug": "oracle-spellcasting",
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "oracle"
-                    ]
-                }
-            },
-            "type": "feat"
-        },
-        {
-            "_id": "mYxxb2gsBvJJcnG8",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.classfeatures.Item.cFe6vFb3gSDyNeS9"
-                }
-            },
-            "img": "icons/sundries/books/book-symbol-spiral-silver-blue.webp",
-            "name": "Spell Repertoire (Oracle)",
-            "sort": 200,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "classfeature",
-                "description": {
-                    "value": "<p>The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank divine spells of your choice and five divine cantrips of your choice. You choose these from the common spells on the divine list or from other divine spells to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Oracle Spells per Day table), you add a spell to your spell repertoire of the same rank. At 2nd level, you select another 1st-rank spell; at 3rd level, you select two 2nd-rank spells, and so on. When you add spells, you might add a higher-rank version of a spell you already have, so you can cast a heightened version of that spell.</p>\n<p>Your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot, and vice versa.</p><h3>Swapping Spells in Your Repertoire</h3><p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip. You can also swap out spells by retraining during downtime.</p>"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": "mg3AigJNRTx32n51",
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core 2"
-                },
-                "rules": [],
-                "slug": "spell-repertoire-oracle",
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "oracle"
-                    ]
-                }
-            },
-            "type": "feat"
-        },
-        {
-            "_id": "kjuakgFIzEBHKWZx",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.classfeatures.Item.ibX2EhKkyUtbOHLj"
-                }
-            },
-            "img": "icons/sundries/scrolls/scroll-runed-brown.webp",
-            "name": "Oracular Curse",
-            "sort": 300,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "classfeature",
-                "description": {
-                    "value": "<p>As an oracle, you can tap into the pure and unmitigated divine power of creation to supplement your spellcasting via cursebound abilities. These abilities grant you special benefits, but the backlash of letting this power into your mortal body manifests as an oracular curse. The more cursebound abilities you use, the more your curse worsens, but you might gain divine benefits even as it tightens its grip on your soul.</p>\n<p>Your oracular curse is expressed using the cursebound condition, a unique condition that affects only oracles. Immediately after the first time you use a cursebound ability, you become cursebound 1, and if you use a cursebound ability while you are already cursebound, you increase the value of your cursebound condition by 1 after the ability resolves. At lower levels, you can tolerate only a modest amount of divine power, and your cursebound condition can't increase beyond cursebound 2; as you grow in levels, you can open yourself to even more power and your cursebound condition can progress to 3 and finally 4. Once saturated in divine power, your soul can't absorb any more, and so you can't use a cursebound ability if you are already at your maximum cursebound condition.</p>\n<p>Your oracular curse lists the specific effects of being cursebound, which are cumulative as your curse progresses. You remain cursebound until you Refocus, which reduces your cursebound condition by 1 in addition to restoring a Focus Point. As your curse is a direct result of divine power, you cannot mitigate, reduce, or remove the effects of your curse or any ability with the cursebound trait by any means other than Refocusing. For example, if a cursebound effect makes creatures @UUID[Compendium.pf2e.conditionitems.Item.Concealed] from you, you can't negate that concealed condition through a magic item or spell, such as @UUID[Compendium.pf2e.spells-srd.Item.Sure Strike] (though you would still benefit from the other effects of that item or spell). Likewise, @UUID[Compendium.pf2e.spells-srd.Item.Cleanse Affliction] and similar abilities don't affect your curse at all.</p>\n<p>At 1st level, you gain a cursebound oracle feat determined by your @UUID[Compendium.pf2e.classfeatures.Item.Mystery], and you can learn additional cursebound abilities through oracle feats.</p><hr /><h3>The Cursebound Condition</h3><p>Your oracular curse is constricting around you as you receive divine punishment after drawing too deeply on your mystery's powers. Cursebound is a condition that affects only creatures with an oracular curse, and cursebound always includes a value. Your specific oracular curse imposes unique negative effects depending on your cursebound value. You can remove the cursebound condition only by Refocusing.</p>"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": "mg3AigJNRTx32n51",
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core 2"
-                },
-                "rules": [
-                    {
-                        "itemType": "feat",
-                        "key": "ItemAlteration",
-                        "mode": "add",
-                        "predicate": [
-                            "item:trait:cursebound"
-                        ],
-                        "property": "description",
-                        "value": [
-                            {
-                                "predicate": [
-                                    {
-                                        "or": [
-                                            {
-                                                "not": "self:condition:cursebound"
-                                            },
-                                            "self:condition:cursebound:1",
-                                            {
-                                                "and": [
-                                                    "self:condition:cursebound:2",
-                                                    "feature:major-curse"
-                                                ]
-                                            },
-                                            {
-                                                "and": [
-                                                    "self:condition:cursebound:3",
-                                                    "feature:extreme-curse"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "text": "PF2E.SpecificRule.Oracle.Cursebound.IncreaseNote"
-                            },
-                            {
-                                "predicate": [
-                                    {
-                                        "or": [
-                                            {
-                                                "and": [
-                                                    "self:condition:cursebound:2",
-                                                    {
-                                                        "not": "feature:major-curse"
-                                                    }
-                                                ]
-                                            },
-                                            {
-                                                "and": [
-                                                    "self:condition:cursebound:3",
-                                                    {
-                                                        "not": "feature:extreme-curse"
-                                                    }
-                                                ]
-                                            },
-                                            "self:condition:cursebound:4"
-                                        ]
-                                    }
-                                ],
-                                "text": "PF2E.SpecificRule.Oracle.Cursebound.MaximumNote"
-                            }
-                        ]
-                    }
-                ],
-                "slug": "oracular-curse",
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "oracle"
-                    ]
-                }
-            },
-            "type": "feat"
-        },
-        {
-            "_id": "XUBaboAf7KhiVvw2",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.classfeatures.Item.NXUOtO9NytHQurlg"
-                }
-            },
-            "img": "systems/pf2e/icons/features/classes/revelation-spells.webp",
-            "name": "Revelation Spells",
-            "sort": 400,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "classfeature",
-                "description": {
-                    "value": "<p>The powers of your mystery manifest in the form of revelation spells. Revelation spells are a type of focus spell. It costs 1 Focus Point to cast a focus spell. You refill your focus pool during your daily preparations, and you can regain 1 Focus Point by spending 10 minutes using the Refocus activity to search for omens in a way befitting your mystery, like gazing into a fire, throwing bones and seeing how they fall, or meditating to hear the voices of those who came before you.</p>\n<p>Focus spells are automatically heightened to half your level rounded up, much like cantrips. Focus spells don't require spell slots, and you can't cast them using spell slots. Certain feats give you more focus spells.</p>\n<p>The maximum Focus Points your focus pool can hold is equal to the number of focus spells you have, but it can never be more than 3 points.</p>\n<p>You learn a revelation spell at 1st level and start with a focus pool of 1 Focus Point. This spell is an initial revelation spell determined by your mystery. You can learn additional revelation spells through oracle feats.</p>"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": "mg3AigJNRTx32n51",
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core 2"
-                },
-                "rules": [],
-                "slug": "revelation-spells",
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "oracle"
-                    ]
-                }
-            },
-            "type": "feat"
-        },
-        {
             "_id": "0xOoRFMnGB96fZuI",
             "flags": {
                 "core": {
@@ -3331,118 +2765,6 @@
                     "value": [
                         "general",
                         "skill"
-                    ]
-                }
-            },
-            "type": "feat"
-        },
-        {
-            "_id": "5cZAiMiqOAshMhEo",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.feats-srd.Item.AmFv3ClkAVRowHLI"
-                }
-            },
-            "img": "icons/sundries/books/book-red-exclamation.webp",
-            "name": "Tengu Weapon Familiarity",
-            "sort": 0,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "ancestry",
-                "description": {
-                    "value": "<p>You gain access to all uncommon weapons with the tengu trait plus the katana, khakkara, temple sword, and wakizashi. You have familiarity with these weapons—for the purpose of proficiency, you treat any of these that are martial weapons as simple weapons and any that are advanced weapons as martial weapons.</p>\n<p>During your daily preparations, you can practice with a weapon from the sword group that's in your possession. You gain familiarity with that weapon as well. This lasts until you practice with a different sword in the same way.</p>\n<p>At 5th level, whenever you get a critical hit with one of these weapons, you get its critical specialization effect.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Sword Practice]</p>"
-                },
-                "level": {
-                    "taken": 1,
-                    "value": 1
-                },
-                "location": "ancestry-1",
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core 2"
-                },
-                "rules": [
-                    {
-                        "key": "ActiveEffectLike",
-                        "mode": "override",
-                        "path": "flags.pf2e.tenguFamiliarSword",
-                        "predicate": [
-                            {
-                                "not": "self:effect:weapon-practice"
-                            }
-                        ],
-                        "value": "none"
-                    },
-                    {
-                        "definition": [
-                            {
-                                "or": [
-                                    "item:category:advanced",
-                                    "item:trait:tengu",
-                                    "item:id:{actor|flags.pf2e.tenguFamiliarSword}"
-                                ]
-                            }
-                        ],
-                        "key": "MartialProficiency",
-                        "label": "PF2E.SpecificRule.MartialProficiency.AdvancedTenguWeapons",
-                        "sameAs": "martial",
-                        "slug": "advanced-tengu-weapons"
-                    },
-                    {
-                        "definition": [
-                            "item:category:martial",
-                            {
-                                "or": [
-                                    "item:trait:tengu",
-                                    "item:base:katana",
-                                    "item:base:khakkara",
-                                    "item:base:temple-sword",
-                                    "item:base:wakazashi",
-                                    "item:id:{actor|flags.pf2e.tenguFamiliarSword}"
-                                ]
-                            }
-                        ],
-                        "key": "MartialProficiency",
-                        "label": "PF2E.SpecificRule.MartialProficiency.MartialTenguWeapons",
-                        "sameAs": "simple",
-                        "slug": "martial-tengu-weapons"
-                    },
-                    {
-                        "key": "CriticalSpecialization",
-                        "predicate": [
-                            {
-                                "gte": [
-                                    "self:level",
-                                    5
-                                ]
-                            },
-                            {
-                                "or": [
-                                    "item:trait:tengu",
-                                    "item:base:katana",
-                                    "item:base:khakkara",
-                                    "item:base:temple-sword",
-                                    "item:base:wakazashi",
-                                    "item:id:{actor|flags.pf2e.tenguFamiliarSword}"
-                                ]
-                            }
-                        ]
-                    }
-                ],
-                "slug": "tengu-weapon-familiarity",
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "tengu"
                     ]
                 }
             },
@@ -3541,6 +2863,746 @@
                         "electricity",
                         "manipulate",
                         "sonic"
+                    ]
+                }
+            },
+            "type": "spell"
+        },
+        {
+            "_id": "WWS5fkvizZj1SNZu",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Tengu Weapon Familiarity",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "ancestry",
+                "description": {
+                    "value": "<p>You gain access to all uncommon weapons with the tengu trait plus the katana, khakkara, temple sword, and wakizashi. You have familiarity with these weapons—for the purpose of proficiency, you treat any of these that are martial weapons as simple weapons and any that are advanced weapons as martial weapons.</p>\n<p>During your daily preparations, you can practice with a weapon from the sword group that's in your possession. You gain familiarity with that weapon as well. This lasts until you practice with a different sword in the same way.</p>\n<p>At 5th level, whenever you get a critical hit with one of these weapons, you get its critical specialization effect.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Sword Practice]</p>"
+                },
+                "level": {
+                    "taken": 1,
+                    "value": 1
+                },
+                "location": "ancestry-1",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core 2"
+                },
+                "rules": [
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "flags.pf2e.tenguFamiliarSword",
+                        "predicate": [
+                            {
+                                "not": "self:effect:sword-practice"
+                            }
+                        ],
+                        "priority": 8,
+                        "value": "none"
+                    },
+                    {
+                        "definition": [
+                            "item:category:advanced",
+                            {
+                                "or": [
+                                    "item:trait:tengu",
+                                    "item:id:{actor|flags.pf2e.tenguFamiliarSword}"
+                                ]
+                            }
+                        ],
+                        "key": "MartialProficiency",
+                        "label": "PF2E.SpecificRule.MartialProficiency.AdvancedTenguWeapons",
+                        "sameAs": "martial",
+                        "slug": "advanced-tengu-weapons"
+                    },
+                    {
+                        "definition": [
+                            "item:category:martial",
+                            {
+                                "or": [
+                                    "item:trait:tengu",
+                                    "item:base:katana",
+                                    "item:base:khakkara",
+                                    "item:base:temple-sword",
+                                    "item:base:wakazashi",
+                                    "item:id:{actor|flags.pf2e.tenguFamiliarSword}"
+                                ]
+                            }
+                        ],
+                        "key": "MartialProficiency",
+                        "label": "PF2E.SpecificRule.MartialProficiency.MartialTenguWeapons",
+                        "sameAs": "simple",
+                        "slug": "martial-tengu-weapons"
+                    },
+                    {
+                        "key": "CriticalSpecialization",
+                        "predicate": [
+                            {
+                                "gte": [
+                                    "self:level",
+                                    5
+                                ]
+                            },
+                            {
+                                "or": [
+                                    "item:trait:tengu",
+                                    "item:base:katana",
+                                    "item:base:khakkara",
+                                    "item:base:temple-sword",
+                                    "item:base:wakazashi",
+                                    "item:id:{actor|flags.pf2e.tenguFamiliarSword}"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "slug": "tengu-weapon-familiarity",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "tengu"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "tdSKM6pDCnCa6ffz",
+            "flags": {
+                "pf2e": {
+                    "itemGrants": {
+                        "tempest": {
+                            "id": "YIubqPsgP0VfbzZO",
+                            "onDelete": "detach"
+                        }
+                    }
+                }
+            },
+            "img": "icons/magic/symbols/question-stone-yellow.webp",
+            "name": "Mystery",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "classfeature",
+                "description": {
+                    "value": "<p>An oracle wields divine power, but not from a single divine being. This power could come from a potent concept or ideal, the attention of multiple divine entities whose areas of concern all touch on that subject, or a direct and dangerous conduit to raw divine power. This is the oracle's mystery, a source of divine magic not beholden to any deity.</p>\n<p>Choose the mystery that empowers your magic. Your mystery grants you additional spells, and special focus spells called revelation spells. Your mystery also gives you a unique cursebound ability that lets you draw upon the divine, as well as dictating the effects of the oracular curse that falls upon you when you touch too much of this power.</p><hr /><ul><li>@UUID[Compendium.pf2e.classfeatures.Item.Ancestors] Voices of past generations teach and haunt you.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Battle] You embody the virtues upheld by heroes of legend.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Bones] Death always seems near, and the dead speak to you.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Cosmos] You draw power from the stars and the spaces between.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Flames] You dance with fire and do your best to remain unscorched by it.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Life] The teeming energies of life flow through you out into the world.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Lore] You gain access to unparalleled, overwhelming knowledge.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Tempest] Wind, waves, and storms rage at your beck and call.</li></ul><h3>Reading a Mystery Entry</h3><p>A mystery entry contains the following information, followed by a description of that mystery's curse.</p>\n<p><strong>Granted Spells</strong> You automatically add the spells listed here to your spell repertoire, as described in Spell Repertoire on page 130. At 1st level, you gain a cantrip and a 1st-rank spell. You learn the other spells on the list as soon as you gain the ability to cast oracle spells of that rank.</p>\n<p><strong>Revelation Spells</strong> You automatically gain your mystery's initial revelation spell at 1st level and can gain more by selecting the Advanced Revelation, Greater Revelation, and Diverse Mystery oracle feats. These spells start on page 259.</p>\n<p><strong>Related Domains</strong> These are the cleric domains associated with your mystery. You gain domain spells, which you can cast as revelation spells, by taking the Domain Acumen and Domain Fluency feats. At 11th level, the divine access class feature also gives you additional slotted spells based on your domains. The domains and their domain spells appear on page 372 of Player Core. Domains marked with an asterisk (*) are found in Pathfinder Lost Omens Divine Mysteries.</p>\n<p><strong>Mystery Skill</strong> You become trained in the listed skill. A few mysteries make you trained in more than one skill.</p>\n<p><strong>Oracle Feat</strong> You gain this 1st-level oracle feat. This is a cursebound feat, so using it aggravates your oracular curse.</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": "mg3AigJNRTx32n51",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core 2"
+                },
+                "rules": [
+                    {
+                        "adjustName": false,
+                        "choices": {
+                            "filter": [
+                                "item:tag:oracle-mystery"
+                            ]
+                        },
+                        "flag": "mystery",
+                        "key": "ChoiceSet",
+                        "prompt": "PF2E.SpecificRule.Oracle.Mystery.Prompt",
+                        "selection": "Compendium.pf2e.classfeatures.Item.Tempest"
+                    },
+                    {
+                        "flag": "tempest",
+                        "key": "GrantItem",
+                        "uuid": "{item|flags.pf2e.rulesSelections.mystery}"
+                    }
+                ],
+                "slug": "mystery",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "oracle"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "YIubqPsgP0VfbzZO",
+            "flags": {
+                "pf2e": {
+                    "grantedBy": {
+                        "id": "tdSKM6pDCnCa6ffz",
+                        "onDelete": "cascade"
+                    },
+                    "itemGrants": {
+                        "curseOfInclementHeadwinds": {
+                            "id": "mnz9yWFgZj4gc7mG",
+                            "onDelete": "detach"
+                        },
+                        "foretellHarm": {
+                            "id": "iB51ZexQXPReTiWL",
+                            "onDelete": "detach"
+                        }
+                    }
+                }
+            },
+            "img": "icons/magic/water/pseudopod-swirl-blue.webp",
+            "name": "Tempest",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "classfeature",
+                "description": {
+                    "value": "<p>The fury of the wind and waves pounds in your heart, whether your power flows from natural storms, a conduit to the elemental Planes of Air and Water, or through reverence of deities such as Gozreh, the tengu god of storms Hei Feng, the pirate queen Besmara, or the elemental lords of air and water.</p>\n<p><strong>Granted Spells</strong> cantrip: @UUID[Compendium.pf2e.spells-srd.Item.Electric Arc]{Electric Arc;} 1st: @UUID[Compendium.pf2e.spells-srd.Item.Thunderstrike]; 4th: @UUID[Compendium.pf2e.spells-srd.Item.Hydraulic Torrent]; 6th: @UUID[Compendium.pf2e.spells-srd.Item.Chain Lightning]</p>\n<p><strong>Revelation Spells</strong> initial: @UUID[Compendium.pf2e.spells-srd.Item.Tempest Touch]; advanced: @UUID[Compendium.pf2e.spells-srd.Item.Thunderburst]; greater: @UUID[Compendium.pf2e.spells-srd.Item.Tempest Form]</p>\n<p><strong>Related Domains</strong> air, cold, lightning, water</p>\n<p><strong>Mystery Skill</strong> Nature</p>\n<p><strong>Oracle Feat</strong> @UUID[Compendium.pf2e.feats-srd.Item.Foretell Harm]</p>\n<p>@UUID[Compendium.pf2e.classfeatures.Item.Curse of Inclement Headwinds]</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core 2"
+                },
+                "rules": [
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "upgrade",
+                        "path": "system.skills.nature.rank",
+                        "value": 1
+                    },
+                    {
+                        "flag": "foretellHarm",
+                        "key": "GrantItem",
+                        "predicate": [
+                            "class:oracle"
+                        ],
+                        "uuid": "Compendium.pf2e.feats-srd.Item.Foretell Harm"
+                    },
+                    {
+                        "flag": "curseOfInclementHeadwinds",
+                        "key": "GrantItem",
+                        "uuid": "Compendium.pf2e.classfeatures.Item.Curse of Inclement Headwinds"
+                    }
+                ],
+                "slug": "tempest",
+                "traits": {
+                    "otherTags": [
+                        "oracle-mystery"
+                    ],
+                    "rarity": "common",
+                    "value": [
+                        "oracle"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "iB51ZexQXPReTiWL",
+            "flags": {
+                "pf2e": {
+                    "grantedBy": {
+                        "id": "YIubqPsgP0VfbzZO",
+                        "onDelete": "cascade"
+                    }
+                }
+            },
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Foretell Harm",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "free"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "class",
+                "description": {
+                    "value": "<p><strong>Frequency</strong> once per round</p>\n<p><strong>Requirements</strong> Your previous action was to Cast a non-cantrip Spell that dealt damage.</p><hr /><p>Your magic echoes ominously as you glimpse injury in the target's future. At the beginning of your target's next turn, it takes damage equal to twice the triggering spell's rank as a seemingly random and minor misfortune finds it. The damage and type of misfortune is of a type matching the spell; for instance, if you dealt fire damage, a flame might spontaneous ignite on them or they might burn a hand on their torch. The target is then temporarily immune to Foretell Harm for 24 hours.</p>"
+                },
+                "frequency": {
+                    "max": 1,
+                    "per": "round"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core 2"
+                },
+                "rules": [],
+                "slug": "foretell-harm",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "cursebound",
+                        "divine",
+                        "oracle"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "mnz9yWFgZj4gc7mG",
+            "flags": {
+                "pf2e": {
+                    "grantedBy": {
+                        "id": "YIubqPsgP0VfbzZO",
+                        "onDelete": "cascade"
+                    }
+                }
+            },
+            "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
+            "name": "Curse of Inclement Headwinds",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "classfeature",
+                "description": {
+                    "value": "<p>The weather seems to always oppose you in ways large and small. Even when you are calm and at rest, your hair and clothing are inconveniently blown about by gentle winds, you are slightly damp from the faintest drizzle, and your touch often comes with a static shock. When you have the @UUID[Compendium.pf2e.conditionitems.Item.Cursebound] condition, you are opposed by the elements, with the following effects.</p>\n<p><strong>Cursebound 1</strong> Lightning is drawn to you. You gain electricity weakness 2 and electricity spells or effects that have additional effects for a creature wearing or holding metal treat you as though you were wearing metal. Any immunity or resistance you have to such spells and effects is suppressed.</p>\n<p><strong>Cursebound 2</strong> Blowing winds impose a -2 circumstance penalty to ranged attack rolls you make.</p>\n<p><strong>Cursebound 3</strong> Your weakness to electricity is equal to 5 + your level.</p>\n<p><strong>Cursebound 4</strong> The raging winds push you back, imposing a -10-foot status penalty to all your Speeds.</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core 2"
+                },
+                "rules": [
+                    {
+                        "key": "Weakness",
+                        "predicate": [
+                            "self:condition:cursebound"
+                        ],
+                        "type": "electricity",
+                        "value": "ternary(gte(@actor.conditions.cursebound.value,3),5+@actor.level,2)"
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "predicate": [
+                            "item:ranged",
+                            {
+                                "gte": [
+                                    "self:condition:cursebound",
+                                    2
+                                ]
+                            }
+                        ],
+                        "selector": "attack-roll",
+                        "type": "circumstance",
+                        "value": -2
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "predicate": [
+                            "self:condition:cursebound:4"
+                        ],
+                        "selector": "speed",
+                        "value": -10
+                    }
+                ],
+                "slug": "curse-of-inclement-headwinds",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "curse",
+                        "divine",
+                        "oracle"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "ZtIwvu5U7Wjy5Knn",
+            "img": "icons/sundries/books/book-symbol-spiral-silver-blue.webp",
+            "name": "Spell Repertoire",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "classfeature",
+                "description": {
+                    "value": "<p><strong>Bard</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank occult spells of your choice and five occult cantrips of your choice. You choose these from the common spells from the occult list or from other occult spells to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Bard Spells per Day table), you add a spell to your spell repertoire of the same rank. At 2nd level, you select another 1st-rank spell; at 3rd level, you select two 2nd-rank spells, and so on. When you add spells, you might add a higher-rank version of a spell you already have, so you can cast a heightened version of that spell.</p>\n<p>Though you gain them at the same rate, your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot, and vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Oracle</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank divine spells of your choice and five divine cantrips of your choice. You choose these from the common spells on the divine list or from other divine spells to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Oracle Spells per Day table), you add a spell to your spell repertoire of the same rank. At 2nd level, you select another 1st-rank spell; at 3rd level, you select two 2nd-rank spells, and so on. When you add spells, you might add a higher-rank version of a spell you already have, so you can cast a heightened version of that spell.</p>\n<p>Your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot, and vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Psychic</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn one 1st-rank occult spell of your choice and three occult cantrips of your choice. You choose these from the common spells from the occult list or from other occult spells to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank. Your choice of conscious mind also grants you additional spells in your repertoire, starting with an additional 1st-rabk spell and two cantrips listed in your conscious mind, which you cast as psi cantrips.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see Table 2), you add a spell to your spell repertoire of the same level. At 2nd level, you select another 1st-rank spell; at 3rd level, you select one 2nd-level spell, and so on. When you add spells, you might add a higher-rank version of a spell you already have, so you can cast a heightened version of that spell. Your conscious mind also adds additional spells to your repertoire as you gain spells of higher levels.</p>\n<p>Though you gain them at the same rate, your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, such as the spells you gain from your conscious mind, it wouldn't give you another spell slot, and vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Sorcerer</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank spells of your choice and four cantrips of your choice, as well as an additional spell and cantrip from your bloodline. You choose these from the common spells from the tradition corresponding to your bloodline, or from other spells from that tradition to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Sorcerer Spells per Day table above), you add a spell to your spell repertoire of the same rank. When you gain a new rank of spells, your first new spell is always the sorcerous gift spell for that rank that's listed in your bloodline, but you can choose the other spells. At 2nd level, you select another 1st-rank spell; at 3rd level, you gain a new spell from your bloodline and two other 2nd-rank spells, and so on. When you add spells, you might select a higher-rank version of a spell you already know so that you can cast a heightened version of that spell.</p>\n<p>Though you gain them at the same rate, your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot or vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your spell repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip, but you can't swap out bloodline spells. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Summoner</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank spells of your choice and five cantrips of your choice. You choose these from the common spells from the tradition corresponding to your eidolon, or from other spells from that tradition to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank. Your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it doesn't give you another spell slot, and vice versa.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see Table 2–4: Summoner Spells per Day), you add a spell of the same rank to your spell repertoire. At 2nd level, you select another 1st-rank spell. At 3rd level, you add the first 2nd-rank spell to your repertoire. At 4th level you gain your second and your spell repertoire reaches its maximum size of five spells.</p>\n<p>At 5th level, in addition to adding two 3rd-rank spells to your repertoire, you lose your lowest rank of spell slots. Any time you lose a rank of spell slots, you lose two spells in your repertoire as well. These can come from spells you already know or out of the number of new spells you're learning. On levels in which you don't change your spell slots, you can swap out multiple spells, as described below.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. If it's a rank at which you lose a set of lower-rank slots, you can replace the two in either order. You can also instead swap a cantrip. You can also swap out spells by retraining during downtime.</p>\n<p>At 6th level and every even level thereafter, you can swap out any number of your spells for different spells of a rank you can cast. When you do, you must keep at least one spell you can cast with your lowest rank of spell slots so you don't end up with slots you can't use. For instance, at 6th level you would need to keep at least one 2nd-rank spell, but all your other spells could be 3rd rank.</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": "mg3AigJNRTx32n51",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
+                },
+                "rules": [
+                    {
+                        "itemId": "{item|id}",
+                        "key": "ItemAlteration",
+                        "mode": "override",
+                        "property": "description",
+                        "value": [
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.PartOne"
+                            },
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.PartTwo"
+                            },
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.PartThree"
+                            },
+                            {
+                                "divider": true,
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.SpellSwapping"
+                            },
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.SpellSwapping"
+                            }
+                        ]
+                    },
+                    {
+                        "itemId": "{item|id}",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "property": "traits",
+                        "value": "{actor|class.slug}"
+                    }
+                ],
+                "slug": "spell-repertoire",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "bard",
+                        "oracle",
+                        "psychic",
+                        "sorcerer",
+                        "summoner"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "iQe93pHvuFYJqkw2",
+            "img": "icons/weapons/axes/axe-double-gold.webp",
+            "name": "Oracle Spellcasting",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "classfeature",
+                "description": {
+                    "value": "<p>You have an unfiltered connection to the great powers of the universe and the planes beyond, and you can let this power spill forth in the form of divine magic. You are a spellcaster, and you can cast spells of the divine tradition using the Cast a Spell activity. As an oracle, when you cast spells, your incantations may spill from your lips rapidly as you speak in tongues or intone in a voice not quite your own, and your gestures might be wild and unrestrained as religious ecstasy briefly touches your mind.</p>\n<p>Each day, you can cast up to two 1st-rank spells. You must know spells to cast them, and you learn them via the spell repertoire class feature. The number of spells you can cast each day is called your spell slots.</p>\n<p>As you increase in level as an oracle, your number of spells per day increases, as does the highest rank of spells you can cast, as shown on the Oracle Spells per Day table (shown below).</p>\n<p>Some of your spells require you to attempt a spell attack to see how effective they are, or have your enemies roll against your spell DC (typically by attempting a saving throw). Since your key attribute is Charisma, your spell attack modifiers and spell DCs use your Charisma modifier.</p><h3>Heightening Spells</h3><p>When you get spell slots of 2nd rank and higher, you can fill those slots with stronger versions of lower-rank spells. This increases the spell's rank, heightening it to match the spell slot. You must have a spell in your spell repertoire at the rank you want to cast in order to heighten it to that rank. Many spells have specific improvements when they are heightened to certain ranks. The signature spells class feature lets you heighten certain spells freely.</p><h3>Cantrips</h3><p>Some of your spells are cantrips. A cantrip is a special type of spell that doesn't use spell slots. You can cast a cantrip at will, any number of times per day. A cantrip is automatically heightened to half your level rounded up—this is usually equal to the highest rank of oracle spell slot you have. For example, as a 1st-level oracle, your cantrips are 1st-rank spells, and as a 5th-level oracle, your cantrips are 3rd-rank spells.</p><table class=\"pf2e\"><thead><tr><th>Your Level</th><th>Cantrips</th><th>1st</th><th>2nd</th><th>3rd</th><th>4th</th><th>5th</th><th>6th</th><th>7th</th><th>8th</th><th>9th</th><th>10th</th></tr></thead><tbody><tr><td>1</td><td>5</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>2</td><td>5</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>3</td><td>5</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>4</td><td>5</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>5</td><td>5</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>6</td><td>5</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>7</td><td>5</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>8</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>9</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>10</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>11</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>12</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>13</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td></tr><tr><td>14</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td></tr><tr><td>15</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td></tr><tr><td>16</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td></tr><tr><td>17</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td></tr><tr><td>18</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td></tr><tr><td>19</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>1*</td></tr><tr><td>20</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>1*</td></tr><tr><td colspan=\"12\">* The oracular clarity class feature gives you a 10th-rank spell slot that works a bit differently from other spell slots.</td></tr></tbody></table>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": "mg3AigJNRTx32n51",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core 2"
+                },
+                "rules": [],
+                "slug": "oracle-spellcasting",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "oracle"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "ibB3F3Y9jRSOcQOD",
+            "img": "icons/sundries/scrolls/scroll-runed-brown.webp",
+            "name": "Oracular Curse",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "classfeature",
+                "description": {
+                    "value": "<p>As an oracle, you can tap into the pure and unmitigated divine power of creation to supplement your spellcasting via cursebound abilities. These abilities grant you special benefits, but the backlash of letting this power into your mortal body manifests as an oracular curse. The more cursebound abilities you use, the more your curse worsens, but you might gain divine benefits even as it tightens its grip on your soul.</p>\n<p>Your oracular curse is expressed using the @UUID[Compendium.pf2e.conditionitems.Item.Cursebound] condition, a unique condition that affects only oracles. Immediately after the first time you use a cursebound ability, you become cursebound 1, and if you use a cursebound ability while you are already cursebound, you increase the value of your cursebound condition by 1 after the ability resolves. At lower levels, you can tolerate only a modest amount of divine power, and your cursebound condition can't increase beyond cursebound 2; as you grow in levels, you can open yourself to even more power and your cursebound condition can progress to 3 and finally 4. Once saturated in divine power, your soul can't absorb any more, and so you can't use a cursebound ability if you are already at your maximum cursebound condition.</p>\n<p>Your oracular curse lists the specific effects of being cursebound, which are cumulative as your curse progresses. You remain cursebound until you Refocus, which reduces your cursebound condition by 1 in addition to restoring a Focus Point. As your curse is a direct result of divine power, you cannot mitigate, reduce, or remove the effects of your curse or any ability with the cursebound trait by any means other than Refocusing. For example, if a cursebound effect makes creatures @UUID[Compendium.pf2e.conditionitems.Item.Concealed] from you, you can't negate that concealed condition through a magic item or spell, such as @UUID[Compendium.pf2e.spells-srd.Item.Sure Strike] (though you would still benefit from the other effects of that item or spell). Likewise, @UUID[Compendium.pf2e.spells-srd.Item.Cleanse Affliction] and similar abilities don't affect your curse at all.</p>\n<p>At 1st level, you gain a cursebound oracle feat determined by your @UUID[Compendium.pf2e.classfeatures.Item.Mystery], and you can learn additional cursebound abilities through oracle feats.</p><hr /><h3>The Cursebound Condition</h3><p>Your oracular curse is constricting around you as you receive divine punishment after drawing too deeply on your mystery's powers. Cursebound is a condition that affects only creatures with an oracular curse, and cursebound always includes a value. Your specific oracular curse imposes unique negative effects depending on your cursebound value. You can remove the cursebound condition only by Refocusing.</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": "mg3AigJNRTx32n51",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core 2"
+                },
+                "rules": [
+                    {
+                        "itemType": "feat",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "predicate": [
+                            "item:trait:cursebound"
+                        ],
+                        "property": "description",
+                        "value": [
+                            {
+                                "predicate": [
+                                    {
+                                        "or": [
+                                            {
+                                                "not": "self:condition:cursebound"
+                                            },
+                                            "self:condition:cursebound:1",
+                                            {
+                                                "and": [
+                                                    "self:condition:cursebound:2",
+                                                    "feature:major-curse"
+                                                ]
+                                            },
+                                            {
+                                                "and": [
+                                                    "self:condition:cursebound:3",
+                                                    "feature:extreme-curse"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "text": "PF2E.SpecificRule.Oracle.Cursebound.IncreaseNote"
+                            },
+                            {
+                                "predicate": [
+                                    {
+                                        "or": [
+                                            {
+                                                "and": [
+                                                    "self:condition:cursebound:2",
+                                                    {
+                                                        "not": "feature:major-curse"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "and": [
+                                                    "self:condition:cursebound:3",
+                                                    {
+                                                        "not": "feature:extreme-curse"
+                                                    }
+                                                ]
+                                            },
+                                            "self:condition:cursebound:4"
+                                        ]
+                                    }
+                                ],
+                                "text": "PF2E.SpecificRule.Oracle.Cursebound.MaximumNote"
+                            }
+                        ]
+                    }
+                ],
+                "slug": "oracular-curse",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "oracle"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "lZMQM4hsvvh18EsE",
+            "img": "systems/pf2e/icons/features/classes/revelation-spells.webp",
+            "name": "Revelation Spells",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "classfeature",
+                "description": {
+                    "value": "<p>The powers of your mystery manifest in the form of revelation spells. Revelation spells are a type of focus spell. It costs 1 Focus Point to cast a focus spell. You refill your focus pool during your daily preparations, and you can regain 1 Focus Point by spending 10 minutes using the Refocus activity to search for omens in a way befitting your mystery, like gazing into a fire, throwing bones and seeing how they fall, or meditating to hear the voices of those who came before you.</p>\n<p>Focus spells are automatically heightened to half your level rounded up, much like cantrips. Focus spells don't require spell slots, and you can't cast them using spell slots. Certain feats give you more focus spells.</p>\n<p>The maximum Focus Points your focus pool can hold is equal to the number of focus spells you have, but it can never be more than 3 points.</p>\n<p>You learn a revelation spell at 1st level and start with a focus pool of 1 Focus Point. This spell is an initial revelation spell determined by your mystery. You can learn additional revelation spells through oracle feats.</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": "mg3AigJNRTx32n51",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core 2"
+                },
+                "rules": [],
+                "slug": "revelation-spells",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "oracle"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "6FswDuZkuq53n43b",
+             "flags": {
+                 "core": {
+                     "sourceId": "Compendium.pf2e.spells-srd.Item.EzB9i7R6aBRAtJCh"
+                 }
+             },
+            "img": "systems/pf2e/icons/spells/tempest-touch.webp",
+            "name": "Tempest Touch",
+            "sort": 0,
+            "system": {
+                "area": null,
+                "cost": {
+                    "value": ""
+                },
+                "counteraction": false,
+                "damage": {
+                    "0": {
+                        "applyMod": false,
+                        "category": null,
+                        "formula": "1d4",
+                        "kinds": [
+                            "damage"
+                        ],
+                        "materials": [],
+                        "type": "bludgeoning"
+                    },
+                    "fl86wl21hskrqrcy": {
+                        "applyMod": false,
+                        "category": null,
+                        "formula": "1d4",
+                        "kinds": [
+                            "damage"
+                        ],
+                        "materials": [],
+                        "type": "cold"
+                    }
+                },
+                "defense": {
+                    "save": {
+                        "basic": false,
+                        "statistic": "fortitude"
+                    }
+                },
+                "description": {
+                    "value": "<p>Your touch calls forth a churning mass of icy water that clings to your target, dealing 1d4 bludgeoning damage and 1d4 cold damage. The target must attempt a Fortitude save.</p><hr /><p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target takes half damage and a –5-foot circumstance penalty to its Speeds until the end of your next turn.</p>\n<p><strong>Failure</strong> The target takes full damage and a –10-foot circumstance penalty to its Speeds until the end of your next turn.</p>\n<p><strong>Critical Failure</strong> As failure, but the target takes double damage.</p><hr /><p><strong>Heightened (+1)</strong> The bludgeoning and cold damage each increase by 1d4.</p>"
+                },
+                "duration": {
+                    "sustained": false,
+                    "value": ""
+                },
+                "heightening": {
+                    "damage": {
+                        "0": "1d4",
+                        "fl86wl21hskrqrcy": "1d4"
+                    },
+                    "interval": 1,
+                    "type": "interval"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": {
+                    "value": "facIZNDbA0QjjG27"
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core 2"
+                },
+                "range": {
+                    "value": "touch"
+                },
+                "requirements": "",
+                "rules": [],
+                "slug": "tempest-touch",
+                "target": {
+                    "value": "1 creature"
+                },
+                "time": {
+                    "value": "1"
+                },
+                "traits": {
+                    "rarity": "uncommon",
+                    "traditions": [],
+                    "value": [
+                        "cold",
+                        "focus",
+                        "manipulate",
+                        "oracle",
+                        "water"
                     ]
                 }
             },

--- a/packs/iconics/korakai-level-3.json
+++ b/packs/iconics/korakai-level-3.json
@@ -1820,103 +1820,6 @@
             "type": "treasure"
         },
         {
-            "_id": "tSncd48M3aXD791q",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.Item.EzB9i7R6aBRAtJCh"
-                }
-            },
-            "img": "systems/pf2e/icons/spells/tempest-touch.webp",
-            "name": "Tempest Touch",
-            "sort": 0,
-            "system": {
-                "area": null,
-                "cost": {
-                    "value": ""
-                },
-                "counteraction": false,
-                "damage": {
-                    "0": {
-                        "applyMod": false,
-                        "category": null,
-                        "formula": "1d4",
-                        "kinds": [
-                            "damage"
-                        ],
-                        "materials": [],
-                        "type": "bludgeoning"
-                    },
-                    "fl86wl21hskrqrcy": {
-                        "applyMod": false,
-                        "category": null,
-                        "formula": "1d4",
-                        "kinds": [
-                            "damage"
-                        ],
-                        "materials": [],
-                        "type": "cold"
-                    }
-                },
-                "defense": {
-                    "save": {
-                        "basic": false,
-                        "statistic": "fortitude"
-                    }
-                },
-                "description": {
-                    "value": "<p>Your touch calls forth a churning mass of icy water that clings to your target, dealing 1d4 bludgeoning damage and 1d4 cold damage. The target must attempt a Fortitude save.</p>\n<hr />\n<p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target takes half damage and a -5-foot circumstance penalty to its Speeds until the end of your next turn.</p>\n<p><strong>Failure</strong> The target takes full damage and a -10-foot circumstance penalty to its Speeds until the end of your next turn.</p>\n<p><strong>Critical Failure</strong> As failure, but the target takes double damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning and cold damage each increase by 1d4.</p>"
-                },
-                "duration": {
-                    "sustained": false,
-                    "value": ""
-                },
-                "heightening": {
-                    "damage": {
-                        "0": "1d4",
-                        "fl86wl21hskrqrcy": "1d4"
-                    },
-                    "interval": 1,
-                    "type": "interval"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": {
-                    "value": "facIZNDbA0QjjG27"
-                },
-                "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": "Pathfinder Advanced Player's Guide"
-                },
-                "range": {
-                    "value": "touch"
-                },
-                "requirements": "",
-                "rules": [],
-                "slug": "tempest-touch",
-                "target": {
-                    "value": "1 creature"
-                },
-                "time": {
-                    "value": "1"
-                },
-                "traits": {
-                    "rarity": "uncommon",
-                    "traditions": [],
-                    "value": [
-                        "cold",
-                        "cursebound",
-                        "focus",
-                        "manipulate",
-                        "oracle",
-                        "water"
-                    ]
-                }
-            },
-            "type": "spell"
-        },
-        {
             "_id": "zzJLHah9rHpVpFEQ",
             "flags": {
                 "core": {
@@ -2674,522 +2577,6 @@
             "type": "class"
         },
         {
-            "_id": "EtbaSLSMUX8PqF3m",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.classfeatures.Item.PRJYLksQEwT39bTl"
-                },
-                "pf2e": {
-                    "itemGrants": {
-                        "tempest": {
-                            "id": "sfFzu9oFnYrmziSB",
-                            "onDelete": "detach"
-                        }
-                    }
-                }
-            },
-            "img": "icons/magic/symbols/question-stone-yellow.webp",
-            "name": "Mystery",
-            "sort": 100,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "classfeature",
-                "description": {
-                    "value": "<p>An oracle wields divine power, but not from a single divine being. This power could come from a potent concept or ideal, the attention of multiple divine entities whose areas of concern all touch on that subject, or a direct and dangerous conduit to raw divine power. This is the oracle's mystery, a source of divine magic not beholden to any deity.</p>\n<p>Choose the mystery that empowers your magic. Your mystery grants you additional spells, and special focus spells called revelation spells. Your mystery also gives you a unique cursebound ability that lets you draw upon the divine, as well as dictating the effects of the oracular curse that falls upon you when you touch too much of this power.</p><hr /><ul><li>@UUID[Compendium.pf2e.classfeatures.Item.Ancestors] Voices of past generations teach and haunt you.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Battle] You embody the virtues upheld by heroes of legend.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Bones] Death always seems near, and the dead speak to you.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Cosmos] You draw power from the stars and the spaces between.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Flames] You dance with fire and do your best to remain unscorched by it.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Life] The teeming energies of life flow through you out into the world.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Lore] You gain access to unparalleled, overwhelming knowledge.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Tempest] Wind, waves, and storms rage at your beck and call.</li></ul><h3>Reading a Mystery Entry</h3><p>A mystery entry contains the following information, followed by a description of that mystery's curse.</p>\n<p><strong>Granted Spells</strong> You automatically add the spells listed here to your spell repertoire, as described in Spell Repertoire on page 130. At 1st level, you gain a cantrip and a 1st-rank spell. You learn the other spells on the list as soon as you gain the ability to cast oracle spells of that rank.</p>\n<p><strong>Revelation Spells</strong> You automatically gain your mystery's initial revelation spell at 1st level and can gain more by selecting the Advanced Revelation, Greater Revelation, and Diverse Mystery oracle feats. These spells start on page 259.</p>\n<p><strong>Related Domains</strong> These are the cleric domains associated with your mystery. You gain domain spells, which you can cast as revelation spells, by taking the Domain Acumen and Domain Fluency feats. At 11th level, the divine access class feature also gives you additional slotted spells based on your domains. The domains and their domain spells appear on page 372 of Player Core. Domains marked with an asterisk (*) are found in Pathfinder Lost Omens Divine Mysteries.</p>\n<p><strong>Mystery Skill</strong> You become trained in the listed skill. A few mysteries make you trained in more than one skill.</p>\n<p><strong>Oracle Feat</strong> You gain this 1st-level oracle feat. This is a cursebound feat, so using it aggravates your oracular curse.</p>"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": "H9mEr51MjkHUbCTM",
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core 2"
-                },
-                "rules": [
-                    {
-                        "adjustName": false,
-                        "choices": {
-                            "filter": [
-                                "item:tag:oracle-mystery"
-                            ]
-                        },
-                        "flag": "mystery",
-                        "key": "ChoiceSet",
-                        "prompt": "PF2E.SpecificRule.Oracle.Mystery.Prompt",
-                        "selection": "Compendium.pf2e.classfeatures.Item.Tempest"
-                    },
-                    {
-                        "flag": "tempest",
-                        "key": "GrantItem",
-                        "uuid": "{item|flags.pf2e.rulesSelections.mystery}"
-                    }
-                ],
-                "slug": "mystery",
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "oracle"
-                    ]
-                }
-            },
-            "type": "feat"
-        },
-        {
-            "_id": "sfFzu9oFnYrmziSB",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.classfeatures.Item.W9cF7wZztLDb1WGY"
-                },
-                "pf2e": {
-                    "grantedBy": {
-                        "id": "EtbaSLSMUX8PqF3m",
-                        "onDelete": "cascade"
-                    },
-                    "itemGrants": {
-                        "foretellHarm": {
-                            "id": "3xi9B8uHVwBih32V",
-                            "onDelete": "detach"
-                        }
-                    }
-                }
-            },
-            "img": "icons/magic/water/pseudopod-swirl-blue.webp",
-            "name": "Tempest",
-            "sort": 0,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "classfeature",
-                "description": {
-                    "value": "<p>The fury of the wind and waves pounds in your heart, whether your power flows from natural storms, a conduit to the elemental Planes of Air and Water, or through reverence of deities such as Gozreh, the tengu god of storms Hei Feng, the pirate queen Besmara, or the elemental lords of air and water.</p>\n<p><strong>Granted Spells</strong> cantrip: @UUID[Compendium.pf2e.spells-srd.Item.Electric Arc]{Electric Arc;} 1st: @UUID[Compendium.pf2e.spells-srd.Item.Thunderstrike]; 4th: @UUID[Compendium.pf2e.spells-srd.Item.Hydraulic Torrent]; 6th: @UUID[Compendium.pf2e.spells-srd.Item.Chain Lightning]</p>\n<p><strong>Revelation Spells</strong> initial: @UUID[Compendium.pf2e.spells-srd.Item.Tempest Touch]; advanced: @UUID[Compendium.pf2e.spells-srd.Item.Thunderburst]; greater: @UUID[Compendium.pf2e.spells-srd.Item.Tempest Form]</p>\n<p><strong>Related Domains</strong> air, cold, lightning, water</p>\n<p><strong>Mystery Skill</strong> Nature</p>\n<p><strong>Oracle Feat</strong> @UUID[Compendium.pf2e.feats-srd.Item.Foretell Harm]</p><h2><strong>Curse of Inclement Headwinds</strong></h2><section class=\"traits\"><p>CURSE</p>\n<p>DIVINE</p>\n<p>ORACLE</p></section><p>The weather seems to always oppose you in ways large and small. Even when you are calm and at rest, your hair and clothing are inconveniently blown about by gentle winds, you are slightly damp from the faintest drizzle, and your touch often comes with a static shock. When you have the cursebound condition, you are opposed by the elements, with the following effects.</p>\n<p><strong>Cursebound 1</strong> Lightning is drawn to you. You gain electricity weakness 2 and electricity spells or effects that have additional effects for a creature wearing or holding metal treat you as though you were wearing metal. Any immunity or resistance you have to such spells and effects is suppressed.</p>\n<p><strong>Cursebound 2</strong> Blowing winds impose a -2 circumstance penalty to ranged attack rolls you make.</p>\n<p><strong>Cursebound 3</strong> Your weakness to electricity is equal to 5 + your level.</p>\n<p><strong>Cursebound 4</strong> The raging winds push you back, imposing a -10-foot status penalty to all your Speeds.</p>"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": null,
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core 2"
-                },
-                "rules": [
-                    {
-                        "key": "ActiveEffectLike",
-                        "mode": "upgrade",
-                        "path": "system.skills.nature.rank",
-                        "value": 1
-                    },
-                    {
-                        "flag": "foretellHarm",
-                        "key": "GrantItem",
-                        "predicate": [
-                            "class:oracle"
-                        ],
-                        "uuid": "Compendium.pf2e.feats-srd.Item.Foretell Harm"
-                    },
-                    {
-                        "key": "Weakness",
-                        "predicate": [
-                            "self:condition:cursebound"
-                        ],
-                        "type": "electricity",
-                        "value": "ternary(gte(@actor.conditions.cursebound.value,3),5+@actor.level,2)"
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "predicate": [
-                            {
-                                "gte": [
-                                    "self:condition:cursebound",
-                                    2
-                                ]
-                            }
-                        ],
-                        "selector": "ranged-attack-roll",
-                        "type": "circumstance",
-                        "value": -2
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "predicate": [
-                            "self:condition:cursebound:4"
-                        ],
-                        "selector": "speed",
-                        "value": -10
-                    }
-                ],
-                "slug": "tempest",
-                "traits": {
-                    "otherTags": [
-                        "oracle-mystery"
-                    ],
-                    "rarity": "common",
-                    "value": [
-                        "oracle"
-                    ]
-                }
-            },
-            "type": "feat"
-        },
-        {
-            "_id": "3xi9B8uHVwBih32V",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.feats-srd.Item.CuVvDrBaVP9nYJlt"
-                },
-                "pf2e": {
-                    "grantedBy": {
-                        "id": "sfFzu9oFnYrmziSB",
-                        "onDelete": "cascade"
-                    }
-                }
-            },
-            "img": "icons/sundries/books/book-red-exclamation.webp",
-            "name": "Foretell Harm",
-            "sort": 0,
-            "system": {
-                "actionType": {
-                    "value": "free"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "class",
-                "description": {
-                    "value": "<p><strong>Frequency</strong> once per round</p>\n<p><strong>Requirements</strong> Your previous action was to Cast a non-cantrip Spell that dealt damage.</p><hr /><p>Your magic echoes ominously as you glimpse injury in the target's future. At the beginning of your target's next turn, it takes damage equal to twice the triggering spell's rank as a seemingly random and minor misfortune finds it. The damage and type of misfortune is of a type matching the spell; for instance, if you dealt fire damage, a flame might spontaneous ignite on them or they might burn a hand on their torch. The target is then temporarily immune to Foretell Harm for 24 hours.</p>"
-                },
-                "frequency": {
-                    "max": 1,
-                    "per": "round"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": null,
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core 2"
-                },
-                "rules": [],
-                "slug": "foretell-harm",
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "cursebound",
-                        "divine",
-                        "oracle"
-                    ]
-                }
-            },
-            "type": "feat"
-        },
-        {
-            "_id": "7D89oFbCZRm3BAzr",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.classfeatures.Item.7AVspOB6ITNzGFZi"
-                }
-            },
-            "img": "icons/weapons/axes/axe-double-gold.webp",
-            "name": "Oracle Spellcasting",
-            "sort": 0,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "classfeature",
-                "description": {
-                    "value": "<p>You have an unfiltered connection to the great powers of the universe and the planes beyond, and you can let this power spill forth in the form of divine magic. You are a spellcaster, and you can cast spells of the divine tradition using the Cast a Spell activity. As an oracle, when you cast spells, your incantations may spill from your lips rapidly as you speak in tongues or intone in a voice not quite your own, and your gestures might be wild and unrestrained as religious ecstasy briefly touches your mind.</p>\n<p>Each day, you can cast up to two 1st-rank spells. You must know spells to cast them, and you learn them via the spell repertoire class feature. The number of spells you can cast each day is called your spell slots.</p>\n<p>As you increase in level as an oracle, your number of spells per day increases, as does the highest rank of spells you can cast, as shown on the Oracle Spells per Day table (shown below).</p>\n<p>Some of your spells require you to attempt a spell attack to see how effective they are, or have your enemies roll against your spell DC (typically by attempting a saving throw). Since your key attribute is Charisma, your spell attack modifiers and spell DCs use your Charisma modifier.</p><h3>Heightening Spells</h3><p>When you get spell slots of 2nd rank and higher, you can fill those slots with stronger versions of lower-rank spells. This increases the spell's rank, heightening it to match the spell slot. You must have a spell in your spell repertoire at the rank you want to cast in order to heighten it to that rank. Many spells have specific improvements when they are heightened to certain ranks. The signature spells class feature lets you heighten certain spells freely.</p><h3>Cantrips</h3><p>Some of your spells are cantrips. A cantrip is a special type of spell that doesn't use spell slots. You can cast a cantrip at will, any number of times per day. A cantrip is automatically heightened to half your level rounded up—this is usually equal to the highest rank of oracle spell slot you have. For example, as a 1st-level oracle, your cantrips are 1st-rank spells, and as a 5th-level oracle, your cantrips are 3rd-rank spells.</p><table class=\"pf2e\"><thead><tr><th>Your Level</th><th>Cantrips</th><th>1st</th><th>2nd</th><th>3rd</th><th>4th</th><th>5th</th><th>6th</th><th>7th</th><th>8th</th><th>9th</th><th>10th</th></tr></thead><tbody><tr><td>1</td><td>5</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>2</td><td>5</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>3</td><td>5</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>4</td><td>5</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>5</td><td>5</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>6</td><td>5</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>7</td><td>5</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>8</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>9</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>10</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>11</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>12</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>13</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td></tr><tr><td>14</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td></tr><tr><td>15</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td></tr><tr><td>16</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td></tr><tr><td>17</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td></tr><tr><td>18</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td></tr><tr><td>19</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>1*</td></tr><tr><td>20</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>1*</td></tr><tr><td colspan=\"12\">* The oracular clarity class feature gives you a 10th-rank spell slot that works a bit differently from other spell slots.</td></tr></tbody></table>"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": "H9mEr51MjkHUbCTM",
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core 2"
-                },
-                "rules": [],
-                "slug": "oracle-spellcasting",
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "oracle"
-                    ]
-                }
-            },
-            "type": "feat"
-        },
-        {
-            "_id": "V9q2555uBBNGoAJi",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.classfeatures.Item.cFe6vFb3gSDyNeS9"
-                }
-            },
-            "img": "icons/sundries/books/book-symbol-spiral-silver-blue.webp",
-            "name": "Spell Repertoire (Oracle)",
-            "sort": 200,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "classfeature",
-                "description": {
-                    "value": "<p>The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank divine spells of your choice and five divine cantrips of your choice. You choose these from the common spells on the divine list or from other divine spells to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Oracle Spells per Day table), you add a spell to your spell repertoire of the same rank. At 2nd level, you select another 1st-rank spell; at 3rd level, you select two 2nd-rank spells, and so on. When you add spells, you might add a higher-rank version of a spell you already have, so you can cast a heightened version of that spell.</p>\n<p>Your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot, and vice versa.</p><h3>Swapping Spells in Your Repertoire</h3><p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip. You can also swap out spells by retraining during downtime.</p>"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": "H9mEr51MjkHUbCTM",
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core 2"
-                },
-                "rules": [],
-                "slug": "spell-repertoire-oracle",
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "oracle"
-                    ]
-                }
-            },
-            "type": "feat"
-        },
-        {
-            "_id": "t2aU4iffUOpJakIK",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.classfeatures.Item.NXUOtO9NytHQurlg"
-                }
-            },
-            "img": "systems/pf2e/icons/features/classes/revelation-spells.webp",
-            "name": "Revelation Spells",
-            "sort": 400,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "classfeature",
-                "description": {
-                    "value": "<p>The powers of your mystery manifest in the form of revelation spells. Revelation spells are a type of focus spell. It costs 1 Focus Point to cast a focus spell. You refill your focus pool during your daily preparations, and you can regain 1 Focus Point by spending 10 minutes using the Refocus activity to search for omens in a way befitting your mystery, like gazing into a fire, throwing bones and seeing how they fall, or meditating to hear the voices of those who came before you.</p>\n<p>Focus spells are automatically heightened to half your level rounded up, much like cantrips. Focus spells don't require spell slots, and you can't cast them using spell slots. Certain feats give you more focus spells.</p>\n<p>The maximum Focus Points your focus pool can hold is equal to the number of focus spells you have, but it can never be more than 3 points.</p>\n<p>You learn a revelation spell at 1st level and start with a focus pool of 1 Focus Point. This spell is an initial revelation spell determined by your mystery. You can learn additional revelation spells through oracle feats.</p>"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": "H9mEr51MjkHUbCTM",
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core 2"
-                },
-                "rules": [],
-                "slug": "revelation-spells",
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "oracle"
-                    ]
-                }
-            },
-            "type": "feat"
-        },
-        {
-            "_id": "I4FMI1KW4jACTgjE",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.classfeatures.Item.ibX2EhKkyUtbOHLj"
-                }
-            },
-            "img": "icons/sundries/scrolls/scroll-runed-brown.webp",
-            "name": "Oracular Curse",
-            "sort": 300,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "classfeature",
-                "description": {
-                    "value": "<p>As an oracle, you can tap into the pure and unmitigated divine power of creation to supplement your spellcasting via cursebound abilities. These abilities grant you special benefits, but the backlash of letting this power into your mortal body manifests as an oracular curse. The more cursebound abilities you use, the more your curse worsens, but you might gain divine benefits even as it tightens its grip on your soul.</p>\n<p>Your oracular curse is expressed using the cursebound condition, a unique condition that affects only oracles. Immediately after the first time you use a cursebound ability, you become cursebound 1, and if you use a cursebound ability while you are already cursebound, you increase the value of your cursebound condition by 1 after the ability resolves. At lower levels, you can tolerate only a modest amount of divine power, and your cursebound condition can't increase beyond cursebound 2; as you grow in levels, you can open yourself to even more power and your cursebound condition can progress to 3 and finally 4. Once saturated in divine power, your soul can't absorb any more, and so you can't use a cursebound ability if you are already at your maximum cursebound condition.</p>\n<p>Your oracular curse lists the specific effects of being cursebound, which are cumulative as your curse progresses. You remain cursebound until you Refocus, which reduces your cursebound condition by 1 in addition to restoring a Focus Point. As your curse is a direct result of divine power, you cannot mitigate, reduce, or remove the effects of your curse or any ability with the cursebound trait by any means other than Refocusing. For example, if a cursebound effect makes creatures @UUID[Compendium.pf2e.conditionitems.Item.Concealed] from you, you can't negate that concealed condition through a magic item or spell, such as @UUID[Compendium.pf2e.spells-srd.Item.Sure Strike] (though you would still benefit from the other effects of that item or spell). Likewise, @UUID[Compendium.pf2e.spells-srd.Item.Cleanse Affliction] and similar abilities don't affect your curse at all.</p>\n<p>At 1st level, you gain a cursebound oracle feat determined by your @UUID[Compendium.pf2e.classfeatures.Item.Mystery], and you can learn additional cursebound abilities through oracle feats.</p><hr /><h3>The Cursebound Condition</h3><p>Your oracular curse is constricting around you as you receive divine punishment after drawing too deeply on your mystery's powers. Cursebound is a condition that affects only creatures with an oracular curse, and cursebound always includes a value. Your specific oracular curse imposes unique negative effects depending on your cursebound value. You can remove the cursebound condition only by Refocusing.</p>"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": "H9mEr51MjkHUbCTM",
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core 2"
-                },
-                "rules": [
-                    {
-                        "itemType": "feat",
-                        "key": "ItemAlteration",
-                        "mode": "add",
-                        "predicate": [
-                            "item:trait:cursebound"
-                        ],
-                        "property": "description",
-                        "value": [
-                            {
-                                "predicate": [
-                                    {
-                                        "or": [
-                                            {
-                                                "not": "self:condition:cursebound"
-                                            },
-                                            "self:condition:cursebound:1",
-                                            {
-                                                "and": [
-                                                    "self:condition:cursebound:2",
-                                                    "feature:major-curse"
-                                                ]
-                                            },
-                                            {
-                                                "and": [
-                                                    "self:condition:cursebound:3",
-                                                    "feature:extreme-curse"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "text": "PF2E.SpecificRule.Oracle.Cursebound.IncreaseNote"
-                            },
-                            {
-                                "predicate": [
-                                    {
-                                        "or": [
-                                            {
-                                                "and": [
-                                                    "self:condition:cursebound:2",
-                                                    {
-                                                        "not": "feature:major-curse"
-                                                    }
-                                                ]
-                                            },
-                                            {
-                                                "and": [
-                                                    "self:condition:cursebound:3",
-                                                    {
-                                                        "not": "feature:extreme-curse"
-                                                    }
-                                                ]
-                                            },
-                                            "self:condition:cursebound:4"
-                                        ]
-                                    }
-                                ],
-                                "text": "PF2E.SpecificRule.Oracle.Cursebound.MaximumNote"
-                            }
-                        ]
-                    }
-                ],
-                "slug": "oracular-curse",
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "oracle"
-                    ]
-                }
-            },
-            "type": "feat"
-        },
-        {
-            "_id": "29eUdshDIS2pf9HS",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.classfeatures.Item.VKRjmXxBFLrJK01c"
-                }
-            },
-            "img": "systems/pf2e/icons/features/classes/signature-spells-sorcerer.webp",
-            "name": "Signature Spells",
-            "sort": 1500,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "classfeature",
-                "description": {
-                    "value": "<p>Experience allows you to cast some spells more flexibly. For each spell rank you have access to, choose one spell of that rank to be a signature spell. You don't need to learn heightened versions of signature spells separately; instead, you can heighten these spells freely. If you've learned a signature spell at a higher rank than its minimum, you can also cast all its lower-rank versions without learning those separately. If you swap out a signature spell, you can choose a replacement signature spell of the same spell rank at which you learned the previous spell. You can also retrain specifically to change a signature spell to a different spell of that rank without swapping any spells; this takes as much time as retraining a spell normally does.</p>"
-                },
-                "level": {
-                    "value": 3
-                },
-                "location": "H9mEr51MjkHUbCTM",
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core"
-                },
-                "rules": [],
-                "slug": "signature-spells",
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "bard",
-                        "oracle",
-                        "psychic",
-                        "sorcerer"
-                    ]
-                }
-            },
-            "type": "feat"
-        },
-        {
             "_id": "wqPtuoUuATO974Lr",
             "flags": {
                 "core": {
@@ -3288,118 +2675,6 @@
                 }
             },
             "type": "spell"
-        },
-        {
-            "_id": "YBzA3iSgxlt9rO2u",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.feats-srd.Item.AmFv3ClkAVRowHLI"
-                }
-            },
-            "img": "icons/sundries/books/book-red-exclamation.webp",
-            "name": "Tengu Weapon Familiarity",
-            "sort": 0,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "ancestry",
-                "description": {
-                    "value": "<p>You gain access to all uncommon weapons with the tengu trait plus the katana, khakkara, temple sword, and wakizashi. You have familiarity with these weapons—for the purpose of proficiency, you treat any of these that are martial weapons as simple weapons and any that are advanced weapons as martial weapons.</p>\n<p>During your daily preparations, you can practice with a weapon from the sword group that's in your possession. You gain familiarity with that weapon as well. This lasts until you practice with a different sword in the same way.</p>\n<p>At 5th level, whenever you get a critical hit with one of these weapons, you get its critical specialization effect.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Sword Practice]</p>"
-                },
-                "level": {
-                    "taken": 1,
-                    "value": 1
-                },
-                "location": "ancestry-1",
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core 2"
-                },
-                "rules": [
-                    {
-                        "key": "ActiveEffectLike",
-                        "mode": "override",
-                        "path": "flags.pf2e.tenguFamiliarSword",
-                        "predicate": [
-                            {
-                                "not": "self:effect:weapon-practice"
-                            }
-                        ],
-                        "value": "none"
-                    },
-                    {
-                        "definition": [
-                            {
-                                "or": [
-                                    "item:category:advanced",
-                                    "item:trait:tengu",
-                                    "item:id:{actor|flags.pf2e.tenguFamiliarSword}"
-                                ]
-                            }
-                        ],
-                        "key": "MartialProficiency",
-                        "label": "PF2E.SpecificRule.MartialProficiency.AdvancedTenguWeapons",
-                        "sameAs": "martial",
-                        "slug": "advanced-tengu-weapons"
-                    },
-                    {
-                        "definition": [
-                            "item:category:martial",
-                            {
-                                "or": [
-                                    "item:trait:tengu",
-                                    "item:base:katana",
-                                    "item:base:khakkara",
-                                    "item:base:temple-sword",
-                                    "item:base:wakazashi",
-                                    "item:id:{actor|flags.pf2e.tenguFamiliarSword}"
-                                ]
-                            }
-                        ],
-                        "key": "MartialProficiency",
-                        "label": "PF2E.SpecificRule.MartialProficiency.MartialTenguWeapons",
-                        "sameAs": "simple",
-                        "slug": "martial-tengu-weapons"
-                    },
-                    {
-                        "key": "CriticalSpecialization",
-                        "predicate": [
-                            {
-                                "gte": [
-                                    "self:level",
-                                    5
-                                ]
-                            },
-                            {
-                                "or": [
-                                    "item:trait:tengu",
-                                    "item:base:katana",
-                                    "item:base:khakkara",
-                                    "item:base:temple-sword",
-                                    "item:base:wakazashi",
-                                    "item:id:{actor|flags.pf2e.tenguFamiliarSword}"
-                                ]
-                            }
-                        ]
-                    }
-                ],
-                "slug": "tengu-weapon-familiarity",
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "tengu"
-                    ]
-                }
-            },
-            "type": "feat"
         },
         {
             "_id": "zPE7cu1zOa0ODVkb",
@@ -4458,6 +3733,788 @@
                         "healing",
                         "manipulate",
                         "vitality"
+                    ]
+                }
+            },
+            "type": "spell"
+        },
+        {
+            "_id": "QmvukXUM2OB4zQ8o",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Tengu Weapon Familiarity",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "ancestry",
+                "description": {
+                    "value": "<p>You gain access to all uncommon weapons with the tengu trait plus the katana, khakkara, temple sword, and wakizashi. You have familiarity with these weapons—for the purpose of proficiency, you treat any of these that are martial weapons as simple weapons and any that are advanced weapons as martial weapons.</p>\n<p>During your daily preparations, you can practice with a weapon from the sword group that's in your possession. You gain familiarity with that weapon as well. This lasts until you practice with a different sword in the same way.</p>\n<p>At 5th level, whenever you get a critical hit with one of these weapons, you get its critical specialization effect.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Sword Practice]</p>"
+                },
+                "level": {
+                    "taken": 1,
+                    "value": 1
+                },
+                "location": "ancestry-1",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core 2"
+                },
+                "rules": [
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "flags.pf2e.tenguFamiliarSword",
+                        "predicate": [
+                            {
+                                "not": "self:effect:sword-practice"
+                            }
+                        ],
+                        "priority": 8,
+                        "value": "none"
+                    },
+                    {
+                        "definition": [
+                            "item:category:advanced",
+                            {
+                                "or": [
+                                    "item:trait:tengu",
+                                    "item:id:{actor|flags.pf2e.tenguFamiliarSword}"
+                                ]
+                            }
+                        ],
+                        "key": "MartialProficiency",
+                        "label": "PF2E.SpecificRule.MartialProficiency.AdvancedTenguWeapons",
+                        "sameAs": "martial",
+                        "slug": "advanced-tengu-weapons"
+                    },
+                    {
+                        "definition": [
+                            "item:category:martial",
+                            {
+                                "or": [
+                                    "item:trait:tengu",
+                                    "item:base:katana",
+                                    "item:base:khakkara",
+                                    "item:base:temple-sword",
+                                    "item:base:wakazashi",
+                                    "item:id:{actor|flags.pf2e.tenguFamiliarSword}"
+                                ]
+                            }
+                        ],
+                        "key": "MartialProficiency",
+                        "label": "PF2E.SpecificRule.MartialProficiency.MartialTenguWeapons",
+                        "sameAs": "simple",
+                        "slug": "martial-tengu-weapons"
+                    },
+                    {
+                        "key": "CriticalSpecialization",
+                        "predicate": [
+                            {
+                                "gte": [
+                                    "self:level",
+                                    5
+                                ]
+                            },
+                            {
+                                "or": [
+                                    "item:trait:tengu",
+                                    "item:base:katana",
+                                    "item:base:khakkara",
+                                    "item:base:temple-sword",
+                                    "item:base:wakazashi",
+                                    "item:id:{actor|flags.pf2e.tenguFamiliarSword}"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "slug": "tengu-weapon-familiarity",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "tengu"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "ot1IygC6NNOL3WRo",
+            "flags": {
+                "pf2e": {
+                    "itemGrants": {
+                        "tempest": {
+                            "id": "Cezg1PRL8zjjKIiZ",
+                            "onDelete": "detach"
+                        }
+                    }
+                }
+            },
+            "img": "icons/magic/symbols/question-stone-yellow.webp",
+            "name": "Mystery",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "classfeature",
+                "description": {
+                    "value": "<p>An oracle wields divine power, but not from a single divine being. This power could come from a potent concept or ideal, the attention of multiple divine entities whose areas of concern all touch on that subject, or a direct and dangerous conduit to raw divine power. This is the oracle's mystery, a source of divine magic not beholden to any deity.</p>\n<p>Choose the mystery that empowers your magic. Your mystery grants you additional spells, and special focus spells called revelation spells. Your mystery also gives you a unique cursebound ability that lets you draw upon the divine, as well as dictating the effects of the oracular curse that falls upon you when you touch too much of this power.</p><hr /><ul><li>@UUID[Compendium.pf2e.classfeatures.Item.Ancestors] Voices of past generations teach and haunt you.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Battle] You embody the virtues upheld by heroes of legend.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Bones] Death always seems near, and the dead speak to you.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Cosmos] You draw power from the stars and the spaces between.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Flames] You dance with fire and do your best to remain unscorched by it.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Life] The teeming energies of life flow through you out into the world.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Lore] You gain access to unparalleled, overwhelming knowledge.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Tempest] Wind, waves, and storms rage at your beck and call.</li></ul><h3>Reading a Mystery Entry</h3><p>A mystery entry contains the following information, followed by a description of that mystery's curse.</p>\n<p><strong>Granted Spells</strong> You automatically add the spells listed here to your spell repertoire, as described in Spell Repertoire on page 130. At 1st level, you gain a cantrip and a 1st-rank spell. You learn the other spells on the list as soon as you gain the ability to cast oracle spells of that rank.</p>\n<p><strong>Revelation Spells</strong> You automatically gain your mystery's initial revelation spell at 1st level and can gain more by selecting the Advanced Revelation, Greater Revelation, and Diverse Mystery oracle feats. These spells start on page 259.</p>\n<p><strong>Related Domains</strong> These are the cleric domains associated with your mystery. You gain domain spells, which you can cast as revelation spells, by taking the Domain Acumen and Domain Fluency feats. At 11th level, the divine access class feature also gives you additional slotted spells based on your domains. The domains and their domain spells appear on page 372 of Player Core. Domains marked with an asterisk (*) are found in Pathfinder Lost Omens Divine Mysteries.</p>\n<p><strong>Mystery Skill</strong> You become trained in the listed skill. A few mysteries make you trained in more than one skill.</p>\n<p><strong>Oracle Feat</strong> You gain this 1st-level oracle feat. This is a cursebound feat, so using it aggravates your oracular curse.</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": "H9mEr51MjkHUbCTM",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core 2"
+                },
+                "rules": [
+                    {
+                        "adjustName": false,
+                        "choices": {
+                            "filter": [
+                                "item:tag:oracle-mystery"
+                            ]
+                        },
+                        "flag": "mystery",
+                        "key": "ChoiceSet",
+                        "prompt": "PF2E.SpecificRule.Oracle.Mystery.Prompt",
+                        "selection": "Compendium.pf2e.classfeatures.Item.Tempest"
+                    },
+                    {
+                        "flag": "tempest",
+                        "key": "GrantItem",
+                        "uuid": "{item|flags.pf2e.rulesSelections.mystery}"
+                    }
+                ],
+                "slug": "mystery",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "oracle"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "Cezg1PRL8zjjKIiZ",
+            "flags": {
+                "pf2e": {
+                    "grantedBy": {
+                        "id": "ot1IygC6NNOL3WRo",
+                        "onDelete": "cascade"
+                    },
+                    "itemGrants": {
+                        "curseOfInclementHeadwinds": {
+                            "id": "pTPn2GRqtC0DFwbA",
+                            "onDelete": "detach"
+                        },
+                        "foretellHarm": {
+                            "id": "TiHpyzZCvA5Fkh5t",
+                            "onDelete": "detach"
+                        }
+                    }
+                }
+            },
+            "img": "icons/magic/water/pseudopod-swirl-blue.webp",
+            "name": "Tempest",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "classfeature",
+                "description": {
+                    "value": "<p>The fury of the wind and waves pounds in your heart, whether your power flows from natural storms, a conduit to the elemental Planes of Air and Water, or through reverence of deities such as Gozreh, the tengu god of storms Hei Feng, the pirate queen Besmara, or the elemental lords of air and water.</p>\n<p><strong>Granted Spells</strong> cantrip: @UUID[Compendium.pf2e.spells-srd.Item.Electric Arc]{Electric Arc;} 1st: @UUID[Compendium.pf2e.spells-srd.Item.Thunderstrike]; 4th: @UUID[Compendium.pf2e.spells-srd.Item.Hydraulic Torrent]; 6th: @UUID[Compendium.pf2e.spells-srd.Item.Chain Lightning]</p>\n<p><strong>Revelation Spells</strong> initial: @UUID[Compendium.pf2e.spells-srd.Item.Tempest Touch]; advanced: @UUID[Compendium.pf2e.spells-srd.Item.Thunderburst]; greater: @UUID[Compendium.pf2e.spells-srd.Item.Tempest Form]</p>\n<p><strong>Related Domains</strong> air, cold, lightning, water</p>\n<p><strong>Mystery Skill</strong> Nature</p>\n<p><strong>Oracle Feat</strong> @UUID[Compendium.pf2e.feats-srd.Item.Foretell Harm]</p>\n<p>@UUID[Compendium.pf2e.classfeatures.Item.Curse of Inclement Headwinds]</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core 2"
+                },
+                "rules": [
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "upgrade",
+                        "path": "system.skills.nature.rank",
+                        "value": 1
+                    },
+                    {
+                        "flag": "foretellHarm",
+                        "key": "GrantItem",
+                        "predicate": [
+                            "class:oracle"
+                        ],
+                        "uuid": "Compendium.pf2e.feats-srd.Item.Foretell Harm"
+                    },
+                    {
+                        "flag": "curseOfInclementHeadwinds",
+                        "key": "GrantItem",
+                        "uuid": "Compendium.pf2e.classfeatures.Item.Curse of Inclement Headwinds"
+                    }
+                ],
+                "slug": "tempest",
+                "traits": {
+                    "otherTags": [
+                        "oracle-mystery"
+                    ],
+                    "rarity": "common",
+                    "value": [
+                        "oracle"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "TiHpyzZCvA5Fkh5t",
+            "flags": {
+                "pf2e": {
+                    "grantedBy": {
+                        "id": "Cezg1PRL8zjjKIiZ",
+                        "onDelete": "cascade"
+                    }
+                }
+            },
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Foretell Harm",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "free"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "class",
+                "description": {
+                    "value": "<p><strong>Frequency</strong> once per round</p>\n<p><strong>Requirements</strong> Your previous action was to Cast a non-cantrip Spell that dealt damage.</p><hr /><p>Your magic echoes ominously as you glimpse injury in the target's future. At the beginning of your target's next turn, it takes damage equal to twice the triggering spell's rank as a seemingly random and minor misfortune finds it. The damage and type of misfortune is of a type matching the spell; for instance, if you dealt fire damage, a flame might spontaneous ignite on them or they might burn a hand on their torch. The target is then temporarily immune to Foretell Harm for 24 hours.</p>"
+                },
+                "frequency": {
+                    "max": 1,
+                    "per": "round"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core 2"
+                },
+                "rules": [],
+                "slug": "foretell-harm",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "cursebound",
+                        "divine",
+                        "oracle"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "pTPn2GRqtC0DFwbA",
+            "flags": {
+                "pf2e": {
+                    "grantedBy": {
+                        "id": "Cezg1PRL8zjjKIiZ",
+                        "onDelete": "cascade"
+                    }
+                }
+            },
+            "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
+            "name": "Curse of Inclement Headwinds",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "classfeature",
+                "description": {
+                    "value": "<p>The weather seems to always oppose you in ways large and small. Even when you are calm and at rest, your hair and clothing are inconveniently blown about by gentle winds, you are slightly damp from the faintest drizzle, and your touch often comes with a static shock. When you have the @UUID[Compendium.pf2e.conditionitems.Item.Cursebound] condition, you are opposed by the elements, with the following effects.</p>\n<p><strong>Cursebound 1</strong> Lightning is drawn to you. You gain electricity weakness 2 and electricity spells or effects that have additional effects for a creature wearing or holding metal treat you as though you were wearing metal. Any immunity or resistance you have to such spells and effects is suppressed.</p>\n<p><strong>Cursebound 2</strong> Blowing winds impose a -2 circumstance penalty to ranged attack rolls you make.</p>\n<p><strong>Cursebound 3</strong> Your weakness to electricity is equal to 5 + your level.</p>\n<p><strong>Cursebound 4</strong> The raging winds push you back, imposing a -10-foot status penalty to all your Speeds.</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core 2"
+                },
+                "rules": [
+                    {
+                        "key": "Weakness",
+                        "predicate": [
+                            "self:condition:cursebound"
+                        ],
+                        "type": "electricity",
+                        "value": "ternary(gte(@actor.conditions.cursebound.value,3),5+@actor.level,2)"
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "predicate": [
+                            "item:ranged",
+                            {
+                                "gte": [
+                                    "self:condition:cursebound",
+                                    2
+                                ]
+                            }
+                        ],
+                        "selector": "attack-roll",
+                        "type": "circumstance",
+                        "value": -2
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "predicate": [
+                            "self:condition:cursebound:4"
+                        ],
+                        "selector": "speed",
+                        "value": -10
+                    }
+                ],
+                "slug": "curse-of-inclement-headwinds",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "curse",
+                        "divine",
+                        "oracle"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "dq9Lcoxwgo5y8drv",
+            "img": "icons/sundries/books/book-symbol-spiral-silver-blue.webp",
+            "name": "Spell Repertoire",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "classfeature",
+                "description": {
+                    "value": "<p><strong>Bard</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank occult spells of your choice and five occult cantrips of your choice. You choose these from the common spells from the occult list or from other occult spells to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Bard Spells per Day table), you add a spell to your spell repertoire of the same rank. At 2nd level, you select another 1st-rank spell; at 3rd level, you select two 2nd-rank spells, and so on. When you add spells, you might add a higher-rank version of a spell you already have, so you can cast a heightened version of that spell.</p>\n<p>Though you gain them at the same rate, your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot, and vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Oracle</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank divine spells of your choice and five divine cantrips of your choice. You choose these from the common spells on the divine list or from other divine spells to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Oracle Spells per Day table), you add a spell to your spell repertoire of the same rank. At 2nd level, you select another 1st-rank spell; at 3rd level, you select two 2nd-rank spells, and so on. When you add spells, you might add a higher-rank version of a spell you already have, so you can cast a heightened version of that spell.</p>\n<p>Your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot, and vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Psychic</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn one 1st-rank occult spell of your choice and three occult cantrips of your choice. You choose these from the common spells from the occult list or from other occult spells to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank. Your choice of conscious mind also grants you additional spells in your repertoire, starting with an additional 1st-rabk spell and two cantrips listed in your conscious mind, which you cast as psi cantrips.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see Table 2), you add a spell to your spell repertoire of the same level. At 2nd level, you select another 1st-rank spell; at 3rd level, you select one 2nd-level spell, and so on. When you add spells, you might add a higher-rank version of a spell you already have, so you can cast a heightened version of that spell. Your conscious mind also adds additional spells to your repertoire as you gain spells of higher levels.</p>\n<p>Though you gain them at the same rate, your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, such as the spells you gain from your conscious mind, it wouldn't give you another spell slot, and vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Sorcerer</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank spells of your choice and four cantrips of your choice, as well as an additional spell and cantrip from your bloodline. You choose these from the common spells from the tradition corresponding to your bloodline, or from other spells from that tradition to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Sorcerer Spells per Day table above), you add a spell to your spell repertoire of the same rank. When you gain a new rank of spells, your first new spell is always the sorcerous gift spell for that rank that's listed in your bloodline, but you can choose the other spells. At 2nd level, you select another 1st-rank spell; at 3rd level, you gain a new spell from your bloodline and two other 2nd-rank spells, and so on. When you add spells, you might select a higher-rank version of a spell you already know so that you can cast a heightened version of that spell.</p>\n<p>Though you gain them at the same rate, your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot or vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your spell repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip, but you can't swap out bloodline spells. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Summoner</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank spells of your choice and five cantrips of your choice. You choose these from the common spells from the tradition corresponding to your eidolon, or from other spells from that tradition to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank. Your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it doesn't give you another spell slot, and vice versa.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see Table 2–4: Summoner Spells per Day), you add a spell of the same rank to your spell repertoire. At 2nd level, you select another 1st-rank spell. At 3rd level, you add the first 2nd-rank spell to your repertoire. At 4th level you gain your second and your spell repertoire reaches its maximum size of five spells.</p>\n<p>At 5th level, in addition to adding two 3rd-rank spells to your repertoire, you lose your lowest rank of spell slots. Any time you lose a rank of spell slots, you lose two spells in your repertoire as well. These can come from spells you already know or out of the number of new spells you're learning. On levels in which you don't change your spell slots, you can swap out multiple spells, as described below.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. If it's a rank at which you lose a set of lower-rank slots, you can replace the two in either order. You can also instead swap a cantrip. You can also swap out spells by retraining during downtime.</p>\n<p>At 6th level and every even level thereafter, you can swap out any number of your spells for different spells of a rank you can cast. When you do, you must keep at least one spell you can cast with your lowest rank of spell slots so you don't end up with slots you can't use. For instance, at 6th level you would need to keep at least one 2nd-rank spell, but all your other spells could be 3rd rank.</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": "H9mEr51MjkHUbCTM",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
+                },
+                "rules": [
+                    {
+                        "itemId": "{item|id}",
+                        "key": "ItemAlteration",
+                        "mode": "override",
+                        "property": "description",
+                        "value": [
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.PartOne"
+                            },
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.PartTwo"
+                            },
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.PartThree"
+                            },
+                            {
+                                "divider": true,
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.SpellSwapping"
+                            },
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.SpellSwapping"
+                            }
+                        ]
+                    },
+                    {
+                        "itemId": "{item|id}",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "property": "traits",
+                        "value": "{actor|class.slug}"
+                    }
+                ],
+                "slug": "spell-repertoire",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "bard",
+                        "oracle",
+                        "psychic",
+                        "sorcerer",
+                        "summoner"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "VDP14Lf0YxdNLDhJ",
+            "img": "icons/weapons/axes/axe-double-gold.webp",
+            "name": "Oracle Spellcasting",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "classfeature",
+                "description": {
+                    "value": "<p>You have an unfiltered connection to the great powers of the universe and the planes beyond, and you can let this power spill forth in the form of divine magic. You are a spellcaster, and you can cast spells of the divine tradition using the Cast a Spell activity. As an oracle, when you cast spells, your incantations may spill from your lips rapidly as you speak in tongues or intone in a voice not quite your own, and your gestures might be wild and unrestrained as religious ecstasy briefly touches your mind.</p>\n<p>Each day, you can cast up to two 1st-rank spells. You must know spells to cast them, and you learn them via the spell repertoire class feature. The number of spells you can cast each day is called your spell slots.</p>\n<p>As you increase in level as an oracle, your number of spells per day increases, as does the highest rank of spells you can cast, as shown on the Oracle Spells per Day table (shown below).</p>\n<p>Some of your spells require you to attempt a spell attack to see how effective they are, or have your enemies roll against your spell DC (typically by attempting a saving throw). Since your key attribute is Charisma, your spell attack modifiers and spell DCs use your Charisma modifier.</p><h3>Heightening Spells</h3><p>When you get spell slots of 2nd rank and higher, you can fill those slots with stronger versions of lower-rank spells. This increases the spell's rank, heightening it to match the spell slot. You must have a spell in your spell repertoire at the rank you want to cast in order to heighten it to that rank. Many spells have specific improvements when they are heightened to certain ranks. The signature spells class feature lets you heighten certain spells freely.</p><h3>Cantrips</h3><p>Some of your spells are cantrips. A cantrip is a special type of spell that doesn't use spell slots. You can cast a cantrip at will, any number of times per day. A cantrip is automatically heightened to half your level rounded up—this is usually equal to the highest rank of oracle spell slot you have. For example, as a 1st-level oracle, your cantrips are 1st-rank spells, and as a 5th-level oracle, your cantrips are 3rd-rank spells.</p><table class=\"pf2e\"><thead><tr><th>Your Level</th><th>Cantrips</th><th>1st</th><th>2nd</th><th>3rd</th><th>4th</th><th>5th</th><th>6th</th><th>7th</th><th>8th</th><th>9th</th><th>10th</th></tr></thead><tbody><tr><td>1</td><td>5</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>2</td><td>5</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>3</td><td>5</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>4</td><td>5</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>5</td><td>5</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>6</td><td>5</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>7</td><td>5</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>8</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>9</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>10</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>11</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>12</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>13</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td></tr><tr><td>14</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td></tr><tr><td>15</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td></tr><tr><td>16</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td></tr><tr><td>17</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td></tr><tr><td>18</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td></tr><tr><td>19</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>1*</td></tr><tr><td>20</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>1*</td></tr><tr><td colspan=\"12\">* The oracular clarity class feature gives you a 10th-rank spell slot that works a bit differently from other spell slots.</td></tr></tbody></table>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": "H9mEr51MjkHUbCTM",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core 2"
+                },
+                "rules": [],
+                "slug": "oracle-spellcasting",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "oracle"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "iDXC5Vi25v36qRmu",
+            "img": "icons/sundries/scrolls/scroll-runed-brown.webp",
+            "name": "Oracular Curse",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "classfeature",
+                "description": {
+                    "value": "<p>As an oracle, you can tap into the pure and unmitigated divine power of creation to supplement your spellcasting via cursebound abilities. These abilities grant you special benefits, but the backlash of letting this power into your mortal body manifests as an oracular curse. The more cursebound abilities you use, the more your curse worsens, but you might gain divine benefits even as it tightens its grip on your soul.</p>\n<p>Your oracular curse is expressed using the @UUID[Compendium.pf2e.conditionitems.Item.Cursebound] condition, a unique condition that affects only oracles. Immediately after the first time you use a cursebound ability, you become cursebound 1, and if you use a cursebound ability while you are already cursebound, you increase the value of your cursebound condition by 1 after the ability resolves. At lower levels, you can tolerate only a modest amount of divine power, and your cursebound condition can't increase beyond cursebound 2; as you grow in levels, you can open yourself to even more power and your cursebound condition can progress to 3 and finally 4. Once saturated in divine power, your soul can't absorb any more, and so you can't use a cursebound ability if you are already at your maximum cursebound condition.</p>\n<p>Your oracular curse lists the specific effects of being cursebound, which are cumulative as your curse progresses. You remain cursebound until you Refocus, which reduces your cursebound condition by 1 in addition to restoring a Focus Point. As your curse is a direct result of divine power, you cannot mitigate, reduce, or remove the effects of your curse or any ability with the cursebound trait by any means other than Refocusing. For example, if a cursebound effect makes creatures @UUID[Compendium.pf2e.conditionitems.Item.Concealed] from you, you can't negate that concealed condition through a magic item or spell, such as @UUID[Compendium.pf2e.spells-srd.Item.Sure Strike] (though you would still benefit from the other effects of that item or spell). Likewise, @UUID[Compendium.pf2e.spells-srd.Item.Cleanse Affliction] and similar abilities don't affect your curse at all.</p>\n<p>At 1st level, you gain a cursebound oracle feat determined by your @UUID[Compendium.pf2e.classfeatures.Item.Mystery], and you can learn additional cursebound abilities through oracle feats.</p><hr /><h3>The Cursebound Condition</h3><p>Your oracular curse is constricting around you as you receive divine punishment after drawing too deeply on your mystery's powers. Cursebound is a condition that affects only creatures with an oracular curse, and cursebound always includes a value. Your specific oracular curse imposes unique negative effects depending on your cursebound value. You can remove the cursebound condition only by Refocusing.</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": "H9mEr51MjkHUbCTM",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core 2"
+                },
+                "rules": [
+                    {
+                        "itemType": "feat",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "predicate": [
+                            "item:trait:cursebound"
+                        ],
+                        "property": "description",
+                        "value": [
+                            {
+                                "predicate": [
+                                    {
+                                        "or": [
+                                            {
+                                                "not": "self:condition:cursebound"
+                                            },
+                                            "self:condition:cursebound:1",
+                                            {
+                                                "and": [
+                                                    "self:condition:cursebound:2",
+                                                    "feature:major-curse"
+                                                ]
+                                            },
+                                            {
+                                                "and": [
+                                                    "self:condition:cursebound:3",
+                                                    "feature:extreme-curse"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "text": "PF2E.SpecificRule.Oracle.Cursebound.IncreaseNote"
+                            },
+                            {
+                                "predicate": [
+                                    {
+                                        "or": [
+                                            {
+                                                "and": [
+                                                    "self:condition:cursebound:2",
+                                                    {
+                                                        "not": "feature:major-curse"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "and": [
+                                                    "self:condition:cursebound:3",
+                                                    {
+                                                        "not": "feature:extreme-curse"
+                                                    }
+                                                ]
+                                            },
+                                            "self:condition:cursebound:4"
+                                        ]
+                                    }
+                                ],
+                                "text": "PF2E.SpecificRule.Oracle.Cursebound.MaximumNote"
+                            }
+                        ]
+                    }
+                ],
+                "slug": "oracular-curse",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "oracle"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "xYBXfR75hPtYKhiv",
+            "img": "systems/pf2e/icons/features/classes/revelation-spells.webp",
+            "name": "Revelation Spells",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "classfeature",
+                "description": {
+                    "value": "<p>The powers of your mystery manifest in the form of revelation spells. Revelation spells are a type of focus spell. It costs 1 Focus Point to cast a focus spell. You refill your focus pool during your daily preparations, and you can regain 1 Focus Point by spending 10 minutes using the Refocus activity to search for omens in a way befitting your mystery, like gazing into a fire, throwing bones and seeing how they fall, or meditating to hear the voices of those who came before you.</p>\n<p>Focus spells are automatically heightened to half your level rounded up, much like cantrips. Focus spells don't require spell slots, and you can't cast them using spell slots. Certain feats give you more focus spells.</p>\n<p>The maximum Focus Points your focus pool can hold is equal to the number of focus spells you have, but it can never be more than 3 points.</p>\n<p>You learn a revelation spell at 1st level and start with a focus pool of 1 Focus Point. This spell is an initial revelation spell determined by your mystery. You can learn additional revelation spells through oracle feats.</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": "H9mEr51MjkHUbCTM",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core 2"
+                },
+                "rules": [],
+                "slug": "revelation-spells",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "oracle"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "XxpD9ENMtPNSmxnI",
+            "img": "systems/pf2e/icons/features/classes/signature-spells-sorcerer.webp",
+            "name": "Signature Spells",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "classfeature",
+                "description": {
+                    "value": "<p>Experience allows you to cast some spells more flexibly. For each spell rank you have access to, choose one spell of that rank to be a signature spell. You don't need to learn heightened versions of signature spells separately; instead, you can heighten these spells freely. If you've learned a signature spell at a higher rank than its minimum, you can also cast all its lower-rank versions without learning those separately. If you swap out a signature spell, you can choose a replacement signature spell of the same spell rank at which you learned the previous spell. You can also retrain specifically to change a signature spell to a different spell of that rank without swapping any spells; this takes as much time as retraining a spell normally does.</p>"
+                },
+                "level": {
+                    "value": 3
+                },
+                "location": "H9mEr51MjkHUbCTM",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
+                },
+                "rules": [],
+                "slug": "signature-spells",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "bard",
+                        "oracle",
+                        "psychic",
+                        "sorcerer"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "DPeEiaQTnxlmWquq",
+             "flags": {
+                 "core": {
+                     "sourceId": "Compendium.pf2e.spells-srd.Item.EzB9i7R6aBRAtJCh"
+                 }
+             },
+            "img": "systems/pf2e/icons/spells/tempest-touch.webp",
+            "name": "Tempest Touch",
+            "sort": 0,
+            "system": {
+                "area": null,
+                "cost": {
+                    "value": ""
+                },
+                "counteraction": false,
+                "damage": {
+                    "0": {
+                        "applyMod": false,
+                        "category": null,
+                        "formula": "1d4",
+                        "kinds": [
+                            "damage"
+                        ],
+                        "materials": [],
+                        "type": "bludgeoning"
+                    },
+                    "fl86wl21hskrqrcy": {
+                        "applyMod": false,
+                        "category": null,
+                        "formula": "1d4",
+                        "kinds": [
+                            "damage"
+                        ],
+                        "materials": [],
+                        "type": "cold"
+                    }
+                },
+                "defense": {
+                    "save": {
+                        "basic": false,
+                        "statistic": "fortitude"
+                    }
+                },
+                "description": {
+                    "value": "<p>Your touch calls forth a churning mass of icy water that clings to your target, dealing 1d4 bludgeoning damage and 1d4 cold damage. The target must attempt a Fortitude save.</p><hr /><p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target takes half damage and a –5-foot circumstance penalty to its Speeds until the end of your next turn.</p>\n<p><strong>Failure</strong> The target takes full damage and a –10-foot circumstance penalty to its Speeds until the end of your next turn.</p>\n<p><strong>Critical Failure</strong> As failure, but the target takes double damage.</p><hr /><p><strong>Heightened (+1)</strong> The bludgeoning and cold damage each increase by 1d4.</p>"
+                },
+                "duration": {
+                    "sustained": false,
+                    "value": ""
+                },
+                "heightening": {
+                    "damage": {
+                        "0": "1d4",
+                        "fl86wl21hskrqrcy": "1d4"
+                    },
+                    "interval": 1,
+                    "type": "interval"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": {
+                    "value": "facIZNDbA0QjjG27"
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core 2"
+                },
+                "range": {
+                    "value": "touch"
+                },
+                "requirements": "",
+                "rules": [],
+                "slug": "tempest-touch",
+                "target": {
+                    "value": "1 creature"
+                },
+                "time": {
+                    "value": "1"
+                },
+                "traits": {
+                    "rarity": "uncommon",
+                    "traditions": [],
+                    "value": [
+                        "cold",
+                        "focus",
+                        "manipulate",
+                        "oracle",
+                        "water"
                     ]
                 }
             },

--- a/packs/iconics/korakai-level-5.json
+++ b/packs/iconics/korakai-level-5.json
@@ -1938,103 +1938,6 @@
             "type": "treasure"
         },
         {
-            "_id": "tSncd48M3aXD791q",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.Item.EzB9i7R6aBRAtJCh"
-                }
-            },
-            "img": "systems/pf2e/icons/spells/tempest-touch.webp",
-            "name": "Tempest Touch",
-            "sort": 0,
-            "system": {
-                "area": null,
-                "cost": {
-                    "value": ""
-                },
-                "counteraction": false,
-                "damage": {
-                    "0": {
-                        "applyMod": false,
-                        "category": null,
-                        "formula": "1d4",
-                        "kinds": [
-                            "damage"
-                        ],
-                        "materials": [],
-                        "type": "bludgeoning"
-                    },
-                    "fl86wl21hskrqrcy": {
-                        "applyMod": false,
-                        "category": null,
-                        "formula": "1d4",
-                        "kinds": [
-                            "damage"
-                        ],
-                        "materials": [],
-                        "type": "cold"
-                    }
-                },
-                "defense": {
-                    "save": {
-                        "basic": false,
-                        "statistic": "fortitude"
-                    }
-                },
-                "description": {
-                    "value": "<p>Your touch calls forth a churning mass of icy water that clings to your target, dealing 1d4 bludgeoning damage and 1d4 cold damage. The target must attempt a Fortitude save.</p>\n<hr />\n<p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target takes half damage and a -5-foot circumstance penalty to its Speeds until the end of your next turn.</p>\n<p><strong>Failure</strong> The target takes full damage and a -10-foot circumstance penalty to its Speeds until the end of your next turn.</p>\n<p><strong>Critical Failure</strong> As failure, but the target takes double damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The bludgeoning and cold damage each increase by 1d4.</p>"
-                },
-                "duration": {
-                    "sustained": false,
-                    "value": ""
-                },
-                "heightening": {
-                    "damage": {
-                        "0": "1d4",
-                        "fl86wl21hskrqrcy": "1d4"
-                    },
-                    "interval": 1,
-                    "type": "interval"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": {
-                    "value": "facIZNDbA0QjjG27"
-                },
-                "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": "Pathfinder Advanced Player's Guide"
-                },
-                "range": {
-                    "value": "touch"
-                },
-                "requirements": "",
-                "rules": [],
-                "slug": "tempest-touch",
-                "target": {
-                    "value": "1 creature"
-                },
-                "time": {
-                    "value": "1"
-                },
-                "traits": {
-                    "rarity": "uncommon",
-                    "traditions": [],
-                    "value": [
-                        "cold",
-                        "cursebound",
-                        "focus",
-                        "manipulate",
-                        "oracle",
-                        "water"
-                    ]
-                }
-            },
-            "type": "spell"
-        },
-        {
             "_id": "zzJLHah9rHpVpFEQ",
             "flags": {
                 "core": {
@@ -2792,522 +2695,6 @@
             "type": "class"
         },
         {
-            "_id": "EtbaSLSMUX8PqF3m",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.classfeatures.Item.PRJYLksQEwT39bTl"
-                },
-                "pf2e": {
-                    "itemGrants": {
-                        "tempest": {
-                            "id": "sfFzu9oFnYrmziSB",
-                            "onDelete": "detach"
-                        }
-                    }
-                }
-            },
-            "img": "icons/magic/symbols/question-stone-yellow.webp",
-            "name": "Mystery",
-            "sort": 100,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "classfeature",
-                "description": {
-                    "value": "<p>An oracle wields divine power, but not from a single divine being. This power could come from a potent concept or ideal, the attention of multiple divine entities whose areas of concern all touch on that subject, or a direct and dangerous conduit to raw divine power. This is the oracle's mystery, a source of divine magic not beholden to any deity.</p>\n<p>Choose the mystery that empowers your magic. Your mystery grants you additional spells, and special focus spells called revelation spells. Your mystery also gives you a unique cursebound ability that lets you draw upon the divine, as well as dictating the effects of the oracular curse that falls upon you when you touch too much of this power.</p><hr /><ul><li>@UUID[Compendium.pf2e.classfeatures.Item.Ancestors] Voices of past generations teach and haunt you.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Battle] You embody the virtues upheld by heroes of legend.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Bones] Death always seems near, and the dead speak to you.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Cosmos] You draw power from the stars and the spaces between.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Flames] You dance with fire and do your best to remain unscorched by it.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Life] The teeming energies of life flow through you out into the world.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Lore] You gain access to unparalleled, overwhelming knowledge.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Tempest] Wind, waves, and storms rage at your beck and call.</li></ul><h3>Reading a Mystery Entry</h3><p>A mystery entry contains the following information, followed by a description of that mystery's curse.</p>\n<p><strong>Granted Spells</strong> You automatically add the spells listed here to your spell repertoire, as described in Spell Repertoire on page 130. At 1st level, you gain a cantrip and a 1st-rank spell. You learn the other spells on the list as soon as you gain the ability to cast oracle spells of that rank.</p>\n<p><strong>Revelation Spells</strong> You automatically gain your mystery's initial revelation spell at 1st level and can gain more by selecting the Advanced Revelation, Greater Revelation, and Diverse Mystery oracle feats. These spells start on page 259.</p>\n<p><strong>Related Domains</strong> These are the cleric domains associated with your mystery. You gain domain spells, which you can cast as revelation spells, by taking the Domain Acumen and Domain Fluency feats. At 11th level, the divine access class feature also gives you additional slotted spells based on your domains. The domains and their domain spells appear on page 372 of Player Core. Domains marked with an asterisk (*) are found in Pathfinder Lost Omens Divine Mysteries.</p>\n<p><strong>Mystery Skill</strong> You become trained in the listed skill. A few mysteries make you trained in more than one skill.</p>\n<p><strong>Oracle Feat</strong> You gain this 1st-level oracle feat. This is a cursebound feat, so using it aggravates your oracular curse.</p>"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": "H9mEr51MjkHUbCTM",
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core 2"
-                },
-                "rules": [
-                    {
-                        "adjustName": false,
-                        "choices": {
-                            "filter": [
-                                "item:tag:oracle-mystery"
-                            ]
-                        },
-                        "flag": "mystery",
-                        "key": "ChoiceSet",
-                        "prompt": "PF2E.SpecificRule.Oracle.Mystery.Prompt",
-                        "selection": "Compendium.pf2e.classfeatures.Item.Tempest"
-                    },
-                    {
-                        "flag": "tempest",
-                        "key": "GrantItem",
-                        "uuid": "{item|flags.pf2e.rulesSelections.mystery}"
-                    }
-                ],
-                "slug": "mystery",
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "oracle"
-                    ]
-                }
-            },
-            "type": "feat"
-        },
-        {
-            "_id": "sfFzu9oFnYrmziSB",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.classfeatures.Item.W9cF7wZztLDb1WGY"
-                },
-                "pf2e": {
-                    "grantedBy": {
-                        "id": "EtbaSLSMUX8PqF3m",
-                        "onDelete": "cascade"
-                    },
-                    "itemGrants": {
-                        "foretellHarm": {
-                            "id": "3xi9B8uHVwBih32V",
-                            "onDelete": "detach"
-                        }
-                    }
-                }
-            },
-            "img": "icons/magic/water/pseudopod-swirl-blue.webp",
-            "name": "Tempest",
-            "sort": 0,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "classfeature",
-                "description": {
-                    "value": "<p>The fury of the wind and waves pounds in your heart, whether your power flows from natural storms, a conduit to the elemental Planes of Air and Water, or through reverence of deities such as Gozreh, the tengu god of storms Hei Feng, the pirate queen Besmara, or the elemental lords of air and water.</p>\n<p><strong>Granted Spells</strong> cantrip: @UUID[Compendium.pf2e.spells-srd.Item.Electric Arc]{Electric Arc;} 1st: @UUID[Compendium.pf2e.spells-srd.Item.Thunderstrike]; 4th: @UUID[Compendium.pf2e.spells-srd.Item.Hydraulic Torrent]; 6th: @UUID[Compendium.pf2e.spells-srd.Item.Chain Lightning]</p>\n<p><strong>Revelation Spells</strong> initial: @UUID[Compendium.pf2e.spells-srd.Item.Tempest Touch]; advanced: @UUID[Compendium.pf2e.spells-srd.Item.Thunderburst]; greater: @UUID[Compendium.pf2e.spells-srd.Item.Tempest Form]</p>\n<p><strong>Related Domains</strong> air, cold, lightning, water</p>\n<p><strong>Mystery Skill</strong> Nature</p>\n<p><strong>Oracle Feat</strong> @UUID[Compendium.pf2e.feats-srd.Item.Foretell Harm]</p><h2><strong>Curse of Inclement Headwinds</strong></h2><section class=\"traits\"><p>CURSE</p>\n<p>DIVINE</p>\n<p>ORACLE</p></section><p>The weather seems to always oppose you in ways large and small. Even when you are calm and at rest, your hair and clothing are inconveniently blown about by gentle winds, you are slightly damp from the faintest drizzle, and your touch often comes with a static shock. When you have the cursebound condition, you are opposed by the elements, with the following effects.</p>\n<p><strong>Cursebound 1</strong> Lightning is drawn to you. You gain electricity weakness 2 and electricity spells or effects that have additional effects for a creature wearing or holding metal treat you as though you were wearing metal. Any immunity or resistance you have to such spells and effects is suppressed.</p>\n<p><strong>Cursebound 2</strong> Blowing winds impose a -2 circumstance penalty to ranged attack rolls you make.</p>\n<p><strong>Cursebound 3</strong> Your weakness to electricity is equal to 5 + your level.</p>\n<p><strong>Cursebound 4</strong> The raging winds push you back, imposing a -10-foot status penalty to all your Speeds.</p>"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": null,
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core 2"
-                },
-                "rules": [
-                    {
-                        "key": "ActiveEffectLike",
-                        "mode": "upgrade",
-                        "path": "system.skills.nature.rank",
-                        "value": 1
-                    },
-                    {
-                        "flag": "foretellHarm",
-                        "key": "GrantItem",
-                        "predicate": [
-                            "class:oracle"
-                        ],
-                        "uuid": "Compendium.pf2e.feats-srd.Item.Foretell Harm"
-                    },
-                    {
-                        "key": "Weakness",
-                        "predicate": [
-                            "self:condition:cursebound"
-                        ],
-                        "type": "electricity",
-                        "value": "ternary(gte(@actor.conditions.cursebound.value,3),5+@actor.level,2)"
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "predicate": [
-                            {
-                                "gte": [
-                                    "self:condition:cursebound",
-                                    2
-                                ]
-                            }
-                        ],
-                        "selector": "ranged-attack-roll",
-                        "type": "circumstance",
-                        "value": -2
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "predicate": [
-                            "self:condition:cursebound:4"
-                        ],
-                        "selector": "speed",
-                        "value": -10
-                    }
-                ],
-                "slug": "tempest",
-                "traits": {
-                    "otherTags": [
-                        "oracle-mystery"
-                    ],
-                    "rarity": "common",
-                    "value": [
-                        "oracle"
-                    ]
-                }
-            },
-            "type": "feat"
-        },
-        {
-            "_id": "3xi9B8uHVwBih32V",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.feats-srd.Item.CuVvDrBaVP9nYJlt"
-                },
-                "pf2e": {
-                    "grantedBy": {
-                        "id": "sfFzu9oFnYrmziSB",
-                        "onDelete": "cascade"
-                    }
-                }
-            },
-            "img": "icons/sundries/books/book-red-exclamation.webp",
-            "name": "Foretell Harm",
-            "sort": 0,
-            "system": {
-                "actionType": {
-                    "value": "free"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "class",
-                "description": {
-                    "value": "<p><strong>Frequency</strong> once per round</p>\n<p><strong>Requirements</strong> Your previous action was to Cast a non-cantrip Spell that dealt damage.</p><hr /><p>Your magic echoes ominously as you glimpse injury in the target's future. At the beginning of your target's next turn, it takes damage equal to twice the triggering spell's rank as a seemingly random and minor misfortune finds it. The damage and type of misfortune is of a type matching the spell; for instance, if you dealt fire damage, a flame might spontaneous ignite on them or they might burn a hand on their torch. The target is then temporarily immune to Foretell Harm for 24 hours.</p>"
-                },
-                "frequency": {
-                    "max": 1,
-                    "per": "round"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": null,
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core 2"
-                },
-                "rules": [],
-                "slug": "foretell-harm",
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "cursebound",
-                        "divine",
-                        "oracle"
-                    ]
-                }
-            },
-            "type": "feat"
-        },
-        {
-            "_id": "7D89oFbCZRm3BAzr",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.classfeatures.Item.7AVspOB6ITNzGFZi"
-                }
-            },
-            "img": "icons/weapons/axes/axe-double-gold.webp",
-            "name": "Oracle Spellcasting",
-            "sort": 0,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "classfeature",
-                "description": {
-                    "value": "<p>You have an unfiltered connection to the great powers of the universe and the planes beyond, and you can let this power spill forth in the form of divine magic. You are a spellcaster, and you can cast spells of the divine tradition using the Cast a Spell activity. As an oracle, when you cast spells, your incantations may spill from your lips rapidly as you speak in tongues or intone in a voice not quite your own, and your gestures might be wild and unrestrained as religious ecstasy briefly touches your mind.</p>\n<p>Each day, you can cast up to two 1st-rank spells. You must know spells to cast them, and you learn them via the spell repertoire class feature. The number of spells you can cast each day is called your spell slots.</p>\n<p>As you increase in level as an oracle, your number of spells per day increases, as does the highest rank of spells you can cast, as shown on the Oracle Spells per Day table (shown below).</p>\n<p>Some of your spells require you to attempt a spell attack to see how effective they are, or have your enemies roll against your spell DC (typically by attempting a saving throw). Since your key attribute is Charisma, your spell attack modifiers and spell DCs use your Charisma modifier.</p><h3>Heightening Spells</h3><p>When you get spell slots of 2nd rank and higher, you can fill those slots with stronger versions of lower-rank spells. This increases the spell's rank, heightening it to match the spell slot. You must have a spell in your spell repertoire at the rank you want to cast in order to heighten it to that rank. Many spells have specific improvements when they are heightened to certain ranks. The signature spells class feature lets you heighten certain spells freely.</p><h3>Cantrips</h3><p>Some of your spells are cantrips. A cantrip is a special type of spell that doesn't use spell slots. You can cast a cantrip at will, any number of times per day. A cantrip is automatically heightened to half your level rounded up—this is usually equal to the highest rank of oracle spell slot you have. For example, as a 1st-level oracle, your cantrips are 1st-rank spells, and as a 5th-level oracle, your cantrips are 3rd-rank spells.</p><table class=\"pf2e\"><thead><tr><th>Your Level</th><th>Cantrips</th><th>1st</th><th>2nd</th><th>3rd</th><th>4th</th><th>5th</th><th>6th</th><th>7th</th><th>8th</th><th>9th</th><th>10th</th></tr></thead><tbody><tr><td>1</td><td>5</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>2</td><td>5</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>3</td><td>5</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>4</td><td>5</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>5</td><td>5</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>6</td><td>5</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>7</td><td>5</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>8</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>9</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>10</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>11</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>12</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>13</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td></tr><tr><td>14</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td></tr><tr><td>15</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td></tr><tr><td>16</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td></tr><tr><td>17</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td></tr><tr><td>18</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td></tr><tr><td>19</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>1*</td></tr><tr><td>20</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>1*</td></tr><tr><td colspan=\"12\">* The oracular clarity class feature gives you a 10th-rank spell slot that works a bit differently from other spell slots.</td></tr></tbody></table>"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": "H9mEr51MjkHUbCTM",
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core 2"
-                },
-                "rules": [],
-                "slug": "oracle-spellcasting",
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "oracle"
-                    ]
-                }
-            },
-            "type": "feat"
-        },
-        {
-            "_id": "V9q2555uBBNGoAJi",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.classfeatures.Item.cFe6vFb3gSDyNeS9"
-                }
-            },
-            "img": "icons/sundries/books/book-symbol-spiral-silver-blue.webp",
-            "name": "Spell Repertoire (Oracle)",
-            "sort": 200,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "classfeature",
-                "description": {
-                    "value": "<p>The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank divine spells of your choice and five divine cantrips of your choice. You choose these from the common spells on the divine list or from other divine spells to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Oracle Spells per Day table), you add a spell to your spell repertoire of the same rank. At 2nd level, you select another 1st-rank spell; at 3rd level, you select two 2nd-rank spells, and so on. When you add spells, you might add a higher-rank version of a spell you already have, so you can cast a heightened version of that spell.</p>\n<p>Your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot, and vice versa.</p><h3>Swapping Spells in Your Repertoire</h3><p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip. You can also swap out spells by retraining during downtime.</p>"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": "H9mEr51MjkHUbCTM",
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core 2"
-                },
-                "rules": [],
-                "slug": "spell-repertoire-oracle",
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "oracle"
-                    ]
-                }
-            },
-            "type": "feat"
-        },
-        {
-            "_id": "t2aU4iffUOpJakIK",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.classfeatures.Item.NXUOtO9NytHQurlg"
-                }
-            },
-            "img": "systems/pf2e/icons/features/classes/revelation-spells.webp",
-            "name": "Revelation Spells",
-            "sort": 400,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "classfeature",
-                "description": {
-                    "value": "<p>The powers of your mystery manifest in the form of revelation spells. Revelation spells are a type of focus spell. It costs 1 Focus Point to cast a focus spell. You refill your focus pool during your daily preparations, and you can regain 1 Focus Point by spending 10 minutes using the Refocus activity to search for omens in a way befitting your mystery, like gazing into a fire, throwing bones and seeing how they fall, or meditating to hear the voices of those who came before you.</p>\n<p>Focus spells are automatically heightened to half your level rounded up, much like cantrips. Focus spells don't require spell slots, and you can't cast them using spell slots. Certain feats give you more focus spells.</p>\n<p>The maximum Focus Points your focus pool can hold is equal to the number of focus spells you have, but it can never be more than 3 points.</p>\n<p>You learn a revelation spell at 1st level and start with a focus pool of 1 Focus Point. This spell is an initial revelation spell determined by your mystery. You can learn additional revelation spells through oracle feats.</p>"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": "H9mEr51MjkHUbCTM",
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core 2"
-                },
-                "rules": [],
-                "slug": "revelation-spells",
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "oracle"
-                    ]
-                }
-            },
-            "type": "feat"
-        },
-        {
-            "_id": "I4FMI1KW4jACTgjE",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.classfeatures.Item.ibX2EhKkyUtbOHLj"
-                }
-            },
-            "img": "icons/sundries/scrolls/scroll-runed-brown.webp",
-            "name": "Oracular Curse",
-            "sort": 300,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "classfeature",
-                "description": {
-                    "value": "<p>As an oracle, you can tap into the pure and unmitigated divine power of creation to supplement your spellcasting via cursebound abilities. These abilities grant you special benefits, but the backlash of letting this power into your mortal body manifests as an oracular curse. The more cursebound abilities you use, the more your curse worsens, but you might gain divine benefits even as it tightens its grip on your soul.</p>\n<p>Your oracular curse is expressed using the cursebound condition, a unique condition that affects only oracles. Immediately after the first time you use a cursebound ability, you become cursebound 1, and if you use a cursebound ability while you are already cursebound, you increase the value of your cursebound condition by 1 after the ability resolves. At lower levels, you can tolerate only a modest amount of divine power, and your cursebound condition can't increase beyond cursebound 2; as you grow in levels, you can open yourself to even more power and your cursebound condition can progress to 3 and finally 4. Once saturated in divine power, your soul can't absorb any more, and so you can't use a cursebound ability if you are already at your maximum cursebound condition.</p>\n<p>Your oracular curse lists the specific effects of being cursebound, which are cumulative as your curse progresses. You remain cursebound until you Refocus, which reduces your cursebound condition by 1 in addition to restoring a Focus Point. As your curse is a direct result of divine power, you cannot mitigate, reduce, or remove the effects of your curse or any ability with the cursebound trait by any means other than Refocusing. For example, if a cursebound effect makes creatures @UUID[Compendium.pf2e.conditionitems.Item.Concealed] from you, you can't negate that concealed condition through a magic item or spell, such as @UUID[Compendium.pf2e.spells-srd.Item.Sure Strike] (though you would still benefit from the other effects of that item or spell). Likewise, @UUID[Compendium.pf2e.spells-srd.Item.Cleanse Affliction] and similar abilities don't affect your curse at all.</p>\n<p>At 1st level, you gain a cursebound oracle feat determined by your @UUID[Compendium.pf2e.classfeatures.Item.Mystery], and you can learn additional cursebound abilities through oracle feats.</p><hr /><h3>The Cursebound Condition</h3><p>Your oracular curse is constricting around you as you receive divine punishment after drawing too deeply on your mystery's powers. Cursebound is a condition that affects only creatures with an oracular curse, and cursebound always includes a value. Your specific oracular curse imposes unique negative effects depending on your cursebound value. You can remove the cursebound condition only by Refocusing.</p>"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": "H9mEr51MjkHUbCTM",
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core 2"
-                },
-                "rules": [
-                    {
-                        "itemType": "feat",
-                        "key": "ItemAlteration",
-                        "mode": "add",
-                        "predicate": [
-                            "item:trait:cursebound"
-                        ],
-                        "property": "description",
-                        "value": [
-                            {
-                                "predicate": [
-                                    {
-                                        "or": [
-                                            {
-                                                "not": "self:condition:cursebound"
-                                            },
-                                            "self:condition:cursebound:1",
-                                            {
-                                                "and": [
-                                                    "self:condition:cursebound:2",
-                                                    "feature:major-curse"
-                                                ]
-                                            },
-                                            {
-                                                "and": [
-                                                    "self:condition:cursebound:3",
-                                                    "feature:extreme-curse"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "text": "PF2E.SpecificRule.Oracle.Cursebound.IncreaseNote"
-                            },
-                            {
-                                "predicate": [
-                                    {
-                                        "or": [
-                                            {
-                                                "and": [
-                                                    "self:condition:cursebound:2",
-                                                    {
-                                                        "not": "feature:major-curse"
-                                                    }
-                                                ]
-                                            },
-                                            {
-                                                "and": [
-                                                    "self:condition:cursebound:3",
-                                                    {
-                                                        "not": "feature:extreme-curse"
-                                                    }
-                                                ]
-                                            },
-                                            "self:condition:cursebound:4"
-                                        ]
-                                    }
-                                ],
-                                "text": "PF2E.SpecificRule.Oracle.Cursebound.MaximumNote"
-                            }
-                        ]
-                    }
-                ],
-                "slug": "oracular-curse",
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "oracle"
-                    ]
-                }
-            },
-            "type": "feat"
-        },
-        {
-            "_id": "29eUdshDIS2pf9HS",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.classfeatures.Item.VKRjmXxBFLrJK01c"
-                }
-            },
-            "img": "systems/pf2e/icons/features/classes/signature-spells-sorcerer.webp",
-            "name": "Signature Spells",
-            "sort": 1500,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "classfeature",
-                "description": {
-                    "value": "<p>Experience allows you to cast some spells more flexibly. For each spell rank you have access to, choose one spell of that rank to be a signature spell. You don't need to learn heightened versions of signature spells separately; instead, you can heighten these spells freely. If you've learned a signature spell at a higher rank than its minimum, you can also cast all its lower-rank versions without learning those separately. If you swap out a signature spell, you can choose a replacement signature spell of the same spell rank at which you learned the previous spell. You can also retrain specifically to change a signature spell to a different spell of that rank without swapping any spells; this takes as much time as retraining a spell normally does.</p>"
-                },
-                "level": {
-                    "value": 3
-                },
-                "location": "H9mEr51MjkHUbCTM",
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core"
-                },
-                "rules": [],
-                "slug": "signature-spells",
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "bard",
-                        "oracle",
-                        "psychic",
-                        "sorcerer"
-                    ]
-                }
-            },
-            "type": "feat"
-        },
-        {
             "_id": "wqPtuoUuATO974Lr",
             "flags": {
                 "core": {
@@ -3406,118 +2793,6 @@
                 }
             },
             "type": "spell"
-        },
-        {
-            "_id": "YBzA3iSgxlt9rO2u",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.feats-srd.Item.AmFv3ClkAVRowHLI"
-                }
-            },
-            "img": "icons/sundries/books/book-red-exclamation.webp",
-            "name": "Tengu Weapon Familiarity",
-            "sort": 0,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "ancestry",
-                "description": {
-                    "value": "<p>You gain access to all uncommon weapons with the tengu trait plus the katana, khakkara, temple sword, and wakizashi. You have familiarity with these weapons—for the purpose of proficiency, you treat any of these that are martial weapons as simple weapons and any that are advanced weapons as martial weapons.</p>\n<p>During your daily preparations, you can practice with a weapon from the sword group that's in your possession. You gain familiarity with that weapon as well. This lasts until you practice with a different sword in the same way.</p>\n<p>At 5th level, whenever you get a critical hit with one of these weapons, you get its critical specialization effect.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Sword Practice]</p>"
-                },
-                "level": {
-                    "taken": 1,
-                    "value": 1
-                },
-                "location": "ancestry-1",
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core 2"
-                },
-                "rules": [
-                    {
-                        "key": "ActiveEffectLike",
-                        "mode": "override",
-                        "path": "flags.pf2e.tenguFamiliarSword",
-                        "predicate": [
-                            {
-                                "not": "self:effect:weapon-practice"
-                            }
-                        ],
-                        "value": "none"
-                    },
-                    {
-                        "definition": [
-                            {
-                                "or": [
-                                    "item:category:advanced",
-                                    "item:trait:tengu",
-                                    "item:id:{actor|flags.pf2e.tenguFamiliarSword}"
-                                ]
-                            }
-                        ],
-                        "key": "MartialProficiency",
-                        "label": "PF2E.SpecificRule.MartialProficiency.AdvancedTenguWeapons",
-                        "sameAs": "martial",
-                        "slug": "advanced-tengu-weapons"
-                    },
-                    {
-                        "definition": [
-                            "item:category:martial",
-                            {
-                                "or": [
-                                    "item:trait:tengu",
-                                    "item:base:katana",
-                                    "item:base:khakkara",
-                                    "item:base:temple-sword",
-                                    "item:base:wakazashi",
-                                    "item:id:{actor|flags.pf2e.tenguFamiliarSword}"
-                                ]
-                            }
-                        ],
-                        "key": "MartialProficiency",
-                        "label": "PF2E.SpecificRule.MartialProficiency.MartialTenguWeapons",
-                        "sameAs": "simple",
-                        "slug": "martial-tengu-weapons"
-                    },
-                    {
-                        "key": "CriticalSpecialization",
-                        "predicate": [
-                            {
-                                "gte": [
-                                    "self:level",
-                                    5
-                                ]
-                            },
-                            {
-                                "or": [
-                                    "item:trait:tengu",
-                                    "item:base:katana",
-                                    "item:base:khakkara",
-                                    "item:base:temple-sword",
-                                    "item:base:wakazashi",
-                                    "item:id:{actor|flags.pf2e.tenguFamiliarSword}"
-                                ]
-                            }
-                        ]
-                    }
-                ],
-                "slug": "tengu-weapon-familiarity",
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "tengu"
-                    ]
-                }
-            },
-            "type": "feat"
         },
         {
             "_id": "NHz4BfavNuHBDjp0",
@@ -4969,98 +4244,6 @@
             "type": "spell"
         },
         {
-            "_id": "v0PtLHpUlSnLbKct",
-            "flags": {
-                "core": {
-                    "sourceId": "Compendium.pf2e.spells-srd.Item.g1eY1vN44mgluE33"
-                }
-            },
-            "img": "systems/pf2e/icons/spells/charged-javelin.webp",
-            "name": "Charged Javelin",
-            "sort": 0,
-            "system": {
-                "area": null,
-                "cost": {
-                    "value": ""
-                },
-                "counteraction": false,
-                "damage": {
-                    "0": {
-                        "applyMod": false,
-                        "category": null,
-                        "formula": "1d6",
-                        "kinds": [
-                            "damage"
-                        ],
-                        "materials": [],
-                        "type": "electricity"
-                    },
-                    "1": {
-                        "applyMod": false,
-                        "category": "persistent",
-                        "formula": "1",
-                        "kinds": [
-                            "damage"
-                        ],
-                        "materials": [],
-                        "type": "electricity"
-                    }
-                },
-                "defense": null,
-                "description": {
-                    "value": "<p>You fire a javelin of electricity that leaves a charged field around its target. Make a spell attack roll. The javelin deals 1d6 electricity damage and 1 persistent electricity damage.</p>\n<p>As long as the target is taking persistent damage from this spell, creatures gain a +1 status bonus to attack rolls with metal weapons or electricity effects against the target, and the target takes a -1 status penalty to saves against electricity effects.</p>\n<hr />\n<p><strong>Critical Success</strong> The javelin deals double damage, both initial and persistent.</p>\n<p><strong>Success</strong> The javelin deals full damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The initial damage increases by 1d6, and the Persistent Damage increases by 1.</p>"
-                },
-                "duration": {
-                    "sustained": false,
-                    "value": ""
-                },
-                "heightening": {
-                    "damage": {
-                        "0": "1d6",
-                        "1": "1"
-                    },
-                    "interval": 1,
-                    "type": "interval"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": {
-                    "value": "facIZNDbA0QjjG27"
-                },
-                "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": "Pathfinder Lost Omens: Gods & Magic"
-                },
-                "range": {
-                    "value": "60 feet"
-                },
-                "requirements": "",
-                "rules": [],
-                "slug": "charged-javelin",
-                "target": {
-                    "value": "1 or more creatures"
-                },
-                "time": {
-                    "value": "2"
-                },
-                "traits": {
-                    "rarity": "common",
-                    "traditions": [],
-                    "value": [
-                        "attack",
-                        "cleric",
-                        "concentrate",
-                        "electricity",
-                        "focus",
-                        "manipulate"
-                    ]
-                }
-            },
-            "type": "spell"
-        },
-        {
             "_id": "urMUMP1J8kxrmXir",
             "flags": {
                 "core": {
@@ -5307,6 +4490,880 @@
                 }
             },
             "type": "feat"
+        },
+        {
+            "_id": "Q8XEftOTKxwavCnH",
+            "flags": {
+                "pf2e": {
+                    "itemGrants": {
+                        "tempest": {
+                            "id": "wgfkEpOBBKBIzvFd",
+                            "onDelete": "detach"
+                        }
+                    }
+                }
+            },
+            "img": "icons/magic/symbols/question-stone-yellow.webp",
+            "name": "Mystery",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "classfeature",
+                "description": {
+                    "value": "<p>An oracle wields divine power, but not from a single divine being. This power could come from a potent concept or ideal, the attention of multiple divine entities whose areas of concern all touch on that subject, or a direct and dangerous conduit to raw divine power. This is the oracle's mystery, a source of divine magic not beholden to any deity.</p>\n<p>Choose the mystery that empowers your magic. Your mystery grants you additional spells, and special focus spells called revelation spells. Your mystery also gives you a unique cursebound ability that lets you draw upon the divine, as well as dictating the effects of the oracular curse that falls upon you when you touch too much of this power.</p><hr /><ul><li>@UUID[Compendium.pf2e.classfeatures.Item.Ancestors] Voices of past generations teach and haunt you.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Battle] You embody the virtues upheld by heroes of legend.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Bones] Death always seems near, and the dead speak to you.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Cosmos] You draw power from the stars and the spaces between.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Flames] You dance with fire and do your best to remain unscorched by it.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Life] The teeming energies of life flow through you out into the world.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Lore] You gain access to unparalleled, overwhelming knowledge.</li><li>@UUID[Compendium.pf2e.classfeatures.Item.Tempest] Wind, waves, and storms rage at your beck and call.</li></ul><h3>Reading a Mystery Entry</h3><p>A mystery entry contains the following information, followed by a description of that mystery's curse.</p>\n<p><strong>Granted Spells</strong> You automatically add the spells listed here to your spell repertoire, as described in Spell Repertoire on page 130. At 1st level, you gain a cantrip and a 1st-rank spell. You learn the other spells on the list as soon as you gain the ability to cast oracle spells of that rank.</p>\n<p><strong>Revelation Spells</strong> You automatically gain your mystery's initial revelation spell at 1st level and can gain more by selecting the Advanced Revelation, Greater Revelation, and Diverse Mystery oracle feats. These spells start on page 259.</p>\n<p><strong>Related Domains</strong> These are the cleric domains associated with your mystery. You gain domain spells, which you can cast as revelation spells, by taking the Domain Acumen and Domain Fluency feats. At 11th level, the divine access class feature also gives you additional slotted spells based on your domains. The domains and their domain spells appear on page 372 of Player Core. Domains marked with an asterisk (*) are found in Pathfinder Lost Omens Divine Mysteries.</p>\n<p><strong>Mystery Skill</strong> You become trained in the listed skill. A few mysteries make you trained in more than one skill.</p>\n<p><strong>Oracle Feat</strong> You gain this 1st-level oracle feat. This is a cursebound feat, so using it aggravates your oracular curse.</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": "H9mEr51MjkHUbCTM",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core 2"
+                },
+                "rules": [
+                    {
+                        "adjustName": false,
+                        "choices": {
+                            "filter": [
+                                "item:tag:oracle-mystery"
+                            ]
+                        },
+                        "flag": "mystery",
+                        "key": "ChoiceSet",
+                        "prompt": "PF2E.SpecificRule.Oracle.Mystery.Prompt",
+                        "selection": "Compendium.pf2e.classfeatures.Item.Tempest"
+                    },
+                    {
+                        "flag": "tempest",
+                        "key": "GrantItem",
+                        "uuid": "{item|flags.pf2e.rulesSelections.mystery}"
+                    }
+                ],
+                "slug": "mystery",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "oracle"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "wgfkEpOBBKBIzvFd",
+            "flags": {
+                "pf2e": {
+                    "grantedBy": {
+                        "id": "Q8XEftOTKxwavCnH",
+                        "onDelete": "cascade"
+                    },
+                    "itemGrants": {
+                        "curseOfInclementHeadwinds": {
+                            "id": "ExEZyhdZDMdel47H",
+                            "onDelete": "detach"
+                        },
+                        "foretellHarm": {
+                            "id": "sthKLncjJCW6KsmB",
+                            "onDelete": "detach"
+                        }
+                    }
+                }
+            },
+            "img": "icons/magic/water/pseudopod-swirl-blue.webp",
+            "name": "Tempest",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "classfeature",
+                "description": {
+                    "value": "<p>The fury of the wind and waves pounds in your heart, whether your power flows from natural storms, a conduit to the elemental Planes of Air and Water, or through reverence of deities such as Gozreh, the tengu god of storms Hei Feng, the pirate queen Besmara, or the elemental lords of air and water.</p>\n<p><strong>Granted Spells</strong> cantrip: @UUID[Compendium.pf2e.spells-srd.Item.Electric Arc]{Electric Arc;} 1st: @UUID[Compendium.pf2e.spells-srd.Item.Thunderstrike]; 4th: @UUID[Compendium.pf2e.spells-srd.Item.Hydraulic Torrent]; 6th: @UUID[Compendium.pf2e.spells-srd.Item.Chain Lightning]</p>\n<p><strong>Revelation Spells</strong> initial: @UUID[Compendium.pf2e.spells-srd.Item.Tempest Touch]; advanced: @UUID[Compendium.pf2e.spells-srd.Item.Thunderburst]; greater: @UUID[Compendium.pf2e.spells-srd.Item.Tempest Form]</p>\n<p><strong>Related Domains</strong> air, cold, lightning, water</p>\n<p><strong>Mystery Skill</strong> Nature</p>\n<p><strong>Oracle Feat</strong> @UUID[Compendium.pf2e.feats-srd.Item.Foretell Harm]</p>\n<p>@UUID[Compendium.pf2e.classfeatures.Item.Curse of Inclement Headwinds]</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core 2"
+                },
+                "rules": [
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "upgrade",
+                        "path": "system.skills.nature.rank",
+                        "value": 1
+                    },
+                    {
+                        "flag": "foretellHarm",
+                        "key": "GrantItem",
+                        "predicate": [
+                            "class:oracle"
+                        ],
+                        "uuid": "Compendium.pf2e.feats-srd.Item.Foretell Harm"
+                    },
+                    {
+                        "flag": "curseOfInclementHeadwinds",
+                        "key": "GrantItem",
+                        "uuid": "Compendium.pf2e.classfeatures.Item.Curse of Inclement Headwinds"
+                    }
+                ],
+                "slug": "tempest",
+                "traits": {
+                    "otherTags": [
+                        "oracle-mystery"
+                    ],
+                    "rarity": "common",
+                    "value": [
+                        "oracle"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "sthKLncjJCW6KsmB",
+            "flags": {
+                "pf2e": {
+                    "grantedBy": {
+                        "id": "wgfkEpOBBKBIzvFd",
+                        "onDelete": "cascade"
+                    }
+                }
+            },
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Foretell Harm",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "free"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "class",
+                "description": {
+                    "value": "<p><strong>Frequency</strong> once per round</p>\n<p><strong>Requirements</strong> Your previous action was to Cast a non-cantrip Spell that dealt damage.</p><hr /><p>Your magic echoes ominously as you glimpse injury in the target's future. At the beginning of your target's next turn, it takes damage equal to twice the triggering spell's rank as a seemingly random and minor misfortune finds it. The damage and type of misfortune is of a type matching the spell; for instance, if you dealt fire damage, a flame might spontaneous ignite on them or they might burn a hand on their torch. The target is then temporarily immune to Foretell Harm for 24 hours.</p>"
+                },
+                "frequency": {
+                    "max": 1,
+                    "per": "round"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core 2"
+                },
+                "rules": [],
+                "slug": "foretell-harm",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "cursebound",
+                        "divine",
+                        "oracle"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "ExEZyhdZDMdel47H",
+            "flags": {
+                "pf2e": {
+                    "grantedBy": {
+                        "id": "wgfkEpOBBKBIzvFd",
+                        "onDelete": "cascade"
+                    }
+                }
+            },
+            "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
+            "name": "Curse of Inclement Headwinds",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "classfeature",
+                "description": {
+                    "value": "<p>The weather seems to always oppose you in ways large and small. Even when you are calm and at rest, your hair and clothing are inconveniently blown about by gentle winds, you are slightly damp from the faintest drizzle, and your touch often comes with a static shock. When you have the @UUID[Compendium.pf2e.conditionitems.Item.Cursebound] condition, you are opposed by the elements, with the following effects.</p>\n<p><strong>Cursebound 1</strong> Lightning is drawn to you. You gain electricity weakness 2 and electricity spells or effects that have additional effects for a creature wearing or holding metal treat you as though you were wearing metal. Any immunity or resistance you have to such spells and effects is suppressed.</p>\n<p><strong>Cursebound 2</strong> Blowing winds impose a -2 circumstance penalty to ranged attack rolls you make.</p>\n<p><strong>Cursebound 3</strong> Your weakness to electricity is equal to 5 + your level.</p>\n<p><strong>Cursebound 4</strong> The raging winds push you back, imposing a -10-foot status penalty to all your Speeds.</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core 2"
+                },
+                "rules": [
+                    {
+                        "key": "Weakness",
+                        "predicate": [
+                            "self:condition:cursebound"
+                        ],
+                        "type": "electricity",
+                        "value": "ternary(gte(@actor.conditions.cursebound.value,3),5+@actor.level,2)"
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "predicate": [
+                            "item:ranged",
+                            {
+                                "gte": [
+                                    "self:condition:cursebound",
+                                    2
+                                ]
+                            }
+                        ],
+                        "selector": "attack-roll",
+                        "type": "circumstance",
+                        "value": -2
+                    },
+                    {
+                        "key": "FlatModifier",
+                        "predicate": [
+                            "self:condition:cursebound:4"
+                        ],
+                        "selector": "speed",
+                        "value": -10
+                    }
+                ],
+                "slug": "curse-of-inclement-headwinds",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "curse",
+                        "divine",
+                        "oracle"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "LgxUzLyfGDsl3G9d",
+            "img": "icons/sundries/books/book-symbol-spiral-silver-blue.webp",
+            "name": "Spell Repertoire",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "classfeature",
+                "description": {
+                    "value": "<p><strong>Bard</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank occult spells of your choice and five occult cantrips of your choice. You choose these from the common spells from the occult list or from other occult spells to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Bard Spells per Day table), you add a spell to your spell repertoire of the same rank. At 2nd level, you select another 1st-rank spell; at 3rd level, you select two 2nd-rank spells, and so on. When you add spells, you might add a higher-rank version of a spell you already have, so you can cast a heightened version of that spell.</p>\n<p>Though you gain them at the same rate, your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot, and vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Oracle</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank divine spells of your choice and five divine cantrips of your choice. You choose these from the common spells on the divine list or from other divine spells to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Oracle Spells per Day table), you add a spell to your spell repertoire of the same rank. At 2nd level, you select another 1st-rank spell; at 3rd level, you select two 2nd-rank spells, and so on. When you add spells, you might add a higher-rank version of a spell you already have, so you can cast a heightened version of that spell.</p>\n<p>Your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot, and vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Psychic</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn one 1st-rank occult spell of your choice and three occult cantrips of your choice. You choose these from the common spells from the occult list or from other occult spells to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank. Your choice of conscious mind also grants you additional spells in your repertoire, starting with an additional 1st-rabk spell and two cantrips listed in your conscious mind, which you cast as psi cantrips.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see Table 2), you add a spell to your spell repertoire of the same level. At 2nd level, you select another 1st-rank spell; at 3rd level, you select one 2nd-level spell, and so on. When you add spells, you might add a higher-rank version of a spell you already have, so you can cast a heightened version of that spell. Your conscious mind also adds additional spells to your repertoire as you gain spells of higher levels.</p>\n<p>Though you gain them at the same rate, your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, such as the spells you gain from your conscious mind, it wouldn't give you another spell slot, and vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Sorcerer</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank spells of your choice and four cantrips of your choice, as well as an additional spell and cantrip from your bloodline. You choose these from the common spells from the tradition corresponding to your bloodline, or from other spells from that tradition to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Sorcerer Spells per Day table above), you add a spell to your spell repertoire of the same rank. When you gain a new rank of spells, your first new spell is always the sorcerous gift spell for that rank that's listed in your bloodline, but you can choose the other spells. At 2nd level, you select another 1st-rank spell; at 3rd level, you gain a new spell from your bloodline and two other 2nd-rank spells, and so on. When you add spells, you might select a higher-rank version of a spell you already know so that you can cast a heightened version of that spell.</p>\n<p>Though you gain them at the same rate, your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot or vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your spell repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip, but you can't swap out bloodline spells. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Summoner</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank spells of your choice and five cantrips of your choice. You choose these from the common spells from the tradition corresponding to your eidolon, or from other spells from that tradition to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank. Your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it doesn't give you another spell slot, and vice versa.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see Table 2–4: Summoner Spells per Day), you add a spell of the same rank to your spell repertoire. At 2nd level, you select another 1st-rank spell. At 3rd level, you add the first 2nd-rank spell to your repertoire. At 4th level you gain your second and your spell repertoire reaches its maximum size of five spells.</p>\n<p>At 5th level, in addition to adding two 3rd-rank spells to your repertoire, you lose your lowest rank of spell slots. Any time you lose a rank of spell slots, you lose two spells in your repertoire as well. These can come from spells you already know or out of the number of new spells you're learning. On levels in which you don't change your spell slots, you can swap out multiple spells, as described below.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. If it's a rank at which you lose a set of lower-rank slots, you can replace the two in either order. You can also instead swap a cantrip. You can also swap out spells by retraining during downtime.</p>\n<p>At 6th level and every even level thereafter, you can swap out any number of your spells for different spells of a rank you can cast. When you do, you must keep at least one spell you can cast with your lowest rank of spell slots so you don't end up with slots you can't use. For instance, at 6th level you would need to keep at least one 2nd-rank spell, but all your other spells could be 3rd rank.</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": "H9mEr51MjkHUbCTM",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
+                },
+                "rules": [
+                    {
+                        "itemId": "{item|id}",
+                        "key": "ItemAlteration",
+                        "mode": "override",
+                        "property": "description",
+                        "value": [
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.PartOne"
+                            },
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.PartTwo"
+                            },
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.PartThree"
+                            },
+                            {
+                                "divider": true,
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.SpellSwapping"
+                            },
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.SpellSwapping"
+                            }
+                        ]
+                    },
+                    {
+                        "itemId": "{item|id}",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "property": "traits",
+                        "value": "{actor|class.slug}"
+                    }
+                ],
+                "slug": "spell-repertoire",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "bard",
+                        "oracle",
+                        "psychic",
+                        "sorcerer",
+                        "summoner"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "dlbxcRY0xjB4aRhT",
+            "img": "icons/weapons/axes/axe-double-gold.webp",
+            "name": "Oracle Spellcasting",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "classfeature",
+                "description": {
+                    "value": "<p>You have an unfiltered connection to the great powers of the universe and the planes beyond, and you can let this power spill forth in the form of divine magic. You are a spellcaster, and you can cast spells of the divine tradition using the Cast a Spell activity. As an oracle, when you cast spells, your incantations may spill from your lips rapidly as you speak in tongues or intone in a voice not quite your own, and your gestures might be wild and unrestrained as religious ecstasy briefly touches your mind.</p>\n<p>Each day, you can cast up to two 1st-rank spells. You must know spells to cast them, and you learn them via the spell repertoire class feature. The number of spells you can cast each day is called your spell slots.</p>\n<p>As you increase in level as an oracle, your number of spells per day increases, as does the highest rank of spells you can cast, as shown on the Oracle Spells per Day table (shown below).</p>\n<p>Some of your spells require you to attempt a spell attack to see how effective they are, or have your enemies roll against your spell DC (typically by attempting a saving throw). Since your key attribute is Charisma, your spell attack modifiers and spell DCs use your Charisma modifier.</p><h3>Heightening Spells</h3><p>When you get spell slots of 2nd rank and higher, you can fill those slots with stronger versions of lower-rank spells. This increases the spell's rank, heightening it to match the spell slot. You must have a spell in your spell repertoire at the rank you want to cast in order to heighten it to that rank. Many spells have specific improvements when they are heightened to certain ranks. The signature spells class feature lets you heighten certain spells freely.</p><h3>Cantrips</h3><p>Some of your spells are cantrips. A cantrip is a special type of spell that doesn't use spell slots. You can cast a cantrip at will, any number of times per day. A cantrip is automatically heightened to half your level rounded up—this is usually equal to the highest rank of oracle spell slot you have. For example, as a 1st-level oracle, your cantrips are 1st-rank spells, and as a 5th-level oracle, your cantrips are 3rd-rank spells.</p><table class=\"pf2e\"><thead><tr><th>Your Level</th><th>Cantrips</th><th>1st</th><th>2nd</th><th>3rd</th><th>4th</th><th>5th</th><th>6th</th><th>7th</th><th>8th</th><th>9th</th><th>10th</th></tr></thead><tbody><tr><td>1</td><td>5</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>2</td><td>5</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>3</td><td>5</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>4</td><td>5</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>5</td><td>5</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>6</td><td>5</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>7</td><td>5</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>8</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>9</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>10</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>11</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>12</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td><td>-</td></tr><tr><td>13</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td><td>-</td></tr><tr><td>14</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td><td>-</td></tr><tr><td>15</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td><td>-</td></tr><tr><td>16</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td><td>-</td></tr><tr><td>17</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>3</td><td>-</td></tr><tr><td>18</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>-</td></tr><tr><td>19</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>1*</td></tr><tr><td>20</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>4</td><td>1*</td></tr><tr><td colspan=\"12\">* The oracular clarity class feature gives you a 10th-rank spell slot that works a bit differently from other spell slots.</td></tr></tbody></table>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": "H9mEr51MjkHUbCTM",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core 2"
+                },
+                "rules": [],
+                "slug": "oracle-spellcasting",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "oracle"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "pewuhXMz3CXKmEgu",
+            "img": "icons/sundries/scrolls/scroll-runed-brown.webp",
+            "name": "Oracular Curse",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "classfeature",
+                "description": {
+                    "value": "<p>As an oracle, you can tap into the pure and unmitigated divine power of creation to supplement your spellcasting via cursebound abilities. These abilities grant you special benefits, but the backlash of letting this power into your mortal body manifests as an oracular curse. The more cursebound abilities you use, the more your curse worsens, but you might gain divine benefits even as it tightens its grip on your soul.</p>\n<p>Your oracular curse is expressed using the @UUID[Compendium.pf2e.conditionitems.Item.Cursebound] condition, a unique condition that affects only oracles. Immediately after the first time you use a cursebound ability, you become cursebound 1, and if you use a cursebound ability while you are already cursebound, you increase the value of your cursebound condition by 1 after the ability resolves. At lower levels, you can tolerate only a modest amount of divine power, and your cursebound condition can't increase beyond cursebound 2; as you grow in levels, you can open yourself to even more power and your cursebound condition can progress to 3 and finally 4. Once saturated in divine power, your soul can't absorb any more, and so you can't use a cursebound ability if you are already at your maximum cursebound condition.</p>\n<p>Your oracular curse lists the specific effects of being cursebound, which are cumulative as your curse progresses. You remain cursebound until you Refocus, which reduces your cursebound condition by 1 in addition to restoring a Focus Point. As your curse is a direct result of divine power, you cannot mitigate, reduce, or remove the effects of your curse or any ability with the cursebound trait by any means other than Refocusing. For example, if a cursebound effect makes creatures @UUID[Compendium.pf2e.conditionitems.Item.Concealed] from you, you can't negate that concealed condition through a magic item or spell, such as @UUID[Compendium.pf2e.spells-srd.Item.Sure Strike] (though you would still benefit from the other effects of that item or spell). Likewise, @UUID[Compendium.pf2e.spells-srd.Item.Cleanse Affliction] and similar abilities don't affect your curse at all.</p>\n<p>At 1st level, you gain a cursebound oracle feat determined by your @UUID[Compendium.pf2e.classfeatures.Item.Mystery], and you can learn additional cursebound abilities through oracle feats.</p><hr /><h3>The Cursebound Condition</h3><p>Your oracular curse is constricting around you as you receive divine punishment after drawing too deeply on your mystery's powers. Cursebound is a condition that affects only creatures with an oracular curse, and cursebound always includes a value. Your specific oracular curse imposes unique negative effects depending on your cursebound value. You can remove the cursebound condition only by Refocusing.</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": "H9mEr51MjkHUbCTM",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core 2"
+                },
+                "rules": [
+                    {
+                        "itemType": "feat",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "predicate": [
+                            "item:trait:cursebound"
+                        ],
+                        "property": "description",
+                        "value": [
+                            {
+                                "predicate": [
+                                    {
+                                        "or": [
+                                            {
+                                                "not": "self:condition:cursebound"
+                                            },
+                                            "self:condition:cursebound:1",
+                                            {
+                                                "and": [
+                                                    "self:condition:cursebound:2",
+                                                    "feature:major-curse"
+                                                ]
+                                            },
+                                            {
+                                                "and": [
+                                                    "self:condition:cursebound:3",
+                                                    "feature:extreme-curse"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "text": "PF2E.SpecificRule.Oracle.Cursebound.IncreaseNote"
+                            },
+                            {
+                                "predicate": [
+                                    {
+                                        "or": [
+                                            {
+                                                "and": [
+                                                    "self:condition:cursebound:2",
+                                                    {
+                                                        "not": "feature:major-curse"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "and": [
+                                                    "self:condition:cursebound:3",
+                                                    {
+                                                        "not": "feature:extreme-curse"
+                                                    }
+                                                ]
+                                            },
+                                            "self:condition:cursebound:4"
+                                        ]
+                                    }
+                                ],
+                                "text": "PF2E.SpecificRule.Oracle.Cursebound.MaximumNote"
+                            }
+                        ]
+                    }
+                ],
+                "slug": "oracular-curse",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "oracle"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "b2kVpgsuLZHX9yVg",
+            "img": "systems/pf2e/icons/features/classes/revelation-spells.webp",
+            "name": "Revelation Spells",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "classfeature",
+                "description": {
+                    "value": "<p>The powers of your mystery manifest in the form of revelation spells. Revelation spells are a type of focus spell. It costs 1 Focus Point to cast a focus spell. You refill your focus pool during your daily preparations, and you can regain 1 Focus Point by spending 10 minutes using the Refocus activity to search for omens in a way befitting your mystery, like gazing into a fire, throwing bones and seeing how they fall, or meditating to hear the voices of those who came before you.</p>\n<p>Focus spells are automatically heightened to half your level rounded up, much like cantrips. Focus spells don't require spell slots, and you can't cast them using spell slots. Certain feats give you more focus spells.</p>\n<p>The maximum Focus Points your focus pool can hold is equal to the number of focus spells you have, but it can never be more than 3 points.</p>\n<p>You learn a revelation spell at 1st level and start with a focus pool of 1 Focus Point. This spell is an initial revelation spell determined by your mystery. You can learn additional revelation spells through oracle feats.</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": "H9mEr51MjkHUbCTM",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core 2"
+                },
+                "rules": [],
+                "slug": "revelation-spells",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "oracle"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "Rq8MQ6QMzO09DkMa",
+            "img": "systems/pf2e/icons/features/classes/signature-spells-sorcerer.webp",
+            "name": "Signature Spells",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "classfeature",
+                "description": {
+                    "value": "<p>Experience allows you to cast some spells more flexibly. For each spell rank you have access to, choose one spell of that rank to be a signature spell. You don't need to learn heightened versions of signature spells separately; instead, you can heighten these spells freely. If you've learned a signature spell at a higher rank than its minimum, you can also cast all its lower-rank versions without learning those separately. If you swap out a signature spell, you can choose a replacement signature spell of the same spell rank at which you learned the previous spell. You can also retrain specifically to change a signature spell to a different spell of that rank without swapping any spells; this takes as much time as retraining a spell normally does.</p>"
+                },
+                "level": {
+                    "value": 3
+                },
+                "location": "H9mEr51MjkHUbCTM",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
+                },
+                "rules": [],
+                "slug": "signature-spells",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "bard",
+                        "oracle",
+                        "psychic",
+                        "sorcerer"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "IGx3lHMaxYgmdUHI",
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Tengu Weapon Familiarity",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "ancestry",
+                "description": {
+                    "value": "<p>You gain access to all uncommon weapons with the tengu trait plus the katana, khakkara, temple sword, and wakizashi. You have familiarity with these weapons—for the purpose of proficiency, you treat any of these that are martial weapons as simple weapons and any that are advanced weapons as martial weapons.</p>\n<p>During your daily preparations, you can practice with a weapon from the sword group that's in your possession. You gain familiarity with that weapon as well. This lasts until you practice with a different sword in the same way.</p>\n<p>At 5th level, whenever you get a critical hit with one of these weapons, you get its critical specialization effect.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Sword Practice]</p>"
+                },
+                "level": {
+                    "taken": 1,
+                    "value": 1
+                },
+                "location": "ancestry-1",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core 2"
+                },
+                "rules": [
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "flags.pf2e.tenguFamiliarSword",
+                        "predicate": [
+                            {
+                                "not": "self:effect:sword-practice"
+                            }
+                        ],
+                        "priority": 8,
+                        "value": "none"
+                    },
+                    {
+                        "definition": [
+                            "item:category:advanced",
+                            {
+                                "or": [
+                                    "item:trait:tengu",
+                                    "item:id:{actor|flags.pf2e.tenguFamiliarSword}"
+                                ]
+                            }
+                        ],
+                        "key": "MartialProficiency",
+                        "label": "PF2E.SpecificRule.MartialProficiency.AdvancedTenguWeapons",
+                        "sameAs": "martial",
+                        "slug": "advanced-tengu-weapons"
+                    },
+                    {
+                        "definition": [
+                            "item:category:martial",
+                            {
+                                "or": [
+                                    "item:trait:tengu",
+                                    "item:base:katana",
+                                    "item:base:khakkara",
+                                    "item:base:temple-sword",
+                                    "item:base:wakazashi",
+                                    "item:id:{actor|flags.pf2e.tenguFamiliarSword}"
+                                ]
+                            }
+                        ],
+                        "key": "MartialProficiency",
+                        "label": "PF2E.SpecificRule.MartialProficiency.MartialTenguWeapons",
+                        "sameAs": "simple",
+                        "slug": "martial-tengu-weapons"
+                    },
+                    {
+                        "key": "CriticalSpecialization",
+                        "predicate": [
+                            {
+                                "gte": [
+                                    "self:level",
+                                    5
+                                ]
+                            },
+                            {
+                                "or": [
+                                    "item:trait:tengu",
+                                    "item:base:katana",
+                                    "item:base:khakkara",
+                                    "item:base:temple-sword",
+                                    "item:base:wakazashi",
+                                    "item:id:{actor|flags.pf2e.tenguFamiliarSword}"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "slug": "tengu-weapon-familiarity",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "tengu"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "9sqCZo2FiV6JSZ90",
+             "flags": {
+                 "core": {
+                     "sourceId": "Compendium.pf2e.spells-srd.Item.EzB9i7R6aBRAtJCh"
+                 }
+             },
+            "img": "systems/pf2e/icons/spells/tempest-touch.webp",
+            "name": "Tempest Touch",
+            "sort": 0,
+            "system": {
+                "area": null,
+                "cost": {
+                    "value": ""
+                },
+                "counteraction": false,
+                "damage": {
+                    "0": {
+                        "applyMod": false,
+                        "category": null,
+                        "formula": "1d4",
+                        "kinds": [
+                            "damage"
+                        ],
+                        "materials": [],
+                        "type": "bludgeoning"
+                    },
+                    "fl86wl21hskrqrcy": {
+                        "applyMod": false,
+                        "category": null,
+                        "formula": "1d4",
+                        "kinds": [
+                            "damage"
+                        ],
+                        "materials": [],
+                        "type": "cold"
+                    }
+                },
+                "defense": {
+                    "save": {
+                        "basic": false,
+                        "statistic": "fortitude"
+                    }
+                },
+                "description": {
+                    "value": "<p>Your touch calls forth a churning mass of icy water that clings to your target, dealing 1d4 bludgeoning damage and 1d4 cold damage. The target must attempt a Fortitude save.</p><hr /><p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target takes half damage and a –5-foot circumstance penalty to its Speeds until the end of your next turn.</p>\n<p><strong>Failure</strong> The target takes full damage and a –10-foot circumstance penalty to its Speeds until the end of your next turn.</p>\n<p><strong>Critical Failure</strong> As failure, but the target takes double damage.</p><hr /><p><strong>Heightened (+1)</strong> The bludgeoning and cold damage each increase by 1d4.</p>"
+                },
+                "duration": {
+                    "sustained": false,
+                    "value": ""
+                },
+                "heightening": {
+                    "damage": {
+                        "0": "1d4",
+                        "fl86wl21hskrqrcy": "1d4"
+                    },
+                    "interval": 1,
+                    "type": "interval"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": {
+                    "value": "facIZNDbA0QjjG27"
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core 2"
+                },
+                "range": {
+                    "value": "touch"
+                },
+                "requirements": "",
+                "rules": [],
+                "slug": "tempest-touch",
+                "target": {
+                    "value": "1 creature"
+                },
+                "time": {
+                    "value": "1"
+                },
+                "traits": {
+                    "rarity": "uncommon",
+                    "traditions": [],
+                    "value": [
+                        "cold",
+                        "focus",
+                        "manipulate",
+                        "oracle",
+                        "water"
+                    ]
+                }
+            },
+            "type": "spell"
+        },
+        {
+            "_id": "5Dx2wV2hBS00BGgH",
+             "flags": {
+                 "core": {
+                     "sourceId": "Compendium.pf2e.spells-srd.Item.g1eY1vN44mgluE33"
+                 }
+             },
+            "img": "systems/pf2e/icons/spells/charged-javelin.webp",
+            "name": "Charged Javelin",
+            "sort": 0,
+            "system": {
+                "area": null,
+                "cost": {
+                    "value": ""
+                },
+                "counteraction": false,
+                "damage": {
+                    "0": {
+                        "applyMod": false,
+                        "category": null,
+                        "formula": "1d6",
+                        "kinds": [
+                            "damage"
+                        ],
+                        "materials": [],
+                        "type": "electricity"
+                    },
+                    "1": {
+                        "applyMod": false,
+                        "category": "persistent",
+                        "formula": "1",
+                        "kinds": [
+                            "damage"
+                        ],
+                        "materials": [],
+                        "type": "electricity"
+                    }
+                },
+                "defense": null,
+                "description": {
+                    "value": "<p>You fire a javelin of electricity that leaves a charged field around its target. Make a spell attack roll. The javelin deals 1d6 electricity damage and 1 persistent electricity damage.</p>\n<p>As long as the target is taking persistent damage from this spell, creatures gain a +1 status bonus to attack rolls with metal weapons or electricity effects against the target, and the target takes a -1 status penalty to saves against electricity effects.</p>\n<hr />\n<p><strong>Critical Success</strong> The javelin deals double damage, both initial and persistent.</p>\n<p><strong>Success</strong> The javelin deals full damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The initial damage increases by 1d6, and the Persistent Damage increases by 1.</p>"
+                },
+                "duration": {
+                    "sustained": false,
+                    "value": ""
+                },
+                "heightening": {
+                    "damage": {
+                        "0": "1d6",
+                        "1": "1"
+                    },
+                    "interval": 1,
+                    "type": "interval"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": {
+                    "value": "facIZNDbA0QjjG27"
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Lost Omens: Gods & Magic"
+                },
+                "range": {
+                    "value": "60 feet"
+                },
+                "requirements": "",
+                "rules": [],
+                "slug": "charged-javelin",
+                "target": {
+                    "value": "1 or more creatures"
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traits": {
+                    "rarity": "common",
+                    "traditions": [],
+                    "value": [
+                        "attack",
+                        "cleric",
+                        "concentrate",
+                        "electricity",
+                        "focus",
+                        "manipulate"
+                    ]
+                }
+            },
+            "type": "spell"
         }
     ],
     "name": "Korakai (Level 5)",


### PR DESCRIPTION
Priority on the ActiveEffectLike had to be lowered to before the MartialProficiency rule elements. It had the wrong slug on its predicate as well. Refreshed the Korakais' copy of the feat, as well as their focus spells since they still had the cursebound trait. Made sure to keep their sourceId.

Also pushed Godless Healing, which keeps nagging at me on extraction to strip that label.