### PR TITLE
Fix regression with editing the first rule element

### DIFF
--- a/src/module/item/base/sheet/sheet.ts
+++ b/src/module/item/base/sheet/sheet.ts
@@ -373,8 +373,8 @@ class ItemSheetPF2e<TItem extends ItemPF2e> extends ItemSheet<TItem, ItemSheetOp
         for (const anchor of htmlQueryAll(rulesPanel, "a.edit-rule-element")) {
             anchor.addEventListener("click", async () => {
                 if (this._submitting) return; // Don't open if already submitting
-                const index = Number(anchor.dataset.ruleIndex ?? "NaN") || null;
-                this.#editingRuleElementIndex = index;
+                const index = Number(anchor.dataset.ruleIndex ?? "NaN");
+                this.#editingRuleElementIndex = Number.isInteger(index) ? index : null;
                 this.#rulesLastScrollTop = rulesPanel?.scrollTop ?? null;
                 this.render();
             });


### PR DESCRIPTION
The ?? null changed to || null which broke 0, but ?? isn't correct for NaN regardless.