### PR TITLE
Update Monastic Weaponry by adding critical specialization to monk weapons

### DIFF
--- a/packs/feats/monastic-weaponry.json
+++ b/packs/feats/monastic-weaponry.json
@@ -43,6 +43,7 @@
             {
                 "key": "CriticalSpecialization",
                 "predicate": [
+                    "feature:expert-strikes",
                     "item:trait:monk"
                 ]
             }

--- a/packs/feats/monastic-weaponry.json
+++ b/packs/feats/monastic-weaponry.json
@@ -39,6 +39,12 @@
                 "maxRank": "master",
                 "sameAs": "unarmed",
                 "slug": "simple-martial-monk-weapons"
+            },
+            {
+                "key": "CriticalSpecialization",
+                "predicate": [
+                    "item:trait:monk"
+                ]
             }
         ],
         "traits": {


### PR DESCRIPTION
Add critical specialization to monk weapons if you have expert strikes, addresses #16687 

![image](https://github.com/user-attachments/assets/1d919d46-a55d-4645-9abf-847a7fd620e7)
