### PR TITLE
Brush up Deity (Champion) class feature

### DIFF
--- a/packs/classfeatures/deity-champion.json
+++ b/packs/classfeatures/deity-champion.json
@@ -134,7 +134,6 @@
                 "key": "AdjustStrike",
                 "mode": "add",
                 "predicate": [
-                    "class:champion",
                     "sanctification:holy"
                 ],
                 "property": "traits",
@@ -144,7 +143,6 @@
                 "key": "AdjustStrike",
                 "mode": "add",
                 "predicate": [
-                    "class:champion",
                     "sanctification:unholy"
                 ],
                 "property": "traits",


### PR DESCRIPTION
- Remove `class:champion` from the holy/unholy strike predicates