### PR TITLE
Fix inline checks for Paradox Engine

### DIFF
--- a/packs/shadows-at-sundown-bestiary/paradox-engine.json
+++ b/packs/shadows-at-sundown-bestiary/paradox-engine.json
@@ -64,7 +64,7 @@
         "creatureType": "",
         "details": {
             "description": "<p>All six sides of this adamantine-reinforced box are covered with Thassilonian runes. Touching a rune allows one to exchange its position with another.</p>",
-            "disable": "<p>@Check[thievery|dc:41|name:Feel the subtle vibrations] (expert) to feel the subtle vibrations when moving a rune to shift into the right position, or @Check[33|dc:Thassilon] (expert) or @Check[society|dc:38|name:Work out the puzzle] (master) while being able to read Thassilonian to work out the anagram puzzle using traditional means, or @UUID[Compendium.pf2e.spells-srd.Item.Dispel Magic] (7th level; counteract DC 34)</p>",
+            "disable": "<p>@Check[thievery|dc:41|name:Feel the subtle vibrations] (expert) to feel the subtle vibrations when moving a rune to shift into the right position, or @Check[thassilon-lore|dc:33|name:Work out the puzzle] (expert) or @Check[society|dc:38|name:Work out the puzzle] (master) while being able to read Thassilonian to work out the anagram puzzle using traditional means, or @UUID[Compendium.pf2e.spells-srd.Item.Dispel Magic] (7th level; counteract DC 34)</p>",
             "isComplex": true,
             "level": {
                 "value": 14

--- a/packs/shadows-at-sundown-bestiary/paradox-engine.json
+++ b/packs/shadows-at-sundown-bestiary/paradox-engine.json
@@ -64,7 +64,7 @@
         "creatureType": "",
         "details": {
             "description": "<p>All six sides of this adamantine-reinforced box are covered with Thassilonian runes. Touching a rune allows one to exchange its position with another.</p>",
-            "disable": "<p>@Check[thievery|dc:41|name:Feel the subtle vibrations] (expert) to feel the subtle vibrations when moving a rune to shift into the right position, or @Check[thassilon-lore|dc:33|name:Work out the puzzle] (expert) or @Check[society|dc:38|name:Work out the puzzle] (master) while being able to read Thassilonian to work out the anagram puzzle using traditional means, or @UUID[Compendium.pf2e.spells-srd.Item.Dispel Magic] (7th level; counteract DC 34)</p>",
+            "disable": "<p>@Check[thievery|dc:41] (expert) to feel the subtle vibrations when moving a rune to shift into the right position, or @Check[Thassilon Lore|dc:33] (expert) or @Check[society|dc:38] (master) while being able to read Thassilonian to work out the anagram puzzle using traditional means, or @UUID[Compendium.pf2e.spells-srd.Item.Dispel Magic] (7th rank; counteract DC 34)</p>",
             "isComplex": true,
             "level": {
                 "value": 14


### PR DESCRIPTION
* Swapped the DC and skill arguments so their order is correct
* Gave it the same name as the disable Society check because as written either Thassilon Lore or Society can be used to "Work out the puzzle"