### PR TITLE
Fix some extract and migrate regressions and delaraius's wand 

### DIFF
--- a/build/lib/compendium-pack.ts
+++ b/build/lib/compendium-pack.ts
@@ -329,11 +329,6 @@ class CompendiumPack {
     ): void {
         const convertOptions = { to: to === "ids" ? "id" : "name", map } as const;
 
-        // Convert compendium source if it exists
-        if (source._stats?.compendiumSource) {
-            source._stats.compendiumSource = CompendiumPack.convertUUID(source._stats.compendiumSource, convertOptions);
-        }
-
         // Convert UUIDs found in places particular to certain item types
         if (itemIsOfType(source, "feat", "action") && source.system.selfEffect) {
             source.system.selfEffect.uuid = CompendiumPack.convertUUID(source.system.selfEffect.uuid, convertOptions);

--- a/build/run-migration.ts
+++ b/build/run-migration.ts
@@ -142,7 +142,6 @@ function setDefaults(source: PackEntry) {
             setDefaults(item);
         }
     } else if (isItemData(source)) {
-        source.system.slug = sluggify(source.name);
         if (itemIsOfType(source, "physical")) {
             source.system.subitems ??= [];
             for (const subItem of source.system.subitems) {
@@ -198,6 +197,7 @@ async function migrate() {
 
                     return fu.mergeObject(source, update, { inplace: false, performDeletions: true });
                 } else if (isItemData(source)) {
+                    source.system.slug = sluggify(source.name);
                     const update = await migrationRunner.getUpdatedItem(source, migrationRunner.migrations);
 
                     pruneDefaults(source);

--- a/packs/curtain-call-bestiary/delaraius-solzakarr.json
+++ b/packs/curtain-call-bestiary/delaraius-solzakarr.json
@@ -3468,6 +3468,9 @@
                 "slug": "magic-wand-9th-rank-spell",
                 "spell": {
                     "_id": "n6hpT8sTeCYZpM1Q",
+                    "_stats": {
+                        "compendiumSource": "Compendium.pf2e.spells-srd.Item.10VcmSYNBrvBphu1"
+                    },
                     "img": "systems/pf2e/icons/spells/massacre.webp",
                     "name": "Massacre",
                     "sort": 0,


### PR DESCRIPTION
Fixes slug being set for embedded migrated items, as well converting source ids on extract when source ids as a whole are not converted.