### PR TITLE
Add spell effect for Charged Javelin

### DIFF
--- a/packs/spell-effects/spell-effect-charged-javelin-attacker.json
+++ b/packs/spell-effects/spell-effect-charged-javelin-attacker.json
@@ -29,7 +29,23 @@
                             "item:trait:electricity",
                             {
                                 "and": [
-                                    "item:material:metal",
+                                    {
+                                        "or": [
+                                            "item:material:abysium",
+                                            "item:material:adamantine",
+                                            "item:material:cold-iron",
+                                            "item:material:dawnsilver",
+                                            "item:material:djezet",
+                                            "item:material:inubrix",
+                                            "item:material:keep-stone",
+                                            "item:material:metal",
+                                            "item:material:noqual",
+                                            "item:material:orichalcum",
+                                            "item:material:siccatite",
+                                            "item:material:silver",
+                                            "item:material:sovereign-steel"
+                                        ]
+                                    },
                                     "item:type:weapon"
                                 ]
                             }

--- a/packs/spell-effects/spell-effect-charged-javelin-attacker.json
+++ b/packs/spell-effects/spell-effect-charged-javelin-attacker.json
@@ -1,0 +1,56 @@
+{
+    "_id": "aNomC4orI44YGBGU",
+    "img": "systems/pf2e/icons/spells/charged-javelin.webp",
+    "name": "Spell Effect: Charged Javelin (Attacker)",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Charged Javelin]</p>\n<p>Creatures gain a +1 status bonus to attack rolls with metal weapons or electricity effects against the target.</p>"
+        },
+        "duration": {
+            "expiry": null,
+            "sustained": false,
+            "unit": "unlimited",
+            "value": -1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Lost Omens: Gods & Magic"
+        },
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    {
+                        "or": [
+                            "item:trait:electricity",
+                            {
+                                "and": [
+                                    "item:material:metal",
+                                    "item:type:weapon"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "selector": "attack-roll",
+                "type": "status",
+                "value": 1
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/spell-effects/spell-effect-charged-javelin.json
+++ b/packs/spell-effects/spell-effect-charged-javelin.json
@@ -1,0 +1,54 @@
+{
+    "_id": "QrigfqVwBCGPylth",
+    "img": "systems/pf2e/icons/spells/charged-javelin.webp",
+    "name": "Spell Effect: Charged Javelin",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Charged Javelin]</p>\n<p>Creatures gain a +1 status bonus to attack rolls with metal weapons or electricity effects against the target, and the target takes a -1 status penalty to saves against electricity effects.</p>"
+        },
+        "duration": {
+            "expiry": null,
+            "sustained": false,
+            "unit": "unlimited",
+            "value": -1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Lost Omens: Gods & Magic"
+        },
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "item:trait:electricity"
+                ],
+                "selector": "saving-throw",
+                "type": "status",
+                "value": -1
+            },
+            {
+                "affects": "origin",
+                "key": "EphemeralEffect",
+                "selectors": [
+                    "attack-roll"
+                ],
+                "uuid": "Compendium.pf2e.spell-effects.Item.Spell Effect: Charged Javelin (Attacker)"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/spells/charged-javelin.json
+++ b/packs/spells/charged-javelin.json
@@ -32,7 +32,7 @@
         },
         "defense": null,
         "description": {
-            "value": "<p>You fire a javelin of electricity that leaves a charged field around its target. Make a spell attack roll. The javelin deals 1d6 electricity damage and 1 persistent electricity damage.</p>\n<p>As long as the target is taking persistent damage from this spell, creatures gain a +1 status bonus to attack rolls with metal weapons or electricity effects against the target, and the target takes a -1 status penalty to saves against electricity effects.</p>\n<hr />\n<p><strong>Critical Success</strong> The javelin deals double damage, both initial and persistent.</p>\n<p><strong>Success</strong> The javelin deals full damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The initial damage increases by 1d6, and the Persistent Damage increases by 1.</p>"
+            "value": "<p>You fire a javelin of electricity that leaves a charged field around its target. Make a spell attack roll. The javelin deals 1d6 electricity damage and 1 persistent electricity damage.</p>\n<p>As long as the target is taking persistent damage from this spell, creatures gain a +1 status bonus to attack rolls with metal weapons or electricity effects against the target, and the target takes a -1 status penalty to saves against electricity effects.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Charged Javelin]</p><hr /><p><strong>Critical Success</strong> The javelin deals double damage, both initial and persistent.</p>\n<p><strong>Success</strong> The javelin deals full damage.</p><hr /><p><strong>Heightened (+1)</strong> The initial damage increases by 1d6, and the persistent damage increases by 1.</p>"
         },
         "duration": {
             "sustained": false,


### PR DESCRIPTION
`item:material:metal` is not an actual roll option, but it will show the bonus in the roll dialog for users to toggle on when targeting the creature with the effect