### PR TITLE
Fix updating frequency of NPC abilities

### DIFF
--- a/src/module/actor/familiar/sheet.ts
+++ b/src/module/actor/familiar/sheet.ts
@@ -65,7 +65,7 @@ export class FamiliarSheetPF2e<TActor extends FamiliarPF2e> extends CreatureShee
                 ).map((item) => {
                     const traits = item.system.traits.value.map((t) => traitSlugToObject(t, CONFIG.PF2E.actionTraits));
                     return {
-                        _id: item.id,
+                        id: item.id,
                         name: item.name,
                         glyph: getActionGlyph(item.actionCost) || null,
                         frequency: item.system.frequency || null,

--- a/src/module/actor/npc/sheet.ts
+++ b/src/module/actor/npc/sheet.ts
@@ -341,9 +341,8 @@ class NPCSheetPF2e extends AbstractNPCSheet {
                     })();
 
                     return {
-                        ...R.pick(item, ["name", "sort"]),
+                        ...R.pick(item, ["id", "name", "sort"]),
                         ...R.pick(attack, ["breakdown", "variants"]),
-                        _id: item.id,
                         attackType: item.isMelee ? "PF2E.NPCAttackMelee" : "PF2E.NPCAttackRanged",
                         traits,
                         effects,
@@ -380,7 +379,7 @@ class NPCSheetPF2e extends AbstractNPCSheet {
                 selfEffect: !!item.system.selfEffect,
             };
 
-            actions[actionGroup].actions.push({ _id: item.id, name: item.name, glyph, traits, frequency, has });
+            actions[actionGroup].actions.push({ id: item.id, name: item.name, glyph, traits, frequency, has });
         }
 
         sheetData.attacks = attacks;

--- a/src/module/actor/npc/types.ts
+++ b/src/module/actor/npc/types.ts
@@ -54,7 +54,7 @@ interface NPCSystemSheetData extends NPCSystemData {
 }
 
 interface NPCStrikeSheetData {
-    _id: string;
+    id: string;
     name: string;
     sort: number;
     breakdown: string;

--- a/src/module/actor/sheet/data-types.ts
+++ b/src/module/actor/sheet/data-types.ts
@@ -66,7 +66,7 @@ interface ActorSheetDataPF2e<TActor extends ActorPF2e> extends ActorSheetData<TA
 }
 
 interface AbilityViewData {
-    _id: string;
+    id: string;
     name: string;
     traits: TraitViewData[];
     glyph: string | null;

--- a/static/templates/actors/army/sheet.hbs
+++ b/static/templates/actors/army/sheet.hbs
@@ -348,14 +348,14 @@
 
 {{#*inline "actionItem"}}
     {{#if action}}
-        <li class="item" {{#if action}}data-item-id="{{action._id}}"{{/if}} {{#if slotId}}data-slot-id="{{slotId}}"{{/if}}>
+        <li class="item" {{#if action}}data-item-id="{{action.id}}"{{/if}} {{#if slotId}}data-slot-id="{{slotId}}"{{/if}}>
             <h4 class="item-name">
                 <a data-action="toggle-summary">{{action.name}}</a>
                 {{{actionGlyph action.actionCost}}}
             </h4>
             {{#if action.system.frequency}}
                 <section class="item-frequency">
-                    <input type="number" value="{{action.system.frequency.value}}" data-item-id="{{action._id}}" data-item-property="system.frequency.value"/>
+                    <input type="number" value="{{action.system.frequency.value}}" data-item-id="{{action.id}}" data-item-property="system.frequency.value"/>
                     <span>
                         /
                         {{action.system.frequency.max}}
@@ -381,7 +381,7 @@
 
 {{#*inline "featItem"}}
     {{#if action}}
-        <li class="item" {{#if action}}data-item-id="{{action._id}}"{{/if}} {{#if slotId}}data-slot-id="{{slotId}}"{{/if}}>
+        <li class="item" {{#if action}}data-item-id="{{action.id}}"{{/if}} {{#if slotId}}data-slot-id="{{slotId}}"{{/if}}>
             <a class="icon item-image">
                 <img class="item-icon" src="{{action.img}}" alt="{{action.name}}" />
                 <i class="fa-solid fa-fw fa-message"></i>
@@ -391,7 +391,7 @@
             </h4>
             {{#if action.system.frequency}}
                 <section class="item-frequency">
-                    <input type="number" value="{{action.system.frequency.value}}" data-item-id="{{action._id}}" data-item-property="system.frequency.value"/>
+                    <input type="number" value="{{action.system.frequency.value}}" data-item-id="{{action.id}}" data-item-property="system.frequency.value"/>
                     <span>
                         /
                         {{action.system.frequency.max}}

--- a/static/templates/actors/familiar/sheet.hbs
+++ b/static/templates/actors/familiar/sheet.hbs
@@ -84,7 +84,7 @@
             <h4>{{localize "PF2E.HitPointsHeader"}}</h4>
         </div>
         <div class="value">
-            <input class="current-hp" id="{{actor._id}}-hit-points" type="number"
+            <input class="current-hp" id="{{actor.id}}-hit-points" type="number"
                 name="system.attributes.hp.value" value="{{data.attributes.hp.value}}" class="current-hp"
                 data-dtype="Number" />
             <div>/ </div>

--- a/static/templates/actors/npc/partials/action.hbs
+++ b/static/templates/actors/npc/partials/action.hbs
@@ -1,4 +1,4 @@
-<li class="item action flexrow" data-action="{{action._id}}" data-item-name="{{action.name}}" data-item-id="{{action._id}}">
+<li class="item action flexrow" data-action="{{action.id}}" data-item-name="{{action.name}}" data-item-id="{{action.id}}">
     <h4>
         <span class="name">
             <strong><a data-action="toggle-summary">{{action.name}}</a></strong>

--- a/static/templates/actors/npc/partials/attack.hbs
+++ b/static/templates/actors/npc/partials/attack.hbs
@@ -1,4 +1,4 @@
-<li class="item action" data-action-index="{{index}}" data-item-type="melee" data-item-id="{{action._id}}" data-strike>
+<li class="item action" data-action-index="{{index}}" data-item-type="melee" data-item-id="{{action.id}}" data-strike>
     <h4>
         {{#if action.description}}
             <a class="name" data-action="toggle-summary">


### PR DESCRIPTION
It entails a change to the view data to match character more closely, meaning it also required a refactor for all existing sheets. Posting abilities to chat and editing still works on npc, character, and familiar sheets. Vehicles remain broken for entirely unrelated reasons involving sheet handlers which I'll handle separately.