### PR TITLE
Add energy and physical damage types to pf2econfig

### DIFF
--- a/src/scripts/config/damage.ts
+++ b/src/scripts/config/damage.ts
@@ -65,6 +65,7 @@ export {
     damageCategoriesUnique,
     damageRollFlavors,
     damageTypes,
+    energyDamageTypes,
     materialDamageEffects,
     physicalDamageTypes,
 };

--- a/src/scripts/config/index.ts
+++ b/src/scripts/config/index.ts
@@ -40,7 +40,7 @@ import { Size } from "@module/data.ts";
 import { JournalSheetPF2e } from "@module/journal-entry/sheet.ts";
 import { configFromLocalization, sluggify } from "@util";
 import * as R from "remeda";
-import { damageCategories, damageRollFlavors, damageTypes, materialDamageEffects } from "./damage.ts";
+import { damageCategories, damageRollFlavors, damageTypes, energyDamageTypes,materialDamageEffects, physicalDamageTypes, } from "./damage.ts";
 import { immunityTypes, resistanceTypes, weaknessTypes } from "./iwr.ts";
 import {
     actionTraits,
@@ -385,7 +385,9 @@ export const PF2ECONFIG = {
     damageTypes,
     damageRollFlavors,
     damageCategories,
+    energyDamageTypes,
     materialDamageEffects,
+    physicalDamageTypes,
     resistanceTypes,
 
     stackGroups: {

--- a/src/scripts/config/index.ts
+++ b/src/scripts/config/index.ts
@@ -40,7 +40,14 @@ import { Size } from "@module/data.ts";
 import { JournalSheetPF2e } from "@module/journal-entry/sheet.ts";
 import { configFromLocalization, sluggify } from "@util";
 import * as R from "remeda";
-import { damageCategories, damageRollFlavors, damageTypes, energyDamageTypes,materialDamageEffects, physicalDamageTypes, } from "./damage.ts";
+import {
+    damageCategories,
+    damageRollFlavors,
+    damageTypes,
+    energyDamageTypes,
+    materialDamageEffects,
+    physicalDamageTypes,
+} from "./damage.ts";
 import { immunityTypes, resistanceTypes, weaknessTypes } from "./iwr.ts";
 import {
     actionTraits,


### PR DESCRIPTION
For ChoiceSets that let you pick any energy damage, so they can be shortened to `config: energyDamageTypes`. Physical is just added for symmetry.