### PR TITLE
Update Scout's Charge to use variant Feint action

### DIFF
--- a/packs/feats/scouts-charge.json
+++ b/packs/feats/scouts-charge.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>You meander around unpredictably, and then ambush your opponents without warning.</p>\n<p>Choose one enemy. Stride, @UUID[Compendium.pf2e.actionspf2e.Item.Feint] against that opponent, and then make a Strike against it. For your Feint, you can attempt a Stealth check instead of the Deception check that's usually required, using the terrain around you to surprise your foe.</p>"
+            "value": "<p>You meander around unpredictably, and then ambush your opponents without warning.</p>\n<p>Choose one enemy. Stride, [[/act feint skill=stealth]]{Feint} against that opponent, and then make a Strike against it. For your Feint, you can attempt a Stealth check instead of the Deception check that's usually required, using the terrain around you to surprise your foe.</p>"
         },
         "level": {
             "value": 4

--- a/packs/feats/scouts-charge.json
+++ b/packs/feats/scouts-charge.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>You meander around unpredictably, and then ambush your opponents without warning.</p>\n<p>Choose one enemy. Stride, [[/act feint skill=stealth]]{Feint} against that opponent, and then make a Strike against it. For your Feint, you can attempt a Stealth check instead of the Deception check that's usually required, using the terrain around you to surprise your foe.</p>"
+            "value": "<p>You meander around unpredictably, and then ambush your opponents without warning.</p>\n<p>Choose one enemy. Stride, @UUID[Compendium.pf2e.actionspf2e.Item.Feint] against that opponent, and then make a Strike against it. For your Feint, you can attempt a [[/act feint skill=stealth]]{Stealth} check instead of the Deception check that's usually required, using the terrain around you to surprise your foe.</p>"
         },
         "level": {
             "value": 4


### PR DESCRIPTION
Per the feat's description, this variant of Feint uses stealth