### PR TITLE
Add Alliance RollOptions and implement Blessed Counterstrike

### DIFF
--- a/packs/feat-effects/effect-blessed-counterstrike.json
+++ b/packs/feat-effects/effect-blessed-counterstrike.json
@@ -1,0 +1,46 @@
+{
+    "_id": "QBLLQzKvfwylOfOG",
+    "img": "systems/pf2e/icons/spells/competitive-edge.webp",
+    "name": "Effect: Blessed Counterstrike",
+    "system": {
+        "description": {
+            "value": "<p><span style=\"font-family:Roboto, sans-serif\">The target gains weakness equal to half your level to all Strikes made by you and your allies.</span></p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "level": {
+            "value": 12
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core 2"
+        },
+        "rules": [
+            {
+                "definition": [
+                    "origin:alliance:opposed",
+                    "action:strike"
+                ],
+                "key": "Weakness",
+                "type": "custom",
+                "value": "floor(@item.origin.level/2)"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feat-effects/effect-blessed-counterstrike.json
+++ b/packs/feat-effects/effect-blessed-counterstrike.json
@@ -4,7 +4,7 @@
     "name": "Effect: Blessed Counterstrike",
     "system": {
         "description": {
-            "value": "<p><span style=\"font-family:Roboto, sans-serif\">The target gains weakness equal to half your level to all Strikes made by you and your allies.</span></p>"
+            "value": "<p>The target gains weakness equal to half your level to all Strikes made by you and your allies.</p>"
         },
         "duration": {
             "expiry": "turn-start",

--- a/packs/feat-effects/effect-blessed-counterstrike.json
+++ b/packs/feat-effects/effect-blessed-counterstrike.json
@@ -1,10 +1,10 @@
 {
     "_id": "QBLLQzKvfwylOfOG",
-    "img": "systems/pf2e/icons/spells/competitive-edge.webp",
+    "img": "icons/magic/symbols/runes-etched-steel-blade.webp",
     "name": "Effect: Blessed Counterstrike",
     "system": {
         "description": {
-            "value": "<p>The target gains weakness equal to half your level to all Strikes made by you and your allies.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Blessed Counterstrike]</p>\n<p>The target gains weakness equal to half your level to all Strikes made by you and your allies.</p>"
         },
         "duration": {
             "expiry": "turn-start",

--- a/packs/feats/blessed-counterstrike.json
+++ b/packs/feats/blessed-counterstrike.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p><strong>Requirements</strong> An enemy triggered your champion's reaction since the end of your last turn.</p><hr /><p>You call upon divine power and make a weapon or unarmed Strike against the enemy who triggered your champion's reaction. The Strike deals one extra weapon damage die. If this Strike hits, until the start of your next turn, the target gains weakness equal to half your level to all Strikes made by you and your allies.</p>"
+            "value": "<p><strong>Requirements</strong> An enemy triggered your champion's reaction since the end of your last turn.</p><hr /><p>You call upon divine power and make a weapon or unarmed Strike against the enemy who triggered your champion's reaction. The Strike deals one extra weapon damage die. If this Strike hits, until the start of your next turn, the target gains weakness equal to half your level to all Strikes made by you and your allies.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Blessed Counterstrike]</p>"
         },
         "level": {
             "value": 12

--- a/src/module/actor/roll-context/base.ts
+++ b/src/module/actor/roll-context/base.ts
@@ -245,40 +245,19 @@ abstract class RollContext<
         })();
 
         const allianceOptions = (() => {
-                const originAlliance = originActor
-                    ? originActor.alliance === null
-                        ? "neutral"
-                        : originActor.alliance === undefined && originActor.hasPlayerOwner
-                          ? "party"
-                          : originActor.alliance === undefined && !originActor.hasPlayerOwner
-                            ? "opposition"
-                            : originActor.alliance
-                    : null;
-                const targetAlliance = targetActor
-                    ? targetActor.alliance === null
-                        ? "neutral"
-                        : targetActor.alliance === undefined && targetActor.hasPlayerOwner
-                          ? "party"
-                          : targetActor.alliance === undefined && !targetActor.hasPlayerOwner
-                            ? "opposition"
-                            : targetActor.alliance
+            const relativeAlliance =
+                originActor && targetActor
+                    ? originActor.isAllyOf(targetActor)
+                        ? "ally"
+                        : originActor.isEnemyOf(targetActor)
+                          ? "opposed"
+                          : "neutral"
                     : null;
 
-                // if either alliance is null, then they are neutral to each other
-                //
-                const relativeAlliance =
-                    originAlliance && targetAlliance
-                        ? originAlliance === "neutral" || targetAlliance === "neutral"
-                            ? "neutral"
-                            : originAlliance === targetAlliance
-                              ? "ally"
-                              : "opposed"
-                        : null;
-
-                return [
-                    originActor ? `origin:alliance:${relativeAlliance}` : null,
-                    targetActor ? `target:alliance:${relativeAlliance}` : null,
-                ].filter(R.isTruthy);
+            return [
+                relativeAlliance ? `origin:alliance:${relativeAlliance}` : null,
+                relativeAlliance ? `target:alliance:${relativeAlliance}` : null,
+            ].filter(R.isTruthy);
         })();
 
         // Get ephemeral effects from the target that affect this actor while attacking


### PR DESCRIPTION
Closes #16169

Implements relative alliance rolloptions based on the relationship between the origin and the target.

Ally - the target and the origin are allies.

Neutral - the target and the origin have no relationship.

Opposed - the target and the origin are in opposing non-neutral alliances.

This PR also implements Blessed Counterstrike as a proof of execution.