### PR TITLE
Only allow bonuses to apply to enabled instances

### DIFF
--- a/src/module/system/damage/formula.ts
+++ b/src/module/system/damage/formula.ts
@@ -115,15 +115,16 @@ function createDamageFormula(
         }
     }
 
+    const bonusableDamage = [
+        ...damage.base,
+        ...damage.dice.filter((d) => d.enabled),
+        ...damage.modifiers.filter((m) => m.enabled && m.value > 0 && m.type === "untyped"),
+    ];
+
     // Add modifiers
     for (const modifier of damage.modifiers.filter((m) => m.enabled && outcomeMatches(m))) {
         // A genuine bonus or penalty must match against both damage type and category: e.g., a bonus to flat damage
         // must not be applied to persistent damage--nor vice versa
-        const bonusableDamage = [
-            ...damage.base,
-            ...damage.dice,
-            ...damage.modifiers.filter((m) => m.value > 0 && m.type === "untyped"),
-        ];
         const matchingDamage =
             modifier.kind === "modifier"
                 ? bonusableDamage.find((b) => b.damageType === (modifier.damageType ?? b.damageType)) ??


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/16669.

It'll still show as enabled in the damage dialog, but it won't affect the outcome. I can't think of a good solution for that right now other than making a redundant check in the dialog itself for "invalid" modifiers.

I'll try a refactor that filters enabled much much sooner next cycle.