### PR TITLE
Add effect for Blessed Counterstrike

### DIFF
--- a/packs/feat-effects/effect-blessed-counterstrike.json
+++ b/packs/feat-effects/effect-blessed-counterstrike.json
@@ -1,0 +1,47 @@
+{
+    "_id": "rYYU6UVHblaJBxFB",
+    "img": "icons/skills/melee/swords-parry-block-blue.webp",
+    "name": "Effect: Blessed Counterstrike",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Blessed Counterstrike]</p>\n<p>The target gains weakness equal to half your level to all Strikes made by you and your allies.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core 2"
+        },
+        "rules": [
+            {
+                "definition": [
+                    "action:strike",
+                    "origin:enemy"
+                ],
+                "key": "Weakness",
+                "label": "PF2E.IWR.Custom.EnemyStrikes",
+                "type": "custom",
+                "value": "floor(@item.origin.level / 2)"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feats/blessed-counterstrike.json
+++ b/packs/feats/blessed-counterstrike.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p><strong>Requirements</strong> An enemy triggered your champion's reaction since the end of your last turn.</p><hr /><p>You call upon divine power and make a weapon or unarmed Strike against the enemy who triggered your champion's reaction. The Strike deals one extra weapon damage die. If this Strike hits, until the start of your next turn, the target gains weakness equal to half your level to all Strikes made by you and your allies.</p>"
+            "value": "<p><strong>Requirements</strong> An enemy triggered your champion's reaction since the end of your last turn.</p><hr /><p>You call upon divine power and make a weapon or unarmed Strike against the enemy who triggered your champion's reaction. The Strike deals one extra weapon damage die. If this Strike hits, until the start of your next turn, the target gains weakness equal to half your level to all Strikes made by you and your allies.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Blessed Counterstrike]</p>"
         },
         "level": {
             "value": 12

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -668,6 +668,7 @@
                 "ColdIronBludgeoning": "cold iron bludgeoning",
                 "CrystalHazards": "crystal hazards",
                 "DraconicBreathWeapons": "draconic breath weapons",
+                "EnemyStrikes": "enemy Strikes",
                 "HolyBludgeoningPiercingSlashing": "holy bludgeoning, piercing and slashing damage",
                 "ImpulseFireFrom": "impulse fire from {origin}",
                 "IngestedPoisons": "ingested poisons",


### PR DESCRIPTION
There is still the issue that the custom weakness is treated as "weakness all" which may not be accurate from a rules perspective.