### PR TITLE
Remove attack bonus from Starlit Transformation effect

### DIFF
--- a/packs/feat-effects/effect-starlit-transformation.json
+++ b/packs/feat-effects/effect-starlit-transformation.json
@@ -72,9 +72,9 @@
                     "bolts-of-starlight"
                 ],
                 "property": "damage-type",
-                "selectors": {
+                "selectors": [
                     "{item|flags.pf2e.rulesSelections.weapon}-damage"
-                },
+                ],
                 "value": "force"
             },
             {

--- a/packs/feat-effects/effect-starlit-transformation.json
+++ b/packs/feat-effects/effect-starlit-transformation.json
@@ -40,9 +40,7 @@
             },
             {
                 "key": "FlatModifier",
-                "selector": [
-                    "{item|flags.pf2e.rulesSelections.weapon}-damage"
-                ],
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-damage",
                 "type": "status",
                 "value": 1
             },
@@ -74,7 +72,9 @@
                     "bolts-of-starlight"
                 ],
                 "property": "damage-type",
-                "selectors": "{item|flags.pf2e.rulesSelections.weapon}-damage",
+                "selectors": {
+                    "{item|flags.pf2e.rulesSelections.weapon}-damage"
+                },
                 "value": "force"
             },
             {

--- a/packs/feat-effects/effect-starlit-transformation.json
+++ b/packs/feat-effects/effect-starlit-transformation.json
@@ -74,9 +74,7 @@
                     "bolts-of-starlight"
                 ],
                 "property": "damage-type",
-                "selectors": [
-                    "{item|flags.pf2e.rulesSelections.weapon}-damage"
-                ],
+                "selectors": "{item|flags.pf2e.rulesSelections.weapon}-damage",
                 "value": "force"
             },
             {

--- a/packs/feat-effects/effect-starlit-transformation.json
+++ b/packs/feat-effects/effect-starlit-transformation.json
@@ -41,7 +41,6 @@
             {
                 "key": "FlatModifier",
                 "selector": [
-                    "{item|flags.pf2e.rulesSelections.weapon}-attack",
                     "{item|flags.pf2e.rulesSelections.weapon}-damage"
                 ],
                 "type": "status",


### PR DESCRIPTION
The action specifies a bonus to damage rolls, not attack rolls