### PR TITLE
Apply aid bonus to attack rolls and skill checks only

### DIFF
--- a/packs/other-effects/effect-aid.json
+++ b/packs/other-effects/effect-aid.json
@@ -51,9 +51,12 @@
             {
                 "key": "FlatModifier",
                 "removeAfterRoll": true,
-                "selector": "all",
+                "selector": [
+                    "attack-roll",
+                    "skill-check"
+                ],
                 "type": "circumstance",
-                "value": "{item|flags.pf2e.rulesSelections.aidBonus}"
+                "value": "@item.flags.pf2e.rulesSelections.aidBonus"
             }
         ],
         "start": {


### PR DESCRIPTION
Aid is triggered by an attack roll or skill check. Also changed the value to a number.