### PR TITLE
Automate Backfire Mantle bonus to saves

### DIFF
--- a/packs/equipment/backfire-mantle-greater.json
+++ b/packs/equipment/backfire-mantle-greater.json
@@ -38,10 +38,11 @@
             {
                 "key": "FlatModifier",
                 "predicate": [
+                    "item:type:spell",
                     {
                         "or": [
-                            "target:self",
-                            "target:ally"
+                            "origin:signature:{actor|signature}",
+                            "origin:ally"
                         ]
                     }
                 ],

--- a/packs/equipment/backfire-mantle.json
+++ b/packs/equipment/backfire-mantle.json
@@ -38,10 +38,11 @@
             {
                 "key": "FlatModifier",
                 "predicate": [
+                    "item:type:spell",
                     {
                         "or": [
-                            "target:self",
-                            "target:ally"
+                            "origin:signature:{actor|signature}",
+                            "origin:ally"
                         ]
                     }
                 ],


### PR DESCRIPTION
It looks like splash resistance is not currently supported, even as a custom resistance.