### PR TITLE
Improve Blood Magic description alteration's formatting

### DIFF
--- a/packs/classfeatures/bloodline-aberrant.json
+++ b/packs/classfeatures/bloodline-aberrant.json
@@ -31,7 +31,7 @@
                 "path": "system.skills.intimidation.rank",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ],
                 "value": 1
@@ -42,7 +42,7 @@
                 "path": "system.skills.occultism.rank",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ],
                 "value": 1
@@ -53,7 +53,7 @@
                 "mode": "add",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     },
                     {
                         "or": [
@@ -133,6 +133,7 @@
             {
                 "itemType": "spell",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -153,6 +154,7 @@
                 "property": "description",
                 "value": [
                     {
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Aberrant",
                         "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Aberrant"
                     },
@@ -164,6 +166,7 @@
             {
                 "itemType": "feat",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -184,6 +187,7 @@
                 "property": "description",
                 "value": [
                     {
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Aberrant",
                         "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Aberrant"
                     },
@@ -198,7 +202,7 @@
                 "option": "feature:bloodline:tradition:occult",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ]
             }

--- a/packs/classfeatures/bloodline-angelic.json
+++ b/packs/classfeatures/bloodline-angelic.json
@@ -31,7 +31,7 @@
                 "path": "system.skills.diplomacy.rank",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ],
                 "value": 1
@@ -42,7 +42,7 @@
                 "path": "system.skills.religion.rank",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ],
                 "value": 1
@@ -53,7 +53,7 @@
                 "mode": "add",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     },
                     {
                         "or": [
@@ -133,6 +133,7 @@
             {
                 "itemType": "spell",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -153,6 +154,7 @@
                 "property": "description",
                 "value": [
                     {
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Angelic",
                         "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Angelic"
                     },
@@ -164,6 +166,7 @@
             {
                 "itemType": "feat",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "item:slug:blood-rising",
@@ -184,6 +187,7 @@
                 "property": "description",
                 "value": [
                     {
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Angelic",
                         "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Angelic"
                     },
@@ -198,7 +202,7 @@
                 "option": "feature:bloodline:tradition:divine",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ]
             }

--- a/packs/classfeatures/bloodline-demonic.json
+++ b/packs/classfeatures/bloodline-demonic.json
@@ -31,7 +31,7 @@
                 "path": "system.skills.intimidation.rank",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ],
                 "value": 1
@@ -42,7 +42,7 @@
                 "path": "system.skills.religion.rank",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolutionn"
                     }
                 ],
                 "value": 1
@@ -53,7 +53,7 @@
                 "mode": "add",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     },
                     {
                         "or": [
@@ -133,6 +133,7 @@
             {
                 "itemType": "spell",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -153,6 +154,7 @@
                 "property": "description",
                 "value": [
                     {
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Demonic",
                         "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Demonic"
                     },
@@ -164,6 +166,7 @@
             {
                 "itemType": "feat",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -184,6 +187,7 @@
                 "property": "description",
                 "value": [
                     {
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Demonic",
                         "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Demonic"
                     },
@@ -198,7 +202,7 @@
                 "option": "feature:bloodline:tradition:divine",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ]
             }

--- a/packs/classfeatures/bloodline-diabolic.json
+++ b/packs/classfeatures/bloodline-diabolic.json
@@ -31,7 +31,7 @@
                 "path": "system.skills.deception.rank",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ],
                 "value": 1
@@ -42,7 +42,7 @@
                 "path": "system.skills.religion.rank",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ],
                 "value": 1
@@ -53,7 +53,7 @@
                 "mode": "add",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     },
                     {
                         "or": [
@@ -133,6 +133,7 @@
             {
                 "itemType": "spell",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -153,6 +154,7 @@
                 "property": "description",
                 "value": [
                     {
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Diabolic",
                         "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Diabolic"
                     },
@@ -164,6 +166,7 @@
             {
                 "itemType": "feat",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -184,6 +187,7 @@
                 "property": "description",
                 "value": [
                     {
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Diabolic",
                         "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Diabolic"
                     },
@@ -198,7 +202,7 @@
                 "option": "feature:bloodline:tradition:divine",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ]
             }

--- a/packs/classfeatures/bloodline-draconic.json
+++ b/packs/classfeatures/bloodline-draconic.json
@@ -328,7 +328,7 @@
                 "path": "system.skills.intimidation.rank",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ],
                 "value": 1
@@ -339,7 +339,7 @@
                 "path": "system.skills.{item|flags.pf2e.rulesSelections.dragonBloodline.skill}.rank",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ],
                 "value": 1
@@ -355,7 +355,7 @@
                 "mode": "add",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     },
                     {
                         "or": [
@@ -641,6 +641,7 @@
             {
                 "itemType": "spell",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -661,6 +662,7 @@
                 "property": "description",
                 "value": [
                     {
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Draconic",
                         "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Draconic"
                     },
@@ -672,6 +674,7 @@
             {
                 "itemType": "feat",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -692,6 +695,7 @@
                 "property": "description",
                 "value": [
                     {
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Draconic",
                         "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Draconic"
                     },
@@ -706,7 +710,7 @@
                 "option": "feature:bloodline:tradition:{item|flags.pf2e.rulesSelections.dragonBloodline.tradition}",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ]
             }

--- a/packs/classfeatures/bloodline-elemental.json
+++ b/packs/classfeatures/bloodline-elemental.json
@@ -31,7 +31,7 @@
                 "path": "system.skills.intimidation.rank",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ],
                 "value": 1
@@ -42,7 +42,7 @@
                 "path": "system.skills.nature.rank",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ],
                 "value": 1
@@ -108,7 +108,7 @@
                 "mode": "add",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     },
                     {
                         "or": [
@@ -257,6 +257,7 @@
             {
                 "itemType": "spell",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -277,6 +278,7 @@
                 "property": "description",
                 "value": [
                     {
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Elemental",
                         "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Elemental"
                     },
@@ -288,6 +290,7 @@
             {
                 "itemType": "feat",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -308,6 +311,7 @@
                 "property": "description",
                 "value": [
                     {
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Elemental",
                         "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Elemental"
                     },
@@ -322,7 +326,7 @@
                 "option": "feature:bloodline:tradition:primal",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ]
             }

--- a/packs/classfeatures/bloodline-fey.json
+++ b/packs/classfeatures/bloodline-fey.json
@@ -31,7 +31,7 @@
                 "path": "system.skills.deception.rank",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ],
                 "value": 1
@@ -42,7 +42,7 @@
                 "path": "system.skills.nature.rank",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ],
                 "value": 1
@@ -53,7 +53,7 @@
                 "mode": "add",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     },
                     {
                         "or": [
@@ -133,6 +133,7 @@
             {
                 "itemType": "spell",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -153,6 +154,7 @@
                 "property": "description",
                 "value": [
                     {
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Fey",
                         "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Fey"
                     },
@@ -164,6 +166,7 @@
             {
                 "itemType": "feat",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -184,6 +187,7 @@
                 "property": "description",
                 "value": [
                     {
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Fey",
                         "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Fey"
                     },
@@ -198,7 +202,7 @@
                 "option": "feature:bloodline:tradition:primal",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ]
             }

--- a/packs/classfeatures/bloodline-genie.json
+++ b/packs/classfeatures/bloodline-genie.json
@@ -31,7 +31,7 @@
                 "path": "system.skills.arcana.rank",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ],
                 "value": 1
@@ -42,7 +42,7 @@
                 "path": "system.skills.deception.rank",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ],
                 "value": 1
@@ -81,7 +81,7 @@
                 "mode": "add",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     },
                     {
                         "or": [
@@ -218,6 +218,7 @@
             {
                 "itemType": "spell",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -238,6 +239,7 @@
                 "property": "description",
                 "value": [
                     {
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Genie",
                         "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Genie"
                     },
@@ -249,6 +251,7 @@
             {
                 "itemType": "feat",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -269,6 +272,7 @@
                 "property": "description",
                 "value": [
                     {
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Genie",
                         "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Genie"
                     },
@@ -283,7 +287,7 @@
                 "option": "feature:bloodline:tradition:arcane",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ]
             }

--- a/packs/classfeatures/bloodline-hag.json
+++ b/packs/classfeatures/bloodline-hag.json
@@ -31,7 +31,7 @@
                 "path": "system.skills.deception.rank",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ],
                 "value": 1
@@ -42,7 +42,7 @@
                 "path": "system.skills.occultism.rank",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ],
                 "value": 1
@@ -53,7 +53,7 @@
                 "mode": "add",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     },
                     {
                         "or": [
@@ -133,6 +133,7 @@
             {
                 "itemType": "spell",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -153,6 +154,7 @@
                 "property": "description",
                 "value": [
                     {
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Hag",
                         "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Hag"
                     },
@@ -164,6 +166,7 @@
             {
                 "itemType": "feat",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -184,6 +187,7 @@
                 "property": "description",
                 "value": [
                     {
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Hag",
                         "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Hag"
                     },
@@ -198,7 +202,7 @@
                 "option": "feature:bloodline:tradition:occult",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ]
             }

--- a/packs/classfeatures/bloodline-harrow.json
+++ b/packs/classfeatures/bloodline-harrow.json
@@ -31,7 +31,7 @@
                 "path": "system.skills.occultism.rank",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ],
                 "value": 1
@@ -42,7 +42,7 @@
                 "path": "system.skills.performance.rank",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ],
                 "value": 1
@@ -53,7 +53,7 @@
                 "mode": "add",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     },
                     {
                         "or": [
@@ -133,6 +133,7 @@
             {
                 "itemType": "spell",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -153,6 +154,7 @@
                 "property": "description",
                 "value": [
                     {
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Harrow",
                         "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Harrow"
                     }
@@ -161,6 +163,7 @@
             {
                 "itemType": "feat",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -181,6 +184,7 @@
                 "property": "description",
                 "value": [
                     {
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Harrow",
                         "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Harrow"
                     }
@@ -192,7 +196,7 @@
                 "option": "feature:bloodline:tradition:occult",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ]
             }

--- a/packs/classfeatures/bloodline-imperial.json
+++ b/packs/classfeatures/bloodline-imperial.json
@@ -31,7 +31,7 @@
                 "path": "system.skills.arcana.rank",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ],
                 "value": 1
@@ -42,7 +42,7 @@
                 "path": "system.skills.society.rank",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ],
                 "value": 1
@@ -53,7 +53,7 @@
                 "mode": "add",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     },
                     {
                         "or": [
@@ -133,6 +133,7 @@
             {
                 "itemType": "spell",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -153,6 +154,7 @@
                 "property": "description",
                 "value": [
                     {
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Imperial",
                         "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Imperial"
                     },
@@ -164,6 +166,7 @@
             {
                 "itemType": "feat",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -184,6 +187,7 @@
                 "property": "description",
                 "value": [
                     {
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Imperial",
                         "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Imperial"
                     },
@@ -198,7 +202,7 @@
                 "option": "feature:bloodline:tradition:arcane",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ]
             }

--- a/packs/classfeatures/bloodline-nymph.json
+++ b/packs/classfeatures/bloodline-nymph.json
@@ -31,7 +31,7 @@
                 "path": "system.skills.diplomacy.rank",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ],
                 "value": 1
@@ -42,7 +42,7 @@
                 "path": "system.skills.nature.rank",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ],
                 "value": 1
@@ -53,7 +53,7 @@
                 "mode": "add",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     },
                     {
                         "or": [
@@ -133,6 +133,7 @@
             {
                 "itemType": "spell",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -153,6 +154,7 @@
                 "property": "description",
                 "value": [
                     {
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Nymph",
                         "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Nymph"
                     },
@@ -164,6 +166,7 @@
             {
                 "itemType": "feat",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -184,6 +187,7 @@
                 "property": "description",
                 "value": [
                     {
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Nymph",
                         "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Nymph"
                     },
@@ -198,7 +202,7 @@
                 "option": "feature:bloodline:tradition:primal",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ]
             }

--- a/packs/classfeatures/bloodline-phoenix.json
+++ b/packs/classfeatures/bloodline-phoenix.json
@@ -31,7 +31,7 @@
                 "path": "system.skills.diplomacy.rank",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ],
                 "value": 1
@@ -42,7 +42,7 @@
                 "path": "system.skills.nature.rank",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ],
                 "value": 1
@@ -53,7 +53,7 @@
                 "mode": "add",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     },
                     {
                         "or": [
@@ -133,6 +133,7 @@
             {
                 "itemType": "spell",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -153,6 +154,7 @@
                 "property": "description",
                 "value": [
                     {
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Phoenix",
                         "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Phoenix"
                     },
@@ -164,6 +166,7 @@
             {
                 "itemType": "feat",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -184,6 +187,7 @@
                 "property": "description",
                 "value": [
                     {
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Phoenix",
                         "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Phoenix"
                     },
@@ -198,7 +202,7 @@
                 "option": "feature:bloodline:tradition:primal",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ]
             }

--- a/packs/classfeatures/bloodline-psychopomp.json
+++ b/packs/classfeatures/bloodline-psychopomp.json
@@ -31,7 +31,7 @@
                 "path": "system.skills.intimidation.rank",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ],
                 "value": 1
@@ -42,7 +42,7 @@
                 "path": "system.skills.religion.rank",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ],
                 "value": 1
@@ -53,7 +53,7 @@
                 "mode": "add",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     },
                     {
                         "or": [
@@ -133,6 +133,7 @@
             {
                 "itemType": "spell",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -153,6 +154,7 @@
                 "property": "description",
                 "value": [
                     {
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Psychopomp",
                         "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Psychopomp"
                     },
@@ -164,6 +166,7 @@
             {
                 "itemType": "feat",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -184,6 +187,7 @@
                 "property": "description",
                 "value": [
                     {
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Psychopomp",
                         "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Psychopomp"
                     },
@@ -198,7 +202,7 @@
                 "option": "feature:bloodline:tradition:divine",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ]
             }

--- a/packs/classfeatures/bloodline-shadow.json
+++ b/packs/classfeatures/bloodline-shadow.json
@@ -31,7 +31,7 @@
                 "path": "system.skills.occultism.rank",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ],
                 "value": 1
@@ -42,7 +42,7 @@
                 "path": "system.skills.stealth.rank",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ],
                 "value": 1
@@ -53,7 +53,7 @@
                 "mode": "add",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     },
                     {
                         "or": [
@@ -133,6 +133,7 @@
             {
                 "itemType": "spell",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -153,6 +154,7 @@
                 "property": "description",
                 "value": [
                     {
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Shadow.Text",
                         "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Shadow"
                     },
@@ -164,6 +166,7 @@
             {
                 "itemType": "feat",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -184,6 +187,7 @@
                 "property": "description",
                 "value": [
                     {
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Shadow.Text",
                         "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Shadow"
                     },
@@ -198,7 +202,7 @@
                 "option": "feature:bloodline:tradition:occult",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ]
             }

--- a/packs/classfeatures/bloodline-undead.json
+++ b/packs/classfeatures/bloodline-undead.json
@@ -31,7 +31,7 @@
                 "path": "system.skills.intimidation.rank",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ],
                 "value": 1
@@ -42,7 +42,7 @@
                 "path": "system.skills.religion.rank",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ],
                 "value": 1
@@ -53,7 +53,7 @@
                 "mode": "add",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     },
                     {
                         "or": [
@@ -133,6 +133,7 @@
             {
                 "itemType": "spell",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -153,6 +154,7 @@
                 "property": "description",
                 "value": [
                     {
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Undead",
                         "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Undead"
                     },
@@ -164,6 +166,7 @@
             {
                 "itemType": "feat",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -184,6 +187,7 @@
                 "property": "description",
                 "value": [
                     {
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Undead",
                         "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Undead"
                     },
@@ -198,7 +202,7 @@
                 "option": "feature:bloodline:tradition:divine",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ]
             }

--- a/packs/classfeatures/bloodline-wyrmblessed.json
+++ b/packs/classfeatures/bloodline-wyrmblessed.json
@@ -31,7 +31,7 @@
                 "path": "system.skills.intimidation.rank",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ],
                 "value": 1
@@ -42,7 +42,7 @@
                 "path": "system.skills.religion.rank",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ],
                 "value": 1
@@ -208,7 +208,7 @@
                 "mode": "add",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     },
                     {
                         "or": [
@@ -288,6 +288,7 @@
             {
                 "itemType": "spell",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -308,6 +309,7 @@
                 "property": "description",
                 "value": [
                     {
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Wyrmblessed",
                         "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Wyrmblessed"
                     },
@@ -319,6 +321,7 @@
             {
                 "itemType": "feat",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -339,6 +342,7 @@
                 "property": "description",
                 "value": [
                     {
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Wyrmblessed",
                         "title": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicLabel.Wyrmblessed"
                     },
@@ -353,7 +357,7 @@
                 "option": "feature:bloodline:tradition:divine",
                 "predicate": [
                     {
-                        "not": "parent:tag:crossblooded-evolution"
+                        "not": "parent:granter:slug:crossblooded-evolution"
                     }
                 ]
             }

--- a/packs/feats/blood-sovereignty.json
+++ b/packs/feats/blood-sovereignty.json
@@ -37,7 +37,7 @@
                 "property": "description",
                 "value": [
                     {
-                        "diviver": true,
+                        "divider": true,
                         "text": "PF2E.SpecificRule.Sorcerer.BloodSovereignty.Description"
                     },
                     {

--- a/packs/feats/blood-sovereignty.json
+++ b/packs/feats/blood-sovereignty.json
@@ -33,9 +33,11 @@
                     "second-blood-magic",
                     "item:tag:blood-magic-spell"
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {
+                        "diviver": true,
                         "text": "PF2E.SpecificRule.Sorcerer.BloodSovereignty.Description"
                     },
                     {

--- a/packs/feats/crossblooded-evolution.json
+++ b/packs/feats/crossblooded-evolution.json
@@ -37,13 +37,6 @@
                 "prompt": "PF2E.SpecificRule.Sorcerer.Bloodline.Prompt"
             },
             {
-                "alterations": [
-                    {
-                        "mode": "add",
-                        "property": "other-tags",
-                        "value": "crossblooded-evolution"
-                    }
-                ],
                 "key": "GrantItem",
                 "uuid": "{item|flags.pf2e.rulesSelections.bloodline}"
             }

--- a/packs/feats/explosion-of-power.json
+++ b/packs/feats/explosion-of-power.json
@@ -65,6 +65,7 @@
             {
                 "itemType": "spell",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -81,16 +82,20 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {
-                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.ExplosionOfPower"
+                        "divider": true,
+                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.ExplosionOfPower",
+                        "title": "{item|name}"
                     }
                 ]
             },
             {
                 "itemType": "feat",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -107,10 +112,13 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {
-                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.ExplosionOfPower"
+                        "divider": true,
+                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.ExplosionOfPower",
+                        "title": "{item|name}"
                     }
                 ]
             },

--- a/packs/feats/propelling-sorcery.json
+++ b/packs/feats/propelling-sorcery.json
@@ -65,6 +65,7 @@
             {
                 "itemType": "spell",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -81,16 +82,20 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {
-                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.PropellingSorcery"
+                        "divider": true,
+                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.PropellingSorcery",
+                        "title": "{item|name}"
                     }
                 ]
             },
             {
                 "itemType": "feat",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -107,10 +112,13 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {
-                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.PropellingSorcery"
+                        "divider": true,
+                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.PropellingSorcery",
+                        "title": "{item|name}"
                     }
                 ]
             }

--- a/packs/feats/reflect-harm.json
+++ b/packs/feats/reflect-harm.json
@@ -65,6 +65,7 @@
             {
                 "itemType": "spell",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -81,16 +82,20 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {
-                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.ReflectHarm"
+                        "divider": true,
+                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.ReflectHarm",
+                        "title": "{item|name}"
                     }
                 ]
             },
             {
                 "itemType": "feat",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -107,10 +112,13 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {
-                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.ReflectHarm"
+                        "divider": true,
+                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.ReflectHarm",
+                        "title": "{item|name}"
                     }
                 ]
             }

--- a/packs/feats/terraforming-trickery.json
+++ b/packs/feats/terraforming-trickery.json
@@ -65,6 +65,7 @@
             {
                 "itemType": "spell",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -81,16 +82,20 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {
-                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.TerraformingTrickery"
+                        "divider": true,
+                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.TerraformingTrickery",
+                        "title": "{item|name}"
                     }
                 ]
             },
             {
                 "itemType": "feat",
                 "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.Title",
                 "mode": "add",
                 "predicate": [
                     "class:sorcerer",
@@ -107,10 +112,13 @@
                         ]
                     }
                 ],
+                "priority": 121,
                 "property": "description",
                 "value": [
                     {
-                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.TerraformingTrickery"
+                        "divider": true,
+                        "text": "PF2E.SpecificRule.Sorcerer.Bloodline.BloodMagicDescription.TerraformingTrickery",
+                        "title": "{item|name}"
                     }
                 ]
             }


### PR DESCRIPTION
Added dividers, used Blood Magic as a label and the specific Blood Magic's name as the title for consistency
![image](https://github.com/user-attachments/assets/06fca735-1ce7-4406-a369-3ad7ed0e9d63)

also
- Pushed back priorities of blood magic feats' description alterations to ensure they're after spells are tagged as blood magic
- Remove unnecessary tag from Crossblooded Evolution, and replace parent tag predicate on bloodlines with granter slug one.